### PR TITLE
Fix check script to use unit tests only

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typecheck:workspace": "turbo run typecheck",
     "docs:build": "turbo run build --filter=@tmux-ide/docs",
     "pack:check": "npm pack --dry-run --cache /tmp/tmux-ide-npm-cache > /dev/null",
-    "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run test && pnpm run docs:build && pnpm run pack:check",
+    "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run test:unit && pnpm run docs:build && pnpm run pack:check",
     "prepublishOnly": "pnpm run check",
     "postinstall": "node scripts/postinstall.js",
     "docs": "turbo run dev --filter=@tmux-ide/docs"


### PR DESCRIPTION
## Summary
- Change `check` script from `pnpm run test` to `pnpm run test:unit`
- Fixes publish workflow failure where `prepublishOnly` runs integration tests that need tmux

## Test plan
- [x] `pnpm run check` passes locally
- [ ] CI passes
- [ ] Publish workflow succeeds after merge + re-tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)