### PR TITLE
fix: use usePathname for static export routing

### DIFF
--- a/dashboard/app/project/[name]/ProjectPage.tsx
+++ b/dashboard/app/project/[name]/ProjectPage.tsx
@@ -44,9 +44,7 @@ export default function ProjectPage() {
   const router = useRouter();
   // Extract project name from URL pathname (not useParams, which returns
   // the build-time placeholder "__fallback" in static exports)
-  const name = decodeURIComponent(
-    pathname.replace(/^\/project\//, "").replace(/\/$/, ""),
-  );
+  const name = decodeURIComponent(pathname.replace(/^\/project\//, "").replace(/\/$/, ""));
   const [activeTab, setActiveTab] = useState<Tab>("kanban");
 
   const fetcher = useCallback(() => fetchProject(name) as Promise<ProjectDetail | null>, [name]);

--- a/dashboard/app/project/[name]/ProjectPage.tsx
+++ b/dashboard/app/project/[name]/ProjectPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   fetchProject,
   fetchEvents,
@@ -40,9 +40,13 @@ const TABS: { id: Tab; label: string }[] = [
 ];
 
 export default function ProjectPage() {
-  const params = useParams<{ name: string }>();
+  const pathname = usePathname();
   const router = useRouter();
-  const name = decodeURIComponent(params.name);
+  // Extract project name from URL pathname (not useParams, which returns
+  // the build-time placeholder "__fallback" in static exports)
+  const name = decodeURIComponent(
+    pathname.replace(/^\/project\//, "").replace(/\/$/, ""),
+  );
   const [activeTab, setActiveTab] = useState<Tab>("kanban");
 
   const fetcher = useCallback(() => fetchProject(name) as Promise<ProjectDetail | null>, [name]);


### PR DESCRIPTION
## Summary

- `useParams()` returns the build-time placeholder `__fallback` in Next.js static exports instead of the actual URL parameter
- Switch to `usePathname()` which always reads the real URL, fixing project page routing in the dashboard

## Test plan

- [x] Dashboard builds successfully
- [x] Dashboard vitest passes (9 tests)  
- [x] 881 unit tests pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)