### PR TITLE
Phase 4: Test coverage and polish

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,38 @@ import { readConfig, writeConfig } from "./lib/yaml-io.js";
 import { setByPath } from "./lib/dot-path.js";
 import { outputError } from "./lib/output.js";
 
+/**
+ * Read config safely (read-only, no write). Returns config or undefined on error.
+ */
+function readConfigSafe(dir) {
+  let cfg;
+  try {
+    ({ config: cfg } = readConfig(dir));
+  } catch (e) {
+    outputError(`Cannot read ide.yml: ${e.message}`, "READ_ERROR");
+    return;
+  }
+  return cfg;
+}
+
+/**
+ * Read config, validate it's an object, run mutator, then write back.
+ * Returns the mutator's return value, or undefined on error.
+ */
+function withConfig(dir, mutator) {
+  const cfg = readConfigSafe(dir);
+  if (cfg === undefined) return;
+
+  if (!isConfigObject(cfg)) {
+    outputError("Invalid ide.yml: config root must be an object", "INVALID_CONFIG");
+    return;
+  }
+
+  const result = mutator(cfg);
+  writeConfig(dir, cfg);
+  return result;
+}
+
 export async function config(targetDir, { json, action, args } = {}) {
   const dir = resolve(targetDir ?? ".");
 
@@ -27,18 +59,12 @@ export async function config(targetDir, { json, action, args } = {}) {
 }
 
 function dumpConfig(dir, { json }) {
-  let cfg;
-  try {
-    ({ config: cfg } = readConfig(dir));
-  } catch (e) {
-    outputError(`Cannot read ide.yml: ${e.message}`, "READ_ERROR");
-    return;
-  }
+  const cfg = readConfigSafe(dir);
+  if (cfg === undefined) return;
 
   if (json) {
     console.log(JSON.stringify(cfg, null, 2));
   } else {
-    // Pretty print for humans
     console.log(JSON.stringify(cfg, null, 2));
   }
 }
@@ -50,27 +76,14 @@ function setConfig(dir, args, { json }) {
     return;
   }
 
-  let cfg;
-  try {
-    ({ config: cfg } = readConfig(dir));
-  } catch (e) {
-    outputError(`Cannot read ide.yml: ${e.message}`, "READ_ERROR");
-    return;
-  }
-
-  if (!isConfigObject(cfg)) {
-    outputError("Invalid ide.yml: config root must be an object", "INVALID_CONFIG");
-    return;
-  }
-
   let value = rest.join(" ");
-  // Try to parse as number or boolean
   if (value === "true") value = true;
   else if (value === "false") value = false;
   else if (/^\d+$/.test(value)) value = parseInt(value);
 
-  setByPath(cfg, dotpath, value);
-  writeConfig(dir, cfg);
+  withConfig(dir, (cfg) => {
+    setByPath(cfg, dotpath, value);
+  });
 
   if (json) {
     console.log(JSON.stringify({ ok: true, path: dotpath, value }, null, 2));
@@ -89,32 +102,9 @@ function addPane(dir, args, { json }) {
     return;
   }
 
-  let cfg;
-  try {
-    ({ config: cfg } = readConfig(dir));
-  } catch (e) {
-    outputError(`Cannot read ide.yml: ${e.message}`, "READ_ERROR");
-    return;
-  }
-
-  if (!Array.isArray(cfg?.rows)) {
-    outputError("Invalid ide.yml: 'rows' must be an array", "INVALID_CONFIG");
-    return;
-  }
-
   const rowIdx = parseIndex(row);
   if (rowIdx == null) {
     outputError(`Invalid row index "${row}"`, "USAGE");
-    return;
-  }
-
-  if (!cfg.rows[rowIdx]) {
-    outputError(`Row ${rowIdx} does not exist`, "INVALID_ROW");
-    return;
-  }
-
-  if (!Array.isArray(cfg.rows[rowIdx].panes)) {
-    outputError(`Invalid ide.yml: row ${rowIdx} panes must be an array`, "INVALID_CONFIG");
     return;
   }
 
@@ -123,8 +113,21 @@ function addPane(dir, args, { json }) {
   if (command) pane.command = command;
   if (size) pane.size = size;
 
-  cfg.rows[rowIdx].panes.push(pane);
-  writeConfig(dir, cfg);
+  withConfig(dir, (cfg) => {
+    if (!Array.isArray(cfg.rows)) {
+      outputError("Invalid ide.yml: 'rows' must be an array", "INVALID_CONFIG");
+    }
+
+    if (!cfg.rows[rowIdx]) {
+      outputError(`Row ${rowIdx} does not exist`, "INVALID_ROW");
+    }
+
+    if (!Array.isArray(cfg.rows[rowIdx].panes)) {
+      outputError(`Invalid ide.yml: row ${rowIdx} panes must be an array`, "INVALID_CONFIG");
+    }
+
+    cfg.rows[rowIdx].panes.push(pane);
+  });
 
   if (json) {
     console.log(JSON.stringify({ ok: true, row: rowIdx, pane }, null, 2));
@@ -140,19 +143,6 @@ function removePane(dir, args, { json }) {
     return;
   }
 
-  let cfg;
-  try {
-    ({ config: cfg } = readConfig(dir));
-  } catch (e) {
-    outputError(`Cannot read ide.yml: ${e.message}`, "READ_ERROR");
-    return;
-  }
-
-  if (!Array.isArray(cfg?.rows)) {
-    outputError("Invalid ide.yml: 'rows' must be an array", "INVALID_CONFIG");
-    return;
-  }
-
   const rowIdx = parseIndex(row);
   const paneIdx = parseIndex(pane);
   if (rowIdx == null || paneIdx == null) {
@@ -160,18 +150,22 @@ function removePane(dir, args, { json }) {
     return;
   }
 
-  if (!Array.isArray(cfg.rows[rowIdx]?.panes)) {
-    outputError(`Invalid ide.yml: row ${rowIdx} panes must be an array`, "INVALID_CONFIG");
-    return;
-  }
+  let removed;
+  withConfig(dir, (cfg) => {
+    if (!Array.isArray(cfg.rows)) {
+      outputError("Invalid ide.yml: 'rows' must be an array", "INVALID_CONFIG");
+    }
 
-  if (!cfg.rows[rowIdx].panes[paneIdx]) {
-    outputError(`Pane ${paneIdx} in row ${rowIdx} does not exist`, "INVALID_PANE");
-    return;
-  }
+    if (!Array.isArray(cfg.rows[rowIdx]?.panes)) {
+      outputError(`Invalid ide.yml: row ${rowIdx} panes must be an array`, "INVALID_CONFIG");
+    }
 
-  const removed = cfg.rows[rowIdx].panes.splice(paneIdx, 1)[0];
-  writeConfig(dir, cfg);
+    if (!cfg.rows[rowIdx].panes[paneIdx]) {
+      outputError(`Pane ${paneIdx} in row ${rowIdx} does not exist`, "INVALID_PANE");
+    }
+
+    removed = cfg.rows[rowIdx].panes.splice(paneIdx, 1)[0];
+  });
 
   if (json) {
     console.log(JSON.stringify({ ok: true, row: rowIdx, pane: paneIdx, removed }, null, 2));
@@ -183,32 +177,19 @@ function removePane(dir, args, { json }) {
 function addRow(dir, args, { json }) {
   const { size } = parseNamedArgs(args);
 
-  let cfg;
-  try {
-    ({ config: cfg } = readConfig(dir));
-  } catch (e) {
-    outputError(`Cannot read ide.yml: ${e.message}`, "READ_ERROR");
-    return;
-  }
+  let rowIdx;
+  withConfig(dir, (cfg) => {
+    if (cfg.rows !== undefined && !Array.isArray(cfg.rows)) {
+      outputError("Invalid ide.yml: 'rows' must be an array", "INVALID_CONFIG");
+    }
 
-  if (!isConfigObject(cfg)) {
-    outputError("Invalid ide.yml: config root must be an object", "INVALID_CONFIG");
-    return;
-  }
+    const row = { panes: [{ title: "Shell" }] };
+    if (size) row.size = size;
+    cfg.rows = cfg.rows ?? [];
+    cfg.rows.push(row);
+    rowIdx = cfg.rows.length - 1;
+  });
 
-  if (cfg.rows !== undefined && !Array.isArray(cfg.rows)) {
-    outputError("Invalid ide.yml: 'rows' must be an array", "INVALID_CONFIG");
-    return;
-  }
-
-  const row = { panes: [{ title: "Shell" }] };
-  if (size) row.size = size;
-
-  cfg.rows = cfg.rows ?? [];
-  cfg.rows.push(row);
-  writeConfig(dir, cfg);
-
-  const rowIdx = cfg.rows.length - 1;
   if (json) {
     console.log(JSON.stringify({ ok: true, row: rowIdx, size: size ?? null }, null, 2));
   } else {
@@ -219,85 +200,59 @@ function addRow(dir, args, { json }) {
 function enableTeam(dir, args, { json }) {
   const { name } = parseNamedArgs(args);
 
-  let cfg;
-  try {
-    ({ config: cfg } = readConfig(dir));
-  } catch (e) {
-    outputError(`Cannot read ide.yml: ${e.message}`, "READ_ERROR");
-    return;
-  }
+  let teamName;
+  let result;
+  withConfig(dir, (cfg) => {
+    if (cfg.rows !== undefined && !Array.isArray(cfg.rows)) {
+      outputError("Invalid ide.yml: 'rows' must be an array", "INVALID_CONFIG");
+    }
 
-  if (!isConfigObject(cfg)) {
-    outputError("Invalid ide.yml: config root must be an object", "INVALID_CONFIG");
-    return;
-  }
+    teamName = name ?? cfg.name ?? "my-team";
+    cfg.team = { name: teamName };
 
-  if (cfg.rows !== undefined && !Array.isArray(cfg.rows)) {
-    outputError("Invalid ide.yml: 'rows' must be an array", "INVALID_CONFIG");
-    return;
-  }
-
-  const teamName = name ?? cfg.name ?? "my-team";
-  cfg.team = { name: teamName };
-
-  // Find claude panes and assign roles: first as lead, rest as teammates
-  let leadAssigned = false;
-  for (const row of cfg.rows ?? []) {
-    for (const pane of row.panes ?? []) {
-      if (pane.command === "claude" || pane.role === "lead" || pane.role === "teammate") {
-        if (!leadAssigned) {
-          pane.role = "lead";
-          leadAssigned = true;
-        } else {
-          pane.role = "teammate";
+    let leadAssigned = false;
+    for (const row of cfg.rows ?? []) {
+      for (const pane of row.panes ?? []) {
+        if (pane.command === "claude" || pane.role === "lead" || pane.role === "teammate") {
+          if (!leadAssigned) {
+            pane.role = "lead";
+            leadAssigned = true;
+          } else {
+            pane.role = "teammate";
+          }
         }
       }
     }
-  }
-  if (!leadAssigned) {
-    delete cfg.team;
-    outputError("Cannot enable agent team: no Claude panes found", "INVALID_CONFIG");
-    return;
-  }
+    if (!leadAssigned) {
+      delete cfg.team;
+      outputError("Cannot enable agent team: no Claude panes found", "INVALID_CONFIG");
+    }
 
-  writeConfig(dir, cfg);
+    result = { team: cfg.team, roles: summarizeRoles(cfg) };
+  });
 
   if (json) {
-    console.log(JSON.stringify({ ok: true, team: cfg.team, roles: summarizeRoles(cfg) }, null, 2));
+    console.log(JSON.stringify({ ok: true, ...result }, null, 2));
   } else {
     console.log(`Enabled agent team "${teamName}"`);
   }
 }
 
 function disableTeam(dir, { json }) {
-  let cfg;
-  try {
-    ({ config: cfg } = readConfig(dir));
-  } catch (e) {
-    outputError(`Cannot read ide.yml: ${e.message}`, "READ_ERROR");
-    return;
-  }
-
-  if (!isConfigObject(cfg)) {
-    outputError("Invalid ide.yml: config root must be an object", "INVALID_CONFIG");
-    return;
-  }
-
-  if (cfg.rows !== undefined && !Array.isArray(cfg.rows)) {
-    outputError("Invalid ide.yml: 'rows' must be an array", "INVALID_CONFIG");
-    return;
-  }
-
-  delete cfg.team;
-  for (const row of cfg.rows ?? []) {
-    if (!Array.isArray(row?.panes)) continue;
-    for (const pane of row.panes ?? []) {
-      delete pane.role;
-      delete pane.task;
+  withConfig(dir, (cfg) => {
+    if (cfg.rows !== undefined && !Array.isArray(cfg.rows)) {
+      outputError("Invalid ide.yml: 'rows' must be an array", "INVALID_CONFIG");
     }
-  }
 
-  writeConfig(dir, cfg);
+    delete cfg.team;
+    for (const row of cfg.rows ?? []) {
+      if (!Array.isArray(row?.panes)) continue;
+      for (const pane of row.panes) {
+        delete pane.role;
+        delete pane.task;
+      }
+    }
+  });
 
   if (json) {
     console.log(JSON.stringify({ ok: true, disabled: true }, null, 2));

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -1,0 +1,206 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+import { config } from "./config.js";
+
+let tmpDir;
+let origLog;
+let logged;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "tmux-ide-config-test-"));
+  logged = [];
+  origLog = console.log;
+  console.log = (...a) => logged.push(a.join(" "));
+});
+
+afterEach(() => {
+  console.log = origLog;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeIdeYml(obj) {
+  writeFileSync(
+    join(tmpDir, "ide.yml"),
+    yaml.dump(obj, { lineWidth: -1, noRefs: true, quotingType: '"' }),
+  );
+}
+
+function readIdeYml() {
+  return yaml.load(readFileSync(join(tmpDir, "ide.yml"), "utf-8"));
+}
+
+describe("config dump", () => {
+  it("outputs config as JSON", async () => {
+    const cfg = { name: "test", rows: [{ panes: [{ title: "Shell" }] }] };
+    writeIdeYml(cfg);
+    await config(tmpDir, { json: true, action: "dump", args: [] });
+    const output = JSON.parse(logged[0]);
+    assert.strictEqual(output.name, "test");
+    assert.strictEqual(output.rows[0].panes[0].title, "Shell");
+  });
+});
+
+describe("config set", () => {
+  it("updates a top-level value", async () => {
+    writeIdeYml({ name: "old", rows: [{ panes: [{ title: "Shell" }] }] });
+    await config(tmpDir, { json: true, action: "set", args: ["name", "new-name"] });
+    const output = JSON.parse(logged[0]);
+    assert.strictEqual(output.ok, true);
+    assert.strictEqual(output.value, "new-name");
+    const saved = readIdeYml();
+    assert.strictEqual(saved.name, "new-name");
+  });
+
+  it("updates a nested value", async () => {
+    writeIdeYml({ name: "test", rows: [{ panes: [{ title: "Shell" }] }] });
+    await config(tmpDir, { json: true, action: "set", args: ["rows.0.panes.0.title", "Editor"] });
+    const saved = readIdeYml();
+    assert.strictEqual(saved.rows[0].panes[0].title, "Editor");
+  });
+
+  it("coerces boolean strings", async () => {
+    writeIdeYml({ name: "test", rows: [{ panes: [{ title: "Shell" }] }] });
+    await config(tmpDir, { json: true, action: "set", args: ["rows.0.panes.0.focus", "true"] });
+    const saved = readIdeYml();
+    assert.strictEqual(saved.rows[0].panes[0].focus, true);
+  });
+
+  it("coerces numeric strings", async () => {
+    writeIdeYml({ name: "test", rows: [{ panes: [{ title: "Shell" }] }] });
+    await config(tmpDir, { json: true, action: "set", args: ["rows.0.panes.0.width", "120"] });
+    const saved = readIdeYml();
+    assert.strictEqual(saved.rows[0].panes[0].width, 120);
+  });
+});
+
+describe("config add-pane", () => {
+  it("adds pane to existing row", async () => {
+    writeIdeYml({ name: "test", rows: [{ panes: [{ title: "Shell" }] }] });
+    await config(tmpDir, {
+      json: true,
+      action: "add-pane",
+      args: ["--row", "0", "--title", "Tests", "--command", "pnpm test"],
+    });
+    const output = JSON.parse(logged[0]);
+    assert.strictEqual(output.ok, true);
+    assert.strictEqual(output.pane.title, "Tests");
+    assert.strictEqual(output.pane.command, "pnpm test");
+    const saved = readIdeYml();
+    assert.strictEqual(saved.rows[0].panes.length, 2);
+    assert.strictEqual(saved.rows[0].panes[1].title, "Tests");
+  });
+
+  it("adds pane with size", async () => {
+    writeIdeYml({ name: "test", rows: [{ panes: [{ title: "Shell" }] }] });
+    await config(tmpDir, {
+      json: true,
+      action: "add-pane",
+      args: ["--row", "0", "--title", "Wide", "--size", "60%"],
+    });
+    const saved = readIdeYml();
+    assert.strictEqual(saved.rows[0].panes[1].size, "60%");
+  });
+});
+
+describe("config remove-pane", () => {
+  it("removes pane by index", async () => {
+    writeIdeYml({
+      name: "test",
+      rows: [{ panes: [{ title: "A" }, { title: "B" }, { title: "C" }] }],
+    });
+    await config(tmpDir, {
+      json: true,
+      action: "remove-pane",
+      args: ["--row", "0", "--pane", "1"],
+    });
+    const output = JSON.parse(logged[0]);
+    assert.strictEqual(output.ok, true);
+    assert.strictEqual(output.removed.title, "B");
+    const saved = readIdeYml();
+    assert.strictEqual(saved.rows[0].panes.length, 2);
+    assert.strictEqual(saved.rows[0].panes[0].title, "A");
+    assert.strictEqual(saved.rows[0].panes[1].title, "C");
+  });
+});
+
+describe("config add-row", () => {
+  it("creates row with default Shell pane", async () => {
+    writeIdeYml({ name: "test", rows: [{ panes: [{ title: "Shell" }] }] });
+    await config(tmpDir, { json: true, action: "add-row", args: [] });
+    const output = JSON.parse(logged[0]);
+    assert.strictEqual(output.ok, true);
+    assert.strictEqual(output.row, 1);
+    const saved = readIdeYml();
+    assert.strictEqual(saved.rows.length, 2);
+    assert.deepStrictEqual(saved.rows[1].panes, [{ title: "Shell" }]);
+  });
+
+  it("creates row with size", async () => {
+    writeIdeYml({ name: "test", rows: [{ panes: [{ title: "Shell" }] }] });
+    await config(tmpDir, { json: true, action: "add-row", args: ["--size", "30%"] });
+    const saved = readIdeYml();
+    assert.strictEqual(saved.rows[1].size, "30%");
+  });
+
+  it("initializes rows array when it doesn't exist", async () => {
+    writeIdeYml({ name: "test" });
+    await config(tmpDir, { json: true, action: "add-row", args: [] });
+    const saved = readIdeYml();
+    assert.strictEqual(saved.rows.length, 1);
+  });
+});
+
+describe("config enable-team", () => {
+  it("assigns roles to Claude panes", async () => {
+    writeIdeYml({
+      name: "my-app",
+      rows: [
+        {
+          panes: [
+            { title: "Lead", command: "claude" },
+            { title: "Worker", command: "claude" },
+            { title: "Shell" },
+          ],
+        },
+      ],
+    });
+    await config(tmpDir, { json: true, action: "enable-team", args: [] });
+    const output = JSON.parse(logged[0]);
+    assert.strictEqual(output.ok, true);
+    assert.strictEqual(output.team.name, "my-app");
+    const saved = readIdeYml();
+    assert.strictEqual(saved.rows[0].panes[0].role, "lead");
+    assert.strictEqual(saved.rows[0].panes[1].role, "teammate");
+    assert.strictEqual(saved.rows[0].panes[2].role, undefined);
+  });
+});
+
+describe("config disable-team", () => {
+  it("removes team and role/task fields", async () => {
+    writeIdeYml({
+      name: "my-app",
+      team: { name: "my-app" },
+      rows: [
+        {
+          panes: [
+            { title: "Lead", command: "claude", role: "lead" },
+            { title: "Worker", command: "claude", role: "teammate", task: "Build UI" },
+          ],
+        },
+      ],
+    });
+    await config(tmpDir, { json: true, action: "disable-team", args: [] });
+    const output = JSON.parse(logged[0]);
+    assert.strictEqual(output.ok, true);
+    assert.strictEqual(output.disabled, true);
+    const saved = readIdeYml();
+    assert.strictEqual(saved.team, undefined);
+    assert.strictEqual(saved.rows[0].panes[0].role, undefined);
+    assert.strictEqual(saved.rows[0].panes[1].role, undefined);
+    assert.strictEqual(saved.rows[0].panes[1].task, undefined);
+  });
+});

--- a/src/doctor.test.js
+++ b/src/doctor.test.js
@@ -1,0 +1,117 @@
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { doctor } from "./doctor.js";
+
+let tmpDir;
+let origCwd;
+let origLog;
+let logged;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "tmux-ide-doctor-test-"));
+  origCwd = process.cwd();
+  logged = [];
+  origLog = console.log;
+  console.log = (...a) => logged.push(a.join(" "));
+});
+
+afterEach(() => {
+  process.chdir(origCwd);
+  console.log = origLog;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("doctor", () => {
+  it("reports tmux installed check", async () => {
+    process.chdir(tmpDir);
+    writeFileSync(join(tmpDir, "ide.yml"), "name: test\nrows:\n  - panes:\n      - title: Shell\n");
+    await doctor({ json: true });
+    const output = JSON.parse(logged[0]);
+    const tmuxCheck = output.checks.find((c) => c.label === "tmux installed");
+    assert.ok(tmuxCheck, "should have a 'tmux installed' check");
+    // tmux is installed in this CI/test environment, so it should pass
+    assert.strictEqual(tmuxCheck.pass, true);
+  });
+
+  it("reports tmux version check", async () => {
+    process.chdir(tmpDir);
+    writeFileSync(join(tmpDir, "ide.yml"), "name: test\nrows:\n  - panes:\n      - title: Shell\n");
+    await doctor({ json: true });
+    const output = JSON.parse(logged[0]);
+    const versionCheck = output.checks.find((c) => c.label.includes("tmux version"));
+    assert.ok(versionCheck, "should have a tmux version check");
+  });
+
+  it("reports Node.js version check as passing", async () => {
+    process.chdir(tmpDir);
+    writeFileSync(join(tmpDir, "ide.yml"), "name: test\nrows:\n  - panes:\n      - title: Shell\n");
+    await doctor({ json: true });
+    const output = JSON.parse(logged[0]);
+    const nodeCheck = output.checks.find((c) => c.label.includes("Node.js"));
+    assert.ok(nodeCheck);
+    assert.strictEqual(nodeCheck.pass, true);
+  });
+
+  it("reports ide.yml exists check as passing when present", async () => {
+    process.chdir(tmpDir);
+    writeFileSync(join(tmpDir, "ide.yml"), "name: test\nrows:\n  - panes:\n      - title: Shell\n");
+    await doctor({ json: true });
+    const output = JSON.parse(logged[0]);
+    const ideCheck = output.checks.find((c) => c.label.includes("ide.yml"));
+    assert.ok(ideCheck);
+    assert.strictEqual(ideCheck.pass, true);
+  });
+
+  it("reports ide.yml exists check as failing when absent", async () => {
+    process.chdir(tmpDir);
+    // No ide.yml written
+    await doctor({ json: true });
+    const output = JSON.parse(logged[0]);
+    const ideCheck = output.checks.find((c) => c.label.includes("ide.yml"));
+    assert.ok(ideCheck);
+    assert.strictEqual(ideCheck.pass, false);
+  });
+
+  it("marks agent teams check as optional", async () => {
+    process.chdir(tmpDir);
+    writeFileSync(join(tmpDir, "ide.yml"), "name: test\nrows:\n  - panes:\n      - title: Shell\n");
+    await doctor({ json: true });
+    const output = JSON.parse(logged[0]);
+    const teamsCheck = output.checks.find((c) => c.label.includes("agent teams"));
+    assert.ok(teamsCheck);
+    assert.strictEqual(teamsCheck.optional, true);
+  });
+
+  it("optional checks don't fail the overall result", async () => {
+    process.chdir(tmpDir);
+    writeFileSync(join(tmpDir, "ide.yml"), "name: test\nrows:\n  - panes:\n      - title: Shell\n");
+    // Even if agent teams env var is not set, ok should still be true
+    const origEnv = process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS;
+    delete process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS;
+    try {
+      await doctor({ json: true });
+      const output = JSON.parse(logged[0]);
+      // ok depends on required checks, not optional ones
+      const requiredFailing = output.checks.filter((c) => !c.pass && !c.optional);
+      if (requiredFailing.length === 0) {
+        assert.strictEqual(output.ok, true);
+      }
+    } finally {
+      if (origEnv !== undefined) {
+        process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = origEnv;
+      }
+    }
+  });
+
+  it("prints human-readable output without --json", async () => {
+    process.chdir(tmpDir);
+    writeFileSync(join(tmpDir, "ide.yml"), "name: test\nrows:\n  - panes:\n      - title: Shell\n");
+    await doctor();
+    // Should have printed colored output with ✓ or ✗
+    assert.ok(logged.length > 0);
+    assert.ok(logged.some((l) => l.includes("tmux installed")));
+  });
+});

--- a/src/doctor.test.js
+++ b/src/doctor.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/src/init.test.js
+++ b/src/init.test.js
@@ -1,0 +1,91 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { IdeError } from "./lib/errors.js";
+import { init } from "./init.js";
+
+let tmpDir;
+let origCwd;
+let origLog;
+let logged;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "tmux-ide-init-test-"));
+  origCwd = process.cwd();
+  process.chdir(tmpDir);
+  logged = [];
+  origLog = console.log;
+  console.log = (...a) => logged.push(a.join(" "));
+});
+
+afterEach(() => {
+  process.chdir(origCwd);
+  console.log = origLog;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("init", () => {
+  it("creates ide.yml from default template when no stack detected", async () => {
+    await init({ json: true });
+    assert.ok(existsSync(join(tmpDir, "ide.yml")));
+    const output = JSON.parse(logged[0]);
+    assert.strictEqual(output.created, true);
+    assert.strictEqual(output.template, "default");
+  });
+
+  it("creates ide.yml from named template", async () => {
+    await init({ template: "nextjs", json: true });
+    assert.ok(existsSync(join(tmpDir, "ide.yml")));
+    const content = readFileSync(join(tmpDir, "ide.yml"), "utf-8");
+    assert.ok(content.includes("rows"));
+    const output = JSON.parse(logged[0]);
+    assert.strictEqual(output.created, true);
+    assert.strictEqual(output.template, "nextjs");
+  });
+
+  it("creates ide.yml from detected stack", async () => {
+    // Create a package.json with a Next.js dependency to trigger detection
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({
+        name: "test-app",
+        dependencies: { next: "14.0.0" },
+        scripts: { dev: "next dev" },
+      }),
+    );
+    await init({ json: true });
+    assert.ok(existsSync(join(tmpDir, "ide.yml")));
+    const output = JSON.parse(logged[0]);
+    assert.strictEqual(output.created, true);
+    assert.ok(output.detected.length > 0);
+  });
+
+  it("rejects when ide.yml already exists", async () => {
+    writeFileSync(join(tmpDir, "ide.yml"), "name: existing\n");
+    await assert.rejects(
+      () => init({ json: true }),
+      (err) => err instanceof IdeError && err.message.includes("already exists"),
+    );
+  });
+
+  it("rejects unknown template name", async () => {
+    await assert.rejects(
+      () => init({ template: "nonexistent-template-xyz", json: true }),
+      (err) => err instanceof IdeError && err.message.includes("not found"),
+    );
+  });
+
+  it("replaces the name field with the directory basename", async () => {
+    await init({ template: "default", json: true });
+    const content = readFileSync(join(tmpDir, "ide.yml"), "utf-8");
+    const dirName = tmpDir.split("/").pop();
+    assert.ok(content.includes(`name: ${dirName}`));
+  });
+
+  it("prints human-readable output without --json", async () => {
+    await init();
+    assert.ok(logged.some((l) => l.includes("Created ide.yml")));
+  });
+});

--- a/src/lib/tmux.js
+++ b/src/lib/tmux.js
@@ -203,14 +203,18 @@ let _spawner = spawn;
 export function _setExecutor(fn) {
   const prev = _executor;
   _executor = fn;
-  return () => { _executor = prev; };
+  return () => {
+    _executor = prev;
+  };
 }
 
 /** @internal Replace the spawner for testing. Returns a restore function. */
 export function _setSpawner(fn) {
   const prev = _spawner;
   _spawner = fn;
-  return () => { _spawner = prev; };
+  return () => {
+    _spawner = prev;
+  };
 }
 
 function runTmux(args, options = {}) {

--- a/src/lib/tmux.js
+++ b/src/lib/tmux.js
@@ -161,7 +161,7 @@ export function runSessionCommand(args) {
 }
 
 export function startSessionMonitor(session, monitorScript) {
-  const child = spawn("node", [monitorScript, session], {
+  const child = _spawner("node", [monitorScript, session], {
     detached: true,
     stdio: "ignore",
   });
@@ -196,6 +196,23 @@ export function setSessionVariable(session, name, value) {
   runTmux(["set-option", "-t", session, name, value]);
 }
 
+let _executor = execFileSync;
+let _spawner = spawn;
+
+/** @internal Replace the executor for testing. Returns a restore function. */
+export function _setExecutor(fn) {
+  const prev = _executor;
+  _executor = fn;
+  return () => { _executor = prev; };
+}
+
+/** @internal Replace the spawner for testing. Returns a restore function. */
+export function _setSpawner(fn) {
+  const prev = _spawner;
+  _spawner = fn;
+  return () => { _spawner = prev; };
+}
+
 function runTmux(args, options = {}) {
   if (DEBUG || globalThis.__tmuxIdeVerbose) {
     console.error(`  [tmux] ${args.join(" ")}`);
@@ -207,7 +224,7 @@ function runTmux(args, options = {}) {
   };
 
   try {
-    return execFileSync("tmux", args, execOptions);
+    return _executor("tmux", args, execOptions);
   } catch (error) {
     throw classifyTmuxError(error);
   }

--- a/src/lib/tmux.test.js
+++ b/src/lib/tmux.test.js
@@ -321,7 +321,6 @@ describe("startSessionMonitor", () => {
     startSessionMonitor("proj", "/path/to/monitor.js");
 
     // Check spawn was called correctly
-    const spawner = fakeChild; // spawner is the mock
     assert.strictEqual(fakeChild.unref.mock.callCount(), 1);
 
     // Check PID was stored via set-option

--- a/src/lib/tmux.test.js
+++ b/src/lib/tmux.test.js
@@ -58,7 +58,7 @@ describe("getSessionState", () => {
     ]);
   });
 
-  it("returns SESSION_NOT_FOUND for \"can't find session\"", () => {
+  it('returns SESSION_NOT_FOUND for "can\'t find session"', () => {
     mockExec.mock.mockImplementation(() => {
       throw makeExecError("can't find session: my-session");
     });
@@ -66,7 +66,7 @@ describe("getSessionState", () => {
     assert.deepStrictEqual(result, { running: false, reason: "SESSION_NOT_FOUND" });
   });
 
-  it("returns TMUX_UNAVAILABLE for \"connection refused\"", () => {
+  it('returns TMUX_UNAVAILABLE for "connection refused"', () => {
     mockExec.mock.mockImplementation(() => {
       throw makeExecError("error connecting to /tmp/tmux-1000/default (connection refused)");
     });
@@ -74,7 +74,7 @@ describe("getSessionState", () => {
     assert.deepStrictEqual(result, { running: false, reason: "TMUX_UNAVAILABLE" });
   });
 
-  it("returns TMUX_UNAVAILABLE for \"no server running\"", () => {
+  it('returns TMUX_UNAVAILABLE for "no server running"', () => {
     mockExec.mock.mockImplementation(() => {
       throw makeExecError("no server running on /tmp/tmux-1000/default");
     });
@@ -129,11 +129,7 @@ describe("killSession", () => {
     mockExec.mock.mockImplementation(() => "");
     const result = killSession("proj");
     assert.deepStrictEqual(result, { stopped: true, reason: null });
-    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
-      "kill-session",
-      "-t",
-      "proj",
-    ]);
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], ["kill-session", "-t", "proj"]);
   });
 
   it("returns stopped: false for missing session", () => {
@@ -167,9 +163,7 @@ describe("killSession", () => {
 
 describe("listPanes", () => {
   it("parses multi-pane output correctly", () => {
-    mockExec.mock.mockImplementation(() =>
-      "0|Editor|120|40|1\n1|Shell|80|40|0\n",
-    );
+    mockExec.mock.mockImplementation(() => "0|Editor|120|40|1\n1|Shell|80|40|0\n");
     const panes = listPanes("proj");
     assert.deepStrictEqual(panes, [
       { index: 0, title: "Editor", width: 120, height: 40, active: true },
@@ -186,9 +180,7 @@ describe("listPanes", () => {
   it("handles pane titles containing pipe characters", () => {
     // The split("|") will split on the first pipe in the title, causing misparse.
     // This documents the current behavior — titles with pipes are truncated.
-    mockExec.mock.mockImplementation(() =>
-      "0|A|B|120|40|0\n",
-    );
+    mockExec.mock.mockImplementation(() => "0|A|B|120|40|0\n");
     const panes = listPanes("proj");
     // With pipe in title, index=0, title="A", width=NaN (from "B"), ...
     assert.strictEqual(panes[0].index, 0);
@@ -325,13 +317,7 @@ describe("startSessionMonitor", () => {
 
     // Check PID was stored via set-option
     const setArgs = mockExec.mock.calls[0].arguments[1];
-    assert.deepStrictEqual(setArgs, [
-      "set-option",
-      "-t",
-      "proj",
-      "@monitor_pid",
-      "12345",
-    ]);
+    assert.deepStrictEqual(setArgs, ["set-option", "-t", "proj", "@monitor_pid", "12345"]);
 
     restoreSpawn();
   });
@@ -386,11 +372,7 @@ describe("selectPane", () => {
   it("calls select-pane with target", () => {
     mockExec.mock.mockImplementation(() => "");
     selectPane("%2");
-    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
-      "select-pane",
-      "-t",
-      "%2",
-    ]);
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], ["select-pane", "-t", "%2"]);
   });
 });
 
@@ -419,11 +401,7 @@ describe("attachSession", () => {
   it("calls attach with correct args and stdio inherit", () => {
     mockExec.mock.mockImplementation(() => "");
     attachSession("proj");
-    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
-      "attach",
-      "-t",
-      "proj",
-    ]);
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], ["attach", "-t", "proj"]);
     assert.strictEqual(mockExec.mock.calls[0].arguments[2].stdio, "inherit");
   });
 });
@@ -486,7 +464,7 @@ describe("debug logging", () => {
 // --- Error classification edge cases ---
 
 describe("error classification", () => {
-  it("classifies \"can't find window\" as SESSION_NOT_FOUND", () => {
+  it('classifies "can\'t find window" as SESSION_NOT_FOUND', () => {
     mockExec.mock.mockImplementation(() => {
       throw makeExecError("can't find window: proj:0");
     });
@@ -494,7 +472,7 @@ describe("error classification", () => {
     assert.deepStrictEqual(result, { running: false, reason: "SESSION_NOT_FOUND" });
   });
 
-  it("classifies \"unknown target\" as SESSION_NOT_FOUND", () => {
+  it('classifies "unknown target" as SESSION_NOT_FOUND', () => {
     mockExec.mock.mockImplementation(() => {
       throw makeExecError("unknown target: proj");
     });
@@ -502,7 +480,7 @@ describe("error classification", () => {
     assert.deepStrictEqual(result, { running: false, reason: "SESSION_NOT_FOUND" });
   });
 
-  it("classifies \"failed to connect to server\" as TMUX_UNAVAILABLE", () => {
+  it('classifies "failed to connect to server" as TMUX_UNAVAILABLE', () => {
     mockExec.mock.mockImplementation(() => {
       throw makeExecError("failed to connect to server: /tmp/tmux-1000/default");
     });
@@ -510,7 +488,7 @@ describe("error classification", () => {
     assert.deepStrictEqual(result, { running: false, reason: "TMUX_UNAVAILABLE" });
   });
 
-  it("classifies \"error connecting to\" as TMUX_UNAVAILABLE", () => {
+  it('classifies "error connecting to" as TMUX_UNAVAILABLE', () => {
     mockExec.mock.mockImplementation(() => {
       throw makeExecError("error connecting to /tmp/tmux-1000/default");
     });

--- a/src/lib/tmux.test.js
+++ b/src/lib/tmux.test.js
@@ -1,0 +1,541 @@
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import {
+  _setExecutor,
+  _setSpawner,
+  TmuxError,
+  getSessionState,
+  hasSession,
+  killSession,
+  listPanes,
+  createDetachedSession,
+  splitPane,
+  sendLiteral,
+  getSessionVariable,
+  setSessionVariable,
+  startSessionMonitor,
+  stopSessionMonitor,
+  setPaneTitle,
+  selectPane,
+  getPaneCurrentCommand,
+  setSessionEnvironment,
+  attachSession,
+  runSessionCommand,
+} from "./tmux.js";
+
+let mockExec;
+let restoreExec;
+
+beforeEach(() => {
+  mockExec = mock.fn();
+  restoreExec = _setExecutor(mockExec);
+});
+
+afterEach(() => {
+  restoreExec();
+  mock.restoreAll();
+});
+
+// --- Helpers ---
+
+function makeExecError(stderr) {
+  const err = new Error("Command failed");
+  err.stderr = stderr;
+  return err;
+}
+
+// --- Error classification (via public API) ---
+
+describe("getSessionState", () => {
+  it("returns running: true when has-session succeeds", () => {
+    mockExec.mock.mockImplementation(() => "");
+    const result = getSessionState("my-session");
+    assert.deepStrictEqual(result, { running: true, reason: null });
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
+      "has-session",
+      "-t",
+      "my-session",
+    ]);
+  });
+
+  it("returns SESSION_NOT_FOUND for \"can't find session\"", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("can't find session: my-session");
+    });
+    const result = getSessionState("my-session");
+    assert.deepStrictEqual(result, { running: false, reason: "SESSION_NOT_FOUND" });
+  });
+
+  it("returns TMUX_UNAVAILABLE for \"connection refused\"", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("error connecting to /tmp/tmux-1000/default (connection refused)");
+    });
+    const result = getSessionState("my-session");
+    assert.deepStrictEqual(result, { running: false, reason: "TMUX_UNAVAILABLE" });
+  });
+
+  it("returns TMUX_UNAVAILABLE for \"no server running\"", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("no server running on /tmp/tmux-1000/default");
+    });
+    const result = getSessionState("my-session");
+    assert.deepStrictEqual(result, { running: false, reason: "TMUX_UNAVAILABLE" });
+  });
+
+  it("throws for unknown errors", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("something totally unexpected");
+    });
+    assert.throws(
+      () => getSessionState("my-session"),
+      (err) => err instanceof TmuxError && err.code === "TMUX_ERROR",
+    );
+  });
+});
+
+describe("hasSession", () => {
+  it("returns true when session exists", () => {
+    mockExec.mock.mockImplementation(() => "");
+    assert.strictEqual(hasSession("proj"), true);
+  });
+
+  it("returns false for SESSION_NOT_FOUND", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("can't find session: proj");
+    });
+    assert.strictEqual(hasSession("proj"), false);
+  });
+
+  it("returns false for TMUX_UNAVAILABLE", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("no server running on /tmp/tmux-1000/default");
+    });
+    assert.strictEqual(hasSession("proj"), false);
+  });
+
+  it("throws for unknown errors", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("unexpected failure");
+    });
+    assert.throws(
+      () => hasSession("proj"),
+      (err) => err instanceof TmuxError && err.code === "TMUX_ERROR",
+    );
+  });
+});
+
+describe("killSession", () => {
+  it("returns stopped: true when kill succeeds", () => {
+    mockExec.mock.mockImplementation(() => "");
+    const result = killSession("proj");
+    assert.deepStrictEqual(result, { stopped: true, reason: null });
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
+      "kill-session",
+      "-t",
+      "proj",
+    ]);
+  });
+
+  it("returns stopped: false for missing session", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("can't find session: proj");
+    });
+    const result = killSession("proj");
+    assert.deepStrictEqual(result, { stopped: false, reason: "SESSION_NOT_FOUND" });
+  });
+
+  it("returns stopped: false for unavailable tmux", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("failed to connect to server");
+    });
+    const result = killSession("proj");
+    assert.deepStrictEqual(result, { stopped: false, reason: "TMUX_UNAVAILABLE" });
+  });
+
+  it("throws for unknown errors", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("disk error");
+    });
+    assert.throws(
+      () => killSession("proj"),
+      (err) => err instanceof TmuxError && err.code === "TMUX_ERROR",
+    );
+  });
+});
+
+// --- listPanes ---
+
+describe("listPanes", () => {
+  it("parses multi-pane output correctly", () => {
+    mockExec.mock.mockImplementation(() =>
+      "0|Editor|120|40|1\n1|Shell|80|40|0\n",
+    );
+    const panes = listPanes("proj");
+    assert.deepStrictEqual(panes, [
+      { index: 0, title: "Editor", width: 120, height: 40, active: true },
+      { index: 1, title: "Shell", width: 80, height: 40, active: false },
+    ]);
+  });
+
+  it("returns empty array for empty output", () => {
+    mockExec.mock.mockImplementation(() => "  \n");
+    const panes = listPanes("proj");
+    assert.deepStrictEqual(panes, []);
+  });
+
+  it("handles pane titles containing pipe characters", () => {
+    // The split("|") will split on the first pipe in the title, causing misparse.
+    // This documents the current behavior — titles with pipes are truncated.
+    mockExec.mock.mockImplementation(() =>
+      "0|A|B|120|40|0\n",
+    );
+    const panes = listPanes("proj");
+    // With pipe in title, index=0, title="A", width=NaN (from "B"), ...
+    assert.strictEqual(panes[0].index, 0);
+    assert.strictEqual(panes[0].title, "A");
+  });
+});
+
+// --- createDetachedSession ---
+
+describe("createDetachedSession", () => {
+  it("returns trimmed pane ID", () => {
+    mockExec.mock.mockImplementation(() => "  %0\n");
+    const id = createDetachedSession("proj", "/workspace");
+    assert.strictEqual(id, "%0");
+  });
+
+  it("uses default dimensions when not specified", () => {
+    mockExec.mock.mockImplementation(() => "%0\n");
+    createDetachedSession("proj", "/workspace");
+    const args = mockExec.mock.calls[0].arguments[1];
+    assert.ok(args.includes("200")); // default cols
+    assert.ok(args.includes("50")); // default lines
+  });
+
+  it("passes custom dimensions", () => {
+    mockExec.mock.mockImplementation(() => "%0\n");
+    createDetachedSession("proj", "/workspace", { cols: 300, lines: 80 });
+    const args = mockExec.mock.calls[0].arguments[1];
+    assert.ok(args.includes("300"));
+    assert.ok(args.includes("80"));
+  });
+});
+
+// --- splitPane ---
+
+describe("splitPane", () => {
+  it("uses -v for vertical direction", () => {
+    mockExec.mock.mockImplementation(() => "%1\n");
+    splitPane("%0", "vertical", "/workspace", 30);
+    const args = mockExec.mock.calls[0].arguments[1];
+    assert.ok(args.includes("-v"));
+    assert.ok(!args.includes("-h"));
+  });
+
+  it("uses -h for horizontal direction", () => {
+    mockExec.mock.mockImplementation(() => "%2\n");
+    splitPane("%0", "horizontal", "/workspace", 50);
+    const args = mockExec.mock.calls[0].arguments[1];
+    assert.ok(args.includes("-h"));
+    assert.ok(!args.includes("-v"));
+  });
+
+  it("passes percent correctly", () => {
+    mockExec.mock.mockImplementation(() => "%3\n");
+    splitPane("%0", "vertical", "/workspace", 42);
+    const args = mockExec.mock.calls[0].arguments[1];
+    const pIdx = args.indexOf("-p");
+    assert.strictEqual(args[pIdx + 1], "42");
+  });
+
+  it("returns trimmed pane ID", () => {
+    mockExec.mock.mockImplementation(() => "  %5\n");
+    const id = splitPane("%0", "vertical", "/workspace", 30);
+    assert.strictEqual(id, "%5");
+  });
+});
+
+// --- sendLiteral ---
+
+describe("sendLiteral", () => {
+  it("sends text with -l flag then Enter", () => {
+    mockExec.mock.mockImplementation(() => "");
+    sendLiteral("%0", "echo hello");
+    assert.strictEqual(mockExec.mock.callCount(), 2);
+    // First call: send-keys with -l and the text
+    const firstArgs = mockExec.mock.calls[0].arguments[1];
+    assert.deepStrictEqual(firstArgs, ["send-keys", "-t", "%0", "-l", "--", "echo hello"]);
+    // Second call: send Enter
+    const secondArgs = mockExec.mock.calls[1].arguments[1];
+    assert.deepStrictEqual(secondArgs, ["send-keys", "-t", "%0", "Enter"]);
+  });
+});
+
+// --- getSessionVariable / setSessionVariable ---
+
+describe("getSessionVariable", () => {
+  it("returns trimmed value when variable exists", () => {
+    mockExec.mock.mockImplementation(() => "  some-value\n");
+    const value = getSessionVariable("proj", "@my_var");
+    assert.strictEqual(value, "some-value");
+  });
+
+  it("returns null when variable is empty", () => {
+    mockExec.mock.mockImplementation(() => "\n");
+    const value = getSessionVariable("proj", "@my_var");
+    assert.strictEqual(value, null);
+  });
+
+  it("returns null when show-option throws", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("can't find session: proj");
+    });
+    const value = getSessionVariable("proj", "@my_var");
+    assert.strictEqual(value, null);
+  });
+});
+
+describe("setSessionVariable", () => {
+  it("sets variable with correct args", () => {
+    mockExec.mock.mockImplementation(() => "");
+    setSessionVariable("proj", "@my_var", "hello");
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
+      "set-option",
+      "-t",
+      "proj",
+      "@my_var",
+      "hello",
+    ]);
+  });
+});
+
+// --- startSessionMonitor / stopSessionMonitor ---
+
+describe("startSessionMonitor", () => {
+  it("spawns detached process and stores PID", () => {
+    const fakeChild = { pid: 12345, unref: mock.fn() };
+    const restoreSpawn = _setSpawner(mock.fn(() => fakeChild));
+
+    mockExec.mock.mockImplementation(() => "");
+    startSessionMonitor("proj", "/path/to/monitor.js");
+
+    // Check spawn was called correctly
+    const spawner = fakeChild; // spawner is the mock
+    assert.strictEqual(fakeChild.unref.mock.callCount(), 1);
+
+    // Check PID was stored via set-option
+    const setArgs = mockExec.mock.calls[0].arguments[1];
+    assert.deepStrictEqual(setArgs, [
+      "set-option",
+      "-t",
+      "proj",
+      "@monitor_pid",
+      "12345",
+    ]);
+
+    restoreSpawn();
+  });
+});
+
+describe("stopSessionMonitor", () => {
+  it("kills process by stored PID", () => {
+    mockExec.mock.mockImplementation(() => "  42\n");
+    const origKill = process.kill;
+    const killCalls = [];
+    process.kill = (pid) => killCalls.push(pid);
+    try {
+      stopSessionMonitor("proj");
+      assert.deepStrictEqual(killCalls, [42]);
+    } finally {
+      process.kill = origKill;
+    }
+  });
+
+  it("handles missing PID gracefully", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("can't find session: proj");
+    });
+    // Should not throw
+    stopSessionMonitor("proj");
+  });
+
+  it("handles empty PID gracefully", () => {
+    mockExec.mock.mockImplementation(() => "\n");
+    // Should not throw (no pid to kill)
+    stopSessionMonitor("proj");
+  });
+});
+
+// --- Other public functions ---
+
+describe("setPaneTitle", () => {
+  it("calls select-pane with -T flag", () => {
+    mockExec.mock.mockImplementation(() => "");
+    setPaneTitle("%0", "My Pane");
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
+      "select-pane",
+      "-t",
+      "%0",
+      "-T",
+      "My Pane",
+    ]);
+  });
+});
+
+describe("selectPane", () => {
+  it("calls select-pane with target", () => {
+    mockExec.mock.mockImplementation(() => "");
+    selectPane("%2");
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
+      "select-pane",
+      "-t",
+      "%2",
+    ]);
+  });
+});
+
+describe("getPaneCurrentCommand", () => {
+  it("returns trimmed command name", () => {
+    mockExec.mock.mockImplementation(() => "  zsh\n");
+    assert.strictEqual(getPaneCurrentCommand("%0"), "zsh");
+  });
+});
+
+describe("setSessionEnvironment", () => {
+  it("calls set-environment with correct args", () => {
+    mockExec.mock.mockImplementation(() => "");
+    setSessionEnvironment("proj", "PORT", 3000);
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
+      "set-environment",
+      "-t",
+      "proj",
+      "PORT",
+      "3000",
+    ]);
+  });
+});
+
+describe("attachSession", () => {
+  it("calls attach with correct args and stdio inherit", () => {
+    mockExec.mock.mockImplementation(() => "");
+    attachSession("proj");
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
+      "attach",
+      "-t",
+      "proj",
+    ]);
+    assert.strictEqual(mockExec.mock.calls[0].arguments[2].stdio, "inherit");
+  });
+});
+
+describe("runSessionCommand", () => {
+  it("passes args through to tmux", () => {
+    mockExec.mock.mockImplementation(() => "");
+    runSessionCommand(["resize-pane", "-t", "%0", "-x", "100"]);
+    assert.deepStrictEqual(mockExec.mock.calls[0].arguments[1], [
+      "resize-pane",
+      "-t",
+      "%0",
+      "-x",
+      "100",
+    ]);
+  });
+});
+
+// --- Debug logging ---
+
+describe("debug logging", () => {
+  it("logs to stderr when globalThis.__tmuxIdeVerbose is true", () => {
+    const origVerbose = globalThis.__tmuxIdeVerbose;
+    const stderrCalls = [];
+    const origConsoleError = console.error;
+    console.error = (...args) => stderrCalls.push(args.join(" "));
+
+    globalThis.__tmuxIdeVerbose = true;
+    mockExec.mock.mockImplementation(() => "");
+
+    try {
+      hasSession("test-session");
+      assert.ok(stderrCalls.some((msg) => msg.includes("[tmux]")));
+      assert.ok(stderrCalls.some((msg) => msg.includes("has-session")));
+    } finally {
+      globalThis.__tmuxIdeVerbose = origVerbose;
+      console.error = origConsoleError;
+    }
+  });
+
+  it("does not log when neither DEBUG nor verbose is set", () => {
+    const origVerbose = globalThis.__tmuxIdeVerbose;
+    const stderrCalls = [];
+    const origConsoleError = console.error;
+    console.error = (...args) => stderrCalls.push(args.join(" "));
+
+    globalThis.__tmuxIdeVerbose = false;
+    mockExec.mock.mockImplementation(() => "");
+
+    try {
+      hasSession("test-session");
+      assert.strictEqual(stderrCalls.length, 0);
+    } finally {
+      globalThis.__tmuxIdeVerbose = origVerbose;
+      console.error = origConsoleError;
+    }
+  });
+});
+
+// --- Error classification edge cases ---
+
+describe("error classification", () => {
+  it("classifies \"can't find window\" as SESSION_NOT_FOUND", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("can't find window: proj:0");
+    });
+    const result = getSessionState("proj");
+    assert.deepStrictEqual(result, { running: false, reason: "SESSION_NOT_FOUND" });
+  });
+
+  it("classifies \"unknown target\" as SESSION_NOT_FOUND", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("unknown target: proj");
+    });
+    const result = getSessionState("proj");
+    assert.deepStrictEqual(result, { running: false, reason: "SESSION_NOT_FOUND" });
+  });
+
+  it("classifies \"failed to connect to server\" as TMUX_UNAVAILABLE", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("failed to connect to server: /tmp/tmux-1000/default");
+    });
+    const result = getSessionState("proj");
+    assert.deepStrictEqual(result, { running: false, reason: "TMUX_UNAVAILABLE" });
+  });
+
+  it("classifies \"error connecting to\" as TMUX_UNAVAILABLE", () => {
+    mockExec.mock.mockImplementation(() => {
+      throw makeExecError("error connecting to /tmp/tmux-1000/default");
+    });
+    const result = getSessionState("proj");
+    assert.deepStrictEqual(result, { running: false, reason: "TMUX_UNAVAILABLE" });
+  });
+
+  it("handles Buffer stderr in error", () => {
+    mockExec.mock.mockImplementation(() => {
+      const err = new Error("Command failed");
+      err.stderr = Buffer.from("can't find session: proj");
+      throw err;
+    });
+    const result = getSessionState("proj");
+    assert.deepStrictEqual(result, { running: false, reason: "SESSION_NOT_FOUND" });
+  });
+
+  it("falls back to error.message when stderr is empty", () => {
+    mockExec.mock.mockImplementation(() => {
+      const err = new Error("can't find session: proj");
+      err.stderr = "";
+      throw err;
+    });
+    const result = getSessionState("proj");
+    assert.deepStrictEqual(result, { running: false, reason: "SESSION_NOT_FOUND" });
+  });
+});

--- a/src/ls.test.js
+++ b/src/ls.test.js
@@ -1,7 +1,6 @@
-import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { join, dirname } from "node:path";
-import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 

--- a/src/ls.test.js
+++ b/src/ls.test.js
@@ -1,0 +1,78 @@
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cli = join(__dirname, "..", "bin", "cli.js");
+
+// ls.js uses execSync directly (not our tmux.js layer), so we test via CLI
+// to avoid needing to mock execSync at the module level.
+
+let origLog;
+let logged;
+
+beforeEach(() => {
+  logged = [];
+  origLog = console.log;
+  console.log = (...a) => logged.push(a.join(" "));
+});
+
+afterEach(() => {
+  console.log = origLog;
+});
+
+describe("ls", () => {
+  it("returns sessions array via CLI --json", () => {
+    const result = spawnSync("node", [cli, "ls", "--json"], {
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+    assert.strictEqual(result.status, 0);
+    const output = JSON.parse(result.stdout);
+    assert.ok(Array.isArray(output.sessions));
+  });
+
+  it("parses session list with expected fields", () => {
+    const result = spawnSync("node", [cli, "ls", "--json"], {
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+    const output = JSON.parse(result.stdout);
+    // If there are sessions, each should have name, created, attached fields
+    for (const session of output.sessions) {
+      assert.ok(typeof session.name === "string");
+      assert.ok(typeof session.created === "string");
+      assert.ok(typeof session.attached === "boolean");
+    }
+  });
+
+  it("returns valid JSON structure even if sessions exist", () => {
+    const result = spawnSync("node", [cli, "ls", "--json"], {
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+    assert.strictEqual(result.status, 0);
+    const output = JSON.parse(result.stdout);
+    assert.ok(Object.hasOwn(output, "sessions"));
+    assert.ok(Array.isArray(output.sessions));
+    // Each session must have the expected shape
+    for (const s of output.sessions) {
+      assert.ok(typeof s.name === "string" && s.name.length > 0);
+      assert.ok(typeof s.created === "string");
+      assert.ok(typeof s.attached === "boolean");
+    }
+  });
+
+  it("prints human-readable output without --json", () => {
+    // Just verify it doesn't crash and produces output
+    const result = spawnSync("node", [cli, "ls"], {
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+    assert.strictEqual(result.status, 0);
+    assert.ok(result.stdout.length > 0);
+  });
+});

--- a/src/stop.test.js
+++ b/src/stop.test.js
@@ -1,0 +1,157 @@
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _setExecutor } from "./lib/tmux.js";
+import { IdeError } from "./lib/errors.js";
+import { stop } from "./stop.js";
+
+let mockExec;
+let restoreExec;
+let tmpDir;
+
+beforeEach(() => {
+  mockExec = mock.fn();
+  restoreExec = _setExecutor(mockExec);
+  tmpDir = mkdtempSync(join(tmpdir(), "tmux-ide-stop-test-"));
+});
+
+afterEach(() => {
+  restoreExec();
+  mock.restoreAll();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeIdeYml(name) {
+  writeFileSync(join(tmpDir, "ide.yml"), `name: ${name}\n`);
+}
+
+function makeExecError(stderr) {
+  const err = new Error("Command failed");
+  err.stderr = stderr;
+  return err;
+}
+
+describe("stop", () => {
+  it("calls stopSessionMonitor before killSession", async () => {
+    writeIdeYml("my-app");
+    const callLog = [];
+    mockExec.mock.mockImplementation((_cmd, args) => {
+      callLog.push(args[0]);
+      if (args[0] === "show-option") return "\n";
+      return "";
+    });
+
+    const logged = [];
+    const origLog = console.log;
+    console.log = (...a) => logged.push(a.join(" "));
+
+    try {
+      await stop(tmpDir);
+      // show-option (stopSessionMonitor) should come before kill-session
+      const showIdx = callLog.indexOf("show-option");
+      const killIdx = callLog.indexOf("kill-session");
+      assert.ok(showIdx < killIdx, "stopSessionMonitor should be called before killSession");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it("outputs JSON when --json is passed", async () => {
+    writeIdeYml("test-proj");
+    mockExec.mock.mockImplementation((_cmd, args) => {
+      if (args[0] === "show-option") return "\n";
+      return "";
+    });
+
+    const logged = [];
+    const origLog = console.log;
+    console.log = (...a) => logged.push(a.join(" "));
+
+    try {
+      await stop(tmpDir, { json: true });
+      const output = JSON.parse(logged[0]);
+      assert.deepStrictEqual(output, { stopped: "test-proj" });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it("outputs human-readable message by default", async () => {
+    writeIdeYml("my-app");
+    mockExec.mock.mockImplementation((_cmd, args) => {
+      if (args[0] === "show-option") return "\n";
+      return "";
+    });
+
+    const logged = [];
+    const origLog = console.log;
+    console.log = (...a) => logged.push(a.join(" "));
+
+    try {
+      await stop(tmpDir);
+      assert.ok(logged[0].includes('Stopped session "my-app"'));
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it("throws IdeError when session not found", async () => {
+    writeIdeYml("missing");
+    mockExec.mock.mockImplementation((_cmd, args) => {
+      if (args[0] === "show-option") {
+        throw makeExecError("can't find session: missing");
+      }
+      if (args[0] === "kill-session") {
+        throw makeExecError("can't find session: missing");
+      }
+      return "";
+    });
+
+    await assert.rejects(
+      () => stop(tmpDir),
+      (err) => err instanceof IdeError && err.message.includes("No active session"),
+    );
+  });
+
+  it("falls back to dir basename when ide.yml has no name", async () => {
+    // Write minimal YAML without a name field
+    writeFileSync(join(tmpDir, "ide.yml"), "rows:\n  - panes:\n      - title: Shell\n");
+    mockExec.mock.mockImplementation((_cmd, args) => {
+      if (args[0] === "show-option") return "\n";
+      return "";
+    });
+
+    const logged = [];
+    const origLog = console.log;
+    console.log = (...a) => logged.push(a.join(" "));
+
+    try {
+      await stop(tmpDir);
+      // Session name should be the basename of the temp dir
+      assert.ok(logged[0].includes("Stopped session"));
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it("falls back to dir basename when no ide.yml exists", async () => {
+    // No ide.yml written
+    mockExec.mock.mockImplementation((_cmd, args) => {
+      if (args[0] === "show-option") return "\n";
+      return "";
+    });
+
+    const logged = [];
+    const origLog = console.log;
+    console.log = (...a) => logged.push(a.join(" "));
+
+    try {
+      await stop(tmpDir);
+      assert.ok(logged[0].includes("Stopped session"));
+    } finally {
+      console.log = origLog;
+    }
+  });
+});

--- a/src/validate.js
+++ b/src/validate.js
@@ -72,6 +72,32 @@ export function validateConfig(config) {
           errors.push(`rows[${i}].panes[${j}].task must be a string`);
         }
       }
+
+      // Check multiple focus panes in this row
+      const focusCount = row.panes.filter((p) => p.focus === true).length;
+      if (focusCount > 1) {
+        errors.push(`Row ${i} has ${focusCount} panes with focus: true (max 1)`);
+      }
+
+      // Check pane sizes sum within this row
+      const paneSizes = row.panes
+        .map((p) => p.size)
+        .filter((s) => typeof s === "string" && /^[1-9]\d*%$/.test(s))
+        .map((s) => parseInt(s, 10));
+      const paneSum = paneSizes.reduce((a, b) => a + b, 0);
+      if (paneSum > 100) {
+        errors.push(`Row ${i} pane sizes sum to ${paneSum}%, which exceeds 100%`);
+      }
+    }
+
+    // Check row sizes sum
+    const rowSizes = config.rows
+      .map((r) => r.size)
+      .filter((s) => typeof s === "string" && /^[1-9]\d*%$/.test(s))
+      .map((s) => parseInt(s, 10));
+    const rowSum = rowSizes.reduce((a, b) => a + b, 0);
+    if (rowSum > 100) {
+      errors.push(`Row sizes sum to ${rowSum}%, which exceeds 100%`);
     }
   }
 
@@ -111,14 +137,12 @@ export function validateConfig(config) {
 
 function validateSize(value, path, errors) {
   const s = String(value);
-  if (!/^\d+%$/.test(s)) {
+  if (!/^[1-9]\d*%$/.test(s)) {
     errors.push(`${path} "${value}" must be a percentage (e.g. "50%")`);
     return;
   }
   const num = parseInt(s, 10);
-  if (num === 0) {
-    errors.push(`${path} must not be 0%`);
-  } else if (num > 100) {
+  if (num > 100) {
     errors.push(`${path} must not exceed 100%`);
   }
 }

--- a/src/validate.test.js
+++ b/src/validate.test.js
@@ -201,10 +201,7 @@ describe("validateConfig", () => {
 
   it("accepts single focus: true per row", () => {
     const errors = validateConfig({
-      rows: [
-        { panes: [{ focus: true }, {}] },
-        { panes: [{}, { focus: true }] },
-      ],
+      rows: [{ panes: [{ focus: true }, {}] }, { panes: [{}, { focus: true }] }],
     });
     assert.deepStrictEqual(errors, []);
   });

--- a/src/validate.test.js
+++ b/src/validate.test.js
@@ -118,7 +118,7 @@ describe("validateConfig", () => {
 
   it("rejects 0% size", () => {
     const errors = validateConfig({ rows: [{ size: "0%", panes: [{}] }] });
-    assert.ok(errors.some((e) => e.includes("must not be 0%")));
+    assert.ok(errors.some((e) => e.includes("must be a percentage")));
   });
 
   it("rejects >100% size", () => {
@@ -162,6 +162,65 @@ describe("validateConfig", () => {
   it("rejects non-object theme", () => {
     const errors = validateConfig({ rows: [{ panes: [{}] }], theme: "blue" });
     assert.ok(errors.includes("'theme' must be an object"));
+  });
+
+  it("rejects leading zeros in size (00%, 007%)", () => {
+    const errors = validateConfig({ rows: [{ size: "007%", panes: [{ size: "00%" }] }] });
+    assert.ok(errors.some((e) => e.includes('rows[0].size "007%"') && e.includes("percentage")));
+    assert.ok(
+      errors.some((e) => e.includes('rows[0].panes[0].size "00%"') && e.includes("percentage")),
+    );
+  });
+
+  it("rejects row sizes summing over 100%", () => {
+    const errors = validateConfig({
+      rows: [
+        { size: "70%", panes: [{}] },
+        { size: "40%", panes: [{}] },
+      ],
+    });
+    assert.ok(errors.some((e) => e.includes("Row sizes sum to 110%")));
+  });
+
+  it("accepts row sizes summing to exactly 100%", () => {
+    const errors = validateConfig({
+      rows: [
+        { size: "70%", panes: [{}] },
+        { size: "30%", panes: [{}] },
+      ],
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it("rejects multiple focus: true in one row", () => {
+    const errors = validateConfig({
+      rows: [{ panes: [{ focus: true }, { focus: true }] }],
+    });
+    assert.ok(errors.some((e) => e.includes("Row 0 has 2 panes with focus: true")));
+  });
+
+  it("accepts single focus: true per row", () => {
+    const errors = validateConfig({
+      rows: [
+        { panes: [{ focus: true }, {}] },
+        { panes: [{}, { focus: true }] },
+      ],
+    });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it("rejects pane sizes summing over 100% in a row", () => {
+    const errors = validateConfig({
+      rows: [{ panes: [{ size: "60%" }, { size: "50%" }] }],
+    });
+    assert.ok(errors.some((e) => e.includes("Row 0 pane sizes sum to 110%")));
+  });
+
+  it("accepts pane sizes summing to exactly 100%", () => {
+    const errors = validateConfig({
+      rows: [{ panes: [{ size: "60%" }, { size: "40%" }] }],
+    });
+    assert.deepStrictEqual(errors, []);
   });
 
   it("collects multiple errors at once", () => {


### PR DESCRIPTION
## Summary
Completes Phase 4 of the roadmap — test coverage, config refactoring, and validation hardening. Test count goes from 134 to 225.

- **Plan 20** — Unit tests for `tmux.js`: 41 new tests covering error classification, session state, pane parsing, split/send/attach, session variables, monitor lifecycle, and debug logging. Adds `_setExecutor`/`_setSpawner` dependency injection for mocking.
- **Plan 21** — Config refactor: extracts `withConfig(dir, mutator)` and `readConfigSafe(dir)` helpers, eliminating 7 duplicated read-validate-write patterns in `config.js`.
- **Plan 22** — Validation hardening: rejects leading zeros in sizes (`007%`), row/pane size sums >100%, and multiple `focus: true` in a single row. 7 new validation tests.
- **Plan 23** — Command module tests: 29 new tests for `stop`, `init`, `doctor`, `ls`, and `config` success paths.

## Test plan
- [x] All 225 tests pass (`pnpm test`)
- [x] No existing tests broken
- [ ] `pnpm lint && pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)