### PR TITLE
Fix widget Bun runtime cwd

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -5,6 +5,7 @@ import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, "..");
 import { launch } from "../src/launch.ts";
 import { init } from "../src/init.ts";
 import { stop } from "../src/stop.ts";
@@ -309,6 +310,7 @@ try {
         const scriptPath = resolve(__dirname, "../src/widgets/setup/index.tsx");
         execFileSync("bun", [scriptPath, "--dir=" + resolve(startTargetDir || "."), "--edit"], {
           stdio: "inherit",
+          cwd: packageRoot,
         });
         break;
       }
@@ -437,7 +439,7 @@ try {
       const setupArgs = [scriptPath, "--dir=" + resolve(startTargetDir || ".")];
       if (positionals[1] === "--edit" || values.edit) setupArgs.push("--edit");
       if (positionals[1] === "--wizard" || values.wizard) setupArgs.push("--wizard");
-      execFileSync("bun", setupArgs, { stdio: "inherit" });
+      execFileSync("bun", setupArgs, { stdio: "inherit", cwd: packageRoot });
       break;
     }
 
@@ -477,6 +479,7 @@ try {
       const scriptPath = resolve(__dirname, "../src/widgets/config/index.tsx");
       execFileSync("bun", [scriptPath, "--dir=" + resolve(startTargetDir || ".")], {
         stdio: "inherit",
+        cwd: packageRoot,
       });
       break;
     }

--- a/src/widgets/resolve.test.ts
+++ b/src/widgets/resolve.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "bun:test";
+import { resolveWidgetCommand } from "./resolve.ts";
+
+describe("resolveWidgetCommand", () => {
+  it("runs widgets from the tmux-ide package root instead of the target project dir", () => {
+    const command = resolveWidgetCommand("tasks", {
+      session: "demo",
+      dir: "/tmp/project",
+      target: null,
+      theme: null,
+    });
+
+    expect(command).toContain("bun ");
+    expect(command).toContain("--session=demo");
+    expect(command).toContain("--dir=/tmp/project");
+    expect(command).not.toContain("cd /tmp/project &&");
+  });
+});

--- a/src/widgets/resolve.ts
+++ b/src/widgets/resolve.ts
@@ -4,6 +4,7 @@ import type { ThemeConfig } from "../types.ts";
 import { shellEscape } from "../lib/shell.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, "..", "..");
 
 interface WidgetOptions {
   session: string;
@@ -35,6 +36,7 @@ export function resolveWidgetCommand(type: string, opts: WidgetOptions): string 
 
   const escapedArgs = args.map(shellEscape).join(" ");
 
-  // cd to project root first so bunfig.toml preload is found
-  return `cd ${shellEscape(opts.dir)} && bun ${shellEscape(scriptPath)} ${escapedArgs}`;
+  // Run from the tmux-ide package root so Bun picks up the widget preload/JSX config.
+  // The target project still comes through --dir.
+  return `cd ${shellEscape(packageRoot)} && bun ${shellEscape(scriptPath)} ${escapedArgs}`;
 }


### PR DESCRIPTION
## Summary
- run widget entrypoints from the tmux-ide package root so Bun picks up the correct preload and JSX runtime config
- keep the target project directory flowing through --dir instead of using it as the Bun working directory
- add a focused test for widget command resolution

## Validation
- bun test src/widgets/resolve.test.ts
- verified tmux-ide setup --wizard starts correctly from a separate project directory