### PR TITLE
Fix publish: add NPM_TOKEN for npm auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,3 +34,5 @@ jobs:
 
       - name: Publish
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `NODE_AUTH_TOKEN` back to the publish step
- OIDC trusted publisher handles provenance, but npm still needs a token to authenticate the publish

## Setup required
Add an `NPM_TOKEN` secret to the `npm` environment:
1. Go to https://www.npmjs.com/settings → Access Tokens → Generate New Token (Automation type)
2. Add it at https://github.com/wavyrai/tmux-ide/settings/environments → `npm` → Environment secrets → `NPM_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)