### PR TITLE
Release 1.3.0: TypeScript migration + test coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,26 +61,33 @@ panes:
 
 ## Architecture
 
-- `bin/cli.js` — CLI entry point and top-level error boundary
-- `src/launch.js` — Launch orchestration for tmux sessions
-- `src/restart.js` — Stop + relaunch flow
-- `src/init.js` — Scaffolds ide.yml with smart detection
-- `src/stop.js` — Kills the tmux session
-- `src/attach.js` — Reattach to running session
-- `src/ls.js` — List tmux sessions
-- `src/doctor.js` — System health check
-- `src/status.js` — Session status query
-- `src/inspect.js` — Resolved config + live tmux inspection
-- `src/validate.js` — Config validation
-- `src/detect.js` — Project stack detection
-- `src/config.js` — Programmatic config mutations
-- `src/lib/tmux.js` — Shared tmux process helpers
-- `src/lib/launch-plan.js` — Pane startup planning + theme option generation
-- `src/lib/yaml-io.js` — Shared config read/write
-- `src/lib/dot-path.js` — Dot-notation get/set
-- `src/lib/output.js` — Structured CLI error/output helpers
-- `src/lib/sizes.js` — Row/pane sizing math
-- `src/*.test.js`, `src/lib/*.test.js` — CLI, unit, and integration coverage
+The project is written in TypeScript. Source lives in `src/`, compiled output in `dist/`. Tests run via Node's `--experimental-strip-types`; the published package ships compiled JS from `tsc`.
+
+- `bin/cli.js` — CLI entry point and top-level error boundary (stays JS, imports from `dist/`)
+- `tsconfig.json` — TypeScript config (strict, NodeNext, rewriteRelativeImportExtensions)
+- `src/types.ts` — Shared interfaces (IdeConfig, Row, Pane, ThemeConfig, PaneAction, SessionState)
+- `src/launch.ts` — Launch orchestration for tmux sessions
+- `src/restart.ts` — Stop + relaunch flow
+- `src/init.ts` — Scaffolds ide.yml with smart detection
+- `src/stop.ts` — Kills the tmux session
+- `src/attach.ts` — Reattach to running session
+- `src/ls.ts` — List tmux sessions
+- `src/doctor.ts` — System health check
+- `src/status.ts` — Session status query
+- `src/inspect.ts` — Resolved config + live tmux inspection
+- `src/validate.ts` — Config validation
+- `src/detect.ts` — Project stack detection
+- `src/config.ts` — Programmatic config mutations
+- `src/lib/tmux.ts` — Shared tmux process helpers
+- `src/lib/launch-plan.ts` — Pane startup planning + theme option generation
+- `src/lib/yaml-io.ts` — Shared config read/write
+- `src/lib/dot-path.ts` — Dot-notation get/set
+- `src/lib/output.ts` — Structured CLI error/output helpers
+- `src/lib/sizes.ts` — Row/pane sizing math
+- `src/lib/errors.ts` — Error class hierarchy (IdeError, ConfigError, TmuxError, SessionError)
+- `src/lib/session-options.ts` — Composable tmux session option builders
+- `src/lib/session-monitor.ts` — Agent/port status monitor (runs as detached process)
+- `src/*.test.ts`, `src/lib/*.test.ts` — CLI, unit, and integration coverage
 - `docs/content/docs/` — User-facing docs site content
 - `.github/workflows/ci.yml` — CI quality gates and release checks
 - `templates/` — Preset configs (default, nextjs, convex, vite, python, go, agent-team, agent-team-nextjs, agent-team-monorepo)

--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -93,10 +93,10 @@ export default function HomePage() {
             tmux-ide
           </span>
           <Link
-            href="/docs/release-1-2-0"
+            href="/docs/release-1-3-0"
             className="inline-flex items-center rounded-full border border-fd-border bg-fd-card px-3 py-1 text-[11px] font-mono font-medium uppercase tracking-[0.18em] text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-foreground"
           >
-            New 1.2.0
+            New 1.3.0
           </Link>
         </div>
         <h1 className="text-4xl sm:text-5xl font-bold tracking-tight text-fd-foreground">

--- a/docs/content/docs/contributing.mdx
+++ b/docs/content/docs/contributing.mdx
@@ -23,6 +23,8 @@ Run these from the repository root:
 
 ```bash
 pnpm test
+pnpm typecheck
+pnpm build
 pnpm docs:build
 pnpm pack:check
 pnpm check
@@ -30,7 +32,9 @@ pnpm check
 
 What they do:
 
-- `pnpm test` runs the Node CLI test suite
+- `pnpm test` runs the Node CLI test suite (uses `--experimental-strip-types` on `.ts` files)
+- `pnpm typecheck` runs `tsc --noEmit` to verify types without emitting output
+- `pnpm build` compiles TypeScript to `dist/` via `tsc`
 - `pnpm docs:build` validates the docs site production build
 - `pnpm pack:check` verifies the published npm package can be packed cleanly
 - `pnpm check` runs the full default pre-push and pre-release check path

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -35,7 +35,7 @@ npx tmux-ide restart # restart with new config
 ```
 
 <Cards>
-  <Card title="What's New in 1.2.0" href="/docs/release-1-2-0" />
+  <Card title="What's New in 1.3.0" href="/docs/release-1-3-0" />
   <Card title="Getting Started" href="/docs/getting-started" />
   <Card title="Configuration" href="/docs/configuration" />
   <Card title="Templates" href="/docs/templates" />

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -2,6 +2,7 @@
   "title": "Docs",
   "pages": [
     "index",
+    "release-1-3-0",
     "release-1-2-0",
     "release-1-1-0",
     "getting-started",

--- a/docs/content/docs/release-1-3-0.mdx
+++ b/docs/content/docs/release-1-3-0.mdx
@@ -1,0 +1,44 @@
+---
+title: Version 1.3.0
+description: Release notes for tmux-ide 1.3.0 — TypeScript migration and validation hardening
+---
+
+# tmux-ide 1.3.0
+
+Version `1.3.0` migrates the entire codebase to TypeScript and strengthens config validation, backed by 225 tests across unit, integration, and CLI contract suites.
+
+## TypeScript Migration
+
+Every source file in `src/` is now TypeScript. The published package still ships compiled JavaScript via `tsc`, so nothing changes for users — but contributors get strict types, better IDE support, and catch-at-compile-time guarantees.
+
+Key interfaces like `IdeConfig`, `Row`, `Pane`, `ThemeConfig`, `PaneAction`, and `SessionState` are defined in `src/types.ts` and used throughout the codebase.
+
+The build pipeline:
+
+- **Dev**: `node --experimental-strip-types` runs `.ts` files directly — no build step needed during development
+- **Build**: `tsc` emits strict JavaScript to `dist/`
+- **Publish**: `bin/cli.js` imports from `dist/`, so the published package works on Node 18+ without TypeScript
+
+## Validation Hardening
+
+The config validator now catches more edge cases:
+
+- **Leading zeros rejected**: sizes like `00%` and `007%` are no longer accepted
+- **Row size sum check**: row sizes that exceed 100% total produce a clear error
+- **Pane size sum check**: pane sizes within a single row that exceed 100% are rejected
+- **Multiple focus check**: only one pane per row can have `focus: true`
+
+## Config Refactor
+
+Internal config mutation code was deduplicated. The repeated read-validate-mutate-write pattern (7 copies) was extracted into `withConfig()` and `readConfigSafe()` helpers. `readConfig()` is now called in exactly one place.
+
+## Test Coverage
+
+The test suite grew to 225 tests covering:
+
+- All CLI commands (structured JSON and human output)
+- Config mutations (set, add-pane, remove-pane, add-row, enable-team, disable-team)
+- Validation edge cases (sizes, focus, sums)
+- tmux session lifecycle (launch, restart, stop, attach, inspect)
+- Agent team layouts and role assignment
+- Doctor checks, detect/init flows, and postinstall behavior

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-ide",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Turn any project into a tmux-powered terminal IDE with a simple ide.yml",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Major release completing the full roadmap (Phases 1-5).

### Phase 4 — Test Coverage & Polish
- 225 tests (up from 134) — unit tests for tmux.js, command modules, config success paths
- Config refactor: `withConfig` helper eliminates 7 duplicated read-validate-write patterns
- Validation hardening: leading zeros, size sums >100%, multiple focus per row

### Phase 5 — TypeScript Migration
- All `src/*.js` → `.ts` with strict types, `noUncheckedIndexedAccess`
- Core interfaces: `IdeConfig`, `Row`, `Pane`, `ThemeConfig`, `PaneAction`, `SessionState`
- `tsc` build step emits to `dist/`, package ships compiled JS
- Tests run via `--experimental-strip-types` (Node 22+)
- CI: lint/build/pack on Node 18/20/22, full tests on Node 22
- ESLint configured for TypeScript with `@typescript-eslint`

### Docs
- Landing page version badge updated to 1.3.0
- CLAUDE.md architecture section updated with .ts references

## Test plan
- [x] All 225 tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm build` emits to `dist/`
- [x] `pnpm format:check` clean
- [x] `node bin/cli.js --help` works from built output

🤖 Generated with [Claude Code](https://claude.com/claude-code)