### PR TITLE
feat: full missions workflow — scaffolding, prompts, skills, docs, daemon fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 2.1.3
+
+### Added
+
+- **Full workspace scaffolding** — `tmux-ide init` now creates library stubs (architecture.md, learnings.md), validation contract template, and AGENTS.md for all agent-team and missions templates
+- **Launch-time scaffolding** — `ensureTaskDocs()` creates library and validation stubs on first orchestrator launch for projects set up before this fix
+- **Expanded lead agent prompt** — milestones, validation contracts, knowledge library, and `--fulfills` flag now included in the master agent startup prompt
+- **General-worker skill fallback** — agents without a specific skill now receive the general-worker role context in dispatch prompts
+- **Post-completion flow in skills** — all skills now explain what happens after task done (orchestrator notification, hooks, auto-dispatch)
+- **Validation awareness in worker skills** — frontend and backend skills now reference the validation contract and knowledge library
+
+### Fixed
+
+- **Orphaned daemon cleanup** — `stop` and `launch` now kill ALL daemon processes for the session (by name matching), preventing zombie processes from holding the port
+- **Daemon health check timeout** — `waitForDaemon()` fetch calls now have explicit 1s timeout to prevent indefinite blocking
+- **Activity feed noise** — heartbeat events filtered from dashboard activity feed
+- **Activity feed time column** — widened from 8ch to 10ch for readability
+
+### Removed
+
+- **Raw idle notifications** — monitor loop no longer sends `Agent "X" is now idle` to the Lead; orchestrator completion handler provides better context
+
 ## 2.1.0
 
 ### Added

--- a/dashboard/components/ActivityFeed.tsx
+++ b/dashboard/components/ActivityFeed.tsx
@@ -41,7 +41,8 @@ export function ActivityFeed({ events, maxEvents = 50 }: ActivityFeedProps) {
     );
   }
 
-  const visible = events.slice(0, maxEvents);
+  // Filter out heartbeat noise — they flood the feed with no actionable info
+  const visible = events.filter((e) => e.type !== "agent_heartbeat").slice(0, maxEvents);
 
   return (
     <div ref={scrollRef} className="flex-1 overflow-y-auto py-1">
@@ -54,7 +55,7 @@ export function ActivityFeed({ events, maxEvents = 50 }: ActivityFeedProps) {
             className="flex items-start h-6 px-3 hover:bg-[var(--surface-hover)]"
           >
             {/* Relative time */}
-            <span className="w-[8ch] shrink-0 text-right text-[var(--dim)] pr-2">
+            <span className="w-[10ch] shrink-0 text-right text-[var(--dim)] pr-2">
               {e.relative ?? ""}
             </span>
 

--- a/docs/content/docs/agent-teams.mdx
+++ b/docs/content/docs/agent-teams.mdx
@@ -36,6 +36,8 @@ The `missions` template creates a lead pane plus specialized teammates for front
 3. **Validation**. When a milestone completes, the validator verifies the claimed assertions.
 4. **Completion**. When all milestones are done and assertions pass, the mission is marked complete and the completion flow can create a PR.
 
+For the full end-to-end lifecycle walkthrough, see [Missions Workflow](/docs/missions-workflow).
+
 ### Quick Start
 
 ```bash
@@ -94,13 +96,19 @@ Validation contracts define what “done” means before work begins. Store them
 Tasks can claim the assertions they fulfill:
 
 ```bash
-tmux-ide task create "Implement login" --milestone M1 --fulfills "VAL-AUTH-001,VAL-AUTH-002"
+tmux-ide task create “Implement login” --milestone M1 --fulfills “VAL-AUTH-001,VAL-AUTH-002”
 tmux-ide validate coverage
-tmux-ide validate assert VAL-AUTH-001 --status passing --evidence "API test passed"
+tmux-ide validate assert VAL-AUTH-001 --status passing --evidence “API test passed”
 tmux-ide validate report
 ```
 
 Use `validate coverage` during planning to make sure every assertion is claimed before execution starts.
+
+### Validator Workflow
+
+After all tasks in a milestone complete, the orchestrator auto-dispatches the validator agent to verify the milestone's assertions. The validator runs the checks defined in the contract, updates each assertion to `passing`, `failing`, or `blocked`, and reports the results. If any assertion fails, the orchestrator can trigger remediation tasks before advancing to the next milestone.
+
+For the full contract format and assertion lifecycle, see [Validation Contracts](/docs/validation-contracts).
 
 ## Knowledge Library
 
@@ -112,6 +120,8 @@ Missions share context through `.tmux-ide/library/` and other repo-level prompt 
 - `AGENTS.md` defines project boundaries and operating rules for every agent
 
 This keeps discoveries from one task available to the next dispatch without rebuilding context manually.
+
+For details on library structure and how content flows between agents, see [Knowledge Library](/docs/knowledge-library).
 
 ## Researcher Agent
 

--- a/docs/content/docs/commands.mdx
+++ b/docs/content/docs/commands.mdx
@@ -230,6 +230,41 @@ tmux-ide milestone update <id> --status active|done|locked
 
 Milestones gate task dispatch — tasks with a milestone only dispatch when that milestone is `active` and all predecessors are `done`.
 
+## `tmux-ide task`
+
+Create and manage tasks within a mission.
+
+```bash
+tmux-ide task create "title" [--goal NN] [--priority N] [--milestone M1] [--assign "Agent"]
+tmux-ide task list [--status todo] [--json]
+tmux-ide task show <id> [--json]
+tmux-ide task update <id> --status review
+tmux-ide task claim <id> --assign "Agent Name"
+tmux-ide task done <id> --proof "description"
+tmux-ide task delete <id>
+```
+
+### Task creation flags
+
+Link a task to validation assertions with `--fulfills`:
+
+```bash
+tmux-ide task create "Implement login endpoint" --fulfills "VAL-AUTH-001,VAL-AUTH-002"
+```
+
+Route a task to a specialist agent with `--specialty`:
+
+```bash
+tmux-ide task create "Build login page" --specialty frontend
+```
+
+The `--proof` flag accepts plain text or a JSON object:
+
+```bash
+tmux-ide task done 003 --proof "All tests passing"
+tmux-ide task done 003 --proof '{"tests":{"passed":10,"total":10},"notes":"CI green"}'
+```
+
 ## `tmux-ide validate`
 
 Manage validation contracts and assertion verification. Also validates `ide.yml` config when called without a subcommand.

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -267,7 +267,9 @@ You are a frontend developer. Focus on React components and CSS.
 
 ## Validation Contract
 
-For missions mode, create `.tasks/validation-contract.md` with assertion IDs that tasks link to via `--fulfills`:
+When you run `tmux-ide init --template missions`, the `.tasks/validation-contract.md` stub and `.tmux-ide/library/` directory are auto-scaffolded for you.
+
+For missions mode, populate `.tasks/validation-contract.md` with assertion IDs that tasks link to via `--fulfills`:
 
 ```markdown
 # Validation Contract
@@ -284,3 +286,5 @@ tmux-ide task create "Implement JWT" --milestone M1 --fulfills "VAL-AUTH-001,VAL
 ```
 
 The coverage invariant warns if any assertion ID is not claimed by at least one task. Run `tmux-ide validate coverage` to check.
+
+For the full contract format, assertion lifecycle, and validator workflow, see [Validation Contracts](/docs/validation-contracts).

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -95,6 +95,16 @@ tmux-ide mission create "Build auth system" -d "JWT + refresh tokens"
 tmux-ide
 ```
 
+### What `tmux-ide init --template missions` scaffolds
+
+```
+.tmux-ide/skills/    — agent role definitions
+.tmux-ide/library/   — architecture.md, learnings.md stubs
+.tasks/              — validation-contract.md stub
+AGENTS.md            — project boundaries
+ide.yml              — session config with orchestrator
+```
+
 This gives you:
 
 - **6 agent panes** (lead, frontend, backend, validator, researcher, shell)
@@ -112,6 +122,10 @@ tmux-ide validate coverage    # check assertion coverage
 ```
 
 See [Configuration](/docs/configuration#orchestrator-config) for all orchestrator options and [What's New in 2.0](/docs/release-2-0-0) for the full feature list.
+
+### Missions Mode Quick Start
+
+For the full mission lifecycle walkthrough, see [Missions Workflow](/docs/missions-workflow). That guide covers planning, execution, validation, and completion end-to-end. For details on validation contracts and the knowledge library, see [Validation Contracts](/docs/validation-contracts) and [Knowledge Library](/docs/knowledge-library).
 
 ## Claude Code Skill
 

--- a/docs/content/docs/knowledge-library.mdx
+++ b/docs/content/docs/knowledge-library.mdx
@@ -1,0 +1,205 @@
+---
+title: Knowledge Library
+description: Persistent project context that gets injected into agent dispatch prompts
+---
+
+## Overview
+
+The `.tmux-ide/library/` directory provides persistent context that the orchestrator injects into every agent dispatch prompt. Instead of each agent starting from zero, the knowledge library gives them shared understanding of your project's architecture, accumulated learnings from completed tasks, and project-level boundaries.
+
+When the orchestrator dispatches a task to an idle agent, it assembles the prompt from several sources — the knowledge library is one of the most important.
+
+## Directory Structure
+
+```
+.tmux-ide/
+  library/
+    architecture.md        # project design context
+    learnings.md           # auto-appended after each task
+  skills/
+    frontend.md            # skill definitions (per-role)
+    backend.md
+    reviewer.md
+    researcher.md
+    general-worker.md
+AGENTS.md                  # project boundaries
+```
+
+All of these files feed into dispatch prompts, but they serve different purposes.
+
+## architecture.md
+
+The orchestrator reads the first 500 characters of `.tmux-ide/library/architecture.md` and injects them into every dispatch prompt. This gives agents immediate context about the project without needing to explore the codebase first.
+
+**What to put here:**
+
+- Module boundaries and directory layout
+- Key architectural patterns (monorepo structure, layered architecture, etc.)
+- Tech stack decisions and their rationale
+- Important conventions (naming, file organization, import patterns)
+
+```markdown
+# Architecture
+
+Monorepo managed with pnpm workspaces and Turborepo.
+
+- apps/web — Next.js 15 frontend (App Router, RSC)
+- apps/api — Hono REST API on Cloudflare Workers
+- packages/db — Drizzle ORM + Postgres migrations
+- packages/ui — Shared React component library
+
+Key patterns:
+- Server components by default, "use client" only when needed
+- All API routes return typed responses via shared zod schemas
+- Database migrations live in packages/db/migrations/
+```
+
+Keep the most critical information in the first 500 characters since that is the cutoff for dispatch prompts.
+
+## learnings.md
+
+The orchestrator auto-appends to `.tmux-ide/library/learnings.md` after each task completion. This creates a growing record of discoveries, gotchas, and solutions that future agents can reference.
+
+You do not need to maintain this file manually. As agents complete tasks, the orchestrator extracts key takeaways and appends them with a timestamp.
+
+**Example of accumulated content:**
+
+```markdown
+## Task 003 — Implement JWT auth (2025-01-15)
+- jose library requires Node 18+ — use jsonwebtoken for broader compat
+- Refresh tokens stored in httpOnly cookies, not localStorage
+- CORS config in wrangler.toml must include credentials: true
+
+## Task 007 — Add rate limiting (2025-01-16)
+- Cloudflare Workers have no native rate limiting — use Durable Objects
+- Rate limit state persists via DO storage, not KV (too slow for counters)
+```
+
+This knowledge accumulates across the entire mission, so agents dispatched later benefit from everything learned earlier.
+
+## AGENTS.md
+
+The `AGENTS.md` file in your project root defines project-level boundaries. Its content is injected into all dispatch prompts, giving every agent a shared understanding of ownership rules and things to avoid.
+
+**What to put here:**
+
+- File/directory ownership (who changes what)
+- Conventions agents must follow
+- Things agents should **not** do
+- CI/test requirements before marking tasks complete
+
+```markdown
+# AGENTS.md
+
+## Conventions
+- Always run `pnpm lint` and `pnpm test` before completing a task
+- Never modify files in packages/db/migrations/ directly — use `pnpm db:generate`
+- CSS uses Tailwind utility classes only — no custom CSS files
+
+## Ownership
+- apps/web — frontend agents only
+- apps/api — backend agents only
+- packages/db — backend agents only (migrations require review)
+
+## Do NOT
+- Install new dependencies without justification in the task proof
+- Modify CI workflows (.github/)
+- Change tsconfig base settings
+```
+
+## Skills
+
+Skill files in `.tmux-ide/skills/` define agent personas. Each file uses YAML frontmatter for metadata and a markdown body for the system prompt injected when that skill is active.
+
+```markdown
+---
+name: frontend
+specialties: [react, css, typescript]
+role: teammate
+description: Frontend component specialist
+---
+
+You are a frontend developer. Focus on React components, styling,
+and client-side state management. Run `pnpm dev` in apps/web to
+preview changes. Always check responsive behavior.
+```
+
+### How skills are injected
+
+When a pane declares `skill: frontend` in `ide.yml`, the orchestrator loads `.tmux-ide/skills/frontend.md` and includes its body in the dispatch prompt for that pane. This means the agent receives role-specific instructions on top of the shared knowledge library context.
+
+### The general-worker fallback
+
+If a pane has no `skill` assigned, the orchestrator falls back to `.tmux-ide/skills/general-worker.md`. This should contain broadly applicable instructions — coding standards, how to run tests, how to signal completion.
+
+```markdown
+---
+name: general-worker
+specialties: []
+role: teammate
+description: General-purpose development agent
+---
+
+You are a general-purpose developer. Follow project conventions,
+run tests before completing work, and document any non-obvious
+decisions in your task proof.
+```
+
+### Specialty matching
+
+Panes declare `specialty: react,css` in `ide.yml`. When the orchestrator picks an agent for a task, it prefers panes whose specialties overlap with the task's tags. The skill file's `specialties` array serves the same purpose — it declares what the skill is good at.
+
+## Tag-Matched References
+
+If a task has tags, the orchestrator checks for matching library files and loads them into the dispatch prompt. For example, a task tagged `"database"` will cause the orchestrator to look for `.tmux-ide/library/database.md` and include its content.
+
+This lets you provide domain-specific context on demand:
+
+```
+.tmux-ide/library/
+  architecture.md      # always loaded
+  learnings.md         # always loaded
+  database.md          # loaded when task has "database" tag
+  auth.md              # loaded when task has "auth" tag
+  testing.md           # loaded when task has "testing" tag
+```
+
+Create these files for any domain where agents consistently need extra context. Only the files matching the task's tags are loaded, so there is no prompt bloat from unused files.
+
+## Scaffolding
+
+Running `tmux-ide init` automatically creates the `.tmux-ide/` directory structure:
+
+```bash
+tmux-ide init
+```
+
+This scaffolds:
+
+```
+.tmux-ide/
+  library/
+    architecture.md      # empty, ready for you to fill in
+    learnings.md         # empty, auto-populated during missions
+  skills/
+    frontend.md
+    backend.md
+    reviewer.md
+    researcher.md
+    general-worker.md
+```
+
+The skill files come pre-populated with sensible defaults based on your detected project stack. The library files start empty — fill in `architecture.md` with your project context before launching a mission.
+
+You can also create skill and library files manually at any time:
+
+```bash
+# Create a new skill
+tmux-ide skill create devops
+
+# List existing skills
+tmux-ide skill list
+
+# Validate all skills have correct frontmatter
+tmux-ide skill validate
+```

--- a/docs/content/docs/knowledge-library.mdx
+++ b/docs/content/docs/knowledge-library.mdx
@@ -49,6 +49,7 @@ Monorepo managed with pnpm workspaces and Turborepo.
 - packages/ui — Shared React component library
 
 Key patterns:
+
 - Server components by default, "use client" only when needed
 - All API routes return typed responses via shared zod schemas
 - Database migrations live in packages/db/migrations/
@@ -66,11 +67,13 @@ You do not need to maintain this file manually. As agents complete tasks, the or
 
 ```markdown
 ## Task 003 — Implement JWT auth (2025-01-15)
+
 - jose library requires Node 18+ — use jsonwebtoken for broader compat
 - Refresh tokens stored in httpOnly cookies, not localStorage
 - CORS config in wrangler.toml must include credentials: true
 
 ## Task 007 — Add rate limiting (2025-01-16)
+
 - Cloudflare Workers have no native rate limiting — use Durable Objects
 - Rate limit state persists via DO storage, not KV (too slow for counters)
 ```
@@ -92,16 +95,19 @@ The `AGENTS.md` file in your project root defines project-level boundaries. Its 
 # AGENTS.md
 
 ## Conventions
+
 - Always run `pnpm lint` and `pnpm test` before completing a task
 - Never modify files in packages/db/migrations/ directly — use `pnpm db:generate`
 - CSS uses Tailwind utility classes only — no custom CSS files
 
 ## Ownership
+
 - apps/web — frontend agents only
 - apps/api — backend agents only
 - packages/db — backend agents only (migrations require review)
 
 ## Do NOT
+
 - Install new dependencies without justification in the task proof
 - Modify CI workflows (.github/)
 - Change tsconfig base settings

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -12,6 +12,9 @@
     "programmatic",
     "templates",
     "agent-teams",
+    "missions-workflow",
+    "validation-contracts",
+    "knowledge-library",
     "contributing",
     "tips"
   ]

--- a/docs/content/docs/missions-workflow.mdx
+++ b/docs/content/docs/missions-workflow.mdx
@@ -1,0 +1,379 @@
+---
+title: Missions Workflow
+description: The complete missions lifecycle from pre-planning through validation and completion
+---
+
+## Overview
+
+Missions are the highest-level unit of work in tmux-ide. A mission defines what you are building, milestones gate progress into phases, and the orchestrator dispatches tasks to specialized agents automatically.
+
+This page walks through the full lifecycle: pre-planning, planning, execution, validation, and completion.
+
+## Scaffolded Directory Structure
+
+Running `tmux-ide init --template missions` creates the following project structure:
+
+```
+your-project/
+├── ide.yml                          # tmux-ide layout config
+├── .tasks/
+│   ├── tasks.json                   # Mission, milestones, goals, and tasks
+│   └── validation-contract.md       # Assertion definitions (VAL-XXX)
+├── .tmux-ide/
+│   ├── skills/
+│   │   ├── frontend.md              # Skill prompt for frontend agents
+│   │   ├── backend.md               # Skill prompt for backend agents
+│   │   ├── reviewer.md              # Skill prompt for the validator
+│   │   └── researcher.md            # Skill prompt for the researcher
+│   └── library/
+│       ├── architecture.md          # Repo-wide context injected into every dispatch
+│       ├── learnings.md             # Appended automatically as tasks complete
+│       └── research-findings.md     # Accumulated research output
+└── AGENTS.md                        # Project boundaries and rules for every agent
+```
+
+The `ide.yml` produced by the missions template gives you this layout:
+
+```
+┌───────────┬───────────┬───────────┐
+│           │           │           │
+│   Lead    │ Frontend  │  Backend  │  70%
+│           │           │           │
+├───────────┼───────────┼───────────┤
+│ Validator │ Researcher│   Shell   │  30%
+└───────────┴───────────┴───────────┘
+```
+
+## Phase 1: Pre-Planning
+
+Before creating the mission in tmux-ide, the lead prepares the shared knowledge that agents will rely on.
+
+### Define the mission scope
+
+Decide what the mission delivers, what is in scope, and what is explicitly out of scope. Write this down in plain language -- it becomes the mission description.
+
+### Write the validation contract
+
+Create `.tasks/validation-contract.md` with concrete, testable assertions. Each assertion gets a unique ID that tasks will reference later.
+
+```md
+# Validation Contract — Auth v2
+
+## Authentication
+- **VAL-AUTH-001**: POST /api/auth/login returns a JWT on valid credentials
+- **VAL-AUTH-002**: POST /api/auth/login returns 401 on invalid credentials
+- **VAL-AUTH-003**: POST /api/auth/refresh returns a new access token given a valid refresh token
+- **VAL-AUTH-004**: Protected routes return 403 when the JWT is expired
+
+## Test Coverage
+- **VAL-TEST-001**: Unit tests cover all auth service functions with >90% line coverage
+- **VAL-TEST-002**: Integration tests exercise the full login-refresh-logout flow
+```
+
+<Callout type="info">
+  Write the contract before planning starts. It defines "done" up front so the validator knows exactly what to check.
+</Callout>
+
+### Update architecture.md
+
+Add relevant context to `.tmux-ide/library/architecture.md` so dispatched agents understand the codebase they are working in.
+
+```md
+# Architecture
+
+## Stack
+- Next.js 14 (App Router)
+- Drizzle ORM + PostgreSQL
+- JWT via jose library
+
+## Key Paths
+- `src/app/api/auth/` — auth route handlers
+- `src/lib/auth/` — token creation, validation, refresh logic
+- `src/middleware.ts` — route protection
+
+## Conventions
+- All API routes return `{ data }` or `{ error }` JSON envelopes
+- Tests live next to source files as `*.test.ts`
+```
+
+## Phase 2: Planning
+
+Mission status: **planning**
+
+### Create the mission
+
+```bash
+tmux-ide mission set "Auth v2" --description "JWT login, token refresh, route protection, and full test coverage"
+```
+
+### Create milestones
+
+Milestones are sequential gates. M1 must complete before M2 starts.
+
+```bash
+tmux-ide milestone create "Foundation" --sequence 1
+tmux-ide milestone create "Implementation" --sequence 2
+tmux-ide milestone create "Validation & Polish" --sequence 3
+```
+
+### Create tasks
+
+Each task belongs to a milestone and can declare which validation assertions it fulfills, what specialty it needs, and what goal it serves.
+
+```bash
+# M1 — Foundation
+tmux-ide task create "Set up auth database schema" \
+  --milestone M1 \
+  --specialty backend \
+  --priority 1 \
+  --goal "Establish the data layer for auth"
+
+tmux-ide task create "Create JWT utility functions" \
+  --milestone M1 \
+  --specialty backend \
+  --priority 2 \
+  --fulfills "VAL-AUTH-001,VAL-AUTH-003" \
+  --goal "Token creation and validation helpers"
+
+# M2 — Implementation
+tmux-ide task create "Build login endpoint" \
+  --milestone M2 \
+  --specialty backend \
+  --priority 1 \
+  --fulfills "VAL-AUTH-001,VAL-AUTH-002" \
+  --goal "POST /api/auth/login with JWT response" \
+  --depends "001,002"
+
+tmux-ide task create "Build refresh endpoint" \
+  --milestone M2 \
+  --specialty backend \
+  --priority 2 \
+  --fulfills "VAL-AUTH-003" \
+  --goal "POST /api/auth/refresh with token rotation" \
+  --depends "002"
+
+tmux-ide task create "Add route protection middleware" \
+  --milestone M2 \
+  --specialty backend \
+  --priority 3 \
+  --fulfills "VAL-AUTH-004" \
+  --goal "Middleware that rejects expired or missing JWTs"
+
+tmux-ide task create "Build login page" \
+  --milestone M2 \
+  --specialty frontend \
+  --priority 2 \
+  --goal "Login form that calls the auth API"
+
+# M3 — Validation & Polish
+tmux-ide task create "Write unit tests for auth service" \
+  --milestone M3 \
+  --specialty backend \
+  --priority 1 \
+  --fulfills "VAL-TEST-001" \
+  --goal "Unit test coverage for all auth functions"
+
+tmux-ide task create "Write integration tests for auth flow" \
+  --milestone M3 \
+  --specialty backend \
+  --priority 2 \
+  --fulfills "VAL-TEST-002" \
+  --goal "End-to-end login, refresh, and logout test" \
+  --depends "007"
+```
+
+### Check coverage
+
+Before leaving planning, verify that every assertion in the validation contract is claimed by at least one task.
+
+```bash
+tmux-ide validate coverage
+```
+
+```
+Validation Coverage Report
+──────────────────────────
+VAL-AUTH-001  ✓  Covered by: 002, 003
+VAL-AUTH-002  ✓  Covered by: 003
+VAL-AUTH-003  ✓  Covered by: 002, 004
+VAL-AUTH-004  ✓  Covered by: 005
+VAL-TEST-001  ✓  Covered by: 007
+VAL-TEST-002  ✓  Covered by: 008
+
+Coverage: 6/6 assertions covered (100%)
+```
+
+If any assertion is uncovered, create additional tasks before proceeding.
+
+### Activate the mission
+
+```bash
+tmux-ide mission plan-complete
+```
+
+This transitions the mission from `planning` to `active`, locks all milestones except M1, and the orchestrator begins dispatching.
+
+## Phase 3: Execution
+
+Mission status: **active**
+
+Once the mission is active and you launch the session with `tmux-ide`, the orchestrator takes over.
+
+### How dispatch works
+
+On each tick (default every 5 seconds), the orchestrator:
+
+1. Identifies idle agent panes (any pane that is not the lead and is not currently working)
+2. Picks the highest-priority unblocked task in the current active milestone
+3. Prefers panes whose `specialty` matches the task's `--specialty`
+4. Builds a full context prompt from the mission description, milestone context, goal, task details, the agent's skill file, and the knowledge library
+5. Sends the prompt to the idle agent via `tmux send-keys`
+
+### What agents receive
+
+Each dispatched agent gets a prompt containing:
+
+- **Mission**: title, description, and current status
+- **Milestone**: which phase this task belongs to
+- **Goal**: the high-level objective the task serves
+- **Task**: title, description, dependencies, and fulfillment targets
+- **Skill**: the contents of `.tmux-ide/skills/<specialty>.md`
+- **Library**: `architecture.md`, `learnings.md`, `AGENTS.md`
+
+### Task completion
+
+When an agent finishes, it reports back:
+
+```bash
+tmux-ide task done 003 \
+  --proof "Login endpoint implemented. Returns JWT on valid creds, 401 on invalid. Tests in src/app/api/auth/login/route.test.ts" \
+  --summary "Implemented POST /api/auth/login using jose for JWT signing. Passwords verified with bcrypt. Response shape: { data: { accessToken, refreshToken, expiresIn } }"
+```
+
+The `--proof` explains what was done and how to verify it. The `--summary` is appended to `learnings.md` so subsequent agents benefit from the knowledge.
+
+### Monitoring progress
+
+```bash
+tmux-ide mission status          # Mission overview with milestone progress
+tmux-ide metrics                 # Task counts, completion rate, time estimates
+tmux-ide metrics agents          # Per-agent utilization and task history
+tmux-ide orch                    # Live orchestrator state (agents, queue, events)
+```
+
+## Phase 4: Validation
+
+Milestone status: **validating**
+
+Validation happens automatically when all tasks in a milestone complete.
+
+### Automatic validator dispatch
+
+When the last task in a milestone is marked done, the orchestrator:
+
+1. Transitions the milestone status to `validating`
+2. Dispatches the validator agent with the validation contract and all assertion IDs that belong to this milestone
+3. The validator reads the contract, inspects the code, runs tests, and checks each assertion
+
+### Reporting assertions
+
+The validator reports the status of each assertion:
+
+```bash
+tmux-ide validate assert VAL-AUTH-001 --status passing \
+  --evidence "POST /api/auth/login returns { accessToken, refreshToken } on valid credentials. Verified via integration test."
+
+tmux-ide validate assert VAL-AUTH-002 --status passing \
+  --evidence "POST /api/auth/login returns 401 with { error: 'Invalid credentials' }. Verified via integration test."
+
+tmux-ide validate assert VAL-AUTH-003 --status failing \
+  --evidence "Refresh endpoint exists but does not rotate the refresh token. Old token remains valid after refresh."
+```
+
+### When all assertions pass
+
+If every assertion for the milestone passes:
+
+1. The milestone status moves to `done`
+2. The next milestone in sequence is unlocked and set to `active`
+3. The orchestrator begins dispatching tasks from the new milestone
+
+### When an assertion fails
+
+If any assertion fails:
+
+1. The orchestrator auto-creates remediation tasks targeting the failing assertions
+2. The milestone status resets to `active`
+3. The remediation tasks are dispatched like any other task
+4. When they complete, the milestone returns to `validating` and the validator runs again
+
+```bash
+# Example: orchestrator auto-creates a remediation task
+# Task 009: "Fix refresh token rotation (remediation for VAL-AUTH-003)"
+#   --milestone M2 --specialty backend --fulfills "VAL-AUTH-003" --priority 1
+```
+
+### Viewing validation state
+
+```bash
+tmux-ide validate report
+```
+
+```
+Validation Report
+─────────────────
+Milestone: M2 — Implementation
+
+VAL-AUTH-001  ✓ passing   Login returns JWT on valid creds
+VAL-AUTH-002  ✓ passing   Invalid creds return 401
+VAL-AUTH-003  ✗ failing   Refresh token not rotated
+VAL-AUTH-004  ✓ passing   Expired JWT returns 403
+
+Status: 3/4 passing — remediation in progress
+```
+
+## Phase 5: Mission Completion
+
+When the final milestone's validation passes and all milestones are `done`, the mission is complete.
+
+### What happens automatically
+
+1. The mission status transitions to `complete`
+2. The orchestrator stops dispatching
+3. The lead is notified of completion
+4. Final metrics are recorded
+
+### Optional: create a pull request
+
+If your workflow ends with a PR, you can create one from the shell:
+
+```bash
+gh pr create --title "Auth v2" --body "JWT login, refresh, route protection, and full test coverage"
+```
+
+### Review the final state
+
+```bash
+tmux-ide mission status
+tmux-ide validate report
+tmux-ide metrics history
+```
+
+## Quick Reference
+
+| Phase | Mission Status | Key Commands |
+|---|---|---|
+| Pre-Planning | -- | Edit `validation-contract.md`, `architecture.md` |
+| Planning | `planning` | `mission set`, `milestone create`, `task create`, `validate coverage`, `mission plan-complete` |
+| Execution | `active` | Automatic dispatch. Monitor with `metrics`, `orch` |
+| Validation | `active` (milestone: `validating`) | `validate assert`, `validate report` |
+| Completion | `complete` | `mission status`, `metrics history` |
+
+## Tips
+
+- Write the validation contract first. It forces clarity about what "done" means before any code is written.
+- Use `--fulfills` on every task. Uncovered assertions are a planning gap that `validate coverage` will catch.
+- Keep milestones small (3-7 tasks). Large milestones delay validation feedback.
+- Add `--depends` between tasks that have real ordering constraints, but avoid over-constraining -- the orchestrator handles priority and specialty matching.
+- Check `tmux-ide metrics agents` to spot agents that are idle or overloaded, and adjust specialties if needed.
+- The knowledge library is cumulative. Task summaries in `learnings.md` help later agents avoid re-discovering the same patterns.

--- a/docs/content/docs/missions-workflow.mdx
+++ b/docs/content/docs/missions-workflow.mdx
@@ -60,18 +60,21 @@ Create `.tasks/validation-contract.md` with concrete, testable assertions. Each 
 # Validation Contract — Auth v2
 
 ## Authentication
+
 - **VAL-AUTH-001**: POST /api/auth/login returns a JWT on valid credentials
 - **VAL-AUTH-002**: POST /api/auth/login returns 401 on invalid credentials
 - **VAL-AUTH-003**: POST /api/auth/refresh returns a new access token given a valid refresh token
 - **VAL-AUTH-004**: Protected routes return 403 when the JWT is expired
 
 ## Test Coverage
+
 - **VAL-TEST-001**: Unit tests cover all auth service functions with >90% line coverage
 - **VAL-TEST-002**: Integration tests exercise the full login-refresh-logout flow
 ```
 
 <Callout type="info">
-  Write the contract before planning starts. It defines "done" up front so the validator knows exactly what to check.
+  Write the contract before planning starts. It defines "done" up front so the validator knows
+  exactly what to check.
 </Callout>
 
 ### Update architecture.md
@@ -82,16 +85,19 @@ Add relevant context to `.tmux-ide/library/architecture.md` so dispatched agents
 # Architecture
 
 ## Stack
+
 - Next.js 14 (App Router)
 - Drizzle ORM + PostgreSQL
 - JWT via jose library
 
 ## Key Paths
+
 - `src/app/api/auth/` — auth route handlers
 - `src/lib/auth/` — token creation, validation, refresh logic
 - `src/middleware.ts` — route protection
 
 ## Conventions
+
 - All API routes return `{ data }` or `{ error }` JSON envelopes
 - Tests live next to source files as `*.test.ts`
 ```
@@ -361,13 +367,13 @@ tmux-ide metrics history
 
 ## Quick Reference
 
-| Phase | Mission Status | Key Commands |
-|---|---|---|
-| Pre-Planning | -- | Edit `validation-contract.md`, `architecture.md` |
-| Planning | `planning` | `mission set`, `milestone create`, `task create`, `validate coverage`, `mission plan-complete` |
-| Execution | `active` | Automatic dispatch. Monitor with `metrics`, `orch` |
-| Validation | `active` (milestone: `validating`) | `validate assert`, `validate report` |
-| Completion | `complete` | `mission status`, `metrics history` |
+| Phase        | Mission Status                     | Key Commands                                                                                   |
+| ------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Pre-Planning | --                                 | Edit `validation-contract.md`, `architecture.md`                                               |
+| Planning     | `planning`                         | `mission set`, `milestone create`, `task create`, `validate coverage`, `mission plan-complete` |
+| Execution    | `active`                           | Automatic dispatch. Monitor with `metrics`, `orch`                                             |
+| Validation   | `active` (milestone: `validating`) | `validate assert`, `validate report`                                                           |
+| Completion   | `complete`                         | `mission status`, `metrics history`                                                            |
 
 ## Tips
 

--- a/docs/content/docs/validation-contracts.mdx
+++ b/docs/content/docs/validation-contracts.mdx
@@ -1,0 +1,461 @@
+---
+title: Validation Contracts
+description: Define testable assertions upfront so every milestone has a clear definition of done
+---
+
+## What Are Validation Contracts
+
+A validation contract is a set of testable claims about your system that you define before any work begins. Each claim, called an **assertion**, describes a concrete, verifiable behavior. The contract acts as an acceptance test plan that lives alongside your task files and drives the validator agent throughout the mission.
+
+Contracts answer a simple question: _how do we know this milestone is actually done?_ Instead of relying on gut checks or manual review, the contract gives every agent a shared, unambiguous checklist.
+
+Contracts are powerful because they:
+
+- Force you to think about acceptance criteria during planning, not after implementation
+- Give the orchestrator a gate between milestones — work does not advance until assertions pass
+- Let the validator agent run independently, checking claims without blocking other agents
+- Provide a clear audit trail of what was verified, when, and with what evidence
+
+## Creating a Contract
+
+Validation contracts live in `.tasks/validation-contract.md` inside your project root. The file is plain Markdown with bold assertion IDs.
+
+```bash
+# Create the file manually or let the lead agent generate it during planning
+mkdir -p .tasks
+touch .tasks/validation-contract.md
+```
+
+### Format
+
+Each assertion is a single line starting with a bold ID followed by a colon and the claim:
+
+```md
+# Validation Contract
+
+## Authentication
+
+**VAL-AUTH-001**: Login endpoint returns a signed JWT on valid credentials
+**VAL-AUTH-002**: Invalid credentials return 401 with a structured error body
+**VAL-AUTH-003**: Expired tokens are rejected with 401 and a `token_expired` code
+**VAL-AUTH-004**: Refresh token endpoint issues a new access token
+
+## API
+
+**VAL-API-001**: All endpoints require a valid Bearer token except /health
+**VAL-API-002**: Rate limiter returns 429 after 100 requests per minute per key
+
+## Data
+
+**VAL-DATA-001**: User creation persists to the database and is retrievable by ID
+**VAL-DATA-002**: Deleting a user cascades to dependent records
+```
+
+The validator parses these IDs from the contract file. You can organize assertions under headings, add prose between them, or include notes — only lines matching the `**VAL-...**:` pattern are treated as assertions.
+
+## Assertion Design
+
+### Naming Conventions
+
+Use a hierarchical ID scheme: `VAL-<DOMAIN>-<NUMBER>`.
+
+| Prefix | Domain |
+| ------------ | --------------------------------- |
+| `VAL-AUTH-` | Authentication and authorization |
+| `VAL-API-` | REST/GraphQL API behavior |
+| `VAL-UI-` | Frontend and user interface |
+| `VAL-DATA-` | Database and data integrity |
+| `VAL-PERF-` | Performance and load |
+| `VAL-SEC-` | Security hardening |
+| `VAL-INT-` | Integration and third-party APIs |
+| `VAL-INFRA-` | Infrastructure and deployment |
+
+Numbers are zero-padded to three digits (`001`, `002`, ...) so they sort naturally.
+
+### What Makes a Good Assertion
+
+A good assertion is:
+
+- **Specific** — describes one observable behavior, not a vague quality
+- **Testable** — an agent or script can verify it with a concrete check
+- **Independent** — can be validated without relying on other assertions passing first
+- **Evidenced** — the validator can attach proof (test output, curl response, screenshot)
+
+**Good:**
+
+```md
+**VAL-AUTH-003**: Expired tokens are rejected with 401 and a `token_expired` code
+```
+
+**Bad:**
+
+```md
+**VAL-AUTH-003**: Auth works correctly
+```
+
+The first assertion tells the validator exactly what to check. The second is unfalsifiable.
+
+### Examples Across Domains
+
+```md
+## Auth
+**VAL-AUTH-001**: POST /auth/login with valid credentials returns 200 and a JWT
+**VAL-AUTH-002**: POST /auth/login with invalid credentials returns 401
+
+## API
+**VAL-API-001**: GET /api/users requires Authorization header; omitting it returns 401
+**VAL-API-002**: GET /api/users?limit=5 returns at most 5 records
+
+## UI
+**VAL-UI-001**: Login form shows inline error on invalid credentials without page reload
+**VAL-UI-002**: Dashboard renders within 2 seconds on a cold load
+
+## Data
+**VAL-DATA-001**: Creating a user with duplicate email returns 409 Conflict
+**VAL-DATA-002**: Soft-deleted users are excluded from list queries by default
+```
+
+## Linking Tasks to Assertions
+
+When you create a task, use the `--fulfills` flag to declare which assertions that task is expected to satisfy:
+
+```bash
+tmux-ide task create "Implement JWT login" \
+  --milestone M1 \
+  --specialty backend \
+  --fulfills "VAL-AUTH-001,VAL-AUTH-002"
+
+tmux-ide task create "Add token refresh" \
+  --milestone M1 \
+  --specialty backend \
+  --fulfills "VAL-AUTH-004"
+
+tmux-ide task create "Build login form" \
+  --milestone M2 \
+  --specialty frontend \
+  --fulfills "VAL-UI-001"
+```
+
+### Coverage Invariant
+
+Before moving from planning to execution, every assertion in the contract should be claimed by at least one task. The `validate coverage` command checks this:
+
+```bash
+tmux-ide validate coverage
+```
+
+```
+Validation Coverage
+  Covered:   10/12 assertions
+  Uncovered: VAL-PERF-001, VAL-SEC-001
+
+  ✗ Coverage incomplete — 2 assertions have no fulfilling task
+```
+
+If coverage is incomplete, create tasks to fill the gaps before running `tmux-ide mission plan-complete`. The orchestrator will not dispatch work for assertions that no task claims.
+
+```bash
+# Fill the gap
+tmux-ide task create "Add rate limit tests" \
+  --milestone M2 \
+  --fulfills "VAL-PERF-001"
+
+tmux-ide task create "Security headers audit" \
+  --milestone M2 \
+  --fulfills "VAL-SEC-001"
+
+# Verify
+tmux-ide validate coverage
+```
+
+```
+Validation Coverage
+  Covered:   12/12 assertions
+  Uncovered: (none)
+
+  ✓ Full coverage
+```
+
+Use `--json` for programmatic checks:
+
+```bash
+tmux-ide validate coverage --json
+```
+
+```json
+{
+  "total": 12,
+  "covered": 12,
+  "uncovered": [],
+  "complete": true
+}
+```
+
+## Validator Workflow
+
+The validator is a dedicated agent pane that verifies assertions as milestones complete. In the `missions` template, the validator pane is preconfigured:
+
+```yaml
+panes:
+  - title: Validator
+    command: claude
+    role: validator
+    skill: reviewer
+```
+
+### How It Works
+
+1. A milestone's tasks all reach `done` status.
+2. The orchestrator triggers validation for that milestone.
+3. The validator reads `.tasks/validation-contract.md` and identifies which assertions are linked to tasks in the completed milestone.
+4. For each assertion, the validator runs the appropriate check — executing tests, curling endpoints, inspecting files, or reviewing code.
+5. The validator calls `tmux-ide validate assert` for each assertion with a status and evidence.
+6. Once all assertions for the milestone are checked, the validator produces a report.
+7. If all assertions pass, the orchestrator advances to the next milestone. If any fail, remediation kicks in.
+
+### Manual Validation
+
+You can also drive validation manually at any time:
+
+```bash
+# Check a specific assertion
+tmux-ide validate assert VAL-AUTH-001 \
+  --status passing \
+  --evidence "POST /auth/login returns 200 with valid JWT (test suite: 3/3 passed)"
+
+# View the full contract with current states
+tmux-ide validate show
+
+# Generate a summary report
+tmux-ide validate report
+```
+
+## Assertion States
+
+Each assertion moves through a lifecycle:
+
+| State | Meaning |
+| ----------- | --------------------------------------------------------------- |
+| `pending` | Default state. The assertion has not been checked yet. |
+| `passing` | The validator confirmed the assertion holds. Evidence attached. |
+| `failing` | The validator checked and the assertion does not hold. |
+| `blocked` | Cannot be validated because a dependency or precondition is missing. |
+
+State transitions:
+
+```
+pending ──→ passing
+pending ──→ failing ──→ passing (after remediation)
+pending ──→ blocked ──→ pending (after unblock) ──→ passing
+```
+
+View assertion states with:
+
+```bash
+tmux-ide validate show
+```
+
+```
+Validation Contract — 12 assertions
+
+  VAL-AUTH-001  passing   Login endpoint returns a signed JWT
+  VAL-AUTH-002  passing   Invalid credentials return 401
+  VAL-AUTH-003  pending   Expired tokens rejected with token_expired code
+  VAL-AUTH-004  failing   Refresh token endpoint issues new access token
+  VAL-API-001   passing   All endpoints require Bearer token
+  VAL-API-002   blocked   Rate limiter returns 429 after 100 req/min
+  ...
+
+Summary: 3 passing, 1 failing, 1 blocked, 7 pending
+```
+
+## Remediation
+
+When assertions fail, the system does not silently move on. Failure triggers a structured remediation flow.
+
+### What Happens on Failure
+
+1. **Milestone blocks.** The orchestrator will not advance to the next milestone while any assertion in the current one is `failing`.
+2. **Auto-task creation.** The orchestrator can create remediation tasks automatically, tagged with the failing assertion IDs.
+3. **Milestone reset.** If the milestone was marked `done` prematurely, it resets to `active` so new tasks can be dispatched.
+4. **Validator re-check.** After remediation tasks complete, the validator re-runs the failing assertions.
+
+### Manual Remediation
+
+If you prefer manual control:
+
+```bash
+# See what failed
+tmux-ide validate report
+
+# Create a fix task
+tmux-ide task create "Fix refresh token rotation" \
+  --milestone M1 \
+  --specialty backend \
+  --fulfills "VAL-AUTH-004"
+
+# After the fix, re-assert
+tmux-ide validate assert VAL-AUTH-004 \
+  --status passing \
+  --evidence "Refresh endpoint returns new access token (test: refresh_flow passed)"
+```
+
+### Blocked Assertions
+
+Mark an assertion as `blocked` when an external dependency prevents validation:
+
+```bash
+tmux-ide validate assert VAL-API-002 \
+  --status blocked \
+  --evidence "Rate limiter depends on Redis, not yet provisioned"
+```
+
+Blocked assertions do not prevent milestone advancement, but they will appear in reports as outstanding items.
+
+## Example Contract
+
+Here is a realistic contract for a todo-list API project with authentication:
+
+```md
+# Validation Contract — Todo API v1
+
+## Authentication
+
+**VAL-AUTH-001**: POST /auth/register creates a user and returns 201 with a JWT
+**VAL-AUTH-002**: POST /auth/register with duplicate email returns 409 Conflict
+**VAL-AUTH-003**: POST /auth/login with valid credentials returns 200 with a JWT
+**VAL-AUTH-004**: POST /auth/login with wrong password returns 401
+**VAL-AUTH-005**: JWT expires after 15 minutes; requests with expired tokens return 401
+
+## API — Todos
+
+**VAL-API-001**: POST /api/todos creates a todo and returns 201
+**VAL-API-002**: GET /api/todos returns only todos belonging to the authenticated user
+**VAL-API-003**: PATCH /api/todos/:id updates title and completed status
+**VAL-API-004**: DELETE /api/todos/:id returns 204 and the todo is no longer retrievable
+**VAL-API-005**: GET /api/todos?completed=true filters to completed todos only
+
+## Data Integrity
+
+**VAL-DATA-001**: Deleting a user cascades to their todos
+**VAL-DATA-002**: Todo titles are trimmed and limited to 255 characters; longer input returns 422
+
+## Security
+
+**VAL-SEC-001**: All /api/* routes return 401 without a valid Authorization header
+**VAL-SEC-002**: Users cannot access or modify todos belonging to other users
+```
+
+### Tasks Fulfilling This Contract
+
+```bash
+tmux-ide task create "User registration endpoint" \
+  --milestone M1 --specialty backend \
+  --fulfills "VAL-AUTH-001,VAL-AUTH-002"
+
+tmux-ide task create "Login endpoint" \
+  --milestone M1 --specialty backend \
+  --fulfills "VAL-AUTH-003,VAL-AUTH-004"
+
+tmux-ide task create "JWT expiry middleware" \
+  --milestone M1 --specialty backend \
+  --fulfills "VAL-AUTH-005"
+
+tmux-ide task create "Todo CRUD endpoints" \
+  --milestone M2 --specialty backend \
+  --fulfills "VAL-API-001,VAL-API-002,VAL-API-003,VAL-API-004,VAL-API-005"
+
+tmux-ide task create "Cascade delete and input validation" \
+  --milestone M2 --specialty backend \
+  --fulfills "VAL-DATA-001,VAL-DATA-002"
+
+tmux-ide task create "Auth guard and ownership checks" \
+  --milestone M2 --specialty backend \
+  --fulfills "VAL-SEC-001,VAL-SEC-002"
+
+# Confirm full coverage
+tmux-ide validate coverage
+```
+
+## Commands Reference
+
+### `validate show`
+
+Display the full validation contract with current assertion states.
+
+```bash
+tmux-ide validate show
+tmux-ide validate show --json
+```
+
+The `--json` output includes every assertion with its ID, description, state, and attached evidence.
+
+### `validate assert`
+
+Set the state of a specific assertion.
+
+```bash
+tmux-ide validate assert <assertion-id> --status <state> --evidence "<text>"
+```
+
+| Flag | Required | Description |
+| ------------ | -------- | --------------------------------------------- |
+| `--status` | Yes | One of `pending`, `passing`, `failing`, `blocked` |
+| `--evidence` | No | Free-text proof attached to the assertion |
+
+```bash
+tmux-ide validate assert VAL-AUTH-001 \
+  --status passing \
+  --evidence "Integration test auth.login.test.ts: 4/4 passed"
+
+tmux-ide validate assert VAL-API-002 \
+  --status failing \
+  --evidence "GET /api/todos returns all todos regardless of user"
+```
+
+### `validate report`
+
+Generate a summary report of the entire contract.
+
+```bash
+tmux-ide validate report
+tmux-ide validate report --json
+```
+
+```
+Validation Report
+  Total:    14 assertions
+  Passing:  10
+  Failing:   1
+  Blocked:   0
+  Pending:   3
+
+  Failing assertions:
+    VAL-API-002  GET /api/todos returns only todos belonging to the authenticated user
+
+  Pending assertions:
+    VAL-DATA-001  Deleting a user cascades to their todos
+    VAL-DATA-002  Todo titles trimmed and limited to 255 characters
+    VAL-SEC-002   Users cannot access or modify other users' todos
+```
+
+### `validate coverage`
+
+Check whether every assertion in the contract is claimed by at least one task via `--fulfills`.
+
+```bash
+tmux-ide validate coverage
+tmux-ide validate coverage --json
+```
+
+Run this before `tmux-ide mission plan-complete` to catch gaps early.
+
+## Best Practices
+
+- Write the contract during planning, before any code exists
+- Keep assertions atomic — one behavior per assertion
+- Use `validate coverage` as a planning checkpoint, not an afterthought
+- Attach concrete evidence when asserting — test names, curl output, or log excerpts
+- Do not skip `blocked` assertions; track them so they surface in reports
+- Re-run `validate report` after every milestone to maintain an accurate audit trail
+- Let the validator agent own assertion state; avoid manually marking assertions as `passing` unless you are debugging

--- a/docs/content/docs/validation-contracts.mdx
+++ b/docs/content/docs/validation-contracts.mdx
@@ -59,16 +59,16 @@ The validator parses these IDs from the contract file. You can organize assertio
 
 Use a hierarchical ID scheme: `VAL-<DOMAIN>-<NUMBER>`.
 
-| Prefix | Domain |
-| ------------ | --------------------------------- |
-| `VAL-AUTH-` | Authentication and authorization |
-| `VAL-API-` | REST/GraphQL API behavior |
-| `VAL-UI-` | Frontend and user interface |
-| `VAL-DATA-` | Database and data integrity |
-| `VAL-PERF-` | Performance and load |
-| `VAL-SEC-` | Security hardening |
-| `VAL-INT-` | Integration and third-party APIs |
-| `VAL-INFRA-` | Infrastructure and deployment |
+| Prefix       | Domain                           |
+| ------------ | -------------------------------- |
+| `VAL-AUTH-`  | Authentication and authorization |
+| `VAL-API-`   | REST/GraphQL API behavior        |
+| `VAL-UI-`    | Frontend and user interface      |
+| `VAL-DATA-`  | Database and data integrity      |
+| `VAL-PERF-`  | Performance and load             |
+| `VAL-SEC-`   | Security hardening               |
+| `VAL-INT-`   | Integration and third-party APIs |
+| `VAL-INFRA-` | Infrastructure and deployment    |
 
 Numbers are zero-padded to three digits (`001`, `002`, ...) so they sort naturally.
 
@@ -99,18 +99,22 @@ The first assertion tells the validator exactly what to check. The second is unf
 
 ```md
 ## Auth
+
 **VAL-AUTH-001**: POST /auth/login with valid credentials returns 200 and a JWT
 **VAL-AUTH-002**: POST /auth/login with invalid credentials returns 401
 
 ## API
+
 **VAL-API-001**: GET /api/users requires Authorization header; omitting it returns 401
 **VAL-API-002**: GET /api/users?limit=5 returns at most 5 records
 
 ## UI
+
 **VAL-UI-001**: Login form shows inline error on invalid credentials without page reload
 **VAL-UI-002**: Dashboard renders within 2 seconds on a cold load
 
 ## Data
+
 **VAL-DATA-001**: Creating a user with duplicate email returns 409 Conflict
 **VAL-DATA-002**: Soft-deleted users are excluded from list queries by default
 ```
@@ -234,11 +238,11 @@ tmux-ide validate report
 
 Each assertion moves through a lifecycle:
 
-| State | Meaning |
-| ----------- | --------------------------------------------------------------- |
-| `pending` | Default state. The assertion has not been checked yet. |
-| `passing` | The validator confirmed the assertion holds. Evidence attached. |
-| `failing` | The validator checked and the assertion does not hold. |
+| State     | Meaning                                                              |
+| --------- | -------------------------------------------------------------------- |
+| `pending` | Default state. The assertion has not been checked yet.               |
+| `passing` | The validator confirmed the assertion holds. Evidence attached.      |
+| `failing` | The validator checked and the assertion does not hold.               |
 | `blocked` | Cannot be validated because a dependency or precondition is missing. |
 
 State transitions:
@@ -342,7 +346,7 @@ Here is a realistic contract for a todo-list API project with authentication:
 
 ## Security
 
-**VAL-SEC-001**: All /api/* routes return 401 without a valid Authorization header
+**VAL-SEC-001**: All /api/\* routes return 401 without a valid Authorization header
 **VAL-SEC-002**: Users cannot access or modify todos belonging to other users
 ```
 
@@ -398,10 +402,10 @@ Set the state of a specific assertion.
 tmux-ide validate assert <assertion-id> --status <state> --evidence "<text>"
 ```
 
-| Flag | Required | Description |
-| ------------ | -------- | --------------------------------------------- |
-| `--status` | Yes | One of `pending`, `passing`, `failing`, `blocked` |
-| `--evidence` | No | Free-text proof attached to the assertion |
+| Flag         | Required | Description                                       |
+| ------------ | -------- | ------------------------------------------------- |
+| `--status`   | Yes      | One of `pending`, `passing`, `failing`, `blocked` |
+| `--evidence` | No       | Free-text proof attached to the assertion         |
 
 ```bash
 tmux-ide validate assert VAL-AUTH-001 \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-ide",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Turn any project into a tmux-powered terminal IDE with a simple ide.yml",
   "type": "module",
   "bin": {

--- a/src/init.ts
+++ b/src/init.ts
@@ -30,25 +30,85 @@ function copyTemplateSkills(targetDir: string): string[] {
   return created;
 }
 
-function scaffoldMissionsWorkspace(dir: string, name: string): string[] {
+function scaffoldLibraryStubs(dir: string): string[] {
   const created: string[] = [];
-  const skillsDir = join(dir, ".tmux-ide", "skills");
-  created.push(...copyTemplateSkills(skillsDir));
-
   const libraryDir = join(dir, ".tmux-ide", "library");
   if (!existsSync(libraryDir)) {
     mkdirSync(libraryDir, { recursive: true });
     created.push(libraryDir);
   }
 
+  const archPath = join(libraryDir, "architecture.md");
+  if (!existsSync(archPath)) {
+    writeFileSync(
+      archPath,
+      "# Architecture\n\n<!-- Describe your project's architecture here. This context is injected into agent dispatch prompts. -->\n",
+    );
+    created.push(archPath);
+  }
+
+  const learningsPath = join(libraryDir, "learnings.md");
+  if (!existsSync(learningsPath)) {
+    writeFileSync(
+      learningsPath,
+      "# Learnings\n\n<!-- Task summaries are automatically appended here by the orchestrator. -->\n",
+    );
+    created.push(learningsPath);
+  }
+
+  return created;
+}
+
+function scaffoldValidationContract(dir: string): string[] {
+  const created: string[] = [];
+  const tasksDir = join(dir, ".tasks");
+  if (!existsSync(tasksDir)) {
+    mkdirSync(tasksDir, { recursive: true });
+  }
+
+  const contractPath = join(tasksDir, "validation-contract.md");
+  if (!existsSync(contractPath)) {
+    writeFileSync(
+      contractPath,
+      "# Validation Contract\n\n<!-- Define assertions that the validator agent will verify. Example: -->\n<!-- - VAL-001: All tests pass -->\n<!-- - VAL-002: No TypeScript errors -->\n<!-- - VAL-003: Lint passes with zero warnings -->\n",
+    );
+    created.push(contractPath);
+  }
+
+  return created;
+}
+
+function scaffoldAgentsMd(dir: string, name: string): string[] {
+  const created: string[] = [];
   const agentsTemplatePath = resolve(__dirname, "..", "templates", "AGENTS.md");
   if (existsSync(agentsTemplatePath)) {
     const agentsPath = join(dir, "AGENTS.md");
-    const content = readFileSync(agentsTemplatePath, "utf-8").replace(/{{name}}/g, name);
-    writeFileSync(agentsPath, content);
-    created.push(agentsPath);
+    if (!existsSync(agentsPath)) {
+      const content = readFileSync(agentsTemplatePath, "utf-8").replace(/{{name}}/g, name);
+      writeFileSync(agentsPath, content);
+      created.push(agentsPath);
+    }
   }
+  return created;
+}
 
+function isTeamTemplate(templateName: string): boolean {
+  return templateName === "missions" || templateName.startsWith("agent-team");
+}
+
+function scaffoldTeamWorkspace(dir: string, name: string): string[] {
+  const created: string[] = [];
+  created.push(...scaffoldLibraryStubs(dir));
+  created.push(...scaffoldValidationContract(dir));
+  created.push(...scaffoldAgentsMd(dir, name));
+  return created;
+}
+
+function scaffoldMissionsWorkspace(dir: string, name: string): string[] {
+  const created: string[] = [];
+  const skillsDir = join(dir, ".tmux-ide", "skills");
+  created.push(...copyTemplateSkills(skillsDir));
+  created.push(...scaffoldTeamWorkspace(dir, name));
   return created;
 }
 
@@ -76,10 +136,17 @@ export async function init({
     const tmpPath = configPath + ".tmp";
     writeFileSync(tmpPath, content);
     renameSync(tmpPath, configPath);
-    const created =
-      template === "missions"
-        ? scaffoldMissionsWorkspace(dir, name)
-        : copyTemplateSkills(join(dir, ".tmux-ide", "skills"));
+    let created: string[];
+    if (template === "missions") {
+      created = scaffoldMissionsWorkspace(dir, name);
+    } else if (isTeamTemplate(template)) {
+      created = [
+        ...copyTemplateSkills(join(dir, ".tmux-ide", "skills")),
+        ...scaffoldTeamWorkspace(dir, name),
+      ];
+    } else {
+      created = copyTemplateSkills(join(dir, ".tmux-ide", "skills"));
+    }
 
     if (json) {
       console.log(JSON.stringify({ created: true, template, name, paths: created }));

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -2,7 +2,7 @@ import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { readConfig, getSessionName } from "./lib/yaml-io.ts";
 import { computeSizes, toSplitPercents } from "./lib/sizes.ts";
 import { outputError } from "./lib/output.ts";
@@ -467,9 +467,43 @@ export function ensureTaskDocs(dir: string): void {
 
   if (existsSync(claudeMdPath)) {
     const content = readFileSync(claudeMdPath, "utf-8");
-    if (content.includes(TASK_DOCS_MARKER)) return;
-    writeFileSync(claudeMdPath, content + TASK_DOCS_SECTION);
+    if (!content.includes(TASK_DOCS_MARKER)) {
+      writeFileSync(claudeMdPath, content + TASK_DOCS_SECTION);
+    }
   } else {
     writeFileSync(claudeMdPath, `# Project\n${TASK_DOCS_SECTION}`);
+  }
+
+  // Ensure library directory and stubs exist
+  const libraryDir = join(dir, ".tmux-ide", "library");
+  if (!existsSync(libraryDir)) {
+    mkdirSync(libraryDir, { recursive: true });
+  }
+  const archPath = join(libraryDir, "architecture.md");
+  if (!existsSync(archPath)) {
+    writeFileSync(
+      archPath,
+      "# Architecture\n\n<!-- Describe your project architecture here. This is injected into agent dispatch prompts. -->\n",
+    );
+  }
+  const learningsPath = join(libraryDir, "learnings.md");
+  if (!existsSync(learningsPath)) {
+    writeFileSync(
+      learningsPath,
+      "# Learnings\n\n<!-- Task summaries are automatically appended here by the orchestrator. -->\n",
+    );
+  }
+
+  // Ensure .tasks/ directory and validation contract stub
+  const tasksDir = join(dir, ".tasks");
+  if (!existsSync(tasksDir)) {
+    mkdirSync(tasksDir, { recursive: true });
+  }
+  const contractPath = join(tasksDir, "validation-contract.md");
+  if (!existsSync(contractPath)) {
+    writeFileSync(
+      contractPath,
+      "# Validation Contract\n\n<!-- Define assertions for the validator agent. Example: -->\n<!-- - VAL-001: All tests pass -->\n<!-- - VAL-002: No TypeScript errors -->\n",
+    );
   }
 }

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -183,7 +183,9 @@ function runBeforeHook(command: string | undefined, dir: string): void {
 async function waitForDaemon(port: number, maxAttempts = 30, delayMs = 100): Promise<boolean> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
-      const res = await fetch(`http://localhost:${port}/health`);
+      const res = await fetch(`http://localhost:${port}/health`, {
+        signal: AbortSignal.timeout(1000),
+      });
       if (res.ok) return true;
     } catch {
       // Not ready yet
@@ -233,6 +235,21 @@ export async function launch(
     const daemonAlive = await isDaemonAlive(commandCenterPort);
     if (!daemonAlive) {
       console.log("Daemon not responding — restarting...");
+
+      // Clean up any orphaned daemon processes from previous runs
+      try {
+        execSync(`pkill -f "daemon-watchdog.ts ${session}" 2>/dev/null || true`, {
+          stdio: "ignore",
+        });
+        execSync(`pkill -f "daemon.ts ${session}" 2>/dev/null || true`, { stdio: "ignore" });
+      } catch {
+        // Best-effort cleanup
+      }
+
+      // Brief wait for orphaned processes to release the port
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      await sleep(500);
+
       const monitorScript = resolve(
         dirname(fileURLToPath(import.meta.url)),
         "lib",
@@ -322,6 +339,18 @@ export async function launch(
   // Store config hash for drift detection on re-launch
   setSessionVariable(session, "@config_hash", configHash(config));
 
+  // Clean up any orphaned daemon processes from previous runs
+  try {
+    execSync(`pkill -f "daemon-watchdog.ts ${session}" 2>/dev/null || true`, { stdio: "ignore" });
+    execSync(`pkill -f "daemon.ts ${session}" 2>/dev/null || true`, { stdio: "ignore" });
+  } catch {
+    // Best-effort cleanup
+  }
+
+  // Brief wait for orphaned processes to release the port
+  const sleepAsync = (ms: number) => new Promise((r) => setTimeout(r, ms));
+  await sleepAsync(500);
+
   // Start background daemon watchdog (command center + session monitor)
   const monitorScript = resolve(
     dirname(fileURLToPath(import.meta.url)),
@@ -376,10 +405,22 @@ export function buildMasterAgentPrompt(config: IdeConfig): string {
     .map((p: Pane) => p.title)
     .filter(Boolean);
 
-  return `You are the Master Agent for this tmux-ide session.
+  const isMissionsMode = config.orchestrator?.dispatch_mode === "missions";
+
+  const milestonesSection = isMissionsMode
+    ? `
+## Milestones
+Milestones gate execution — tasks in M2 won't dispatch until M1 is validated.
+- tmux-ide milestone create "title" --sequence N
+- tmux-ide milestone list --json
+- tmux-ide mission plan-complete  (activates milestones, starts dispatch)
+`
+    : "";
+
+  return `You are the Lead Agent for this tmux-ide session.
 
 ## Your role
-You coordinate a team of coding agents. The human gives you high-level goals, and you break them into structured tasks that your teammates execute.
+You coordinate a team of coding agents. The human gives you high-level goals, and you break them into structured tasks that your teammates execute. You plan, delegate, and review — you do not implement.
 
 ## Your teammates
 ${teammatePanes.map((t) => `- ${t}`).join("\n")}
@@ -388,21 +429,38 @@ ${teammatePanes.map((t) => `- ${t}`).join("\n")}
 - tmux-ide mission set "title" --description "..."
 - tmux-ide goal create "title" --priority N --acceptance "criteria"
 - tmux-ide goal list --json
-- tmux-ide task create "title" --goal NN --priority N
+- tmux-ide task create "title" --goal NN --priority N --specialty "type" --fulfills "VAL-001,VAL-002"
 - tmux-ide task list --json
 - tmux-ide task show NNN --json (shows full mission→goal→task context)
 - tmux-ide task done NNN --proof "what was accomplished"
 - tmux-ide goal done NN
 
 ## How it works
-1. You create tasks with tmux-ide task create
-2. The orchestrator automatically assigns unassigned tasks to idle teammates
-3. Teammates work in the project directory
-4. When teammates finish, they run tmux-ide task done
-5. You get notified and review their work
-6. You report progress to the human
+1. Set the mission: tmux-ide mission set "title" --description "..."
+2. Create goals with acceptance criteria
+3. Create tasks under goals — use --specialty to hint agent type, --fulfills to link validation assertions
+4. The orchestrator automatically dispatches unassigned tasks to idle teammates
+5. Teammates work in the project directory
+6. When teammates finish, they run tmux-ide task done
+7. You get notified and review their work
+8. You report progress to the human
+${milestonesSection}
+## Validation contracts
+Define acceptance criteria in .tasks/validation-contract.md using assertion IDs:
+  **VAL-001**: All tests pass
+  **VAL-002**: No TypeScript errors
+Link tasks to assertions: tmux-ide task create "title" --fulfills "VAL-001,VAL-002"
+After a milestone's tasks complete, the Validator agent automatically verifies assertions.
+
+## Knowledge library
+- .tmux-ide/library/architecture.md — project context injected into agent prompts
+- .tmux-ide/library/learnings.md — auto-appended by orchestrator after task completion
+- AGENTS.md — project boundaries injected into all agent prompts
+Update architecture.md when the project structure changes significantly.
 
 ## Important
+- Do NOT use --assign when creating tasks — the orchestrator handles dispatch automatically
+- Use --specialty to hint which agent type should pick it up
 - Focus on PLANNING and REVIEWING, not implementing
 - Break work into small, clear tasks (one per teammate)
 - Each task should be completable independently
@@ -460,6 +518,22 @@ The \`--proof\` flag accepts either a plain string (stored as \`notes\`) or a JS
 ### Task Dependencies
 
 Use \`--depends "001,002"\` to declare that a task depends on other tasks. The orchestrator will not dispatch a task until all its dependencies are complete.
+
+### Milestones
+
+\`\`\`bash
+tmux-ide milestone create "title" --sequence N
+tmux-ide milestone list [--json]
+tmux-ide mission plan-complete  # activate milestones and start dispatch
+\`\`\`
+
+### Validation
+
+\`\`\`bash
+tmux-ide validate show [--json]
+tmux-ide validate assert VAL-001 --status passing --evidence "what you verified"
+tmux-ide validate coverage [--json]
+\`\`\`
 `;
 
 export function ensureTaskDocs(dir: string): void {

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -236,8 +236,9 @@ export function buildTaskPrompt(dir: string, task: Task, config?: OrchestratorCo
   }
 
   // 4. Skill context
-  if (task.specialty) {
-    const skill = loadSkill(dir, task.specialty);
+  {
+    const skillName = task.specialty ?? "general-worker";
+    const skill = loadSkill(dir, skillName);
     if (skill?.body) {
       prompt += `## Your Role: ${skill.name}\n`;
       prompt += `${skill.body}\n\n`;

--- a/src/stop.ts
+++ b/src/stop.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import { execSync } from "node:child_process";
 import { getSessionName } from "./lib/yaml-io.ts";
 import { outputError } from "./lib/output.ts";
 import { killSession, stopSessionMonitor } from "./lib/tmux.ts";
@@ -12,6 +13,14 @@ export async function stop(
 
   // Stop the session monitor before killing the session
   stopSessionMonitor(session);
+
+  // Kill any orphaned daemon processes for this session
+  try {
+    execSync(`pkill -f "daemon-watchdog.ts ${session}" 2>/dev/null || true`, { stdio: "ignore" });
+    execSync(`pkill -f "daemon.ts ${session}" 2>/dev/null || true`, { stdio: "ignore" });
+  } catch {
+    // Best-effort cleanup
+  }
 
   const result = killSession(session);
 

--- a/templates/skills/backend.md
+++ b/templates/skills/backend.md
@@ -21,6 +21,19 @@ You are a backend development specialist.
 4. Verify behavior against acceptance criteria
 5. Report the result, evidence, and any operational concerns
 
+## Context
+
+Your dispatch prompt includes relevant excerpts from the knowledge library (.tmux-ide/library/) and AGENTS.md. Use these for architectural decisions.
+
+## After Completion
+
+When you finish, the orchestrator will:
+
+- Notify the lead with your proof and summary
+- Run any configured after-run hooks (e.g., linting)
+- Auto-dispatch the next available task
+- Append your summary to the learnings library
+
 ## Completion Protocol
 
 When done, run:

--- a/templates/skills/frontend.md
+++ b/templates/skills/frontend.md
@@ -21,6 +21,19 @@ You are a frontend development specialist.
 4. Run relevant tests or validation checks
 5. Report what changed, what you verified, and any follow-up risks
 
+## Context
+
+Your dispatch prompt includes relevant excerpts from the knowledge library (.tmux-ide/library/) and AGENTS.md. Use these for architectural decisions.
+
+## After Completion
+
+When you finish, the orchestrator will:
+
+- Notify the lead with your proof and summary
+- Run any configured after-run hooks (e.g., linting)
+- Auto-dispatch the next available task
+- Append your summary to the learnings library
+
 ## Completion Protocol
 
 When done, run:

--- a/templates/skills/general-worker.md
+++ b/templates/skills/general-worker.md
@@ -21,6 +21,19 @@ You are a general-purpose development agent.
 4. Verify all tests pass
 5. Report completion with proof and a summary of key learnings
 
+## Context
+
+You are a general-purpose agent. Your dispatch prompt includes mission, goal, and task context along with relevant library excerpts. Follow the task description closely.
+
+## After Completion
+
+When you finish, the orchestrator will:
+
+- Notify the lead with your proof and summary
+- Run any configured after-run hooks (e.g., linting)
+- Auto-dispatch the next available task
+- Append your summary to the learnings library
+
 ## Completion Protocol
 
 When done, run:

--- a/templates/skills/researcher.md
+++ b/templates/skills/researcher.md
@@ -67,3 +67,12 @@ Your proof should include:
 - The most important findings
 - Why they matter
 - The exact next action you recommend
+
+## After Completion
+
+When you finish, the orchestrator will:
+
+- Notify the lead with your proof and summary
+- Run any configured after-run hooks
+- Auto-dispatch the next available task
+- Append your summary to the learnings library

--- a/templates/skills/reviewer.md
+++ b/templates/skills/reviewer.md
@@ -28,3 +28,15 @@ tmux-ide validate assert <ASSERT_ID> --status failing --evidence "what's wrong"
 tmux-ide validate assert <ASSERT_ID> --status blocked --evidence "why it's blocked"
 
 The orchestrator will detect your results and advance the milestone automatically.
+
+If you find issues beyond the validation contract:
+tmux-ide task update <TASK_ID> --discovered-issues "description of issue"
+
+## After Completion
+
+When you finish, the orchestrator will:
+
+- Notify the lead with your proof and summary
+- Run any configured after-run hooks (e.g., linting)
+- Auto-dispatch the next available task
+- Append your summary to the learnings library


### PR DESCRIPTION
## Summary

Comprehensive 2.1.3 release making the full missions workflow work end-to-end:

- **Scaffolding**: `tmux-ide init` creates library stubs, validation contract, AGENTS.md for all team templates
- **Lead prompt**: milestones, validation contracts, knowledge library, `--fulfills` pattern
- **Worker skills**: post-completion flow, validation awareness, general-worker fallback
- **Daemon reliability**: orphan cleanup, port release, health check timeout
- **Dashboard**: heartbeat noise filtered from activity feed
- **Docs**: 3 new pages (missions-workflow, validation-contracts, knowledge-library) + 4 existing pages updated

## Test plan

- [x] 881 tests pass, 0 fail
- [x] TypeScript clean
- [x] ESLint clean
- [x] Prettier clean
- [x] Dashboard builds as static export

🤖 Generated with [Claude Code](https://claude.com/claude-code)