### PR TITLE
fix: daemon startup blocked by hanging lsof, TDZ crash, and Node warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-ide",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Turn any project into a tmux-powered terminal IDE with a simple ide.yml",
   "type": "module",
   "bin": {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -24,7 +24,7 @@ function runCli(args, { cwd, env } = {}) {
     }
   }
 
-  return spawnSync("node", [cli, ...args], {
+  return spawnSync("node", ["--no-warnings", cli, ...args], {
     cwd,
     env: mergedEnv,
     encoding: "utf-8",

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -117,6 +117,14 @@ function listPanes(): MonitorPane[] {
 }
 
 // ---------------------------------------------------------------------------
+// Forward declarations for shutdown — must be initialised before tick() runs
+// because tick() may call shutdown() synchronously on the first invocation.
+// ---------------------------------------------------------------------------
+
+let stopOrchestrator: (() => void) | null = null;
+let httpServer: Server | null = null;
+
+// ---------------------------------------------------------------------------
 // Monitor loop
 // ---------------------------------------------------------------------------
 
@@ -171,14 +179,13 @@ function tick(): void {
   lastState = stateKey;
 }
 
-const monitorInterval = setInterval(tick, INTERVAL);
-tick(); // run immediately
+// NOTE: monitor loop is started AFTER the command center and orchestrator
+// are kicked off (see bottom of file) so that a slow lsof/ps inside tick()
+// cannot block the HTTP server from binding its port.
 
 // ---------------------------------------------------------------------------
 // Orchestrator (if enabled in ide.yml)
 // ---------------------------------------------------------------------------
-
-let stopOrchestrator: (() => void) | null = null;
 
 async function startOrchestrator(): Promise<void> {
   try {
@@ -241,13 +248,9 @@ async function startOrchestrator(): Promise<void> {
   }
 }
 
-void startOrchestrator();
-
 // ---------------------------------------------------------------------------
 // Command Center HTTP + WebSocket server
 // ---------------------------------------------------------------------------
-
-let httpServer: Server | null = null;
 
 async function startCommandCenter(): Promise<void> {
   try {
@@ -415,6 +418,12 @@ async function startCommandCenter(): Promise<void> {
 }
 
 void startCommandCenter();
+void startOrchestrator();
+
+// Start the monitor loop last — tick() uses execFileSync (lsof, ps) which
+// can block the event loop for seconds if the system is under load.
+const monitorInterval = setInterval(tick, INTERVAL);
+tick();
 
 // ---------------------------------------------------------------------------
 // Unified shutdown

--- a/src/lib/session-monitor.ts
+++ b/src/lib/session-monitor.ts
@@ -23,6 +23,7 @@ function getListeningPids(): Set<string> {
     const raw = execFileSync("lsof", ["-nP", "-iTCP", "-sTCP:LISTEN", "-FpPn"], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2000,
     });
     const pids = new Set<string>();
     let currentPid: string | null = null;
@@ -49,6 +50,7 @@ function getProcessTree(): Map<string, string> {
     const raw = execFileSync("ps", ["-axo", "pid=,ppid="], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2000,
     });
     const tree = new Map<string, string>();
     for (const line of raw.trim().split("\n")) {


### PR DESCRIPTION
## Problem

The dashboard on port 6060 was unreachable even though the daemon process was alive. Three independent issues:

1. **Hanging lsof blocks event loop**: `computePortPanes()` calls `execFileSync("lsof", ...)` with no timeout. On macOS, zombie lsof processes can hold a kernel lock that makes all subsequent lsof calls hang forever. Since `tick()` ran before `startCommandCenter()`, the event loop was permanently blocked and the HTTP server never started.

2. **TDZ crash**: `tick()` runs immediately on module load and may call `shutdown()` if the tmux session is gone. `stopOrchestrator` and `httpServer` were declared with `let` after `tick()`, causing a `ReferenceError` (temporal dead zone).

3. **CLI test failures**: Node v24 emits an `ExperimentalWarning` for type stripping to stderr, which broke `JSON.parse(result.stderr)` in 8 cli contract tests.

## Fix

1. Add 2s timeout to `lsof` and `ps` `execFileSync` calls in `session-monitor.ts`
2. Reorder daemon startup: kick off `startCommandCenter()` and `startOrchestrator()` **before** the monitor loop so a slow `tick()` can't block the HTTP server
3. Move `stopOrchestrator`/`httpServer` declarations above `tick()` to prevent TDZ
4. Pass `--no-warnings` to node in `cli.test.ts`

## Testing

881 tests pass, 0 failures.