### PR TITLE
Update landing page version badge to 1.2.0

### DIFF
--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -93,10 +93,10 @@ export default function HomePage() {
             tmux-ide
           </span>
           <Link
-            href="/docs/release-1-1-0"
+            href="/docs/release-1-2-0"
             className="inline-flex items-center rounded-full border border-fd-border bg-fd-card px-3 py-1 text-[11px] font-mono font-medium uppercase tracking-[0.18em] text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-foreground"
           >
-            New 1.1.0
+            New 1.2.0
           </Link>
         </div>
         <h1 className="text-4xl sm:text-5xl font-bold tracking-tight text-fd-foreground">

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -35,7 +35,7 @@ npx tmux-ide restart # restart with new config
 ```
 
 <Cards>
-  <Card title="What's New in 1.1.0" href="/docs/release-1-1-0" />
+  <Card title="What's New in 1.2.0" href="/docs/release-1-2-0" />
   <Card title="Getting Started" href="/docs/getting-started" />
   <Card title="Configuration" href="/docs/configuration" />
   <Card title="Templates" href="/docs/templates" />


### PR DESCRIPTION
## Summary

- Update version badge on landing page from 1.1.0 → 1.2.0
- Update docs index card to link to 1.2.0 release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)