### PR TITLE
Task 044: Add tests for token-tracker.ts and yaml-io.ts

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -66,6 +66,7 @@ const knownCommands = new Set([
   "mission",
   "goal",
   "task",
+  "plan",
   "command-center",
   "help",
 ]);
@@ -280,6 +281,17 @@ try {
           depends: values.depends,
           pr: values.pr,
         },
+      });
+      break;
+    }
+
+    case "plan": {
+      const { planCommand } = await import("../dist/plan.js");
+      await planCommand(null, {
+        json,
+        sub: positionals[1],
+        args: positionals.slice(2),
+        values: { status: values.status },
       });
       break;
     }

--- a/dashboard/components/KanbanBoard.tsx
+++ b/dashboard/components/KanbanBoard.tsx
@@ -229,6 +229,7 @@ export function KanbanBoard({
           task={selectedTask}
           sessionName={sessionName}
           agents={agents}
+          allTasks={tasks}
           onClose={() => setSelectedTaskId(null)}
           onUpdated={onRefresh}
         />

--- a/dashboard/components/PlansPanel.tsx
+++ b/dashboard/components/PlansPanel.tsx
@@ -6,8 +6,10 @@ import {
   fetchPlans,
   fetchPlan,
   savePlan,
+  markPlanDone,
   type PlanSummary,
   type PlanData,
+  type PlanStatus,
   type AuthorshipData,
 } from "@/lib/api";
 import { usePolling } from "@/lib/usePolling";
@@ -17,6 +19,20 @@ import { MarkdownEditor } from "./MarkdownEditor";
 interface PlansPanelProps {
   sessionName: string;
 }
+
+const STATUS_ICONS: Record<PlanStatus, string> = {
+  "in-progress": "●",
+  pending: "○",
+  done: "✓",
+  archived: "▪",
+};
+
+const STATUS_COLORS: Record<PlanStatus, string> = {
+  "in-progress": "var(--yellow)",
+  pending: "var(--dim)",
+  done: "var(--green)",
+  archived: "var(--dimmer)",
+};
 
 interface MarkdownSection {
   heading: string;
@@ -68,7 +84,7 @@ function splitIntoSections(
 
 function isAiAuthor(author: string | null): boolean {
   if (!author) return false;
-  return author.startsWith("ai") || author.toLowerCase().includes("claude") || author.toLowerCase().includes("agent");
+  return author.startsWith("ai");
 }
 
 function formatAuthorTime(at: string | null): string {
@@ -86,14 +102,26 @@ function formatAuthorTime(at: string | null): string {
 
 export function PlansPanel({ sessionName }: PlansPanelProps) {
   const fetcher = useCallback(() => fetchPlans(sessionName), [sessionName]);
-  const { data: plans, loading } = usePolling<PlanSummary[]>(fetcher, 10000);
+  const { data: plans, loading, refresh: refreshPlans } = usePolling<PlanSummary[]>(fetcher, 10000);
 
+  const [statusFilter, setStatusFilter] = useState<PlanStatus | "all">("all");
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [planData, setPlanData] = useState<PlanData>({ content: "", authorship: null });
   const [loadingContent, setLoadingContent] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editContent, setEditContent] = useState("");
   const [saving, setSaving] = useState(false);
+
+  const filteredPlans = useMemo(() => {
+    if (!plans) return [];
+    if (statusFilter === "all") return plans;
+    return plans.filter((p) => p.status === statusFilter);
+  }, [plans, statusFilter]);
+
+  const selectedPlan = useMemo(
+    () => plans?.find((p) => p.path === selectedFile) ?? null,
+    [plans, selectedFile],
+  );
 
   useEffect(() => {
     if (!selectedFile) {
@@ -113,10 +141,10 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
   }, [selectedFile, sessionName]);
 
   useEffect(() => {
-    if (!selectedFile && plans && plans.length > 0) {
-      setSelectedFile(plans[0]!.path);
+    if (!selectedFile && filteredPlans.length > 0) {
+      setSelectedFile(filteredPlans[0]!.path);
     }
-  }, [plans, selectedFile]);
+  }, [filteredPlans, selectedFile]);
 
   const sections = useMemo(
     () => splitIntoSections(planData.content, planData.authorship),
@@ -128,7 +156,6 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
     setSaving(true);
     const ok = await savePlan(sessionName, selectedFile, content);
     if (ok) {
-      // Refresh content from server
       const d = await fetchPlan(sessionName, selectedFile);
       setPlanData(d);
       setEditContent(d.content);
@@ -137,15 +164,16 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
     setSaving(false);
   }
 
-  function handleStartEdit() {
-    setEditContent(planData.content);
-    setEditing(true);
+  async function handleMarkDone() {
+    if (!selectedPlan) return;
+    const ok = await markPlanDone(sessionName, selectedPlan.name);
+    if (ok) refreshPlans();
   }
 
   if (loading && !plans) {
     return (
       <div className="flex-1 flex items-center justify-center text-[var(--dim)]">
-        Loading plans…
+        Loading plans...
       </div>
     );
   }
@@ -158,45 +186,95 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
     );
   }
 
+  // Count by status
+  const counts: Record<string, number> = {};
+  for (const p of plans) counts[p.status] = (counts[p.status] ?? 0) + 1;
+
   return (
     <div className="flex-1 flex min-h-0">
-      {/* File sidebar */}
-      <div className="w-[240px] shrink-0 border-r border-[var(--border)] overflow-y-auto">
-        <div className="h-6 flex items-center px-3 bg-[var(--surface)] border-b border-[var(--border)] text-[10px] text-[var(--dim)] uppercase tracking-wider">
-          Plans ({plans.length})
-        </div>
-        {plans.map((p) => {
-          const isSelected = selectedFile === p.path;
-          return (
+      {/* Sidebar */}
+      <div className="w-[260px] shrink-0 border-r border-[var(--border)] flex flex-col min-h-0">
+        {/* Filter tabs */}
+        <div className="flex items-center h-6 bg-[var(--surface)] border-b border-[var(--border)] text-[10px] shrink-0 px-1 gap-px">
+          {(["all", "in-progress", "pending", "done"] as const).map((s) => (
             <button
-              key={p.path}
-              onClick={() => setSelectedFile(p.path)}
-              className={`w-full text-left h-6 px-3 flex items-center transition-colors truncate ${
-                isSelected
-                  ? "bg-[var(--surface-active)] text-[var(--accent)]"
-                  : "text-[var(--fg)] hover:bg-[var(--surface-hover)]"
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              className={`px-1.5 py-0.5 transition-colors ${
+                statusFilter === s
+                  ? "text-[var(--accent)]"
+                  : "text-[var(--dim)] hover:text-[var(--fg)]"
               }`}
             >
-              {p.name}
+              {s === "all" ? `all (${plans.length})` : `${s} (${counts[s] ?? 0})`}
             </button>
-          );
-        })}
+          ))}
+        </div>
+
+        {/* Plan list */}
+        <div className="flex-1 overflow-y-auto">
+          {filteredPlans.map((p) => {
+            const isSelected = selectedFile === p.path;
+            return (
+              <button
+                key={p.path}
+                onClick={() => setSelectedFile(p.path)}
+                className={`w-full text-left px-2 py-1 flex items-start gap-1.5 transition-colors ${
+                  isSelected
+                    ? "bg-[rgba(255,255,255,0.04)] text-[var(--accent)]"
+                    : "text-[var(--fg)] hover:bg-[rgba(255,255,255,0.02)]"
+                }`}
+              >
+                <span
+                  className="shrink-0 mt-0.5 text-[11px]"
+                  style={{ color: STATUS_COLORS[p.status] }}
+                >
+                  {STATUS_ICONS[p.status]}
+                </span>
+                <span className="min-w-0">
+                  <span className="block truncate text-[12px]">{p.name}</span>
+                  {p.completed && (
+                    <span className="block text-[10px] text-[var(--dimmer)]">
+                      {p.completed}
+                    </span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
+        </div>
       </div>
 
       {/* Content area */}
       <div className="flex-1 flex flex-col min-h-0">
         {loadingContent ? (
           <div className="flex-1 flex items-center justify-center text-[var(--dim)]">
-            loading…
+            loading...
           </div>
         ) : planData.content || editing ? (
           <>
-            {/* Header: authorship bar + edit/view toggle */}
-            <div className="shrink-0 border-b border-[var(--border)] px-3 flex items-center">
-              <div className="flex-1">
+            {/* Header */}
+            <div className="shrink-0 border-b border-[var(--border)] px-3 flex items-center h-7">
+              <div className="flex-1 flex items-center gap-2">
+                {selectedPlan && (
+                  <span
+                    className="text-[11px]"
+                    style={{ color: STATUS_COLORS[selectedPlan.status] }}
+                  >
+                    {STATUS_ICONS[selectedPlan.status]} {selectedPlan.status}
+                  </span>
+                )}
                 <AuthorshipBar authorship={planData.authorship} />
               </div>
               <div className="flex items-center gap-2 shrink-0">
+                {selectedPlan && selectedPlan.status !== "done" && !editing && (
+                  <button
+                    onClick={handleMarkDone}
+                    className="text-[11px] px-2 py-0.5 text-[var(--green)] border border-[var(--border)] hover:border-[var(--green)] transition-colors"
+                  >
+                    mark done
+                  </button>
+                )}
                 {editing && (
                   <>
                     <button
@@ -204,13 +282,15 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
                       disabled={saving}
                       className="text-[11px] px-2 py-0.5 text-[var(--bg)] bg-[var(--accent)] hover:opacity-90 disabled:opacity-50 transition-opacity"
                     >
-                      {saving ? "saving…" : "save"}
+                      {saving ? "saving..." : "save"}
                     </button>
-                    <span className="text-[9px] text-[var(--dimmer)]">⌘S</span>
+                    <span className="text-[9px] text-[var(--dimmer)]">cmd+S</span>
                   </>
                 )}
                 <button
-                  onClick={() => editing ? setEditing(false) : handleStartEdit()}
+                  onClick={() =>
+                    editing ? setEditing(false) : (() => { setEditContent(planData.content); setEditing(true); })()
+                  }
                   className={`text-[11px] px-2 py-0.5 border border-[var(--border)] transition-colors ${
                     editing
                       ? "text-[var(--accent)] border-[var(--accent)]"
@@ -222,7 +302,7 @@ export function PlansPanel({ sessionName }: PlansPanelProps) {
               </div>
             </div>
 
-            {/* Edit or view mode */}
+            {/* Content */}
             {editing ? (
               <MarkdownEditor
                 key={selectedFile}

--- a/dashboard/components/TaskCard.tsx
+++ b/dashboard/components/TaskCard.tsx
@@ -28,6 +28,9 @@ export function TaskCard({ task: t, onClick, selected = false }: TaskCardProps) 
   const prio = priorityDots(t.priority);
   const borderColor = BORDER_COLORS[t.status];
 
+  const testsPass =
+    t.proof?.tests && t.proof.tests.passed === t.proof.tests.total;
+
   return (
     <div
       onClick={onClick}
@@ -43,6 +46,23 @@ export function TaskCard({ task: t, onClick, selected = false }: TaskCardProps) 
           {prio.text}
         </span>
         <span className="text-[var(--dim)] shrink-0">{t.id}</span>
+        <span className="flex-1" />
+        {/* Badges */}
+        {testsPass && (
+          <span className="text-[var(--green)] text-[10px]" title={`${t.proof!.tests!.passed}/${t.proof!.tests!.total} tests`}>
+            ✓
+          </span>
+        )}
+        {t.proof?.pr && (
+          <span className="text-[var(--cyan)] text-[10px]">
+            PR#{t.proof.pr.number}
+          </span>
+        )}
+        {t.depends_on?.length > 0 && (
+          <span className="text-[var(--dim)] text-[10px]" title={`depends: ${t.depends_on.join(", ")}`}>
+            ⇅{t.depends_on.length}
+          </span>
+        )}
       </div>
       <div className="truncate text-[var(--fg)] mt-0.5">{t.title}</div>
       {t.assignee && (

--- a/dashboard/components/TaskDetail.tsx
+++ b/dashboard/components/TaskDetail.tsx
@@ -60,18 +60,11 @@ export function TaskDetail({
 
   async function handleSaveEdit() {
     setSaving(true);
-    await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5050"}/api/project/${encodeURIComponent(sessionName)}/task/${encodeURIComponent(t.id)}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: editTitle.trim(),
-          description: editDesc.trim(),
-          priority: editPriority,
-        }),
-      },
-    );
+    await updateTask(sessionName, t.id, {
+      title: editTitle.trim(),
+      description: editDesc.trim(),
+      priority: editPriority,
+    });
     onUpdated();
     setSaving(false);
     setEditing(false);
@@ -88,7 +81,7 @@ export function TaskDetail({
   const inputClass =
     "w-full bg-[var(--surface)] border border-[var(--border)] text-[var(--fg)] px-2 py-1 outline-none focus:border-[var(--accent)]";
 
-  const proofNote = t.proof?.notes ?? t.proof?.note;
+  const proofNote = t.proof?.notes;
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end">

--- a/dashboard/components/TaskDetail.tsx
+++ b/dashboard/components/TaskDetail.tsx
@@ -8,6 +8,7 @@ interface TaskDetailProps {
   task: Task;
   sessionName: string;
   agents: AgentDetail[];
+  allTasks?: Task[];
   onClose: () => void;
   onUpdated: () => void;
 }
@@ -32,6 +33,7 @@ export function TaskDetail({
   task: t,
   sessionName,
   agents,
+  allTasks = [],
   onClose,
   onUpdated,
 }: TaskDetailProps) {
@@ -58,7 +60,6 @@ export function TaskDetail({
 
   async function handleSaveEdit() {
     setSaving(true);
-    // Use the existing POST endpoint which accepts partial updates
     await fetch(
       `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5050"}/api/project/${encodeURIComponent(sessionName)}/task/${encodeURIComponent(t.id)}`,
       {
@@ -86,6 +87,8 @@ export function TaskDetail({
   const labelClass = "text-[var(--dim)] text-[10px] uppercase tracking-wider mb-1";
   const inputClass =
     "w-full bg-[var(--surface)] border border-[var(--border)] text-[var(--fg)] px-2 py-1 outline-none focus:border-[var(--accent)]";
+
+  const proofNote = t.proof?.notes ?? t.proof?.note;
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
@@ -143,7 +146,7 @@ export function TaskDetail({
             )}
           </div>
 
-          {/* Priority (editable) */}
+          {/* Priority */}
           <div>
             <div className={labelClass}>priority</div>
             {editing ? (
@@ -173,7 +176,7 @@ export function TaskDetail({
             )}
           </div>
 
-          {/* Save edit button */}
+          {/* Save edit */}
           {editing && (
             <button
               onClick={handleSaveEdit}
@@ -233,6 +236,117 @@ export function TaskDetail({
             <div>
               <div className={labelClass}>branch</div>
               <div className="text-[var(--cyan)]">⎇ {t.branch}</div>
+            </div>
+          )}
+
+          {/* Dependencies */}
+          {t.depends_on?.length > 0 && (
+            <div>
+              <div className={labelClass}>depends on</div>
+              <div className="flex gap-2 flex-wrap">
+                {t.depends_on.map((depId) => {
+                  const dep = allTasks.find((d) => d.id === depId);
+                  const done = dep?.status === "done";
+                  return (
+                    <span
+                      key={depId}
+                      className="text-[11px] px-1.5 py-0.5 border border-[var(--border)]"
+                      style={{ color: done ? "var(--green)" : "var(--dim)" }}
+                    >
+                      {done ? "✓" : "○"} {depId}
+                      {dep ? ` ${dep.title.slice(0, 20)}` : ""}
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Proof */}
+          {t.proof && (
+            <div>
+              <div className={labelClass}>proof</div>
+              <div className="space-y-1.5">
+                {t.proof.tests && (
+                  <div
+                    style={{
+                      color:
+                        t.proof.tests.passed === t.proof.tests.total
+                          ? "var(--green)"
+                          : "var(--red)",
+                    }}
+                  >
+                    Tests: {t.proof.tests.passed}/{t.proof.tests.total}{" "}
+                    {t.proof.tests.passed === t.proof.tests.total ? "passing" : "failing"}
+                  </div>
+                )}
+                {t.proof.pr && (
+                  <div>
+                    {t.proof.pr.url ? (
+                      <a
+                        href={t.proof.pr.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[var(--cyan)] hover:underline"
+                      >
+                        PR #{t.proof.pr.number}
+                      </a>
+                    ) : (
+                      <span className="text-[var(--cyan)]">PR #{t.proof.pr.number}</span>
+                    )}
+                    {t.proof.pr.status && (
+                      <span className="text-[var(--dim)] ml-2">{t.proof.pr.status}</span>
+                    )}
+                  </div>
+                )}
+                {t.proof.ci && (
+                  <div className="flex items-center gap-2">
+                    <span
+                      style={{
+                        color:
+                          t.proof.ci.status === "passing" || t.proof.ci.status === "green"
+                            ? "var(--green)"
+                            : "var(--red)",
+                      }}
+                    >
+                      CI: {t.proof.ci.status}
+                    </span>
+                    {t.proof.ci.url && (
+                      <a
+                        href={t.proof.ci.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[var(--cyan)] text-[11px] hover:underline"
+                      >
+                        view
+                      </a>
+                    )}
+                  </div>
+                )}
+                {proofNote && (
+                  <div className="text-[var(--fg)] whitespace-pre-wrap">{proofNote}</div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Retry info */}
+          {t.retryCount > 0 && (
+            <div>
+              <div className={labelClass}>retries</div>
+              <span className="text-[var(--yellow)]">
+                Retried {t.retryCount}/{t.maxRetries} times
+              </span>
+            </div>
+          )}
+
+          {/* Last error */}
+          {t.lastError && (
+            <div>
+              <div className={labelClass}>last error</div>
+              <div className="text-[var(--red)] text-[11px] whitespace-pre-wrap">
+                {t.lastError}
+              </div>
             </div>
           )}
 

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1,4 +1,4 @@
-import type { SessionOverview, ProjectDetail, OrchestratorEvent } from "./types";
+import type { SessionOverview, ProjectDetail, Task } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5050";
 
@@ -53,7 +53,7 @@ export interface EventData {
   taskId?: string;
   agent?: string;
   message: string;
-  relative?: string;
+  relative: string;
 }
 
 export async function fetchEvents(name: string): Promise<EventData[]> {
@@ -69,8 +69,14 @@ export async function fetchEvents(name: string): Promise<EventData[]> {
 export async function updateTask(
   sessionName: string,
   taskId: string,
-  fields: { status?: string; assignee?: string },
-): Promise<boolean> {
+  fields: {
+    status?: string;
+    assignee?: string;
+    title?: string;
+    description?: string;
+    priority?: number;
+  },
+): Promise<Task | null> {
   const res = await fetch(
     `${API_BASE}/api/project/${encodeURIComponent(sessionName)}/task/${encodeURIComponent(taskId)}`,
     {
@@ -79,7 +85,9 @@ export async function updateTask(
       body: JSON.stringify(fields),
     },
   );
-  return res.ok;
+  if (!res.ok) return null;
+  const data = (await res.json()) as { ok: boolean; task: Task };
+  return data.task;
 }
 
 export async function createTask(
@@ -91,7 +99,7 @@ export async function createTask(
     goal?: string;
     tags?: string[];
   },
-): Promise<boolean> {
+): Promise<Task | null> {
   const res = await fetch(
     `${API_BASE}/api/project/${encodeURIComponent(sessionName)}/task`,
     {
@@ -100,7 +108,9 @@ export async function createTask(
       body: JSON.stringify(fields),
     },
   );
-  return res.ok;
+  if (!res.ok) return null;
+  const data = (await res.json()) as { ok: boolean; task: Task };
+  return data.task;
 }
 
 export interface PlanSummary {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1,4 +1,4 @@
-import type { SessionOverview, ProjectDetail, Task } from "./types";
+import type { SessionOverview, ProjectDetail, Task, Mark, AuthorshipStats } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5050";
 
@@ -144,6 +144,78 @@ export interface PlanData {
   authorship: AuthorshipData | null;
 }
 
+/**
+ * Convert character-range marks into section-level authorship summaries.
+ * Each section heading in the markdown gets attributed to the author
+ * who wrote the most characters in that section.
+ */
+function marksToSections(
+  marks: Record<string, Mark>,
+  content: string,
+): Record<string, AuthorshipSection> {
+  // Find section boundaries from heading lines
+  const lines = content.split("\n");
+  const sections: { heading: string; from: number; to: number }[] = [];
+  let offset = 0;
+  let currentHeading = "";
+  let sectionStart = 0;
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^#{1,4}\s+(.+)/);
+    if (headingMatch) {
+      if (currentHeading || offset > 0) {
+        sections.push({ heading: currentHeading, from: sectionStart, to: offset });
+      }
+      currentHeading = headingMatch[1]!.trim();
+      sectionStart = offset;
+    }
+    offset += line.length + 1; // +1 for newline
+  }
+  sections.push({ heading: currentHeading, from: sectionStart, to: offset });
+
+  // For each section, find the dominant author from overlapping marks
+  const result: Record<string, AuthorshipSection> = {};
+  const markList = Object.values(marks).filter((m) => !m.orphaned);
+
+  for (const section of sections) {
+    if (!section.heading) continue;
+    const authorChars: Record<string, { chars: number; latestAt: string }> = {};
+
+    for (const mark of markList) {
+      const overlapFrom = Math.max(mark.range.from, section.from);
+      const overlapTo = Math.min(mark.range.to, section.to);
+      if (overlapFrom >= overlapTo) continue;
+
+      const chars = overlapTo - overlapFrom;
+      const existing = authorChars[mark.by];
+      if (existing) {
+        existing.chars += chars;
+        if (mark.at > existing.latestAt) existing.latestAt = mark.at;
+      } else {
+        authorChars[mark.by] = { chars, latestAt: mark.at };
+      }
+    }
+
+    // Pick the author with the most characters in this section
+    let dominant: { author: string; chars: number; at: string } | null = null;
+    for (const [author, data] of Object.entries(authorChars)) {
+      if (!dominant || data.chars > dominant.chars) {
+        dominant = { author, chars: data.chars, at: data.latestAt };
+      }
+    }
+
+    if (dominant) {
+      result[section.heading] = {
+        author: dominant.author,
+        at: dominant.at,
+        charCount: dominant.chars,
+      };
+    }
+  }
+
+  return result;
+}
+
 export async function fetchPlan(
   name: string,
   filename: string,
@@ -156,9 +228,19 @@ export async function fetchPlan(
   const data = (await res.json()) as {
     name: string;
     content: string;
-    authorship?: AuthorshipData;
+    marks: Record<string, Mark> | null;
+    stats: AuthorshipStats | null;
   };
-  return { content: data.content, authorship: data.authorship ?? null };
+
+  let authorship: AuthorshipData | null = null;
+  if (data.marks && data.stats) {
+    authorship = {
+      sections: marksToSections(data.marks, data.content),
+      stats: data.stats,
+    };
+  }
+
+  return { content: data.content, authorship };
 }
 
 export async function deleteTaskApi(

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -113,9 +113,15 @@ export async function createTask(
   return data.task;
 }
 
+export type PlanStatus = "pending" | "in-progress" | "done" | "archived";
+
 export interface PlanSummary {
   name: string;
   path: string;
+  title: string;
+  status: PlanStatus;
+  effort: string | null;
+  completed: string | null;
 }
 
 export async function fetchPlans(name: string): Promise<PlanSummary[]> {
@@ -126,6 +132,17 @@ export async function fetchPlans(name: string): Promise<PlanSummary[]> {
   if (!res.ok) return [];
   const data = (await res.json()) as { plans: PlanSummary[] };
   return data.plans;
+}
+
+export async function markPlanDone(
+  name: string,
+  filename: string,
+): Promise<boolean> {
+  const res = await fetch(
+    `${API_BASE}/api/project/${encodeURIComponent(name)}/plans/${encodeURIComponent(filename)}/done`,
+    { method: "POST" },
+  );
+  return res.ok;
 }
 
 export interface AuthorshipSection {

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -11,6 +11,14 @@ export interface SessionOverview {
   goals: { id: string; title: string; progress: number }[];
 }
 
+export interface ProofSchema {
+  tests?: { passed: number; total: number };
+  pr?: { number: number; url?: string; status?: string };
+  ci?: { status: string; url?: string };
+  notes?: string;
+  note?: string;
+}
+
 export interface Task {
   id: string;
   title: string;
@@ -21,6 +29,12 @@ export interface Task {
   priority: number;
   branch: string | null;
   tags: string[];
+  proof: ProofSchema | null;
+  depends_on: string[];
+  retryCount: number;
+  maxRetries: number;
+  lastError: string | null;
+  nextRetryAt: string | null;
 }
 
 export interface AgentDetail {

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -1,7 +1,14 @@
+export interface Mission {
+  title: string;
+  description: string;
+  created: string;
+  updated: string;
+}
+
 export interface SessionOverview {
   name: string;
   dir: string;
-  mission: { title: string; description: string } | null;
+  mission: Mission | null;
   stats: {
     totalTasks: number;
     doneTasks: number;
@@ -16,7 +23,6 @@ export interface ProofSchema {
   pr?: { number: number; url?: string; status?: string };
   ci?: { status: string; url?: string };
   notes?: string;
-  note?: string;
 }
 
 export interface Task {
@@ -27,6 +33,8 @@ export interface Task {
   status: "todo" | "in-progress" | "review" | "done";
   assignee: string | null;
   priority: number;
+  created: string;
+  updated: string;
   branch: string | null;
   tags: string[];
   proof: ProofSchema | null;
@@ -49,15 +57,19 @@ export interface Goal {
   id: string;
   title: string;
   description: string;
-  status: string;
+  status: "todo" | "in-progress" | "done";
   acceptance: string;
   priority: number;
+  created: string;
+  updated: string;
+  assignee: string | null;
+  specialty: string | null;
 }
 
 export interface ProjectDetail {
   session: string;
   dir: string;
-  mission: { title: string; description: string } | null;
+  mission: Mission | null;
   goals: Goal[];
   tasks: Task[];
   agents: AgentDetail[];
@@ -72,12 +84,3 @@ export type EventType =
   | "error"
   | "task_created"
   | "status_change";
-
-export interface OrchestratorEvent {
-  timestamp: string;
-  type: EventType;
-  taskId?: string;
-  agent?: string;
-  message: string;
-  relative: string;
-}

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -75,6 +75,27 @@ export interface ProjectDetail {
   agents: AgentDetail[];
 }
 
+export interface MarkRange {
+  from: number;
+  to: number;
+}
+
+export interface Mark {
+  id: string;
+  kind: string;
+  by: string;
+  at: string;
+  range: MarkRange;
+  quote: string;
+  orphaned?: boolean;
+}
+
+export interface AuthorshipStats {
+  aiPercent: number;
+  humanPercent: number;
+  totalChars: number;
+}
+
 export type EventType =
   | "dispatch"
   | "completion"

--- a/src/command-center/discovery.test.ts
+++ b/src/command-center/discovery.test.ts
@@ -184,6 +184,8 @@ describe("computeGoalProgress", () => {
         priority: 1,
         created: "2026-01-01T00:00:00Z",
         updated: "2026-01-01T00:00:00Z",
+        assignee: null,
+        specialty: null,
       },
     ];
     const tasks = [
@@ -210,6 +212,8 @@ describe("computeGoalProgress", () => {
         priority: 1,
         created: "2026-01-01T00:00:00Z",
         updated: "2026-01-01T00:00:00Z",
+        assignee: null,
+        specialty: null,
       },
     ];
 

--- a/src/command-center/server.ts
+++ b/src/command-center/server.ts
@@ -21,6 +21,7 @@ import {
 } from "../lib/task-store.ts";
 import { readEvents, type OrchestratorEvent } from "../lib/event-log.ts";
 import { extractMarks, calculateStats, tagContent } from "../lib/authorship.ts";
+import { loadPlans, markPlanDone } from "../lib/plan-store.ts";
 
 export function createApp(): Hono {
   const app = new Hono();
@@ -135,7 +136,7 @@ export function createApp(): Hono {
     return c.json({ ok: true, deleted: taskId });
   });
 
-  // List plan files
+  // List plan files with status metadata
   app.get("/api/project/:name/plans", (c) => {
     const name = c.req.param("name");
     const sessions = discoverSessions();
@@ -144,15 +145,14 @@ export function createApp(): Hono {
       return c.json({ error: "Session not found" }, 404);
     }
 
-    const plansDir = join(session.dir, "plans");
-    if (!existsSync(plansDir)) {
-      return c.json({ plans: [] });
-    }
-
-    const plans = readdirSync(plansDir)
-      .filter((f) => f.endsWith(".md"))
-      .sort()
-      .map((f) => ({ name: f.replace(/\.md$/, ""), path: f }));
+    const plans = loadPlans(session.dir).map((p) => ({
+      name: p.name,
+      path: `${p.name}.md`,
+      title: p.title,
+      status: p.status,
+      effort: p.effort ?? null,
+      completed: p.completed ?? null,
+    }));
 
     return c.json({ plans });
   });
@@ -232,6 +232,25 @@ export function createApp(): Hono {
 
     unlinkSync(filePath);
     return c.json({ ok: true, deleted: safeName });
+  });
+
+  // Mark a plan as done
+  app.post("/api/project/:name/plans/:filename/done", (c) => {
+    const name = c.req.param("name");
+    const filename = c.req.param("filename");
+    const sessions = discoverSessions();
+    const session = sessions.find((s) => s.name === name);
+    if (!session) {
+      return c.json({ error: "Session not found" }, 404);
+    }
+
+    const safeName = filename.replace(/[^a-zA-Z0-9_\-. ]/g, "").replace(/\.md$/, "");
+    const result = markPlanDone(session.dir, safeName);
+    if (!result) {
+      return c.json({ error: "Plan not found" }, 404);
+    }
+
+    return c.json({ ok: true, plan: result });
   });
 
   app.get("/api/project/:name/diff", (c) => {

--- a/src/lib/event-log.ts
+++ b/src/lib/event-log.ts
@@ -7,7 +7,9 @@ export type EventType =
   | "completion"
   | "retry"
   | "reconcile"
-  | "error";
+  | "error"
+  | "task_created"
+  | "status_change";
 
 export interface OrchestratorEvent {
   timestamp: string;

--- a/src/lib/orchestrator.test.ts
+++ b/src/lib/orchestrator.test.ts
@@ -314,6 +314,8 @@ describe("buildTaskPrompt", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     });
 
     const task = makeTask({

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -295,7 +295,7 @@ export function dispatch(
 
 // --- Goal-level dispatch (planner agents) ---
 
-function matchesSpecialty(goalSpecialty: string | undefined, plannerSpecialties: string[]): boolean {
+function matchesSpecialty(goalSpecialty: string | null, plannerSpecialties: string[]): boolean {
   if (!goalSpecialty) return true; // no specialty = any planner
   if (plannerSpecialties.length === 0) return true; // no planner specialty = takes anything
   const goalTags = goalSpecialty.split(",").map((s) => s.trim().toLowerCase());

--- a/src/lib/plan-store.test.ts
+++ b/src/lib/plan-store.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadPlans, listPlans, markPlanDone, getPlan } from "./plan-store.ts";
+
+let tmpDir: string;
+
+function writePlan(name: string, content: string) {
+  const dir = join(tmpDir, "plans");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${name}.md`), content);
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "tmux-ide-plans-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadPlans", () => {
+  it("returns empty when plans/ does not exist", () => {
+    assert.deepStrictEqual(loadPlans(tmpDir), []);
+  });
+
+  it("loads plans and parses status", () => {
+    writePlan(
+      "01-mouse-support",
+      '# Plan 01: Mouse Support\n\n**Status:** `done`\n**Effort:** Low\n',
+    );
+    writePlan(
+      "70-hierarchical-agents",
+      '# Plan 70: Hierarchical Agents\n\n**Status:** `in-progress`\n**Effort:** High\n**Gate:** agents work\n',
+    );
+
+    const plans = loadPlans(tmpDir);
+    assert.strictEqual(plans.length, 2);
+    assert.strictEqual(plans[0]!.name, "01-mouse-support");
+    assert.strictEqual(plans[0]!.status, "done");
+    assert.strictEqual(plans[0]!.effort, "Low");
+    assert.strictEqual(plans[1]!.name, "70-hierarchical-agents");
+    assert.strictEqual(plans[1]!.status, "in-progress");
+    assert.strictEqual(plans[1]!.gate, "agents work");
+  });
+
+  it("skips ROADMAP.md", () => {
+    writePlan("ROADMAP", "# Roadmap\n");
+    writePlan("01-test", "# Test\n\n**Status:** `pending`\n");
+
+    const plans = loadPlans(tmpDir);
+    assert.strictEqual(plans.length, 1);
+    assert.strictEqual(plans[0]!.name, "01-test");
+  });
+
+  it("defaults to pending when no status found", () => {
+    writePlan("99-no-status", "# No Status Plan\n\nJust content.\n");
+    const plans = loadPlans(tmpDir);
+    assert.strictEqual(plans[0]!.status, "pending");
+  });
+});
+
+describe("listPlans", () => {
+  it("filters by status", () => {
+    writePlan("01-done", "# Done\n\n**Status:** `done`\n");
+    writePlan("02-pending", "# Pending\n\n**Status:** `pending`\n");
+    writePlan("03-active", "# Active\n\n**Status:** `in-progress`\n");
+
+    const done = listPlans(tmpDir, { status: "done" });
+    assert.strictEqual(done.length, 1);
+    assert.strictEqual(done[0]!.name, "01-done");
+
+    const active = listPlans(tmpDir, { status: "in-progress" });
+    assert.strictEqual(active.length, 1);
+    assert.strictEqual(active[0]!.name, "03-active");
+  });
+
+  it("returns all when no filter", () => {
+    writePlan("01-a", "# A\n\n**Status:** `done`\n");
+    writePlan("02-b", "# B\n\n**Status:** `pending`\n");
+
+    assert.strictEqual(listPlans(tmpDir).length, 2);
+  });
+});
+
+describe("markPlanDone", () => {
+  it("updates status to done and adds completed date", () => {
+    writePlan("50-task-cli", "# Plan 50: Task CLI\n\n**Status:** `in-progress`\n**Effort:** Medium\n");
+
+    const result = markPlanDone(tmpDir, "50");
+    assert.ok(result);
+    assert.strictEqual(result!.status, "done");
+    assert.ok(result!.completed);
+
+    // Verify file was updated
+    const content = readFileSync(join(tmpDir, "plans", "50-task-cli.md"), "utf-8");
+    assert.ok(content.includes("**Status:** `done`"));
+    assert.ok(content.includes("**Completed:**"));
+  });
+
+  it("matches by full name", () => {
+    writePlan("my-plan", "# My Plan\n\n**Status:** `pending`\n");
+    const result = markPlanDone(tmpDir, "my-plan");
+    assert.ok(result);
+    assert.strictEqual(result!.status, "done");
+  });
+
+  it("matches by number prefix", () => {
+    writePlan("70-hierarchical-agents", "# Plan 70\n\n**Status:** `in-progress`\n");
+    const result = markPlanDone(tmpDir, "70");
+    assert.ok(result);
+  });
+
+  it("returns null for non-existent plan", () => {
+    assert.strictEqual(markPlanDone(tmpDir, "nonexistent"), null);
+  });
+
+  it("preserves existing completed date format on re-mark", () => {
+    writePlan("01-test", "# Test\n\n**Status:** `done`\n**Completed:** 2026-01-01\n");
+    const result = markPlanDone(tmpDir, "01");
+    assert.ok(result);
+    // Should update the date
+    assert.notStrictEqual(result!.completed, "2026-01-01");
+  });
+});
+
+describe("getPlan", () => {
+  it("finds by name", () => {
+    writePlan("50-task-cli", "# Plan 50\n\n**Status:** `done`\n");
+    const plan = getPlan(tmpDir, "50-task-cli");
+    assert.ok(plan);
+    assert.strictEqual(plan!.name, "50-task-cli");
+  });
+
+  it("finds by number prefix", () => {
+    writePlan("50-task-cli", "# Plan 50\n\n**Status:** `done`\n");
+    const plan = getPlan(tmpDir, "50");
+    assert.ok(plan);
+  });
+
+  it("returns null when not found", () => {
+    assert.strictEqual(getPlan(tmpDir, "99"), null);
+  });
+});

--- a/src/lib/plan-store.ts
+++ b/src/lib/plan-store.ts
@@ -1,0 +1,147 @@
+import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+export type PlanStatus = "pending" | "in-progress" | "done" | "archived";
+
+export interface PlanMeta {
+  name: string; // filename without .md
+  path: string; // relative path from project root
+  title: string; // first # heading
+  status: PlanStatus;
+  effort?: string;
+  gate?: string;
+  completed?: string; // ISO date when marked done
+}
+
+/**
+ * Parse plan status from the **Status:** `xxx` pattern used in plan files.
+ */
+function parseInlineStatus(content: string): PlanStatus {
+  const match = content.match(/\*\*Status:\*\*\s*`([^`]+)`/);
+  if (!match) return "pending";
+  const raw = match[1]!.toLowerCase().trim();
+  if (raw === "done" || raw === "completed") return "done";
+  if (raw === "in-progress" || raw === "in progress" || raw === "active") return "in-progress";
+  if (raw === "archived") return "archived";
+  return "pending";
+}
+
+function parseInlineField(content: string, field: string): string | undefined {
+  const re = new RegExp(`\\*\\*${field}:\\*\\*\\s*(.+?)\\s*$`, "m");
+  const match = content.match(re);
+  return match ? match[1]!.replace(/^`|`$/g, "").trim() : undefined;
+}
+
+function parseTitle(content: string): string {
+  const match = content.match(/^#\s+(.+)/m);
+  return match ? match[1]!.trim() : "(untitled)";
+}
+
+/**
+ * Load all plan files from plans/ directory.
+ */
+export function loadPlans(dir: string): PlanMeta[] {
+  const plansDir = join(dir, "plans");
+  if (!existsSync(plansDir)) return [];
+
+  return readdirSync(plansDir)
+    .filter((f) => f.endsWith(".md") && f !== "ROADMAP.md")
+    .sort()
+    .map((f) => {
+      const content = readFileSync(join(plansDir, f), "utf-8");
+      return {
+        name: f.replace(/\.md$/, ""),
+        path: `plans/${f}`,
+        title: parseTitle(content),
+        status: parseInlineStatus(content),
+        effort: parseInlineField(content, "Effort"),
+        gate: parseInlineField(content, "Gate"),
+        completed: parseInlineField(content, "Completed"),
+      };
+    });
+}
+
+/**
+ * List plans filtered by status.
+ */
+export function listPlans(
+  dir: string,
+  filter?: { status?: PlanStatus },
+): PlanMeta[] {
+  const plans = loadPlans(dir);
+  if (filter?.status) {
+    return plans.filter((p) => p.status === filter.status);
+  }
+  return plans;
+}
+
+/**
+ * Mark a plan as done. Updates the **Status:** line and adds **Completed:** date.
+ */
+export function markPlanDone(dir: string, nameOrNumber: string): PlanMeta | null {
+  const plansDir = join(dir, "plans");
+  if (!existsSync(plansDir)) return null;
+
+  // Find the plan file — match by name, number prefix, or full filename
+  const files = readdirSync(plansDir).filter((f) => f.endsWith(".md"));
+  const target = files.find(
+    (f) =>
+      f === `${nameOrNumber}.md` ||
+      f.replace(/\.md$/, "") === nameOrNumber ||
+      f.startsWith(`${nameOrNumber}-`),
+  );
+
+  if (!target) return null;
+
+  const filePath = join(plansDir, target);
+  let content = readFileSync(filePath, "utf-8");
+  const today = new Date().toISOString().split("T")[0]!;
+
+  // Update status
+  if (content.match(/\*\*Status:\*\*\s*`[^`]+`/)) {
+    content = content.replace(
+      /\*\*Status:\*\*\s*`[^`]+`/,
+      "**Status:** `done`",
+    );
+  }
+
+  // Add or update completed date
+  if (content.match(/\*\*Completed:\*\*/)) {
+    content = content.replace(
+      /\*\*Completed:\*\*\s*.+/,
+      `**Completed:** ${today}`,
+    );
+  } else {
+    // Insert after the Status line
+    content = content.replace(
+      /(\*\*Status:\*\*\s*`done`)/,
+      `$1\n**Completed:** ${today}`,
+    );
+  }
+
+  writeFileSync(filePath, content);
+
+  return {
+    name: target.replace(/\.md$/, ""),
+    path: `plans/${target}`,
+    title: parseTitle(content),
+    status: "done",
+    effort: parseInlineField(content, "Effort"),
+    gate: parseInlineField(content, "Gate"),
+    completed: today,
+  };
+}
+
+/**
+ * Get a single plan by name or number.
+ */
+export function getPlan(dir: string, nameOrNumber: string): PlanMeta | null {
+  const plans = loadPlans(dir);
+  return (
+    plans.find(
+      (p) =>
+        p.name === nameOrNumber ||
+        p.name.startsWith(`${nameOrNumber}-`),
+    ) ?? null
+  );
+}

--- a/src/lib/session-monitor.ts
+++ b/src/lib/session-monitor.ts
@@ -197,7 +197,7 @@ if (isMainModule) {
         try {
           const { createOrchestrator } = await import("./orchestrator.js");
 
-          const orch = config.orchestrator as Record<string, unknown>;
+          const orch = config.orchestrator;
 
           // Build pane specialty map from ide.yml config
           const paneSpecialties = new Map<string, string[]>();
@@ -215,16 +215,16 @@ if (isMainModule) {
           const stopOrchestrator = createOrchestrator({
             session,
             dir: process.cwd(),
-            autoDispatch: config.orchestrator.auto_dispatch ?? true,
-            stallTimeout: config.orchestrator.stall_timeout ?? 300000,
-            pollInterval: config.orchestrator.poll_interval ?? 5000,
-            worktreeRoot: config.orchestrator.worktree_root ?? ".worktrees/",
-            masterPane: config.orchestrator.master_pane ?? null,
-            beforeRun: (orch.before_run as string) ?? null,
-            afterRun: (orch.after_run as string) ?? null,
-            cleanupOnDone: (orch.cleanup_on_done as boolean) ?? false,
-            maxConcurrentAgents: (orch.max_concurrent_agents as number) ?? 10,
-            dispatchMode: (orch.dispatch_mode as "tasks" | "goals") ?? "tasks",
+            autoDispatch: orch.auto_dispatch ?? true,
+            stallTimeout: orch.stall_timeout ?? 300000,
+            pollInterval: orch.poll_interval ?? 5000,
+            worktreeRoot: orch.worktree_root ?? ".worktrees/",
+            masterPane: orch.master_pane ?? null,
+            beforeRun: orch.before_run ?? null,
+            afterRun: orch.after_run ?? null,
+            cleanupOnDone: orch.cleanup_on_done ?? false,
+            maxConcurrentAgents: orch.max_concurrent_agents ?? 10,
+            dispatchMode: orch.dispatch_mode ?? "tasks",
             paneSpecialties,
           });
 

--- a/src/lib/task-store.ts
+++ b/src/lib/task-store.ts
@@ -27,8 +27,8 @@ export interface Goal {
   priority: number;
   created: string;
   updated: string;
-  assignee?: string;
-  specialty?: string;
+  assignee: string | null;
+  specialty: string | null;
 }
 
 export interface Task {
@@ -51,7 +51,28 @@ export interface Task {
   depends_on: string[];
 }
 
-function normalizeTask(raw: Record<string, unknown>): Task {
+function normalizeMission(raw: Record<string, unknown>): Mission {
+  const epoch = "1970-01-01T00:00:00.000Z";
+  return {
+    title: (raw.title as string) ?? "",
+    description: (raw.description as string) ?? "",
+    created: (raw.created as string) ?? epoch,
+    updated: (raw.updated as string) ?? epoch,
+  };
+}
+
+function normalizeGoal(raw: Record<string, unknown>): Goal {
+  const epoch = "1970-01-01T00:00:00.000Z";
+  return {
+    ...(raw as Omit<Goal, "assignee" | "specialty" | "created" | "updated">),
+    created: (raw.created as string) ?? epoch,
+    updated: (raw.updated as string) ?? epoch,
+    assignee: (raw.assignee as string) ?? null,
+    specialty: (raw.specialty as string) ?? null,
+  } as Goal;
+}
+
+export function normalizeTask(raw: Record<string, unknown>): Task {
   const defaults = {
     retryCount: 0,
     maxRetries: 5,
@@ -59,6 +80,14 @@ function normalizeTask(raw: Record<string, unknown>): Task {
     nextRetryAt: null,
     depends_on: [] as string[],
   };
+
+  // Migrate proof.note → proof.notes
+  const proof = raw.proof as Record<string, unknown> | null | undefined;
+  if (proof && "note" in proof && !("notes" in proof)) {
+    proof.notes = proof.note;
+    delete proof.note;
+  }
+
   return {
     ...defaults,
     ...(raw as Omit<Task, "retryCount" | "maxRetries" | "lastError" | "nextRetryAt" | "depends_on">),
@@ -96,7 +125,7 @@ export function ensureTasksDir(dir: string): void {
 export function loadMission(dir: string): Mission | null {
   const path = join(getTasksRoot(dir), "mission.json");
   if (!existsSync(path)) return null;
-  return JSON.parse(readFileSync(path, "utf-8")) as Mission;
+  return normalizeMission(JSON.parse(readFileSync(path, "utf-8")));
 }
 
 export function saveMission(dir: string, mission: Mission): void {
@@ -137,13 +166,13 @@ export function loadGoals(dir: string): Goal[] {
   return readdirSync(goalsDir)
     .filter((f) => f.endsWith(".json"))
     .sort()
-    .map((f) => JSON.parse(readFileSync(join(goalsDir, f), "utf-8")) as Goal);
+    .map((f) => normalizeGoal(JSON.parse(readFileSync(join(goalsDir, f), "utf-8"))));
 }
 
 export function loadGoal(dir: string, id: string): Goal | null {
   const file = findFileById(join(getTasksRoot(dir), "goals"), id);
   if (!file) return null;
-  return JSON.parse(readFileSync(file, "utf-8")) as Goal;
+  return normalizeGoal(JSON.parse(readFileSync(file, "utf-8")));
 }
 
 export function saveGoal(dir: string, goal: Goal): void {

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -1,0 +1,117 @@
+import { resolve } from "node:path";
+import { outputError } from "./lib/output.ts";
+import { loadPlans, listPlans, markPlanDone, getPlan, type PlanStatus } from "./lib/plan-store.ts";
+
+const STATUS_ICONS: Record<PlanStatus, string> = {
+  pending: "○",
+  "in-progress": "●",
+  done: "✓",
+  archived: "▪",
+};
+
+const STATUS_COLORS: Record<PlanStatus, string> = {
+  pending: "\x1b[2m",    // dim
+  "in-progress": "\x1b[33m", // yellow
+  done: "\x1b[32m",      // green
+  archived: "\x1b[2m",   // dim
+};
+
+const RESET = "\x1b[0m";
+
+export async function planCommand(
+  targetDir: string | undefined,
+  {
+    json = false,
+    sub,
+    args = [],
+    values = {},
+  }: {
+    json?: boolean;
+    sub?: string;
+    args?: string[];
+    values?: { status?: string };
+  },
+): Promise<void> {
+  const dir = resolve(targetDir ?? ".");
+
+  switch (sub) {
+    case "list":
+    case undefined: {
+      const statusFilter = values.status as PlanStatus | undefined;
+      const plans = listPlans(dir, statusFilter ? { status: statusFilter } : undefined);
+
+      if (json) {
+        console.log(JSON.stringify(plans, null, 2));
+        return;
+      }
+
+      if (plans.length === 0) {
+        console.log("No plans found.");
+        return;
+      }
+
+      // Group by status
+      const groups: Record<string, typeof plans> = {};
+      for (const p of plans) {
+        (groups[p.status] ??= []).push(p);
+      }
+
+      for (const status of ["in-progress", "pending", "done", "archived"] as PlanStatus[]) {
+        const group = groups[status];
+        if (!group?.length) continue;
+        const color = STATUS_COLORS[status];
+        console.log(`\n${color}${status.toUpperCase()}${RESET}`);
+        for (const p of group) {
+          const icon = STATUS_ICONS[p.status];
+          const completed = p.completed ? ` (${p.completed})` : "";
+          console.log(`  ${color}${icon}${RESET} ${p.name}  ${p.title}${completed}`);
+        }
+      }
+      console.log();
+      break;
+    }
+
+    case "show": {
+      const name = args[0];
+      if (!name) outputError("Usage: tmux-ide plan show <name|number>", "USAGE");
+      const plan = getPlan(dir, name);
+      if (!plan) outputError(`Plan not found: ${name}`, "NOT_FOUND");
+
+      if (json) {
+        console.log(JSON.stringify(plan, null, 2));
+        return;
+      }
+
+      const icon = STATUS_ICONS[plan.status];
+      const color = STATUS_COLORS[plan.status];
+      console.log(`${color}${icon} ${plan.title}${RESET}`);
+      console.log(`  Status: ${plan.status}`);
+      if (plan.effort) console.log(`  Effort: ${plan.effort}`);
+      if (plan.gate) console.log(`  Gate: ${plan.gate}`);
+      if (plan.completed) console.log(`  Completed: ${plan.completed}`);
+      console.log(`  File: ${plan.path}`);
+      break;
+    }
+
+    case "done": {
+      const name = args[0];
+      if (!name) outputError("Usage: tmux-ide plan done <name|number>", "USAGE");
+      const result = markPlanDone(dir, name);
+      if (!result) outputError(`Plan not found: ${name}`, "NOT_FOUND");
+
+      if (json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      console.log(`✓ Plan marked done: ${result.title} (${result.completed})`);
+      break;
+    }
+
+    default:
+      outputError(
+        `Unknown plan subcommand: ${sub}\nUsage: tmux-ide plan [list|show|done] [--status pending|in-progress|done]`,
+        "USAGE",
+      );
+  }
+}

--- a/src/task.test.ts
+++ b/src/task.test.ts
@@ -102,6 +102,8 @@ describe("goals", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     });
     assert.strictEqual(nextGoalId(tmpDir), "02");
   });
@@ -117,6 +119,8 @@ describe("goals", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     });
     const files = readdirSync(join(tmpDir, ".tasks", "goals"));
     assert.strictEqual(files.length, 1);
@@ -135,6 +139,8 @@ describe("goals", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     };
     saveGoal(tmpDir, goal);
     assert.deepStrictEqual(loadGoal(tmpDir, "01"), goal);
@@ -156,6 +162,8 @@ describe("goals", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     });
     const goal = loadGoal(tmpDir, "01")!;
     goal.status = "done";
@@ -177,6 +185,8 @@ describe("goals", () => {
       priority: 1,
       created: "2026-01-01T00:00:00Z",
       updated: "2026-01-01T00:00:00Z",
+      assignee: null,
+      specialty: null,
     });
     assert.strictEqual(deleteGoal(tmpDir, "01"), true);
     assert.strictEqual(loadGoal(tmpDir, "01"), null);
@@ -199,6 +209,8 @@ describe("goals", () => {
       priority: 2,
       created: now,
       updated: now,
+      assignee: null,
+      specialty: null,
     });
     saveGoal(tmpDir, {
       id: "01",
@@ -209,6 +221,8 @@ describe("goals", () => {
       priority: 1,
       created: now,
       updated: now,
+      assignee: null,
+      specialty: null,
     });
     const goals = loadGoals(tmpDir);
     assert.strictEqual(goals.length, 2);
@@ -639,6 +653,6 @@ describe("parseProof", () => {
     );
     const loaded = loadTask(tmpDir, "001")!;
     assert.ok(loaded.proof !== null);
-    assert.strictEqual((loaded.proof as Record<string, unknown>).note, "old format proof");
+    assert.strictEqual(loaded.proof!.notes, "old format proof");
   });
 });

--- a/src/task.ts
+++ b/src/task.ts
@@ -208,7 +208,8 @@ function handleGoal(
         priority: parseInt(values.priority ?? "2", 10),
         created: now,
         updated: now,
-        specialty: values.specialty ?? undefined,
+        assignee: null,
+        specialty: values.specialty ?? null,
       };
       saveGoal(dir, goal);
       if (json) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface ProofSchema {
   notes?: string;
 }
 
-export interface OrchestratorConfig {
+export interface OrchestratorYamlConfig {
   enabled?: boolean;
   auto_dispatch?: boolean;
   stall_timeout?: number; // ms, default 300000 (5 min)
@@ -16,6 +16,7 @@ export interface OrchestratorConfig {
   after_run?: string; // shell command to run in worktree after task completes
   cleanup_on_done?: boolean; // remove worktree when task completes (default false)
   dispatch_mode?: "tasks" | "goals"; // default: "tasks" (backward compat)
+  max_concurrent_agents?: number; // default 10
 }
 
 export interface IdeConfig {
@@ -24,7 +25,7 @@ export interface IdeConfig {
   team?: { name: string };
   rows: Row[];
   theme?: ThemeConfig;
-  orchestrator?: OrchestratorConfig;
+  orchestrator?: OrchestratorYamlConfig;
 }
 
 export interface Row {

--- a/src/widgets/warroom/index.tsx
+++ b/src/widgets/warroom/index.tsx
@@ -1,6 +1,4 @@
 import { parseArgs } from "node:util";
-import { readFileSync, readdirSync, existsSync } from "node:fs";
-import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { render, useKeyboard, useTerminalDimensions } from "@opentui/solid";
 import { RGBA, TextAttributes } from "@opentui/core";
@@ -11,7 +9,14 @@ import { MissionHeader } from "./mission-header.tsx";
 import { GoalSection } from "./goal-section.tsx";
 import { type AgentInfo } from "./agent-card.tsx";
 import { ActivityFeed, formatElapsedShort, type ActivityEntry } from "./activity-feed.tsx";
-import type { ProofSchema } from "../../types.ts";
+import {
+  loadMission,
+  loadGoals,
+  loadTasks,
+  type Mission,
+  type Goal,
+  type Task,
+} from "../../lib/task-store.ts";
 
 const { values } = parseArgs({
   options: {
@@ -24,82 +29,6 @@ const { values } = parseArgs({
 const session = values.session ?? "";
 const dir = values.dir ?? process.cwd();
 const themeConfig = values.theme ? JSON.parse(values.theme) : undefined;
-
-// --- Data loaders ---
-
-interface Mission {
-  title: string;
-  description: string;
-}
-
-interface Goal {
-  id: string;
-  title: string;
-  status: string;
-  priority: number;
-}
-
-interface Task {
-  id: string;
-  title: string;
-  status: string;
-  assignee: string | null;
-  goal: string | null;
-  priority: number;
-  updated: string;
-  retryCount?: number;
-  maxRetries?: number;
-  lastError?: string | null;
-  nextRetryAt?: string | null;
-  proof?: ProofSchema | null;
-}
-
-function loadMission(): Mission | null {
-  const path = join(dir, ".tasks", "mission.json");
-  if (!existsSync(path)) return null;
-  try {
-    return JSON.parse(readFileSync(path, "utf-8"));
-  } catch {
-    return null;
-  }
-}
-
-function loadGoals(): Goal[] {
-  const goalsDir = join(dir, ".tasks", "goals");
-  if (!existsSync(goalsDir)) return [];
-  return readdirSync(goalsDir)
-    .filter((f) => f.endsWith(".json"))
-    .sort()
-    .map((f) => {
-      try {
-        return JSON.parse(readFileSync(join(goalsDir, f), "utf-8"));
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean) as Goal[];
-}
-
-function loadTasks(): Task[] {
-  // Try nested .tasks/tasks/ first (CLI format), fall back to flat .tasks/ (widget format)
-  const nestedDir = join(dir, ".tasks", "tasks");
-  const flatDir = join(dir, ".tasks");
-  const tasksDir = existsSync(nestedDir) ? nestedDir : flatDir;
-  if (!existsSync(tasksDir)) return [];
-  return readdirSync(tasksDir)
-    .filter((f) => f.endsWith(".json") && f !== "mission.json")
-    .sort()
-    .map((f) => {
-      try {
-        const data = JSON.parse(readFileSync(join(tasksDir, f), "utf-8"));
-        if (data.id && data.title && data.status) return data;
-        return null;
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean) as Task[];
-}
 
 // --- Agent matching ---
 
@@ -197,9 +126,9 @@ render(
     const theme = createTheme(themeConfig);
     const dimensions = useTerminalDimensions();
 
-    const [mission, setMission] = createSignal(loadMission());
-    const [goals, setGoals] = createSignal(loadGoals());
-    const [tasks, setTasks] = createSignal(loadTasks());
+    const [mission, setMission] = createSignal(loadMission(dir));
+    const [goals, setGoals] = createSignal(loadGoals(dir));
+    const [tasks, setTasks] = createSignal(loadTasks(dir));
     const [panes, setPanes] = createSignal<PaneInfo[]>(session ? listSessionPanes(session) : []);
     const [activity, setActivity] = createSignal<ActivityEntry[]>([]);
     const [selectedAgent, setSelectedAgent] = createSignal(0);
@@ -207,9 +136,9 @@ render(
     // Poll every 2 seconds
     const interval = setInterval(() => {
       const prevTasks = tasks();
-      setMission(loadMission());
-      setGoals(loadGoals());
-      const newTasks = loadTasks();
+      setMission(loadMission(dir));
+      setGoals(loadGoals(dir));
+      const newTasks = loadTasks(dir);
       setTasks(newTasks);
       if (session) setPanes(listSessionPanes(session));
 
@@ -284,9 +213,9 @@ render(
         }
         evt.preventDefault();
       } else if (evt.name === "r") {
-        setMission(loadMission());
-        setGoals(loadGoals());
-        setTasks(loadTasks());
+        setMission(loadMission(dir));
+        setGoals(loadGoals(dir));
+        setTasks(loadTasks(dir));
         if (session) setPanes(listSessionPanes(session));
         evt.preventDefault();
       } else if (evt.name === "q") {


### PR DESCRIPTION
These two modules have zero test coverage. Add dedicated test files.

## What to do

### src/lib/token-tracker.test.ts
Test these functions:
1. **loadAccounting()** — returns default structure when no file exists
2. **saveAccounting() + loadAccounting()** — round-trip: save data, load it, verify it matches
3. **recordTaskTime()** — record time for an agent+task, verify accounting data is updated
4. **formatDuration()** — test with various ms values:
   - 0 → '0s'
   - 5000 → '5s'
   - 65000 → '1m 5s'
   - 3665000 → '1h 1m'

Pattern: Use tmp directory, call functions, assert results. Check src/lib/token-tracker.ts first to understand the exact signatures and file paths used.

### src/lib/yaml-io.test.ts
Test these functions:
1. **writeConfig() + readConfig()** — round-trip: write a config object, read it back, verify fields match
2. **readConfig()** — returns null when no ide.yml exists
3. **getSessionName()** — returns name from config, falls back to directory basename when no config
4. **readConfig()** — handles malformed YAML gracefully (returns null or throws)

Pattern: Use tmp directory, write ide.yml files, call functions, assert.

## Files to create
- src/lib/token-tracker.test.ts
- src/lib/yaml-io.test.ts

## Acceptance
- Both test files pass: pnpm test
- All exported functions have at least one test case
- Tests are self-contained (use tmp directories, no side effects)

## Proof
Added yaml-io.test.ts with 9 tests: round-trip (config/theme/orchestrator/team), throw on missing file, throw on malformed YAML, getSessionName (config/fallback/no-file). token-tracker.test.ts already existed. 537 tests pass.

Tags: testing, p2