### PR TITLE
Improve README setup and feature coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 Requirements:
 
 - Node.js 18 or newer
+- Bun 1.0 or newer
 - pnpm 10 or newer
 - tmux 3.0 or newer for manual CLI smoke tests
 
@@ -12,7 +13,10 @@ Install dependencies:
 
 ```bash
 pnpm install --frozen-lockfile
+npm link
 ```
+
+`npm link` is optional, but it is the easiest way to exercise the locally checked-out CLI as `tmux-ide`.
 
 ## Development Workflow
 
@@ -37,17 +41,19 @@ pnpm check
 For a manual tmux smoke test:
 
 ```bash
-node bin/cli.js init
-node bin/cli.js inspect --json
-node bin/cli.js
+bun bin/cli.ts init
+bun bin/cli.ts inspect --json
+tmux-ide
 ```
 
 Then in another shell:
 
 ```bash
-node bin/cli.js status --json
-node bin/cli.js stop --json
+tmux-ide status --json
+tmux-ide stop --json
 ```
+
+Run the launch step from a real interactive terminal. In headless or restricted PTYs, tmux can still create the session but the attach step may fail with terminal capability errors such as `open terminal failed: terminal does not support clear`.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,31 @@ Turn any project into a tmux-powered terminal IDE with a simple `ide.yml` config
 
 ## Install
 
+Prerequisites:
+
+- `tmux` >= 3.0
+- `Node.js` >= 18
+- `bun` on your `PATH` (`tmux-ide` is published with a `#!/usr/bin/env bun` entrypoint)
+
+On macOS:
+
+```bash
+brew install tmux bun
+```
+
+Then install `tmux-ide`:
+
 ```bash
 npm install -g tmux-ide
 ```
+
+Or run it with `npx` without a global install:
+
+```bash
+npx tmux-ide --version
+```
+
+`npx` still requires `bun` to be installed locally because it executes the same published CLI entrypoint.
 
 Global install also registers the bundled Claude Code skill and enables `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in `~/.claude/settings.json` if Claude Code is installed locally on the machine.
 
@@ -16,12 +38,17 @@ Global install also registers the bundled Claude Code skill and enables `CLAUDE_
 
 ```bash
 tmux-ide init         # Scaffold ide.yml (auto-detects your stack)
+tmux-ide doctor       # Check tmux + runtime prerequisites in this project
 tmux-ide              # Launch the IDE
 tmux-ide stop         # Kill the session
 tmux-ide restart      # Stop and relaunch
 tmux-ide attach       # Reattach to a running session
 tmux-ide inspect      # Inspect effective config + runtime state
 ```
+
+`tmux-ide init` writes both `ide.yml` and built-in role files under `.tmux-ide/skills/`.
+
+The default scaffold includes panes that run `claude`. If Claude Code is not installed on the machine, edit `ide.yml` before the first `tmux-ide` launch and replace or remove those commands.
 
 ## ide.yml Format
 
@@ -138,6 +165,7 @@ Release note convention:
 
 - **tmux** >= 3.0
 - **Node.js** >= 18
+- **Bun** on your `PATH`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/wavyrai/tmux-ide/actions/workflows/ci.yml/badge.svg)](https://github.com/wavyrai/tmux-ide/actions/workflows/ci.yml)
 
-Turn any project into a tmux-powered terminal IDE with a simple `ide.yml` config file.
+Turn any project into a tmux-powered terminal IDE or autonomous multi-agent workspace with a simple `ide.yml` config file.
 
 ## Install
 
@@ -34,7 +34,14 @@ npx tmux-ide --version
 
 Global install also registers the bundled Claude Code skill and enables `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in `~/.claude/settings.json` if Claude Code is installed locally on the machine.
 
+## Two Modes
+
+- **Classic mode**: define panes in `ide.yml`, launch dev servers and shells, and manage the tmux session with `attach`, `restart`, `inspect`, and `status`.
+- **Missions mode**: run an orchestrated multi-agent workspace with a lead, specialist teammates, milestone gating, validation contracts, a knowledge library, researcher audits, and a live dashboard.
+
 ## Quick Start
+
+### Classic Mode
 
 ```bash
 tmux-ide init         # Scaffold ide.yml (auto-detects your stack)
@@ -50,7 +57,43 @@ tmux-ide inspect      # Inspect effective config + runtime state
 
 The default scaffold includes panes that run `claude`. If Claude Code is not installed on the machine, edit `ide.yml` before the first `tmux-ide` launch and replace or remove those commands.
 
+### Missions Mode
+
+```bash
+tmux-ide init --template missions
+tmux-ide mission create "Build auth system" -d "JWT + refresh tokens"
+tmux-ide
+```
+
+The `missions` template scaffolds:
+
+- `ide.yml` with an orchestrator-enabled team layout
+- `.tmux-ide/skills/` with built-in specialist roles
+- `.tmux-ide/library/` for architecture notes and learnings
+- `.tasks/validation-contract.md` for assertion-based verification
+- `AGENTS.md` for project boundaries and conventions
+
+Useful follow-up commands:
+
+```bash
+tmux-ide mission status       # Milestones, tasks, and validation progress
+tmux-ide metrics              # Session and agent telemetry
+tmux-ide validate coverage    # Check assertion coverage gaps
+tmux-ide orchestrator         # Orchestrator state
+```
+
+The missions layout also starts the dashboard / command center, which by default is served at `http://localhost:6060`.
+
+If you prefer guided setup over editing YAML directly, use:
+
+```bash
+tmux-ide setup
+tmux-ide settings
+```
+
 ## ide.yml Format
+
+Classic pane layout:
 
 ```yaml
 name: project-name # tmux session name
@@ -82,40 +125,105 @@ theme: # optional color overrides
   fg: colour248
 ```
 
+Additional fields for agent teams and missions:
+
+```yaml
+team:
+  name: missions
+
+rows:
+  - size: 70%
+    panes:
+      - title: Lead
+        command: claude
+        role: lead
+      - title: Frontend
+        command: claude
+        role: teammate
+        specialty: frontend
+      - title: Validator
+        command: claude
+        role: validator
+        skill: reviewer
+
+orchestrator:
+  enabled: true
+  auto_dispatch: true
+  dispatch_mode: missions
+  poll_interval: 5000
+  stall_timeout: 300000
+  master_pane: Lead
+```
+
+Advanced config supports:
+
+- `team` metadata to enable Claude Code agent teams in the tmux session
+- per-pane `role`, `task`, `skill`, and `specialty` fields for dispatch-aware layouts
+- an `orchestrator` block for autonomous dispatch, services, research triggers, and webhooks
+- `.tmux-ide/skills/` and `.tmux-ide/library/` as project-local skill and knowledge sources
+
 ## Commands
 
-| Command                                            | Description                             |
-| -------------------------------------------------- | --------------------------------------- |
-| `tmux-ide`                                         | Launch IDE from `ide.yml`               |
-| `tmux-ide <path>`                                  | Launch from a specific directory        |
-| `tmux-ide init [--template <name>]`                | Scaffold a new `ide.yml`                |
-| `tmux-ide stop`                                    | Kill the current IDE session            |
-| `tmux-ide restart`                                 | Stop and relaunch the IDE session       |
-| `tmux-ide attach`                                  | Reattach to a running session           |
-| `tmux-ide ls`                                      | List all tmux sessions                  |
-| `tmux-ide status`                                  | Show session status                     |
-| `tmux-ide inspect`                                 | Show effective config and runtime state |
-| `tmux-ide doctor`                                  | Check system requirements               |
-| `tmux-ide validate`                                | Validate `ide.yml`                      |
-| `tmux-ide detect`                                  | Detect project stack and explain why    |
-| `tmux-ide detect --write`                          | Detect and write `ide.yml`              |
-| `tmux-ide config`                                  | Dump config as JSON                     |
-| `tmux-ide config set <path> <value>`               | Set a config value                      |
-| `tmux-ide config add-pane --row <N>`               | Add a pane to a row                     |
-| `tmux-ide config remove-pane --row <N> --pane <M>` | Remove a pane                           |
-| `tmux-ide config add-row [--size <percent>]`       | Add a new row                           |
-| `tmux-ide config enable-team --name <name>`        | Enable agent teams                      |
-| `tmux-ide config disable-team`                     | Disable agent teams                     |
+### Session Lifecycle
+
+- `tmux-ide` / `tmux-ide <path>`: launch from `ide.yml`
+- `tmux-ide init [--template <name>]`: scaffold a config
+- `tmux-ide attach`, `stop`, `restart`, `ls`, `status`, `inspect`
+- `tmux-ide doctor`: check runtime prerequisites
+- `tmux-ide detect [--write]`: infer a layout from the current project
+
+### Setup and Config
+
+- `tmux-ide setup`: interactive TUI setup wizard
+- `tmux-ide settings`: interactive TUI config manager
+- `tmux-ide config`: dump config as JSON
+- `tmux-ide config set <path> <value>`: set a config value
+- `tmux-ide config add-pane --row <N> --title <T> [--command <C>]`
+- `tmux-ide config remove-pane --row <N> --pane <M>`
+- `tmux-ide config add-row [--size <percent>]`
+- `tmux-ide config enable-team [--name <name>]`
+- `tmux-ide config disable-team`
+- `tmux-ide config edit`: open the config tree editor
+
+### Missions, Goals, and Tasks
+
+- `tmux-ide mission`: create, show, clear, and advance the current mission lifecycle
+- `tmux-ide milestone`: manage sequential execution phases
+- `tmux-ide goal`: manage goals and their acceptance criteria
+- `tmux-ide task`: create, claim, complete, update, delete, and inspect tasks
+- `tmux-ide plan`: inspect planning state
+- `tmux-ide research`: inspect or manually trigger researcher audits
+
+### Validation, Skills, and Metrics
+
+- `tmux-ide validate`: validate `ide.yml` or manage validation contract state
+- `tmux-ide validate show|assert|report|coverage`
+- `tmux-ide skill list|show|create|validate`
+- `tmux-ide metrics`, `metrics agents`, `metrics timeline`, `metrics eval`, `metrics history`
+
+### Messaging and Orchestration
+
+- `tmux-ide send <target> <message>`: send a message to a pane by title, name, role, or pane ID
+- `tmux-ide dispatch <task-id>`: print task context for dispatch
+- `tmux-ide notify <message>`: send a notification to the lead pane
+- `tmux-ide orchestrator` / `tmux-ide orch`: show orchestrator state
+- `tmux-ide command-center --port <port>`: run the standalone command-center server
+
+### Remote and Networking
+
+- `tmux-ide tunnel start|stop|status|url`: expose a local session
+- `tmux-ide remote register|machines|status`: register and inspect remote machine state
 
 All commands support `--json` for structured output.
 
-`tmux-ide detect` now includes reasoning about the package manager, language, framework, and dev-command signals it used. `tmux-ide inspect` combines config validation, resolved layout details, and live tmux state in one command.
+For the full command reference, see [docs/content/docs/commands.mdx](docs/content/docs/commands.mdx). For programmatic workflows, see [docs/content/docs/programmatic.mdx](docs/content/docs/programmatic.mdx).
 
 ## Templates
 
 Use `tmux-ide init --template <name>` with one of:
 
 - `default` - General-purpose layout
+- `missions` - Full autonomous workflow with orchestrator, validator, researcher, and dashboard
 - `nextjs` - Next.js development
 - `convex` - Convex + Next.js
 - `vite` - Vite project
@@ -124,6 +232,15 @@ Use `tmux-ide init --template <name>` with one of:
 - `agent-team` - Agent team with lead + teammates
 - `agent-team-nextjs` - Agent team for Next.js
 - `agent-team-monorepo` - Agent team for monorepos
+
+## Docs
+
+- [docs/content/docs/getting-started.mdx](docs/content/docs/getting-started.mdx) for first-run setup
+- [docs/content/docs/configuration.mdx](docs/content/docs/configuration.mdx) for the full `ide.yml` reference
+- [docs/content/docs/templates.mdx](docs/content/docs/templates.mdx) for template walkthroughs
+- [docs/content/docs/agent-teams.mdx](docs/content/docs/agent-teams.mdx) for lead / teammate and missions concepts
+- [docs/content/docs/missions-workflow.mdx](docs/content/docs/missions-workflow.mdx) for the full mission lifecycle
+- [docs/content/docs/commands.mdx](docs/content/docs/commands.mdx) for the full CLI reference
 
 ## Contributor Workflow
 


### PR DESCRIPTION
## Summary
- document the real runtime prerequisites and first-run assumptions
- expand the root README to cover classic mode and missions mode
- surface the broader command, template, and configuration surface in the README

## Validation
- verified local install and setup flow from the checked-out repo
- confirmed the published CLI requires Bun on PATH
- exercised init, inspect, status, and stop flows locally