### PR TITLE
fix(release): dashboard typecheck — add chat-solid path alias + type threadId

### DIFF
--- a/dashboard/src/components/ChatView.tsx
+++ b/dashboard/src/components/ChatView.tsx
@@ -382,7 +382,7 @@ export function ChatView(props: ChatViewProps) {
         wsUrl: withWsBase("/ws/events"),
         bearerToken: resolveAuthToken(),
         highlightCodeFences: highlightFences,
-        onDelete: (threadId) => setConfirmDeleteId(threadId),
+        onDelete: (threadId: string) => setConfirmDeleteId(threadId),
       });
     }),
   );

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -19,6 +19,7 @@
     "paths": {
       "@/*": ["./src/*"],
       "@tmux-ide/contracts": ["../packages/contracts/src/index.ts"],
+      "@tmux-ide/chat-solid": ["../packages/chat-solid/src/index.tsx"],
       "@tmux-ide/v2-solid-widgets": ["../packages/v2-solid-widgets/src/index.tsx"]
     },
     "types": ["vite/client", "@testing-library/jest-dom"]


### PR DESCRIPTION
## Summary

- Adds `@tmux-ide/chat-solid` path alias to `dashboard/tsconfig.json` (was missing, causing 3 TS errors in the publish workflow typecheck)
- Annotates `threadId: string` in `ChatView.tsx` `onDelete` callback (implicit any)

These two errors were blocking the `release.yml` publish workflow.

## Test plan
- [ ] `cd dashboard && pnpm typecheck` passes locally ✓