### PR TITLE
fix: orchestrator dispatch, idle notification spam, dynamic version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-ide",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Turn any project into a tmux-powered terminal IDE with a simple ide.yml",
   "type": "module",
   "bin": {

--- a/src/command-center/server.ts
+++ b/src/command-center/server.ts
@@ -1,7 +1,8 @@
 import { execFileSync, execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { cors } from "hono/cors";
@@ -87,6 +88,11 @@ export interface CreateAppOptions {
   tunnelManager?: TunnelManager;
   remoteRegistry?: RemoteRegistry;
 }
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgVersion: string = JSON.parse(
+  readFileSync(join(__dirname, "../../package.json"), "utf-8"),
+).version;
 
 const ALLOWED_MILESTONE_TRANSITIONS = new Map([
   ["locked", new Set(["active"])],
@@ -1410,7 +1416,7 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     return c.json({
       ok: true,
       uptime: Math.round(process.uptime()),
-      version: "2.1.0",
+      version: pkgVersion,
     });
   });
 

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -115,8 +115,6 @@ function listPanes(): MonitorPane[] {
 // ---------------------------------------------------------------------------
 
 let lastState = "";
-let prevAgentStates = new Map<string, "busy" | "idle" | null>();
-let monitorInitialized = false;
 
 function tick(): void {
   if (!sessionExists()) {
@@ -158,22 +156,10 @@ function tick(): void {
     }
   }
 
-  // Notify master pane when an agent transitions from busy → idle
-  if (monitorInitialized) {
-    const masterPane = panes.find((p) => p.role === "lead");
-    if (masterPane) {
-      for (const pane of panes) {
-        const prev = prevAgentStates.get(pane.id);
-        const curr = agentStates.get(pane.id);
-        if (prev === "busy" && curr === "idle" && pane.id !== masterPane.id) {
-          const label = pane.name ?? pane.title ?? pane.id;
-          tmuxSilent("send-keys", "-t", masterPane.id, `Agent "${label}" is now idle`, "Enter");
-        }
-      }
-    }
-  }
-  monitorInitialized = true;
-  prevAgentStates = agentStates;
+  // Agent idle notifications removed — the orchestrator's completion
+  // handler already notifies the lead pane with task context when a
+  // task finishes. Raw busy→idle transitions from the monitor loop
+  // fired on spinner gaps between tool calls, spamming the lead.
 
   tmuxSilent("refresh-client", "-S");
   lastState = stateKey;

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -905,8 +905,8 @@ export function dispatch(
     .filter((t) => {
       // Skip if already claimed
       if (state.claimedTasks.has(t.id)) return false;
-      // Regular todo tasks
-      if (t.status === "todo" && !t.assignee) {
+      // Regular todo tasks (include pre-assigned tasks — assignee is a preference hint)
+      if (t.status === "todo") {
         // Skip if waiting for scheduled retry (nextRetryAt is in the future)
         if (t.nextRetryAt && new Date(t.nextRetryAt).getTime() > now) return false;
         // Check dependencies: all depends_on tasks must be done
@@ -1058,6 +1058,14 @@ export function findBestAgent(
 ): PaneInfo | null {
   const candidates = idleAgents.filter((p) => !excludeIds.has(p.id));
   if (candidates.length === 0) return null;
+
+  // Pre-assigned agent preference: if the task has an assignee (set at creation time),
+  // prefer that agent if it's idle. This treats assignee as a preference hint.
+  if (task.assignee) {
+    const preferred = candidates.find((p) => agentIdentifier(p) === task.assignee);
+    if (preferred) return preferred;
+    // Preferred agent not idle — fall through to normal matching
+  }
 
   // No specialty required — any idle agent works
   if (!task.specialty) return candidates[0] ?? null;


### PR DESCRIPTION
## Summary

- **Pre-assigned task dispatch**: tasks created with `--assign` are now treated as preferences, not locks. Orchestrator prefers the named agent if idle, falls back to specialty matching otherwise.
- **Remove idle notification spam**: the monitor loop's raw `Agent "X" is now idle` messages interrupted the Lead on every spinner gap. Removed — orchestrator completion handler already notifies with task context.
- **Dynamic health version**: `/health` endpoint reads version from `package.json` instead of hardcoded string.

## Test plan

- [x] 881 tests pass, 0 fail
- [x] TypeScript clean
- [x] ESLint clean
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)