### PR TITLE
Revert publish workflow to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies


### PR DESCRIPTION
Node 24 was the working configuration for npm OIDC publishing. Node 22 caused a 404 on publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)