### PR TITLE
Task 045: Set up Vitest in dashboard with initial API tests

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -66,6 +66,7 @@ const knownCommands = new Set([
   "mission",
   "goal",
   "task",
+  "plan",
   "command-center",
   "help",
 ]);
@@ -280,6 +281,17 @@ try {
           depends: values.depends,
           pr: values.pr,
         },
+      });
+      break;
+    }
+
+    case "plan": {
+      const { planCommand } = await import("../dist/plan.js");
+      await planCommand(null, {
+        json,
+        sub: positionals[1],
+        args: positionals.slice(2),
+        values: { status: values.status },
       });
       break;
     }

--- a/dashboard/components/KanbanBoard.tsx
+++ b/dashboard/components/KanbanBoard.tsx
@@ -229,6 +229,7 @@ export function KanbanBoard({
           task={selectedTask}
           sessionName={sessionName}
           agents={agents}
+          allTasks={tasks}
           onClose={() => setSelectedTaskId(null)}
           onUpdated={onRefresh}
         />

--- a/dashboard/components/PlansPanel.tsx
+++ b/dashboard/components/PlansPanel.tsx
@@ -6,8 +6,10 @@ import {
   fetchPlans,
   fetchPlan,
   savePlan,
+  markPlanDone,
   type PlanSummary,
   type PlanData,
+  type PlanStatus,
   type AuthorshipData,
 } from "@/lib/api";
 import { usePolling } from "@/lib/usePolling";
@@ -17,6 +19,20 @@ import { MarkdownEditor } from "./MarkdownEditor";
 interface PlansPanelProps {
   sessionName: string;
 }
+
+const STATUS_ICONS: Record<PlanStatus, string> = {
+  "in-progress": "●",
+  pending: "○",
+  done: "✓",
+  archived: "▪",
+};
+
+const STATUS_COLORS: Record<PlanStatus, string> = {
+  "in-progress": "var(--yellow)",
+  pending: "var(--dim)",
+  done: "var(--green)",
+  archived: "var(--dimmer)",
+};
 
 interface MarkdownSection {
   heading: string;
@@ -68,7 +84,7 @@ function splitIntoSections(
 
 function isAiAuthor(author: string | null): boolean {
   if (!author) return false;
-  return author.startsWith("ai") || author.toLowerCase().includes("claude") || author.toLowerCase().includes("agent");
+  return author.startsWith("ai");
 }
 
 function formatAuthorTime(at: string | null): string {
@@ -86,14 +102,26 @@ function formatAuthorTime(at: string | null): string {
 
 export function PlansPanel({ sessionName }: PlansPanelProps) {
   const fetcher = useCallback(() => fetchPlans(sessionName), [sessionName]);
-  const { data: plans, loading } = usePolling<PlanSummary[]>(fetcher, 10000);
+  const { data: plans, loading, refresh: refreshPlans } = usePolling<PlanSummary[]>(fetcher, 10000);
 
+  const [statusFilter, setStatusFilter] = useState<PlanStatus | "all">("all");
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [planData, setPlanData] = useState<PlanData>({ content: "", authorship: null });
   const [loadingContent, setLoadingContent] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editContent, setEditContent] = useState("");
   const [saving, setSaving] = useState(false);
+
+  const filteredPlans = useMemo(() => {
+    if (!plans) return [];
+    if (statusFilter === "all") return plans;
+    return plans.filter((p) => p.status === statusFilter);
+  }, [plans, statusFilter]);
+
+  const selectedPlan = useMemo(
+    () => plans?.find((p) => p.path === selectedFile) ?? null,
+    [plans, selectedFile],
+  );
 
   useEffect(() => {
     if (!selectedFile) {
@@ -113,10 +141,10 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
   }, [selectedFile, sessionName]);
 
   useEffect(() => {
-    if (!selectedFile && plans && plans.length > 0) {
-      setSelectedFile(plans[0]!.path);
+    if (!selectedFile && filteredPlans.length > 0) {
+      setSelectedFile(filteredPlans[0]!.path);
     }
-  }, [plans, selectedFile]);
+  }, [filteredPlans, selectedFile]);
 
   const sections = useMemo(
     () => splitIntoSections(planData.content, planData.authorship),
@@ -128,7 +156,6 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
     setSaving(true);
     const ok = await savePlan(sessionName, selectedFile, content);
     if (ok) {
-      // Refresh content from server
       const d = await fetchPlan(sessionName, selectedFile);
       setPlanData(d);
       setEditContent(d.content);
@@ -137,15 +164,16 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
     setSaving(false);
   }
 
-  function handleStartEdit() {
-    setEditContent(planData.content);
-    setEditing(true);
+  async function handleMarkDone() {
+    if (!selectedPlan) return;
+    const ok = await markPlanDone(sessionName, selectedPlan.name);
+    if (ok) refreshPlans();
   }
 
   if (loading && !plans) {
     return (
       <div className="flex-1 flex items-center justify-center text-[var(--dim)]">
-        Loading plans…
+        Loading plans...
       </div>
     );
   }
@@ -158,45 +186,95 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
     );
   }
 
+  // Count by status
+  const counts: Record<string, number> = {};
+  for (const p of plans) counts[p.status] = (counts[p.status] ?? 0) + 1;
+
   return (
     <div className="flex-1 flex min-h-0">
-      {/* File sidebar */}
-      <div className="w-[240px] shrink-0 border-r border-[var(--border)] overflow-y-auto">
-        <div className="h-6 flex items-center px-3 bg-[var(--surface)] border-b border-[var(--border)] text-[10px] text-[var(--dim)] uppercase tracking-wider">
-          Plans ({plans.length})
-        </div>
-        {plans.map((p) => {
-          const isSelected = selectedFile === p.path;
-          return (
+      {/* Sidebar */}
+      <div className="w-[260px] shrink-0 border-r border-[var(--border)] flex flex-col min-h-0">
+        {/* Filter tabs */}
+        <div className="flex items-center h-6 bg-[var(--surface)] border-b border-[var(--border)] text-[10px] shrink-0 px-1 gap-px">
+          {(["all", "in-progress", "pending", "done"] as const).map((s) => (
             <button
-              key={p.path}
-              onClick={() => setSelectedFile(p.path)}
-              className={`w-full text-left h-6 px-3 flex items-center transition-colors truncate ${
-                isSelected
-                  ? "bg-[var(--surface-active)] text-[var(--accent)]"
-                  : "text-[var(--fg)] hover:bg-[var(--surface-hover)]"
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              className={`px-1.5 py-0.5 transition-colors ${
+                statusFilter === s
+                  ? "text-[var(--accent)]"
+                  : "text-[var(--dim)] hover:text-[var(--fg)]"
               }`}
             >
-              {p.name}
+              {s === "all" ? `all (${plans.length})` : `${s} (${counts[s] ?? 0})`}
             </button>
-          );
-        })}
+          ))}
+        </div>
+
+        {/* Plan list */}
+        <div className="flex-1 overflow-y-auto">
+          {filteredPlans.map((p) => {
+            const isSelected = selectedFile === p.path;
+            return (
+              <button
+                key={p.path}
+                onClick={() => setSelectedFile(p.path)}
+                className={`w-full text-left px-2 py-1 flex items-start gap-1.5 transition-colors ${
+                  isSelected
+                    ? "bg-[rgba(255,255,255,0.04)] text-[var(--accent)]"
+                    : "text-[var(--fg)] hover:bg-[rgba(255,255,255,0.02)]"
+                }`}
+              >
+                <span
+                  className="shrink-0 mt-0.5 text-[11px]"
+                  style={{ color: STATUS_COLORS[p.status] }}
+                >
+                  {STATUS_ICONS[p.status]}
+                </span>
+                <span className="min-w-0">
+                  <span className="block truncate text-[12px]">{p.name}</span>
+                  {p.completed && (
+                    <span className="block text-[10px] text-[var(--dimmer)]">
+                      {p.completed}
+                    </span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
+        </div>
       </div>
 
       {/* Content area */}
       <div className="flex-1 flex flex-col min-h-0">
         {loadingContent ? (
           <div className="flex-1 flex items-center justify-center text-[var(--dim)]">
-            loading…
+            loading...
           </div>
         ) : planData.content || editing ? (
           <>
-            {/* Header: authorship bar + edit/view toggle */}
-            <div className="shrink-0 border-b border-[var(--border)] px-3 flex items-center">
-              <div className="flex-1">
+            {/* Header */}
+            <div className="shrink-0 border-b border-[var(--border)] px-3 flex items-center h-7">
+              <div className="flex-1 flex items-center gap-2">
+                {selectedPlan && (
+                  <span
+                    className="text-[11px]"
+                    style={{ color: STATUS_COLORS[selectedPlan.status] }}
+                  >
+                    {STATUS_ICONS[selectedPlan.status]} {selectedPlan.status}
+                  </span>
+                )}
                 <AuthorshipBar authorship={planData.authorship} />
               </div>
               <div className="flex items-center gap-2 shrink-0">
+                {selectedPlan && selectedPlan.status !== "done" && !editing && (
+                  <button
+                    onClick={handleMarkDone}
+                    className="text-[11px] px-2 py-0.5 text-[var(--green)] border border-[var(--border)] hover:border-[var(--green)] transition-colors"
+                  >
+                    mark done
+                  </button>
+                )}
                 {editing && (
                   <>
                     <button
@@ -204,13 +282,15 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
                       disabled={saving}
                       className="text-[11px] px-2 py-0.5 text-[var(--bg)] bg-[var(--accent)] hover:opacity-90 disabled:opacity-50 transition-opacity"
                     >
-                      {saving ? "saving…" : "save"}
+                      {saving ? "saving..." : "save"}
                     </button>
-                    <span className="text-[9px] text-[var(--dimmer)]">⌘S</span>
+                    <span className="text-[9px] text-[var(--dimmer)]">cmd+S</span>
                   </>
                 )}
                 <button
-                  onClick={() => editing ? setEditing(false) : handleStartEdit()}
+                  onClick={() =>
+                    editing ? setEditing(false) : (() => { setEditContent(planData.content); setEditing(true); })()
+                  }
                   className={`text-[11px] px-2 py-0.5 border border-[var(--border)] transition-colors ${
                     editing
                       ? "text-[var(--accent)] border-[var(--accent)]"
@@ -222,7 +302,7 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
               </div>
             </div>
 
-            {/* Edit or view mode */}
+            {/* Content */}
             {editing ? (
               <MarkdownEditor
                 key={selectedFile}

--- a/dashboard/components/TaskCard.tsx
+++ b/dashboard/components/TaskCard.tsx
@@ -28,6 +28,9 @@ export function TaskCard({ task: t, onClick, selected = false }: TaskCardProps) 
   const prio = priorityDots(t.priority);
   const borderColor = BORDER_COLORS[t.status];
 
+  const testsPass =
+    t.proof?.tests && t.proof.tests.passed === t.proof.tests.total;
+
   return (
     <div
       onClick={onClick}
@@ -43,6 +46,23 @@ export function TaskCard({ task: t, onClick, selected = false }: TaskCardProps) 
           {prio.text}
         </span>
         <span className="text-[var(--dim)] shrink-0">{t.id}</span>
+        <span className="flex-1" />
+        {/* Badges */}
+        {testsPass && (
+          <span className="text-[var(--green)] text-[10px]" title={`${t.proof!.tests!.passed}/${t.proof!.tests!.total} tests`}>
+            ✓
+          </span>
+        )}
+        {t.proof?.pr && (
+          <span className="text-[var(--cyan)] text-[10px]">
+            PR#{t.proof.pr.number}
+          </span>
+        )}
+        {t.depends_on?.length > 0 && (
+          <span className="text-[var(--dim)] text-[10px]" title={`depends: ${t.depends_on.join(", ")}`}>
+            ⇅{t.depends_on.length}
+          </span>
+        )}
       </div>
       <div className="truncate text-[var(--fg)] mt-0.5">{t.title}</div>
       {t.assignee && (

--- a/dashboard/components/TaskDetail.tsx
+++ b/dashboard/components/TaskDetail.tsx
@@ -60,18 +60,11 @@ export function TaskDetail({
 
   async function handleSaveEdit() {
     setSaving(true);
-    await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5050"}/api/project/${encodeURIComponent(sessionName)}/task/${encodeURIComponent(t.id)}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: editTitle.trim(),
-          description: editDesc.trim(),
-          priority: editPriority,
-        }),
-      },
-    );
+    await updateTask(sessionName, t.id, {
+      title: editTitle.trim(),
+      description: editDesc.trim(),
+      priority: editPriority,
+    });
     onUpdated();
     setSaving(false);
     setEditing(false);
@@ -88,7 +81,7 @@ export function TaskDetail({
   const inputClass =
     "w-full bg-[var(--surface)] border border-[var(--border)] text-[var(--fg)] px-2 py-1 outline-none focus:border-[var(--accent)]";
 
-  const proofNote = t.proof?.notes ?? t.proof?.note;
+  const proofNote = t.proof?.notes;
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end">

--- a/dashboard/components/TaskDetail.tsx
+++ b/dashboard/components/TaskDetail.tsx
@@ -8,6 +8,7 @@ interface TaskDetailProps {
   task: Task;
   sessionName: string;
   agents: AgentDetail[];
+  allTasks?: Task[];
   onClose: () => void;
   onUpdated: () => void;
 }
@@ -32,6 +33,7 @@ export function TaskDetail({
   task: t,
   sessionName,
   agents,
+  allTasks = [],
   onClose,
   onUpdated,
 }: TaskDetailProps) {
@@ -58,7 +60,6 @@ export function TaskDetail({
 
   async function handleSaveEdit() {
     setSaving(true);
-    // Use the existing POST endpoint which accepts partial updates
     await fetch(
       `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5050"}/api/project/${encodeURIComponent(sessionName)}/task/${encodeURIComponent(t.id)}`,
       {
@@ -86,6 +87,8 @@ export function TaskDetail({
   const labelClass = "text-[var(--dim)] text-[10px] uppercase tracking-wider mb-1";
   const inputClass =
     "w-full bg-[var(--surface)] border border-[var(--border)] text-[var(--fg)] px-2 py-1 outline-none focus:border-[var(--accent)]";
+
+  const proofNote = t.proof?.notes ?? t.proof?.note;
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
@@ -143,7 +146,7 @@ export function TaskDetail({
             )}
           </div>
 
-          {/* Priority (editable) */}
+          {/* Priority */}
           <div>
             <div className={labelClass}>priority</div>
             {editing ? (
@@ -173,7 +176,7 @@ export function TaskDetail({
             )}
           </div>
 
-          {/* Save edit button */}
+          {/* Save edit */}
           {editing && (
             <button
               onClick={handleSaveEdit}
@@ -233,6 +236,117 @@ export function TaskDetail({
             <div>
               <div className={labelClass}>branch</div>
               <div className="text-[var(--cyan)]">⎇ {t.branch}</div>
+            </div>
+          )}
+
+          {/* Dependencies */}
+          {t.depends_on?.length > 0 && (
+            <div>
+              <div className={labelClass}>depends on</div>
+              <div className="flex gap-2 flex-wrap">
+                {t.depends_on.map((depId) => {
+                  const dep = allTasks.find((d) => d.id === depId);
+                  const done = dep?.status === "done";
+                  return (
+                    <span
+                      key={depId}
+                      className="text-[11px] px-1.5 py-0.5 border border-[var(--border)]"
+                      style={{ color: done ? "var(--green)" : "var(--dim)" }}
+                    >
+                      {done ? "✓" : "○"} {depId}
+                      {dep ? ` ${dep.title.slice(0, 20)}` : ""}
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Proof */}
+          {t.proof && (
+            <div>
+              <div className={labelClass}>proof</div>
+              <div className="space-y-1.5">
+                {t.proof.tests && (
+                  <div
+                    style={{
+                      color:
+                        t.proof.tests.passed === t.proof.tests.total
+                          ? "var(--green)"
+                          : "var(--red)",
+                    }}
+                  >
+                    Tests: {t.proof.tests.passed}/{t.proof.tests.total}{" "}
+                    {t.proof.tests.passed === t.proof.tests.total ? "passing" : "failing"}
+                  </div>
+                )}
+                {t.proof.pr && (
+                  <div>
+                    {t.proof.pr.url ? (
+                      <a
+                        href={t.proof.pr.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[var(--cyan)] hover:underline"
+                      >
+                        PR #{t.proof.pr.number}
+                      </a>
+                    ) : (
+                      <span className="text-[var(--cyan)]">PR #{t.proof.pr.number}</span>
+                    )}
+                    {t.proof.pr.status && (
+                      <span className="text-[var(--dim)] ml-2">{t.proof.pr.status}</span>
+                    )}
+                  </div>
+                )}
+                {t.proof.ci && (
+                  <div className="flex items-center gap-2">
+                    <span
+                      style={{
+                        color:
+                          t.proof.ci.status === "passing" || t.proof.ci.status === "green"
+                            ? "var(--green)"
+                            : "var(--red)",
+                      }}
+                    >
+                      CI: {t.proof.ci.status}
+                    </span>
+                    {t.proof.ci.url && (
+                      <a
+                        href={t.proof.ci.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[var(--cyan)] text-[11px] hover:underline"
+                      >
+                        view
+                      </a>
+                    )}
+                  </div>
+                )}
+                {proofNote && (
+                  <div className="text-[var(--fg)] whitespace-pre-wrap">{proofNote}</div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Retry info */}
+          {t.retryCount > 0 && (
+            <div>
+              <div className={labelClass}>retries</div>
+              <span className="text-[var(--yellow)]">
+                Retried {t.retryCount}/{t.maxRetries} times
+              </span>
+            </div>
+          )}
+
+          {/* Last error */}
+          {t.lastError && (
+            <div>
+              <div className={labelClass}>last error</div>
+              <div className="text-[var(--red)] text-[11px] whitespace-pre-wrap">
+                {t.lastError}
+              </div>
             </div>
           )}
 

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { marksToSections } from "../api";
+import type { Mark } from "../types";
+
+function makeMark(overrides: Partial<Mark> & { range: Mark["range"] }): Mark {
+  return {
+    id: "m1",
+    kind: "authored",
+    by: "ai:Claude",
+    at: "2026-03-21T10:00:00Z",
+    quote: "text",
+    ...overrides,
+  };
+}
+
+describe("marksToSections", () => {
+  it("returns empty object for empty marks", () => {
+    const result = marksToSections({}, "# Heading\nSome text");
+    expect(result).toEqual({});
+  });
+
+  it("attributes a section to the mark author", () => {
+    const content = "# Introduction\nSome intro text here";
+    const marks: Record<string, Mark> = {
+      m1: makeMark({
+        by: "ai:Claude",
+        range: { from: 0, to: content.length },
+        at: "2026-03-21T10:00:00Z",
+      }),
+    };
+
+    const result = marksToSections(marks, content);
+    expect(result["Introduction"]).toBeDefined();
+    expect(result["Introduction"]!.author).toBe("ai:Claude");
+    expect(result["Introduction"]!.charCount).toBeGreaterThan(0);
+  });
+
+  it("picks dominant author when multiple authors contribute", () => {
+    const content = "# Design\nShort bit by human. And then a much longer section written entirely by AI that has many more characters.";
+    const marks: Record<string, Mark> = {
+      m1: makeMark({
+        id: "m1",
+        by: "human:thijs",
+        range: { from: 9, to: 30 },
+        at: "2026-03-21T10:00:00Z",
+      }),
+      m2: makeMark({
+        id: "m2",
+        by: "ai:Claude",
+        range: { from: 30, to: content.length },
+        at: "2026-03-21T10:05:00Z",
+      }),
+    };
+
+    const result = marksToSections(marks, content);
+    expect(result["Design"]!.author).toBe("ai:Claude");
+  });
+
+  it("handles multiple sections independently", () => {
+    const content = "# Section A\nText A\n# Section B\nText B";
+    const sectionAEnd = content.indexOf("# Section B");
+    const marks: Record<string, Mark> = {
+      m1: makeMark({
+        id: "m1",
+        by: "human:thijs",
+        range: { from: 0, to: sectionAEnd },
+        at: "2026-03-21T10:00:00Z",
+      }),
+      m2: makeMark({
+        id: "m2",
+        by: "ai:Claude",
+        range: { from: sectionAEnd, to: content.length },
+        at: "2026-03-21T10:05:00Z",
+      }),
+    };
+
+    const result = marksToSections(marks, content);
+    expect(result["Section A"]!.author).toBe("human:thijs");
+    expect(result["Section B"]!.author).toBe("ai:Claude");
+  });
+
+  it("skips orphaned marks", () => {
+    const content = "# Heading\nSome text";
+    const marks: Record<string, Mark> = {
+      m1: makeMark({
+        by: "ai:Claude",
+        range: { from: 0, to: content.length },
+        orphaned: true,
+      }),
+    };
+
+    const result = marksToSections(marks, content);
+    expect(result).toEqual({});
+  });
+});
+
+describe("fetchPlan", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("transforms marks + stats into authorship data", async () => {
+    const mockResponse = {
+      name: "test-plan",
+      content: "# Plan\nContent here",
+      marks: {
+        m1: makeMark({
+          by: "ai:Claude",
+          range: { from: 0, to: 20 },
+        }),
+      },
+      stats: { aiPercent: 100, humanPercent: 0, totalChars: 20 },
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      }),
+    );
+
+    const { fetchPlan } = await import("../api");
+    const result = await fetchPlan("session", "test-plan");
+
+    expect(result.content).toBe("# Plan\nContent here");
+    expect(result.authorship).not.toBeNull();
+    expect(result.authorship!.stats.aiPercent).toBe(100);
+    expect(result.authorship!.sections["Plan"]).toBeDefined();
+  });
+
+  it("returns null authorship when marks are null", async () => {
+    const mockResponse = {
+      name: "test-plan",
+      content: "# Plan\nNo marks",
+      marks: null,
+      stats: null,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      }),
+    );
+
+    const { fetchPlan } = await import("../api");
+    const result = await fetchPlan("session", "test-plan");
+
+    expect(result.content).toBe("# Plan\nNo marks");
+    expect(result.authorship).toBeNull();
+  });
+});
+
+describe("updateTask", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns Task object on success", async () => {
+    const mockTask = {
+      id: "001",
+      title: "Test",
+      status: "in-progress",
+      assignee: "Claude",
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, task: mockTask }),
+      }),
+    );
+
+    const { updateTask } = await import("../api");
+    const result = await updateTask("session", "001", { status: "in-progress" });
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("001");
+    expect(result!.status).toBe("in-progress");
+  });
+
+  it("returns null on failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false }),
+    );
+
+    const { updateTask } = await import("../api");
+    const result = await updateTask("session", "001", { status: "done" });
+
+    expect(result).toBeNull();
+  });
+});

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -166,7 +166,7 @@ export interface PlanData {
  * Each section heading in the markdown gets attributed to the author
  * who wrote the most characters in that section.
  */
-function marksToSections(
+export function marksToSections(
   marks: Record<string, Mark>,
   content: string,
 ): Record<string, AuthorshipSection> {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1,4 +1,4 @@
-import type { SessionOverview, ProjectDetail, OrchestratorEvent } from "./types";
+import type { SessionOverview, ProjectDetail, Task } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5050";
 
@@ -53,7 +53,7 @@ export interface EventData {
   taskId?: string;
   agent?: string;
   message: string;
-  relative?: string;
+  relative: string;
 }
 
 export async function fetchEvents(name: string): Promise<EventData[]> {
@@ -69,8 +69,14 @@ export async function fetchEvents(name: string): Promise<EventData[]> {
 export async function updateTask(
   sessionName: string,
   taskId: string,
-  fields: { status?: string; assignee?: string },
-): Promise<boolean> {
+  fields: {
+    status?: string;
+    assignee?: string;
+    title?: string;
+    description?: string;
+    priority?: number;
+  },
+): Promise<Task | null> {
   const res = await fetch(
     `${API_BASE}/api/project/${encodeURIComponent(sessionName)}/task/${encodeURIComponent(taskId)}`,
     {
@@ -79,7 +85,9 @@ export async function updateTask(
       body: JSON.stringify(fields),
     },
   );
-  return res.ok;
+  if (!res.ok) return null;
+  const data = (await res.json()) as { ok: boolean; task: Task };
+  return data.task;
 }
 
 export async function createTask(
@@ -91,7 +99,7 @@ export async function createTask(
     goal?: string;
     tags?: string[];
   },
-): Promise<boolean> {
+): Promise<Task | null> {
   const res = await fetch(
     `${API_BASE}/api/project/${encodeURIComponent(sessionName)}/task`,
     {
@@ -100,7 +108,9 @@ export async function createTask(
       body: JSON.stringify(fields),
     },
   );
-  return res.ok;
+  if (!res.ok) return null;
+  const data = (await res.json()) as { ok: boolean; task: Task };
+  return data.task;
 }
 
 export interface PlanSummary {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1,4 +1,4 @@
-import type { SessionOverview, ProjectDetail, Task } from "./types";
+import type { SessionOverview, ProjectDetail, Task, Mark, AuthorshipStats } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5050";
 
@@ -144,6 +144,78 @@ export interface PlanData {
   authorship: AuthorshipData | null;
 }
 
+/**
+ * Convert character-range marks into section-level authorship summaries.
+ * Each section heading in the markdown gets attributed to the author
+ * who wrote the most characters in that section.
+ */
+function marksToSections(
+  marks: Record<string, Mark>,
+  content: string,
+): Record<string, AuthorshipSection> {
+  // Find section boundaries from heading lines
+  const lines = content.split("\n");
+  const sections: { heading: string; from: number; to: number }[] = [];
+  let offset = 0;
+  let currentHeading = "";
+  let sectionStart = 0;
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^#{1,4}\s+(.+)/);
+    if (headingMatch) {
+      if (currentHeading || offset > 0) {
+        sections.push({ heading: currentHeading, from: sectionStart, to: offset });
+      }
+      currentHeading = headingMatch[1]!.trim();
+      sectionStart = offset;
+    }
+    offset += line.length + 1; // +1 for newline
+  }
+  sections.push({ heading: currentHeading, from: sectionStart, to: offset });
+
+  // For each section, find the dominant author from overlapping marks
+  const result: Record<string, AuthorshipSection> = {};
+  const markList = Object.values(marks).filter((m) => !m.orphaned);
+
+  for (const section of sections) {
+    if (!section.heading) continue;
+    const authorChars: Record<string, { chars: number; latestAt: string }> = {};
+
+    for (const mark of markList) {
+      const overlapFrom = Math.max(mark.range.from, section.from);
+      const overlapTo = Math.min(mark.range.to, section.to);
+      if (overlapFrom >= overlapTo) continue;
+
+      const chars = overlapTo - overlapFrom;
+      const existing = authorChars[mark.by];
+      if (existing) {
+        existing.chars += chars;
+        if (mark.at > existing.latestAt) existing.latestAt = mark.at;
+      } else {
+        authorChars[mark.by] = { chars, latestAt: mark.at };
+      }
+    }
+
+    // Pick the author with the most characters in this section
+    let dominant: { author: string; chars: number; at: string } | null = null;
+    for (const [author, data] of Object.entries(authorChars)) {
+      if (!dominant || data.chars > dominant.chars) {
+        dominant = { author, chars: data.chars, at: data.latestAt };
+      }
+    }
+
+    if (dominant) {
+      result[section.heading] = {
+        author: dominant.author,
+        at: dominant.at,
+        charCount: dominant.chars,
+      };
+    }
+  }
+
+  return result;
+}
+
 export async function fetchPlan(
   name: string,
   filename: string,
@@ -156,9 +228,19 @@ export async function fetchPlan(
   const data = (await res.json()) as {
     name: string;
     content: string;
-    authorship?: AuthorshipData;
+    marks: Record<string, Mark> | null;
+    stats: AuthorshipStats | null;
   };
-  return { content: data.content, authorship: data.authorship ?? null };
+
+  let authorship: AuthorshipData | null = null;
+  if (data.marks && data.stats) {
+    authorship = {
+      sections: marksToSections(data.marks, data.content),
+      stats: data.stats,
+    };
+  }
+
+  return { content: data.content, authorship };
 }
 
 export async function deleteTaskApi(

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -113,9 +113,15 @@ export async function createTask(
   return data.task;
 }
 
+export type PlanStatus = "pending" | "in-progress" | "done" | "archived";
+
 export interface PlanSummary {
   name: string;
   path: string;
+  title: string;
+  status: PlanStatus;
+  effort: string | null;
+  completed: string | null;
 }
 
 export async function fetchPlans(name: string): Promise<PlanSummary[]> {
@@ -126,6 +132,17 @@ export async function fetchPlans(name: string): Promise<PlanSummary[]> {
   if (!res.ok) return [];
   const data = (await res.json()) as { plans: PlanSummary[] };
   return data.plans;
+}
+
+export async function markPlanDone(
+  name: string,
+  filename: string,
+): Promise<boolean> {
+  const res = await fetch(
+    `${API_BASE}/api/project/${encodeURIComponent(name)}/plans/${encodeURIComponent(filename)}/done`,
+    { method: "POST" },
+  );
+  return res.ok;
 }
 
 export interface AuthorshipSection {

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -11,6 +11,14 @@ export interface SessionOverview {
   goals: { id: string; title: string; progress: number }[];
 }
 
+export interface ProofSchema {
+  tests?: { passed: number; total: number };
+  pr?: { number: number; url?: string; status?: string };
+  ci?: { status: string; url?: string };
+  notes?: string;
+  note?: string;
+}
+
 export interface Task {
   id: string;
   title: string;
@@ -21,6 +29,12 @@ export interface Task {
   priority: number;
   branch: string | null;
   tags: string[];
+  proof: ProofSchema | null;
+  depends_on: string[];
+  retryCount: number;
+  maxRetries: number;
+  lastError: string | null;
+  nextRetryAt: string | null;
 }
 
 export interface AgentDetail {

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -1,7 +1,14 @@
+export interface Mission {
+  title: string;
+  description: string;
+  created: string;
+  updated: string;
+}
+
 export interface SessionOverview {
   name: string;
   dir: string;
-  mission: { title: string; description: string } | null;
+  mission: Mission | null;
   stats: {
     totalTasks: number;
     doneTasks: number;
@@ -16,7 +23,6 @@ export interface ProofSchema {
   pr?: { number: number; url?: string; status?: string };
   ci?: { status: string; url?: string };
   notes?: string;
-  note?: string;
 }
 
 export interface Task {
@@ -27,6 +33,8 @@ export interface Task {
   status: "todo" | "in-progress" | "review" | "done";
   assignee: string | null;
   priority: number;
+  created: string;
+  updated: string;
   branch: string | null;
   tags: string[];
   proof: ProofSchema | null;
@@ -49,15 +57,19 @@ export interface Goal {
   id: string;
   title: string;
   description: string;
-  status: string;
+  status: "todo" | "in-progress" | "done";
   acceptance: string;
   priority: number;
+  created: string;
+  updated: string;
+  assignee: string | null;
+  specialty: string | null;
 }
 
 export interface ProjectDetail {
   session: string;
   dir: string;
-  mission: { title: string; description: string } | null;
+  mission: Mission | null;
   goals: Goal[];
   tasks: Task[];
   agents: AgentDetail[];
@@ -72,12 +84,3 @@ export type EventType =
   | "error"
   | "task_created"
   | "status_change";
-
-export interface OrchestratorEvent {
-  timestamp: string;
-  type: EventType;
-  taskId?: string;
-  agent?: string;
-  message: string;
-  relative: string;
-}

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -75,6 +75,27 @@ export interface ProjectDetail {
   agents: AgentDetail[];
 }
 
+export interface MarkRange {
+  from: number;
+  to: number;
+}
+
+export interface Mark {
+  id: string;
+  kind: string;
+  by: string;
+  at: string;
+  range: MarkRange;
+  quote: string;
+  orphaned?: boolean;
+}
+
+export interface AuthorshipStats {
+  aiPercent: number;
+  humanPercent: number;
+  totalChars: number;
+}
+
 export type EventType =
   | "dispatch"
   | "completion"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --port 3000",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.3",
@@ -34,8 +36,11 @@
     "@tailwindcss/postcss": "^4.2.1",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
+    "@vitejs/plugin-react": "^6.0.1",
+    "happy-dom": "^20.8.4",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
   }
 }

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "happy-dom",
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,48 @@ importers:
 
   dashboard:
     dependencies:
+      '@codemirror/commands':
+        specifier: ^6.10.3
+        version: 6.10.3
+      '@codemirror/lang-markdown':
+        specifier: ^6.5.0
+        version: 6.5.0
+      '@codemirror/language':
+        specifier: ^6.12.2
+        version: 6.12.2
+      '@codemirror/state':
+        specifier: ^6.6.0
+        version: 6.6.0
+      '@codemirror/theme-one-dark':
+        specifier: ^6.1.3
+        version: 6.1.3
+      '@codemirror/view':
+        specifier: ^6.40.0
+        version: 6.40.0
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
+      '@milkdown/core':
+        specifier: ^7.19.0
+        version: 7.19.0
+      '@milkdown/ctx':
+        specifier: ^7.19.0
+        version: 7.19.0
+      '@milkdown/preset-commonmark':
+        specifier: ^7.19.0
+        version: 7.19.0
+      '@milkdown/react':
+        specifier: ^7.19.0
+        version: 7.19.0(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@milkdown/theme-nord':
+        specifier: ^7.19.0
+        version: 7.19.0
       '@pierre/diffs':
         specifier: ^1.1.2
         version: 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -84,6 +126,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.2.1
@@ -94,6 +139,12 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))
+      happy-dom:
+        specifier: ^20.8.4
+        version: 20.8.4
       postcss:
         specifier: ^8.5.8
         version: 8.5.8
@@ -103,6 +154,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(happy-dom@20.8.4)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))
 
   docs:
     dependencies:
@@ -311,11 +365,132 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-angular@0.1.4':
+    resolution: {integrity: sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==}
+
+  '@codemirror/lang-cpp@6.0.3':
+    resolution: {integrity: sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-go@6.0.1':
+    resolution: {integrity: sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-java@6.0.2':
+    resolution: {integrity: sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-jinja@6.0.0':
+    resolution: {integrity: sha512-47MFmRcR8UAxd8DReVgj7WJN1WSAMT7OJnewwugZM4XiHWkOjgJQqvEM1NpMj9ALMPyxmlziEI1opH9IaEvmaw==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-less@6.0.2':
+    resolution: {integrity: sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==}
+
+  '@codemirror/lang-liquid@6.3.2':
+    resolution: {integrity: sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/lang-php@6.0.2':
+    resolution: {integrity: sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==}
+
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/lang-rust@6.0.2':
+    resolution: {integrity: sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==}
+
+  '@codemirror/lang-sass@6.0.2':
+    resolution: {integrity: sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/lang-vue@0.1.3':
+    resolution: {integrity: sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==}
+
+  '@codemirror/lang-wast@6.0.2':
+    resolution: {integrity: sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==}
+
+  '@codemirror/lang-xml@6.1.0':
+    resolution: {integrity: sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==}
+
+  '@codemirror/lang-yaml@6.1.2':
+    resolution: {integrity: sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==}
+
+  '@codemirror/language-data@6.5.2':
+    resolution: {integrity: sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==}
+
+  '@codemirror/language@6.12.2':
+    resolution: {integrity: sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==}
+
+  '@codemirror/legacy-modes@6.5.2':
+    resolution: {integrity: sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/search@6.6.0':
+    resolution: {integrity: sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.40.0':
+    resolution: {integrity: sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==}
+
   '@dimforge/rapier2d-simd-compat@0.17.3':
     resolution: {integrity: sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==}
 
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
   '@emnapi/runtime@1.9.0':
     resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -828,8 +1003,141 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@lezer/common@1.5.1':
+    resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
+
+  '@lezer/cpp@1.1.5':
+    resolution: {integrity: sha512-DIhSXmYtJKLehrjzDFN+2cPt547ySQ41nA8yqcDf/GxMc+YM736xqltFkvADL2M0VebU5I+3+4ks2Vv+Kyq3Aw==}
+
+  '@lezer/css@1.3.2':
+    resolution: {integrity: sha512-tRZAPl1j0pkmPL/pGG85GAbyQYnYv0j6UEdEt5e4ZYvp+OxDu2zVp2c/YddiuO8ZTa2CHsVELqRd/fGWjlISrg==}
+
+  '@lezer/go@1.0.1':
+    resolution: {integrity: sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/java@1.1.3':
+    resolution: {integrity: sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.8':
+    resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
+
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+
+  '@lezer/php@1.0.5':
+    resolution: {integrity: sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==}
+
+  '@lezer/python@1.1.18':
+    resolution: {integrity: sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==}
+
+  '@lezer/rust@1.0.2':
+    resolution: {integrity: sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==}
+
+  '@lezer/sass@1.1.0':
+    resolution: {integrity: sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==}
+
+  '@lezer/xml@1.0.6':
+    resolution: {integrity: sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@milkdown/components@7.19.0':
+    resolution: {integrity: sha512-l/xasav/CPVXQZWs5oiFtnWw2zMk4Bq1EmKFElzsaKJCCW7ZBofasoGoQY5h0j+CDM8nAe8WLTq87WWWb9Ut6A==}
+    peerDependencies:
+      '@codemirror/language': ^6
+      '@codemirror/state': ^6
+      '@codemirror/view': ^6
+
+  '@milkdown/core@7.19.0':
+    resolution: {integrity: sha512-x5vxnVCxxKSGCa1+J7I4RzEDl4KkvsXJF6xm1zCtvj0BCsbCFGiUVx2AtLcFkkvWZ5530CuOouDJ9FC27yoCoA==}
+
+  '@milkdown/crepe@7.19.0':
+    resolution: {integrity: sha512-3vY/5l8xc3LS1bh/bzzfuVhiFPP1gBYCSTp6iu6TXUgMHJvu8Tp2yhyBrjIWhiogA281cuA50i9gG47wOjWAIQ==}
+
+  '@milkdown/ctx@7.19.0':
+    resolution: {integrity: sha512-tdG9jm6yk6PRSvFZW5rRSqOGrKdcNdbXJwfGiEGr538pgKYhJ/yKPF3HmfupkhGyxabRP/PydQa4q/N/OOs03g==}
+
+  '@milkdown/exception@7.19.0':
+    resolution: {integrity: sha512-ykgjxqrOueTCjmDGr0aidulZa1mC6bg4f8eDyMiT0wd4vB+3iYmQxY8NxdKwUqlz4UM5KBnbyFlGlgQsQDL+ew==}
+
+  '@milkdown/kit@7.19.0':
+    resolution: {integrity: sha512-q+FF2dLMpw056mwowg1de+vcDl2gLyNfBmOCJ1WjJSqw4evlcYcKjYgKZWViE/WLOjryQDQhDlg0g58/uUFiyQ==}
+
+  '@milkdown/plugin-block@7.19.0':
+    resolution: {integrity: sha512-VCOscCUXOlkOO/i3PYUHHJ9nAk3rjBGlEB6Rs3Ge7hJbuv2Hb/5mTiWI2KRARu1deGaEaYUjsH8NX+BOH3ZMew==}
+
+  '@milkdown/plugin-clipboard@7.19.0':
+    resolution: {integrity: sha512-V29/XE3M/ffvc5Owdm9tdUaD/GZ5AHMgbpBkd6+2/PH09MfGA9CPTpAjhqxxkWEi3CoT0HapdoceKuzd5bD7Nw==}
+
+  '@milkdown/plugin-cursor@7.19.0':
+    resolution: {integrity: sha512-NGAuTxSbOdy3nHQ8bTk9I6Vi1eX14xpcN7QU65aIJM01RnGhTBx5cF6f82n0IWTXMbN+MVOuQfqywfdRx1ukLw==}
+
+  '@milkdown/plugin-history@7.19.0':
+    resolution: {integrity: sha512-bC5bN0Ep5AC3hkiPS6LJTkorBoe5S7meJNzO0WqcIpkwckHD3M59Z7uz6dSUZdxVcL5IcFegDVsEYkiDq1Jcrw==}
+
+  '@milkdown/plugin-indent@7.19.0':
+    resolution: {integrity: sha512-P9rJK9OHCmqry37pAFcknY3VVvAEpUt7RflfdjFXSb3aGyJb+TDaQBiTHgxzTTXmvmAaPGLm2uuGtx34ThrA1A==}
+
+  '@milkdown/plugin-listener@7.19.0':
+    resolution: {integrity: sha512-shEVqcC2SKH0jaB74ReztNxG5hXjby26S1lN+evHKtsy2cB2vbWH2eHqSZkl8EGbLZJrqDsHwDKxTNTwB/oMSg==}
+
+  '@milkdown/plugin-slash@7.19.0':
+    resolution: {integrity: sha512-mdcqxOC9voMHKBScCGZjtSU6xTd6/Z6Oc7XsTQ5Yc0XqRgqcYAL3ti/1dtP2BMy8zXu/pHegatOzGWO9DlrcUQ==}
+
+  '@milkdown/plugin-tooltip@7.19.0':
+    resolution: {integrity: sha512-2HBiMgQ3aY/jdbxRRAbUkglk+PACCNGL7AERssRhr3G3Ph+eNwJYpK6VN7eHsUyDbFSP0koS7npr6U2kZWThFg==}
+
+  '@milkdown/plugin-trailing@7.19.0':
+    resolution: {integrity: sha512-VbAqrvZq4S0kFVipuNmM+Qg8PvvT6SUXhRCMWzM0tX1I7H6Lie+oT/G5bpNPSKh7BNi7pbCllLGi0/L88vSzSw==}
+
+  '@milkdown/plugin-upload@7.19.0':
+    resolution: {integrity: sha512-dAcxLf8TvCljgrRUa65lV3MYA5HAmCOjVHS0CzKCfC568T4eg3K2kSbr+EFEYCSR7vCbLjm/o9F4kI4qaWmAAw==}
+
+  '@milkdown/preset-commonmark@7.19.0':
+    resolution: {integrity: sha512-8rPEd4S3ny5wuFJvnZdieedKxFeW3KU5Rz54LYhA/nYPG+tE9q5lqDs0ZzHNoJdXMiLWbNf/dd0QokHVNlbQLQ==}
+
+  '@milkdown/preset-gfm@7.19.0':
+    resolution: {integrity: sha512-wW5ShJUhIaWNnbtv4IjV+xh9TvVId+Lm8CAurUs2E1nBX2N5wHTzzl2/9WOTt/g4u49e64rJewkwZJri8MPy7g==}
+
+  '@milkdown/prose@7.19.0':
+    resolution: {integrity: sha512-T/uYqSr4YT4uZtu4nBxTWyvZhVs2Lzh9qpcYH81PVwtZUT3b57+e+39s1D7UKAwFGi0qB7qZu/53l6pcw8radg==}
+
+  '@milkdown/react@7.19.0':
+    resolution: {integrity: sha512-rtvnM2tC8A0IAzkG2u7XYPNtN08Yek+z9AHUbf4SRyVbXsOCTRSZxA7FEGul1iLl6TUz4oU8tQnMHPH4iWXBtA==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  '@milkdown/theme-nord@7.19.0':
+    resolution: {integrity: sha512-TBbUuAJT8wiw3wZVVpDuA0U+UmNUulRgdtXnu72y2QNHdMLmYalw0Yjfx11cDEB52/Ld/z+xHuRvPNf30OSMjw==}
+
+  '@milkdown/transformer@7.19.0':
+    resolution: {integrity: sha512-Ui1vwbyTd1nAaieTylI8ibNbXSAxygkiFjkwOPGO5w0Eu7leH+0hVrbeGUCSzYdJfjGsN537CYu/8kvLIR+lQg==}
+
+  '@milkdown/utils@7.19.0':
+    resolution: {integrity: sha512-aIu8j7TypVn+4ZWgrIUjpljIulAVwNERWNZgkfYLQLOv+BbF1gIbpoB7t3w0RD2EeENrEu0P3J0Sl5LDMbyDRQ==}
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
   '@next/env@16.1.6':
     resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
@@ -882,6 +1190,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ocavue/utils@1.6.0':
+    resolution: {integrity: sha512-8W3q1hxx9qFdrYgPtbElllG/tqYkO/dMhlRUiqasO0SuDFTj78azSQjhIrBTFWxlBPPsSZN6zXYHmb3RwN2Jtg==}
+
   '@opentui/core-darwin-arm64@0.1.88':
     resolution: {integrity: sha512-oGRexWwZFeQJymOK5ORrLrwJUbPHMYaFa0EcLnlhvPnymm1xyMcRKm39ez0WSIdtiCCi/PmMHX95CfyyJB5VMA==}
     cpu: [arm64]
@@ -925,6 +1236,9 @@ packages:
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
+
+  '@oxc-project/types@0.120.0':
+    resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -1383,6 +1697,101 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+    resolution: {integrity: sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+    resolution: {integrity: sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+    resolution: {integrity: sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+    resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+    resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+    resolution: {integrity: sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+    resolution: {integrity: sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+    resolution: {integrity: sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.10':
+    resolution: {integrity: sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==}
+
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
 
@@ -1604,8 +2013,17 @@ packages:
   '@tsconfig/bun@1.0.10':
     resolution: {integrity: sha512-5AV5YknQjNyoYzZ/8NG0dawqew/wH+x7ANiCfCIn29qo0cdbd1EryvFD1k5NSZWLBMOI/fGqMIaxi58GPIP9Cg==}
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1624,6 +2042,15 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+
+  '@types/lodash@4.17.24':
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -1648,11 +2075,20 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
@@ -1716,6 +2152,77 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+
+  '@vue/compiler-core@3.5.30':
+    resolution: {integrity: sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==}
+
+  '@vue/compiler-dom@3.5.30':
+    resolution: {integrity: sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==}
+
+  '@vue/compiler-sfc@3.5.30':
+    resolution: {integrity: sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==}
+
+  '@vue/compiler-ssr@3.5.30':
+    resolution: {integrity: sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==}
+
+  '@vue/reactivity@3.5.30':
+    resolution: {integrity: sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==}
+
+  '@vue/runtime-core@3.5.30':
+    resolution: {integrity: sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==}
+
+  '@vue/runtime-dom@3.5.30':
+    resolution: {integrity: sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==}
+
+  '@vue/server-renderer@3.5.30':
+    resolution: {integrity: sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==}
+    peerDependencies:
+      vue: 3.5.30
+
+  '@vue/shared@3.5.30':
+    resolution: {integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==}
+
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
@@ -1745,6 +2252,10 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -1841,6 +2352,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -1867,17 +2382,27 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1928,6 +2453,9 @@ packages:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+
   electron-to-chromium@1.5.321:
     resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
 
@@ -1942,6 +2470,9 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -2025,6 +2556,9 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -2042,6 +2576,10 @@ packages:
 
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2106,6 +2644,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fumadocs-core@16.6.13:
     resolution: {integrity: sha512-RqOM7A/JiIQBjaEBs7b8rH/ULrGG70h3MBOPYDZwdJoZYbFZ2m41tEgHCeMtcEmFRr/W6vqO2Y8WnPu/QCfCQg==}
@@ -2252,6 +2795,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  happy-dom@20.8.4:
+    resolution: {integrity: sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ==}
+    engines: {node: '>=20.0.0'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -2292,6 +2839,9 @@ packages:
 
   html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -2390,6 +2940,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  katex@0.16.40:
+    resolution: {integrity: sha512-1DJcK/L05k1Y9Gf7wMcyuqFOL6BiY3vY0CFcAM/LPRN04NALxcl6u7lOWNsp3f/bCHWxigzQl6FbR95XJ4R84Q==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2403,8 +2957,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.31.1:
     resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -2415,8 +2981,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.31.1:
     resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -2427,8 +3005,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.31.1:
     resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -2439,8 +3029,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -2451,8 +3053,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -2463,8 +3077,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.31.1:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   locate-path@3.0.0:
@@ -2474,6 +3098,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.17.23:
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -2507,6 +3134,9 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  mdast-util-definitions@6.0.0:
+    resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -2530,6 +3160,9 @@ packages:
 
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-math@3.0.0:
+    resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -2578,6 +3211,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-extension-mdx-expression@3.0.1:
     resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
@@ -2709,6 +3345,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.7:
+    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -2753,6 +3394,9 @@ packages:
     resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   omggif@1.0.10:
     resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
 
@@ -2765,6 +3409,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -2825,6 +3472,9 @@ packages:
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   peek-readable@4.1.0:
     resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
@@ -2887,6 +3537,65 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  prosemirror-changeset@2.4.0:
+    resolution: {integrity: sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-drop-indicator@0.1.3:
+    resolution: {integrity: sha512-fJV6G2tHIVXZLUuc60fS9ly1/GuGOlAZUm67S1El+kGFUYh27Hyv6hcGx3rrJ+Q/JZL5jnyAibIZYYWpPqE45g==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-model@1.25.4:
+    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+
+  prosemirror-safari-ime-span@1.0.2:
+    resolution: {integrity: sha512-QJqD8s1zE/CuK56kDsUhndh5hiHh/gFnAuPOA9ytva2s85/ZEt2tNWeALTJN48DtWghSKOmiBsvVn2OlnJ5H2w==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-transform@1.11.0:
+    resolution: {integrity: sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==}
+
+  prosemirror-view@1.41.7:
+    resolution: {integrity: sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==}
+
+  prosemirror-virtual-cursor@0.4.2:
+    resolution: {integrity: sha512-pUMKnIuOhhnMcgIJUjhIQTVJruBEGxfMBVQSrK0g2qhGPDm1i12KdsVaFw15dYk+29tZcxjMeR7P5VDKwmbwJg==}
+    peerDependencies:
+      prosemirror-model: ^1.0.0
+      prosemirror-state: ^1.0.0
+      prosemirror-view: ^1.0.0
+    peerDependenciesMeta:
+      prosemirror-model:
+        optional: true
+      prosemirror-state:
+        optional: true
+      prosemirror-view:
+        optional: true
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2895,6 +3604,12 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-medium-image-zoom@5.4.1:
     resolution: {integrity: sha512-DD2iZYaCfAwiQGR8AN62r/cDJYoXhezlYJc5HY4TzBUGuGge43CptG0f7m0PEIM72aN6GfpjohvY1yYdtCJB7g==}
@@ -2980,6 +3695,12 @@ packages:
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
+  remark-inline-links@7.0.0:
+    resolution: {integrity: sha512-4uj1pPM+F495ySZhTIB6ay2oSkTsKgmYaKk/q5HIdhX2fuyLEegpjWa0VdJRJ01sgOqAFo7MBKdDUejIYBMVMQ==}
+
+  remark-math@6.0.0:
+    resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
+
   remark-mdx@3.1.1:
     resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
 
@@ -3002,6 +3723,14 @@ packages:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  rolldown@1.0.0-rc.10:
+    resolution: {integrity: sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   s-js@0.4.9:
     resolution: {integrity: sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ==}
@@ -3057,6 +3786,9 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-xml-to-json@1.2.4:
     resolution: {integrity: sha512-3MY16e0ocMHL7N1ufpdObURGyX+lCo0T/A+y6VCwosLdH1HSda4QZl1Sdt/O+2qWp48WFi26XEp5rF0LoaL0Dg==}
     engines: {node: '>=20.12.2'}
@@ -3075,9 +3807,15 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stage-js@1.0.1:
     resolution: {integrity: sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw==}
     engines: {node: '>=18.0'}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -3088,6 +3826,9 @@ packages:
   strtok3@6.3.0:
     resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
     engines: {node: '>=10'}
+
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -3125,6 +3866,9 @@ packages:
   three@0.177.0:
     resolution: {integrity: sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
@@ -3135,6 +3879,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   token-types@4.2.1:
     resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
@@ -3269,6 +4017,95 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.0.1:
+    resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vue@3.5.30:
+    resolution: {integrity: sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -3280,14 +4117,35 @@ packages:
       '@types/emscripten':
         optional: true
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xml-parse-from-string@1.0.1:
     resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
@@ -3518,10 +4376,301 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+
+  '@codemirror/lang-angular@0.1.4':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.2
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@codemirror/lang-cpp@6.0.3':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@lezer/cpp': 1.1.5
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/css': 1.3.2
+
+  '@codemirror/lang-go@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/go': 1.0.1
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/css': 1.3.2
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-java@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@lezer/java': 1.1.3
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-jinja@6.0.0':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.2
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-less@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.2
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@codemirror/lang-liquid@6.3.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/markdown': 1.6.3
+
+  '@codemirror/lang-php@6.0.2':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/php': 1.0.5
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/python': 1.1.18
+
+  '@codemirror/lang-rust@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@lezer/rust': 1.0.2
+
+  '@codemirror/lang-sass@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/sass': 1.1.0
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@codemirror/lang-vue@0.1.3':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.2
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@codemirror/lang-wast@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@codemirror/lang-xml@6.1.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/xml': 1.0.6
+
+  '@codemirror/lang-yaml@6.1.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+      '@lezer/yaml': 1.0.4
+
+  '@codemirror/language-data@6.5.2':
+    dependencies:
+      '@codemirror/lang-angular': 0.1.4
+      '@codemirror/lang-cpp': 6.0.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-go': 6.0.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-java': 6.0.2
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/lang-jinja': 6.0.0
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-less': 6.0.2
+      '@codemirror/lang-liquid': 6.3.2
+      '@codemirror/lang-markdown': 6.5.0
+      '@codemirror/lang-php': 6.0.2
+      '@codemirror/lang-python': 6.2.1
+      '@codemirror/lang-rust': 6.0.2
+      '@codemirror/lang-sass': 6.0.2
+      '@codemirror/lang-sql': 6.10.0
+      '@codemirror/lang-vue': 0.1.3
+      '@codemirror/lang-wast': 6.0.2
+      '@codemirror/lang-xml': 6.1.0
+      '@codemirror/lang-yaml': 6.1.2
+      '@codemirror/language': 6.12.2
+      '@codemirror/legacy-modes': 6.5.2
+
+  '@codemirror/language@6.12.2':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+      style-mod: 4.1.3
+
+  '@codemirror/legacy-modes@6.5.2':
+    dependencies:
+      '@codemirror/language': 6.12.2
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      crelt: 1.0.6
+
+  '@codemirror/search@6.6.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/highlight': 1.2.3
+
+  '@codemirror/view@6.40.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@dimforge/rapier2d-simd-compat@0.17.3':
     optional: true
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@emnapi/core@1.9.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3987,6 +5136,101 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lezer/common@1.5.1': {}
+
+  '@lezer/cpp@1.1.5':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/css@1.3.2':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/go@1.0.1':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/java@1.1.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/lr@1.4.8':
+    dependencies:
+      '@lezer/common': 1.5.1
+
+  '@lezer/markdown@1.6.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+
+  '@lezer/php@1.0.5':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/python@1.1.18':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/rust@1.0.2':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/sass@1.1.0':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/xml@1.0.6':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/yaml@1.0.4':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@marijn/find-cluster-break@1.0.2': {}
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.8
@@ -4017,6 +5261,296 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@milkdown/components@7.19.0(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(typescript@5.9.3)':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@floating-ui/dom': 1.7.6
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/exception': 7.19.0
+      '@milkdown/plugin-tooltip': 7.19.0
+      '@milkdown/preset-commonmark': 7.19.0
+      '@milkdown/preset-gfm': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/transformer': 7.19.0
+      '@milkdown/utils': 7.19.0
+      '@types/lodash-es': 4.17.12
+      clsx: 2.1.1
+      dompurify: 3.3.3
+      lodash-es: 4.17.23
+      nanoid: 5.1.7
+      unist-util-visit: 5.1.0
+      vue: 3.5.30(typescript@5.9.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@milkdown/core@7.19.0':
+    dependencies:
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/exception': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/transformer': 7.19.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/crepe@7.19.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7)(typescript@5.9.3)':
+    dependencies:
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.2
+      '@codemirror/language-data': 6.5.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.40.0
+      '@milkdown/kit': 7.19.0(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(typescript@5.9.3)
+      '@types/lodash-es': 4.17.12
+      clsx: 2.1.1
+      codemirror: 6.0.2
+      katex: 0.16.40
+      lodash-es: 4.17.23
+      prosemirror-virtual-cursor: 0.4.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7)
+      remark-math: 6.0.0
+      unist-util-visit: 5.1.0
+      vue: 3.5.30(typescript@5.9.3)
+    transitivePeerDependencies:
+      - prosemirror-model
+      - prosemirror-state
+      - prosemirror-view
+      - supports-color
+      - typescript
+
+  '@milkdown/ctx@7.19.0':
+    dependencies:
+      '@milkdown/exception': 7.19.0
+
+  '@milkdown/exception@7.19.0': {}
+
+  '@milkdown/kit@7.19.0(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(typescript@5.9.3)':
+    dependencies:
+      '@milkdown/components': 7.19.0(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(typescript@5.9.3)
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/plugin-block': 7.19.0
+      '@milkdown/plugin-clipboard': 7.19.0
+      '@milkdown/plugin-cursor': 7.19.0
+      '@milkdown/plugin-history': 7.19.0
+      '@milkdown/plugin-indent': 7.19.0
+      '@milkdown/plugin-listener': 7.19.0
+      '@milkdown/plugin-slash': 7.19.0
+      '@milkdown/plugin-tooltip': 7.19.0
+      '@milkdown/plugin-trailing': 7.19.0
+      '@milkdown/plugin-upload': 7.19.0
+      '@milkdown/preset-commonmark': 7.19.0
+      '@milkdown/preset-gfm': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/transformer': 7.19.0
+      '@milkdown/utils': 7.19.0
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
+      - supports-color
+      - typescript
+
+  '@milkdown/plugin-block@7.19.0':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/utils': 7.19.0
+      '@types/lodash-es': 4.17.12
+      lodash-es: 4.17.23
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/plugin-clipboard@7.19.0':
+    dependencies:
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/utils': 7.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/plugin-cursor@7.19.0':
+    dependencies:
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/utils': 7.19.0
+      prosemirror-drop-indicator: 0.1.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/plugin-history@7.19.0':
+    dependencies:
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/utils': 7.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/plugin-indent@7.19.0':
+    dependencies:
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/utils': 7.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/plugin-listener@7.19.0':
+    dependencies:
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@types/lodash-es': 4.17.12
+      lodash-es: 4.17.23
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/plugin-slash@7.19.0':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/utils': 7.19.0
+      '@types/lodash-es': 4.17.12
+      lodash-es: 4.17.23
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/plugin-tooltip@7.19.0':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/utils': 7.19.0
+      '@types/lodash-es': 4.17.12
+      lodash-es: 4.17.23
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/plugin-trailing@7.19.0':
+    dependencies:
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/utils': 7.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/plugin-upload@7.19.0':
+    dependencies:
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/exception': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/utils': 7.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/preset-commonmark@7.19.0':
+    dependencies:
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/exception': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/transformer': 7.19.0
+      '@milkdown/utils': 7.19.0
+      remark-inline-links: 7.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/preset-gfm@7.19.0':
+    dependencies:
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/exception': 7.19.0
+      '@milkdown/preset-commonmark': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/transformer': 7.19.0
+      '@milkdown/utils': 7.19.0
+      prosemirror-safari-ime-span: 1.0.2
+      remark-gfm: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/prose@7.19.0':
+    dependencies:
+      '@milkdown/exception': 7.19.0
+      prosemirror-changeset: 2.4.0
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+
+  '@milkdown/react@7.19.0(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+    dependencies:
+      '@milkdown/crepe': 7.19.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7)(typescript@5.9.3)
+      '@milkdown/kit': 7.19.0(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(typescript@5.9.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
+      - prosemirror-model
+      - prosemirror-state
+      - prosemirror-view
+      - supports-color
+      - typescript
+
+  '@milkdown/theme-nord@7.19.0':
+    dependencies:
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/prose': 7.19.0
+      clsx: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/transformer@7.19.0':
+    dependencies:
+      '@milkdown/exception': 7.19.0
+      '@milkdown/prose': 7.19.0
+      remark: 15.0.1
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@milkdown/utils@7.19.0':
+    dependencies:
+      '@milkdown/core': 7.19.0
+      '@milkdown/ctx': 7.19.0
+      '@milkdown/exception': 7.19.0
+      '@milkdown/prose': 7.19.0
+      '@milkdown/transformer': 7.19.0
+      nanoid: 5.1.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@16.1.6': {}
 
   '@next/swc-darwin-arm64@16.1.6':
@@ -4042,6 +5576,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
+
+  '@ocavue/utils@1.6.0': {}
 
   '@opentui/core-darwin-arm64@0.1.88': {}
 
@@ -4100,6 +5636,8 @@ snapshots:
       - web-tree-sitter
 
   '@orama/orama@3.1.18': {}
+
+  '@oxc-project/types@0.120.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -4530,6 +6068,57 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.10': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
+
   '@shikijs/core@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -4744,9 +6333,21 @@ snapshots:
 
   '@tsconfig/bun@1.0.10': {}
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -4763,6 +6364,14 @@ snapshots:
   '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/katex@0.16.8': {}
+
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.24
+
+  '@types/lodash@4.17.24': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -4786,9 +6395,18 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.5.0
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4883,6 +6501,106 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitejs/plugin-react@6.0.1(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)
+
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vue/compiler-core@3.5.30':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/shared': 3.5.30
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.30':
+    dependencies:
+      '@vue/compiler-core': 3.5.30
+      '@vue/shared': 3.5.30
+
+  '@vue/compiler-sfc@3.5.30':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/compiler-core': 3.5.30
+      '@vue/compiler-dom': 3.5.30
+      '@vue/compiler-ssr': 3.5.30
+      '@vue/shared': 3.5.30
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.8
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.30':
+    dependencies:
+      '@vue/compiler-dom': 3.5.30
+      '@vue/shared': 3.5.30
+
+  '@vue/reactivity@3.5.30':
+    dependencies:
+      '@vue/shared': 3.5.30
+
+  '@vue/runtime-core@3.5.30':
+    dependencies:
+      '@vue/reactivity': 3.5.30
+      '@vue/shared': 3.5.30
+
+  '@vue/runtime-dom@3.5.30':
+    dependencies:
+      '@vue/reactivity': 3.5.30
+      '@vue/runtime-core': 3.5.30
+      '@vue/shared': 3.5.30
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.30
+      '@vue/shared': 3.5.30
+      vue: 3.5.30(typescript@5.9.3)
+
+  '@vue/shared@3.5.30': {}
+
   '@webgpu/types@0.1.69':
     optional: true
 
@@ -4910,6 +6628,8 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -5002,6 +6722,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -5022,13 +6744,27 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.2
+      '@codemirror/lint': 6.9.5
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+
   collapse-white-space@2.1.0: {}
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@8.3.0: {}
+
   compute-scroll-into-view@3.1.1: {}
 
   convert-source-map@2.0.0: {}
+
+  crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5064,6 +6800,10 @@ snapshots:
 
   diff@8.0.3: {}
 
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   electron-to-chromium@1.5.321: {}
 
   enhanced-resolve@5.20.0:
@@ -5074,6 +6814,8 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  es-module-lexer@2.0.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -5221,6 +6963,8 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -5232,6 +6976,8 @@ snapshots:
   events@3.3.0: {}
 
   exif-parser@0.1.12: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -5285,6 +7031,9 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
 
   fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@babel/core@7.28.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
     dependencies:
@@ -5421,6 +7170,18 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  happy-dom@20.8.4:
+    dependencies:
+      '@types/node': 25.5.0
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -5541,6 +7302,8 @@ snapshots:
 
   html-entities@2.3.3: {}
 
+  html-url-attributes@3.0.1: {}
+
   html-void-elements@3.0.0: {}
 
   ieee754@1.2.1: {}
@@ -5634,6 +7397,10 @@ snapshots:
 
   json5@2.2.3: {}
 
+  katex@0.16.40:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -5646,34 +7413,67 @@ snapshots:
   lightningcss-android-arm64@1.31.1:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.31.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.31.1:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.31.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.31.1:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.31.1:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.31.1:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.31.1:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.31.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.31.1:
@@ -5692,6 +7492,22 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
 
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   locate-path@3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -5700,6 +7516,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.17.23: {}
 
   longest-streak@3.1.0: {}
 
@@ -5724,6 +7542,12 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@17.0.1: {}
+
+  mdast-util-definitions@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.1.0
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -5803,6 +7627,18 @@ snapshots:
       mdast-util-gfm-table: 2.0.0
       mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-math@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      longest-streak: 3.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5963,6 +7799,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.40
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-extension-mdx-expression@3.0.1:
@@ -6184,6 +8030,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.7: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
@@ -6223,6 +8071,8 @@ snapshots:
 
   npm-to-yarn@3.0.1: {}
 
+  obug@2.1.1: {}
+
   omggif@1.0.10: {}
 
   oniguruma-parser@0.12.1: {}
@@ -6241,6 +8091,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  orderedmap@2.1.1: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -6300,6 +8152,8 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
+  pathe@2.0.3: {}
+
   peek-readable@4.1.0: {}
 
   picocolors@1.1.1: {}
@@ -6348,12 +8202,122 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  prosemirror-changeset@2.4.0:
+    dependencies:
+      prosemirror-transform: 1.11.0
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-drop-indicator@0.1.3:
+    dependencies:
+      '@ocavue/utils': 1.6.0
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.7
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.7
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-model@1.25.4:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-safari-ime-span@1.0.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.7
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+
+  prosemirror-transform@1.11.0:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-view@1.41.7:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-virtual-cursor@0.4.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7):
+    optionalDependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.7
+
   punycode@2.3.1: {}
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.4
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-medium-image-zoom@5.4.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -6467,6 +8431,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remark-inline-links@7.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-definitions: 6.0.0
+      unist-util-visit: 5.1.0
+
+  remark-math@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-math: 3.0.0
+      micromark-extension-math: 3.1.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-mdx@3.1.1:
     dependencies:
       mdast-util-mdx: 3.0.0
@@ -6513,6 +8492,29 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rolldown@1.0.0-rc.10:
+    dependencies:
+      '@oxc-project/types': 0.120.0
+      '@rolldown/pluginutils': 1.0.0-rc.10
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.10
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.10
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.10
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.10
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.10
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.10
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.10
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
+
+  rope-sequence@1.3.4: {}
 
   s-js@0.4.9: {}
 
@@ -6596,6 +8598,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   simple-xml-to-json@1.2.4: {}
 
   solid-js@1.9.11:
@@ -6610,8 +8614,12 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   stage-js@1.0.1:
     optional: true
+
+  std-env@4.0.0: {}
 
   string_decoder@1.3.0:
     dependencies:
@@ -6626,6 +8634,8 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
       peek-readable: 4.1.0
+
+  style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
     dependencies:
@@ -6653,6 +8663,8 @@ snapshots:
   three@0.177.0:
     optional: true
 
+  tinybench@2.9.0: {}
+
   tinycolor2@1.6.0: {}
 
   tinyexec@1.0.4: {}
@@ -6661,6 +8673,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   token-types@4.2.1:
     dependencies:
@@ -6800,15 +8814,77 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.10
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.5.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.0(@types/node@25.5.0)(happy-dom@20.8.4)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+      happy-dom: 20.8.4
+    transitivePeerDependencies:
+      - msw
+
+  vue@3.5.30(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.30
+      '@vue/compiler-sfc': 3.5.30
+      '@vue/runtime-dom': 3.5.30
+      '@vue/server-renderer': 3.5.30(vue@3.5.30(typescript@5.9.3))
+      '@vue/shared': 3.5.30
+    optionalDependencies:
+      typescript: 5.9.3
+
+  w3c-keyname@2.2.8: {}
+
   web-namespaces@2.0.1: {}
 
   web-tree-sitter@0.25.10: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
+
+  ws@8.20.0: {}
 
   xml-parse-from-string@1.0.1: {}
 

--- a/src/command-center/discovery.test.ts
+++ b/src/command-center/discovery.test.ts
@@ -184,6 +184,8 @@ describe("computeGoalProgress", () => {
         priority: 1,
         created: "2026-01-01T00:00:00Z",
         updated: "2026-01-01T00:00:00Z",
+        assignee: null,
+        specialty: null,
       },
     ];
     const tasks = [
@@ -210,6 +212,8 @@ describe("computeGoalProgress", () => {
         priority: 1,
         created: "2026-01-01T00:00:00Z",
         updated: "2026-01-01T00:00:00Z",
+        assignee: null,
+        specialty: null,
       },
     ];
 

--- a/src/command-center/server.ts
+++ b/src/command-center/server.ts
@@ -21,6 +21,7 @@ import {
 } from "../lib/task-store.ts";
 import { readEvents, type OrchestratorEvent } from "../lib/event-log.ts";
 import { extractMarks, calculateStats, tagContent } from "../lib/authorship.ts";
+import { loadPlans, markPlanDone } from "../lib/plan-store.ts";
 
 export function createApp(): Hono {
   const app = new Hono();
@@ -135,7 +136,7 @@ export function createApp(): Hono {
     return c.json({ ok: true, deleted: taskId });
   });
 
-  // List plan files
+  // List plan files with status metadata
   app.get("/api/project/:name/plans", (c) => {
     const name = c.req.param("name");
     const sessions = discoverSessions();
@@ -144,15 +145,14 @@ export function createApp(): Hono {
       return c.json({ error: "Session not found" }, 404);
     }
 
-    const plansDir = join(session.dir, "plans");
-    if (!existsSync(plansDir)) {
-      return c.json({ plans: [] });
-    }
-
-    const plans = readdirSync(plansDir)
-      .filter((f) => f.endsWith(".md"))
-      .sort()
-      .map((f) => ({ name: f.replace(/\.md$/, ""), path: f }));
+    const plans = loadPlans(session.dir).map((p) => ({
+      name: p.name,
+      path: `${p.name}.md`,
+      title: p.title,
+      status: p.status,
+      effort: p.effort ?? null,
+      completed: p.completed ?? null,
+    }));
 
     return c.json({ plans });
   });
@@ -232,6 +232,25 @@ export function createApp(): Hono {
 
     unlinkSync(filePath);
     return c.json({ ok: true, deleted: safeName });
+  });
+
+  // Mark a plan as done
+  app.post("/api/project/:name/plans/:filename/done", (c) => {
+    const name = c.req.param("name");
+    const filename = c.req.param("filename");
+    const sessions = discoverSessions();
+    const session = sessions.find((s) => s.name === name);
+    if (!session) {
+      return c.json({ error: "Session not found" }, 404);
+    }
+
+    const safeName = filename.replace(/[^a-zA-Z0-9_\-. ]/g, "").replace(/\.md$/, "");
+    const result = markPlanDone(session.dir, safeName);
+    if (!result) {
+      return c.json({ error: "Plan not found" }, 404);
+    }
+
+    return c.json({ ok: true, plan: result });
   });
 
   app.get("/api/project/:name/diff", (c) => {

--- a/src/lib/event-log.ts
+++ b/src/lib/event-log.ts
@@ -7,7 +7,9 @@ export type EventType =
   | "completion"
   | "retry"
   | "reconcile"
-  | "error";
+  | "error"
+  | "task_created"
+  | "status_change";
 
 export interface OrchestratorEvent {
   timestamp: string;

--- a/src/lib/orchestrator.test.ts
+++ b/src/lib/orchestrator.test.ts
@@ -314,6 +314,8 @@ describe("buildTaskPrompt", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     });
 
     const task = makeTask({

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -295,7 +295,7 @@ export function dispatch(
 
 // --- Goal-level dispatch (planner agents) ---
 
-function matchesSpecialty(goalSpecialty: string | undefined, plannerSpecialties: string[]): boolean {
+function matchesSpecialty(goalSpecialty: string | null, plannerSpecialties: string[]): boolean {
   if (!goalSpecialty) return true; // no specialty = any planner
   if (plannerSpecialties.length === 0) return true; // no planner specialty = takes anything
   const goalTags = goalSpecialty.split(",").map((s) => s.trim().toLowerCase());

--- a/src/lib/plan-store.test.ts
+++ b/src/lib/plan-store.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadPlans, listPlans, markPlanDone, getPlan } from "./plan-store.ts";
+
+let tmpDir: string;
+
+function writePlan(name: string, content: string) {
+  const dir = join(tmpDir, "plans");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${name}.md`), content);
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "tmux-ide-plans-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadPlans", () => {
+  it("returns empty when plans/ does not exist", () => {
+    assert.deepStrictEqual(loadPlans(tmpDir), []);
+  });
+
+  it("loads plans and parses status", () => {
+    writePlan(
+      "01-mouse-support",
+      '# Plan 01: Mouse Support\n\n**Status:** `done`\n**Effort:** Low\n',
+    );
+    writePlan(
+      "70-hierarchical-agents",
+      '# Plan 70: Hierarchical Agents\n\n**Status:** `in-progress`\n**Effort:** High\n**Gate:** agents work\n',
+    );
+
+    const plans = loadPlans(tmpDir);
+    assert.strictEqual(plans.length, 2);
+    assert.strictEqual(plans[0]!.name, "01-mouse-support");
+    assert.strictEqual(plans[0]!.status, "done");
+    assert.strictEqual(plans[0]!.effort, "Low");
+    assert.strictEqual(plans[1]!.name, "70-hierarchical-agents");
+    assert.strictEqual(plans[1]!.status, "in-progress");
+    assert.strictEqual(plans[1]!.gate, "agents work");
+  });
+
+  it("skips ROADMAP.md", () => {
+    writePlan("ROADMAP", "# Roadmap\n");
+    writePlan("01-test", "# Test\n\n**Status:** `pending`\n");
+
+    const plans = loadPlans(tmpDir);
+    assert.strictEqual(plans.length, 1);
+    assert.strictEqual(plans[0]!.name, "01-test");
+  });
+
+  it("defaults to pending when no status found", () => {
+    writePlan("99-no-status", "# No Status Plan\n\nJust content.\n");
+    const plans = loadPlans(tmpDir);
+    assert.strictEqual(plans[0]!.status, "pending");
+  });
+});
+
+describe("listPlans", () => {
+  it("filters by status", () => {
+    writePlan("01-done", "# Done\n\n**Status:** `done`\n");
+    writePlan("02-pending", "# Pending\n\n**Status:** `pending`\n");
+    writePlan("03-active", "# Active\n\n**Status:** `in-progress`\n");
+
+    const done = listPlans(tmpDir, { status: "done" });
+    assert.strictEqual(done.length, 1);
+    assert.strictEqual(done[0]!.name, "01-done");
+
+    const active = listPlans(tmpDir, { status: "in-progress" });
+    assert.strictEqual(active.length, 1);
+    assert.strictEqual(active[0]!.name, "03-active");
+  });
+
+  it("returns all when no filter", () => {
+    writePlan("01-a", "# A\n\n**Status:** `done`\n");
+    writePlan("02-b", "# B\n\n**Status:** `pending`\n");
+
+    assert.strictEqual(listPlans(tmpDir).length, 2);
+  });
+});
+
+describe("markPlanDone", () => {
+  it("updates status to done and adds completed date", () => {
+    writePlan("50-task-cli", "# Plan 50: Task CLI\n\n**Status:** `in-progress`\n**Effort:** Medium\n");
+
+    const result = markPlanDone(tmpDir, "50");
+    assert.ok(result);
+    assert.strictEqual(result!.status, "done");
+    assert.ok(result!.completed);
+
+    // Verify file was updated
+    const content = readFileSync(join(tmpDir, "plans", "50-task-cli.md"), "utf-8");
+    assert.ok(content.includes("**Status:** `done`"));
+    assert.ok(content.includes("**Completed:**"));
+  });
+
+  it("matches by full name", () => {
+    writePlan("my-plan", "# My Plan\n\n**Status:** `pending`\n");
+    const result = markPlanDone(tmpDir, "my-plan");
+    assert.ok(result);
+    assert.strictEqual(result!.status, "done");
+  });
+
+  it("matches by number prefix", () => {
+    writePlan("70-hierarchical-agents", "# Plan 70\n\n**Status:** `in-progress`\n");
+    const result = markPlanDone(tmpDir, "70");
+    assert.ok(result);
+  });
+
+  it("returns null for non-existent plan", () => {
+    assert.strictEqual(markPlanDone(tmpDir, "nonexistent"), null);
+  });
+
+  it("preserves existing completed date format on re-mark", () => {
+    writePlan("01-test", "# Test\n\n**Status:** `done`\n**Completed:** 2026-01-01\n");
+    const result = markPlanDone(tmpDir, "01");
+    assert.ok(result);
+    // Should update the date
+    assert.notStrictEqual(result!.completed, "2026-01-01");
+  });
+});
+
+describe("getPlan", () => {
+  it("finds by name", () => {
+    writePlan("50-task-cli", "# Plan 50\n\n**Status:** `done`\n");
+    const plan = getPlan(tmpDir, "50-task-cli");
+    assert.ok(plan);
+    assert.strictEqual(plan!.name, "50-task-cli");
+  });
+
+  it("finds by number prefix", () => {
+    writePlan("50-task-cli", "# Plan 50\n\n**Status:** `done`\n");
+    const plan = getPlan(tmpDir, "50");
+    assert.ok(plan);
+  });
+
+  it("returns null when not found", () => {
+    assert.strictEqual(getPlan(tmpDir, "99"), null);
+  });
+});

--- a/src/lib/plan-store.ts
+++ b/src/lib/plan-store.ts
@@ -1,0 +1,147 @@
+import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+export type PlanStatus = "pending" | "in-progress" | "done" | "archived";
+
+export interface PlanMeta {
+  name: string; // filename without .md
+  path: string; // relative path from project root
+  title: string; // first # heading
+  status: PlanStatus;
+  effort?: string;
+  gate?: string;
+  completed?: string; // ISO date when marked done
+}
+
+/**
+ * Parse plan status from the **Status:** `xxx` pattern used in plan files.
+ */
+function parseInlineStatus(content: string): PlanStatus {
+  const match = content.match(/\*\*Status:\*\*\s*`([^`]+)`/);
+  if (!match) return "pending";
+  const raw = match[1]!.toLowerCase().trim();
+  if (raw === "done" || raw === "completed") return "done";
+  if (raw === "in-progress" || raw === "in progress" || raw === "active") return "in-progress";
+  if (raw === "archived") return "archived";
+  return "pending";
+}
+
+function parseInlineField(content: string, field: string): string | undefined {
+  const re = new RegExp(`\\*\\*${field}:\\*\\*\\s*(.+?)\\s*$`, "m");
+  const match = content.match(re);
+  return match ? match[1]!.replace(/^`|`$/g, "").trim() : undefined;
+}
+
+function parseTitle(content: string): string {
+  const match = content.match(/^#\s+(.+)/m);
+  return match ? match[1]!.trim() : "(untitled)";
+}
+
+/**
+ * Load all plan files from plans/ directory.
+ */
+export function loadPlans(dir: string): PlanMeta[] {
+  const plansDir = join(dir, "plans");
+  if (!existsSync(plansDir)) return [];
+
+  return readdirSync(plansDir)
+    .filter((f) => f.endsWith(".md") && f !== "ROADMAP.md")
+    .sort()
+    .map((f) => {
+      const content = readFileSync(join(plansDir, f), "utf-8");
+      return {
+        name: f.replace(/\.md$/, ""),
+        path: `plans/${f}`,
+        title: parseTitle(content),
+        status: parseInlineStatus(content),
+        effort: parseInlineField(content, "Effort"),
+        gate: parseInlineField(content, "Gate"),
+        completed: parseInlineField(content, "Completed"),
+      };
+    });
+}
+
+/**
+ * List plans filtered by status.
+ */
+export function listPlans(
+  dir: string,
+  filter?: { status?: PlanStatus },
+): PlanMeta[] {
+  const plans = loadPlans(dir);
+  if (filter?.status) {
+    return plans.filter((p) => p.status === filter.status);
+  }
+  return plans;
+}
+
+/**
+ * Mark a plan as done. Updates the **Status:** line and adds **Completed:** date.
+ */
+export function markPlanDone(dir: string, nameOrNumber: string): PlanMeta | null {
+  const plansDir = join(dir, "plans");
+  if (!existsSync(plansDir)) return null;
+
+  // Find the plan file — match by name, number prefix, or full filename
+  const files = readdirSync(plansDir).filter((f) => f.endsWith(".md"));
+  const target = files.find(
+    (f) =>
+      f === `${nameOrNumber}.md` ||
+      f.replace(/\.md$/, "") === nameOrNumber ||
+      f.startsWith(`${nameOrNumber}-`),
+  );
+
+  if (!target) return null;
+
+  const filePath = join(plansDir, target);
+  let content = readFileSync(filePath, "utf-8");
+  const today = new Date().toISOString().split("T")[0]!;
+
+  // Update status
+  if (content.match(/\*\*Status:\*\*\s*`[^`]+`/)) {
+    content = content.replace(
+      /\*\*Status:\*\*\s*`[^`]+`/,
+      "**Status:** `done`",
+    );
+  }
+
+  // Add or update completed date
+  if (content.match(/\*\*Completed:\*\*/)) {
+    content = content.replace(
+      /\*\*Completed:\*\*\s*.+/,
+      `**Completed:** ${today}`,
+    );
+  } else {
+    // Insert after the Status line
+    content = content.replace(
+      /(\*\*Status:\*\*\s*`done`)/,
+      `$1\n**Completed:** ${today}`,
+    );
+  }
+
+  writeFileSync(filePath, content);
+
+  return {
+    name: target.replace(/\.md$/, ""),
+    path: `plans/${target}`,
+    title: parseTitle(content),
+    status: "done",
+    effort: parseInlineField(content, "Effort"),
+    gate: parseInlineField(content, "Gate"),
+    completed: today,
+  };
+}
+
+/**
+ * Get a single plan by name or number.
+ */
+export function getPlan(dir: string, nameOrNumber: string): PlanMeta | null {
+  const plans = loadPlans(dir);
+  return (
+    plans.find(
+      (p) =>
+        p.name === nameOrNumber ||
+        p.name.startsWith(`${nameOrNumber}-`),
+    ) ?? null
+  );
+}

--- a/src/lib/session-monitor.ts
+++ b/src/lib/session-monitor.ts
@@ -197,7 +197,7 @@ if (isMainModule) {
         try {
           const { createOrchestrator } = await import("./orchestrator.js");
 
-          const orch = config.orchestrator as Record<string, unknown>;
+          const orch = config.orchestrator;
 
           // Build pane specialty map from ide.yml config
           const paneSpecialties = new Map<string, string[]>();
@@ -215,16 +215,16 @@ if (isMainModule) {
           const stopOrchestrator = createOrchestrator({
             session,
             dir: process.cwd(),
-            autoDispatch: config.orchestrator.auto_dispatch ?? true,
-            stallTimeout: config.orchestrator.stall_timeout ?? 300000,
-            pollInterval: config.orchestrator.poll_interval ?? 5000,
-            worktreeRoot: config.orchestrator.worktree_root ?? ".worktrees/",
-            masterPane: config.orchestrator.master_pane ?? null,
-            beforeRun: (orch.before_run as string) ?? null,
-            afterRun: (orch.after_run as string) ?? null,
-            cleanupOnDone: (orch.cleanup_on_done as boolean) ?? false,
-            maxConcurrentAgents: (orch.max_concurrent_agents as number) ?? 10,
-            dispatchMode: (orch.dispatch_mode as "tasks" | "goals") ?? "tasks",
+            autoDispatch: orch.auto_dispatch ?? true,
+            stallTimeout: orch.stall_timeout ?? 300000,
+            pollInterval: orch.poll_interval ?? 5000,
+            worktreeRoot: orch.worktree_root ?? ".worktrees/",
+            masterPane: orch.master_pane ?? null,
+            beforeRun: orch.before_run ?? null,
+            afterRun: orch.after_run ?? null,
+            cleanupOnDone: orch.cleanup_on_done ?? false,
+            maxConcurrentAgents: orch.max_concurrent_agents ?? 10,
+            dispatchMode: orch.dispatch_mode ?? "tasks",
             paneSpecialties,
           });
 

--- a/src/lib/task-store.ts
+++ b/src/lib/task-store.ts
@@ -27,8 +27,8 @@ export interface Goal {
   priority: number;
   created: string;
   updated: string;
-  assignee?: string;
-  specialty?: string;
+  assignee: string | null;
+  specialty: string | null;
 }
 
 export interface Task {
@@ -51,7 +51,28 @@ export interface Task {
   depends_on: string[];
 }
 
-function normalizeTask(raw: Record<string, unknown>): Task {
+function normalizeMission(raw: Record<string, unknown>): Mission {
+  const epoch = "1970-01-01T00:00:00.000Z";
+  return {
+    title: (raw.title as string) ?? "",
+    description: (raw.description as string) ?? "",
+    created: (raw.created as string) ?? epoch,
+    updated: (raw.updated as string) ?? epoch,
+  };
+}
+
+function normalizeGoal(raw: Record<string, unknown>): Goal {
+  const epoch = "1970-01-01T00:00:00.000Z";
+  return {
+    ...(raw as Omit<Goal, "assignee" | "specialty" | "created" | "updated">),
+    created: (raw.created as string) ?? epoch,
+    updated: (raw.updated as string) ?? epoch,
+    assignee: (raw.assignee as string) ?? null,
+    specialty: (raw.specialty as string) ?? null,
+  } as Goal;
+}
+
+export function normalizeTask(raw: Record<string, unknown>): Task {
   const defaults = {
     retryCount: 0,
     maxRetries: 5,
@@ -59,6 +80,14 @@ function normalizeTask(raw: Record<string, unknown>): Task {
     nextRetryAt: null,
     depends_on: [] as string[],
   };
+
+  // Migrate proof.note → proof.notes
+  const proof = raw.proof as Record<string, unknown> | null | undefined;
+  if (proof && "note" in proof && !("notes" in proof)) {
+    proof.notes = proof.note;
+    delete proof.note;
+  }
+
   return {
     ...defaults,
     ...(raw as Omit<Task, "retryCount" | "maxRetries" | "lastError" | "nextRetryAt" | "depends_on">),
@@ -96,7 +125,7 @@ export function ensureTasksDir(dir: string): void {
 export function loadMission(dir: string): Mission | null {
   const path = join(getTasksRoot(dir), "mission.json");
   if (!existsSync(path)) return null;
-  return JSON.parse(readFileSync(path, "utf-8")) as Mission;
+  return normalizeMission(JSON.parse(readFileSync(path, "utf-8")));
 }
 
 export function saveMission(dir: string, mission: Mission): void {
@@ -137,13 +166,13 @@ export function loadGoals(dir: string): Goal[] {
   return readdirSync(goalsDir)
     .filter((f) => f.endsWith(".json"))
     .sort()
-    .map((f) => JSON.parse(readFileSync(join(goalsDir, f), "utf-8")) as Goal);
+    .map((f) => normalizeGoal(JSON.parse(readFileSync(join(goalsDir, f), "utf-8"))));
 }
 
 export function loadGoal(dir: string, id: string): Goal | null {
   const file = findFileById(join(getTasksRoot(dir), "goals"), id);
   if (!file) return null;
-  return JSON.parse(readFileSync(file, "utf-8")) as Goal;
+  return normalizeGoal(JSON.parse(readFileSync(file, "utf-8")));
 }
 
 export function saveGoal(dir: string, goal: Goal): void {

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -1,0 +1,117 @@
+import { resolve } from "node:path";
+import { outputError } from "./lib/output.ts";
+import { loadPlans, listPlans, markPlanDone, getPlan, type PlanStatus } from "./lib/plan-store.ts";
+
+const STATUS_ICONS: Record<PlanStatus, string> = {
+  pending: "○",
+  "in-progress": "●",
+  done: "✓",
+  archived: "▪",
+};
+
+const STATUS_COLORS: Record<PlanStatus, string> = {
+  pending: "\x1b[2m",    // dim
+  "in-progress": "\x1b[33m", // yellow
+  done: "\x1b[32m",      // green
+  archived: "\x1b[2m",   // dim
+};
+
+const RESET = "\x1b[0m";
+
+export async function planCommand(
+  targetDir: string | undefined,
+  {
+    json = false,
+    sub,
+    args = [],
+    values = {},
+  }: {
+    json?: boolean;
+    sub?: string;
+    args?: string[];
+    values?: { status?: string };
+  },
+): Promise<void> {
+  const dir = resolve(targetDir ?? ".");
+
+  switch (sub) {
+    case "list":
+    case undefined: {
+      const statusFilter = values.status as PlanStatus | undefined;
+      const plans = listPlans(dir, statusFilter ? { status: statusFilter } : undefined);
+
+      if (json) {
+        console.log(JSON.stringify(plans, null, 2));
+        return;
+      }
+
+      if (plans.length === 0) {
+        console.log("No plans found.");
+        return;
+      }
+
+      // Group by status
+      const groups: Record<string, typeof plans> = {};
+      for (const p of plans) {
+        (groups[p.status] ??= []).push(p);
+      }
+
+      for (const status of ["in-progress", "pending", "done", "archived"] as PlanStatus[]) {
+        const group = groups[status];
+        if (!group?.length) continue;
+        const color = STATUS_COLORS[status];
+        console.log(`\n${color}${status.toUpperCase()}${RESET}`);
+        for (const p of group) {
+          const icon = STATUS_ICONS[p.status];
+          const completed = p.completed ? ` (${p.completed})` : "";
+          console.log(`  ${color}${icon}${RESET} ${p.name}  ${p.title}${completed}`);
+        }
+      }
+      console.log();
+      break;
+    }
+
+    case "show": {
+      const name = args[0];
+      if (!name) outputError("Usage: tmux-ide plan show <name|number>", "USAGE");
+      const plan = getPlan(dir, name);
+      if (!plan) outputError(`Plan not found: ${name}`, "NOT_FOUND");
+
+      if (json) {
+        console.log(JSON.stringify(plan, null, 2));
+        return;
+      }
+
+      const icon = STATUS_ICONS[plan.status];
+      const color = STATUS_COLORS[plan.status];
+      console.log(`${color}${icon} ${plan.title}${RESET}`);
+      console.log(`  Status: ${plan.status}`);
+      if (plan.effort) console.log(`  Effort: ${plan.effort}`);
+      if (plan.gate) console.log(`  Gate: ${plan.gate}`);
+      if (plan.completed) console.log(`  Completed: ${plan.completed}`);
+      console.log(`  File: ${plan.path}`);
+      break;
+    }
+
+    case "done": {
+      const name = args[0];
+      if (!name) outputError("Usage: tmux-ide plan done <name|number>", "USAGE");
+      const result = markPlanDone(dir, name);
+      if (!result) outputError(`Plan not found: ${name}`, "NOT_FOUND");
+
+      if (json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      console.log(`✓ Plan marked done: ${result.title} (${result.completed})`);
+      break;
+    }
+
+    default:
+      outputError(
+        `Unknown plan subcommand: ${sub}\nUsage: tmux-ide plan [list|show|done] [--status pending|in-progress|done]`,
+        "USAGE",
+      );
+  }
+}

--- a/src/task.test.ts
+++ b/src/task.test.ts
@@ -102,6 +102,8 @@ describe("goals", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     });
     assert.strictEqual(nextGoalId(tmpDir), "02");
   });
@@ -117,6 +119,8 @@ describe("goals", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     });
     const files = readdirSync(join(tmpDir, ".tasks", "goals"));
     assert.strictEqual(files.length, 1);
@@ -135,6 +139,8 @@ describe("goals", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     };
     saveGoal(tmpDir, goal);
     assert.deepStrictEqual(loadGoal(tmpDir, "01"), goal);
@@ -156,6 +162,8 @@ describe("goals", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     });
     const goal = loadGoal(tmpDir, "01")!;
     goal.status = "done";
@@ -177,6 +185,8 @@ describe("goals", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     });
     assert.strictEqual(deleteGoal(tmpDir, "01"), true);
     assert.strictEqual(loadGoal(tmpDir, "01"), null);
@@ -199,6 +209,8 @@ describe("goals", () => {
       priority: 2,
       created: now,
       updated: now,
+      assignee: null,
+      specialty: null,
     });
     saveGoal(tmpDir, {
       id: "01",
@@ -209,6 +221,8 @@ describe("goals", () => {
       priority: 1,
       created: now,
       updated: now,
+      assignee: null,
+      specialty: null,
     });
     const goals = loadGoals(tmpDir);
     assert.strictEqual(goals.length, 2);
@@ -639,6 +653,6 @@ describe("parseProof", () => {
     );
     const loaded = loadTask(tmpDir, "001")!;
     assert.ok(loaded.proof !== null);
-    assert.strictEqual((loaded.proof as Record<string, unknown>).note, "old format proof");
+    assert.strictEqual(loaded.proof!.notes, "old format proof");
   });
 });

--- a/src/task.ts
+++ b/src/task.ts
@@ -208,7 +208,8 @@ function handleGoal(
         priority: parseInt(values.priority ?? "2", 10),
         created: now,
         updated: now,
-        specialty: values.specialty ?? undefined,
+        assignee: null,
+        specialty: values.specialty ?? null,
       };
       saveGoal(dir, goal);
       if (json) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface ProofSchema {
   notes?: string;
 }
 
-export interface OrchestratorConfig {
+export interface OrchestratorYamlConfig {
   enabled?: boolean;
   auto_dispatch?: boolean;
   stall_timeout?: number; // ms, default 300000 (5 min)
@@ -16,6 +16,7 @@ export interface OrchestratorConfig {
   after_run?: string; // shell command to run in worktree after task completes
   cleanup_on_done?: boolean; // remove worktree when task completes (default false)
   dispatch_mode?: "tasks" | "goals"; // default: "tasks" (backward compat)
+  max_concurrent_agents?: number; // default 10
 }
 
 export interface IdeConfig {
@@ -24,7 +25,7 @@ export interface IdeConfig {
   team?: { name: string };
   rows: Row[];
   theme?: ThemeConfig;
-  orchestrator?: OrchestratorConfig;
+  orchestrator?: OrchestratorYamlConfig;
 }
 
 export interface Row {

--- a/src/widgets/warroom/index.tsx
+++ b/src/widgets/warroom/index.tsx
@@ -1,6 +1,4 @@
 import { parseArgs } from "node:util";
-import { readFileSync, readdirSync, existsSync } from "node:fs";
-import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { render, useKeyboard, useTerminalDimensions } from "@opentui/solid";
 import { RGBA, TextAttributes } from "@opentui/core";
@@ -11,7 +9,14 @@ import { MissionHeader } from "./mission-header.tsx";
 import { GoalSection } from "./goal-section.tsx";
 import { type AgentInfo } from "./agent-card.tsx";
 import { ActivityFeed, formatElapsedShort, type ActivityEntry } from "./activity-feed.tsx";
-import type { ProofSchema } from "../../types.ts";
+import {
+  loadMission,
+  loadGoals,
+  loadTasks,
+  type Mission,
+  type Goal,
+  type Task,
+} from "../../lib/task-store.ts";
 
 const { values } = parseArgs({
   options: {
@@ -24,82 +29,6 @@ const { values } = parseArgs({
 const session = values.session ?? "";
 const dir = values.dir ?? process.cwd();
 const themeConfig = values.theme ? JSON.parse(values.theme) : undefined;
-
-// --- Data loaders ---
-
-interface Mission {
-  title: string;
-  description: string;
-}
-
-interface Goal {
-  id: string;
-  title: string;
-  status: string;
-  priority: number;
-}
-
-interface Task {
-  id: string;
-  title: string;
-  status: string;
-  assignee: string | null;
-  goal: string | null;
-  priority: number;
-  updated: string;
-  retryCount?: number;
-  maxRetries?: number;
-  lastError?: string | null;
-  nextRetryAt?: string | null;
-  proof?: ProofSchema | null;
-}
-
-function loadMission(): Mission | null {
-  const path = join(dir, ".tasks", "mission.json");
-  if (!existsSync(path)) return null;
-  try {
-    return JSON.parse(readFileSync(path, "utf-8"));
-  } catch {
-    return null;
-  }
-}
-
-function loadGoals(): Goal[] {
-  const goalsDir = join(dir, ".tasks", "goals");
-  if (!existsSync(goalsDir)) return [];
-  return readdirSync(goalsDir)
-    .filter((f) => f.endsWith(".json"))
-    .sort()
-    .map((f) => {
-      try {
-        return JSON.parse(readFileSync(join(goalsDir, f), "utf-8"));
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean) as Goal[];
-}
-
-function loadTasks(): Task[] {
-  // Try nested .tasks/tasks/ first (CLI format), fall back to flat .tasks/ (widget format)
-  const nestedDir = join(dir, ".tasks", "tasks");
-  const flatDir = join(dir, ".tasks");
-  const tasksDir = existsSync(nestedDir) ? nestedDir : flatDir;
-  if (!existsSync(tasksDir)) return [];
-  return readdirSync(tasksDir)
-    .filter((f) => f.endsWith(".json") && f !== "mission.json")
-    .sort()
-    .map((f) => {
-      try {
-        const data = JSON.parse(readFileSync(join(tasksDir, f), "utf-8"));
-        if (data.id && data.title && data.status) return data;
-        return null;
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean) as Task[];
-}
 
 // --- Agent matching ---
 
@@ -197,9 +126,9 @@ render(
     const theme = createTheme(themeConfig);
     const dimensions = useTerminalDimensions();
 
-    const [mission, setMission] = createSignal(loadMission());
-    const [goals, setGoals] = createSignal(loadGoals());
-    const [tasks, setTasks] = createSignal(loadTasks());
+    const [mission, setMission] = createSignal(loadMission(dir));
+    const [goals, setGoals] = createSignal(loadGoals(dir));
+    const [tasks, setTasks] = createSignal(loadTasks(dir));
     const [panes, setPanes] = createSignal<PaneInfo[]>(session ? listSessionPanes(session) : []);
     const [activity, setActivity] = createSignal<ActivityEntry[]>([]);
     const [selectedAgent, setSelectedAgent] = createSignal(0);
@@ -207,9 +136,9 @@ render(
     // Poll every 2 seconds
     const interval = setInterval(() => {
       const prevTasks = tasks();
-      setMission(loadMission());
-      setGoals(loadGoals());
-      const newTasks = loadTasks();
+      setMission(loadMission(dir));
+      setGoals(loadGoals(dir));
+      const newTasks = loadTasks(dir);
       setTasks(newTasks);
       if (session) setPanes(listSessionPanes(session));
 
@@ -284,9 +213,9 @@ render(
         }
         evt.preventDefault();
       } else if (evt.name === "r") {
-        setMission(loadMission());
-        setGoals(loadGoals());
-        setTasks(loadTasks());
+        setMission(loadMission(dir));
+        setGoals(loadGoals(dir));
+        setTasks(loadTasks(dir));
         if (session) setPanes(listSessionPanes(session));
         evt.preventDefault();
       } else if (evt.name === "q") {


### PR DESCRIPTION
The dashboard has zero tests. Set up Vitest with React Testing Library and write initial tests for the API client functions.

## What to do

1. Install test dependencies in dashboard/:
   ```bash
   cd dashboard
   pnpm add -D vitest @testing-library/react @testing-library/jest-dom happy-dom
   ```

2. Create dashboard/vitest.config.ts:
   ```ts
   import { defineConfig } from 'vitest/config';
   import react from '@vitejs/plugin-react';
   import path from 'path';

   export default defineConfig({
     plugins: [react()],
     test: {
       environment: 'happy-dom',
       globals: true,
     },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, '.'),
       },
     },
   });
   ```

3. Add test script to dashboard/package.json:
   ```json
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest"
   }
   ```

4. Create dashboard/lib/__tests__/api.test.ts with tests for pure functions:

   **Test marksToSections():**
   - Export marksToSections from api.ts (add 'export' keyword)
   - Test with empty marks → empty sections
   - Test with one mark covering a heading section → correct author attribution
   - Test with multiple authors → dominant author wins

   **Test fetchPlan() with mocked fetch:**
   - Mock global.fetch to return {marks, stats, content, name}
   - Verify authorship data is transformed correctly
   - Verify null marks → null authorship

   **Test updateTask() return type:**
   - Mock fetch to return {ok:true, task:{...}}
   - Verify returns Task object (not boolean)

5. Run tests: cd dashboard && pnpm test

## Files to create
- dashboard/vitest.config.ts
- dashboard/lib/__tests__/api.test.ts

## Files to modify
- dashboard/package.json (add test scripts + dev dependencies)
- dashboard/lib/api.ts (export marksToSections)

## Acceptance
- `cd dashboard && pnpm test` runs and passes
- At least 5 test cases covering marksToSections and fetch functions
- Vitest config resolves @ alias correctly

## Proof
Set up Vitest with happy-dom in dashboard. Created vitest.config.ts, added test scripts, exported marksToSections. 9 tests across 3 suites: marksToSections (5 cases: empty, single author, dominant author, multi-section, orphaned), fetchPlan (2 cases: marks→authorship, null marks), updateTask (2 cases: success returns Task, failure returns null). All pass.

Tags: testing, dashboard, vitest, p2