### PR TITLE
fix: move platform-specific OpenTUI deps to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@hono/node-server": "^1.19.11",
     "@hono/zod-validator": "^0.7.6",
     "@opentui/core": "^0.1.88",
-    "@opentui/core-darwin-arm64": "^0.1.88",
     "@opentui/solid": "^0.1.88",
     "@parcel/watcher": "^2.5.6",
     "@types/ws": "^8.18.1",
@@ -71,6 +70,11 @@
     "solid-js": "^1.9.11",
     "ws": "^8.20.0",
     "zod": "^4.3.6"
+  },
+  "optionalDependencies": {
+    "@opentui/core-darwin-arm64": "^0.1.88",
+    "@opentui/core-linux-x64": "^0.1.88",
+    "@opentui/core-linux-arm64": "^0.1.88"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
The `@opentui/core-darwin-arm64` package was listed as a regular dependency, which caused `npm install -g tmux-ide` to fail on Linux and other non-macOS platforms with:
npm error code EBADPLATFORM
npm error notsup Unsupported platform for @opentui/core-darwin-arm64@0.1.95
## Solution
Move platform-specific OpenTUI packages to `optionalDependencies`:
- `@opentui/core-darwin-arm64` (macOS ARM64)
- `@opentui/core-linux-x64` (Linux x64)
- `@opentui/core-linux-arm64` (Linux ARM64)
This allows npm to install only the package compatible with the current platform and silently skip the others.
## Testing
- [x] `npm install` works on Linux x64
- [x] `npm install -g .` works on Linux x64