### PR TITLE
Fix publish workflow: add build step before tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,14 +24,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Run checks
-        run: pnpm run lint:workspace && pnpm run format:check && pnpm run test:unit && pnpm run docs:build && pnpm run pack:check
+        run: pnpm run check
 
       - name: Publish
         run: npm publish --access public


### PR DESCRIPTION
## Summary
The publish workflow had an inline command that was missing `pnpm run build`, so `dist/` didn't exist when tests ran. Now uses `pnpm run check` which includes the build step.

Also pins Node to 22 (consistent with CI).

## Test plan
- [x] `pnpm run check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)