### PR TITLE
Task 101: Implement layout persistence with schema versioning

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,6 +19,7 @@ import { detect } from "../dist/detect.js";
 import { config } from "../dist/config.js";
 import { restart } from "../dist/restart.js";
 import { taskCommand } from "../dist/task.js";
+import { send } from "../dist/send.js";
 import { IdeError } from "../dist/lib/errors.js";
 import { printCommandError } from "../dist/lib/output.js";
 
@@ -55,6 +56,9 @@ const { positionals, values } = parseArgs({
     // setup command flags
     edit: { type: "boolean" },
     wizard: { type: "boolean" },
+    // send command flags
+    to: { type: "string" },
+    "no-enter": { type: "boolean" },
   },
 });
 
@@ -76,6 +80,9 @@ const knownCommands = new Set([
   "task",
   "plan",
   "setup",
+  "send",
+  "orchestrator",
+  "settings",
   "command-center",
   "help",
 ]);
@@ -92,7 +99,7 @@ if (values.verbose) {
   globalThis.__tmuxIdeVerbose = true;
 }
 
-const ALIASES = { t: "task", g: "goal", m: "mission" };
+const ALIASES = { t: "task", g: "goal", m: "mission", orch: "orchestrator", o: "orchestrator" };
 const firstPositional = positionals[0];
 const resolved = ALIASES[firstPositional] ?? firstPositional;
 const hasKnownCommand = resolved ? knownCommands.has(resolved) : false;
@@ -118,6 +125,7 @@ ${bold("Usage:")}
   ${cyan("tmux-ide <path>")}             ${dim("Launch from a specific directory")}
   ${cyan("tmux-ide setup")}              ${dim("Interactive TUI setup wizard")}
   ${cyan("tmux-ide setup --edit")}       ${dim("Open config tree editor")}
+  ${cyan("tmux-ide settings")}           ${dim("Interactive TUI config manager")}
   ${cyan("tmux-ide init")} [--template]  ${dim("Scaffold a new ide.yml (auto-detects stack)")}
   ${cyan("tmux-ide stop")}               ${dim("Kill the current IDE session")}
   ${cyan("tmux-ide restart")}            ${dim("Stop and relaunch the IDE session")}
@@ -136,6 +144,15 @@ ${bold("Usage:")}
   ${cyan("tmux-ide config add-row")} [--size <percent>]
   ${cyan("tmux-ide config enable-team")} [--name <N>]   ${dim("Enable agent teams")}
   ${cyan("tmux-ide config disable-team")}               ${dim("Disable agent teams")}
+
+${bold("Pane Messaging:")}
+  ${cyan("tmux-ide send")} <target> <message>     ${dim("Send message to a pane")}
+  ${cyan("tmux-ide send")} --to <name> <message>   ${dim("Target by name, title, role, or ID")}
+  ${cyan("tmux-ide send")} <target> --no-enter msg  ${dim("Send text without pressing Enter")}
+
+${bold("Orchestrator:")}
+  ${cyan("tmux-ide orchestrator")} [--json]         ${dim("Show orchestrator status")}
+  ${cyan("tmux-ide orch")}                          ${dim("Alias for orchestrator")}
 
 ${bold("Task Management:")}
   ${cyan("tmux-ide mission set")} "title"              ${dim("Set the project mission")}
@@ -239,7 +256,9 @@ try {
       } else if (sub === "edit") {
         // Launch setup TUI in edit mode
         const scriptPath = resolve(__dirname, "../src/widgets/setup/index.tsx");
-        execFileSync("bun", [scriptPath, "--dir=" + resolve(startTargetDir || "."), "--edit"], { stdio: "inherit" });
+        execFileSync("bun", [scriptPath, "--dir=" + resolve(startTargetDir || "."), "--edit"], {
+          stdio: "inherit",
+        });
         break;
       }
 
@@ -318,6 +337,32 @@ try {
       if (positionals[1] === "--edit" || values.edit) setupArgs.push("--edit");
       if (positionals[1] === "--wizard" || values.wizard) setupArgs.push("--wizard");
       execFileSync("bun", setupArgs, { stdio: "inherit" });
+      break;
+    }
+
+    case "send": {
+      const target = values.to ?? positionals[1];
+      const messageStart = values.to ? 1 : 2;
+      let message = positionals.slice(messageStart).join(" ");
+      if (!message && !process.stdin.isTTY) {
+        const { readFileSync } = await import("node:fs");
+        message = readFileSync(0, "utf-8").trim();
+      }
+      await send(null, { json, to: target, message, noEnter: values["no-enter"] });
+      break;
+    }
+
+    case "orchestrator": {
+      const { orchestratorStatus } = await import("../dist/orchestrator-status.js");
+      await orchestratorStatus(positionals[1], { json });
+      break;
+    }
+
+    case "settings": {
+      const scriptPath = resolve(__dirname, "../src/widgets/config/index.tsx");
+      execFileSync("bun", [scriptPath, "--dir=" + resolve(startTargetDir || ".")], {
+        stdio: "inherit",
+      });
       break;
     }
 

--- a/src/command-center/discovery.ts
+++ b/src/command-center/discovery.ts
@@ -87,13 +87,7 @@ export function listTmuxSessions(): string[] {
 }
 
 export function getSessionCwd(session: string): string {
-  return tmuxSilent([
-    "display-message",
-    "-t",
-    session,
-    "-p",
-    "#{pane_current_path}",
-  ]);
+  return tmuxSilent(["display-message", "-t", session, "-p", "#{pane_current_path}"]);
 }
 
 function formatElapsed(isoDate: string): string {
@@ -191,6 +185,41 @@ export function buildProjectDetail(info: SessionInfo): ProjectDetail {
     goals: info.goals,
     tasks: info.tasks,
     agents,
+  };
+}
+
+export interface OrchestratorSnapshot {
+  running: boolean;
+  claimedCount: number;
+  agents: AgentDetail[];
+  inProgressCount: number;
+  pendingCount: number;
+}
+
+export function buildOrchestratorSnapshot(info: SessionInfo): OrchestratorSnapshot {
+  const agents: AgentDetail[] = info.panes
+    .filter((p) => isAgentPane(p))
+    .map((pane) => {
+      const name = agentIdentifier(pane);
+      const assignedTask = info.tasks.find(
+        (t) => t.assignee === name && t.status === "in-progress",
+      );
+      return {
+        paneTitle: name,
+        paneId: pane.id,
+        isBusy: isAgentBusy(pane),
+        taskTitle: assignedTask?.title ?? null,
+        taskId: assignedTask?.id ?? null,
+        elapsed: assignedTask ? formatElapsed(assignedTask.updated) : "",
+      };
+    });
+
+  return {
+    running: agents.length > 0,
+    claimedCount: info.tasks.filter((t) => t.status === "in-progress").length,
+    agents,
+    inProgressCount: info.tasks.filter((t) => t.status === "in-progress").length,
+    pendingCount: info.tasks.filter((t) => t.status === "todo").length,
   };
 }
 

--- a/src/command-center/server.ts
+++ b/src/command-center/server.ts
@@ -1,5 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  unlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
@@ -8,19 +15,14 @@ import {
   discoverSessions,
   buildOverviews,
   buildProjectDetail,
+  buildOrchestratorSnapshot,
   updateTask,
   type SessionOverview,
   type ProjectDetail,
 } from "./discovery.ts";
 import { listSessionPanes } from "../widgets/lib/pane-comms.ts";
-import {
-  ensureTasksDir,
-  nextTaskId,
-  saveTask,
-  deleteTask,
-  type Task,
-} from "../lib/task-store.ts";
-import { readEvents, type OrchestratorEvent } from "../lib/event-log.ts";
+import { ensureTasksDir, nextTaskId, saveTask, deleteTask, type Task } from "../lib/task-store.ts";
+import { readEvents } from "../lib/event-log.ts";
 import { extractMarks, calculateStats, tagContent } from "../lib/authorship.ts";
 import { loadPlans, markPlanDone } from "../lib/plan-store.ts";
 import { zValidator } from "@hono/zod-validator";
@@ -193,7 +195,11 @@ export function createApp(): Hono {
 
     // Sanitize filename — no path traversal
     const safeName = filename.replace(/[^a-zA-Z0-9_\-. ]/g, "");
-    const filePath = join(session.dir, "plans", safeName.endsWith(".md") ? safeName : `${safeName}.md`);
+    const filePath = join(
+      session.dir,
+      "plans",
+      safeName.endsWith(".md") ? safeName : `${safeName}.md`,
+    );
 
     if (!existsSync(filePath)) {
       return c.json({ error: "Plan not found" }, 404);
@@ -223,7 +229,11 @@ export function createApp(): Hono {
     const body = c.req.valid("json");
 
     const safeName = filename.replace(/[^a-zA-Z0-9_\-. ]/g, "");
-    const filePath = join(session.dir, "plans", safeName.endsWith(".md") ? safeName : `${safeName}.md`);
+    const filePath = join(
+      session.dir,
+      "plans",
+      safeName.endsWith(".md") ? safeName : `${safeName}.md`,
+    );
     const plansDir = join(session.dir, "plans");
     if (!existsSync(plansDir)) mkdirSync(plansDir, { recursive: true });
 
@@ -245,7 +255,11 @@ export function createApp(): Hono {
     }
 
     const safeName = filename.replace(/[^a-zA-Z0-9_\-. ]/g, "");
-    const filePath = join(session.dir, "plans", safeName.endsWith(".md") ? safeName : `${safeName}.md`);
+    const filePath = join(
+      session.dir,
+      "plans",
+      safeName.endsWith(".md") ? safeName : `${safeName}.md`,
+    );
 
     if (!existsSync(filePath)) {
       return c.json({ error: "Plan not found" }, 404);
@@ -413,11 +427,13 @@ export function createApp(): Hono {
     return c.json({ events: withRelative });
   });
 
-  // SSE endpoint — polls every 2s and emits changes
+  // SSE endpoint — cursor-based event streaming with orchestrator state
   app.get("/api/events", (c) => {
     return streamSSE(c, async (stream) => {
       let prevOverviews: SessionOverview[] = [];
       let prevDetails = new Map<string, ProjectDetail>();
+      const eventCursors = new Map<string, number>(); // session → last-seen event count
+      let prevOrchHashes = new Map<string, string>(); // session → orchestrator snapshot hash
 
       const poll = () => {
         const sessions = discoverSessions();
@@ -459,8 +475,39 @@ export function createApp(): Hono {
           }
         }
 
-        // Detect task-level changes per session
+        // Per-session: event log cursor + orchestrator state + task/agent diffs
         for (const session of sessions) {
+          // Cursor-based event streaming from event log
+          const events = readEvents(session.dir);
+          const cursor = eventCursors.get(session.name) ?? 0;
+
+          // Handle log rotation: if events.length < cursor, log was rotated
+          const effectiveCursor = events.length < cursor ? 0 : cursor;
+          const newEvents = events.slice(effectiveCursor);
+
+          for (const evt of newEvents) {
+            const eventId = `${evt.timestamp}:${evt.type}:${evt.taskId ?? ""}`;
+            stream.writeSSE({
+              id: eventId,
+              event: "orchestrator_event",
+              data: JSON.stringify({ session: session.name, ...evt }),
+            });
+          }
+          eventCursors.set(session.name, events.length);
+
+          // Orchestrator state snapshot (emit only on change)
+          const orchSnapshot = buildOrchestratorSnapshot(session);
+          const orchHash = JSON.stringify(orchSnapshot);
+          const prevHash = prevOrchHashes.get(session.name);
+          if (orchHash !== prevHash) {
+            stream.writeSSE({
+              event: "orchestrator_state",
+              data: JSON.stringify({ session: session.name, ...orchSnapshot }),
+            });
+            prevOrchHashes.set(session.name, orchHash);
+          }
+
+          // Task-level and agent-level diffs (existing logic)
           const detail = buildProjectDetail(session);
           const prevDetail = prevDetails.get(session.name);
 

--- a/src/lib/event-log.ts
+++ b/src/lib/event-log.ts
@@ -2,6 +2,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, statSync, renameSy
 import { join } from "node:path";
 import { StructuredEventSchemaZ } from "../schemas/domain.ts";
 import type { z } from "zod";
+import { fireWebhooks, type WebhookConfig } from "./webhook.ts";
 
 export type EventType =
   | "dispatch"
@@ -11,7 +12,8 @@ export type EventType =
   | "reconcile"
   | "error"
   | "task_created"
-  | "status_change";
+  | "status_change"
+  | "send";
 
 export interface OrchestratorEvent {
   timestamp: string;
@@ -23,6 +25,13 @@ export interface OrchestratorEvent {
 
 export type StructuredEvent = z.infer<typeof StructuredEventSchemaZ>;
 
+let _webhooks: WebhookConfig[] = [];
+
+/** Configure webhook URLs for event delivery. Call once at startup. */
+export function setWebhookConfig(webhooks: WebhookConfig[]): void {
+  _webhooks = webhooks;
+}
+
 /**
  * Generate a human-readable message from a structured event's typed fields.
  */
@@ -33,7 +42,8 @@ export function formatEventMessage(event: StructuredEvent): string {
       return `Dispatched task ${event.taskId} to ${event.agent}${branch}`;
     }
     case "completion": {
-      const duration = event.durationMs != null ? ` in ${Math.round(event.durationMs / 1000)}s` : "";
+      const duration =
+        event.durationMs != null ? ` in ${Math.round(event.durationMs / 1000)}s` : "";
       return `Task ${event.taskId} completed by ${event.agent}${duration}`;
     }
     case "stall":
@@ -53,6 +63,11 @@ export function formatEventMessage(event: StructuredEvent): string {
       return `Task ${event.taskId} created: "${event.title}"`;
     case "status_change":
       return `Task ${event.taskId} status: ${event.from} → ${event.to}`;
+    case "send": {
+      const preview =
+        event.message.length > 50 ? event.message.slice(0, 50) + "..." : event.message;
+      return `Sent to ${event.target}: "${preview}"`;
+    }
   }
 }
 
@@ -81,11 +96,13 @@ export function appendEvent(dir: string, event: OrchestratorEvent | StructuredEv
   // validate with schema before writing
   if (!("message" in event) || StructuredEventSchemaZ.safeParse(event).success) {
     appendFileSync(logPath, JSON.stringify(event) + "\n");
+    if (_webhooks.length > 0) fireWebhooks(_webhooks, event);
     return;
   }
 
   // Old-format event with free-form message — write as-is
   appendFileSync(logPath, JSON.stringify(event) + "\n");
+  if (_webhooks.length > 0) fireWebhooks(_webhooks, event);
 }
 
 export function readEvents(dir: string): OrchestratorEvent[] {

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -36,11 +36,7 @@ import {
   type Goal,
 } from "./task-store.ts";
 import { recordTaskTime } from "./token-tracker.ts";
-import {
-  listSessionPanes,
-  sendCommand,
-  type PaneInfo,
-} from "../widgets/lib/pane-comms.ts";
+import { listSessionPanes, sendCommand, type PaneInfo } from "../widgets/lib/pane-comms.ts";
 import { createWorktree, removeWorktree, validateWorktreePath } from "./worktree.ts";
 import { appendEvent } from "./event-log.ts";
 import { isGhAvailable, createTaskPr } from "./github-pr.ts";
@@ -68,10 +64,7 @@ export interface OrchestratorState {
   taskClaimTimes: Map<string, number>;
 }
 
-export function runHook(
-  command: string,
-  cwd: string,
-): { ok: true } | { ok: false; error: string } {
+export function runHook(command: string, cwd: string): { ok: true } | { ok: false; error: string } {
   try {
     execSync(command, { cwd, timeout: 60000, stdio: "pipe" });
     return { ok: true };
@@ -95,10 +88,26 @@ export function normalizePaneTitle(title: string): string {
 
 // French names for agents — fun, memorable, and stable across spinner changes
 const AGENT_NAMES = [
-  "François", "Amélie", "Louis", "Camille", "Marcel",
-  "Colette", "Henri", "Margaux", "René", "Léonie",
-  "Étienne", "Fleur", "Gaston", "Isabelle", "Jacques",
-  "Lucienne", "Nicolas", "Odette", "Pierre", "Rosalie",
+  "François",
+  "Amélie",
+  "Louis",
+  "Camille",
+  "Marcel",
+  "Colette",
+  "Henri",
+  "Margaux",
+  "René",
+  "Léonie",
+  "Étienne",
+  "Fleur",
+  "Gaston",
+  "Isabelle",
+  "Jacques",
+  "Lucienne",
+  "Nicolas",
+  "Odette",
+  "Pierre",
+  "Rosalie",
 ];
 
 // Get a stable, memorable identifier for an agent pane
@@ -131,9 +140,10 @@ export function isAgentBusy(pane: PaneInfo): boolean {
  */
 function isAtAgentPrompt(paneId: string): boolean {
   try {
-    const lastLine = execFileSync("tmux", [
-      "capture-pane", "-t", paneId, "-p", "-S", "-1",
-    ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    const lastLine = execFileSync("tmux", ["capture-pane", "-t", paneId, "-p", "-S", "-1"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
     return lastLine.includes("❯");
   } catch {
     return false;
@@ -218,7 +228,8 @@ export function dispatch(
   const idleAgents = panes.filter((p) => {
     // Master pane check: use role when available, fall back to title
     if (p.role === "lead") return false;
-    if (!p.role && config.masterPane && normalizePaneTitle(p.title) === config.masterPane) return false;
+    if (!p.role && config.masterPane && normalizePaneTitle(p.title) === config.masterPane)
+      return false;
     if (!isIdleForDispatch(p)) return false;
     // Don't dispatch to a pane that already has an in-progress task assigned
     const name = agentIdentifier(p);
@@ -334,10 +345,7 @@ function matchesSpecialty(goalSpecialty: string | null, plannerSpecialties: stri
   return goalTags.some((tag) => plannerSpecialties.includes(tag));
 }
 
-export function getPaneSpecialties(
-  config: OrchestratorConfig,
-  pane: PaneInfo,
-): string[] {
+export function getPaneSpecialties(config: OrchestratorConfig, pane: PaneInfo): string[] {
   const key = pane.name ?? pane.title;
   return config.paneSpecialties.get(key) ?? [];
 }
@@ -357,11 +365,7 @@ function slugifyGoal(text: string): string {
     .slice(0, 30);
 }
 
-export function buildGoalPrompt(
-  dir: string,
-  goal: Goal,
-  planner: PaneInfo,
-): string {
+export function buildGoalPrompt(dir: string, goal: Goal, planner: PaneInfo): string {
   const mission = loadMission(dir);
   const name = agentIdentifier(planner);
   const specialtyLabel = goal.specialty ?? "general";
@@ -404,13 +408,12 @@ export function dispatchGoals(
   const idlePlanners = panes.filter((p) => {
     if (p.index === 0) return false;
     if (p.role === "lead") return false;
-    if (!p.role && config.masterPane && normalizePaneTitle(p.title) === config.masterPane) return false;
+    if (!p.role && config.masterPane && normalizePaneTitle(p.title) === config.masterPane)
+      return false;
     if (!isPlannerPane(config, p)) return false;
     if (!isIdleForDispatch(p)) return false;
     const name = agentIdentifier(p);
-    const hasActiveGoal = goals.some(
-      (g) => g.assignee === name && g.status === "in-progress",
-    );
+    const hasActiveGoal = goals.some((g) => g.assignee === name && g.status === "in-progress");
     if (hasActiveGoal) return false;
     return true;
   });
@@ -520,9 +523,13 @@ export function detectCompletions(
         let baseBranch: string | undefined;
         try {
           baseBranch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
-            cwd: config.dir, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
+            cwd: config.dir,
+            encoding: "utf-8",
+            stdio: ["ignore", "pipe", "ignore"],
           }).trim();
-        } catch { /* fall back to repo default */ }
+        } catch {
+          /* fall back to repo default */
+        }
         const pr = createTaskPr(task, config.dir, baseBranch);
         if (pr) {
           if (!task.proof) task.proof = {};
@@ -554,8 +561,8 @@ export function detectCompletions(
       }
 
       if (config.masterPane) {
-        const masterPaneInfo = panes.find((p) => p.role === "lead") ??
-          panes.find((p) => p.title === config.masterPane);
+        const masterPaneInfo =
+          panes.find((p) => p.role === "lead") ?? panes.find((p) => p.title === config.masterPane);
         if (masterPaneInfo) {
           const proofStr = task.proof ? JSON.stringify(task.proof) : "no proof provided";
           sendCommand(
@@ -606,6 +613,7 @@ export function reconcile(
 interface PersistedState {
   claimedTasks: string[];
   taskClaimTimes: Record<string, number>;
+  lastActivity?: Record<string, number>;
 }
 
 function stateFilePath(dir: string): string {
@@ -618,6 +626,7 @@ export function saveOrchestratorState(dir: string, state: OrchestratorState): vo
   const data: PersistedState = {
     claimedTasks: [...state.claimedTasks],
     taskClaimTimes: Object.fromEntries(state.taskClaimTimes),
+    lastActivity: Object.fromEntries(state.lastActivity),
   };
   writeFileSync(stateFilePath(dir), JSON.stringify(data, null, 2) + "\n");
 }
@@ -635,6 +644,11 @@ export function loadOrchestratorState(dir: string, state: OrchestratorState): vo
         state.taskClaimTimes.set(id, time);
       }
     }
+    if (data.lastActivity && typeof data.lastActivity === "object") {
+      for (const [id, time] of Object.entries(data.lastActivity)) {
+        state.lastActivity.set(id, time);
+      }
+    }
   } catch {
     // Corrupted state file — start fresh
   }
@@ -648,9 +662,7 @@ export function loadOrchestratorState(dir: string, state: OrchestratorState): vo
  */
 export function syncClaims(dir: string, state: OrchestratorState): void {
   const tasks = loadTasks(dir);
-  const inProgressIds = new Set(
-    tasks.filter((t) => t.status === "in-progress").map((t) => t.id),
-  );
+  const inProgressIds = new Set(tasks.filter((t) => t.status === "in-progress").map((t) => t.id));
   // Remove stale claims
   for (const id of state.claimedTasks) {
     if (!inProgressIds.has(id)) {
@@ -663,10 +675,7 @@ export function syncClaims(dir: string, state: OrchestratorState): void {
   }
 }
 
-export function gracefulShutdown(
-  config: OrchestratorConfig,
-  state: OrchestratorState,
-): void {
+export function gracefulShutdown(config: OrchestratorConfig, state: OrchestratorState): void {
   // Release all in-progress tasks back to todo
   const tasks = loadTasks(config.dir);
   for (const task of tasks) {
@@ -707,7 +716,8 @@ export function reloadConfig(
 ): void {
   if (patch.pollInterval !== undefined) target.pollInterval = patch.pollInterval;
   if (patch.stallTimeout !== undefined) target.stallTimeout = patch.stallTimeout;
-  if (patch.maxConcurrentAgents !== undefined) target.maxConcurrentAgents = patch.maxConcurrentAgents;
+  if (patch.maxConcurrentAgents !== undefined)
+    target.maxConcurrentAgents = patch.maxConcurrentAgents;
   if (patch.autoDispatch !== undefined) target.autoDispatch = patch.autoDispatch;
   if (patch.cleanupOnDone !== undefined) target.cleanupOnDone = patch.cleanupOnDone;
   if (patch.beforeRun !== undefined) target.beforeRun = patch.beforeRun;
@@ -786,7 +796,8 @@ export function createOrchestrator(initialConfig: OrchestratorConfig): () => voi
           reloadConfig(config, {
             pollInterval: (orch.poll_interval as number | undefined) ?? config.pollInterval,
             stallTimeout: (orch.stall_timeout as number | undefined) ?? config.stallTimeout,
-            maxConcurrentAgents: (orch.max_concurrent_agents as number | undefined) ?? config.maxConcurrentAgents,
+            maxConcurrentAgents:
+              (orch.max_concurrent_agents as number | undefined) ?? config.maxConcurrentAgents,
             autoDispatch: (orch.auto_dispatch as boolean | undefined) ?? config.autoDispatch,
             cleanupOnDone: (orch.cleanup_on_done as boolean | undefined) ?? config.cleanupOnDone,
             beforeRun: (orch.before_run as string | undefined) ?? config.beforeRun,

--- a/src/lib/session-monitor.ts
+++ b/src/lib/session-monitor.ts
@@ -155,7 +155,15 @@ if (isMainModule) {
     if (!raw) return [];
     return raw.split("\n").map((line) => {
       const [id, pid, cmd, title, role, type, name] = line.split("\t");
-      return { id: id!, pid: pid!, cmd, title, role: role || undefined, type: type || undefined, name: name || undefined };
+      return {
+        id: id!,
+        pid: pid!,
+        cmd,
+        title,
+        role: role || undefined,
+        type: type || undefined,
+        name: name || undefined,
+      };
     });
   }
 
@@ -214,6 +222,12 @@ if (isMainModule) {
       if (config.orchestrator?.enabled) {
         try {
           const { createOrchestrator } = await import("./orchestrator.js");
+
+          // Configure webhooks for event delivery
+          if (config.orchestrator.webhooks?.length) {
+            const { setWebhookConfig } = await import("./event-log.js");
+            setWebhookConfig(config.orchestrator.webhooks);
+          }
 
           const orch = config.orchestrator;
 

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -1,0 +1,51 @@
+import { createHmac } from "node:crypto";
+import type { OrchestratorEvent, StructuredEvent } from "./event-log.ts";
+
+export interface WebhookConfig {
+  url: string;
+  events?: string[];
+  secret?: string;
+}
+
+/**
+ * Fire webhooks for an event. Fire-and-forget — never blocks the caller.
+ * Failures are silently ignored (logged only in debug mode).
+ */
+export function fireWebhooks(
+  webhooks: WebhookConfig[],
+  event: OrchestratorEvent | StructuredEvent,
+): void {
+  const eventType = event.type;
+
+  for (const hook of webhooks) {
+    // Filter by event type if configured
+    if (hook.events && hook.events.length > 0 && !hook.events.includes(eventType)) {
+      continue;
+    }
+
+    const body = JSON.stringify(event);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "User-Agent": "tmux-ide-webhook/1.0",
+    };
+
+    // HMAC-SHA256 signing
+    if (hook.secret) {
+      const signature = createHmac("sha256", hook.secret).update(body).digest("hex");
+      headers["X-Signature-256"] = `sha256=${signature}`;
+    }
+
+    // Fire-and-forget with 5s timeout
+    fetch(hook.url, {
+      method: "POST",
+      headers,
+      body,
+      signal: AbortSignal.timeout(5000),
+    }).catch(() => {
+      // Silently ignore webhook failures
+      if (process.env.TMUX_IDE_DEBUG === "1") {
+        process.stderr.write(`Webhook failed: ${hook.url}\n`);
+      }
+    });
+  }
+}

--- a/src/orchestrator-status.ts
+++ b/src/orchestrator-status.ts
@@ -1,0 +1,234 @@
+import { resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getSessionName, readConfig } from "./lib/yaml-io.ts";
+import { getSessionState } from "./lib/tmux.ts";
+import { loadTasks, loadMission } from "./lib/task-store.ts";
+import { readEvents } from "./lib/event-log.ts";
+import { listSessionPanes } from "./widgets/lib/pane-comms.ts";
+import { isAgentPane, isAgentBusy, agentIdentifier } from "./lib/orchestrator.ts";
+
+function formatElapsed(ms: number): string {
+  if (ms < 60000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3600000) return `${Math.round(ms / 60000)}m`;
+  return `${(ms / 3600000).toFixed(1)}h`;
+}
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60000) return `${Math.round(ms / 1000)}s ago`;
+  if (ms < 3600000) return `${Math.round(ms / 60000)}m ago`;
+  return `${(ms / 3600000).toFixed(1)}h ago`;
+}
+
+export async function orchestratorStatus(
+  targetDir: string | undefined,
+  { json }: { json?: boolean } = {},
+): Promise<void> {
+  const dir = resolve(targetDir ?? ".");
+  const { name: session } = getSessionName(dir);
+
+  // Read config
+  let orchConfig: {
+    autoDispatch: boolean;
+    dispatchMode: string;
+    pollInterval: number;
+    stallTimeout: number;
+    maxConcurrentAgents: number;
+    worktreeRoot: string;
+    masterPane: string | null;
+    cleanupOnDone: boolean;
+  } | null = null;
+
+  try {
+    const { config } = readConfig(dir);
+    const orch = config.orchestrator;
+    if (orch) {
+      orchConfig = {
+        autoDispatch: orch.auto_dispatch ?? true,
+        dispatchMode: orch.dispatch_mode ?? "tasks",
+        pollInterval: orch.poll_interval ?? 5000,
+        stallTimeout: orch.stall_timeout ?? 300000,
+        maxConcurrentAgents: orch.max_concurrent_agents ?? 10,
+        worktreeRoot: orch.worktree_root ?? ".worktrees/",
+        masterPane: orch.master_pane ?? null,
+        cleanupOnDone: orch.cleanup_on_done ?? false,
+      };
+    }
+  } catch {
+    // No config or unreadable
+  }
+
+  // Check if session is running
+  const state = getSessionState(session);
+  const running = state.running && orchConfig?.autoDispatch !== undefined;
+
+  // Read persisted orchestrator state
+  const statePath = join(dir, ".tasks", "orchestrator-state.json");
+  let claimedTasks: string[] = [];
+  let taskClaimTimes: Record<string, number> = {};
+
+  if (existsSync(statePath)) {
+    try {
+      const data = JSON.parse(readFileSync(statePath, "utf-8"));
+      claimedTasks = data.claimedTasks ?? [];
+      taskClaimTimes = data.taskClaimTimes ?? {};
+    } catch {
+      // Corrupted state
+    }
+  }
+
+  // Load tasks, panes
+  const tasks = loadTasks(dir);
+  const mission = loadMission(dir);
+
+  // Agent info from tmux panes
+  const agents: Array<{
+    name: string;
+    paneId: string;
+    state: "busy" | "idle";
+    currentTask: { id: string; title: string; elapsed: string } | null;
+  }> = [];
+
+  if (state.running) {
+    const panes = listSessionPanes(session);
+    const agentPanes = panes.filter((p) => isAgentPane(p));
+
+    for (const pane of agentPanes) {
+      const name = agentIdentifier(pane);
+      const busy = isAgentBusy(pane);
+      const assignedTask = tasks.find((t) => t.status === "in-progress" && t.assignee === name);
+
+      let currentTask: { id: string; title: string; elapsed: string } | null = null;
+      if (assignedTask) {
+        const claimTime = taskClaimTimes[assignedTask.id];
+        const elapsed = claimTime
+          ? formatElapsed(Date.now() - claimTime)
+          : formatElapsed(Date.now() - new Date(assignedTask.updated).getTime());
+        currentTask = { id: assignedTask.id, title: assignedTask.title, elapsed };
+      }
+
+      agents.push({
+        name,
+        paneId: pane.id,
+        state: busy ? "busy" : "idle",
+        currentTask,
+      });
+    }
+  }
+
+  // Categorize tasks
+  const inProgressTasks = tasks
+    .filter((t) => t.status === "in-progress")
+    .map((t) => {
+      const claimTime = taskClaimTimes[t.id];
+      const elapsed = claimTime
+        ? formatElapsed(Date.now() - claimTime)
+        : formatElapsed(Date.now() - new Date(t.updated).getTime());
+      return { id: t.id, title: t.title, assignee: t.assignee ?? "unassigned", elapsed };
+    });
+
+  const doneTaskIds = new Set(tasks.filter((t) => t.status === "done").map((t) => t.id));
+  const pendingTasks = tasks
+    .filter((t) => t.status === "todo")
+    .sort((a, b) => a.priority - b.priority)
+    .map((t) => {
+      const blockedBy = t.depends_on.filter((dep) => !doneTaskIds.has(dep));
+      return {
+        id: t.id,
+        title: t.title,
+        priority: t.priority,
+        blocked: blockedBy.length > 0,
+        blockedBy: blockedBy.length > 0 ? blockedBy : undefined,
+      };
+    });
+
+  const recentlyDone = tasks
+    .filter((t) => t.status === "done")
+    .sort((a, b) => new Date(b.updated).getTime() - new Date(a.updated).getTime())
+    .slice(0, 5)
+    .map((t) => ({ id: t.id, title: t.title, completedAt: t.updated }));
+
+  // Recent events
+  const allEvents = readEvents(dir);
+  const recentEvents = allEvents.slice(-10).reverse();
+
+  const data = {
+    running,
+    config: orchConfig,
+    agents,
+    tasks: { inProgress: inProgressTasks, pending: pendingTasks, recentlyDone },
+    claims: { count: claimedTasks.length, taskIds: claimedTasks },
+    recentEvents,
+  };
+
+  if (json) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  // Human-readable output
+  const noColor = "NO_COLOR" in process.env;
+  const bold = (s: string) => (noColor ? s : `\x1b[1m${s}\x1b[22m`);
+  const dim = (s: string) => (noColor ? s : `\x1b[2m${s}\x1b[22m`);
+  const green = (s: string) => (noColor ? s : `\x1b[32m${s}\x1b[39m`);
+  const yellow = (s: string) => (noColor ? s : `\x1b[33m${s}\x1b[39m`);
+
+  console.log(`${bold("Orchestrator:")} ${running ? green("running") : dim("stopped")}`);
+
+  if (orchConfig) {
+    const stallMin = Math.round(orchConfig.stallTimeout / 60000);
+    console.log(
+      `  Poll: ${orchConfig.pollInterval}ms | Stall: ${stallMin}m | Mode: ${orchConfig.dispatchMode} | Auto-dispatch: ${orchConfig.autoDispatch ? "on" : "off"}`,
+    );
+    console.log(
+      `  Max concurrent: ${orchConfig.maxConcurrentAgents} | Cleanup: ${orchConfig.cleanupOnDone ? "on" : "off"}`,
+    );
+  }
+
+  if (mission) {
+    console.log(`\n${bold("Mission:")} ${mission.title}`);
+  }
+
+  // Agents
+  const busyCount = agents.filter((a) => a.state === "busy").length;
+  console.log(`\n${bold("Agents")} (${busyCount} busy / ${agents.length} total):`);
+  if (agents.length === 0) {
+    console.log(`  ${dim("No agents detected")}`);
+  }
+  for (const agent of agents) {
+    const stateLabel = agent.state === "busy" ? yellow("busy") : green("idle");
+    const taskLabel = agent.currentTask
+      ? ` -> ${agent.currentTask.id} "${agent.currentTask.title}" (${agent.currentTask.elapsed})`
+      : "";
+    console.log(`  ${agent.name.padEnd(12)} ${agent.paneId.padEnd(5)} ${stateLabel}${taskLabel}`);
+  }
+
+  // In-progress
+  if (inProgressTasks.length > 0) {
+    console.log(`\n${bold("In-progress")} (${inProgressTasks.length}):`);
+    for (const t of inProgressTasks) {
+      console.log(`  ${t.id}  "${t.title}"  @${t.assignee}  ${dim(t.elapsed)}`);
+    }
+  }
+
+  // Pending
+  if (pendingTasks.length > 0) {
+    console.log(`\n${bold("Pending")} (${pendingTasks.length}):`);
+    for (const t of pendingTasks.slice(0, 10)) {
+      const blocked = t.blocked ? dim(` (blocked by ${t.blockedBy!.join(", ")})`) : "";
+      console.log(`  ${t.id}  "${t.title}"  P${t.priority}${blocked}`);
+    }
+    if (pendingTasks.length > 10) {
+      console.log(`  ${dim(`... and ${pendingTasks.length - 10} more`)}`);
+    }
+  }
+
+  // Recent events
+  if (recentEvents.length > 0) {
+    console.log(`\n${bold("Recent Events")}:`);
+    for (const evt of recentEvents) {
+      console.log(`  ${dim(formatRelative(evt.timestamp))}  ${evt.type.padEnd(15)} ${evt.message}`);
+    }
+  }
+}

--- a/src/schemas/domain.ts
+++ b/src/schemas/domain.ts
@@ -5,9 +5,7 @@ import { z } from "zod";
 // ---------------------------------------------------------------------------
 
 export const ProofSchemaZ = z.object({
-  tests: z
-    .object({ passed: z.number(), total: z.number() })
-    .optional(),
+  tests: z.object({ passed: z.number(), total: z.number() }).optional(),
   pr: z
     .object({
       number: z.number(),
@@ -15,9 +13,7 @@ export const ProofSchemaZ = z.object({
       status: z.string().optional(),
     })
     .optional(),
-  ci: z
-    .object({ status: z.string(), url: z.string().optional() })
-    .optional(),
+  ci: z.object({ status: z.string(), url: z.string().optional() }).optional(),
   notes: z.string().optional(),
 });
 
@@ -80,6 +76,7 @@ export const EventTypeSchemaZ = z.enum([
   "error",
   "task_created",
   "status_change",
+  "send",
 ]);
 
 export const OrchestratorEventSchemaZ = z.object({
@@ -159,6 +156,14 @@ const StatusChangeEventZ = z.object({
   to: z.string(),
 });
 
+const SendEventZ = z.object({
+  timestamp: z.string(),
+  type: z.literal("send"),
+  target: z.string(),
+  paneId: z.string(),
+  message: z.string(),
+});
+
 export const StructuredEventSchemaZ = z.union([
   DispatchEventZ,
   CompletionEventZ,
@@ -168,6 +173,7 @@ export const StructuredEventSchemaZ = z.union([
   ErrorEventZ,
   TaskCreatedEventZ,
   StatusChangeEventZ,
+  SendEventZ,
 ]);
 
 // ---------------------------------------------------------------------------
@@ -181,15 +187,7 @@ export const MarkRangeSchemaZ = z.object({
 
 export const MarkSchemaZ = z.object({
   id: z.string(),
-  kind: z.enum([
-    "authored",
-    "approved",
-    "flagged",
-    "comment",
-    "insert",
-    "delete",
-    "replace",
-  ]),
+  kind: z.enum(["authored", "approved", "flagged", "comment", "insert", "delete", "replace"]),
   by: z.string(),
   at: z.string(),
   range: MarkRangeSchemaZ,
@@ -207,12 +205,7 @@ export const AuthorshipStatsSchemaZ = z.object({
 // PlanStatus / PlanMeta (from src/lib/plan-store.ts)
 // ---------------------------------------------------------------------------
 
-export const PlanStatusSchemaZ = z.enum([
-  "pending",
-  "in-progress",
-  "done",
-  "archived",
-]);
+export const PlanStatusSchemaZ = z.enum(["pending", "in-progress", "done", "archived"]);
 
 export const PlanMetaSchemaZ = z.object({
   name: z.string(),

--- a/src/schemas/ide-config.ts
+++ b/src/schemas/ide-config.ts
@@ -16,7 +16,7 @@ export const PaneSchema = z.object({
   title: z.string().optional(),
   command: z.string().optional(),
   type: z
-    .enum(["explorer", "changes", "preview", "tasks", "warroom", "costs"])
+    .enum(["explorer", "changes", "preview", "tasks", "warroom", "costs", "config"])
     .optional(),
   target: z.string().optional(),
   dir: z.string().optional(),
@@ -33,6 +33,12 @@ export const RowSchema = z.object({
   panes: z.array(PaneSchema).min(1),
 });
 
+export const WebhookConfigSchema = z.object({
+  url: z.string(),
+  events: z.array(z.string()).optional(),
+  secret: z.string().optional(),
+});
+
 export const OrchestratorYamlConfigSchema = z.object({
   enabled: z.boolean().optional(),
   auto_dispatch: z.boolean().optional(),
@@ -46,6 +52,7 @@ export const OrchestratorYamlConfigSchema = z.object({
   dispatch_mode: z.enum(["tasks", "goals"]).optional(),
   max_concurrent_agents: z.number().optional(),
   widgets: z.boolean().optional(),
+  webhooks: z.array(WebhookConfigSchema).optional(),
 });
 
 export const IdeConfigSchema = z.object({
@@ -83,9 +90,7 @@ export const SessionStateSchema = z.object({
 export type ThemeConfig = z.infer<typeof ThemeConfigSchema>;
 export type Pane = z.infer<typeof PaneSchema>;
 export type Row = z.infer<typeof RowSchema>;
-export type OrchestratorYamlConfig = z.infer<
-  typeof OrchestratorYamlConfigSchema
->;
+export type OrchestratorYamlConfig = z.infer<typeof OrchestratorYamlConfigSchema>;
 export type IdeConfig = z.infer<typeof IdeConfigSchema>;
 export type PaneAction = z.infer<typeof PaneActionSchema>;
 export type SessionState = z.infer<typeof SessionStateSchema>;

--- a/src/send.ts
+++ b/src/send.ts
@@ -1,0 +1,150 @@
+import { resolve } from "node:path";
+import { getSessionName } from "./lib/yaml-io.ts";
+import { getSessionState } from "./lib/tmux.ts";
+import {
+  listSessionPanes,
+  sendCommand,
+  sendText,
+  getPaneBusyStatus,
+  type PaneInfo,
+  type PaneBusyStatus,
+} from "./widgets/lib/pane-comms.ts";
+import { appendEvent } from "./lib/event-log.ts";
+import { IdeError } from "./lib/errors.ts";
+
+interface SendOptions {
+  json?: boolean;
+  to?: string;
+  message?: string;
+  noEnter?: boolean;
+}
+
+/**
+ * Resolve a target string to a pane. Priority:
+ * 1. Exact pane ID (%N)
+ * 2. @ide_name match
+ * 3. Exact title match
+ * 4. Role match (lead, teammate, planner)
+ * 5. Case-insensitive partial title match
+ */
+function resolvePane(panes: PaneInfo[], target: string): PaneInfo | null {
+  // 1. Exact pane ID
+  if (target.startsWith("%")) {
+    return panes.find((p) => p.id === target) ?? null;
+  }
+
+  // 2. @ide_name match
+  const byName = panes.find((p) => p.name === target);
+  if (byName) return byName;
+
+  // 3. Exact title match
+  const byTitle = panes.find((p) => p.title === target);
+  if (byTitle) return byTitle;
+
+  // 4. Role match
+  const lower = target.toLowerCase();
+  if (["lead", "teammate", "planner"].includes(lower)) {
+    const byRole = panes.find((p) => p.role === lower);
+    if (byRole) return byRole;
+  }
+
+  // 5. Case-insensitive partial title match
+  const byPattern = panes.find((p) => p.title.toLowerCase().includes(lower));
+  if (byPattern) return byPattern;
+
+  return null;
+}
+
+function prepareMessage(message: string, busyStatus: PaneBusyStatus): string {
+  if (busyStatus === "agent") {
+    // Collapse multiline to single line for Claude Code TUI
+    // Prevents paste preview that requires manual Enter
+    return message.replace(/\n+/g, " ").trim();
+  }
+  return message;
+}
+
+export async function send(targetDir: string | undefined, opts: SendOptions): Promise<void> {
+  const dir = resolve(targetDir ?? ".");
+  const { name: session } = getSessionName(dir);
+  const { json, to: target, message: rawMessage, noEnter } = opts;
+
+  if (!target) {
+    throw new IdeError("Missing target. Usage: tmux-ide send <target> <message>", {
+      code: "USAGE",
+    });
+  }
+
+  if (!rawMessage) {
+    throw new IdeError("Missing message. Usage: tmux-ide send <target> <message>", {
+      code: "USAGE",
+    });
+  }
+
+  // Verify session is running
+  const state = getSessionState(session);
+  if (!state.running) {
+    throw new IdeError(`Session "${session}" is not running`, {
+      code: "SESSION_NOT_FOUND",
+    });
+  }
+
+  const panes = listSessionPanes(session);
+  const pane = resolvePane(panes, target);
+  if (!pane) {
+    const available = panes
+      .map((p) => {
+        const label = p.name ?? p.title;
+        return `  ${p.id}  ${label}${p.role ? ` (${p.role})` : ""}`;
+      })
+      .join("\n");
+    throw new IdeError(`Pane "${target}" not found.\n\nAvailable panes:\n${available}`, {
+      code: "PANE_NOT_FOUND",
+    });
+  }
+
+  const busyStatus = getPaneBusyStatus(session, pane.id);
+  const message = prepareMessage(rawMessage, busyStatus);
+
+  if (noEnter) {
+    sendText(session, pane.id, message);
+  } else {
+    sendCommand(session, pane.id, message);
+  }
+
+  // Log send event
+  appendEvent(dir, {
+    timestamp: new Date().toISOString(),
+    type: "send",
+    target: pane.name ?? pane.title,
+    paneId: pane.id,
+    message: message.length > 100 ? message.slice(0, 100) + "..." : message,
+  });
+
+  const result = {
+    ok: true,
+    session,
+    target: {
+      paneId: pane.id,
+      name: pane.name,
+      title: pane.title,
+      role: pane.role,
+    },
+    message,
+    busyStatus,
+    ...(busyStatus === "agent" ? { warning: "agent_busy" } : {}),
+  };
+
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  const label = pane.name ?? pane.title;
+  const preview = message.length > 60 ? message.slice(0, 60) + "..." : message;
+  console.log(`Sent to "${label}" (${pane.id}): ${preview}`);
+
+  if (busyStatus === "agent") {
+    console.log("Warning: agent appears busy. Message sent anyway.");
+  }
+}

--- a/src/widgets/config/index.tsx
+++ b/src/widgets/config/index.tsx
@@ -1,0 +1,442 @@
+import "@opentui/solid/runtime-plugin-support";
+import { parseArgs } from "node:util";
+import { render, useKeyboard, useTerminalDimensions } from "@opentui/solid";
+import { RGBA, TextAttributes } from "@opentui/core";
+import { createSignal, createMemo, Show } from "solid-js";
+import { createTheme, type RGBA as RGBAType, type WidgetTheme } from "../lib/theme.ts";
+import {
+  flattenConfigTree,
+  updateConfigAtPath,
+  addPane,
+  removePane,
+  addRow,
+  removeRow,
+  validateSetupConfig,
+  type TreeNode,
+} from "../lib/config-model.ts";
+import { readConfig, writeConfig } from "../../lib/yaml-io.ts";
+import { hasSession } from "../../lib/tmux.ts";
+import type { IdeConfig } from "../../schemas/ide-config.ts";
+import { ConfigTree } from "../setup/config-tree.tsx";
+import { FieldEditor, type FieldType } from "../setup/field-editor.tsx";
+
+const { values } = parseArgs({
+  options: {
+    session: { type: "string" },
+    dir: { type: "string" },
+    theme: { type: "string" },
+  },
+});
+
+const dir = values.dir ?? process.cwd();
+const themeConfig = values.theme ? JSON.parse(values.theme) : undefined;
+
+function toRGBA(c: RGBAType): RGBA {
+  return RGBA.fromInts(c.r, c.g, c.b, c.a);
+}
+
+type Tab = "layout" | "team" | "orchestrator" | "theme";
+const TABS: { id: Tab; label: string }[] = [
+  { id: "layout", label: "Layout" },
+  { id: "team", label: "Team" },
+  { id: "orchestrator", label: "Orch." },
+  { id: "theme", label: "Theme" },
+];
+
+function inferFieldType(path: string[]): { type: FieldType; enumValues?: string[] } {
+  const last = path[path.length - 1] ?? "";
+
+  // Boolean fields
+  if (["focus", "enabled", "auto_dispatch", "cleanup_on_done", "widgets"].includes(last)) {
+    return { type: "boolean" };
+  }
+
+  // Enum fields
+  if (last === "role") return { type: "enum", enumValues: ["lead", "teammate", "planner"] };
+  if (last === "type")
+    return {
+      type: "enum",
+      enumValues: ["explorer", "changes", "preview", "tasks", "warroom", "costs", "config"],
+    };
+  if (last === "dispatch_mode") return { type: "enum", enumValues: ["tasks", "goals"] };
+
+  // Size fields
+  if (last === "size") return { type: "size" };
+
+  // Number fields rendered as string (will be coerced)
+  return { type: "string" };
+}
+
+function coerceValue(raw: unknown, path: string[]): unknown {
+  if (typeof raw !== "string") return raw;
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  const last = path[path.length - 1] ?? "";
+  if (["stall_timeout", "poll_interval", "max_concurrent_agents", "priority"].includes(last)) {
+    const num = parseInt(raw, 10);
+    if (!isNaN(num)) return num;
+  }
+  return raw;
+}
+
+function getValueAtPath(config: IdeConfig, path: string[]): string {
+  let current: unknown = config;
+  for (const key of path) {
+    if (current === null || current === undefined) return "";
+    if (typeof current === "object") {
+      current = (current as Record<string, unknown>)[key];
+    } else {
+      return "";
+    }
+  }
+  return current === null || current === undefined ? "" : String(current);
+}
+
+render(
+  () => {
+    const theme = createTheme(themeConfig);
+    const dimensions = useTerminalDimensions();
+
+    // Load config
+    let initialConfig: IdeConfig;
+    try {
+      const result = readConfig(dir);
+      initialConfig = result.config;
+    } catch {
+      console.error("No ide.yml found. Run 'tmux-ide init' first.");
+      process.exit(1);
+    }
+
+    const [config, setConfig] = createSignal<IdeConfig>(initialConfig);
+    const [savedConfig, setSavedConfig] = createSignal(JSON.stringify(initialConfig));
+    const [activeTab, setActiveTab] = createSignal<Tab>("layout");
+    const [editingField, setEditingField] = createSignal<string[] | null>(null);
+    const [statusMsg, setStatusMsg] = createSignal<string | null>(null);
+
+    const dirty = createMemo(() => JSON.stringify(config()) !== savedConfig());
+    const validation = createMemo(() => validateSetupConfig(config()));
+
+    function handleSave() {
+      writeConfig(dir, config());
+      setSavedConfig(JSON.stringify(config()));
+      setStatusMsg("Saved");
+      setTimeout(() => setStatusMsg(null), 2000);
+    }
+
+    function handleEditField(path: string[]) {
+      setEditingField(path);
+    }
+
+    function handleFieldSave(path: string[], value: unknown) {
+      const coerced = coerceValue(value, path);
+      setConfig(updateConfigAtPath(config(), path, coerced));
+      setEditingField(null);
+    }
+
+    function handleAddPane(rowIdx: number) {
+      setConfig(addPane(config(), rowIdx));
+    }
+
+    function handleDelete(path: string[]) {
+      // Handle row deletion
+      if (path.length === 2 && path[0] === "rows" && /^\d+$/.test(path[1]!)) {
+        setConfig(removeRow(config(), parseInt(path[1]!, 10)));
+        return;
+      }
+      // Handle pane deletion
+      if (path.length >= 4 && path[0] === "rows" && path[2] === "panes") {
+        const rowIdx = parseInt(path[1]!, 10);
+        const paneIdx = parseInt(path[3]!, 10);
+        if (!isNaN(rowIdx) && !isNaN(paneIdx)) {
+          setConfig(removePane(config(), rowIdx, paneIdx));
+        }
+      }
+    }
+
+    function handleConfigChange(newConfig: IdeConfig) {
+      setConfig(newConfig);
+    }
+
+    // Tab-level keyboard handling (when not editing a field)
+    useKeyboard((evt) => {
+      if (editingField() !== null) return; // Let field editor handle keys
+
+      if (evt.name === "tab") {
+        const tabs = TABS.map((t) => t.id);
+        const idx = tabs.indexOf(activeTab());
+        setActiveTab(tabs[(idx + 1) % tabs.length]!);
+        evt.preventDefault();
+      } else if (evt.name === "q") {
+        if (dirty()) {
+          setStatusMsg("Unsaved changes! Ctrl+S to save, then q to quit.");
+          setTimeout(() => setStatusMsg(null), 3000);
+        } else {
+          process.exit(0);
+        }
+        evt.preventDefault();
+      } else if (evt.ctrl && evt.name === "s") {
+        handleSave();
+        evt.preventDefault();
+      } else if (evt.ctrl && evt.name === "r") {
+        handleSave();
+        const sessionName = config().name ?? dir.split("/").pop() ?? "ide";
+        if (hasSession(sessionName)) {
+          const { execFileSync } = require("node:child_process");
+          try {
+            execFileSync("tmux-ide", ["restart"], { cwd: dir, stdio: "inherit" });
+          } catch {
+            /* restart may close our pane */
+          }
+        }
+        process.exit(0);
+      } else if (evt.name === "1") {
+        setActiveTab("layout");
+        evt.preventDefault();
+      } else if (evt.name === "2") {
+        setActiveTab("team");
+        evt.preventDefault();
+      } else if (evt.name === "3") {
+        setActiveTab("orchestrator");
+        evt.preventDefault();
+      } else if (evt.name === "4") {
+        setActiveTab("theme");
+        evt.preventDefault();
+      }
+    });
+
+    // Team panel: simple form for team config
+    function TeamPanel() {
+      const cfg = config();
+      const teamEnabled = !!cfg.team;
+      const teamName = cfg.team?.name ?? "";
+
+      const panes: { row: number; pane: number; title: string; role: string | undefined }[] = [];
+      cfg.rows.forEach((row, ri) => {
+        row.panes.forEach((p, pi) => {
+          panes.push({ row: ri, pane: pi, title: p.title ?? `Row ${ri} Pane ${pi}`, role: p.role });
+        });
+      });
+
+      return (
+        <box paddingLeft={1}>
+          <text fg={toRGBA(theme.accent)} attributes={TextAttributes.BOLD}>
+            Team Configuration
+          </text>
+          <box paddingTop={1}>
+            <text fg={toRGBA(theme.fg)}>
+              Team: {teamEnabled ? `enabled (${teamName})` : "disabled"}
+            </text>
+          </box>
+          <box paddingTop={1}>
+            <text fg={toRGBA(theme.fgMuted)}>
+              {teamEnabled
+                ? "Use 'tmux-ide config disable-team' to disable"
+                : "Use 'tmux-ide config enable-team --name <N>' to enable"}
+            </text>
+          </box>
+          <box paddingTop={1}>
+            <text fg={toRGBA(theme.accent)} attributes={TextAttributes.BOLD}>
+              Pane Roles
+            </text>
+          </box>
+          {panes.map((p) => (
+            <box paddingLeft={1}>
+              <text fg={toRGBA(theme.fg)}>
+                {p.title}: {p.role ?? "none"}
+              </text>
+            </box>
+          ))}
+        </box>
+      );
+    }
+
+    // Orchestrator panel: display orchestrator settings
+    function OrchestratorPanel() {
+      const cfg = config();
+      const orch = cfg.orchestrator;
+      const fields: [string, string][] = [
+        ["enabled", String(orch?.enabled ?? false)],
+        ["auto_dispatch", String(orch?.auto_dispatch ?? true)],
+        ["dispatch_mode", orch?.dispatch_mode ?? "tasks"],
+        ["poll_interval", String(orch?.poll_interval ?? 5000)],
+        ["stall_timeout", String(orch?.stall_timeout ?? 300000)],
+        ["max_concurrent_agents", String(orch?.max_concurrent_agents ?? 10)],
+        ["worktree_root", orch?.worktree_root ?? ".worktrees/"],
+        ["cleanup_on_done", String(orch?.cleanup_on_done ?? false)],
+        ["widgets", String(orch?.widgets ?? false)],
+      ];
+
+      return (
+        <box paddingLeft={1}>
+          <text fg={toRGBA(theme.accent)} attributes={TextAttributes.BOLD}>
+            Orchestrator Settings
+          </text>
+          <box paddingTop={1}>
+            {fields.map(([key, val]) => (
+              <box flexDirection="row" gap={1}>
+                <text fg={toRGBA(theme.fgMuted)}>{key!.padEnd(24)}</text>
+                <text fg={toRGBA(theme.fg)}>{val}</text>
+              </box>
+            ))}
+          </box>
+          <box paddingTop={1}>
+            <text fg={toRGBA(theme.fgMuted)}>
+              Edit via Layout tab or: tmux-ide config set orchestrator.enabled true
+            </text>
+          </box>
+        </box>
+      );
+    }
+
+    // Theme panel: display theme settings
+    function ThemePanel() {
+      const cfg = config();
+      const t = cfg.theme;
+      const fields: [string, string][] = [
+        ["accent", t?.accent ?? "(default)"],
+        ["border", t?.border ?? "(default)"],
+        ["bg", t?.bg ?? "(default)"],
+        ["fg", t?.fg ?? "(default)"],
+      ];
+
+      return (
+        <box paddingLeft={1}>
+          <text fg={toRGBA(theme.accent)} attributes={TextAttributes.BOLD}>
+            Theme Colors
+          </text>
+          <box paddingTop={1}>
+            {fields.map(([key, val]) => (
+              <box flexDirection="row" gap={1}>
+                <text fg={toRGBA(theme.fgMuted)}>{key!.padEnd(12)}</text>
+                <text fg={toRGBA(theme.fg)}>{val}</text>
+              </box>
+            ))}
+          </box>
+          <box paddingTop={1}>
+            <text fg={toRGBA(theme.fgMuted)}>
+              Edit via Layout tab or: tmux-ide config set theme.accent colour75
+            </text>
+          </box>
+        </box>
+      );
+    }
+
+    return (
+      <box
+        width={dimensions().width}
+        height={dimensions().height}
+        backgroundColor={toRGBA(theme.bg)}
+        flexDirection="column"
+      >
+        {/* Title bar */}
+        <box
+          flexShrink={0}
+          flexDirection="row"
+          justifyContent="space-between"
+          paddingLeft={1}
+          paddingRight={1}
+        >
+          <text fg={toRGBA(theme.accent)} attributes={TextAttributes.BOLD}>
+            Settings
+          </text>
+          <box flexDirection="row" gap={2}>
+            {dirty() ? <text fg={toRGBA(theme.gitModified)}>unsaved</text> : null}
+            <text fg={toRGBA(theme.fgMuted)}>Ctrl+S:save</text>
+          </box>
+        </box>
+
+        {/* Main content */}
+        <box flexGrow={1} flexDirection="row">
+          {/* Tab sidebar */}
+          <box flexShrink={0} width={10} paddingLeft={1}>
+            {TABS.map((tab) => {
+              const isActive = () => activeTab() === tab.id;
+              return (
+                <box
+                  flexShrink={0}
+                  backgroundColor={isActive() ? toRGBA(theme.selected) : undefined}
+                  onMouseUp={() => setActiveTab(tab.id)}
+                >
+                  <text
+                    fg={toRGBA(isActive() ? theme.accent : theme.fgMuted)}
+                    attributes={isActive() ? TextAttributes.BOLD : 0}
+                  >
+                    {isActive() ? ">" : " "} {tab.label}
+                  </text>
+                </box>
+              );
+            })}
+          </box>
+
+          {/* Content area */}
+          <box flexGrow={1}>
+            <Show
+              when={editingField() !== null}
+              fallback={
+                <>
+                  <Show when={activeTab() === "layout"}>
+                    <ConfigTree
+                      config={config()}
+                      onEditField={handleEditField}
+                      onAddPane={handleAddPane}
+                      onDelete={handleDelete}
+                      onSave={handleSave}
+                      onConfigChange={handleConfigChange}
+                      theme={theme}
+                    />
+                  </Show>
+                  <Show when={activeTab() === "team"}>
+                    <TeamPanel />
+                  </Show>
+                  <Show when={activeTab() === "orchestrator"}>
+                    <OrchestratorPanel />
+                  </Show>
+                  <Show when={activeTab() === "theme"}>
+                    <ThemePanel />
+                  </Show>
+                </>
+              }
+            >
+              <FieldEditor
+                path={editingField()!}
+                value={getValueAtPath(config(), editingField()!)}
+                fieldType={inferFieldType(editingField()!).type}
+                enumValues={inferFieldType(editingField()!).enumValues}
+                onSave={handleFieldSave}
+                onCancel={() => setEditingField(null)}
+                theme={theme}
+              />
+            </Show>
+          </box>
+        </box>
+
+        {/* Status bar */}
+        <box flexShrink={0} paddingLeft={1} paddingRight={1}>
+          <box flexShrink={0} height={1}>
+            <text fg={toRGBA(theme.border)} wrapMode="none">
+              {"─".repeat(Math.max(1, dimensions().width - 2))}
+            </text>
+          </box>
+          <box flexDirection="row" gap={2}>
+            {validation().valid ? (
+              <text fg={toRGBA(theme.gitAdded)}>Valid</text>
+            ) : (
+              <text fg={toRGBA(theme.gitDeleted)}>Invalid</text>
+            )}
+            {statusMsg() ? <text fg={toRGBA(theme.accent)}>{statusMsg()}</text> : null}
+            <text fg={toRGBA(theme.fgMuted)}>Tab:switch</text>
+            <text fg={toRGBA(theme.fgMuted)}>1-4:tabs</text>
+            <text fg={toRGBA(theme.fgMuted)}>Ctrl+R:restart</text>
+            <text fg={toRGBA(theme.fgMuted)}>q:quit</text>
+          </box>
+        </box>
+      </box>
+    );
+  },
+  {
+    targetFps: 30,
+    exitOnCtrlC: true,
+    useKittyKeyboard: {},
+    autoFocus: false,
+  },
+);

--- a/src/widgets/lib/config-model.ts
+++ b/src/widgets/lib/config-model.ts
@@ -1,0 +1,116 @@
+import { IdeConfigSchema, type IdeConfig, type Row } from "../../schemas/ide-config.ts";
+
+// ---------------------------------------------------------------------------
+// Config Tree
+// ---------------------------------------------------------------------------
+
+export interface TreeNode {
+  path: string[];
+  label: string;
+  value: string | null;
+  depth: number;
+  expandable: boolean;
+}
+
+function flattenValue(obj: unknown, path: string[], depth: number, nodes: TreeNode[]): void {
+  if (Array.isArray(obj)) {
+    const label = path[path.length - 1] ?? "";
+    nodes.push({ path: [...path], label, value: null, depth, expandable: true });
+    for (let i = 0; i < obj.length; i++) {
+      flattenValue(obj[i], [...path, String(i)], depth + 1, nodes);
+    }
+  } else if (obj !== null && typeof obj === "object") {
+    const label = path[path.length - 1] ?? "";
+    nodes.push({ path: [...path], label, value: null, depth, expandable: true });
+    for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
+      flattenValue(val, [...path, key], depth + 1, nodes);
+    }
+  } else {
+    const label = path[path.length - 1] ?? "";
+    nodes.push({
+      path: [...path],
+      label,
+      value: obj === undefined || obj === null ? null : String(obj),
+      depth,
+      expandable: false,
+    });
+  }
+}
+
+export function flattenConfigTree(config: IdeConfig): TreeNode[] {
+  const nodes: TreeNode[] = [];
+  for (const [key, val] of Object.entries(config)) {
+    if (val === undefined) continue;
+    flattenValue(val, [key], 0, nodes);
+  }
+  return nodes;
+}
+
+// ---------------------------------------------------------------------------
+// Config Mutations
+// ---------------------------------------------------------------------------
+
+export function deepClone<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj)) as T;
+}
+
+export function updateConfigAtPath(config: IdeConfig, path: string[], value: unknown): IdeConfig {
+  const cloned = deepClone(config);
+  let current: Record<string, unknown> = cloned as unknown as Record<string, unknown>;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i]!;
+    current = current[key] as Record<string, unknown>;
+  }
+  const lastKey = path[path.length - 1]!;
+  current[lastKey] = value;
+  return cloned;
+}
+
+export function addPane(config: IdeConfig, rowIdx: number): IdeConfig {
+  const cloned = deepClone(config);
+  const row = cloned.rows[rowIdx];
+  if (!row) return cloned;
+  row.panes.push({ title: "New Pane" });
+  return cloned;
+}
+
+export function removePane(config: IdeConfig, rowIdx: number, paneIdx: number): IdeConfig {
+  const cloned = deepClone(config);
+  const row = cloned.rows[rowIdx];
+  if (!row) return cloned;
+  if (row.panes.length <= 1) return cloned;
+  row.panes.splice(paneIdx, 1);
+  return cloned;
+}
+
+export function addRow(config: IdeConfig, size?: string): IdeConfig {
+  const cloned = deepClone(config);
+  const row: Row = { panes: [{ title: "Shell" }] };
+  if (size) row.size = size;
+  cloned.rows.push(row);
+  return cloned;
+}
+
+export function removeRow(config: IdeConfig, rowIdx: number): IdeConfig {
+  const cloned = deepClone(config);
+  if (cloned.rows.length <= 1) return cloned;
+  cloned.rows.splice(rowIdx, 1);
+  return cloned;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export function validateSetupConfig(
+  config: unknown,
+): { valid: true; config: IdeConfig } | { valid: false; errors: string[] } {
+  const result = IdeConfigSchema.safeParse(config);
+  if (result.success) {
+    return { valid: true, config: result.data };
+  }
+  return {
+    valid: false,
+    errors: result.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`),
+  };
+}

--- a/src/widgets/resolve.ts
+++ b/src/widgets/resolve.ts
@@ -21,6 +21,7 @@ const WIDGET_ENTRY_POINTS: Record<string, string> = {
   warroom: "warroom/index.tsx",
   costs: "costs/index.tsx",
   setup: "setup/index.tsx",
+  config: "config/index.tsx",
 };
 
 export function resolveWidgetCommand(type: string, opts: WidgetOptions): string {

--- a/src/widgets/setup/setup-model.ts
+++ b/src/widgets/setup/setup-model.ts
@@ -1,8 +1,20 @@
-import { IdeConfigSchema, type IdeConfig, type Pane, type Row } from "../../schemas/ide-config.ts";
-import type { z } from "zod";
+import type { IdeConfig } from "../../schemas/ide-config.ts";
+
+// Re-export shared config model utilities
+export {
+  type TreeNode,
+  flattenConfigTree,
+  updateConfigAtPath,
+  addPane,
+  removePane,
+  addRow,
+  removeRow,
+  deepClone,
+  validateSetupConfig,
+} from "../lib/config-model.ts";
 
 // ---------------------------------------------------------------------------
-// Layout Presets
+// Layout Presets (setup-specific)
 // ---------------------------------------------------------------------------
 
 export interface DetectedInfo {
@@ -116,9 +128,7 @@ export const PRESETS: LayoutPreset[] = [
         rows: [
           {
             size: "60%",
-            panes: [
-              { title: "Claude", command: "claude", focus: true },
-            ],
+            panes: [{ title: "Claude", command: "claude", focus: true }],
           },
           {
             panes: [
@@ -134,7 +144,8 @@ export const PRESETS: LayoutPreset[] = [
   {
     id: "agent-team",
     label: "Agent Team",
-    description: "Lead + 2 teammates on top, warroom/tasks/explorer/preview widgets below with orchestrator.",
+    description:
+      "Lead + 2 teammates on top, warroom/tasks/explorer/preview widgets below with orchestrator.",
     diagram: [
       "┌───────────┬───────────┬───────────┐",
       "│           │           │           │",
@@ -174,121 +185,4 @@ export const PRESETS: LayoutPreset[] = [
 
 export function getPreset(id: string): LayoutPreset | undefined {
   return PRESETS.find((p) => p.id === id);
-}
-
-// ---------------------------------------------------------------------------
-// Config Tree
-// ---------------------------------------------------------------------------
-
-export interface TreeNode {
-  path: string[];
-  label: string;
-  value: string | null;
-  depth: number;
-  expandable: boolean;
-}
-
-function flattenValue(
-  obj: unknown,
-  path: string[],
-  depth: number,
-  nodes: TreeNode[],
-): void {
-  if (Array.isArray(obj)) {
-    const label = path[path.length - 1] ?? "";
-    nodes.push({ path: [...path], label, value: null, depth, expandable: true });
-    for (let i = 0; i < obj.length; i++) {
-      flattenValue(obj[i], [...path, String(i)], depth + 1, nodes);
-    }
-  } else if (obj !== null && typeof obj === "object") {
-    const label = path[path.length - 1] ?? "";
-    nodes.push({ path: [...path], label, value: null, depth, expandable: true });
-    for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
-      flattenValue(val, [...path, key], depth + 1, nodes);
-    }
-  } else {
-    const label = path[path.length - 1] ?? "";
-    nodes.push({
-      path: [...path],
-      label,
-      value: obj === undefined || obj === null ? null : String(obj),
-      depth,
-      expandable: false,
-    });
-  }
-}
-
-export function flattenConfigTree(config: IdeConfig): TreeNode[] {
-  const nodes: TreeNode[] = [];
-  // Flatten top-level keys (skip the root container itself)
-  for (const [key, val] of Object.entries(config)) {
-    if (val === undefined) continue;
-    flattenValue(val, [key], 0, nodes);
-  }
-  return nodes;
-}
-
-// ---------------------------------------------------------------------------
-// Config Mutations
-// ---------------------------------------------------------------------------
-
-function deepClone<T>(obj: T): T {
-  return JSON.parse(JSON.stringify(obj)) as T;
-}
-
-export function updateConfigAtPath(
-  config: IdeConfig,
-  path: string[],
-  value: unknown,
-): IdeConfig {
-  const cloned = deepClone(config);
-  let current: Record<string, unknown> = cloned as unknown as Record<string, unknown>;
-  for (let i = 0; i < path.length - 1; i++) {
-    const key = path[i]!;
-    current = current[key] as Record<string, unknown>;
-  }
-  const lastKey = path[path.length - 1]!;
-  current[lastKey] = value;
-  return cloned;
-}
-
-export function addPane(config: IdeConfig, rowIdx: number): IdeConfig {
-  const cloned = deepClone(config);
-  const row = cloned.rows[rowIdx];
-  if (!row) return cloned;
-  row.panes.push({ title: "New Pane" });
-  return cloned;
-}
-
-export function removePane(
-  config: IdeConfig,
-  rowIdx: number,
-  paneIdx: number,
-): IdeConfig {
-  const cloned = deepClone(config);
-  const row = cloned.rows[rowIdx];
-  if (!row) return cloned;
-  // Don't remove the last pane — rows require at least 1
-  if (row.panes.length <= 1) return cloned;
-  row.panes.splice(paneIdx, 1);
-  return cloned;
-}
-
-// ---------------------------------------------------------------------------
-// Validation
-// ---------------------------------------------------------------------------
-
-export function validateSetupConfig(
-  config: unknown,
-): { valid: true; config: IdeConfig } | { valid: false; errors: string[] } {
-  const result = IdeConfigSchema.safeParse(config);
-  if (result.success) {
-    return { valid: true, config: result.data };
-  }
-  return {
-    valid: false,
-    errors: result.error.issues.map(
-      (issue) => `${issue.path.join(".")}: ${issue.message}`,
-    ),
-  };
 }


### PR DESCRIPTION
Create app/TmuxIde/Services/LayoutPersistenceService.swift. Save CanvasLayout to ~/Library/Application Support/tmux-ide-app/layouts/{sessionName}.json on every mutation (debounced 200ms). Restore on session select. Schema: {schemaVersion: 1, layout: CanvasLayout}. On load: validate schemaVersion, prune orphaned item refs (panes that no longer exist in tmux), reset camera if focused item is gone. On corrupt JSON: backup to .corrupt.{timestamp}.json, reset to empty layout. Wire into SessionCanvasService — after loadSession(), check for persisted layout first, fall back to auto-generated from panes. Reference context/IDX0/idx0/Services/Session/SessionService+LayoutPersistence.swift for the pattern.

## Proof
Created LayoutPersistenceService with full schema versioning, orphan pruning, and corrupt file recovery. Files: (1) app/TmuxIde/Services/LayoutPersistenceService.swift — new service with schema v1, PersistedLayoutPayload wrapper, debounced saves (200ms via DispatchWorkItem), load with schema validation (rejects future versions), orphaned pane ref pruning (removes items referencing deleted tmux panes), camera state reset (validates workspace/column/item IDs still exist), corrupt JSON backup (.corrupt.{timestamp}.json), atomic writes, per-session files at ~/Library/Application Support/tmux-ide-app/layouts/{session}.json. (2) Updated SessionCanvasService — accepts optional LayoutPersistenceService, loadSession() checks persisted layout first then falls back to auto-generated, updates pane titles from live data, adds new panes not in persisted layout, Combine observer auto-saves on every layout mutation, flushPendingSaves() for app termination. (3) Updated BootstrapCoordinator — added layoutsDirectory to FileSystemPaths, ensured in ensureDirectories(). (4) Updated AppCoordinator — creates LayoutPersistenceService, passes to SessionCanvasService, calls flushPendingSaves() in prepareForTermination().

Tags: persistence, swift