### PR TITLE
fix: daemon command center fails to start when cwd differs from package location

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-ide",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Turn any project into a tmux-powered terminal IDE with a simple ide.yml",
   "type": "module",
   "bin": {

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -12,7 +12,13 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, statSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { createServer, type Server } from "node:http";
+import { createRequire } from "node:module";
 import { computePortPanes, computeAgentStates } from "./session-monitor.ts";
+
+// Anchor bare-specifier resolution to this file so dependencies like
+// @hono/node-server resolve from tmux-ide's own node_modules regardless
+// of the process's working directory.
+const _require = createRequire(import.meta.url);
 
 /** Remove dispatch files older than 24 hours */
 function cleanupDispatchFiles(dir: string): void {
@@ -246,7 +252,7 @@ let httpServer: Server | null = null;
 async function startCommandCenter(): Promise<void> {
   try {
     const { createApp } = await import("../command-center/server.ts");
-    const { getRequestListener } = await import("@hono/node-server");
+    const { getRequestListener } = await import(_require.resolve("@hono/node-server"));
     const { AuthService } = await import("./auth/auth-service.ts");
     const { AuthConfigSchema } = await import("./auth/types.ts");
     const { TunnelManager } = await import("./tunnels/manager.ts");


### PR DESCRIPTION
## Problem

When the tmux-ide daemon spawns as a background process, it runs with `cwd` set to the user's project directory. The `await import("@hono/node-server")` bare-specifier dynamic import resolves from `cwd`, not from the daemon file's location, so it silently fails to find the package (which lives in tmux-ide's own `node_modules`).

This causes the Command Center HTTP server to never start — the dashboard on port 6060 is unreachable even though the daemon process is alive.

## Fix

Use `createRequire(import.meta.url)` to create a require function anchored to the daemon file's location. The bare-specifier import becomes:

```ts
const _require = createRequire(import.meta.url);
const { getRequestListener } = await import(_require.resolve("@hono/node-server"));
```

This resolves the package from tmux-ide's own `node_modules` regardless of the process's working directory. Works across Node, Bun, npm, pnpm, global installs, local installs, and any cwd.

## Version

Bumped to 2.1.4.