### PR TITLE
Task 053: Replace validate.ts with schema-driven validation

### DIFF
--- a/src/__tests__/support.ts
+++ b/src/__tests__/support.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Task, Goal, Mission } from "../lib/task-store.ts";
+import type { PaneInfo } from "../widgets/lib/pane-comms.ts";
+import type { OrchestratorConfig, OrchestratorState } from "../lib/orchestrator.ts";
+import type { Mark, MarkKind, MarkRange } from "../lib/authorship.ts";
+import { ensureTasksDir, saveTask, saveGoal } from "../lib/task-store.ts";
+
+// ---------------------------------------------------------------------------
+// Factory: Task
+// ---------------------------------------------------------------------------
+
+export function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "001",
+    title: "Test task",
+    description: "",
+    goal: null,
+    status: "todo",
+    assignee: null,
+    priority: 1,
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+    branch: null,
+    tags: [],
+    proof: null,
+    retryCount: 0,
+    maxRetries: 5,
+    lastError: null,
+    nextRetryAt: null,
+    depends_on: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory: Goal
+// ---------------------------------------------------------------------------
+
+export function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: "01",
+    title: "Test goal",
+    description: "",
+    status: "todo",
+    acceptance: "",
+    priority: 1,
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+    assignee: null,
+    specialty: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory: Mission
+// ---------------------------------------------------------------------------
+
+export function makeMission(overrides: Partial<Mission> = {}): Mission {
+  return {
+    title: "Test mission",
+    description: "",
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory: PaneInfo
+// ---------------------------------------------------------------------------
+
+export function makePane(overrides: Partial<PaneInfo> = {}): PaneInfo {
+  return {
+    id: "%1",
+    index: 0,
+    title: "Agent 1",
+    currentCommand: "zsh",
+    width: 80,
+    height: 24,
+    active: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory: OrchestratorConfig
+// ---------------------------------------------------------------------------
+
+export function makeOrchestratorConfig(
+  dir: string,
+  overrides: Partial<OrchestratorConfig> = {},
+): OrchestratorConfig {
+  return {
+    session: "test",
+    dir,
+    autoDispatch: true,
+    stallTimeout: 300000,
+    pollInterval: 5000,
+    worktreeRoot: ".worktrees",
+    masterPane: "Master",
+    beforeRun: null,
+    afterRun: null,
+    cleanupOnDone: false,
+    maxConcurrentAgents: 10,
+    dispatchMode: "tasks",
+    paneSpecialties: new Map(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory: OrchestratorState
+// ---------------------------------------------------------------------------
+
+export function makeOrchestratorState(
+  overrides: Partial<OrchestratorState> = {},
+): OrchestratorState {
+  return {
+    lastActivity: new Map(),
+    previousTasks: new Map(),
+    claimedTasks: new Set(),
+    taskClaimTimes: new Map(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory: Mark
+// ---------------------------------------------------------------------------
+
+export function makeMark(overrides: Partial<Mark> = {}): Mark {
+  return {
+    id: "m1",
+    kind: "authored" as MarkKind,
+    by: "ai:test",
+    at: "2026-01-01T00:00:00Z",
+    range: { from: 0, to: 10 } as MarkRange,
+    quote: "test quote",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TestProject: temp directory with .tasks scaffolding
+// ---------------------------------------------------------------------------
+
+export class TestProject {
+  readonly dir: string;
+
+  constructor() {
+    this.dir = mkdtempSync(join(tmpdir(), "tmux-ide-test-"));
+  }
+
+  cleanup(): void {
+    rmSync(this.dir, { recursive: true, force: true });
+  }
+
+  initTasks(): void {
+    ensureTasksDir(this.dir);
+  }
+
+  addTask(overrides: Partial<Task> = {}): Task {
+    const task = makeTask(overrides);
+    saveTask(this.dir, task);
+    return task;
+  }
+
+  addGoal(overrides: Partial<Goal> = {}): Goal {
+    const goal = makeGoal(overrides);
+    saveGoal(this.dir, goal);
+    return goal;
+  }
+}


### PR DESCRIPTION
Rewrite src/validate.ts validateConfig() to use IdeConfigSchema.safeParse() from src/schemas/ide-config.ts for syntactic validation. On safeParse failure, map zod issue paths and messages to the same string[] format as current. Keep 4 semantic checks as second pass after schema parse succeeds: (1) row sizes sum <= 100%, (2) per-row pane sizes sum <= 100%, (3) max 1 focus:true per row, (4) type and command cannot coexist on same pane. Change src/types.ts to a thin re-export shim: export all types from "./schemas/index.ts". This keeps all 15+ existing importers working without changes. Read current validate.ts and validate.test.ts first to understand exact error message format. All 47 validate tests must pass UNCHANGED. Gate: pnpm test.

## Proof
Rewrote src/validate.ts to use IdeConfigSchema.safeParse() for syntactic validation with custom Zod issue-to-string mapper matching exact legacy error formats. Added .min(1) to rows/panes arrays in schema. 4 semantic checks (row sizes sum, pane sizes sum, max 1 focus, type+command coexistence) run as second pass. Converted src/types.ts to thin re-export shim from schemas. Added ProofSchema type export to domain.ts. All 564 tests pass (0 failures), all 47 validate tests unchanged.

Tags: validation, schemas, phase-3