### PR TITLE
Fix launch crash when tmux server is not running

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-ide",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Turn any project into a tmux-powered terminal IDE with a simple ide.yml",
   "type": "module",
   "bin": {

--- a/src/lib/tmux.js
+++ b/src/lib/tmux.js
@@ -40,7 +40,10 @@ export function hasSession(session) {
     runTmux(["has-session", "-t", session]);
     return true;
   } catch (error) {
-    if (error instanceof TmuxError && error.code === "SESSION_NOT_FOUND") {
+    if (
+      error instanceof TmuxError &&
+      (error.code === "SESSION_NOT_FOUND" || error.code === "TMUX_UNAVAILABLE")
+    ) {
       return false;
     }
     throw error;


### PR DESCRIPTION
## Summary
- After a reboot, `tmux-ide` crashed with "tmux is unavailable or its socket is inaccessible" because `hasSession()` only handled `SESSION_NOT_FOUND`, not `TMUX_UNAVAILABLE`
- Now treats "no server running" the same as "no session" — returns `false` so launch proceeds to create a new session
- Bumps version to 1.2.1

## Test plan
- [x] All 134 tests pass
- [ ] Reboot machine, run `tmux-ide` — should launch without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)