### PR TITLE
SSH remotes + central agent control plane (see, and control, every Claude/codex session from one place)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27022,6 +27022,16 @@ import { createRequire as createRequire3 } from "node:module";
 import { existsSync as existsSync37, readdirSync as readdirSync11, statSync as statSync10, unlinkSync as unlinkSync5 } from "node:fs";
 import { join as join40 } from "node:path";
 import { WebSocket, WebSocketServer as WebSocketServer2 } from "ws";
+function resolveOwnVersion() {
+  for (const candidate of ["../../package.json", "../package.json"]) {
+    try {
+      const pkg = requireFromHere(candidate);
+      if (typeof pkg.version === "string") return pkg.version;
+    } catch {
+    }
+  }
+  return "0.0.0";
+}
 function tmux3(...args) {
   return execFileSync8("tmux", args, {
     encoding: "utf-8",
@@ -27531,11 +27541,10 @@ async function startEmbeddedDaemon(opts) {
     localBypassToken,
     silent: opts.silent
   });
-  const pkg = requireFromHere("../../package.json");
   writeCanonicalDaemonInfo({
     pid: process.pid,
     port,
-    version: pkg.version ?? "0.0.0",
+    version: resolveOwnVersion(),
     startedAt: (/* @__PURE__ */ new Date()).toISOString(),
     bindHostname,
     authToken
@@ -27789,8 +27798,14 @@ function daemonBaseUrl(info) {
 }
 function expectedDaemonVersion() {
   try {
-    const pkg = requireFromHere2("../../package.json");
-    return pkg.version ?? "0.0.0";
+    for (const candidate of ["../../package.json", "../package.json"]) {
+      try {
+        const pkg = requireFromHere2(candidate);
+        if (typeof pkg.version === "string") return pkg.version;
+      } catch {
+      }
+    }
+    return "0.0.0";
   } catch {
     return "0.0.0";
   }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16635,7 +16635,7 @@ function listAllTmuxPanes() {
     if (!line) continue;
     const parts = line.split("	");
     if (parts.length < FIXED_FIELDS) continue;
-    const [session, id, index, cmd, cwd, pid, width, height, active2, role, name, type] = parts;
+    const [session, id, index, cmd, cwd, pid, width, height, active2, role, name, type, owned] = parts;
     if (!session || !id) continue;
     panes.push({
       session,
@@ -16650,7 +16650,8 @@ function listAllTmuxPanes() {
       active: active2 === "1",
       role: role || null,
       name: name || null,
-      type: type || null
+      type: type || null,
+      owned: owned === "1"
     });
   }
   return panes;
@@ -16664,7 +16665,7 @@ function inferAgentTool(currentCommand) {
 }
 function discoverTmuxAgents(managedSessions) {
   return listAllTmuxPanes().filter((pane) => isAgentPane(pane)).map((pane) => {
-    const managed = managedSessions.has(pane.session);
+    const managed = managedSessions.has(pane.session) || pane.owned;
     return {
       id: `${pane.session}:${pane.id}`,
       kind: managed ? "managed" : "tmux-unmanaged",
@@ -16684,7 +16685,28 @@ function discoverTmuxAgents(managedSessions) {
     };
   });
 }
-var FIELDS, FIXED_FIELDS;
+function sanitizeOption(value, max) {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0);
+    if (code < 32 || code === 127 || code >= 128 && code <= 159) continue;
+    out += ch;
+    if (out.length >= max) break;
+  }
+  return out;
+}
+function claimPane(paneId, opts = {}) {
+  if (!PANE_ID_RE.test(paneId)) throw new InvalidPaneIdError(paneId);
+  tmux("set-option", "-p", "-t", paneId, "@ide_owned", "1");
+  if (opts.name)
+    tmux("set-option", "-p", "-t", paneId, "@ide_name", sanitizeOption(opts.name, 200));
+  if (opts.role) tmux("set-option", "-p", "-t", paneId, "@ide_role", sanitizeOption(opts.role, 64));
+}
+function releasePane(paneId) {
+  if (!PANE_ID_RE.test(paneId)) throw new InvalidPaneIdError(paneId);
+  tmux("set-option", "-p", "-u", "-t", paneId, "@ide_owned");
+}
+var FIELDS, FIXED_FIELDS, PANE_ID_RE, InvalidPaneIdError;
 var init_agent_discovery = __esm({
   "packages/daemon/src/lib/agent-discovery.ts"() {
     "use strict";
@@ -16703,9 +16725,17 @@ var init_agent_discovery = __esm({
       "#{@ide_role}",
       "#{@ide_name}",
       "#{@ide_type}",
+      "#{@ide_owned}",
       "#{pane_title}"
     ];
     FIXED_FIELDS = FIELDS.length - 1;
+    PANE_ID_RE = /^%\d+$/;
+    InvalidPaneIdError = class extends Error {
+      constructor(paneId) {
+        super(`Invalid tmux pane id: ${paneId}`);
+        this.name = "InvalidPaneIdError";
+      }
+    };
   }
 });
 
@@ -17381,7 +17411,7 @@ var init_agent_registry = __esm({
 
 // packages/daemon/src/command-center/schemas.ts
 import { z as z20 } from "zod";
-var updateTaskSchema, createTaskSchema, savePlanSchema, savePlanContentSchema, sendCommandSchema, agentSendSchema, createMilestoneSchema, updateMilestoneSchema, updateAssertionSchema, triggerResearchSchema, launchSchema, stopSchema, skillNameRegex, createSkillSchema, updateSkillSchema;
+var updateTaskSchema, createTaskSchema, savePlanSchema, savePlanContentSchema, sendCommandSchema, agentSendSchema, agentClaimSchema, agentReleaseSchema, createMilestoneSchema, updateMilestoneSchema, updateAssertionSchema, triggerResearchSchema, launchSchema, stopSchema, skillNameRegex, createSkillSchema, updateSkillSchema;
 var init_schemas = __esm({
   "packages/daemon/src/command-center/schemas.ts"() {
     "use strict";
@@ -17415,6 +17445,16 @@ var init_schemas = __esm({
       machineId: z20.string().min(1).max(256).nullish(),
       message: z20.string().min(1, "Message is required").max(1e4),
       noEnter: z20.boolean().optional()
+    });
+    agentClaimSchema = z20.object({
+      id: z20.string().min(1).max(512),
+      machineId: z20.string().min(1).max(256).nullish(),
+      name: z20.string().min(1).max(200).optional(),
+      role: z20.string().min(1).max(64).optional()
+    });
+    agentReleaseSchema = z20.object({
+      id: z20.string().min(1).max(512),
+      machineId: z20.string().min(1).max(256).nullish()
     });
     createMilestoneSchema = z20.object({
       title: z20.string().trim().min(1, "Title is required"),
@@ -24982,43 +25022,58 @@ function createApp(options = {}) {
     }
     return c.json(AgentListSchemaZ.parse({ agents }));
   });
-  app.post("/api/agents/send", zValidator2("json", agentSendSchema), async (c) => {
-    const { id, machineId, message, noEnter } = c.req.valid("json");
+  async function resolveAgentTarget(id, machineId) {
     if (machineId) {
       const sshUrl = await resolveSshMachineUrl(machineId);
       const hqMachine = sshUrl ? null : remoteRegistry?.getMachine(machineId);
       const baseUrl = sshUrl ?? hqMachine?.url;
       if (!baseUrl || !isHttpUrl(baseUrl)) {
-        return c.json({ error: `Unknown machine: ${machineId}` }, 404);
+        return { kind: "error", status: 404, body: { error: `Unknown machine: ${machineId}` } };
       }
       const prefix = `${machineId}:`;
       if (!id.startsWith(prefix)) {
-        return c.json({ error: "Agent id does not belong to that machine" }, 400);
+        return {
+          kind: "error",
+          status: 400,
+          body: { error: "Agent id does not belong to that machine" }
+        };
       }
       const headers = { "Content-Type": "application/json" };
       if (hqMachine) headers.Authorization = `Bearer ${hqMachine.token}`;
-      try {
-        const controller = new AbortController();
-        const tid = setTimeout(() => controller.abort(), 5e3);
-        const res = await fetch(`${baseUrl}/api/agents/send`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({ id: id.slice(prefix.length), message, noEnter }),
-          signal: controller.signal,
-          redirect: "manual"
-        });
-        clearTimeout(tid);
-        const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-        if (res.ok) return c.json(body);
-        return c.json({ ...body, remoteStatus: res.status }, 502);
-      } catch {
-        return c.json({ error: `Machine ${machineId} is unreachable` }, 502);
-      }
+      return { kind: "remote", baseUrl, headers, forwardId: id.slice(prefix.length) };
     }
     const agent = localAgents().find((candidate) => candidate.id === id);
-    if (!agent) {
-      return c.json({ error: `Agent not found: ${id}` }, 404);
+    if (!agent) return { kind: "error", status: 404, body: { error: `Agent not found: ${id}` } };
+    return { kind: "local", agent };
+  }
+  async function proxyAgentPost(target, path4, body, machineId) {
+    try {
+      const controller = new AbortController();
+      const tid = setTimeout(() => controller.abort(), 5e3);
+      const res = await fetch(`${target.baseUrl}${path4}`, {
+        method: "POST",
+        headers: target.headers,
+        body: JSON.stringify({ ...body, id: target.forwardId }),
+        signal: controller.signal,
+        redirect: "manual"
+      });
+      clearTimeout(tid);
+      const respBody = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+      if (res.ok) return { status: 200, body: respBody };
+      return { status: 502, body: { ...respBody, remoteStatus: res.status } };
+    } catch {
+      return { status: 502, body: { error: `Machine ${machineId} is unreachable` } };
     }
+  }
+  app.post("/api/agents/send", zValidator2("json", agentSendSchema), async (c) => {
+    const { id, machineId, message, noEnter } = c.req.valid("json");
+    const target = await resolveAgentTarget(id, machineId);
+    if (target.kind === "error") return c.json(target.body, target.status);
+    if (target.kind === "remote") {
+      const r = await proxyAgentPost(target, "/api/agents/send", { message, noEnter }, machineId);
+      return c.json(r.body, r.status);
+    }
+    const { agent } = target;
     if (agent.kind === "external" || !agent.session || !agent.paneId) {
       return c.json({ error: "External agents are observe-only (no pane to drive)" }, 409);
     }
@@ -25033,6 +25088,44 @@ function createApp(options = {}) {
       ok: true,
       agent: { id: agent.id, session: agent.session, paneId: agent.paneId }
     });
+  });
+  app.post("/api/agents/claim", zValidator2("json", agentClaimSchema), async (c) => {
+    const { id, machineId, name, role } = c.req.valid("json");
+    const target = await resolveAgentTarget(id, machineId);
+    if (target.kind === "error") return c.json(target.body, target.status);
+    if (target.kind === "remote") {
+      const r = await proxyAgentPost(target, "/api/agents/claim", { name, role }, machineId);
+      return c.json(r.body, r.status);
+    }
+    const { agent } = target;
+    if (agent.kind === "external" || !agent.paneId) {
+      return c.json({ error: "External agents have no pane to claim" }, 409);
+    }
+    try {
+      claimPane(agent.paneId, { name, role });
+    } catch (err) {
+      if (err instanceof InvalidPaneIdError) return c.json({ error: err.message }, 400);
+      throw err;
+    }
+    return c.json({ ok: true, agent: { id: agent.id, paneId: agent.paneId, name: name ?? null } });
+  });
+  app.post("/api/agents/release", zValidator2("json", agentReleaseSchema), async (c) => {
+    const { id, machineId } = c.req.valid("json");
+    const target = await resolveAgentTarget(id, machineId);
+    if (target.kind === "error") return c.json(target.body, target.status);
+    if (target.kind === "remote") {
+      const r = await proxyAgentPost(target, "/api/agents/release", {}, machineId);
+      return c.json(r.body, r.status);
+    }
+    const { agent } = target;
+    if (!agent.paneId) return c.json({ error: "Agent has no pane to release" }, 409);
+    try {
+      releasePane(agent.paneId);
+    } catch (err) {
+      if (err instanceof InvalidPaneIdError) return c.json({ error: err.message }, 400);
+      throw err;
+    }
+    return c.json({ ok: true, agent: { id: agent.id, paneId: agent.paneId } });
   });
   const tunnelManager = options.tunnelManager ?? null;
   app.get("/api/tunnel", async (c) => {
@@ -29930,6 +30023,45 @@ async function sendToAgent(opts) {
   const where = machineId === null ? "this machine" : agent.machineName ?? machineId;
   console.log(`Sent to ${agent.name} [${agent.id}] on ${where}.`);
 }
+async function claimAgent(opts) {
+  const info = requireDaemonInfo();
+  const { agents } = await fetchAgentList(info);
+  const { agent, machineId } = resolveSendTarget(agents, opts.id);
+  const path4 = opts.release ? "/api/agents/release" : "/api/agents/claim";
+  const { url, headers } = daemonRequest(info, path4);
+  let res;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(
+        opts.release ? { id: opts.id, machineId } : { id: opts.id, machineId, name: opts.name, role: opts.role }
+      ),
+      signal: timeoutSignal5(15e3)
+    });
+  } catch {
+    throw new IdeError(NO_DAEMON_MESSAGE, { code: "DAEMON_UNAVAILABLE", exitCode: 1 });
+  }
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const detail = typeof body.error === "string" ? body.error : `HTTP ${res.status}`;
+    throw new IdeError(`${opts.release ? "Release" : "Claim"} failed: ${detail}`, {
+      code: opts.release ? "RELEASE_FAILED" : "CLAIM_FAILED",
+      exitCode: 1
+    });
+  }
+  if (opts.json) {
+    console.log(JSON.stringify(body));
+    return;
+  }
+  const where = machineId === null ? "this machine" : agent.machineName ?? machineId;
+  if (opts.release) {
+    console.log(`Released ${agent.name} [${agent.id}] on ${where} (back to unmanaged).`);
+  } else {
+    const label = opts.name ?? agent.name;
+    console.log(`Owned ${label} [${agent.id}] on ${where} \u2014 now managed.`);
+  }
+}
 async function agentsCommand(opts) {
   const sub = opts.sub;
   if (sub === void 0 || sub === "list") {
@@ -29948,8 +30080,25 @@ async function agentsCommand(opts) {
     await sendToAgent({ id, message, noEnter: opts.noEnter, json: opts.json });
     return;
   }
+  if (sub === "claim" || sub === "release") {
+    const [id] = opts.args ?? [];
+    if (!id) {
+      throw new IdeError(
+        `Usage: tmux-ide agents ${sub} <agent-id>` + (sub === "claim" ? " [--name <name>] [--role <role>]" : "") + "\nRun `tmux-ide agents` to list agent ids.",
+        { code: "USAGE", exitCode: 1 }
+      );
+    }
+    await claimAgent({
+      id,
+      name: opts.name,
+      role: opts.role,
+      release: sub === "release",
+      json: opts.json
+    });
+    return;
+  }
   throw new IdeError(
-    "Usage:\n  tmux-ide agents [list] [--json]\n  tmux-ide agents send <agent-id> <message...> [--no-enter] [--json]\n(For the plain-terminal hook reporter, see `tmux-ide agent`.)",
+    "Usage:\n  tmux-ide agents [list] [--json]\n  tmux-ide agents send <agent-id> <message...> [--no-enter] [--json]\n  tmux-ide agents claim <agent-id> [--name <name>] [--role <role>]\n  tmux-ide agents release <agent-id>\n(For the plain-terminal hook reporter, see `tmux-ide agent`.)",
     { code: "USAGE", exitCode: 1 }
   );
 }
@@ -32784,7 +32933,9 @@ try {
         sub: positionals[1],
         args: positionals.slice(2),
         json,
-        noEnter: values["no-enter"] === true
+        noEnter: values["no-enter"] === true,
+        name: typeof values.name === "string" ? values.name : void 0,
+        role: typeof values.role === "string" ? values.role : void 0
       });
       break;
     }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17214,12 +17214,21 @@ async function fetchAgents(baseUrl) {
   }
 }
 async function listSshAgentSources() {
-  const remotes = (await readSshRemotes()).filter((remote) => tunnelPort(remote) !== null);
-  const probes = remotes.map(async (remote) => {
-    const agents = await fetchAgents(tunnelBaseUrl(remote));
-    if (!agents) return null;
-    return { machineId: sshMachineId(remote.name), machineName: remote.name, agents };
-  });
+  const byUrl = /* @__PURE__ */ new Map();
+  for (const remote of await readSshRemotes()) {
+    const url = tunnelBaseUrl(remote);
+    if (!url) continue;
+    const current = byUrl.get(url);
+    const launched = (candidate) => candidate.lastLaunchedAt ?? "";
+    if (!current || launched(remote) > launched(current)) byUrl.set(url, remote);
+  }
+  const probes = [...byUrl.entries()].map(
+    async ([url, remote]) => {
+      const agents = await fetchAgents(url);
+      if (!agents) return null;
+      return { machineId: sshMachineId(remote.name), machineName: remote.name, agents };
+    }
+  );
   return (await Promise.all(probes)).filter((source) => !!source);
 }
 var SSH_MACHINE_PREFIX, PROBE_TIMEOUT_MS;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -336,6 +336,11 @@ function sendLiteral(targetPane, text) {
   runTmux(["send-keys", "-t", targetPane, "-l", "--", text], { stdio: "inherit" });
   runTmux(["send-keys", "-t", targetPane, "Enter"], { stdio: "inherit" });
 }
+function getPaneCurrentCommand(targetPane) {
+  return runTmux(["display-message", "-p", "-t", targetPane, "#{pane_current_command}"], {
+    encoding: "utf-8"
+  }).trim();
+}
 function selectPane(targetPane) {
   runTmux(["select-pane", "-t", targetPane], { stdio: "inherit" });
 }
@@ -3203,6 +3208,14 @@ var init_canonical_daemon = __esm({
 });
 
 // packages/daemon/src/launch.ts
+var launch_exports = {};
+__export(launch_exports, {
+  buildMasterAgentPrompt: () => buildMasterAgentPrompt,
+  buildPaneMap: () => buildPaneMap,
+  ensureTaskDocs: () => ensureTaskDocs,
+  launch: () => launch,
+  waitForPaneCommand: () => waitForPaneCommand
+});
 import { resolve as resolve5, join as join2 } from "node:path";
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -3213,8 +3226,30 @@ function stripWidgetPanes(rows) {
     panes: row.panes.filter((p) => !p.type)
   })).filter((row) => row.panes.length > 0);
 }
+function sleepMs(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
 function configHash(config2) {
   return createHash("sha256").update(JSON.stringify(config2)).digest("hex").slice(0, 12);
+}
+function waitForPaneCommand(targetPane, expectedCommands, {
+  attempts = 20,
+  delayMs = 100,
+  getCurrentCommand = getPaneCurrentCommand,
+  sleep = sleepMs
+} = {}) {
+  const allowed = new Set(expectedCommands.map((command2) => command2.toLowerCase()));
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const current = getCurrentCommand(targetPane)?.trim().toLowerCase();
+      if (current && allowed.has(current)) return true;
+    } catch {
+    }
+    if (attempt < attempts - 1) {
+      sleep(delayMs);
+    }
+  }
+  return false;
 }
 function buildPaneMap(rows, dir, rootPaneId, splitPaneFn) {
   const rowSizes = computeSizes(rows);
@@ -6013,7 +6048,7 @@ function sendLiteralToPane(_session, paneId, text) {
 function sendEnterToPane(_session, paneId) {
   tmux("send-keys", "-t", paneId, "Enter");
 }
-function sleepMs(ms) {
+function sleepMs2(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 function sendCommand(session, paneId, command2) {
@@ -6025,11 +6060,11 @@ function sendCommand(session, paneId, command2) {
   }
   if (status4 === "agent") {
     if (command2.length < 200) {
-      sleepMs(150);
+      sleepMs2(150);
     } else {
-      sleepMs(5e3);
+      sleepMs2(5e3);
       tmux("send-keys", "-t", paneId, "Enter");
-      sleepMs(2e3);
+      sleepMs2(2e3);
     }
     tmux("send-keys", "-t", paneId, "Enter");
     return true;
@@ -10551,8 +10586,8 @@ function makeJsonRpcEndpoint(opts) {
   let resolveClosed;
   const pending = /* @__PURE__ */ new Map();
   const notificationHandlers = /* @__PURE__ */ new Set();
-  const closed = new Promise((resolve34) => {
-    resolveClosed = resolve34;
+  const closed = new Promise((resolve35) => {
+    resolveClosed = resolve35;
   });
   function log2(direction, payload) {
     opts.logger?.({ direction, payload });
@@ -10646,8 +10681,8 @@ function makeJsonRpcEndpoint(opts) {
       const id = nextId++;
       const envelope = { jsonrpc: "2.0", id, method };
       if (params !== void 0) envelope.params = params;
-      const promise = new Promise((resolve34, reject) => {
-        pending.set(id, { resolve: resolve34, reject });
+      const promise = new Promise((resolve35, reject) => {
+        pending.set(id, { resolve: resolve35, reject });
       });
       write(envelope);
       return promise;
@@ -12240,8 +12275,8 @@ function makeJsonRpcEndpoint2(opts) {
   let resolveClosed;
   const pending = /* @__PURE__ */ new Map();
   const notificationHandlers = /* @__PURE__ */ new Set();
-  const closed = new Promise((resolve34) => {
-    resolveClosed = resolve34;
+  const closed = new Promise((resolve35) => {
+    resolveClosed = resolve35;
   });
   function log2(direction, payload) {
     opts.logger?.({ direction, payload });
@@ -12344,8 +12379,8 @@ function makeJsonRpcEndpoint2(opts) {
       const id = nextId++;
       const envelope = { id, method };
       if (params !== void 0) envelope.params = params;
-      const promise = new Promise((resolve34, reject) => {
-        pending.set(id, { resolve: resolve34, reject });
+      const promise = new Promise((resolve35, reject) => {
+        pending.set(id, { resolve: resolve35, reject });
       });
       write(envelope);
       return promise;
@@ -13210,12 +13245,12 @@ function makePermissionCoordinator(opts) {
     async request(threadId, req) {
       await opts.beforeEmit?.(threadId);
       const requestId = randomUUID4();
-      return new Promise((resolve34) => {
+      return new Promise((resolve35) => {
         const timer = setTimeout(() => {
           remove(requestId)?.resolve(autoRejectResponse(req.options));
         }, opts.permissionTimeoutMs);
         timer.unref?.();
-        pending.set(requestId, { threadId, options: req.options, resolve: resolve34, timer });
+        pending.set(requestId, { threadId, options: req.options, resolve: resolve35, timer });
         opts.busEmit({
           type: "chat.permission.request",
           threadId,
@@ -13706,8 +13741,8 @@ function asReasoningEffort(value) {
   return KNOWN_REASONING_EFFORTS.includes(value) ? value : null;
 }
 async function dispatchCodexPrompt(input) {
-  const completed = new Promise((resolve34) => {
-    input.bindActivePrompt({ promptId: input.promptId, turnId: null, resolve: resolve34 });
+  const completed = new Promise((resolve35) => {
+    input.bindActivePrompt({ promptId: input.promptId, turnId: null, resolve: resolve35 });
   });
   try {
     const effortLevel = input.reasoningEffort ? asReasoningEffort(input.reasoningEffort) : null;
@@ -13896,8 +13931,8 @@ async function defaultProbeCodexModels(binaryPath, opts = {}) {
       }
       return accumulated;
     })();
-    const timeout = new Promise((resolve34) => {
-      timer = setTimeout(() => resolve34(null), timeoutMs);
+    const timeout = new Promise((resolve35) => {
+      timer = setTimeout(() => resolve35(null), timeoutMs);
     });
     const result = await Promise.race([work, timeout]);
     if (result === null) return null;
@@ -13947,10 +13982,10 @@ async function resolveFromPath3(binary) {
   return null;
 }
 async function defaultExec(cmd, args, opts = {}) {
-  return await new Promise((resolve34) => {
+  return await new Promise((resolve35) => {
     execFile2(cmd, args, { timeout: opts.timeoutMs }, (err, stdout, stderr) => {
       const exitCode = err && typeof err.code === "number" ? err.code : err ? null : 0;
-      resolve34({ stdout, stderr, code: exitCode });
+      resolve35({ stdout, stderr, code: exitCode });
     });
   });
 }
@@ -16894,7 +16929,7 @@ var init_errors6 = __esm({
 import { execFile as execFile3 } from "node:child_process";
 import { Effect } from "effect";
 function runRaw(cwd, args) {
-  return new Promise((resolve34, reject) => {
+  return new Promise((resolve35, reject) => {
     execFile3(
       "git",
       args,
@@ -16916,7 +16951,7 @@ function runRaw(cwd, args) {
           reject(failure);
           return;
         }
-        resolve34({ stdout: out, stderr: errOut });
+        resolve35({ stdout: out, stderr: errOut });
       }
     );
   });
@@ -17192,7 +17227,7 @@ function toPayload2(err) {
   }
 }
 function runCli(cmd, args, cwd) {
-  return new Promise((resolve34, reject) => {
+  return new Promise((resolve35, reject) => {
     execFile4(
       cmd,
       args,
@@ -17218,7 +17253,7 @@ function runCli(cmd, args, cwd) {
           });
           return;
         }
-        resolve34({ stdout: out, stderr: errOut });
+        resolve35({ stdout: out, stderr: errOut });
       }
     );
   });
@@ -18052,12 +18087,12 @@ async function* runSearch(opts) {
     rl.close();
   }
   const exit = await new Promise(
-    (resolve34) => {
+    (resolve35) => {
       if (child.exitCode !== null || child.signalCode !== null) {
-        resolve34({ code: child.exitCode, signal: child.signalCode });
+        resolve35({ code: child.exitCode, signal: child.signalCode });
         return;
       }
-      child.once("exit", (code, sig) => resolve34({ code, signal: sig }));
+      child.once("exit", (code, sig) => resolve35({ code, signal: sig }));
     }
   );
   const aborted = opts.signal.aborted;
@@ -20363,7 +20398,7 @@ async function createLspClient(input) {
     async waitForDiagnostics(file, timeoutMs) {
       const existing = diagnosticsByFile.get(file);
       if (existing) return existing;
-      return new Promise((resolve34) => {
+      return new Promise((resolve35) => {
         const timer = setTimeout(() => {
           const waiters2 = diagnosticsWaiters.get(file);
           if (waiters2) {
@@ -20371,11 +20406,11 @@ async function createLspClient(input) {
             if (idx >= 0) waiters2.splice(idx, 1);
             if (waiters2.length === 0) diagnosticsWaiters.delete(file);
           }
-          resolve34(diagnosticsByFile.get(file) ?? []);
+          resolve35(diagnosticsByFile.get(file) ?? []);
         }, timeoutMs);
         const done = () => {
           clearTimeout(timer);
-          resolve34(diagnosticsByFile.get(file) ?? []);
+          resolve35(diagnosticsByFile.get(file) ?? []);
         };
         const waiters = diagnosticsWaiters.get(file) ?? [];
         waiters.push(done);
@@ -23739,14 +23774,14 @@ function createApp(options = {}) {
       return c.json({ error: "Failed to write ide.yml", detail: message }, 500);
     }
   });
-  const execFileAsync3 = promisify2(execFile6);
+  const execFileAsync4 = promisify2(execFile6);
   app.post("/api/project/:name/restart", async (c) => {
     const name = c.req.param("name");
     const sessions = discoverSessions();
     const session = sessions.find((s) => s.name === name);
     if (!session) return c.json({ error: "Session not found" }, 404);
     try {
-      await execFileAsync3("tmux-ide", ["restart", "--json"], {
+      await execFileAsync4("tmux-ide", ["restart", "--json"], {
         cwd: session.dir,
         timeout: 3e4,
         env: { ...process.env, TMUX: "" }
@@ -23769,7 +23804,7 @@ function createApp(options = {}) {
       return c.json({ ok: true, session: name, status: "already_running" });
     }
     try {
-      await execFileAsync3("tmux-ide", ["--json"], {
+      await execFileAsync4("tmux-ide", ["--json"], {
         cwd: session.dir,
         timeout: 3e4,
         env: { ...process.env, TMUX: "" }
@@ -24462,10 +24497,10 @@ var init_tailscale = __esm({
             const resetProcess = spawnImpl(this.tailscaleExecutable, ["serve", "reset"], {
               stdio: ["ignore", "pipe", "pipe"]
             });
-            await new Promise((resolve34) => {
-              resetProcess.on("exit", () => resolve34());
-              resetProcess.on("error", () => resolve34());
-              setTimeout(resolve34, 1e3);
+            await new Promise((resolve35) => {
+              resetProcess.on("exit", () => resolve35());
+              resetProcess.on("error", () => resolve35());
+              setTimeout(resolve35, 1e3);
             });
           } catch {
             log.debug("Failed to reset serve config (this is normal if none exists)");
@@ -24517,7 +24552,7 @@ var init_tailscale = __esm({
               }
             });
           }
-          await new Promise((resolve34, reject) => {
+          await new Promise((resolve35, reject) => {
             let settled = false;
             const settlePromise = (isSuccess, error) => {
               if (settled) return;
@@ -24526,7 +24561,7 @@ var init_tailscale = __esm({
               if (isSuccess) {
                 log.info("Tailscale Serve started successfully");
                 this.startTime = /* @__PURE__ */ new Date();
-                resolve34();
+                resolve35();
               } else {
                 const errorMessage2 = error instanceof Error ? error.message : error || "Tailscale Serve failed to start";
                 this.lastError = errorMessage2;
@@ -24600,10 +24635,10 @@ var init_tailscale = __esm({
           const resetProcess = spawnImpl(this.tailscaleExecutable, ["funnel", "reset"], {
             stdio: ["ignore", "pipe", "pipe"]
           });
-          await new Promise((resolve34) => {
-            resetProcess.on("exit", () => resolve34());
-            resetProcess.on("error", () => resolve34());
-            setTimeout(resolve34, 2e3);
+          await new Promise((resolve35) => {
+            resetProcess.on("exit", () => resolve35());
+            resetProcess.on("error", () => resolve35());
+            setTimeout(resolve35, 2e3);
           });
           log.debug("Funnel configuration reset completed");
         } catch {
@@ -24635,7 +24670,7 @@ var init_tailscale = __esm({
               log.debug(`\u{1F4E5} Funnel stderr: ${data.toString().trim()}`);
             });
           }
-          await new Promise((resolve34, reject) => {
+          await new Promise((resolve35, reject) => {
             const timeout = setTimeout(() => {
               reject(new Error("Funnel start timeout"));
             }, 1e4);
@@ -24653,7 +24688,7 @@ var init_tailscale = __esm({
                 this.funnelEnabled = true;
                 this.funnelError = void 0;
                 this.funnelStartTime = /* @__PURE__ */ new Date();
-                resolve34();
+                resolve35();
               } else {
                 log.info(`\u274C Funnel failed with exit code ${code}: ${stderr || "No error message"}`);
                 reject(new Error(`Funnel failed with exit code ${code}: ${stderr}`));
@@ -24682,17 +24717,17 @@ var init_tailscale = __esm({
           const resetProcess = spawnImpl(this.tailscaleExecutable, ["funnel", "reset"], {
             stdio: ["ignore", "pipe", "pipe"]
           });
-          await new Promise((resolve34) => {
+          await new Promise((resolve35) => {
             resetProcess.on("exit", (code) => {
               if (code === 0) {
                 log.info("\u2705 Tailscale Funnel stopped successfully");
               } else {
                 log.warn(`Funnel reset exited with code ${code}`);
               }
-              resolve34();
+              resolve35();
             });
-            resetProcess.on("error", () => resolve34());
-            setTimeout(resolve34, 3e3);
+            resetProcess.on("error", () => resolve35());
+            setTimeout(resolve35, 3e3);
           });
           this.funnelEnabled = false;
           this.funnelStartTime = void 0;
@@ -24715,15 +24750,15 @@ var init_tailscale = __esm({
           const resetProcess = spawnImpl(this.tailscaleExecutable, ["serve", "reset"], {
             stdio: ["ignore", "pipe", "pipe"]
           });
-          await new Promise((resolve34) => {
+          await new Promise((resolve35) => {
             resetProcess.on("exit", (code) => {
               if (code === 0) {
                 log.debug("Tailscale Serve configuration reset successfully");
               }
-              resolve34();
+              resolve35();
             });
-            resetProcess.on("error", () => resolve34());
-            setTimeout(resolve34, 2e3);
+            resetProcess.on("error", () => resolve35());
+            setTimeout(resolve35, 2e3);
           });
         } catch {
           log.debug("Failed to reset serve config during stop");
@@ -24733,14 +24768,14 @@ var init_tailscale = __esm({
           return;
         }
         log.info("Stopping Tailscale Serve process...");
-        return new Promise((resolve34) => {
+        return new Promise((resolve35) => {
           if (!this.serveProcess) {
-            resolve34();
+            resolve35();
             return;
           }
           const cleanup = () => {
             this.cleanup();
-            resolve34();
+            resolve35();
           };
           const forceKillTimeout = setTimeout(() => {
             if (this.serveProcess && !this.serveProcess.killed) {
@@ -24928,7 +24963,7 @@ var init_tailscale = __esm({
        * Check if Tailscale Serve is available on this tailnet
        */
       async checkServeAvailability() {
-        return new Promise((resolve34) => {
+        return new Promise((resolve35) => {
           const statusProcess = spawnImpl(this.tailscaleExecutable, ["serve", "status", "--json"], {
             stdio: ["ignore", "pipe", "pipe"]
           });
@@ -24946,25 +24981,25 @@ var init_tailscale = __esm({
           }
           statusProcess.on("exit", (code) => {
             if (stderr) {
-              resolve34(stderr);
+              resolve35(stderr);
             } else if (code === 0) {
               try {
                 JSON.parse(stdout);
-                resolve34(stdout);
+                resolve35(stdout);
               } catch {
-                resolve34(stdout);
+                resolve35(stdout);
               }
             } else {
-              resolve34(stdout || "Tailscale Serve status check failed");
+              resolve35(stdout || "Tailscale Serve status check failed");
             }
           });
           statusProcess.on("error", (error) => {
-            resolve34(error.message);
+            resolve35(error.message);
           });
           setTimeout(() => {
             if (!statusProcess.killed) {
               statusProcess.kill("SIGTERM");
-              resolve34("Timeout checking Tailscale Serve availability");
+              resolve35("Timeout checking Tailscale Serve availability");
             }
           }, 3e3);
         });
@@ -24973,7 +25008,7 @@ var init_tailscale = __esm({
        * Verify that Tailscale Serve is actually configured for the given port
        */
       async verifyServeConfiguration(port) {
-        return new Promise((resolve34) => {
+        return new Promise((resolve35) => {
           const statusProcess = spawnImpl(this.tailscaleExecutable, ["serve", "status", "--json"], {
             stdio: ["ignore", "pipe", "pipe"]
           });
@@ -24997,28 +25032,28 @@ var init_tailscale = __esm({
                 log.debug(
                   `Tailscale Serve JSON status check: port ${port} configured = ${isConfigured}`
                 );
-                resolve34(isConfigured);
+                resolve35(isConfigured);
               } catch {
                 log.debug("JSON parsing failed, trying text parsing as fallback");
                 const isConfigured = this.parseServeStatus(stdout, port);
                 log.debug(
                   `Tailscale Serve text status check: port ${port} configured = ${isConfigured}`
                 );
-                resolve34(isConfigured);
+                resolve35(isConfigured);
               }
             } else {
               log.debug(`Tailscale serve status failed with code ${code}: ${stderr}`);
-              resolve34(false);
+              resolve35(false);
             }
           });
           statusProcess.on("error", (error) => {
             log.debug(`Failed to run tailscale serve status: ${error.message}`);
-            resolve34(false);
+            resolve35(false);
           });
           setTimeout(() => {
             if (!statusProcess.killed) {
               statusProcess.kill("SIGTERM");
-              resolve34(false);
+              resolve35(false);
             }
           }, 3e3);
         });
@@ -25171,13 +25206,13 @@ var init_tailscale = __esm({
             }
           }
         }
-        return new Promise((resolve34, reject) => {
+        return new Promise((resolve35, reject) => {
           const checkProcess = spawnImpl("which", ["tailscale"], {
             stdio: ["ignore", "pipe", "pipe"]
           });
           checkProcess.on("exit", (code) => {
             if (code === 0) {
-              resolve34();
+              resolve35();
             } else {
               reject(new Error("Tailscale command not found. Please install Tailscale first."));
             }
@@ -25226,13 +25261,13 @@ var init_ngrok = __esm({
         ];
         for (const ngrokPath of possiblePaths) {
           try {
-            const result = await new Promise((resolve34) => {
+            const result = await new Promise((resolve35) => {
               const proc = spawnImpl2(ngrokPath, ["version"], { stdio: "ignore" });
-              proc.on("close", (code) => resolve34(code === 0));
-              proc.on("error", () => resolve34(false));
+              proc.on("close", (code) => resolve35(code === 0));
+              proc.on("error", () => resolve35(false));
               setTimeout(() => {
                 proc.kill();
-                resolve34(false);
+                resolve35(false);
               }, 2e3);
             });
             if (result) {
@@ -25269,7 +25304,7 @@ var init_ngrok = __esm({
           args.push("--region", this.config.region);
         }
         log.log(`Starting ngrok tunnel on port ${this.config.port}...`);
-        return new Promise((resolve34, reject) => {
+        return new Promise((resolve35, reject) => {
           this.ngrokProcess = spawnImpl2(ngrokPath, args, {
             stdio: ["ignore", "pipe", "pipe"]
           });
@@ -25294,7 +25329,7 @@ var init_ngrok = __esm({
                   this.isRunning = true;
                   cleanup();
                   log.log(`Ngrok tunnel started: ${record.url}`);
-                  resolve34(this.currentTunnel);
+                  resolve35(this.currentTunnel);
                 }
                 if (record.lvl === "error" || record.err) {
                   log.error("Ngrok error:", record.err || record.msg);
@@ -25341,9 +25376,9 @@ var init_ngrok = __esm({
           return;
         }
         log.log("Stopping ngrok tunnel...");
-        return new Promise((resolve34) => {
+        return new Promise((resolve35) => {
           if (!this.ngrokProcess) {
-            resolve34();
+            resolve35();
             return;
           }
           const killTimeout = setTimeout(() => {
@@ -25351,7 +25386,7 @@ var init_ngrok = __esm({
               log.warn("Ngrok process did not exit gracefully, forcing kill");
               this.ngrokProcess.kill("SIGKILL");
             }
-            resolve34();
+            resolve35();
           }, 5e3);
           this.ngrokProcess.on("close", () => {
             clearTimeout(killTimeout);
@@ -25359,7 +25394,7 @@ var init_ngrok = __esm({
             this.currentTunnel = null;
             this.isRunning = false;
             log.log("Ngrok tunnel stopped");
-            resolve34();
+            resolve35();
           });
           this.ngrokProcess.kill("SIGTERM");
         });
@@ -25434,13 +25469,13 @@ var init_cloudflare = __esm({
       async checkCloudflaredBinary() {
         for (const cloudflaredPath of _CloudflareService.cloudflaredPaths) {
           try {
-            const result = await new Promise((resolve34) => {
+            const result = await new Promise((resolve35) => {
               const proc = spawnImpl3(cloudflaredPath, ["--version"], { stdio: "ignore" });
-              proc.on("close", (code) => resolve34(code === 0));
-              proc.on("error", () => resolve34(false));
+              proc.on("close", (code) => resolve35(code === 0));
+              proc.on("error", () => resolve35(false));
               setTimeout(() => {
                 proc.kill();
-                resolve34(false);
+                resolve35(false);
               }, 2e3);
             });
             if (result) {
@@ -25476,7 +25511,7 @@ var init_cloudflare = __esm({
             "cloudflared binary not found. Please install cloudflared: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/"
           );
         }
-        return new Promise((resolve34, reject) => {
+        return new Promise((resolve35, reject) => {
           this.cloudflaredProcess = spawnImpl3(cloudflaredPath, args, {
             stdio: ["ignore", "pipe", "pipe"]
           });
@@ -25501,7 +25536,7 @@ var init_cloudflare = __esm({
               this.isRunning = true;
               cleanup();
               log.log(`Cloudflare tunnel started: ${publicUrl}`);
-              resolve34(this.currentTunnel);
+              resolve35(this.currentTunnel);
             }
             if (output.toLowerCase().includes("error") && !resolved2) {
               log.error("Cloudflare error:", output);
@@ -25542,9 +25577,9 @@ var init_cloudflare = __esm({
           return;
         }
         log.log("Stopping Cloudflare tunnel...");
-        return new Promise((resolve34) => {
+        return new Promise((resolve35) => {
           if (!this.cloudflaredProcess) {
-            resolve34();
+            resolve35();
             return;
           }
           const killTimeout = setTimeout(() => {
@@ -25552,7 +25587,7 @@ var init_cloudflare = __esm({
               log.warn("Cloudflared process did not exit gracefully, forcing kill");
               this.cloudflaredProcess.kill("SIGKILL");
             }
-            resolve34();
+            resolve35();
           }, 5e3);
           this.cloudflaredProcess.on("close", () => {
             clearTimeout(killTimeout);
@@ -25560,7 +25595,7 @@ var init_cloudflare = __esm({
             this.currentTunnel = null;
             this.isRunning = false;
             log.log("Cloudflare tunnel stopped");
-            resolve34();
+            resolve35();
           });
           this.cloudflaredProcess.kill("SIGTERM");
         });
@@ -25974,6 +26009,10 @@ var init_client5 = __esm({
 });
 
 // packages/daemon/src/lib/daemon-embed.ts
+var daemon_embed_exports = {};
+__export(daemon_embed_exports, {
+  startEmbeddedDaemon: () => startEmbeddedDaemon
+});
 import { execFileSync as execFileSync8 } from "node:child_process";
 import { randomBytes as randomBytes5 } from "node:crypto";
 import { createServer } from "node:http";
@@ -26017,13 +26056,13 @@ function validatePort(port) {
 }
 async function pickFreePort(hostname2) {
   const probe = createServer();
-  return await new Promise((resolve34, reject) => {
+  return await new Promise((resolve35, reject) => {
     probe.once("error", reject);
     probe.listen(0, hostname2, () => {
       const address = probe.address();
       const port = typeof address === "object" && address ? address.port : null;
       probe.close(() => {
-        if (port) resolve34(port);
+        if (port) resolve35(port);
         else reject(new DaemonStartupError("Could not allocate daemon port", "bind_failed"));
       });
     });
@@ -26208,21 +26247,21 @@ function attachWebSockets(server, opts = {}) {
           ws.terminate();
         }
       }
-      const closeWss = (wss) => Promise.race([new Promise((resolve34) => wss.close(() => resolve34())), delay(100)]);
+      const closeWss = (wss) => Promise.race([new Promise((resolve35) => wss.close(() => resolve35())), delay(100)]);
       await Promise.all([closeWss(eventsWss), closeWss(ptyWss)]);
     }
   };
 }
 function waitForServerClose(server) {
-  return new Promise((resolve34, reject) => {
+  return new Promise((resolve35, reject) => {
     server.close((err) => {
       if (err) reject(err);
-      else resolve34();
+      else resolve35();
     });
   });
 }
 function delay(ms) {
-  return new Promise((resolve34) => setTimeout(resolve34, ms));
+  return new Promise((resolve35) => setTimeout(resolve35, ms));
 }
 function generateLocalBypassToken() {
   return randomBytes5(32).toString("base64url");
@@ -26350,7 +26389,7 @@ async function startHttpServer({
     localBypassToken,
     bindHostname
   });
-  await new Promise((resolve34, reject) => {
+  await new Promise((resolve35, reject) => {
     const onError = (err) => {
       server.off("listening", onListening);
       if (err.code === "EADDRINUSE") {
@@ -26374,7 +26413,7 @@ async function startHttpServer({
           `[daemon] Command Center on http://${bindHostname}:${requestedPort} (session: ${sessionName})`
         );
       }
-      resolve34();
+      resolve35();
     };
     server.once("error", onError);
     server.once("listening", onListening);
@@ -27345,8 +27384,8 @@ var require_package = __commonJS({
         prepublishOnly: "pnpm build:cli && pnpm check && pnpm --filter @tmux-ide/dashboard build && node scripts/prepublish-check.mjs",
         typecheck: 'echo "root typecheck deferred to per-package turbo run"',
         dev: "node bin/cli.js",
-        test: "vitest run",
-        "test:unit": "vitest run",
+        test: "vitest run --dir src src/cli.test.ts",
+        "test:unit": "vitest run --dir src src/cli.test.ts",
         "test:chat-e2e": "pnpm --filter @tmux-ide/daemon exec vitest run src/chat/__tests__/chat-pipeline.e2e.test.ts",
         lint: "eslint bin scripts packages/contracts/src packages/tmux-bridge/src packages/daemon/src packages/v2-solid-widgets/src packages/chat-solid/src && pnpm run check:silo-mounts",
         "lint:workspace": "turbo run lint && pnpm run check:silo-mounts",
@@ -27428,7 +27467,8 @@ var require_package = __commonJS({
         globals: "^17.4.0",
         prettier: "^3.8.1",
         turbo: "^2.3.3",
-        typescript: "^5.9.3"
+        typescript: "^5.9.3",
+        vitest: "^4.1.0"
       }
     };
   }
@@ -28384,12 +28424,460 @@ var init_tunnel = __esm({
   }
 });
 
+// packages/daemon/src/ssh-remote.ts
+var ssh_remote_exports = {};
+__export(ssh_remote_exports, {
+  buildRemoteServeScript: () => buildRemoteServeScript,
+  buildSshForwardArgs: () => buildSshForwardArgs,
+  parseSshConfigHosts: () => parseSshConfigHosts,
+  remoteServeCommand: () => remoteServeCommand,
+  shellQuote: () => shellQuote,
+  sshRemoteCommand: () => sshRemoteCommand,
+  validateRemoteName: () => validateRemoteName,
+  validateRemotePath: () => validateRemotePath,
+  validateSshAlias: () => validateSshAlias
+});
+import { spawn as spawn10, execFile as execFile7 } from "node:child_process";
+import { mkdir as mkdir2, readFile as readFile3, writeFile as writeFile2, chmod } from "node:fs/promises";
+import { existsSync as existsSync40 } from "node:fs";
+import { homedir as homedir14 } from "node:os";
+import { dirname as dirname17, join as join43, resolve as resolve31 } from "node:path";
+import { promisify as promisify3 } from "node:util";
+import { createServer as createServer2 } from "node:net";
+function remotesFilePath() {
+  return process.env.TMUX_IDE_SSH_REMOTES_FILE ?? join43(homedir14(), ".tmux-ide", "ssh-remotes.json");
+}
+function sshConfigPath() {
+  return process.env.TMUX_IDE_SSH_CONFIG ?? join43(homedir14(), ".ssh", "config");
+}
+function emptyStore() {
+  return { version: 1, remotes: [] };
+}
+async function readStore() {
+  const file = remotesFilePath();
+  if (!existsSync40(file)) return emptyStore();
+  try {
+    const parsed = JSON.parse(await readFile3(file, "utf-8"));
+    if (parsed.version !== 1 || !Array.isArray(parsed.remotes)) return emptyStore();
+    return {
+      version: 1,
+      remotes: parsed.remotes.filter(isSshRemote)
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+async function writeStore(store) {
+  const file = remotesFilePath();
+  await mkdir2(dirname17(file), { recursive: true, mode: 448 });
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile2(tmp, JSON.stringify(store, null, 2) + "\n", { encoding: "utf-8", mode: 384 });
+  await chmod(tmp, 384);
+  await import("node:fs/promises").then(({ rename: rename2 }) => rename2(tmp, file));
+}
+function isSshRemote(value) {
+  if (!value || typeof value !== "object") return false;
+  const remote = value;
+  if (typeof remote.name !== "string") return false;
+  if (typeof remote.host !== "string") return false;
+  if (typeof remote.path !== "string") return false;
+  if (typeof remote.addedAt !== "string") return false;
+  if (remote.localPort !== void 0 && !isValidPort(remote.localPort)) return false;
+  if (remote.remotePort !== void 0 && !isValidPort(remote.remotePort)) return false;
+  return true;
+}
+function isValidPort(port) {
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
+}
+function parsePort(value, label) {
+  if (value === void 0 || value === false) return void 0;
+  if (value === true || value.trim() === "") {
+    throw new IdeError(`${label} requires a numeric value`, { code: "USAGE" });
+  }
+  const port = Number(value);
+  if (!isValidPort(port)) {
+    throw new IdeError(`${label} must be an integer from 1 to 65535`, { code: "USAGE" });
+  }
+  return port;
+}
+function parseSshConfigHosts(contents) {
+  const hosts = /* @__PURE__ */ new Set();
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const match = line.match(/^Host\s+(.+)$/i);
+    if (!match) continue;
+    for (const host of match[1].split(/\s+/)) {
+      if (!host || host.includes("*") || host.includes("?") || host.startsWith("!")) continue;
+      hosts.add(host);
+    }
+  }
+  return [...hosts].sort((a, b) => a.localeCompare(b));
+}
+function validateRemoteName(name) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(name)) {
+    throw new IdeError(
+      "Remote name must start with a letter or number and contain only letters, numbers, dot, underscore, or dash.",
+      { code: "USAGE" }
+    );
+  }
+}
+function validateSshAlias(host) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}$/.test(host)) {
+    throw new IdeError(
+      "SSH host must be a config alias or host string without whitespace or shell metacharacters.",
+      { code: "USAGE" }
+    );
+  }
+  if (host.startsWith("-")) {
+    throw new IdeError("SSH host cannot start with '-'", { code: "USAGE" });
+  }
+}
+function validateRemotePath(path4) {
+  if (!path4 || /[\0\r\n]/.test(path4)) {
+    throw new IdeError("Remote path must be a single non-empty path.", { code: "USAGE" });
+  }
+}
+function shellQuote(value) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+function buildRemoteServeScript(remotePath, remotePort) {
+  validateRemotePath(remotePath);
+  if (!isValidPort(remotePort)) {
+    throw new IdeError("Remote port must be an integer from 1 to 65535", { code: "USAGE" });
+  }
+  const quotedPath = shellQuote(remotePath);
+  return [
+    `cd ${quotedPath}`,
+    "mkdir -p .tmux-ide",
+    'if ! command -v tmux-ide >/dev/null 2>&1; then echo "tmux-ide not found on remote PATH" >&2; exit 127; fi',
+    `nohup tmux-ide __remote-serve --port ${remotePort} > .tmux-ide/remote-daemon.log 2>&1 < /dev/null &`
+  ].join(" && ");
+}
+function buildSshForwardArgs(opts) {
+  validateSshAlias(opts.host);
+  if (!isValidPort(opts.localPort) || !isValidPort(opts.remotePort)) {
+    throw new IdeError("SSH tunnel ports must be integers from 1 to 65535", { code: "USAGE" });
+  }
+  return [
+    "-N",
+    "-L",
+    `${DEFAULT_LOCAL_HOST}:${opts.localPort}:127.0.0.1:${opts.remotePort}`,
+    "-o",
+    "ExitOnForwardFailure=yes",
+    "-o",
+    "ServerAliveInterval=15",
+    opts.host
+  ];
+}
+async function pickFreeLocalPort() {
+  const server = createServer2();
+  return await new Promise((resolvePort2, reject) => {
+    server.once("error", reject);
+    server.listen(0, DEFAULT_LOCAL_HOST, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : null;
+      server.close(() => {
+        if (port) resolvePort2(port);
+        else reject(new IdeError("Could not allocate a local tunnel port", { code: "PORT_ERROR" }));
+      });
+    });
+  });
+}
+async function assertLocalPortFree(port) {
+  const server = createServer2();
+  await new Promise((resolvePort2, reject) => {
+    server.once(
+      "error",
+      () => reject(new IdeError(`Local port ${port} is already in use`, { code: "PORT_IN_USE" }))
+    );
+    server.listen(port, DEFAULT_LOCAL_HOST, () => {
+      server.close(() => resolvePort2());
+    });
+  });
+}
+function openInBrowser2(url) {
+  const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+  try {
+    const child = spawn10(cmd, [url], { detached: true, stdio: "ignore" });
+    child.unref();
+  } catch {
+  }
+}
+async function waitForHealth(url, timeoutMs = 15e3) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+  while (Date.now() < deadline) {
+    try {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 750).unref?.();
+      const res = await fetch(`${url}healthz`, { signal: controller.signal });
+      if (res.ok) return;
+      lastError = `HTTP ${res.status}`;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    await new Promise((resolveTimer) => setTimeout(resolveTimer, 250));
+  }
+  throw new IdeError(
+    `Remote dashboard did not become healthy through the SSH tunnel: ${lastError}`,
+    {
+      code: "REMOTE_UNHEALTHY"
+    }
+  );
+}
+async function runRemoteServe(remote, remotePort) {
+  const script = buildRemoteServeScript(remote.path, remotePort);
+  try {
+    await execFileAsync2("ssh", [remote.host, script], { timeout: 1e4 });
+  } catch (err) {
+    const stderr = err instanceof Error && "stderr" in err && typeof err.stderr === "string" ? err.stderr.trim() : "";
+    throw new IdeError(`Failed to start tmux-ide on ${remote.host}${stderr ? `: ${stderr}` : ""}`, {
+      code: "SSH_REMOTE_START_FAILED"
+    });
+  }
+}
+async function startTunnel(remote, localPort, remotePort) {
+  const args = buildSshForwardArgs({ host: remote.host, localPort, remotePort });
+  const child = spawn10("ssh", args, { detached: true, stdio: "ignore" });
+  child.unref();
+  await new Promise((resolveStart, reject) => {
+    const timer = setTimeout(resolveStart, 500);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      reject(
+        new IdeError(
+          `SSH tunnel exited before it was ready (${signal ?? `code ${code ?? "unknown"}`})`,
+          { code: "SSH_TUNNEL_FAILED" }
+        )
+      );
+    });
+    child.once("error", (err) => {
+      clearTimeout(timer);
+      reject(
+        new IdeError(`Failed to start ssh tunnel: ${err.message}`, { code: "SSH_TUNNEL_FAILED" })
+      );
+    });
+  });
+  return {
+    pid: child.pid ?? 0,
+    stop: () => {
+      if (!child.pid) return;
+      try {
+        process.kill(-child.pid, "SIGTERM");
+      } catch {
+        try {
+          child.kill("SIGTERM");
+        } catch {
+        }
+      }
+    }
+  };
+}
+function printRemotes(remotes) {
+  if (remotes.length === 0) {
+    console.log("No SSH remotes configured");
+    return;
+  }
+  for (const remote of remotes) {
+    const local = remote.localPort ? ` local:${remote.localPort}` : "";
+    const remotePort = remote.remotePort ? ` remote:${remote.remotePort}` : "";
+    console.log(`  ${remote.name} \u2014 ${remote.host}:${remote.path}${local}${remotePort}`);
+  }
+}
+async function listHosts(json2) {
+  const file = sshConfigPath();
+  const hosts = existsSync40(file) ? parseSshConfigHosts(await readFile3(file, "utf-8")) : [];
+  if (json2) {
+    console.log(JSON.stringify({ hosts }));
+  } else if (hosts.length === 0) {
+    console.log("No concrete SSH hosts found");
+  } else {
+    for (const host of hosts) console.log(host);
+  }
+}
+async function addRemote(opts) {
+  const name = opts.args?.[0];
+  const host = opts.values?.host;
+  const path4 = opts.values?.path;
+  if (!name || typeof host !== "string" || typeof path4 !== "string") {
+    throw new IdeError(
+      "Usage: tmux-ide remote ssh add <name> --host <ssh-host> --path <remote-project-dir> [--local-port N] [--remote-port N]",
+      { code: "USAGE" }
+    );
+  }
+  validateRemoteName(name);
+  validateSshAlias(host);
+  validateRemotePath(path4);
+  const localPort = parsePort(opts.values?.["local-port"], "--local-port");
+  const remotePort = parsePort(opts.values?.["remote-port"], "--remote-port");
+  const store = await readStore();
+  const next = {
+    name,
+    host,
+    path: path4,
+    localPort,
+    remotePort,
+    addedAt: (/* @__PURE__ */ new Date()).toISOString()
+  };
+  const index = store.remotes.findIndex((remote) => remote.name === name);
+  if (index >= 0) store.remotes[index] = next;
+  else store.remotes.push(next);
+  await writeStore(store);
+  if (opts.json) console.log(JSON.stringify({ ok: true, remote: next }));
+  else console.log(`Saved SSH remote ${name} (${host}:${path4})`);
+}
+async function removeRemote(opts) {
+  const name = opts.args?.[0];
+  if (!name) {
+    throw new IdeError("Usage: tmux-ide remote ssh remove <name>", { code: "USAGE" });
+  }
+  const store = await readStore();
+  const before = store.remotes.length;
+  store.remotes = store.remotes.filter((remote) => remote.name !== name);
+  await writeStore(store);
+  const removed = store.remotes.length !== before;
+  if (opts.json) console.log(JSON.stringify({ ok: true, removed }));
+  else
+    console.log(removed ? `Removed SSH remote ${name}` : `SSH remote ${name} was not configured`);
+}
+async function getConfiguredRemote(name) {
+  if (!name) {
+    throw new IdeError("Usage: tmux-ide remote ssh launch <name>", { code: "USAGE" });
+  }
+  validateRemoteName(name);
+  const store = await readStore();
+  const remote = store.remotes.find((candidate) => candidate.name === name);
+  if (!remote) {
+    throw new IdeError(`SSH remote ${name} is not configured`, { code: "REMOTE_NOT_FOUND" });
+  }
+  return remote;
+}
+async function launchRemote(opts) {
+  const remote = await getConfiguredRemote(opts.args?.[0]);
+  const remotePort = remote.remotePort ?? DEFAULT_REMOTE_PORT;
+  const localPort = remote.localPort ?? await pickFreeLocalPort();
+  if (remote.localPort) await assertLocalPortFree(localPort);
+  await runRemoteServe(remote, remotePort);
+  const tunnel = await startTunnel(remote, localPort, remotePort);
+  const url = `http://${DEFAULT_LOCAL_HOST}:${localPort}/`;
+  try {
+    await waitForHealth(url);
+  } catch (err) {
+    tunnel.stop();
+    throw err;
+  }
+  if (opts.json) {
+    console.log(
+      JSON.stringify({ ok: true, url, localPort, remotePort, tunnelPid: tunnel.pid, remote })
+    );
+  } else {
+    console.log(`Dashboard: ${url}`);
+    console.log(`Tunnel: ${remote.host} 127.0.0.1:${localPort} -> 127.0.0.1:${remotePort}`);
+  }
+  if (opts.values?.["no-open"] !== true) openInBrowser2(url);
+}
+async function statusRemote(opts) {
+  const remote = await getConfiguredRemote(opts.args?.[0]);
+  const localPort = remote.localPort;
+  const url = localPort ? `http://${DEFAULT_LOCAL_HOST}:${localPort}/` : null;
+  let healthy = false;
+  if (url) {
+    try {
+      const res = await fetch(`${url}healthz`);
+      healthy = res.ok;
+    } catch {
+      healthy = false;
+    }
+  }
+  if (opts.json) {
+    console.log(JSON.stringify({ remote, url, healthy }));
+  } else {
+    console.log(`Remote: ${remote.name}`);
+    console.log(`SSH host: ${remote.host}`);
+    console.log(`Path: ${remote.path}`);
+    console.log(`Remote daemon bind: 127.0.0.1:${remote.remotePort ?? DEFAULT_REMOTE_PORT}`);
+    if (url) console.log(`Local URL: ${url} (${healthy ? "healthy" : "not reachable"})`);
+    else console.log("Local URL: dynamic; run launch to allocate a tunnel port");
+  }
+}
+async function sshRemoteCommand(opts) {
+  const sub = opts.args?.[0];
+  const args = opts.args?.slice(1) ?? [];
+  switch (sub) {
+    case "hosts":
+      await listHosts(opts.json);
+      break;
+    case "list": {
+      const store = await readStore();
+      if (opts.json) console.log(JSON.stringify({ remotes: store.remotes }));
+      else printRemotes(store.remotes);
+      break;
+    }
+    case "add":
+      await addRemote({ ...opts, args });
+      break;
+    case "remove":
+      await removeRemote({ ...opts, args });
+      break;
+    case "launch":
+    case "dashboard":
+      await launchRemote({ ...opts, args });
+      break;
+    case "status":
+      await statusRemote({ ...opts, args });
+      break;
+    default:
+      throw new IdeError(
+        "Usage: tmux-ide remote ssh hosts|list|add|remove|launch|dashboard|status",
+        { code: "USAGE" }
+      );
+  }
+}
+async function remoteServeCommand(opts) {
+  const port = parsePort(opts.port, "--port") ?? DEFAULT_REMOTE_PORT;
+  const dir = resolve31(".");
+  const { readConfig: readConfig2, getSessionName: getSessionName2 } = await Promise.resolve().then(() => (init_yaml_io(), yaml_io_exports));
+  const { launch: launch2 } = await Promise.resolve().then(() => (init_launch(), launch_exports));
+  const { startEmbeddedDaemon: startEmbeddedDaemon2 } = await Promise.resolve().then(() => (init_daemon_embed(), daemon_embed_exports));
+  const { readCanonicalDaemonInfo: readCanonicalDaemonInfo2, isCanonicalDaemonAlive: isCanonicalDaemonAlive2 } = await Promise.resolve().then(() => (init_canonical_daemon(), canonical_daemon_exports));
+  const existing = readCanonicalDaemonInfo2();
+  if (existing && existing.port === port && existing.bindHostname === "127.0.0.1") {
+    if (await isCanonicalDaemonAlive2(existing)) return;
+  }
+  const { config: config2 } = readConfig2(dir);
+  const { name: fallbackName } = getSessionName2(dir);
+  const sessionName = config2.name ?? fallbackName;
+  await launch2(dir, { attach: false });
+  const handle = await startEmbeddedDaemon2({
+    sessionName,
+    port,
+    bindHostname: "127.0.0.1"
+  });
+  const stop2 = async () => {
+    await handle.stop({ gracefulMs: 500 });
+  };
+  process.once("SIGINT", () => void stop2().finally(() => process.exit(0)));
+  process.once("SIGTERM", () => void stop2().finally(() => process.exit(0)));
+  await new Promise(() => void 0);
+}
+var execFileAsync2, DEFAULT_REMOTE_PORT, DEFAULT_LOCAL_HOST;
+var init_ssh_remote = __esm({
+  "packages/daemon/src/ssh-remote.ts"() {
+    "use strict";
+    init_errors2();
+    execFileAsync2 = promisify3(execFile7);
+    DEFAULT_REMOTE_PORT = 6060;
+    DEFAULT_LOCAL_HOST = "127.0.0.1";
+  }
+});
+
 // packages/daemon/src/remote.ts
 var remote_exports = {};
 __export(remote_exports, {
   remoteCommand: () => remoteCommand
 });
-import { resolve as resolve31 } from "node:path";
+import { resolve as resolve32 } from "node:path";
 async function loadHQConfig(dir) {
   try {
     const { readConfig: readConfig2 } = await Promise.resolve().then(() => (init_yaml_io(), yaml_io_exports));
@@ -28402,9 +28890,14 @@ async function loadHQConfig(dir) {
   return null;
 }
 async function remoteCommand(targetDir, opts) {
-  const dir = resolve31(targetDir ?? ".");
+  const dir = resolve32(targetDir ?? ".");
   const { json: json2, sub } = opts;
   switch (sub) {
+    case "ssh": {
+      const { sshRemoteCommand: sshRemoteCommand2 } = await Promise.resolve().then(() => (init_ssh_remote(), ssh_remote_exports));
+      await sshRemoteCommand2({ ...opts, args: opts.args ?? [] });
+      break;
+    }
     case "register": {
       const hqConfig = await loadHQConfig(dir);
       if (!hqConfig || hqConfig.role !== "remote") {
@@ -28439,10 +28932,10 @@ async function remoteCommand(targetDir, opts) {
       } else {
         console.log(`Registered with HQ as ${client.getName()} (${client.getRemoteId()})`);
       }
-      await new Promise((resolve34) => {
+      await new Promise((resolve35) => {
         const shutdown = async () => {
           await client.destroy();
-          resolve34();
+          resolve35();
         };
         process.once("SIGINT", () => void shutdown());
         process.once("SIGTERM", () => void shutdown());
@@ -28503,7 +28996,7 @@ async function remoteCommand(targetDir, opts) {
     default:
       throw new IdeError(
         `Unknown remote subcommand: ${sub ?? "(none)"}
-Usage: tmux-ide remote register|machines|status`,
+Usage: tmux-ide remote register|machines|status|ssh`,
         { code: "USAGE" }
       );
   }
@@ -28522,7 +29015,7 @@ var command_center_exports = {};
 __export(command_center_exports, {
   startCommandCenter: () => startCommandCenter
 });
-import { createServer as createServer2 } from "node:http";
+import { createServer as createServer3 } from "node:http";
 import { getRequestListener } from "@hono/node-server";
 async function startCommandCenter(options = {}) {
   const port = options.port ?? 6060;
@@ -28532,11 +29025,11 @@ async function startCommandCenter(options = {}) {
   if (options.authConfig) appOpts.authConfig = options.authConfig;
   const app = createApp(appOpts);
   const listener = getRequestListener(app.fetch);
-  const server = createServer2(listener);
-  return new Promise((resolve34) => {
+  const server = createServer3(listener);
+  return new Promise((resolve35) => {
     server.listen(port, hostname2, () => {
       console.log(`Command Center API on http://${hostname2}:${port}`);
-      resolve34(server);
+      resolve35(server);
     });
   });
 }
@@ -28554,7 +29047,7 @@ __export(server_exports2, {
   resolvePort: () => resolvePort,
   start: () => start
 });
-import { createServer as createServer3 } from "node:http";
+import { createServer as createServer4 } from "node:http";
 import { parse } from "node:url";
 import { Hono as Hono2 } from "hono";
 import { getRequestListener as getRequestListener2 } from "@hono/node-server";
@@ -28575,7 +29068,7 @@ function createApp2() {
 async function start(port) {
   const resolvedPort = resolvePort(port);
   const app = createApp2();
-  const server = createServer3(getRequestListener2(app.fetch));
+  const server = createServer4(getRequestListener2(app.fetch));
   const ptyWss = new WebSocketServer3({ noServer: true });
   server.on("upgrade", (req, socket, head) => {
     const { pathname } = parse(req.url ?? "/", true);
@@ -28589,21 +29082,21 @@ async function start(port) {
       handlePtyWebSocket(ws, id);
     });
   });
-  await new Promise((resolve34, reject) => {
+  await new Promise((resolve35, reject) => {
     server.once("error", reject);
     server.listen(resolvedPort, "0.0.0.0", () => {
       server.off("error", reject);
-      resolve34();
+      resolve35();
     });
   });
   console.log(`tmux-ide server listening on http://0.0.0.0:${resolvedPort}`);
   return {
     port: resolvedPort,
     server,
-    close: () => new Promise((resolve34, reject) => {
+    close: () => new Promise((resolve35, reject) => {
       shutdownPtyBridges();
       ptyWss.close();
-      server.close((err) => err ? reject(err) : resolve34());
+      server.close((err) => err ? reject(err) : resolve35());
     })
   };
 }
@@ -28739,8 +29232,8 @@ var init_chat = __esm({
 });
 
 // packages/daemon/src/chat/checkpoint-engine.ts
-import { execFile as execFile7 } from "node:child_process";
-import { promisify as promisify3 } from "node:util";
+import { execFile as execFile8 } from "node:child_process";
+import { promisify as promisify4 } from "node:util";
 function makeCheckpointEngine(opts = {}) {
   const exec = opts.exec ?? defaultExec2;
   function buildRefName(threadId, turnId) {
@@ -28844,7 +29337,7 @@ function makeCheckpointEngine(opts = {}) {
 }
 async function defaultExec2(args, cwd) {
   try {
-    const { stdout } = await execFileAsync2("git", args, {
+    const { stdout } = await execFileAsync3("git", args, {
       cwd,
       encoding: "utf8",
       maxBuffer: 32 * 1024 * 1024
@@ -28913,11 +29406,11 @@ async function detectDirtyConflicts(cwd, checkpointRef, exec) {
   );
   return refPaths.filter((p) => dirtyPaths.has(p));
 }
-var execFileAsync2, REF_PREFIX, NAME_STATUS_KIND_MAP, CheckpointEngineError, SAFE_REF_SEGMENT;
+var execFileAsync3, REF_PREFIX, NAME_STATUS_KIND_MAP, CheckpointEngineError, SAFE_REF_SEGMENT;
 var init_checkpoint_engine = __esm({
   "packages/daemon/src/chat/checkpoint-engine.ts"() {
     "use strict";
-    execFileAsync2 = promisify3(execFile7);
+    execFileAsync3 = promisify4(execFile8);
     REF_PREFIX = "refs/tmux-ide/checkpoints";
     NAME_STATUS_KIND_MAP = {
       M: "modified",
@@ -28946,7 +29439,7 @@ var checkpoint_exports = {};
 __export(checkpoint_exports, {
   checkpointCommand: () => checkpointCommand
 });
-import { resolve as resolve32 } from "node:path";
+import { resolve as resolve33 } from "node:path";
 function fail(message, code, json2) {
   if (json2) {
     process.stderr.write(`${JSON.stringify({ ok: false, code, message })}
@@ -28962,7 +29455,7 @@ async function checkpointCommand(opts) {
   if (!sub) {
     fail("Missing subcommand. Usage: tmux-ide checkpoint <list|revert> ...", "USAGE", opts.json);
   }
-  const workspaceDir = resolve32(opts.workspaceDir ?? ".");
+  const workspaceDir = resolve33(opts.workspaceDir ?? ".");
   const engine = makeCheckpointEngine();
   switch (sub) {
     case "list": {
@@ -29034,9 +29527,9 @@ var init_checkpoint = __esm({
 // bin/cli.ts
 init_launch();
 import { parseArgs } from "node:util";
-import { resolve as resolve33, dirname as dirname17 } from "node:path";
+import { resolve as resolve34, dirname as dirname18 } from "node:path";
 import { execFileSync as execFileSync9 } from "node:child_process";
-import { existsSync as existsSync40 } from "node:fs";
+import { existsSync as existsSync41 } from "node:fs";
 import { fileURLToPath as fileURLToPath7 } from "node:url";
 
 // packages/daemon/src/init.ts
@@ -30804,7 +31297,7 @@ async function dashboard(opts = {}) {
 // bin/cli.ts
 init_errors2();
 init_output();
-var __dirname5 = dirname17(fileURLToPath7(import.meta.url));
+var __dirname5 = dirname18(fileURLToPath7(import.meta.url));
 var { positionals, values } = parseArgs({
   allowPositionals: true,
   strict: false,
@@ -30851,6 +31344,10 @@ var { positionals, values } = parseArgs({
     // remote command flags
     url: { type: "string" },
     "hq-url": { type: "string" },
+    host: { type: "string" },
+    path: { type: "string" },
+    "local-port": { type: "string" },
+    "remote-port": { type: "string" },
     // send command flags
     to: { type: "string" },
     "no-enter": { type: "boolean" },
@@ -30895,6 +31392,7 @@ var knownCommands = /* @__PURE__ */ new Set([
   "remote",
   "checkpoint",
   "chat",
+  "__remote-serve",
   "help"
 ]);
 if (values.version) {
@@ -30974,6 +31472,13 @@ ${bold("Multi-agent Chat:")}
   ${cyan("tmux-ide chat session add")} <thread-id> --provider <name> [--role <role>]
                                   ${dim("Register a Session on a Thread (lead|teammate|planner|validator|researcher)")}
 
+${bold("SSH Remotes:")}
+  ${cyan("tmux-ide remote ssh hosts")} [--json]       ${dim("List concrete Host aliases from ~/.ssh/config")}
+  ${cyan("tmux-ide remote ssh add")} <name> --host <ssh-host> --path <dir>
+                                  ${dim("Save a tunnel-only remote project")}
+  ${cyan("tmux-ide remote ssh launch")} <name> [--no-open]
+                                  ${dim("Open a local SSH tunnel to a remote tmux-ide dashboard")}
+
 ${bold("Task Management:")}
   ${cyan("tmux-ide mission set")} "title"              ${dim("Set the project mission")}
   ${cyan("tmux-ide mission show")}                     ${dim("Show current mission")}
@@ -30997,7 +31502,7 @@ ${bold("Flags:")}
   ${cyan("-v, --version")}               ${dim("Show version number")}`);
 }
 function execBunWidget(scriptPath, args, commandLabel) {
-  const widgetMissing = !existsSync40(scriptPath);
+  const widgetMissing = !existsSync41(scriptPath);
   let bunMissing = false;
   try {
     execFileSync9("bun", ["--version"], { stdio: "ignore" });
@@ -31101,10 +31606,10 @@ try {
         action = "disable-team";
         configArgs = [];
       } else if (sub === "edit") {
-        const scriptPath = resolve33(__dirname5, "../packages/daemon/src/widgets/setup/index.tsx");
+        const scriptPath = resolve34(__dirname5, "../packages/daemon/src/widgets/setup/index.tsx");
         execBunWidget(
           scriptPath,
-          ["--dir=" + resolve33(startTargetDir || "."), "--edit"],
+          ["--dir=" + resolve34(startTargetDir || "."), "--edit"],
           "config edit"
         );
         break;
@@ -31220,8 +31725,8 @@ try {
       break;
     }
     case "setup": {
-      const scriptPath = resolve33(__dirname5, "../packages/daemon/src/widgets/setup/index.tsx");
-      const setupArgs = ["--dir=" + resolve33(startTargetDir || ".")];
+      const scriptPath = resolve34(__dirname5, "../packages/daemon/src/widgets/setup/index.tsx");
+      const setupArgs = ["--dir=" + resolve34(startTargetDir || ".")];
       if (positionals[1] === "--edit" || values.edit) setupArgs.push("--edit");
       if (positionals[1] === "--wizard" || values.wizard) setupArgs.push("--wizard");
       execBunWidget(scriptPath, setupArgs, "setup");
@@ -31256,8 +31761,8 @@ try {
       break;
     }
     case "settings": {
-      const scriptPath = resolve33(__dirname5, "../packages/daemon/src/widgets/config/index.tsx");
-      execBunWidget(scriptPath, ["--dir=" + resolve33(startTargetDir || ".")], "settings");
+      const scriptPath = resolve34(__dirname5, "../packages/daemon/src/widgets/config/index.tsx");
+      execBunWidget(scriptPath, ["--dir=" + resolve34(startTargetDir || ".")], "settings");
       break;
     }
     case "tunnel": {
@@ -31283,9 +31788,19 @@ try {
         args: positionals.slice(2),
         values: {
           url: values.url,
-          "hq-url": values["hq-url"]
+          "hq-url": values["hq-url"],
+          host: values.host,
+          path: values.path,
+          "local-port": values["local-port"],
+          "remote-port": values["remote-port"],
+          "no-open": values["no-open"]
         }
       });
+      break;
+    }
+    case "__remote-serve": {
+      const { remoteServeCommand: remoteServeCommand2 } = await Promise.resolve().then(() => (init_ssh_remote(), ssh_remote_exports));
+      await remoteServeCommand2({ port: values.port });
       break;
     }
     case "command-center": {
@@ -31300,7 +31815,7 @@ try {
     }
     case "server": {
       if ("bun" in process.versions) {
-        const scriptPath = resolve33(__dirname5, "../packages/daemon/src/server/standalone.ts");
+        const scriptPath = resolve34(__dirname5, "../packages/daemon/src/server/standalone.ts");
         const serverArgs = ["--experimental-strip-types", scriptPath];
         if (values.port) serverArgs.push("--port", values.port);
         execFileSync9("node", serverArgs, { stdio: "inherit" });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -326,8 +326,10 @@ function splitPane(targetPane, direction, cwd, percent) {
       direction === "vertical" ? "-v" : "-h",
       "-c",
       cwd,
-      "-p",
-      String(percent)
+      // `-l N%` (tmux ≥3.1) — the old `-p N` percentage flag is gone from
+      // some builds (e.g. 3.4 fails with "size missing").
+      "-l",
+      `${percent}%`
     ],
     { encoding: "utf-8" }
   ).trim();
@@ -16858,6 +16860,14 @@ function buildSshForwardArgs(opts) {
     "ExitOnForwardFailure=yes",
     "-o",
     "ServerAliveInterval=15",
+    // The tunnel must be a dedicated connection we own. Under ControlMaster
+    // multiplexing (common with SSM ProxyCommand setups) the `-N` client can
+    // exit immediately after handing off to the persistent master, taking its
+    // forward down with it. Disable mux for this one connection.
+    "-o",
+    "ControlMaster=no",
+    "-o",
+    "ControlPath=none",
     opts.host
   ];
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -713,10 +713,10 @@ var init_hq = __esm({
   "packages/contracts/src/lib-internal/hq.ts"() {
     "use strict";
     RegistrationPayloadSchema = z2.object({
-      id: z2.string().min(1),
-      name: z2.string().min(1),
-      url: z2.string().url(),
-      token: z2.string().min(1)
+      id: z2.string().min(1).max(256),
+      name: z2.string().min(1).max(256),
+      url: z2.string().url().max(2048),
+      token: z2.string().min(1).max(512)
     });
     HQConfigSchema = z2.object({
       enabled: z2.boolean().default(false),
@@ -852,7 +852,7 @@ var init_ide_config = __esm({
 
 // packages/contracts/src/domain.ts
 import { z as z4 } from "zod";
-var ProofSchemaZ, MilestoneSchemaZ, MissionSchemaZ, GoalSchemaZ, TaskSchemaZ, EventTypeSchemaZ, OrchestratorEventSchemaZ, DispatchEventZ, CompletionEventZ, StallEventZ, RetryEventZ, ReconcileEventZ, ErrorEventZ, TaskCreatedEventZ, StatusChangeEventZ, SendEventZ, NotifyEventZ, MilestoneValidatingEventZ, MilestoneCompleteEventZ, ValidationDispatchEventZ, RemediationEventZ, ValidationFailedEventZ, PlanningEventZ, MissionCompleteEventZ, DiscoveredIssueEventZ, ResearchDispatchEventZ, ResearchFindingEventZ, WebhookTestEventZ, StructuredEventSchemaZ, MarkRangeSchemaZ, MarkSchemaZ, AuthorshipStatsSchemaZ, PlanStatusSchemaZ, PlanMetaSchemaZ, PaneInfoSchemaZ, AgentDetailSchemaZ, SessionStatsSchemaZ, SessionOverviewSchemaZ, ProjectDetailSchemaZ;
+var ProofSchemaZ, MilestoneSchemaZ, MissionSchemaZ, GoalSchemaZ, TaskSchemaZ, EventTypeSchemaZ, OrchestratorEventSchemaZ, DispatchEventZ, CompletionEventZ, StallEventZ, RetryEventZ, ReconcileEventZ, ErrorEventZ, TaskCreatedEventZ, StatusChangeEventZ, SendEventZ, NotifyEventZ, MilestoneValidatingEventZ, MilestoneCompleteEventZ, ValidationDispatchEventZ, RemediationEventZ, ValidationFailedEventZ, PlanningEventZ, MissionCompleteEventZ, DiscoveredIssueEventZ, ResearchDispatchEventZ, ResearchFindingEventZ, WebhookTestEventZ, StructuredEventSchemaZ, MarkRangeSchemaZ, MarkSchemaZ, AuthorshipStatsSchemaZ, PlanStatusSchemaZ, PlanMetaSchemaZ, PaneInfoSchemaZ, AgentDetailSchemaZ, SessionStatsSchemaZ, SessionOverviewSchemaZ, ProjectDetailSchemaZ, AgentToolSchemaZ, AgentKindSchemaZ, AgentStatusSchemaZ, AgentRecordSchemaZ, AgentRegisterPayloadSchemaZ, AgentHeartbeatPayloadSchemaZ, AgentListSchemaZ;
 var init_domain = __esm({
   "packages/contracts/src/domain.ts"() {
     "use strict";
@@ -1199,6 +1199,50 @@ var init_domain = __esm({
       goals: z4.array(GoalSchemaZ),
       tasks: z4.array(TaskSchemaZ),
       agents: z4.array(AgentDetailSchemaZ)
+    });
+    AgentToolSchemaZ = z4.enum(["claude", "codex", "unknown"]);
+    AgentKindSchemaZ = z4.enum(["managed", "tmux-unmanaged", "external"]);
+    AgentStatusSchemaZ = z4.enum(["busy", "idle", "offline"]);
+    AgentRecordSchemaZ = z4.object({
+      // Stable id. tmux agents (local): `${session}:${paneId}`; HQ namespaces
+      // remote ids with `${machineId}:` during aggregation. external agents: the
+      // hook-supplied id (typically the Claude session id). Bounds matter because
+      // HQ validates untrusted remote responses against this same schema.
+      id: z4.string().max(512),
+      kind: AgentKindSchemaZ,
+      tool: AgentToolSchemaZ,
+      name: z4.string().max(256),
+      status: AgentStatusSchemaZ,
+      session: z4.string().max(256).nullable(),
+      paneId: z4.string().max(64).nullable(),
+      paneTitle: z4.string().max(512).nullable(),
+      cwd: z4.string().max(4096).nullable(),
+      taskId: z4.string().max(128).nullable(),
+      taskTitle: z4.string().max(512).nullable(),
+      pid: z4.number().nullable(),
+      // ISO timestamp of last observed activity / heartbeat.
+      lastActivity: z4.string().max(64),
+      // null = this (local) machine; set by HQ when aggregating remotes.
+      machineId: z4.string().max(256).nullable(),
+      machineName: z4.string().max(256).nullable()
+    });
+    AgentRegisterPayloadSchemaZ = z4.object({
+      id: z4.string().min(1).max(256),
+      tool: AgentToolSchemaZ.default("claude"),
+      name: z4.string().max(256).optional(),
+      cwd: z4.string().max(4096).optional(),
+      session: z4.string().max(256).optional(),
+      pid: z4.number().int().positive().optional(),
+      status: AgentStatusSchemaZ.optional(),
+      taskTitle: z4.string().max(512).optional()
+    });
+    AgentHeartbeatPayloadSchemaZ = z4.object({
+      id: z4.string().min(1).max(256),
+      status: AgentStatusSchemaZ.optional(),
+      taskTitle: z4.string().max(512).optional()
+    });
+    AgentListSchemaZ = z4.object({
+      agents: z4.array(AgentRecordSchemaZ)
     });
   }
 });
@@ -1905,7 +1949,7 @@ import { z as z10 } from "zod";
 function isActionName(name) {
   return name in ActionContractsZ;
 }
-var ProjectScopeInputZ, ProofInputZ, SkillSchemaZ, ProjectOpenTerminalInputZ, ProjectOpenTerminalResultZ, ProjectLaunchInputZ, ProjectLaunchResultZ, ProjectStopInputZ, ProjectStopResultZ, ProjectRestartInputZ, ProjectRestartResultZ, ProjectActivateInputZ, ProjectActivateResultZ, TerminalRespawnInputZ, TerminalRespawnResultZ, TerminalStopInputZ, TerminalStopResultZ, TaskCreateInputZ, TaskCreateResultZ, TaskUpdateInputZ, TaskUpdateResultZ, TaskClaimInputZ, TaskClaimResultZ, TaskDoneInputZ, TaskDoneResultZ, TaskDeleteInputZ, TaskDeleteResultZ, GoalCreateInputZ, GoalCreateResultZ, GoalUpdateInputZ, GoalUpdateResultZ, GoalDoneInputZ, GoalDoneResultZ, GoalDeleteInputZ, GoalDeleteResultZ, MilestoneCreateInputZ, MilestoneCreateResultZ, MilestoneUpdateInputZ, MilestoneUpdateResultZ, MissionSetInputZ, MissionSetResultZ, MissionPlanCompleteInputZ, MissionPlanCompleteResultZ, MissionClearInputZ, MissionClearResultZ, SkillCreateInputZ, SkillCreateResultZ, SkillUpdateInputZ, SkillUpdateResultZ, SkillDeleteInputZ, SkillDeleteResultZ, ConfigSetInputZ, ConfigResultZ, ConfigAddPaneInputZ, ConfigAddPaneResultZ, ConfigRemovePaneInputZ, ConfigRemovePaneResultZ, ConfigAddRowInputZ, ConfigAddRowResultZ, ConfigEnableTeamInputZ, ConfigEnableTeamResultZ, ConfigDisableTeamInputZ, ConfigDisableTeamResultZ, AssertionEntryZ, ValidationReportZ, ValidationAssertInputZ, ValidationAssertResultZ, ValidationReportInputZ, ValidationReportResultZ, WebhookAddInputZ, WebhookAddResultZ, WebhookRemoveInputZ, WebhookRemoveResultZ, WebhookTestInputZ, WebhookTestResultZ, AppSetRemoteAccessInputZ, AppSetRemoteAccessResultZ, DaemonShutdownInputZ, DaemonShutdownResultZ, StopReasonZ, AgentProviderZ, ContentBlockZ, SessionUpdateZ, ChatThreadUsageSummaryZ, ThreadMessageZ, ThreadIndexEntryZ, ThreadStateZ, ChatThreadListInputZ, ChatThreadListResultZ, ProviderOptionSelectionZ, ProviderModelInfoZ, ChatProvidersListInputZ, ChatProvidersListResultZ, ChatThreadCreateInputZ, ChatThreadCreateResultZ, ChatThreadDeleteInputZ, ChatThreadDeleteResultZ, ChatThreadRenameInputZ, ChatThreadRenameResultZ, ChatThreadSetProviderInputZ, ChatThreadSetProviderResultZ, ChatThreadGetInputZ, ChatThreadGetResultZ, ChatThreadUsageInputZ, ChatThreadUsageResultZ, ChatSessionSendInputZ, ChatSessionSendResultZ, ChatSessionCancelInputZ, ChatSessionCancelResultZ, ChatSessionEditFromTurnInputZ, ChatSessionEditFromTurnResultZ, ChatPermissionRespondInputZ, ChatPermissionRespondResultZ, ChatContextCaptureTerminalInputZ, ChatContextCaptureTerminalResultZ, ActionContractsZ, ACTION_NAMES;
+var ProjectScopeInputZ, ProofInputZ, SkillSchemaZ, ProjectOpenTerminalInputZ, ProjectOpenTerminalResultZ, ProjectLaunchInputZ, ProjectLaunchResultZ, ProjectStopInputZ, ProjectStopResultZ, ProjectRestartInputZ, ProjectRestartResultZ, ProjectActivateInputZ, ProjectActivateResultZ, TerminalRespawnInputZ, TerminalRespawnResultZ, TerminalStopInputZ, TerminalStopResultZ, TaskCreateInputZ, TaskCreateResultZ, TaskUpdateInputZ, TaskUpdateResultZ, TaskClaimInputZ, TaskClaimResultZ, TaskDoneInputZ, TaskDoneResultZ, TaskDeleteInputZ, TaskDeleteResultZ, GoalCreateInputZ, GoalCreateResultZ, GoalUpdateInputZ, GoalUpdateResultZ, GoalDoneInputZ, GoalDoneResultZ, GoalDeleteInputZ, GoalDeleteResultZ, MilestoneCreateInputZ, MilestoneCreateResultZ, MilestoneUpdateInputZ, MilestoneUpdateResultZ, MissionSetInputZ, MissionSetResultZ, MissionPlanCompleteInputZ, MissionPlanCompleteResultZ, MissionClearInputZ, MissionClearResultZ, SkillCreateInputZ, SkillCreateResultZ, SkillUpdateInputZ, SkillUpdateResultZ, SkillDeleteInputZ, SkillDeleteResultZ, ConfigSetInputZ, ConfigResultZ, ConfigAddPaneInputZ, ConfigAddPaneResultZ, ConfigRemovePaneInputZ, ConfigRemovePaneResultZ, ConfigAddRowInputZ, ConfigAddRowResultZ, ConfigEnableTeamInputZ, ConfigEnableTeamResultZ, ConfigDisableTeamInputZ, ConfigDisableTeamResultZ, AssertionEntryZ, ValidationReportZ, ValidationAssertInputZ, ValidationAssertResultZ, ValidationReportInputZ, ValidationReportResultZ, WebhookAddInputZ, WebhookAddResultZ, WebhookRemoveInputZ, WebhookRemoveResultZ, WebhookTestInputZ, WebhookTestResultZ, AppSetRemoteAccessInputZ, AppSetRemoteAccessResultZ, DaemonShutdownInputZ, DaemonShutdownResultZ, AgentRegisterInputZ, AgentRegisterResultZ, AgentHeartbeatInputZ, AgentHeartbeatResultZ, AgentUnregisterInputZ, AgentUnregisterResultZ, StopReasonZ, AgentProviderZ, ContentBlockZ, SessionUpdateZ, ChatThreadUsageSummaryZ, ThreadMessageZ, ThreadIndexEntryZ, ThreadStateZ, ChatThreadListInputZ, ChatThreadListResultZ, ProviderOptionSelectionZ, ProviderModelInfoZ, ChatProvidersListInputZ, ChatProvidersListResultZ, ChatThreadCreateInputZ, ChatThreadCreateResultZ, ChatThreadDeleteInputZ, ChatThreadDeleteResultZ, ChatThreadRenameInputZ, ChatThreadRenameResultZ, ChatThreadSetProviderInputZ, ChatThreadSetProviderResultZ, ChatThreadGetInputZ, ChatThreadGetResultZ, ChatThreadUsageInputZ, ChatThreadUsageResultZ, ChatSessionSendInputZ, ChatSessionSendResultZ, ChatSessionCancelInputZ, ChatSessionCancelResultZ, ChatSessionEditFromTurnInputZ, ChatSessionEditFromTurnResultZ, ChatPermissionRespondInputZ, ChatPermissionRespondResultZ, ChatContextCaptureTerminalInputZ, ChatContextCaptureTerminalResultZ, ActionContractsZ, ACTION_NAMES;
 var init_actions_contract = __esm({
   "packages/contracts/src/actions-contract.ts"() {
     "use strict";
@@ -2237,6 +2281,22 @@ var init_actions_contract = __esm({
     });
     DaemonShutdownResultZ = z10.object({
       stopping: z10.literal(true)
+    });
+    AgentRegisterInputZ = AgentRegisterPayloadSchemaZ;
+    AgentRegisterResultZ = z10.object({ ok: z10.literal(true) });
+    AgentHeartbeatInputZ = AgentHeartbeatPayloadSchemaZ;
+    AgentHeartbeatResultZ = z10.object({
+      ok: z10.literal(true),
+      // `false` when no agent with that id was registered (the hook should
+      // re-register). The action still succeeds at the transport level.
+      known: z10.boolean()
+    });
+    AgentUnregisterInputZ = z10.object({
+      id: z10.string().min(1).max(256)
+    });
+    AgentUnregisterResultZ = z10.object({
+      ok: z10.literal(true),
+      removed: z10.boolean()
     });
     StopReasonZ = z10.enum([
       "end_turn",
@@ -2624,6 +2684,18 @@ var init_actions_contract = __esm({
       "daemon.shutdown": {
         input: DaemonShutdownInputZ,
         result: DaemonShutdownResultZ
+      },
+      "agent.register": {
+        input: AgentRegisterInputZ,
+        result: AgentRegisterResultZ
+      },
+      "agent.heartbeat": {
+        input: AgentHeartbeatInputZ,
+        result: AgentHeartbeatResultZ
+      },
+      "agent.unregister": {
+        input: AgentUnregisterInputZ,
+        result: AgentUnregisterResultZ
       },
       "chat.thread.list": {
         input: ChatThreadListInputZ,
@@ -5984,13 +6056,14 @@ var init_ws_route = __esm({
   }
 });
 
-// packages/daemon/src/widgets/lib/pane-comms.ts
+// packages/daemon/src/lib/tmux-exec.ts
 import { execFileSync as execFileSync3 } from "node:child_process";
+function runTmux2(args, options) {
+  return _executor2("tmux", args, options);
+}
 function tmux(...args) {
   try {
-    return _executor2("tmux", args, {
-      stdio: ["pipe", "pipe", "pipe"]
-    }).trim();
+    return _executor2("tmux", args, { stdio: ["pipe", "pipe", "pipe"] }).trim();
   } catch (error) {
     const stderr = error?.stderr?.toString() ?? "";
     if (stderr.includes("no server running") || stderr.includes("can't find session")) {
@@ -5999,6 +6072,15 @@ function tmux(...args) {
     throw error;
   }
 }
+var _executor2;
+var init_tmux_exec = __esm({
+  "packages/daemon/src/lib/tmux-exec.ts"() {
+    "use strict";
+    _executor2 = (cmd, args, options) => execFileSync3(cmd, args, { encoding: "utf-8", ...options }).toString();
+  }
+});
+
+// packages/daemon/src/widgets/lib/pane-comms.ts
 function listSessionPanes(session) {
   const format = [
     "#{pane_id}",
@@ -6074,7 +6156,7 @@ function sendCommand(session, paneId, command2) {
 }
 function captureLastLine(paneId) {
   try {
-    return _executor2("tmux", ["capture-pane", "-t", paneId, "-p", "-S", "-1"], {
+    return runTmux2(["capture-pane", "-t", paneId, "-p", "-S", "-1"], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"]
     }).trim();
@@ -6082,11 +6164,11 @@ function captureLastLine(paneId) {
     return "";
   }
 }
-var _executor2, SHELL_COMMANDS;
+var SHELL_COMMANDS;
 var init_pane_comms = __esm({
   "packages/daemon/src/widgets/lib/pane-comms.ts"() {
     "use strict";
-    _executor2 = (cmd, args, options) => execFileSync3(cmd, args, { encoding: "utf-8", ...options }).toString();
+    init_tmux_exec();
     SHELL_COMMANDS = /* @__PURE__ */ new Set(["zsh", "bash", "sh", "fish"]);
   }
 });
@@ -16542,9 +16624,745 @@ var init_workflow_store = __esm({
   }
 });
 
+// packages/daemon/src/lib/agent-discovery.ts
+function listAllTmuxPanes() {
+  const output = tmux("list-panes", "-a", "-F", FIELDS.join("	"));
+  if (!output) return [];
+  const panes = [];
+  for (const line of output.split("\n")) {
+    if (!line) continue;
+    const parts = line.split("	");
+    if (parts.length < FIXED_FIELDS) continue;
+    const [session, id, index, cmd, cwd, pid, width, height, active2, role, name, type] = parts;
+    if (!session || !id) continue;
+    panes.push({
+      session,
+      id,
+      index: parseInt(index, 10) || 0,
+      title: parts.slice(FIXED_FIELDS).join("	"),
+      currentCommand: cmd ?? "",
+      cwd: cwd || null,
+      pid: pid ? parseInt(pid, 10) || null : null,
+      width: parseInt(width, 10) || 0,
+      height: parseInt(height, 10) || 0,
+      active: active2 === "1",
+      role: role || null,
+      name: name || null,
+      type: type || null
+    });
+  }
+  return panes;
+}
+function inferAgentTool(currentCommand) {
+  const cmd = currentCommand.toLowerCase();
+  if (cmd.startsWith("codex")) return "codex";
+  if (cmd.startsWith("claude")) return "claude";
+  if (/^\d+\.\d+/.test(cmd)) return "claude";
+  return "unknown";
+}
+function discoverTmuxAgents(managedSessions) {
+  return listAllTmuxPanes().filter((pane) => isAgentPane(pane)).map((pane) => {
+    const managed = managedSessions.has(pane.session);
+    return {
+      id: `${pane.session}:${pane.id}`,
+      kind: managed ? "managed" : "tmux-unmanaged",
+      tool: inferAgentTool(pane.currentCommand),
+      name: agentIdentifier(pane),
+      status: isAgentBusy(pane) ? "busy" : "idle",
+      session: pane.session,
+      paneId: pane.id,
+      paneTitle: pane.title,
+      cwd: pane.cwd,
+      taskId: null,
+      taskTitle: null,
+      pid: pane.pid,
+      lastActivity: (/* @__PURE__ */ new Date()).toISOString(),
+      machineId: null,
+      machineName: null
+    };
+  });
+}
+var FIELDS, FIXED_FIELDS;
+var init_agent_discovery = __esm({
+  "packages/daemon/src/lib/agent-discovery.ts"() {
+    "use strict";
+    init_orchestrator();
+    init_tmux_exec();
+    FIELDS = [
+      "#{session_name}",
+      "#{pane_id}",
+      "#{pane_index}",
+      "#{pane_current_command}",
+      "#{pane_current_path}",
+      "#{pane_pid}",
+      "#{pane_width}",
+      "#{pane_height}",
+      "#{pane_active}",
+      "#{@ide_role}",
+      "#{@ide_name}",
+      "#{@ide_type}",
+      "#{pane_title}"
+    ];
+    FIXED_FIELDS = FIELDS.length - 1;
+  }
+});
+
+// packages/daemon/src/ssh-remote.ts
+var ssh_remote_exports = {};
+__export(ssh_remote_exports, {
+  buildRemoteServeScript: () => buildRemoteServeScript,
+  buildSshForwardArgs: () => buildSshForwardArgs,
+  parseSshConfigHosts: () => parseSshConfigHosts,
+  readSshRemotes: () => readSshRemotes,
+  remoteServeCommand: () => remoteServeCommand,
+  remotesFilePath: () => remotesFilePath,
+  shellQuote: () => shellQuote,
+  sshRemoteCommand: () => sshRemoteCommand,
+  validateRemoteName: () => validateRemoteName,
+  validateRemotePath: () => validateRemotePath,
+  validateSshAlias: () => validateSshAlias
+});
+import { spawn as spawn6, execFile as execFile3 } from "node:child_process";
+import { mkdir as mkdir2, readFile as readFile2, writeFile as writeFile2, chmod } from "node:fs/promises";
+import { existsSync as existsSync24 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { dirname as dirname10, join as join25, resolve as resolve17 } from "node:path";
+import { promisify } from "node:util";
+import { createServer } from "node:net";
+function remotesFilePath() {
+  return process.env.TMUX_IDE_SSH_REMOTES_FILE ?? join25(homedir8(), ".tmux-ide", "ssh-remotes.json");
+}
+async function readSshRemotes() {
+  return (await readStore()).remotes;
+}
+function sshConfigPath() {
+  return process.env.TMUX_IDE_SSH_CONFIG ?? join25(homedir8(), ".ssh", "config");
+}
+function emptyStore() {
+  return { version: 1, remotes: [] };
+}
+async function readStore() {
+  const file = remotesFilePath();
+  if (!existsSync24(file)) return emptyStore();
+  try {
+    const parsed = JSON.parse(await readFile2(file, "utf-8"));
+    if (parsed.version !== 1 || !Array.isArray(parsed.remotes)) return emptyStore();
+    return {
+      version: 1,
+      remotes: parsed.remotes.filter(isSshRemote)
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+async function writeStore(store) {
+  const file = remotesFilePath();
+  await mkdir2(dirname10(file), { recursive: true, mode: 448 });
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile2(tmp, JSON.stringify(store, null, 2) + "\n", { encoding: "utf-8", mode: 384 });
+  await chmod(tmp, 384);
+  await import("node:fs/promises").then(({ rename: rename2 }) => rename2(tmp, file));
+}
+function isSshRemote(value) {
+  if (!value || typeof value !== "object") return false;
+  const remote = value;
+  if (typeof remote.name !== "string") return false;
+  if (typeof remote.host !== "string") return false;
+  if (typeof remote.path !== "string") return false;
+  if (typeof remote.addedAt !== "string") return false;
+  if (remote.localPort !== void 0 && !isValidPort(remote.localPort)) return false;
+  if (remote.remotePort !== void 0 && !isValidPort(remote.remotePort)) return false;
+  if (remote.lastLocalPort !== void 0 && !isValidPort(remote.lastLocalPort)) return false;
+  if (remote.lastLaunchedAt !== void 0 && typeof remote.lastLaunchedAt !== "string")
+    return false;
+  return true;
+}
+function isValidPort(port) {
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
+}
+function parsePort(value, label) {
+  if (value === void 0 || value === false) return void 0;
+  if (value === true || value.trim() === "") {
+    throw new IdeError(`${label} requires a numeric value`, { code: "USAGE" });
+  }
+  const port = Number(value);
+  if (!isValidPort(port)) {
+    throw new IdeError(`${label} must be an integer from 1 to 65535`, { code: "USAGE" });
+  }
+  return port;
+}
+function parseSshConfigHosts(contents) {
+  const hosts = /* @__PURE__ */ new Set();
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const match = line.match(/^Host\s+(.+)$/i);
+    if (!match) continue;
+    for (const host of match[1].split(/\s+/)) {
+      if (!host || host.includes("*") || host.includes("?") || host.startsWith("!")) continue;
+      hosts.add(host);
+    }
+  }
+  return [...hosts].sort((a, b) => a.localeCompare(b));
+}
+function validateRemoteName(name) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(name)) {
+    throw new IdeError(
+      "Remote name must start with a letter or number and contain only letters, numbers, dot, underscore, or dash.",
+      { code: "USAGE" }
+    );
+  }
+}
+function validateSshAlias(host) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}$/.test(host)) {
+    throw new IdeError(
+      "SSH host must be a config alias or host string without whitespace or shell metacharacters.",
+      { code: "USAGE" }
+    );
+  }
+  if (host.startsWith("-")) {
+    throw new IdeError("SSH host cannot start with '-'", { code: "USAGE" });
+  }
+}
+function validateRemotePath(path4) {
+  if (!path4 || /[\0\r\n]/.test(path4)) {
+    throw new IdeError("Remote path must be a single non-empty path.", { code: "USAGE" });
+  }
+}
+function shellQuote(value) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+function buildRemoteServeScript(remotePath, remotePort) {
+  validateRemotePath(remotePath);
+  if (!isValidPort(remotePort)) {
+    throw new IdeError("Remote port must be an integer from 1 to 65535", { code: "USAGE" });
+  }
+  const quotedPath = shellQuote(remotePath);
+  return [
+    `cd ${quotedPath}`,
+    "mkdir -p .tmux-ide",
+    'if ! command -v tmux-ide >/dev/null 2>&1; then echo "tmux-ide not found on remote PATH" >&2; exit 127; fi',
+    `nohup tmux-ide __remote-serve --port ${remotePort} > .tmux-ide/remote-daemon.log 2>&1 < /dev/null &`
+  ].join(" && ");
+}
+function buildSshForwardArgs(opts) {
+  validateSshAlias(opts.host);
+  if (!isValidPort(opts.localPort) || !isValidPort(opts.remotePort)) {
+    throw new IdeError("SSH tunnel ports must be integers from 1 to 65535", { code: "USAGE" });
+  }
+  return [
+    "-N",
+    "-L",
+    `${DEFAULT_LOCAL_HOST}:${opts.localPort}:127.0.0.1:${opts.remotePort}`,
+    "-o",
+    "ExitOnForwardFailure=yes",
+    "-o",
+    "ServerAliveInterval=15",
+    opts.host
+  ];
+}
+async function pickFreeLocalPort() {
+  const server = createServer();
+  return await new Promise((resolvePort2, reject) => {
+    server.once("error", reject);
+    server.listen(0, DEFAULT_LOCAL_HOST, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : null;
+      server.close(() => {
+        if (port) resolvePort2(port);
+        else reject(new IdeError("Could not allocate a local tunnel port", { code: "PORT_ERROR" }));
+      });
+    });
+  });
+}
+async function assertLocalPortFree(port) {
+  const server = createServer();
+  await new Promise((resolvePort2, reject) => {
+    server.once(
+      "error",
+      () => reject(new IdeError(`Local port ${port} is already in use`, { code: "PORT_IN_USE" }))
+    );
+    server.listen(port, DEFAULT_LOCAL_HOST, () => {
+      server.close(() => resolvePort2());
+    });
+  });
+}
+function openInBrowser(url) {
+  const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+  try {
+    const child = spawn6(cmd, [url], { detached: true, stdio: "ignore" });
+    child.unref();
+  } catch {
+  }
+}
+async function waitForHealth(url, timeoutMs = 15e3) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+  while (Date.now() < deadline) {
+    try {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 750).unref?.();
+      const res = await fetch(`${url}healthz`, { signal: controller.signal });
+      if (res.ok) return;
+      lastError = `HTTP ${res.status}`;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    await new Promise((resolveTimer) => setTimeout(resolveTimer, 250));
+  }
+  throw new IdeError(
+    `Remote dashboard did not become healthy through the SSH tunnel: ${lastError}`,
+    {
+      code: "REMOTE_UNHEALTHY"
+    }
+  );
+}
+async function runRemoteServe(remote, remotePort) {
+  const script = buildRemoteServeScript(remote.path, remotePort);
+  try {
+    await execFileAsync("ssh", [remote.host, script], { timeout: 1e4 });
+  } catch (err) {
+    const stderr = err instanceof Error && "stderr" in err && typeof err.stderr === "string" ? err.stderr.trim() : "";
+    throw new IdeError(`Failed to start tmux-ide on ${remote.host}${stderr ? `: ${stderr}` : ""}`, {
+      code: "SSH_REMOTE_START_FAILED"
+    });
+  }
+}
+async function startTunnel(remote, localPort, remotePort) {
+  const args = buildSshForwardArgs({ host: remote.host, localPort, remotePort });
+  const child = spawn6("ssh", args, { detached: true, stdio: "ignore" });
+  child.unref();
+  await new Promise((resolveStart, reject) => {
+    const timer = setTimeout(resolveStart, 500);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      reject(
+        new IdeError(
+          `SSH tunnel exited before it was ready (${signal ?? `code ${code ?? "unknown"}`})`,
+          { code: "SSH_TUNNEL_FAILED" }
+        )
+      );
+    });
+    child.once("error", (err) => {
+      clearTimeout(timer);
+      reject(
+        new IdeError(`Failed to start ssh tunnel: ${err.message}`, { code: "SSH_TUNNEL_FAILED" })
+      );
+    });
+  });
+  return {
+    pid: child.pid ?? 0,
+    stop: () => {
+      if (!child.pid) return;
+      try {
+        process.kill(-child.pid, "SIGTERM");
+      } catch {
+        try {
+          child.kill("SIGTERM");
+        } catch {
+        }
+      }
+    }
+  };
+}
+function printRemotes(remotes) {
+  if (remotes.length === 0) {
+    console.log("No SSH remotes configured");
+    return;
+  }
+  for (const remote of remotes) {
+    const local = remote.localPort ? ` local:${remote.localPort}` : "";
+    const remotePort = remote.remotePort ? ` remote:${remote.remotePort}` : "";
+    console.log(`  ${remote.name} \u2014 ${remote.host}:${remote.path}${local}${remotePort}`);
+  }
+}
+async function listHosts(json2) {
+  const file = sshConfigPath();
+  const hosts = existsSync24(file) ? parseSshConfigHosts(await readFile2(file, "utf-8")) : [];
+  if (json2) {
+    console.log(JSON.stringify({ hosts }));
+  } else if (hosts.length === 0) {
+    console.log("No concrete SSH hosts found");
+  } else {
+    for (const host of hosts) console.log(host);
+  }
+}
+async function addRemote(opts) {
+  const name = opts.args?.[0];
+  const host = opts.values?.host;
+  const path4 = opts.values?.path;
+  if (!name || typeof host !== "string" || typeof path4 !== "string") {
+    throw new IdeError(
+      "Usage: tmux-ide remote ssh add <name> --host <ssh-host> --path <remote-project-dir> [--local-port N] [--remote-port N]",
+      { code: "USAGE" }
+    );
+  }
+  validateRemoteName(name);
+  validateSshAlias(host);
+  validateRemotePath(path4);
+  const localPort = parsePort(opts.values?.["local-port"], "--local-port");
+  const remotePort = parsePort(opts.values?.["remote-port"], "--remote-port");
+  const store = await readStore();
+  const next = {
+    name,
+    host,
+    path: path4,
+    localPort,
+    remotePort,
+    addedAt: (/* @__PURE__ */ new Date()).toISOString()
+  };
+  const index = store.remotes.findIndex((remote) => remote.name === name);
+  if (index >= 0) store.remotes[index] = next;
+  else store.remotes.push(next);
+  await writeStore(store);
+  if (opts.json) console.log(JSON.stringify({ ok: true, remote: next }));
+  else console.log(`Saved SSH remote ${name} (${host}:${path4})`);
+}
+async function removeRemote(opts) {
+  const name = opts.args?.[0];
+  if (!name) {
+    throw new IdeError("Usage: tmux-ide remote ssh remove <name>", { code: "USAGE" });
+  }
+  const store = await readStore();
+  const before = store.remotes.length;
+  store.remotes = store.remotes.filter((remote) => remote.name !== name);
+  await writeStore(store);
+  const removed = store.remotes.length !== before;
+  if (opts.json) console.log(JSON.stringify({ ok: true, removed }));
+  else
+    console.log(removed ? `Removed SSH remote ${name}` : `SSH remote ${name} was not configured`);
+}
+async function getConfiguredRemote(name) {
+  if (!name) {
+    throw new IdeError("Usage: tmux-ide remote ssh launch <name>", { code: "USAGE" });
+  }
+  validateRemoteName(name);
+  const store = await readStore();
+  const remote = store.remotes.find((candidate) => candidate.name === name);
+  if (!remote) {
+    throw new IdeError(`SSH remote ${name} is not configured`, { code: "REMOTE_NOT_FOUND" });
+  }
+  return remote;
+}
+async function launchRemote(opts) {
+  const remote = await getConfiguredRemote(opts.args?.[0]);
+  const remotePort = remote.remotePort ?? DEFAULT_REMOTE_PORT;
+  const localPort = remote.localPort ?? await pickFreeLocalPort();
+  if (remote.localPort) await assertLocalPortFree(localPort);
+  await runRemoteServe(remote, remotePort);
+  const tunnel = await startTunnel(remote, localPort, remotePort);
+  const url = `http://${DEFAULT_LOCAL_HOST}:${localPort}/`;
+  try {
+    await waitForHealth(url);
+  } catch (err) {
+    tunnel.stop();
+    throw err;
+  }
+  const store = await readStore();
+  const stored = store.remotes.find((candidate) => candidate.name === remote.name);
+  if (stored) {
+    stored.lastLocalPort = localPort;
+    stored.lastLaunchedAt = (/* @__PURE__ */ new Date()).toISOString();
+    await writeStore(store);
+  }
+  if (opts.json) {
+    console.log(
+      JSON.stringify({ ok: true, url, localPort, remotePort, tunnelPid: tunnel.pid, remote })
+    );
+  } else {
+    console.log(`Dashboard: ${url}`);
+    console.log(`Tunnel: ${remote.host} 127.0.0.1:${localPort} -> 127.0.0.1:${remotePort}`);
+  }
+  if (opts.values?.["no-open"] !== true) openInBrowser(url);
+}
+async function statusRemote(opts) {
+  const remote = await getConfiguredRemote(opts.args?.[0]);
+  const localPort = remote.localPort;
+  const url = localPort ? `http://${DEFAULT_LOCAL_HOST}:${localPort}/` : null;
+  let healthy = false;
+  if (url) {
+    try {
+      const res = await fetch(`${url}healthz`);
+      healthy = res.ok;
+    } catch {
+      healthy = false;
+    }
+  }
+  if (opts.json) {
+    console.log(JSON.stringify({ remote, url, healthy }));
+  } else {
+    console.log(`Remote: ${remote.name}`);
+    console.log(`SSH host: ${remote.host}`);
+    console.log(`Path: ${remote.path}`);
+    console.log(`Remote daemon bind: 127.0.0.1:${remote.remotePort ?? DEFAULT_REMOTE_PORT}`);
+    if (url) console.log(`Local URL: ${url} (${healthy ? "healthy" : "not reachable"})`);
+    else console.log("Local URL: dynamic; run launch to allocate a tunnel port");
+  }
+}
+async function sshRemoteCommand(opts) {
+  const sub = opts.args?.[0];
+  const args = opts.args?.slice(1) ?? [];
+  switch (sub) {
+    case "hosts":
+      await listHosts(opts.json);
+      break;
+    case "list": {
+      const store = await readStore();
+      if (opts.json) console.log(JSON.stringify({ remotes: store.remotes }));
+      else printRemotes(store.remotes);
+      break;
+    }
+    case "add":
+      await addRemote({ ...opts, args });
+      break;
+    case "remove":
+      await removeRemote({ ...opts, args });
+      break;
+    case "launch":
+    case "dashboard":
+      await launchRemote({ ...opts, args });
+      break;
+    case "status":
+      await statusRemote({ ...opts, args });
+      break;
+    default:
+      throw new IdeError(
+        "Usage: tmux-ide remote ssh hosts|list|add|remove|launch|dashboard|status",
+        { code: "USAGE" }
+      );
+  }
+}
+async function remoteServeCommand(opts) {
+  const port = parsePort(opts.port, "--port") ?? DEFAULT_REMOTE_PORT;
+  const dir = resolve17(".");
+  const { readConfig: readConfig2, getSessionName: getSessionName2 } = await Promise.resolve().then(() => (init_yaml_io(), yaml_io_exports));
+  const { launch: launch2 } = await Promise.resolve().then(() => (init_launch(), launch_exports));
+  const { startEmbeddedDaemon: startEmbeddedDaemon2 } = await Promise.resolve().then(() => (init_daemon_embed(), daemon_embed_exports));
+  const { readCanonicalDaemonInfo: readCanonicalDaemonInfo2, isCanonicalDaemonAlive: isCanonicalDaemonAlive2 } = await Promise.resolve().then(() => (init_canonical_daemon(), canonical_daemon_exports));
+  const existing = readCanonicalDaemonInfo2();
+  if (existing && existing.port === port && existing.bindHostname === "127.0.0.1") {
+    if (await isCanonicalDaemonAlive2(existing)) return;
+  }
+  const { config: config2 } = readConfig2(dir);
+  const { name: fallbackName } = getSessionName2(dir);
+  const sessionName = config2.name ?? fallbackName;
+  await launch2(dir, { attach: false });
+  const handle = await startEmbeddedDaemon2({
+    sessionName,
+    port,
+    bindHostname: "127.0.0.1"
+  });
+  const stop2 = async () => {
+    await handle.stop({ gracefulMs: 500 });
+  };
+  process.once("SIGINT", () => void stop2().finally(() => process.exit(0)));
+  process.once("SIGTERM", () => void stop2().finally(() => process.exit(0)));
+  await new Promise(() => void 0);
+}
+var execFileAsync, DEFAULT_REMOTE_PORT, DEFAULT_LOCAL_HOST;
+var init_ssh_remote = __esm({
+  "packages/daemon/src/ssh-remote.ts"() {
+    "use strict";
+    init_errors2();
+    execFileAsync = promisify(execFile3);
+    DEFAULT_REMOTE_PORT = 6060;
+    DEFAULT_LOCAL_HOST = "127.0.0.1";
+  }
+});
+
+// packages/daemon/src/lib/agent-remotes.ts
+function sshMachineId(remoteName) {
+  return `${SSH_MACHINE_PREFIX}${remoteName}`;
+}
+function tunnelPort(remote) {
+  return remote.localPort ?? remote.lastLocalPort ?? null;
+}
+function tunnelBaseUrl(remote) {
+  const port = tunnelPort(remote);
+  return port ? `http://127.0.0.1:${port}` : null;
+}
+async function resolveSshMachineUrl(machineId) {
+  if (!machineId.startsWith(SSH_MACHINE_PREFIX)) return null;
+  const name = machineId.slice(SSH_MACHINE_PREFIX.length);
+  const remote = (await readSshRemotes()).find((candidate) => candidate.name === name);
+  return remote ? tunnelBaseUrl(remote) : null;
+}
+async function fetchAgents(baseUrl) {
+  try {
+    const controller = new AbortController();
+    const tid = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    const res = await fetch(`${baseUrl}/api/agents`, {
+      signal: controller.signal,
+      redirect: "manual"
+    });
+    clearTimeout(tid);
+    if (!res.ok) return null;
+    const parsed = AgentListSchemaZ.safeParse(await res.json());
+    return parsed.success ? parsed.data.agents : null;
+  } catch {
+    return null;
+  }
+}
+async function listSshAgentSources() {
+  const remotes = (await readSshRemotes()).filter((remote) => tunnelPort(remote) !== null);
+  const probes = remotes.map(async (remote) => {
+    const agents = await fetchAgents(tunnelBaseUrl(remote));
+    if (!agents) return null;
+    return { machineId: sshMachineId(remote.name), machineName: remote.name, agents };
+  });
+  return (await Promise.all(probes)).filter((source) => !!source);
+}
+var SSH_MACHINE_PREFIX, PROBE_TIMEOUT_MS;
+var init_agent_remotes = __esm({
+  "packages/daemon/src/lib/agent-remotes.ts"() {
+    "use strict";
+    init_src2();
+    init_ssh_remote();
+    SSH_MACHINE_PREFIX = "ssh:";
+    PROBE_TIMEOUT_MS = 2500;
+  }
+});
+
+// packages/daemon/src/lib/agent-registry.ts
+function getDefaultExternalAgentRegistry() {
+  if (!_default2) _default2 = new ExternalAgentRegistry();
+  return _default2;
+}
+function sanitizeDisplay(value) {
+  const chars = [];
+  for (const ch of value) {
+    const code = ch.codePointAt(0);
+    if (code < 32 || code === 127 || code >= 128 && code <= 159) continue;
+    chars.push(ch);
+    if (chars.length >= 512) break;
+  }
+  return chars.join("");
+}
+function sanitizeRemoteAgent(a, remote) {
+  const machineId = sanitizeDisplay(remote.machineId);
+  return {
+    ...a,
+    id: `${machineId}:${sanitizeDisplay(a.id)}`,
+    name: sanitizeDisplay(a.name),
+    session: a.session === null ? null : sanitizeDisplay(a.session),
+    paneTitle: a.paneTitle === null ? null : sanitizeDisplay(a.paneTitle),
+    cwd: a.cwd === null ? null : sanitizeDisplay(a.cwd),
+    taskTitle: a.taskTitle === null ? null : sanitizeDisplay(a.taskTitle),
+    machineId,
+    machineName: sanitizeDisplay(remote.machineName)
+  };
+}
+function aggregateHqAgents(localAgents, selfMachineName, remotes) {
+  const selfName = sanitizeDisplay(selfMachineName);
+  const out = localAgents.map((a) => ({
+    ...a,
+    machineId: null,
+    machineName: selfName
+  }));
+  for (const remote of remotes) {
+    for (const a of remote.agents) {
+      out.push(sanitizeRemoteAgent(a, remote));
+    }
+  }
+  return out;
+}
+function mergeLocalAgents(tmuxAgents, externalAgents) {
+  const tmuxPids = new Set(
+    tmuxAgents.map((a) => a.pid).filter((pid) => pid !== null)
+  );
+  const externalOnly = externalAgents.filter((a) => a.pid === null || !tmuxPids.has(a.pid));
+  return [...tmuxAgents, ...externalOnly];
+}
+var ExternalAgentRegistry, _default2;
+var init_agent_registry = __esm({
+  "packages/daemon/src/lib/agent-registry.ts"() {
+    "use strict";
+    ExternalAgentRegistry = class {
+      agents = /* @__PURE__ */ new Map();
+      offlineAfterMs;
+      evictAfterMs;
+      maxEntries;
+      constructor(opts) {
+        this.offlineAfterMs = opts?.offlineAfterMs ?? 5 * 6e4;
+        this.evictAfterMs = opts?.evictAfterMs ?? 30 * 6e4;
+        this.maxEntries = opts?.maxEntries ?? 1e3;
+      }
+      evictOldest() {
+        let oldestId = null;
+        let oldestSeen = Infinity;
+        for (const [id, entry] of this.agents) {
+          if (entry.lastSeen < oldestSeen) {
+            oldestSeen = entry.lastSeen;
+            oldestId = id;
+          }
+        }
+        if (oldestId !== null) this.agents.delete(oldestId);
+      }
+      register(payload, now = Date.now()) {
+        const existing = this.agents.get(payload.id);
+        if (!existing && this.agents.size >= this.maxEntries) this.evictOldest();
+        this.agents.set(payload.id, {
+          id: payload.id,
+          tool: payload.tool,
+          name: payload.name ?? existing?.name ?? payload.id.slice(0, 12),
+          cwd: payload.cwd ?? existing?.cwd ?? null,
+          session: payload.session ?? existing?.session ?? null,
+          pid: payload.pid ?? existing?.pid ?? null,
+          status: payload.status ?? existing?.status ?? "idle",
+          taskTitle: payload.taskTitle ?? existing?.taskTitle ?? null,
+          registeredAt: existing?.registeredAt ?? now,
+          lastSeen: now
+        });
+      }
+      heartbeat(payload, now = Date.now()) {
+        const entry = this.agents.get(payload.id);
+        if (!entry) return false;
+        entry.lastSeen = now;
+        if (payload.status) entry.status = payload.status;
+        if (payload.taskTitle !== void 0) entry.taskTitle = payload.taskTitle;
+        return true;
+      }
+      unregister(id) {
+        return this.agents.delete(id);
+      }
+      /** Drop entries that have been silent past the eviction window. */
+      prune(now = Date.now()) {
+        for (const [id, entry] of this.agents) {
+          if (now - entry.lastSeen > this.evictAfterMs) this.agents.delete(id);
+        }
+      }
+      /** Snapshot as unified AgentRecords; stale entries surface as `offline`. */
+      list(now = Date.now()) {
+        this.prune(now);
+        return Array.from(this.agents.values()).map((entry) => {
+          const stale = now - entry.lastSeen > this.offlineAfterMs;
+          return {
+            id: entry.id,
+            kind: "external",
+            tool: entry.tool,
+            name: entry.name,
+            status: stale ? "offline" : entry.status,
+            session: entry.session,
+            paneId: null,
+            paneTitle: null,
+            cwd: entry.cwd,
+            taskId: null,
+            taskTitle: entry.taskTitle,
+            pid: entry.pid,
+            lastActivity: new Date(entry.lastSeen).toISOString(),
+            machineId: null,
+            machineName: null
+          };
+        });
+      }
+    };
+    _default2 = null;
+  }
+});
+
 // packages/daemon/src/command-center/schemas.ts
 import { z as z20 } from "zod";
-var updateTaskSchema, createTaskSchema, savePlanSchema, savePlanContentSchema, sendCommandSchema, createMilestoneSchema, updateMilestoneSchema, updateAssertionSchema, triggerResearchSchema, launchSchema, stopSchema, skillNameRegex, createSkillSchema, updateSkillSchema;
+var updateTaskSchema, createTaskSchema, savePlanSchema, savePlanContentSchema, sendCommandSchema, agentSendSchema, createMilestoneSchema, updateMilestoneSchema, updateAssertionSchema, triggerResearchSchema, launchSchema, stopSchema, skillNameRegex, createSkillSchema, updateSkillSchema;
 var init_schemas = __esm({
   "packages/daemon/src/command-center/schemas.ts"() {
     "use strict";
@@ -16571,6 +17389,12 @@ var init_schemas = __esm({
     sendCommandSchema = z20.object({
       target: z20.string().min(1, "Target pane is required"),
       message: z20.string().min(1, "Message is required"),
+      noEnter: z20.boolean().optional()
+    });
+    agentSendSchema = z20.object({
+      id: z20.string().min(1).max(512),
+      machineId: z20.string().min(1).max(256).nullish(),
+      message: z20.string().min(1, "Message is required").max(1e4),
       noEnter: z20.boolean().optional()
     });
     createMilestoneSchema = z20.object({
@@ -16926,11 +17750,11 @@ var init_errors6 = __esm({
 });
 
 // packages/daemon/src/git/git-service.ts
-import { execFile as execFile3 } from "node:child_process";
+import { execFile as execFile4 } from "node:child_process";
 import { Effect } from "effect";
 function runRaw(cwd, args) {
   return new Promise((resolve35, reject) => {
-    execFile3(
+    execFile4(
       "git",
       args,
       {
@@ -17204,7 +18028,7 @@ var init_git_service = __esm({
 });
 
 // packages/daemon/src/git/github-service.ts
-import { execFile as execFile4 } from "node:child_process";
+import { execFile as execFile5 } from "node:child_process";
 import { Effect as Effect2, Data as Data2 } from "effect";
 function toPayload2(err) {
   switch (err._tag) {
@@ -17228,7 +18052,7 @@ function toPayload2(err) {
 }
 function runCli(cmd, args, cwd) {
   return new Promise((resolve35, reject) => {
-    execFile4(
+    execFile5(
       cmd,
       args,
       {
@@ -17586,17 +18410,17 @@ var init_github_service = __esm({
 });
 
 // packages/daemon/src/lib/terminals-store.ts
-import { existsSync as existsSync24, mkdirSync as mkdirSync20, readFileSync as readFileSync19, renameSync as renameSync14, writeFileSync as writeFileSync19 } from "node:fs";
-import { dirname as dirname10, join as join25 } from "node:path";
+import { existsSync as existsSync25, mkdirSync as mkdirSync20, readFileSync as readFileSync19, renameSync as renameSync14, writeFileSync as writeFileSync19 } from "node:fs";
+import { dirname as dirname11, join as join26 } from "node:path";
 function path(dir) {
-  return join25(dir, TERMINALS_FILE);
+  return join26(dir, TERMINALS_FILE);
 }
 function ensureDir(dir) {
-  mkdirSync20(dirname10(path(dir)), { recursive: true });
+  mkdirSync20(dirname11(path(dir)), { recursive: true });
 }
 function loadTerminals(dir) {
   const file = path(dir);
-  if (!existsSync24(file)) return [];
+  if (!existsSync25(file)) return [];
   try {
     const body = readFileSync19(file, "utf-8");
     const parsed = JSON.parse(body);
@@ -17677,9 +18501,9 @@ __export(auth_service_exports, {
   AuthService: () => AuthService
 });
 import * as crypto2 from "node:crypto";
-import { readFileSync as readFileSync20, existsSync as existsSync25 } from "node:fs";
-import { join as join26 } from "node:path";
-import { homedir as homedir8 } from "node:os";
+import { readFileSync as readFileSync20, existsSync as existsSync26 } from "node:fs";
+import { join as join27 } from "node:path";
+import { homedir as homedir9 } from "node:os";
 function base64url(buf) {
   const b = typeof buf === "string" ? Buffer.from(buf) : buf;
   return b.toString("base64url");
@@ -17821,9 +18645,9 @@ var init_auth_service = __esm({
       }
       checkSSHKeyAuthorization(userId, publicKey) {
         try {
-          const home = userId === process.env.USER ? homedir8() : `/home/${userId}`;
-          const authKeysPath = join26(home, ".ssh", "authorized_keys");
-          if (!existsSync25(authKeysPath)) return false;
+          const home = userId === process.env.USER ? homedir9() : `/home/${userId}`;
+          const authKeysPath = join27(home, ".ssh", "authorized_keys");
+          if (!existsSync26(authKeysPath)) return false;
           const authorizedKeys = readFileSync20(authKeysPath, "utf-8");
           const parts = publicKey.trim().split(" ");
           const keyData = parts.length > 1 ? parts[1] : parts[0];
@@ -17882,7 +18706,7 @@ var init_types2 = __esm({
 });
 
 // packages/daemon/src/command-center/search.ts
-import { spawn as spawn6 } from "node:child_process";
+import { spawn as spawn7 } from "node:child_process";
 import { createInterface } from "node:readline";
 import { z as z21 } from "zod";
 async function resolveRipgrepPath() {
@@ -18028,7 +18852,7 @@ function relativizePath(absolute, searchRoot) {
 }
 async function* runSearch(opts) {
   const args = buildRgArgs(opts.query, opts.searchRoot);
-  const spawnFn = opts.spawn ?? spawn6;
+  const spawnFn = opts.spawn ?? spawn7;
   const startedAt = Date.now();
   let child;
   try {
@@ -18130,7 +18954,7 @@ var init_search = __esm({
 
 // packages/daemon/src/command-center/search-replace.ts
 import { readFileSync as readFileSync21, renameSync as renameSync15, rmSync as rmSync4, statSync as statSync5, writeFileSync as writeFileSync20 } from "node:fs";
-import { dirname as dirname11, resolve as pathResolve } from "node:path";
+import { dirname as dirname12, resolve as pathResolve } from "node:path";
 import { z as z22 } from "zod";
 function resolveSandboxedPath(sessionDir, relPath) {
   if (!relPath) return null;
@@ -18219,7 +19043,7 @@ function executeReplace(sessionDir, body, deps2 = {}) {
       continue;
     }
     try {
-      const parent = dirname11(target);
+      const parent = dirname12(target);
       if (!parent) {
         skipped.push({ path: file.path, reason: "write_failed" });
         continue;
@@ -18264,26 +19088,26 @@ var init_search_replace = __esm({
 });
 
 // packages/daemon/src/command-center/static.ts
-import { existsSync as existsSync26, readFileSync as readFileSync22, statSync as statSync6 } from "node:fs";
-import { resolve as resolve17, dirname as dirname12, join as join27, extname } from "node:path";
+import { existsSync as existsSync27, readFileSync as readFileSync22, statSync as statSync6 } from "node:fs";
+import { resolve as resolve18, dirname as dirname13, join as join28, extname } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 function resolveDashboardOut() {
   const override = process.env.TMUX_IDE_DASHBOARD_OUT;
-  if (override) return existsSync26(override) ? override : null;
-  const here = dirname12(fileURLToPath3(import.meta.url));
+  if (override) return existsSync27(override) ? override : null;
+  const here = dirname13(fileURLToPath3(import.meta.url));
   let current = here;
   let workspaceMatch = null;
   let firstMatch = null;
   for (let i = 0; i < 10; i += 1) {
-    const candidate = join27(current, "dashboard", "dist");
-    if (existsSync26(candidate)) {
+    const candidate = join28(current, "dashboard", "dist");
+    if (existsSync27(candidate)) {
       if (firstMatch === null) firstMatch = candidate;
-      if (existsSync26(join27(current, "pnpm-workspace.yaml"))) {
+      if (existsSync27(join28(current, "pnpm-workspace.yaml"))) {
         workspaceMatch = candidate;
         break;
       }
     }
-    const parent = resolve17(current, "..");
+    const parent = resolve18(current, "..");
     if (parent === current) break;
     current = parent;
   }
@@ -18292,7 +19116,7 @@ function resolveDashboardOut() {
 function readCached(filePath) {
   const cached = fileCache.get(filePath);
   if (cached) return cached;
-  if (!existsSync26(filePath) || !statSync6(filePath).isFile()) return null;
+  if (!existsSync27(filePath) || !statSync6(filePath).isFile()) return null;
   const ext = extname(filePath);
   const mimeType = MIME_TYPES[ext] ?? "application/octet-stream";
   const content = new Uint8Array(readFileSync22(filePath));
@@ -18327,10 +19151,10 @@ function serveDashboard() {
         "Cache-Control": cacheControl(path4, file.mimeType)
       }
     });
-    const exactPath = join27(outDir, normalized);
+    const exactPath = join28(outDir, normalized);
     const exactFile = readCached(exactPath);
     if (exactFile) return serve(exactFile);
-    const rootIndex = join27(outDir, "index.html");
+    const rootIndex = join28(outDir, "index.html");
     const rootFile = readCached(rootIndex);
     if (rootFile) return serve(rootFile);
     await next();
@@ -18356,14 +19180,14 @@ var init_static = __esm({
 });
 
 // packages/daemon/src/notes/service.ts
-import { existsSync as existsSync27, mkdirSync as mkdirSync21, readFileSync as readFileSync23, renameSync as renameSync16, statSync as statSync7, writeFileSync as writeFileSync21 } from "node:fs";
-import { dirname as dirname13, join as join28 } from "node:path";
+import { existsSync as existsSync28, mkdirSync as mkdirSync21, readFileSync as readFileSync23, renameSync as renameSync16, statSync as statSync7, writeFileSync as writeFileSync21 } from "node:fs";
+import { dirname as dirname14, join as join29 } from "node:path";
 function notePath(sessionDir) {
-  return join28(sessionDir, NOTES_REL_PATH);
+  return join29(sessionDir, NOTES_REL_PATH);
 }
 function readNote(sessionDir) {
   const path4 = notePath(sessionDir);
-  if (!existsSync27(path4)) return { content: "", updatedAt: null };
+  if (!existsSync28(path4)) return { content: "", updatedAt: null };
   try {
     const content = readFileSync23(path4, "utf8");
     const stat = statSync7(path4);
@@ -18374,7 +19198,7 @@ function readNote(sessionDir) {
 }
 function writeNote(sessionDir, content) {
   const path4 = notePath(sessionDir);
-  mkdirSync21(dirname13(path4), { recursive: true });
+  mkdirSync21(dirname14(path4), { recursive: true });
   const tmp = `${path4}.${process.pid}.${Date.now()}.tmp`;
   writeFileSync21(tmp, content, "utf8");
   renameSync16(tmp, path4);
@@ -18617,9 +19441,9 @@ var init_project_stop = __esm({
 });
 
 // packages/daemon/src/restart.ts
-import { resolve as resolve18 } from "node:path";
+import { resolve as resolve19 } from "node:path";
 async function restart(targetDir, { json: json2, attach: attach2 } = {}) {
-  const dir = resolve18(targetDir ?? ".");
+  const dir = resolve19(targetDir ?? ".");
   const { name: session } = getSessionName(dir);
   stopSessionMonitor(session);
   const result = killSession(session);
@@ -18762,11 +19586,11 @@ var init_terminal_stop = __esm({
 });
 
 // packages/daemon/src/command-center/actions/handlers/task-system.ts
-import { resolve as resolve19 } from "node:path";
+import { resolve as resolve20 } from "node:path";
 function resolveActionDir(input, deps2 = {}) {
   if (deps2.dir) return deps2.dir;
   const name = input.name ?? input.sessionName;
-  if (!name) return resolve19(".");
+  if (!name) return resolve20(".");
   const sessions = (deps2.discoverSessions ?? discoverSessions)();
   const session = sessions.find((candidate) => candidate.name === name);
   if (!session) {
@@ -19007,11 +19831,11 @@ var init_skill_actions = __esm({
 });
 
 // packages/daemon/src/command-center/actions/handlers/config-actions.ts
-import { existsSync as existsSync28 } from "node:fs";
-import { join as join29 } from "node:path";
+import { existsSync as existsSync29 } from "node:fs";
+import { join as join30 } from "node:path";
 function mutateConfigAction(input, deps2, fn) {
   const context = resolveProjectContext(input, deps2);
-  if (!existsSync28(join29(context.dir, "ide.yml"))) {
+  if (!existsSync29(join30(context.dir, "ide.yml"))) {
     throw new ActionError({
       code: "ide_yml_missing",
       message: "ide.yml was not found",
@@ -19123,10 +19947,10 @@ var init_validation_actions = __esm({
 });
 
 // packages/daemon/src/command-center/actions/handlers/webhook-actions.ts
-import { existsSync as existsSync29 } from "node:fs";
-import { join as join30 } from "node:path";
+import { existsSync as existsSync30 } from "node:fs";
+import { join as join31 } from "node:path";
 function assertIdeYml(dir) {
-  if (!existsSync29(join30(dir, "ide.yml"))) {
+  if (!existsSync30(join31(dir, "ide.yml"))) {
     throw new ActionError({
       code: "ide_yml_missing",
       message: "ide.yml was not found",
@@ -19199,14 +20023,37 @@ var init_webhook_actions = __esm({
   }
 });
 
+// packages/daemon/src/command-center/actions/handlers/agent-actions.ts
+function registryFrom(deps2) {
+  return deps2.registry ?? getDefaultExternalAgentRegistry();
+}
+function agentRegisterHandler(input, deps2 = {}) {
+  registryFrom(deps2).register(input);
+  return { ok: true };
+}
+function agentHeartbeatHandler(input, deps2 = {}) {
+  const known = registryFrom(deps2).heartbeat(input);
+  return { ok: true, known };
+}
+function agentUnregisterHandler(input, deps2 = {}) {
+  const removed = registryFrom(deps2).unregister(input.id);
+  return { ok: true, removed };
+}
+var init_agent_actions = __esm({
+  "packages/daemon/src/command-center/actions/handlers/agent-actions.ts"() {
+    "use strict";
+    init_agent_registry();
+  }
+});
+
 // packages/daemon/src/chat/context-actions.ts
-import { execFile as execFile5 } from "node:child_process";
-import { promisify } from "node:util";
+import { execFile as execFile6 } from "node:child_process";
+import { promisify as promisify2 } from "node:util";
 function badRequest2(message, details) {
   return new ActionError({ code: "bad_request", message, details });
 }
 async function tmux2(args, deps2, input) {
-  const exec = deps2.execFile ?? execFileAsync;
+  const exec = deps2.execFile ?? execFileAsync2;
   try {
     const result = await exec("tmux", args, {
       encoding: "utf8",
@@ -19236,12 +20083,12 @@ async function chatContextCaptureTerminalHandler(input, deps2 = {}) {
     capturedAt: (deps2.now?.() ?? /* @__PURE__ */ new Date()).toISOString()
   };
 }
-var execFileAsync, CAPTURE_MAX_BUFFER;
+var execFileAsync2, CAPTURE_MAX_BUFFER;
 var init_context_actions = __esm({
   "packages/daemon/src/chat/context-actions.ts"() {
     "use strict";
     init_errors3();
-    execFileAsync = promisify(execFile5);
+    execFileAsync2 = promisify2(execFile6);
     CAPTURE_MAX_BUFFER = 10 * 1024 * 1024;
   }
 });
@@ -19269,6 +20116,7 @@ var init_registry2 = __esm({
     init_webhook_actions();
     init_app_set_remote_access();
     init_daemon_shutdown();
+    init_agent_actions();
     init_context_actions();
     init_chat_actions();
     actionRegistry = {
@@ -19457,6 +20305,21 @@ var init_registry2 = __esm({
         resultSchema: ActionContractsZ["daemon.shutdown"].result,
         handler: daemonShutdownHandler
       },
+      "agent.register": {
+        inputSchema: ActionContractsZ["agent.register"].input,
+        resultSchema: ActionContractsZ["agent.register"].result,
+        handler: agentRegisterHandler
+      },
+      "agent.heartbeat": {
+        inputSchema: ActionContractsZ["agent.heartbeat"].input,
+        resultSchema: ActionContractsZ["agent.heartbeat"].result,
+        handler: agentHeartbeatHandler
+      },
+      "agent.unregister": {
+        inputSchema: ActionContractsZ["agent.unregister"].input,
+        resultSchema: ActionContractsZ["agent.unregister"].result,
+        handler: agentUnregisterHandler
+      },
       "chat.thread.list": {
         inputSchema: ActionContractsZ["chat.thread.list"].input,
         resultSchema: ActionContractsZ["chat.thread.list"].result,
@@ -19619,7 +20482,7 @@ var init_dispatcher = __esm({
 });
 
 // packages/daemon/src/lib/project-init-runner.ts
-import { spawn as spawn7 } from "node:child_process";
+import { spawn as spawn8 } from "node:child_process";
 function lineStreamer(onChunk) {
   let pending = "";
   return {
@@ -19641,7 +20504,7 @@ function lineStreamer(onChunk) {
   };
 }
 async function runInit(options) {
-  const spawnFn = options.spawnFn ?? spawn7;
+  const spawnFn = options.spawnFn ?? spawn8;
   const command2 = options.command ?? "tmux-ide";
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const args = ["init"];
@@ -19774,12 +20637,12 @@ var init_inspect = __esm({
 
 // packages/daemon/src/lib/filesystem-browser.ts
 import { realpathSync as realpathSync3, readdirSync as readdirSync8, statSync as statSync8 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { isAbsolute as isAbsolute5, join as join31, resolve as resolve20, sep } from "node:path";
+import { homedir as homedir10 } from "node:os";
+import { isAbsolute as isAbsolute5, join as join32, resolve as resolve21, sep } from "node:path";
 function resolveHome() {
   const override = process.env.TMUX_IDE_HOME_OVERRIDE;
   if (override && override.trim().length > 0) return override;
-  return homedir9();
+  return homedir10();
 }
 function preflight(rawPath, io) {
   const trimmed = rawPath.trim();
@@ -19793,12 +20656,12 @@ function preflight(rawPath, io) {
   if (candidate === "~") {
     candidate = io.home();
   } else if (candidate.startsWith("~/")) {
-    candidate = join31(io.home(), candidate.slice(2));
+    candidate = join32(io.home(), candidate.slice(2));
   }
   if (!isAbsolute5(candidate)) {
     throw new InvalidPathError("Path must be absolute");
   }
-  return resolve20(candidate);
+  return resolve21(candidate);
 }
 function isUnderRoot(canonical, root) {
   if (canonical === root) return true;
@@ -19814,7 +20677,7 @@ function assertInsideSandbox(canonical, home) {
 }
 function computeParentPath(canonical, home) {
   if (canonical === "/" || canonical === sep) return null;
-  const parent = resolve20(canonical, "..");
+  const parent = resolve21(canonical, "..");
   if (parent === canonical) return null;
   try {
     assertInsideSandbox(parent, home);
@@ -19906,7 +20769,7 @@ function browseDirectory(input, io = realIo2) {
   const entries = [];
   for (const dirent of dirents) {
     if (!showHidden && dirent.name.startsWith(".")) continue;
-    const fullPath = join31(canonical, dirent.name);
+    const fullPath = join32(canonical, dirent.name);
     const { entry } = classifyDirent(dirent, fullPath, io);
     if (entry !== null) entries.push(entry);
   }
@@ -19954,8 +20817,8 @@ var init_filesystem_browser = __esm({
 });
 
 // packages/daemon/src/lib/project-inspect.ts
-import { existsSync as existsSync30 } from "node:fs";
-import { isAbsolute as isAbsolute6, resolve as resolve21 } from "node:path";
+import { existsSync as existsSync31 } from "node:fs";
+import { isAbsolute as isAbsolute6, resolve as resolve22 } from "node:path";
 function narrowPackageManager(raw) {
   if (!raw) return null;
   return KNOWN_PACKAGE_MANAGERS.has(raw) ? raw : null;
@@ -19965,8 +20828,8 @@ function inferTestCommand(packageManager) {
   return packageManager === "npm" ? "npm test" : `${packageManager} test`;
 }
 async function inspectProject(dir, io = {}) {
-  const exists = io.exists ?? existsSync30;
-  const absoluteDir = isAbsolute6(dir) ? dir : resolve21(dir);
+  const exists = io.exists ?? existsSync31;
+  const absoluteDir = isAbsolute6(dir) ? dir : resolve22(dir);
   if (!exists(absoluteDir)) {
     throw new InspectDirNotFoundError(absoluteDir);
   }
@@ -20006,8 +20869,8 @@ var init_project_inspect = __esm({
 
 // packages/daemon/src/lib/project-onboard.ts
 import yaml4 from "js-yaml";
-import { existsSync as existsSync31 } from "node:fs";
-import { join as join32 } from "node:path";
+import { existsSync as existsSync32 } from "node:fs";
+import { join as join33 } from "node:path";
 function composeIdeYmlConfig(input) {
   if (!Number.isInteger(input.agents) || input.agents < 1 || input.agents > 3) {
     throw new OnboardInvalidInputError(
@@ -20065,8 +20928,8 @@ function composeIdeYmlConfig(input) {
   }
   return config2;
 }
-function assertNoExistingIdeYml(dir, exists = existsSync31) {
-  const path4 = join32(dir, "ide.yml");
+function assertNoExistingIdeYml(dir, exists = existsSync32) {
+  const path4 = join33(dir, "ide.yml");
   if (exists(path4)) {
     throw new OnboardConflictError(path4);
   }
@@ -20093,15 +20956,15 @@ var init_project_onboard = __esm({
 });
 
 // packages/daemon/src/lsp/launch.ts
-import { spawn as spawn8 } from "node:child_process";
-import { existsSync as existsSync32 } from "node:fs";
-import { delimiter as delimiter2, extname as extname2, join as join33 } from "node:path";
+import { spawn as spawn9 } from "node:child_process";
+import { existsSync as existsSync33 } from "node:fs";
+import { delimiter as delimiter2, extname as extname2, join as join34 } from "node:path";
 function findOnPath(binary) {
   const envPath = process.env.PATH ?? "";
   for (const dir of envPath.split(PATH_DELIM)) {
     if (!dir) continue;
-    const candidate = join33(dir, binary);
-    if (existsSync32(candidate)) return candidate;
+    const candidate = join34(dir, binary);
+    if (existsSync33(candidate)) return candidate;
   }
   return null;
 }
@@ -20111,8 +20974,8 @@ function resolveBinary(config2, workspaceRoot) {
     return override;
   }
   for (const rel of config2.workspaceLookups ?? []) {
-    const candidate = join33(workspaceRoot, rel);
-    if (existsSync32(candidate)) return candidate;
+    const candidate = join34(workspaceRoot, rel);
+    if (existsSync33(candidate)) return candidate;
   }
   return findOnPath(config2.defaultBinary);
 }
@@ -20128,7 +20991,7 @@ function launchLanguageServer(language, workspaceRoot) {
   const config2 = languageServerConfig(language);
   const resolved2 = resolveBinary(config2, workspaceRoot);
   if (!resolved2) return null;
-  const proc = spawn8(resolved2, [...config2.args], {
+  const proc = spawn9(resolved2, [...config2.args], {
     cwd: workspaceRoot,
     stdio: ["pipe", "pipe", "pipe"],
     env: { ...process.env }
@@ -20165,7 +21028,7 @@ var init_launch2 = __esm({
         defaultBinary: "typescript-language-server",
         binaryEnvVar: "TMUX_IDE_LSP_TYPESCRIPT",
         args: ["--stdio"],
-        workspaceLookups: [join33("node_modules", ".bin", "typescript-language-server")]
+        workspaceLookups: [join34("node_modules", ".bin", "typescript-language-server")]
       },
       {
         language: "python",
@@ -20209,7 +21072,7 @@ var init_launch2 = __esm({
 
 // packages/daemon/src/lsp/client.ts
 import { pathToFileURL, fileURLToPath as fileURLToPath4 } from "node:url";
-import { readFile as readFile2 } from "node:fs/promises";
+import { readFile as readFile3 } from "node:fs/promises";
 import {
   createProtocolConnection,
   StreamMessageReader,
@@ -20316,7 +21179,7 @@ async function createLspClient(input) {
   await connection.sendNotification(InitializedNotification.type, {});
   async function ensureOpen(file) {
     if (openDocs.has(file)) return;
-    const text = await readFile2(file, "utf-8").catch(() => "");
+    const text = await readFile3(file, "utf-8").catch(() => "");
     openDocs.set(file, { version: 0, text });
     await connection.sendNotification(DidOpenTextDocumentNotification.type, {
       textDocument: {
@@ -20333,7 +21196,7 @@ async function createLspClient(input) {
       await ensureOpen(file);
       return;
     }
-    const text = await readFile2(file, "utf-8").catch(() => current.text);
+    const text = await readFile3(file, "utf-8").catch(() => current.text);
     if (text === current.text) return;
     const nextVersion = current.version + 1;
     openDocs.set(file, { version: nextVersion, text });
@@ -20862,9 +21725,9 @@ var init_provider_registry = __esm({
 });
 
 // packages/daemon/src/chat/provider-store.ts
-import { existsSync as existsSync33, mkdirSync as mkdirSync22, readFileSync as readFileSync24, renameSync as renameSync17, writeFileSync as writeFileSync22 } from "node:fs";
-import { dirname as dirname14, join as join34 } from "node:path";
-import { homedir as homedir10 } from "node:os";
+import { existsSync as existsSync34, mkdirSync as mkdirSync22, readFileSync as readFileSync24, renameSync as renameSync17, writeFileSync as writeFileSync22 } from "node:fs";
+import { dirname as dirname15, join as join35 } from "node:path";
+import { homedir as homedir11 } from "node:os";
 import { randomBytes as randomBytes3 } from "node:crypto";
 function toSummary(instance) {
   const cfg = instance.config;
@@ -20881,10 +21744,10 @@ function toSummary(instance) {
   return summary;
 }
 function defaultProvidersFilePath() {
-  return process.env.TMUX_IDE_PROVIDERS_FILE ?? join34(homedir10(), ".tmux-ide", "providers.json");
+  return process.env.TMUX_IDE_PROVIDERS_FILE ?? join35(homedir11(), ".tmux-ide", "providers.json");
 }
 function readProvidersFile(filePath) {
-  if (!existsSync33(filePath)) {
+  if (!existsSync34(filePath)) {
     return { version: 1, providers: [] };
   }
   let raw;
@@ -20915,8 +21778,8 @@ function readProvidersFile(filePath) {
   return validated.data;
 }
 function writeProvidersFile(filePath, data) {
-  const dir = dirname14(filePath);
-  if (!existsSync33(dir)) {
+  const dir = dirname15(filePath);
+  if (!existsSync34(dir)) {
     mkdirSync22(dir, { recursive: true });
   }
   const tmp = `${filePath}.${randomBytes3(4).toString("hex")}.tmp`;
@@ -21042,13 +21905,13 @@ __export(files_exports, {
   createIgnoreFilter: () => createIgnoreFilter,
   readDirectory: () => readDirectory
 });
-import { readdirSync as readdirSync9, readFileSync as readFileSync25, existsSync as existsSync34 } from "node:fs";
-import { join as join35, relative as relative3 } from "node:path";
+import { readdirSync as readdirSync9, readFileSync as readFileSync25, existsSync as existsSync35 } from "node:fs";
+import { join as join36, relative as relative3 } from "node:path";
 import ignore from "ignore";
 function createIgnoreFilter(rootDir) {
   const ig = ignore();
-  const gitignorePath = join35(rootDir, ".gitignore");
-  if (existsSync34(gitignorePath)) {
+  const gitignorePath = join36(rootDir, ".gitignore");
+  if (existsSync35(gitignorePath)) {
     ig.add(readFileSync25(gitignorePath, "utf-8"));
   }
   return ig;
@@ -21064,14 +21927,14 @@ function readDirectory(dir, rootDir, ig, showHidden, showIgnored = false) {
     if (ALWAYS_IGNORE.has(e.name)) return false;
     if (!showHidden && e.name.startsWith(".")) return false;
     if (showIgnored) return true;
-    const rel = relative3(rootDir, join35(dir, e.name));
+    const rel = relative3(rootDir, join36(dir, e.name));
     try {
       return !ig.ignores(e.isDirectory() ? rel + "/" : rel);
     } catch {
       return true;
     }
   }).map((e) => {
-    const rel = relative3(rootDir, join35(dir, e.name));
+    const rel = relative3(rootDir, join36(dir, e.name));
     let isIgnored = false;
     try {
       isIgnored = ig.ignores(e.isDirectory() ? rel + "/" : rel);
@@ -21080,7 +21943,7 @@ function readDirectory(dir, rootDir, ig, showHidden, showIgnored = false) {
     return {
       name: e.name,
       path: rel,
-      absolutePath: join35(dir, e.name),
+      absolutePath: join36(dir, e.name),
       isDir: e.isDirectory(),
       ignored: isIgnored
     };
@@ -21154,10 +22017,10 @@ __export(server_exports, {
   createApp: () => createApp,
   getSseMetrics: () => getSseMetrics
 });
-import { execFileSync as execFileSync6, execFile as execFile6 } from "node:child_process";
-import { promisify as promisify2 } from "node:util";
+import { execFileSync as execFileSync6, execFile as execFile7 } from "node:child_process";
+import { promisify as promisify3 } from "node:util";
 import {
-  existsSync as existsSync35,
+  existsSync as existsSync36,
   readFileSync as readFileSync26,
   writeFileSync as writeFileSync23,
   mkdirSync as mkdirSync23,
@@ -21169,7 +22032,7 @@ import {
   readSync,
   closeSync
 } from "node:fs";
-import { join as join36, dirname as dirname15, basename as basename9 } from "node:path";
+import { join as join37, dirname as dirname16, basename as basename9 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 import { Hono } from "hono";
 import { streamSSE, stream as streamResponse } from "hono/streaming";
@@ -21177,12 +22040,12 @@ import { cors } from "hono/cors";
 import { zValidator as zValidator2 } from "@hono/zod-validator";
 import { Effect as Effect3 } from "effect";
 import { realpathSync as realpathSync4 } from "node:fs";
-import { homedir as homedir11 } from "node:os";
+import { homedir as homedir12, hostname as hostname2 } from "node:os";
 import { isAbsolute as isAbsolute7, resolve as pathResolve2 } from "node:path";
 import { randomUUID as randomUUID11 } from "node:crypto";
 import { WebSocketServer } from "ws";
 function resolvePackageVersion() {
-  const candidates = [join36(__dirname3, "../../package.json"), join36(__dirname3, "../package.json")];
+  const candidates = [join37(__dirname3, "../../package.json"), join37(__dirname3, "../package.json")];
   for (const candidate of candidates) {
     try {
       const parsed = JSON.parse(readFileSync26(candidate, "utf-8"));
@@ -21247,17 +22110,17 @@ function safePlanName(filename) {
 }
 function planFilePath(projectDir, filename) {
   const safeName = safePlanName(filename);
-  return join36(projectDir, "plans", safeName.endsWith(".md") ? safeName : `${safeName}.md`);
+  return join37(projectDir, "plans", safeName.endsWith(".md") ? safeName : `${safeName}.md`);
 }
 function writePlanAtomic(filePath, content) {
-  const dir = dirname15(filePath);
+  const dir = dirname16(filePath);
   mkdirSync23(dir, { recursive: true });
-  const tmpPath = join36(dir, `.${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`);
+  const tmpPath = join37(dir, `.${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`);
   try {
     writeFileSync23(tmpPath, content);
     renameSync18(tmpPath, filePath);
   } finally {
-    if (existsSync35(tmpPath)) {
+    if (existsSync36(tmpPath)) {
       try {
         unlinkSync4(tmpPath);
       } catch {
@@ -21349,7 +22212,7 @@ function sandboxResolveDir(rawDir) {
   if (trimmed.includes("\0")) {
     return { error: "invalid-path", message: "Path contains a null byte", status: 400 };
   }
-  const home = process.env.TMUX_IDE_HOME_OVERRIDE && process.env.TMUX_IDE_HOME_OVERRIDE.trim().length > 0 ? process.env.TMUX_IDE_HOME_OVERRIDE : homedir11();
+  const home = process.env.TMUX_IDE_HOME_OVERRIDE && process.env.TMUX_IDE_HOME_OVERRIDE.trim().length > 0 ? process.env.TMUX_IDE_HOME_OVERRIDE : homedir12();
   let candidate = trimmed;
   if (candidate === "~") {
     candidate = home;
@@ -21753,8 +22616,8 @@ function createApp(options = {}) {
       return c.json({ error: "Session not found" }, 404);
     }
     const plans = loadPlans(session.dir).map((p) => {
-      const filePath = join36(session.dir, "plans", `${p.name}.md`);
-      const raw = existsSync35(filePath) ? readFileSync26(filePath, "utf-8") : "";
+      const filePath = join37(session.dir, "plans", `${p.name}.md`);
+      const raw = existsSync36(filePath) ? readFileSync26(filePath, "utf-8") : "";
       const frontmatter = parsePlanFrontmatterSummary(raw);
       return {
         name: p.name,
@@ -21763,7 +22626,7 @@ function createApp(options = {}) {
         status: frontmatter.status ?? p.status,
         effort: p.effort ?? null,
         owner: frontmatter.owner,
-        updated: existsSync35(filePath) ? statSync9(filePath).mtime.toISOString() : null,
+        updated: existsSync36(filePath) ? statSync9(filePath).mtime.toISOString() : null,
         completed: p.completed ?? null
       };
     });
@@ -21779,7 +22642,7 @@ function createApp(options = {}) {
     }
     const safeName = safePlanName(filename);
     const filePath = planFilePath(session.dir, filename);
-    if (!existsSync35(filePath)) {
+    if (!existsSync36(filePath)) {
       return c.json({ error: "Plan not found" }, 404);
     }
     const raw = readFileSync26(filePath, "utf-8");
@@ -21819,7 +22682,7 @@ function createApp(options = {}) {
         return c.json({ error: "Session not found" }, 404);
       }
       const filePath = planFilePath(session.dir, filename);
-      if (!existsSync35(filePath)) {
+      if (!existsSync36(filePath)) {
         return c.json({ error: "Plan not found" }, 404);
       }
       const body = c.req.valid("json");
@@ -21837,7 +22700,7 @@ function createApp(options = {}) {
     }
     const safeName = safePlanName(filename);
     const filePath = planFilePath(session.dir, filename);
-    if (!existsSync35(filePath)) {
+    if (!existsSync36(filePath)) {
       return c.json({ error: "Plan not found" }, 404);
     }
     unlinkSync4(filePath);
@@ -21883,7 +22746,7 @@ function createApp(options = {}) {
       return c.json({ ok: true, plan: result });
     }
     const filePath = planFilePath(session.dir, filename);
-    if (!existsSync35(filePath)) {
+    if (!existsSync36(filePath)) {
       return c.json({ error: "Plan not found" }, 404);
     }
     const patched = patchPlanStatus(readFileSync26(filePath, "utf-8"), status4);
@@ -23224,7 +24087,7 @@ function createApp(options = {}) {
       let previousMissionHash = "";
       let eventCursor = 0;
       let lastPing = Date.now();
-      const tasksRoot = join36(session.dir, ".tasks");
+      const tasksRoot = join37(session.dir, ".tasks");
       function writeSse(event, payload) {
         sseMetrics.messagesSent += 1;
         void stream.writeSSE({ event, data: JSON.stringify(freezePayload(payload)) });
@@ -23774,7 +24637,7 @@ function createApp(options = {}) {
       return c.json({ error: "Failed to write ide.yml", detail: message }, 500);
     }
   });
-  const execFileAsync4 = promisify2(execFile6);
+  const execFileAsync4 = promisify3(execFile7);
   app.post("/api/project/:name/restart", async (c) => {
     const name = c.req.param("name");
     const sessions = discoverSessions();
@@ -24033,6 +24896,125 @@ function createApp(options = {}) {
     if (!removed) return c.json({ error: "Machine not found" }, 404);
     return c.json({ ok: true });
   });
+  function localAgents() {
+    const managed = new Set(
+      getDefaultWorkspaceRegistry().list().map((w) => w.sessionName)
+    );
+    const tmuxAgents = discoverTmuxAgents(managed);
+    const external = getDefaultExternalAgentRegistry().list();
+    return mergeLocalAgents(tmuxAgents, external);
+  }
+  app.get("/api/agents", (c) => {
+    const payload = AgentListSchemaZ.parse({ agents: localAgents() });
+    return c.json(payload);
+  });
+  const MAX_HQ_MACHINES = 50;
+  const MAX_HQ_AGENTS = 2e3;
+  const isHttpUrl = (u) => {
+    try {
+      const proto = new URL(u).protocol;
+      return proto === "http:" || proto === "https:";
+    } catch {
+      return false;
+    }
+  };
+  app.get("/api/hq/agents", async (c) => {
+    const selfName = options.hqMachineName ?? hostname2();
+    const sshSourcesPromise = listSshAgentSources();
+    let remotes = [];
+    if (remoteRegistry) {
+      const candidates = remoteRegistry.getMachines().filter((m) => m.name !== selfName && isHttpUrl(m.url));
+      if (candidates.length > MAX_HQ_MACHINES) {
+        logger.warn(
+          "hq-agents",
+          `fan-out capped: ${candidates.length} machines, querying first ${MAX_HQ_MACHINES}`
+        );
+      }
+      const fanout = candidates.slice(0, MAX_HQ_MACHINES).map(async (machine) => {
+        try {
+          const controller = new AbortController();
+          const tid = setTimeout(() => controller.abort(), 5e3);
+          const res = await fetch(`${machine.url}/api/agents`, {
+            headers: { Authorization: `Bearer ${machine.token}` },
+            signal: controller.signal,
+            // Don't chase redirects from a (possibly hostile) remote with the
+            // machine's bearer attached — treat a 3xx as a failed fetch.
+            redirect: "manual"
+          });
+          clearTimeout(tid);
+          if (!res.ok) return null;
+          const parsed = AgentListSchemaZ.safeParse(await res.json());
+          if (!parsed.success) return null;
+          return { machineId: machine.id, machineName: machine.name, agents: parsed.data.agents };
+        } catch {
+          return null;
+        }
+      });
+      remotes = (await Promise.all(fanout)).filter((r) => r !== null);
+    }
+    remotes = [...remotes, ...await sshSourcesPromise];
+    let agents = aggregateHqAgents(localAgents(), selfName, remotes);
+    if (agents.length > MAX_HQ_AGENTS) {
+      logger.warn(
+        "hq-agents",
+        `response capped: ${agents.length} agents, returning first ${MAX_HQ_AGENTS} (local first)`
+      );
+      agents = agents.slice(0, MAX_HQ_AGENTS);
+    }
+    return c.json(AgentListSchemaZ.parse({ agents }));
+  });
+  app.post("/api/agents/send", zValidator2("json", agentSendSchema), async (c) => {
+    const { id, machineId, message, noEnter } = c.req.valid("json");
+    if (machineId) {
+      const sshUrl = await resolveSshMachineUrl(machineId);
+      const hqMachine = sshUrl ? null : remoteRegistry?.getMachine(machineId);
+      const baseUrl = sshUrl ?? hqMachine?.url;
+      if (!baseUrl || !isHttpUrl(baseUrl)) {
+        return c.json({ error: `Unknown machine: ${machineId}` }, 404);
+      }
+      const prefix = `${machineId}:`;
+      if (!id.startsWith(prefix)) {
+        return c.json({ error: "Agent id does not belong to that machine" }, 400);
+      }
+      const headers = { "Content-Type": "application/json" };
+      if (hqMachine) headers.Authorization = `Bearer ${hqMachine.token}`;
+      try {
+        const controller = new AbortController();
+        const tid = setTimeout(() => controller.abort(), 5e3);
+        const res = await fetch(`${baseUrl}/api/agents/send`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ id: id.slice(prefix.length), message, noEnter }),
+          signal: controller.signal,
+          redirect: "manual"
+        });
+        clearTimeout(tid);
+        const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+        if (res.ok) return c.json(body);
+        return c.json({ ...body, remoteStatus: res.status }, 502);
+      } catch {
+        return c.json({ error: `Machine ${machineId} is unreachable` }, 502);
+      }
+    }
+    const agent = localAgents().find((candidate) => candidate.id === id);
+    if (!agent) {
+      return c.json({ error: `Agent not found: ${id}` }, 404);
+    }
+    if (agent.kind === "external" || !agent.session || !agent.paneId) {
+      return c.json({ error: "External agents are observe-only (no pane to drive)" }, 409);
+    }
+    const busyStatus = getPaneBusyStatus(agent.session, agent.paneId);
+    const prepared = busyStatus === "agent" ? message.replace(/\n+/g, " ").trim() : message;
+    if (noEnter) {
+      sendText(agent.session, agent.paneId, prepared);
+    } else {
+      sendCommand(agent.session, agent.paneId, prepared);
+    }
+    return c.json({
+      ok: true,
+      agent: { id: agent.id, session: agent.session, paneId: agent.paneId }
+    });
+  });
   const tunnelManager = options.tunnelManager ?? null;
   app.get("/api/tunnel", async (c) => {
     if (!tunnelManager) return c.json({ running: false, provider: null });
@@ -24155,7 +25137,7 @@ function createApp(options = {}) {
     if (!parsed.success) {
       return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
     }
-    if (!existsSync35(parsed.data.dir)) {
+    if (!existsSync36(parsed.data.dir)) {
       return c.json({ error: `Directory "${parsed.data.dir}" does not exist` }, 400);
     }
     const jobId = randomUUID11();
@@ -24295,9 +25277,9 @@ function createApp(options = {}) {
 }
 function listAvailableTemplates() {
   const __filename = fileURLToPath5(import.meta.url);
-  const __dir = dirname15(__filename);
-  const templatesDir = join36(__dir, "..", "..", "..", "..", "templates");
-  if (!existsSync35(templatesDir)) return [];
+  const __dir = dirname16(__filename);
+  const templatesDir = join37(__dir, "..", "..", "..", "..", "templates");
+  if (!existsSync36(templatesDir)) return [];
   const labels = {
     default: { label: "Default", description: "Single Claude pane + dev/shell row" },
     nextjs: {
@@ -24378,6 +25360,10 @@ var init_server = __esm({
     init_plan_store2();
     init_workflow_store();
     init_workspace_registry();
+    init_agent_discovery();
+    init_agent_remotes();
+    init_agent_registry();
+    init_src2();
     init_src2();
     init_schemas();
     init_git_service();
@@ -24413,7 +25399,7 @@ var init_server = __esm({
     init_src2();
     init_provider_store();
     init_src2();
-    __dirname3 = dirname15(fileURLToPath5(import.meta.url));
+    __dirname3 = dirname16(fileURLToPath5(import.meta.url));
     pkgVersion = resolvePackageVersion();
     projectStreamConnections = 0;
     ALLOWED_MILESTONE_TRANSITIONS = /* @__PURE__ */ new Map([
@@ -25774,16 +26760,19 @@ var init_registry4 = __esm({
       healthCheckTimer = null;
       healthInterval;
       healthTimeout;
+      maxMachines;
       isShuttingDown;
       constructor(opts) {
         this.healthInterval = opts?.healthInterval ?? 15e3;
         this.healthTimeout = opts?.healthTimeout ?? 5e3;
+        this.maxMachines = opts?.maxMachines ?? 256;
         this.isShuttingDown = opts?.isShuttingDown ?? (() => false);
         this.startHealthChecker();
       }
       register(remote) {
         const existing = this.machines.get(remote.id);
         if (existing) {
+          if (existing.name !== remote.name) this.machinesByName.delete(existing.name);
           existing.name = remote.name;
           existing.url = remote.url;
           existing.token = remote.token;
@@ -25794,6 +26783,9 @@ var init_registry4 = __esm({
         }
         if (this.machinesByName.has(remote.name)) {
           throw new Error(`Machine with name '${remote.name}' is already registered`);
+        }
+        if (this.machines.size >= this.maxMachines) {
+          throw new Error(`HQ registry full (${this.maxMachines} machines)`);
         }
         const now = /* @__PURE__ */ new Date();
         const machine = {
@@ -26015,10 +27007,10 @@ __export(daemon_embed_exports, {
 });
 import { execFileSync as execFileSync8 } from "node:child_process";
 import { randomBytes as randomBytes5 } from "node:crypto";
-import { createServer } from "node:http";
+import { createServer as createServer2 } from "node:http";
 import { createRequire as createRequire3 } from "node:module";
-import { existsSync as existsSync36, readdirSync as readdirSync11, statSync as statSync10, unlinkSync as unlinkSync5 } from "node:fs";
-import { join as join39 } from "node:path";
+import { existsSync as existsSync37, readdirSync as readdirSync11, statSync as statSync10, unlinkSync as unlinkSync5 } from "node:fs";
+import { join as join40 } from "node:path";
 import { WebSocket, WebSocketServer as WebSocketServer2 } from "ws";
 function tmux3(...args) {
   return execFileSync8("tmux", args, {
@@ -26054,11 +27046,11 @@ function validatePort(port) {
     throw new DaemonStartupError(`Invalid daemon port: ${port}`, "port_invalid");
   }
 }
-async function pickFreePort(hostname2) {
-  const probe = createServer();
+async function pickFreePort(hostname3) {
+  const probe = createServer2();
   return await new Promise((resolve35, reject) => {
     probe.once("error", reject);
-    probe.listen(0, hostname2, () => {
+    probe.listen(0, hostname3, () => {
       const address = probe.address();
       const port = typeof address === "object" && address ? address.port : null;
       probe.close(() => {
@@ -26108,12 +27100,12 @@ function listPanes2(sessionName) {
   });
 }
 function cleanupDispatchFiles(dir) {
-  const dispatchDir = join39(dir, ".tasks", "dispatch");
-  if (!existsSync36(dispatchDir)) return;
+  const dispatchDir = join40(dir, ".tasks", "dispatch");
+  if (!existsSync37(dispatchDir)) return;
   const cutoff = Date.now() - 24 * 60 * 60 * 1e3;
   try {
     for (const file of readdirSync11(dispatchDir)) {
-      const filePath = join39(dispatchDir, file);
+      const filePath = join40(dispatchDir, file);
       try {
         const mtime = statSync10(filePath).mtimeMs;
         if (mtime < cutoff) unlinkSync5(filePath);
@@ -26363,11 +27355,13 @@ async function startHttpServer({
     healthInterval: hqConfig.heartbeat_interval,
     isShuttingDown: () => registryShuttingDown
   }) : void 0;
+  const { hostname: osHostname } = await import("node:os");
   const app = createApp3({
     authService,
     authConfig,
     tunnelManager,
     remoteRegistry,
+    hqMachineName: hqConfig?.machine_name ?? osHostname(),
     remoteAccess: {
       bindHostname,
       token: authToken ?? null,
@@ -26378,7 +27372,7 @@ async function startHttpServer({
     const health = getTaskStoreHealth();
     return c.json({ ...health, ok: health.ok, session: sessionName });
   });
-  const server = createServer(getRequestListener3(app.fetch));
+  const server = createServer2(getRequestListener3(app.fetch));
   const sockets = /* @__PURE__ */ new Set();
   server.on("connection", (socket) => {
     sockets.add(socket);
@@ -26558,7 +27552,7 @@ async function startEmbeddedDaemon(opts) {
     if (existing) {
       if (options.orchestrate && !existing.orchestrated) {
         const project2 = getProject(projectName);
-        if (project2 && existsSync36(join39(project2.dir, "ide.yml"))) {
+        if (project2 && existsSync37(join40(project2.dir, "ide.yml"))) {
           existing.stop = await orchestratorStarter(project2.name, project2.dir);
           existing.orchestrated = true;
         }
@@ -26581,7 +27575,7 @@ async function startEmbeddedDaemon(opts) {
         }
       };
     }
-    const shouldOrchestrate = options.orchestrate === true && existsSync36(join39(project.dir, "ide.yml"));
+    const shouldOrchestrate = options.orchestrate === true && existsSync37(join40(project.dir, "ide.yml"));
     const stopOrchestrator = shouldOrchestrate ? await orchestratorStarter(project.name, project.dir) : () => void 0;
     activeProjectStops.set(project.name, {
       stop: stopOrchestrator,
@@ -26906,7 +27900,7 @@ var init_cli_action_bridge = __esm({
 });
 
 // packages/daemon/src/config.ts
-import { resolve as resolve22 } from "node:path";
+import { resolve as resolve23 } from "node:path";
 function readConfigSafe(dir) {
   let cfg;
   try {
@@ -27040,7 +28034,7 @@ function configDisableTeam(dir) {
   }).config;
 }
 async function config(targetDir, { json: json2, action, args } = {}) {
-  const dir = resolve22(targetDir ?? ".");
+  const dir = resolve23(targetDir ?? ".");
   if (await tryDispatchConfigAction(dir, { json: json2, action, args: args ?? [] })) return;
   switch (action) {
     case "dump":
@@ -27375,7 +28369,8 @@ var require_package = __commonJS({
         "scripts",
         "skill",
         "templates",
-        "dashboard/dist"
+        "dashboard/dist",
+        "packages/daemon/dist"
       ],
       scripts: {
         build: "pnpm build:cli",
@@ -27479,14 +28474,14 @@ var plan_exports = {};
 __export(plan_exports, {
   planCommand: () => planCommand
 });
-import { resolve as resolve24 } from "node:path";
+import { resolve as resolve25 } from "node:path";
 async function planCommand(targetDir, {
   json: json2 = false,
   sub,
   args = [],
   values: values2 = {}
 }) {
-  const dir = resolve24(targetDir ?? ".");
+  const dir = resolve25(targetDir ?? ".");
   switch (sub) {
     case "list":
     case void 0: {
@@ -27589,11 +28584,11 @@ var skill_exports = {};
 __export(skill_exports, {
   skillCommand: () => skillCommand
 });
-import { resolve as resolve25, join as join40, dirname as dirname16 } from "node:path";
-import { existsSync as existsSync37, mkdirSync as mkdirSync24, readFileSync as readFileSync27, rmSync as rmSync5, writeFileSync as writeFileSync24 } from "node:fs";
+import { resolve as resolve26, join as join41, dirname as dirname17 } from "node:path";
+import { existsSync as existsSync38, mkdirSync as mkdirSync24, readFileSync as readFileSync27, rmSync as rmSync5, writeFileSync as writeFileSync24 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
 function scaffoldSkillContent(name) {
-  const templatePath = resolve25(
+  const templatePath = resolve26(
     __dirname4,
     "..",
     "..",
@@ -27602,7 +28597,7 @@ function scaffoldSkillContent(name) {
     "skills",
     "general-worker.md"
   );
-  if (existsSync37(templatePath)) {
+  if (existsSync38(templatePath)) {
     return readFileSync27(templatePath, "utf-8").replace(/^name: .+/m, `name: ${name}`);
   }
   return `---
@@ -27627,17 +28622,17 @@ async function tryDispatchSkillAction(dir, { json: json2, sub, args }) {
       const content = scaffoldSkillContent(name);
       const result = await tryDispatchAction("skill.create", { name, content }, { cwd: dir });
       if (!result) return false;
-      const filePath = join40(dir, ".tmux-ide", "skills", `${name}.md`);
+      const filePath = join41(dir, ".tmux-ide", "skills", `${name}.md`);
       if (json2) console.log(JSON.stringify({ created: true, path: filePath }));
       else console.log(`Created skill "${result.skill.name}" at ${filePath}`);
       return true;
     }
     if (sub === "update" && args[0] && args[1]) {
       const name = args[0];
-      const content = readFileSync27(resolve25(dir, args[1]), "utf-8");
+      const content = readFileSync27(resolve26(dir, args[1]), "utf-8");
       const result = await tryDispatchAction("skill.update", { name, content }, { cwd: dir });
       if (!result) return false;
-      const filePath = join40(dir, ".tmux-ide", "skills", `${name}.md`);
+      const filePath = join41(dir, ".tmux-ide", "skills", `${name}.md`);
       if (json2) console.log(JSON.stringify({ updated: true, path: filePath }));
       else console.log(`Updated skill "${result.skill.name}" at ${filePath}`);
       return true;
@@ -27660,7 +28655,7 @@ async function skillCommand(targetDir, {
   sub,
   args = []
 }) {
-  const dir = resolve25(targetDir ?? ".");
+  const dir = resolve26(targetDir ?? ".");
   if (await tryDispatchSkillAction(dir, { json: json2, sub, args })) return;
   switch (sub) {
     case "list": {
@@ -27710,13 +28705,13 @@ ${skill.body}`);
     case "create": {
       const name = args[0];
       if (!name) outputError("Usage: tmux-ide skill create <name>", "USAGE");
-      const skillsDir = join40(dir, ".tmux-ide", "skills");
-      const filePath = join40(skillsDir, `${name}.md`);
-      if (existsSync37(filePath)) {
+      const skillsDir = join41(dir, ".tmux-ide", "skills");
+      const filePath = join41(skillsDir, `${name}.md`);
+      if (existsSync38(filePath)) {
         outputError(`Skill "${name}" already exists at ${filePath}`, "EXISTS");
       }
       const content = scaffoldSkillContent(name);
-      if (!existsSync37(skillsDir)) mkdirSync24(skillsDir, { recursive: true });
+      if (!existsSync38(skillsDir)) mkdirSync24(skillsDir, { recursive: true });
       writeFileSync24(filePath, content);
       if (json2) {
         console.log(JSON.stringify({ created: true, path: filePath }));
@@ -27729,10 +28724,10 @@ ${skill.body}`);
       const name = args[0];
       const contentPath = args[1];
       if (!name || !contentPath) outputError("Usage: tmux-ide skill update <name> <file>", "USAGE");
-      const content = readFileSync27(resolve25(dir, contentPath), "utf-8");
-      const skillsDir = join40(dir, ".tmux-ide", "skills");
-      const filePath = join40(skillsDir, `${name}.md`);
-      if (!existsSync37(skillsDir)) mkdirSync24(skillsDir, { recursive: true });
+      const content = readFileSync27(resolve26(dir, contentPath), "utf-8");
+      const skillsDir = join41(dir, ".tmux-ide", "skills");
+      const filePath = join41(skillsDir, `${name}.md`);
+      if (!existsSync38(skillsDir)) mkdirSync24(skillsDir, { recursive: true });
       writeFileSync24(filePath, content.endsWith("\n") ? content : `${content}
 `);
       if (json2) {
@@ -27745,8 +28740,8 @@ ${skill.body}`);
     case "delete": {
       const name = args[0];
       if (!name) outputError("Usage: tmux-ide skill delete <name>", "USAGE");
-      const filePath = join40(dir, ".tmux-ide", "skills", `${name}.md`);
-      if (!existsSync37(filePath)) outputError(`Skill "${name}" not found`, "NOT_FOUND");
+      const filePath = join41(dir, ".tmux-ide", "skills", `${name}.md`);
+      if (!existsSync38(filePath)) outputError(`Skill "${name}" not found`, "NOT_FOUND");
       rmSync5(filePath);
       if (json2) {
         console.log(JSON.stringify({ deleted: true }));
@@ -27811,7 +28806,7 @@ var init_skill = __esm({
     init_skill_registry();
     init_yaml_io();
     init_cli_action_bridge();
-    __dirname4 = dirname16(fileURLToPath6(import.meta.url));
+    __dirname4 = dirname17(fileURLToPath6(import.meta.url));
   }
 });
 
@@ -27820,7 +28815,7 @@ var metrics_cli_exports = {};
 __export(metrics_cli_exports, {
   metricsCommand: () => metricsCommand
 });
-import { resolve as resolve26 } from "node:path";
+import { resolve as resolve27 } from "node:path";
 function fmtDuration(ms) {
   if (ms < 6e4) return `${Math.round(ms / 1e3)}s`;
   if (ms < 36e5) return `${Math.round(ms / 6e4)}m`;
@@ -27835,7 +28830,7 @@ async function metricsCommand(targetDir, {
   json: json2 = false,
   sub
 }) {
-  const dir = resolve26(targetDir ?? ".");
+  const dir = resolve27(targetDir ?? ".");
   switch (sub) {
     case "agents": {
       const metrics = computeMetrics(dir);
@@ -27988,18 +28983,18 @@ var dispatch_exports = {};
 __export(dispatch_exports, {
   dispatch: () => dispatch2
 });
-import { resolve as resolve27, join as join41 } from "node:path";
-import { existsSync as existsSync38, readFileSync as readFileSync28 } from "node:fs";
+import { resolve as resolve28, join as join42 } from "node:path";
+import { existsSync as existsSync39, readFileSync as readFileSync28 } from "node:fs";
 async function dispatch2(targetDir, opts) {
-  const dir = resolve27(targetDir ?? ".");
+  const dir = resolve28(targetDir ?? ".");
   const { taskId, json: json2 } = opts;
   if (!taskId) {
     throw new IdeError("Missing task ID. Usage: tmux-ide dispatch <id>", {
       code: "USAGE"
     });
   }
-  const dispatchFile = join41(dir, ".tasks", "dispatch", `${taskId}.md`);
-  const hasDispatchFile = existsSync38(dispatchFile);
+  const dispatchFile = join42(dir, ".tasks", "dispatch", `${taskId}.md`);
+  const hasDispatchFile = existsSync39(dispatchFile);
   const task = loadTask(dir, taskId);
   if (!task && !hasDispatchFile) {
     throw new IdeError(`Task "${taskId}" not found and no dispatch file exists`, {
@@ -28072,9 +29067,9 @@ var notify_exports = {};
 __export(notify_exports, {
   notify: () => notify
 });
-import { resolve as resolve28 } from "node:path";
+import { resolve as resolve29 } from "node:path";
 async function notify(targetDir, opts) {
-  const dir = resolve28(targetDir ?? ".");
+  const dir = resolve29(targetDir ?? ".");
   const { message, json: json2 } = opts;
   const { name: session } = getSessionName(dir);
   if (!message) {
@@ -28139,9 +29134,9 @@ var orchestrator_status_exports = {};
 __export(orchestrator_status_exports, {
   orchestratorStatus: () => orchestratorStatus
 });
-import { resolve as resolve29 } from "node:path";
-import { existsSync as existsSync39, readFileSync as readFileSync29 } from "node:fs";
-import { join as join42 } from "node:path";
+import { resolve as resolve30 } from "node:path";
+import { existsSync as existsSync40, readFileSync as readFileSync29 } from "node:fs";
+import { join as join43 } from "node:path";
 function formatElapsed2(ms) {
   if (ms < 6e4) return `${Math.round(ms / 1e3)}s`;
   if (ms < 36e5) return `${Math.round(ms / 6e4)}m`;
@@ -28154,7 +29149,7 @@ function formatRelative(iso) {
   return `${(ms / 36e5).toFixed(1)}h ago`;
 }
 async function orchestratorStatus(targetDir, { json: json2 } = {}) {
-  const dir = resolve29(targetDir ?? ".");
+  const dir = resolve30(targetDir ?? ".");
   const { name: session } = getSessionName(dir);
   let orchConfig = null;
   try {
@@ -28174,10 +29169,10 @@ async function orchestratorStatus(targetDir, { json: json2 } = {}) {
   }
   const state = getSessionState(session);
   const running = state.running && orchConfig?.autoDispatch !== void 0;
-  const statePath = join42(dir, ".tasks", "orchestrator-state.json");
+  const statePath = join43(dir, ".tasks", "orchestrator-state.json");
   let claimedTasks = [];
   let taskClaimTimes = {};
-  if (existsSync39(statePath)) {
+  if (existsSync40(statePath)) {
     try {
       const data2 = JSON.parse(readFileSync29(statePath, "utf-8"));
       claimedTasks = data2.claimedTasks ?? [];
@@ -28311,7 +29306,7 @@ var tunnel_exports = {};
 __export(tunnel_exports, {
   tunnelCommand: () => tunnelCommand
 });
-import { resolve as resolve30 } from "node:path";
+import { resolve as resolve31 } from "node:path";
 function getManager(dir, session) {
   if (!manager) {
     manager = new TunnelManager({ session, dir });
@@ -28346,7 +29341,7 @@ async function resolveTunnelConfig(dir, overrides) {
   );
 }
 async function tunnelCommand(targetDir, opts) {
-  const dir = resolve30(targetDir ?? ".");
+  const dir = resolve31(targetDir ?? ".");
   const { json: json2, sub } = opts;
   const session = await resolveSession();
   const mgr = getManager(dir, session);
@@ -28421,454 +29416,6 @@ var init_tunnel = __esm({
     init_manager();
     init_types3();
     manager = null;
-  }
-});
-
-// packages/daemon/src/ssh-remote.ts
-var ssh_remote_exports = {};
-__export(ssh_remote_exports, {
-  buildRemoteServeScript: () => buildRemoteServeScript,
-  buildSshForwardArgs: () => buildSshForwardArgs,
-  parseSshConfigHosts: () => parseSshConfigHosts,
-  remoteServeCommand: () => remoteServeCommand,
-  shellQuote: () => shellQuote,
-  sshRemoteCommand: () => sshRemoteCommand,
-  validateRemoteName: () => validateRemoteName,
-  validateRemotePath: () => validateRemotePath,
-  validateSshAlias: () => validateSshAlias
-});
-import { spawn as spawn10, execFile as execFile7 } from "node:child_process";
-import { mkdir as mkdir2, readFile as readFile3, writeFile as writeFile2, chmod } from "node:fs/promises";
-import { existsSync as existsSync40 } from "node:fs";
-import { homedir as homedir14 } from "node:os";
-import { dirname as dirname17, join as join43, resolve as resolve31 } from "node:path";
-import { promisify as promisify3 } from "node:util";
-import { createServer as createServer2 } from "node:net";
-function remotesFilePath() {
-  return process.env.TMUX_IDE_SSH_REMOTES_FILE ?? join43(homedir14(), ".tmux-ide", "ssh-remotes.json");
-}
-function sshConfigPath() {
-  return process.env.TMUX_IDE_SSH_CONFIG ?? join43(homedir14(), ".ssh", "config");
-}
-function emptyStore() {
-  return { version: 1, remotes: [] };
-}
-async function readStore() {
-  const file = remotesFilePath();
-  if (!existsSync40(file)) return emptyStore();
-  try {
-    const parsed = JSON.parse(await readFile3(file, "utf-8"));
-    if (parsed.version !== 1 || !Array.isArray(parsed.remotes)) return emptyStore();
-    return {
-      version: 1,
-      remotes: parsed.remotes.filter(isSshRemote)
-    };
-  } catch {
-    return emptyStore();
-  }
-}
-async function writeStore(store) {
-  const file = remotesFilePath();
-  await mkdir2(dirname17(file), { recursive: true, mode: 448 });
-  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
-  await writeFile2(tmp, JSON.stringify(store, null, 2) + "\n", { encoding: "utf-8", mode: 384 });
-  await chmod(tmp, 384);
-  await import("node:fs/promises").then(({ rename: rename2 }) => rename2(tmp, file));
-}
-function isSshRemote(value) {
-  if (!value || typeof value !== "object") return false;
-  const remote = value;
-  if (typeof remote.name !== "string") return false;
-  if (typeof remote.host !== "string") return false;
-  if (typeof remote.path !== "string") return false;
-  if (typeof remote.addedAt !== "string") return false;
-  if (remote.localPort !== void 0 && !isValidPort(remote.localPort)) return false;
-  if (remote.remotePort !== void 0 && !isValidPort(remote.remotePort)) return false;
-  return true;
-}
-function isValidPort(port) {
-  return Number.isInteger(port) && port >= 1 && port <= 65535;
-}
-function parsePort(value, label) {
-  if (value === void 0 || value === false) return void 0;
-  if (value === true || value.trim() === "") {
-    throw new IdeError(`${label} requires a numeric value`, { code: "USAGE" });
-  }
-  const port = Number(value);
-  if (!isValidPort(port)) {
-    throw new IdeError(`${label} must be an integer from 1 to 65535`, { code: "USAGE" });
-  }
-  return port;
-}
-function parseSshConfigHosts(contents) {
-  const hosts = /* @__PURE__ */ new Set();
-  for (const rawLine of contents.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith("#")) continue;
-    const match = line.match(/^Host\s+(.+)$/i);
-    if (!match) continue;
-    for (const host of match[1].split(/\s+/)) {
-      if (!host || host.includes("*") || host.includes("?") || host.startsWith("!")) continue;
-      hosts.add(host);
-    }
-  }
-  return [...hosts].sort((a, b) => a.localeCompare(b));
-}
-function validateRemoteName(name) {
-  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(name)) {
-    throw new IdeError(
-      "Remote name must start with a letter or number and contain only letters, numbers, dot, underscore, or dash.",
-      { code: "USAGE" }
-    );
-  }
-}
-function validateSshAlias(host) {
-  if (!/^[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}$/.test(host)) {
-    throw new IdeError(
-      "SSH host must be a config alias or host string without whitespace or shell metacharacters.",
-      { code: "USAGE" }
-    );
-  }
-  if (host.startsWith("-")) {
-    throw new IdeError("SSH host cannot start with '-'", { code: "USAGE" });
-  }
-}
-function validateRemotePath(path4) {
-  if (!path4 || /[\0\r\n]/.test(path4)) {
-    throw new IdeError("Remote path must be a single non-empty path.", { code: "USAGE" });
-  }
-}
-function shellQuote(value) {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-function buildRemoteServeScript(remotePath, remotePort) {
-  validateRemotePath(remotePath);
-  if (!isValidPort(remotePort)) {
-    throw new IdeError("Remote port must be an integer from 1 to 65535", { code: "USAGE" });
-  }
-  const quotedPath = shellQuote(remotePath);
-  return [
-    `cd ${quotedPath}`,
-    "mkdir -p .tmux-ide",
-    'if ! command -v tmux-ide >/dev/null 2>&1; then echo "tmux-ide not found on remote PATH" >&2; exit 127; fi',
-    `nohup tmux-ide __remote-serve --port ${remotePort} > .tmux-ide/remote-daemon.log 2>&1 < /dev/null &`
-  ].join(" && ");
-}
-function buildSshForwardArgs(opts) {
-  validateSshAlias(opts.host);
-  if (!isValidPort(opts.localPort) || !isValidPort(opts.remotePort)) {
-    throw new IdeError("SSH tunnel ports must be integers from 1 to 65535", { code: "USAGE" });
-  }
-  return [
-    "-N",
-    "-L",
-    `${DEFAULT_LOCAL_HOST}:${opts.localPort}:127.0.0.1:${opts.remotePort}`,
-    "-o",
-    "ExitOnForwardFailure=yes",
-    "-o",
-    "ServerAliveInterval=15",
-    opts.host
-  ];
-}
-async function pickFreeLocalPort() {
-  const server = createServer2();
-  return await new Promise((resolvePort2, reject) => {
-    server.once("error", reject);
-    server.listen(0, DEFAULT_LOCAL_HOST, () => {
-      const address = server.address();
-      const port = typeof address === "object" && address ? address.port : null;
-      server.close(() => {
-        if (port) resolvePort2(port);
-        else reject(new IdeError("Could not allocate a local tunnel port", { code: "PORT_ERROR" }));
-      });
-    });
-  });
-}
-async function assertLocalPortFree(port) {
-  const server = createServer2();
-  await new Promise((resolvePort2, reject) => {
-    server.once(
-      "error",
-      () => reject(new IdeError(`Local port ${port} is already in use`, { code: "PORT_IN_USE" }))
-    );
-    server.listen(port, DEFAULT_LOCAL_HOST, () => {
-      server.close(() => resolvePort2());
-    });
-  });
-}
-function openInBrowser2(url) {
-  const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-  try {
-    const child = spawn10(cmd, [url], { detached: true, stdio: "ignore" });
-    child.unref();
-  } catch {
-  }
-}
-async function waitForHealth(url, timeoutMs = 15e3) {
-  const deadline = Date.now() + timeoutMs;
-  let lastError = "";
-  while (Date.now() < deadline) {
-    try {
-      const controller = new AbortController();
-      setTimeout(() => controller.abort(), 750).unref?.();
-      const res = await fetch(`${url}healthz`, { signal: controller.signal });
-      if (res.ok) return;
-      lastError = `HTTP ${res.status}`;
-    } catch (err) {
-      lastError = err instanceof Error ? err.message : String(err);
-    }
-    await new Promise((resolveTimer) => setTimeout(resolveTimer, 250));
-  }
-  throw new IdeError(
-    `Remote dashboard did not become healthy through the SSH tunnel: ${lastError}`,
-    {
-      code: "REMOTE_UNHEALTHY"
-    }
-  );
-}
-async function runRemoteServe(remote, remotePort) {
-  const script = buildRemoteServeScript(remote.path, remotePort);
-  try {
-    await execFileAsync2("ssh", [remote.host, script], { timeout: 1e4 });
-  } catch (err) {
-    const stderr = err instanceof Error && "stderr" in err && typeof err.stderr === "string" ? err.stderr.trim() : "";
-    throw new IdeError(`Failed to start tmux-ide on ${remote.host}${stderr ? `: ${stderr}` : ""}`, {
-      code: "SSH_REMOTE_START_FAILED"
-    });
-  }
-}
-async function startTunnel(remote, localPort, remotePort) {
-  const args = buildSshForwardArgs({ host: remote.host, localPort, remotePort });
-  const child = spawn10("ssh", args, { detached: true, stdio: "ignore" });
-  child.unref();
-  await new Promise((resolveStart, reject) => {
-    const timer = setTimeout(resolveStart, 500);
-    child.once("exit", (code, signal) => {
-      clearTimeout(timer);
-      reject(
-        new IdeError(
-          `SSH tunnel exited before it was ready (${signal ?? `code ${code ?? "unknown"}`})`,
-          { code: "SSH_TUNNEL_FAILED" }
-        )
-      );
-    });
-    child.once("error", (err) => {
-      clearTimeout(timer);
-      reject(
-        new IdeError(`Failed to start ssh tunnel: ${err.message}`, { code: "SSH_TUNNEL_FAILED" })
-      );
-    });
-  });
-  return {
-    pid: child.pid ?? 0,
-    stop: () => {
-      if (!child.pid) return;
-      try {
-        process.kill(-child.pid, "SIGTERM");
-      } catch {
-        try {
-          child.kill("SIGTERM");
-        } catch {
-        }
-      }
-    }
-  };
-}
-function printRemotes(remotes) {
-  if (remotes.length === 0) {
-    console.log("No SSH remotes configured");
-    return;
-  }
-  for (const remote of remotes) {
-    const local = remote.localPort ? ` local:${remote.localPort}` : "";
-    const remotePort = remote.remotePort ? ` remote:${remote.remotePort}` : "";
-    console.log(`  ${remote.name} \u2014 ${remote.host}:${remote.path}${local}${remotePort}`);
-  }
-}
-async function listHosts(json2) {
-  const file = sshConfigPath();
-  const hosts = existsSync40(file) ? parseSshConfigHosts(await readFile3(file, "utf-8")) : [];
-  if (json2) {
-    console.log(JSON.stringify({ hosts }));
-  } else if (hosts.length === 0) {
-    console.log("No concrete SSH hosts found");
-  } else {
-    for (const host of hosts) console.log(host);
-  }
-}
-async function addRemote(opts) {
-  const name = opts.args?.[0];
-  const host = opts.values?.host;
-  const path4 = opts.values?.path;
-  if (!name || typeof host !== "string" || typeof path4 !== "string") {
-    throw new IdeError(
-      "Usage: tmux-ide remote ssh add <name> --host <ssh-host> --path <remote-project-dir> [--local-port N] [--remote-port N]",
-      { code: "USAGE" }
-    );
-  }
-  validateRemoteName(name);
-  validateSshAlias(host);
-  validateRemotePath(path4);
-  const localPort = parsePort(opts.values?.["local-port"], "--local-port");
-  const remotePort = parsePort(opts.values?.["remote-port"], "--remote-port");
-  const store = await readStore();
-  const next = {
-    name,
-    host,
-    path: path4,
-    localPort,
-    remotePort,
-    addedAt: (/* @__PURE__ */ new Date()).toISOString()
-  };
-  const index = store.remotes.findIndex((remote) => remote.name === name);
-  if (index >= 0) store.remotes[index] = next;
-  else store.remotes.push(next);
-  await writeStore(store);
-  if (opts.json) console.log(JSON.stringify({ ok: true, remote: next }));
-  else console.log(`Saved SSH remote ${name} (${host}:${path4})`);
-}
-async function removeRemote(opts) {
-  const name = opts.args?.[0];
-  if (!name) {
-    throw new IdeError("Usage: tmux-ide remote ssh remove <name>", { code: "USAGE" });
-  }
-  const store = await readStore();
-  const before = store.remotes.length;
-  store.remotes = store.remotes.filter((remote) => remote.name !== name);
-  await writeStore(store);
-  const removed = store.remotes.length !== before;
-  if (opts.json) console.log(JSON.stringify({ ok: true, removed }));
-  else
-    console.log(removed ? `Removed SSH remote ${name}` : `SSH remote ${name} was not configured`);
-}
-async function getConfiguredRemote(name) {
-  if (!name) {
-    throw new IdeError("Usage: tmux-ide remote ssh launch <name>", { code: "USAGE" });
-  }
-  validateRemoteName(name);
-  const store = await readStore();
-  const remote = store.remotes.find((candidate) => candidate.name === name);
-  if (!remote) {
-    throw new IdeError(`SSH remote ${name} is not configured`, { code: "REMOTE_NOT_FOUND" });
-  }
-  return remote;
-}
-async function launchRemote(opts) {
-  const remote = await getConfiguredRemote(opts.args?.[0]);
-  const remotePort = remote.remotePort ?? DEFAULT_REMOTE_PORT;
-  const localPort = remote.localPort ?? await pickFreeLocalPort();
-  if (remote.localPort) await assertLocalPortFree(localPort);
-  await runRemoteServe(remote, remotePort);
-  const tunnel = await startTunnel(remote, localPort, remotePort);
-  const url = `http://${DEFAULT_LOCAL_HOST}:${localPort}/`;
-  try {
-    await waitForHealth(url);
-  } catch (err) {
-    tunnel.stop();
-    throw err;
-  }
-  if (opts.json) {
-    console.log(
-      JSON.stringify({ ok: true, url, localPort, remotePort, tunnelPid: tunnel.pid, remote })
-    );
-  } else {
-    console.log(`Dashboard: ${url}`);
-    console.log(`Tunnel: ${remote.host} 127.0.0.1:${localPort} -> 127.0.0.1:${remotePort}`);
-  }
-  if (opts.values?.["no-open"] !== true) openInBrowser2(url);
-}
-async function statusRemote(opts) {
-  const remote = await getConfiguredRemote(opts.args?.[0]);
-  const localPort = remote.localPort;
-  const url = localPort ? `http://${DEFAULT_LOCAL_HOST}:${localPort}/` : null;
-  let healthy = false;
-  if (url) {
-    try {
-      const res = await fetch(`${url}healthz`);
-      healthy = res.ok;
-    } catch {
-      healthy = false;
-    }
-  }
-  if (opts.json) {
-    console.log(JSON.stringify({ remote, url, healthy }));
-  } else {
-    console.log(`Remote: ${remote.name}`);
-    console.log(`SSH host: ${remote.host}`);
-    console.log(`Path: ${remote.path}`);
-    console.log(`Remote daemon bind: 127.0.0.1:${remote.remotePort ?? DEFAULT_REMOTE_PORT}`);
-    if (url) console.log(`Local URL: ${url} (${healthy ? "healthy" : "not reachable"})`);
-    else console.log("Local URL: dynamic; run launch to allocate a tunnel port");
-  }
-}
-async function sshRemoteCommand(opts) {
-  const sub = opts.args?.[0];
-  const args = opts.args?.slice(1) ?? [];
-  switch (sub) {
-    case "hosts":
-      await listHosts(opts.json);
-      break;
-    case "list": {
-      const store = await readStore();
-      if (opts.json) console.log(JSON.stringify({ remotes: store.remotes }));
-      else printRemotes(store.remotes);
-      break;
-    }
-    case "add":
-      await addRemote({ ...opts, args });
-      break;
-    case "remove":
-      await removeRemote({ ...opts, args });
-      break;
-    case "launch":
-    case "dashboard":
-      await launchRemote({ ...opts, args });
-      break;
-    case "status":
-      await statusRemote({ ...opts, args });
-      break;
-    default:
-      throw new IdeError(
-        "Usage: tmux-ide remote ssh hosts|list|add|remove|launch|dashboard|status",
-        { code: "USAGE" }
-      );
-  }
-}
-async function remoteServeCommand(opts) {
-  const port = parsePort(opts.port, "--port") ?? DEFAULT_REMOTE_PORT;
-  const dir = resolve31(".");
-  const { readConfig: readConfig2, getSessionName: getSessionName2 } = await Promise.resolve().then(() => (init_yaml_io(), yaml_io_exports));
-  const { launch: launch2 } = await Promise.resolve().then(() => (init_launch(), launch_exports));
-  const { startEmbeddedDaemon: startEmbeddedDaemon2 } = await Promise.resolve().then(() => (init_daemon_embed(), daemon_embed_exports));
-  const { readCanonicalDaemonInfo: readCanonicalDaemonInfo2, isCanonicalDaemonAlive: isCanonicalDaemonAlive2 } = await Promise.resolve().then(() => (init_canonical_daemon(), canonical_daemon_exports));
-  const existing = readCanonicalDaemonInfo2();
-  if (existing && existing.port === port && existing.bindHostname === "127.0.0.1") {
-    if (await isCanonicalDaemonAlive2(existing)) return;
-  }
-  const { config: config2 } = readConfig2(dir);
-  const { name: fallbackName } = getSessionName2(dir);
-  const sessionName = config2.name ?? fallbackName;
-  await launch2(dir, { attach: false });
-  const handle = await startEmbeddedDaemon2({
-    sessionName,
-    port,
-    bindHostname: "127.0.0.1"
-  });
-  const stop2 = async () => {
-    await handle.stop({ gracefulMs: 500 });
-  };
-  process.once("SIGINT", () => void stop2().finally(() => process.exit(0)));
-  process.once("SIGTERM", () => void stop2().finally(() => process.exit(0)));
-  await new Promise(() => void 0);
-}
-var execFileAsync2, DEFAULT_REMOTE_PORT, DEFAULT_LOCAL_HOST;
-var init_ssh_remote = __esm({
-  "packages/daemon/src/ssh-remote.ts"() {
-    "use strict";
-    init_errors2();
-    execFileAsync2 = promisify3(execFile7);
-    DEFAULT_REMOTE_PORT = 6060;
-    DEFAULT_LOCAL_HOST = "127.0.0.1";
   }
 });
 
@@ -29010,6 +29557,385 @@ var init_remote = __esm({
   }
 });
 
+// packages/daemon/src/agent-hook.ts
+var agent_hook_exports = {};
+__export(agent_hook_exports, {
+  agentCommand: () => agentCommand,
+  buildHookSnippet: () => buildHookSnippet,
+  buildPayload: () => buildPayload,
+  buildReportRequest: () => buildReportRequest,
+  hostnameForClient: () => hostnameForClient2,
+  mergeHooks: () => mergeHooks
+});
+import { readFileSync as readFileSync30, mkdirSync as mkdirSync25, renameSync as renameSync19, existsSync as existsSync41, writeFileSync as writeFileSync25 } from "node:fs";
+import { homedir as homedir15 } from "node:os";
+import { basename as basename10, dirname as dirname18, join as join44 } from "node:path";
+function parseStdin(raw) {
+  if (!raw.trim()) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") return parsed;
+  } catch {
+  }
+  return {};
+}
+function reportingTool() {
+  return process.env.TMUX_IDE_AGENT_TOOL === "codex" ? "codex" : "claude";
+}
+function buildPayload(event, stdin) {
+  const id = typeof stdin.session_id === "string" ? stdin.session_id.trim() : "";
+  if (!id) return null;
+  if (event === "stop") {
+    return { id };
+  }
+  if (event === "idle") {
+    return { id, status: "idle" };
+  }
+  const tool = reportingTool();
+  const cwd = typeof stdin.cwd === "string" && stdin.cwd ? stdin.cwd : void 0;
+  const name = cwd ? `${tool}@${basename10(cwd)}` : tool;
+  return {
+    id,
+    tool,
+    name,
+    cwd,
+    session: id,
+    pid: typeof process.ppid === "number" ? process.ppid : void 0,
+    status: "busy"
+  };
+}
+function timeoutSignal4(ms) {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms).unref?.();
+  return controller.signal;
+}
+function hostnameForClient2(bindHostname) {
+  return bindHostname === "0.0.0.0" ? "127.0.0.1" : bindHostname;
+}
+function buildReportRequest(info, action) {
+  const baseUrl = `http://${hostnameForClient2(info.bindHostname)}:${info.port}`;
+  const headers = { "Content-Type": "application/json" };
+  if (info.authToken) headers.Authorization = `Bearer ${info.authToken}`;
+  return { url: `${baseUrl}/api/v2/action/${action}`, headers };
+}
+async function report(event) {
+  if (process.env.TMUX) return;
+  let raw;
+  try {
+    raw = readFileSync30(0, "utf-8");
+  } catch {
+    return;
+  }
+  if (raw.length > 256 * 1024) return;
+  const stdin = parseStdin(raw);
+  const payload = buildPayload(event, stdin);
+  if (!payload) return;
+  const info = readCanonicalDaemonInfo();
+  if (!info) return;
+  const { url, headers } = buildReportRequest(info, EVENT_TO_ACTION[event]);
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+      signal: timeoutSignal4(1500)
+    });
+  } catch {
+  }
+}
+function settingsPath() {
+  return process.env.CLAUDE_CONFIG_DIR ? join44(process.env.CLAUDE_CONFIG_DIR, "settings.json") : join44(homedir15(), ".claude", "settings.json");
+}
+function buildHookSnippet() {
+  const snippet = {};
+  for (const [hookName, event] of Object.entries(HOOK_EVENTS)) {
+    snippet[hookName] = [
+      { hooks: [{ type: "command", command: `tmux-ide agent report ${event}` }] }
+    ];
+  }
+  return snippet;
+}
+function isOurHookEntry(entry) {
+  return entry.type === "command" && /\btmux-ide agent report\b/.test(entry.command);
+}
+function mergeHooks(existing, snippet) {
+  const merged = { ...existing ?? {} };
+  for (const [hookName, matchers] of Object.entries(snippet)) {
+    const current = Array.isArray(merged[hookName]) ? merged[hookName] : [];
+    const cleaned = current.map((matcher) => ({
+      ...matcher,
+      hooks: (matcher.hooks ?? []).filter((entry) => !isOurHookEntry(entry))
+    })).filter((matcher) => matcher.hooks.length > 0);
+    merged[hookName] = [...cleaned, ...matchers];
+  }
+  return merged;
+}
+async function installHooks(opts) {
+  const snippet = buildHookSnippet();
+  if (opts.print) {
+    console.log(JSON.stringify({ hooks: snippet }, null, 2));
+    return;
+  }
+  const path4 = settingsPath();
+  let settings = {};
+  if (existsSync41(path4)) {
+    try {
+      settings = JSON.parse(readFileSync30(path4, "utf-8"));
+    } catch {
+      throw new Error(
+        `Could not parse ${path4}. Fix the JSON or run "tmux-ide agent hook install --print" and merge manually.`
+      );
+    }
+  }
+  const existingHooks = settings.hooks && typeof settings.hooks === "object" ? settings.hooks : void 0;
+  settings.hooks = mergeHooks(existingHooks, snippet);
+  mkdirSync25(dirname18(path4), { recursive: true });
+  const tmp = `${path4}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync25(tmp, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+  renameSync19(tmp, path4);
+  if (opts.json) {
+    console.log(JSON.stringify({ ok: true, path: path4, events: Object.keys(snippet) }));
+  } else {
+    console.log(`Installed tmux-ide agent hooks into ${path4}`);
+    console.log(`Events: ${Object.keys(snippet).join(", ")}`);
+    console.log("Restart your Claude Code sessions for the hooks to take effect.");
+  }
+}
+async function agentCommand(opts) {
+  const sub = opts.sub;
+  if (sub === "report") {
+    const event = opts.args?.[0];
+    if (event === "start" || event === "activity" || event === "idle" || event === "stop") {
+      try {
+        await report(event);
+      } catch {
+      }
+    }
+    process.exit(0);
+  }
+  if (sub === "hook") {
+    const hookSub = opts.args?.[0];
+    if (hookSub === "install") {
+      await installHooks({ print: opts.print, json: opts.json });
+      return;
+    }
+    throw new Error("Usage: tmux-ide agent hook install [--print]");
+  }
+  throw new Error(
+    "Usage:\n  tmux-ide agent report <start|activity|idle|stop>\n  tmux-ide agent hook install [--print]"
+  );
+}
+var EVENT_TO_ACTION, HOOK_EVENTS;
+var init_agent_hook = __esm({
+  "packages/daemon/src/agent-hook.ts"() {
+    "use strict";
+    init_canonical_daemon();
+    EVENT_TO_ACTION = {
+      // start/activity re-register (register is an idempotent upsert) so a session
+      // evicted after a long idle reappears on its next prompt or tool call.
+      // idle is a lightweight status-only heartbeat fired when a turn ends — the
+      // agent stays on the roster (just not "busy"), instead of vanishing between
+      // turns. stop is the real teardown (session exit).
+      start: "agent.register",
+      activity: "agent.register",
+      idle: "agent.heartbeat",
+      stop: "agent.unregister"
+    };
+    HOOK_EVENTS = {
+      SessionStart: "start",
+      UserPromptSubmit: "activity",
+      PreToolUse: "activity",
+      Stop: "idle",
+      SessionEnd: "stop"
+    };
+  }
+});
+
+// packages/daemon/src/agents-cli.ts
+var agents_cli_exports = {};
+__export(agents_cli_exports, {
+  agentsCommand: () => agentsCommand,
+  findAgentById: () => findAgentById,
+  formatAgentLine: () => formatAgentLine,
+  formatAgentList: () => formatAgentList,
+  groupAgentsByMachine: () => groupAgentsByMachine,
+  resolveSendTarget: () => resolveSendTarget
+});
+function findAgentById(agents, id) {
+  return agents.find((agent) => agent.id === id);
+}
+function resolveSendTarget(agents, id) {
+  const agent = findAgentById(agents, id);
+  if (!agent) {
+    throw new IdeError(`Agent not found: ${id}. Run \`tmux-ide agents\` to list agent ids.`, {
+      code: "AGENT_NOT_FOUND",
+      exitCode: 1
+    });
+  }
+  return { agent, machineId: agent.machineId };
+}
+function groupAgentsByMachine(agents) {
+  const groups = /* @__PURE__ */ new Map();
+  for (const agent of agents) {
+    const key = agent.machineId ?? "";
+    let group = groups.get(key);
+    if (!group) {
+      group = { machineId: agent.machineId, machineName: agent.machineName, agents: [] };
+      groups.set(key, group);
+    }
+    group.agents.push(agent);
+  }
+  const ordered = [...groups.values()];
+  ordered.sort((a, b) => Number(a.machineId !== null) - Number(b.machineId !== null));
+  return ordered;
+}
+function formatAgentLine(agent) {
+  const location = agent.session && agent.paneId ? `${agent.session}\xB7${agent.paneId}` : agent.cwd ?? "";
+  const parts = [`${STATUS_GLYPHS[agent.status]} ${agent.name}`, agent.tool, agent.kind];
+  if (location) parts.push(location);
+  if (agent.taskTitle) parts.push(`\u2014 ${agent.taskTitle}`);
+  parts.push(`[${agent.id}]`);
+  return `  ${parts.join("  ")}`;
+}
+function formatAgentList(agents) {
+  if (agents.length === 0) {
+    return "No agents found.";
+  }
+  const lines = [];
+  for (const group of groupAgentsByMachine(agents)) {
+    const label = group.machineId === null ? group.machineName ? `${group.machineName} (this machine)` : "this machine" : group.machineName ?? group.machineId;
+    lines.push(label);
+    for (const agent of group.agents) {
+      lines.push(formatAgentLine(agent));
+    }
+  }
+  return lines.join("\n");
+}
+function requireDaemonInfo() {
+  const info = readCanonicalDaemonInfo();
+  if (!info) {
+    throw new IdeError(NO_DAEMON_MESSAGE, { code: "DAEMON_UNAVAILABLE", exitCode: 1 });
+  }
+  return info;
+}
+function daemonRequest(info, path4) {
+  const url = `http://${hostnameForClient2(info.bindHostname)}:${info.port}${path4}`;
+  const headers = { "Content-Type": "application/json" };
+  if (info.authToken) headers.Authorization = `Bearer ${info.authToken}`;
+  return { url, headers };
+}
+function timeoutSignal5(ms) {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms).unref?.();
+  return controller.signal;
+}
+async function fetchAgentList(info) {
+  const { url, headers } = daemonRequest(info, "/api/hq/agents");
+  let res;
+  try {
+    res = await fetch(url, { headers, signal: timeoutSignal5(15e3) });
+  } catch {
+    throw new IdeError(NO_DAEMON_MESSAGE, { code: "DAEMON_UNAVAILABLE", exitCode: 1 });
+  }
+  if (!res.ok) {
+    throw new IdeError(`Daemon replied ${res.status} to GET /api/hq/agents`, {
+      code: "DAEMON_ERROR",
+      exitCode: 1
+    });
+  }
+  const raw = await res.json();
+  const parsed = AgentListSchemaZ.safeParse(raw);
+  if (!parsed.success) {
+    throw new IdeError("Daemon returned an unexpected /api/hq/agents payload", {
+      code: "DAEMON_ERROR",
+      exitCode: 1
+    });
+  }
+  return { agents: parsed.data.agents, raw };
+}
+async function listAgents(opts) {
+  const info = requireDaemonInfo();
+  const { agents, raw } = await fetchAgentList(info);
+  if (opts.json) {
+    console.log(JSON.stringify(raw));
+    return;
+  }
+  console.log(formatAgentList(agents));
+}
+async function sendToAgent(opts) {
+  const info = requireDaemonInfo();
+  const { agents } = await fetchAgentList(info);
+  const { agent, machineId } = resolveSendTarget(agents, opts.id);
+  const { url, headers } = daemonRequest(info, "/api/agents/send");
+  let res;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        id: opts.id,
+        machineId,
+        message: opts.message,
+        noEnter: opts.noEnter ? true : void 0
+      }),
+      signal: timeoutSignal5(15e3)
+    });
+  } catch {
+    throw new IdeError(NO_DAEMON_MESSAGE, { code: "DAEMON_UNAVAILABLE", exitCode: 1 });
+  }
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const detail = typeof body.error === "string" ? body.error : `HTTP ${res.status}`;
+    const code = res.status === 409 ? "AGENT_OBSERVE_ONLY" : "SEND_FAILED";
+    throw new IdeError(`Send failed: ${detail}`, { code, exitCode: 1 });
+  }
+  if (opts.json) {
+    console.log(JSON.stringify(body));
+    return;
+  }
+  const where = machineId === null ? "this machine" : agent.machineName ?? machineId;
+  console.log(`Sent to ${agent.name} [${agent.id}] on ${where}.`);
+}
+async function agentsCommand(opts) {
+  const sub = opts.sub;
+  if (sub === void 0 || sub === "list") {
+    await listAgents({ json: opts.json });
+    return;
+  }
+  if (sub === "send") {
+    const [id, ...messageParts] = opts.args ?? [];
+    const message = messageParts.join(" ");
+    if (!id || !message) {
+      throw new IdeError(
+        "Usage: tmux-ide agents send <agent-id> <message...> [--no-enter]\nRun `tmux-ide agents` to list agent ids.",
+        { code: "USAGE", exitCode: 1 }
+      );
+    }
+    await sendToAgent({ id, message, noEnter: opts.noEnter, json: opts.json });
+    return;
+  }
+  throw new IdeError(
+    "Usage:\n  tmux-ide agents [list] [--json]\n  tmux-ide agents send <agent-id> <message...> [--no-enter] [--json]\n(For the plain-terminal hook reporter, see `tmux-ide agent`.)",
+    { code: "USAGE", exitCode: 1 }
+  );
+}
+var NO_DAEMON_MESSAGE, STATUS_GLYPHS;
+var init_agents_cli = __esm({
+  "packages/daemon/src/agents-cli.ts"() {
+    "use strict";
+    init_src2();
+    init_agent_hook();
+    init_canonical_daemon();
+    init_errors2();
+    NO_DAEMON_MESSAGE = "No tmux-ide daemon running \u2014 start one with `tmux-ide`";
+    STATUS_GLYPHS = {
+      busy: "\u25CF",
+      idle: "\u25CB",
+      offline: "\u25CC"
+    };
+  }
+});
+
 // packages/daemon/src/command-center/index.ts
 var command_center_exports = {};
 __export(command_center_exports, {
@@ -29019,7 +29945,7 @@ import { createServer as createServer3 } from "node:http";
 import { getRequestListener } from "@hono/node-server";
 async function startCommandCenter(options = {}) {
   const port = options.port ?? 6060;
-  const hostname2 = options.hostname ?? "0.0.0.0";
+  const hostname3 = options.hostname ?? "0.0.0.0";
   const appOpts = {};
   if (options.authService) appOpts.authService = options.authService;
   if (options.authConfig) appOpts.authConfig = options.authConfig;
@@ -29027,8 +29953,8 @@ async function startCommandCenter(options = {}) {
   const listener = getRequestListener(app.fetch);
   const server = createServer3(listener);
   return new Promise((resolve35) => {
-    server.listen(port, hostname2, () => {
-      console.log(`Command Center API on http://${hostname2}:${port}`);
+    server.listen(port, hostname3, () => {
+      console.log(`Command Center API on http://${hostname3}:${port}`);
       resolve35(server);
     });
   });
@@ -29527,9 +30453,9 @@ var init_checkpoint = __esm({
 // bin/cli.ts
 init_launch();
 import { parseArgs } from "node:util";
-import { resolve as resolve34, dirname as dirname18 } from "node:path";
+import { resolve as resolve34, dirname as dirname19 } from "node:path";
 import { execFileSync as execFileSync9 } from "node:child_process";
-import { existsSync as existsSync41 } from "node:fs";
+import { existsSync as existsSync42 } from "node:fs";
 import { fileURLToPath as fileURLToPath7 } from "node:url";
 
 // packages/daemon/src/init.ts
@@ -30155,7 +31081,7 @@ init_src();
 init_pane_comms();
 init_research();
 init_cli_action_bridge();
-import { resolve as resolve23 } from "node:path";
+import { resolve as resolve24 } from "node:path";
 function splitList(raw) {
   return raw?.split(",").map((value) => value.trim()).filter(Boolean);
 }
@@ -30396,7 +31322,7 @@ async function taskCommand(targetDir, {
   args = [],
   values: values2 = {}
 }) {
-  const dir = resolve23(targetDir ?? ".");
+  const dir = resolve24(targetDir ?? ".");
   if (await tryDispatchTaskAction(dir, { json: json2, action, sub, args, values: values2 })) return;
   switch (action) {
     case "mission":
@@ -30822,7 +31748,7 @@ function handleValidation(dir, sub, args, values2, json2) {
         break;
       }
       const entries = Object.values(state.assertions);
-      const report = {
+      const report2 = {
         total: entries.length,
         passing: entries.filter((e) => e.status === "passing").length,
         failing: entries.filter((e) => e.status === "failing").length,
@@ -30830,13 +31756,13 @@ function handleValidation(dir, sub, args, values2, json2) {
         blocked: entries.filter((e) => e.status === "blocked").length
       };
       if (json2) {
-        console.log(JSON.stringify(report, null, 2));
+        console.log(JSON.stringify(report2, null, 2));
       } else {
-        console.log(`Validation Report: ${report.total} assertions`);
-        console.log(`  Passing: ${report.passing}`);
-        console.log(`  Failing: ${report.failing}`);
-        console.log(`  Pending: ${report.pending}`);
-        if (report.blocked > 0) console.log(`  Blocked: ${report.blocked}`);
+        console.log(`Validation Report: ${report2.total} assertions`);
+        console.log(`  Passing: ${report2.passing}`);
+        console.log(`  Failing: ${report2.failing}`);
+        console.log(`  Pending: ${report2.pending}`);
+        if (report2.blocked > 0) console.log(`  Blocked: ${report2.blocked}`);
       }
       break;
     }
@@ -31264,12 +32190,12 @@ init_send();
 // packages/daemon/src/dashboard.ts
 init_canonical_daemon();
 init_errors2();
-import { spawn as spawn9 } from "node:child_process";
-function openInBrowser(url) {
+import { spawn as spawn10 } from "node:child_process";
+function openInBrowser2(url) {
   const platform = process.platform;
   const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
   try {
-    const child = spawn9(cmd, [url], { stdio: "ignore", detached: true });
+    const child = spawn10(cmd, [url], { stdio: "ignore", detached: true });
     child.unref();
   } catch {
   }
@@ -31290,14 +32216,14 @@ async function dashboard(opts = {}) {
 `);
   }
   if (opts.open !== false) {
-    openInBrowser(url);
+    openInBrowser2(url);
   }
 }
 
 // bin/cli.ts
 init_errors2();
 init_output();
-var __dirname5 = dirname18(fileURLToPath7(import.meta.url));
+var __dirname5 = dirname19(fileURLToPath7(import.meta.url));
 var { positionals, values } = parseArgs({
   allowPositionals: true,
   strict: false,
@@ -31354,6 +32280,8 @@ var { positionals, values } = parseArgs({
     // dashboard command flags
     open: { type: "boolean" },
     "no-open": { type: "boolean" },
+    // agent hook command flags
+    print: { type: "boolean" },
     // chat command flags (T078)
     role: { type: "string" }
   }
@@ -31392,6 +32320,8 @@ var knownCommands = /* @__PURE__ */ new Set([
   "remote",
   "checkpoint",
   "chat",
+  "agent",
+  "agents",
   "__remote-serve",
   "help"
 ]);
@@ -31479,6 +32409,12 @@ ${bold("SSH Remotes:")}
   ${cyan("tmux-ide remote ssh launch")} <name> [--no-open]
                                   ${dim("Open a local SSH tunnel to a remote tmux-ide dashboard")}
 
+${bold("Agent Fleet:")}
+  ${cyan("tmux-ide agents")} [list] [--json]          ${dim("Every agent across machines (see also: agent)")}
+  ${cyan("tmux-ide agents send")} <agent-id> <msg...> ${dim("Send input to any agent, local or remote")}
+  ${cyan("tmux-ide agent hook install")} [--print]    ${dim("Self-report hooks for plain-terminal sessions")}
+  ${cyan("tmux-ide agent report")} <event>            ${dim("Invoked by Claude Code hooks (see also: agents)")}
+
 ${bold("Task Management:")}
   ${cyan("tmux-ide mission set")} "title"              ${dim("Set the project mission")}
   ${cyan("tmux-ide mission show")}                     ${dim("Show current mission")}
@@ -31502,7 +32438,7 @@ ${bold("Flags:")}
   ${cyan("-v, --version")}               ${dim("Show version number")}`);
 }
 function execBunWidget(scriptPath, args, commandLabel) {
-  const widgetMissing = !existsSync41(scriptPath);
+  const widgetMissing = !existsSync42(scriptPath);
   let bunMissing = false;
   try {
     execFileSync9("bun", ["--version"], { stdio: "ignore" });
@@ -31737,8 +32673,8 @@ try {
       const messageStart = values.to ? 1 : 2;
       let message = positionals.slice(messageStart).join(" ");
       if (!message && !process.stdin.isTTY) {
-        const { readFileSync: readFileSync30 } = await import("node:fs");
-        message = readFileSync30(0, "utf-8").trim();
+        const { readFileSync: readFileSync31 } = await import("node:fs");
+        message = readFileSync31(0, "utf-8").trim();
       }
       await send(null, { json, to: target, message, noEnter: values["no-enter"] });
       break;
@@ -31795,6 +32731,26 @@ try {
           "remote-port": values["remote-port"],
           "no-open": values["no-open"]
         }
+      });
+      break;
+    }
+    case "agent": {
+      const { agentCommand: agentCommand2 } = await Promise.resolve().then(() => (init_agent_hook(), agent_hook_exports));
+      await agentCommand2({
+        sub: positionals[1],
+        args: positionals.slice(2),
+        json,
+        print: values.print === true
+      });
+      break;
+    }
+    case "agents": {
+      const { agentsCommand: agentsCommand2 } = await Promise.resolve().then(() => (init_agents_cli(), agents_cli_exports));
+      await agentsCommand2({
+        sub: positionals[1],
+        args: positionals.slice(2),
+        json,
+        noEnter: values["no-enter"] === true
       });
       break;
     }

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -73,6 +73,10 @@ const { positionals, values } = parseArgs({
     // remote command flags
     url: { type: "string" },
     "hq-url": { type: "string" },
+    host: { type: "string" },
+    path: { type: "string" },
+    "local-port": { type: "string" },
+    "remote-port": { type: "string" },
     // send command flags
     to: { type: "string" },
     "no-enter": { type: "boolean" },
@@ -118,6 +122,7 @@ const knownCommands = new Set([
   "remote",
   "checkpoint",
   "chat",
+  "__remote-serve",
   "help",
 ]);
 
@@ -203,6 +208,13 @@ ${bold("Orchestrator:")}
 ${bold("Multi-agent Chat:")}
   ${cyan("tmux-ide chat session add")} <thread-id> --provider <name> [--role <role>]
                                   ${dim("Register a Session on a Thread (lead|teammate|planner|validator|researcher)")}
+
+${bold("SSH Remotes:")}
+  ${cyan("tmux-ide remote ssh hosts")} [--json]       ${dim("List concrete Host aliases from ~/.ssh/config")}
+  ${cyan("tmux-ide remote ssh add")} <name> --host <ssh-host> --path <dir>
+                                  ${dim("Save a tunnel-only remote project")}
+  ${cyan("tmux-ide remote ssh launch")} <name> [--no-open]
+                                  ${dim("Open a local SSH tunnel to a remote tmux-ide dashboard")}
 
 ${bold("Task Management:")}
   ${cyan("tmux-ide mission set")} "title"              ${dim("Set the project mission")}
@@ -555,8 +567,19 @@ try {
         values: {
           url: values.url,
           "hq-url": values["hq-url"],
+          host: values.host,
+          path: values.path,
+          "local-port": values["local-port"],
+          "remote-port": values["remote-port"],
+          "no-open": values["no-open"],
         },
       });
+      break;
+    }
+
+    case "__remote-serve": {
+      const { remoteServeCommand } = await import("../packages/daemon/src/ssh-remote.ts");
+      await remoteServeCommand({ port: values.port });
       break;
     }
 

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -83,6 +83,8 @@ const { positionals, values } = parseArgs({
     // dashboard command flags
     open: { type: "boolean" },
     "no-open": { type: "boolean" },
+    // agent hook command flags
+    print: { type: "boolean" },
     // chat command flags (T078)
     role: { type: "string" },
   },
@@ -122,6 +124,8 @@ const knownCommands = new Set([
   "remote",
   "checkpoint",
   "chat",
+  "agent",
+  "agents",
   "__remote-serve",
   "help",
 ]);
@@ -215,6 +219,12 @@ ${bold("SSH Remotes:")}
                                   ${dim("Save a tunnel-only remote project")}
   ${cyan("tmux-ide remote ssh launch")} <name> [--no-open]
                                   ${dim("Open a local SSH tunnel to a remote tmux-ide dashboard")}
+
+${bold("Agent Fleet:")}
+  ${cyan("tmux-ide agents")} [list] [--json]          ${dim("Every agent across machines (see also: agent)")}
+  ${cyan("tmux-ide agents send")} <agent-id> <msg...> ${dim("Send input to any agent, local or remote")}
+  ${cyan("tmux-ide agent hook install")} [--print]    ${dim("Self-report hooks for plain-terminal sessions")}
+  ${cyan("tmux-ide agent report")} <event>            ${dim("Invoked by Claude Code hooks (see also: agents)")}
 
 ${bold("Task Management:")}
   ${cyan("tmux-ide mission set")} "title"              ${dim("Set the project mission")}
@@ -573,6 +583,28 @@ try {
           "remote-port": values["remote-port"],
           "no-open": values["no-open"],
         },
+      });
+      break;
+    }
+
+    case "agent": {
+      const { agentCommand } = await import("../packages/daemon/src/agent-hook.ts");
+      await agentCommand({
+        sub: positionals[1],
+        args: positionals.slice(2),
+        json,
+        print: values.print === true,
+      });
+      break;
+    }
+
+    case "agents": {
+      const { agentsCommand } = await import("../packages/daemon/src/agents-cli.ts");
+      await agentsCommand({
+        sub: positionals[1],
+        args: positionals.slice(2),
+        json,
+        noEnter: values["no-enter"] === true,
       });
       break;
     }

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -605,6 +605,8 @@ try {
         args: positionals.slice(2),
         json,
         noEnter: values["no-enter"] === true,
+        name: typeof values.name === "string" ? values.name : undefined,
+        role: typeof values.role === "string" ? values.role : undefined,
       });
       break;
     }

--- a/dashboard/src/components/ActivityBar.tsx
+++ b/dashboard/src/components/ActivityBar.tsx
@@ -16,6 +16,7 @@
 import { createSignal, For, onCleanup, onMount, Show, type Component } from "solid-js";
 import {
   BookOpen,
+  Bot,
   CheckSquare,
   Files,
   GitCompare,
@@ -44,6 +45,7 @@ export type ActivityBarViewId =
   | "skills"
   | "notes"
   | "mission"
+  | "agents"
   | "chat"
   | "terminal"
   | "widgets";
@@ -140,6 +142,14 @@ export function V2ActivityBar(props: V2ActivityBarProps) {
       Icon: Target,
       label: "mission",
       onClick: () => props.onView("mission"),
+    },
+    {
+      id: "agents",
+      view: "agents",
+      Icon: Bot,
+      label: "agents",
+      tooltip: "agents · fleet roster",
+      onClick: () => props.onView("agents"),
     },
     {
       id: "chat",

--- a/dashboard/src/components/v2/AgentsView.tsx
+++ b/dashboard/src/components/v2/AgentsView.tsx
@@ -1,0 +1,323 @@
+/**
+ * AgentsView — fleet-wide agent roster.
+ *
+ * A single read-only surface that lists every Claude/codex agent across
+ * all machines so the user sees their laptop + remote (SSM) boxes and
+ * their sessions in one place.
+ *
+ * Data flows from `GET /api/hq/agents` (aggregated across machines),
+ * falling back to `GET /api/agents` (this host only) when HQ 404s. The
+ * AgentRecord shape comes straight from @tmux-ide/contracts — agents are
+ * grouped by machine, then by session (tmux) vs "external".
+ *
+ * Observe-only for now: no actions. Matches the MissionStatementView
+ * polling / Tailwind conventions used by the other v2 views.
+ */
+
+import { createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { Bot } from "lucide-solid";
+import type { AgentRecord } from "@tmux-ide/contracts";
+import { API_BASE } from "@/lib/api";
+
+interface AgentsViewProps {
+  projectName: string;
+}
+
+const STATUS_COLOR: Record<AgentRecord["status"], string> = {
+  busy: "var(--yellow)",
+  idle: "var(--green)",
+  offline: "var(--dim)",
+};
+
+const KIND_LABEL: Record<AgentRecord["kind"], string> = {
+  managed: "managed",
+  "tmux-unmanaged": "unmanaged",
+  external: "external",
+};
+
+type LoadState = "loading" | "ready" | "error";
+
+const THIS_MACHINE = "This machine";
+const EXTERNAL_GROUP = "external";
+
+/**
+ * Polls the fleet roster every `intervalMs` (default 4 s). Prefers
+ * `/api/hq/agents`; on a 404 it falls back to `/api/agents` (this host)
+ * and remembers the fallback so subsequent ticks skip the HQ probe.
+ */
+function createAgentsPoll(intervalMs = 4000): {
+  agents: () => AgentRecord[];
+  state: () => LoadState;
+  error: () => string | null;
+} {
+  const [agents, setAgents] = createSignal<AgentRecord[]>([]);
+  const [state, setState] = createSignal<LoadState>("loading");
+  const [error, setError] = createSignal<string | null>(null);
+
+  let cancelled = false;
+  let useFallback = false;
+
+  async function fetchFrom(path: string): Promise<AgentRecord[] | "missing" | "error"> {
+    try {
+      const res = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
+      if (res.status === 404) return "missing";
+      if (!res.ok) return "error";
+      const body = (await res.json()) as { agents?: AgentRecord[] };
+      return body.agents ?? [];
+    } catch {
+      return "error";
+    }
+  }
+
+  async function tick(): Promise<void> {
+    let result = useFallback ? "missing" : await fetchFrom("/api/hq/agents");
+    if (result === "missing") {
+      useFallback = true;
+      result = await fetchFrom("/api/agents");
+    }
+    if (cancelled) return;
+    if (result === "missing" || result === "error") {
+      // Only surface the error banner when we have nothing to show; a
+      // transient blip while data is already on screen stays quiet.
+      setState((prev) => (prev === "ready" ? "ready" : "error"));
+      if (state() !== "ready") setError("Couldn't reach the agents API");
+      return;
+    }
+    setAgents(result);
+    setError(null);
+    setState("ready");
+  }
+
+  void tick();
+  const timer = setInterval(() => void tick(), intervalMs);
+  onCleanup(() => {
+    cancelled = true;
+    clearInterval(timer);
+  });
+
+  return { agents, state, error };
+}
+
+interface MachineGroup {
+  machineName: string;
+  agents: AgentRecord[];
+  sessions: SessionGroup[];
+}
+
+interface SessionGroup {
+  key: string;
+  label: string;
+  isExternal: boolean;
+  agents: AgentRecord[];
+}
+
+function groupByMachine(agents: AgentRecord[]): MachineGroup[] {
+  const byMachine = new Map<string, AgentRecord[]>();
+  for (const agent of agents) {
+    const machine = agent.machineName ?? THIS_MACHINE;
+    const list = byMachine.get(machine);
+    if (list) list.push(agent);
+    else byMachine.set(machine, [agent]);
+  }
+
+  const machines: MachineGroup[] = [];
+  for (const [machineName, machineAgents] of byMachine) {
+    const bySession = new Map<string, SessionGroup>();
+    for (const agent of machineAgents) {
+      const isExternal = agent.kind === "external";
+      const key = isExternal ? EXTERNAL_GROUP : (agent.session ?? EXTERNAL_GROUP);
+      const label = isExternal ? "external" : (agent.session ?? "external");
+      const group = bySession.get(key);
+      if (group) group.agents.push(agent);
+      else bySession.set(key, { key, label, isExternal, agents: [agent] });
+    }
+    machines.push({
+      machineName,
+      agents: machineAgents,
+      // External sessions sink to the bottom; named sessions sort alpha.
+      sessions: [...bySession.values()].sort((a, b) => {
+        if (a.isExternal !== b.isExternal) return a.isExternal ? 1 : -1;
+        return a.label.localeCompare(b.label);
+      }),
+    });
+  }
+
+  // "This machine" first, then the rest alphabetically.
+  return machines.sort((a, b) => {
+    if (a.machineName === THIS_MACHINE) return -1;
+    if (b.machineName === THIS_MACHINE) return 1;
+    return a.machineName.localeCompare(b.machineName);
+  });
+}
+
+export function AgentsView(_props: AgentsViewProps): JSX.Element {
+  const { agents, state, error } = createAgentsPoll();
+
+  const machines = createMemo(() => groupByMachine(agents()));
+  const busyCount = createMemo(() => agents().filter((a) => a.status === "busy").length);
+
+  return (
+    <div
+      data-testid="agents-view"
+      class="flex h-full min-h-0 w-full flex-col overflow-y-auto bg-[var(--bg)] text-[var(--fg)]"
+      style={{ "font-family": "var(--font-mono)", "font-size": "var(--text-base)" }}
+    >
+      <Header total={agents().length} busy={busyCount()} machines={machines().length} />
+
+      <Show
+        when={state() !== "loading"}
+        fallback={
+          <div
+            data-testid="agents-loading"
+            class="flex flex-1 items-center justify-center gap-3 p-8 text-[var(--dim)]"
+          >
+            <div class="h-4 w-4 animate-spin rounded-full border-2 border-[var(--border)] border-t-[var(--accent)]" />
+            <span>Loading agents…</span>
+          </div>
+        }
+      >
+        <Show
+          when={!(state() === "error" && agents().length === 0)}
+          fallback={
+            <div
+              data-testid="agents-error"
+              class="flex flex-1 items-center justify-center p-8 text-center text-[var(--red,#cc6666)]"
+            >
+              {error() ?? "Couldn't reach the agents API"}
+            </div>
+          }
+        >
+          <Show
+            when={agents().length > 0}
+            fallback={
+              <div
+                data-testid="agents-empty"
+                class="flex flex-1 items-center justify-center p-8 text-center text-[var(--dim)]"
+              >
+                No agents online.
+              </div>
+            }
+          >
+            <div class="flex flex-col gap-4 p-4">
+              <For each={machines()}>{(machine) => <MachineSection group={machine} />}</For>
+            </div>
+          </Show>
+        </Show>
+      </Show>
+    </div>
+  );
+}
+
+function Header(props: { total: number; busy: number; machines: number }): JSX.Element {
+  return (
+    <header class="sticky top-0 z-10 flex items-center gap-3 border-b border-[var(--border)] bg-[var(--bg-strong,var(--bg))] px-4 py-3">
+      <Bot size={16} strokeWidth={1.75} aria-hidden="true" class="text-[var(--accent)]" />
+      <span class="font-medium text-[var(--fg)]">Agents</span>
+      <span class="ml-auto flex items-center gap-3 text-sm tabular-nums text-[var(--dim)]">
+        <span data-testid="agents-summary-total">
+          {props.total} {props.total === 1 ? "agent" : "agents"}
+        </span>
+        <span data-testid="agents-summary-busy">{props.busy} busy</span>
+        <span data-testid="agents-summary-machines">
+          {props.machines} {props.machines === 1 ? "machine" : "machines"}
+        </span>
+      </span>
+    </header>
+  );
+}
+
+function MachineSection(props: { group: MachineGroup }): JSX.Element {
+  return (
+    <section
+      data-agents-machine={props.group.machineName}
+      class="rounded-md border border-[var(--border)] bg-[var(--surface)]"
+    >
+      <div class="flex items-center gap-2 border-b border-[var(--border-weak,var(--border))] px-3 py-2">
+        <span aria-hidden="true" class="text-[var(--dim)]">
+          ▣
+        </span>
+        <span class="font-medium text-[var(--fg)]">{props.group.machineName}</span>
+        <span class="ml-auto text-sm tabular-nums text-[var(--dim)]">
+          {props.group.agents.length}
+        </span>
+      </div>
+      <div class="flex flex-col gap-3 p-3">
+        <For each={props.group.sessions}>{(session) => <SessionBlock group={session} />}</For>
+      </div>
+    </section>
+  );
+}
+
+function SessionBlock(props: { group: SessionGroup }): JSX.Element {
+  return (
+    <div data-agents-session={props.group.key}>
+      <div class="mb-1 flex items-center gap-2 text-xs uppercase tracking-wider text-[var(--dim)]">
+        <span aria-hidden="true">{props.group.isExternal ? "◇" : "⊟"}</span>
+        <span>{props.group.label}</span>
+      </div>
+      <div class="flex flex-col gap-1">
+        <For each={props.group.agents}>{(agent) => <AgentRow agent={agent} />}</For>
+      </div>
+    </div>
+  );
+}
+
+function AgentRow(props: { agent: AgentRecord }): JSX.Element {
+  const agent = () => props.agent;
+  const subtitle = createMemo(() => {
+    const a = agent();
+    if (a.session && a.paneTitle) return `${a.session} · ${a.paneTitle}`;
+    if (a.paneTitle) return a.paneTitle;
+    return a.cwd ?? null;
+  });
+
+  return (
+    <div
+      data-agents-row={agent().id}
+      data-agents-status={agent().status}
+      class="flex items-center gap-2 rounded border border-[var(--border)] bg-[var(--bg-strong,var(--surface))] px-2 py-1.5"
+    >
+      <StatusDot status={agent().status} />
+      <span
+        class="rounded border border-[var(--border)] px-1 text-xs uppercase tracking-wider text-[var(--fg-secondary)]"
+        title={`tool: ${agent().tool}`}
+      >
+        {agent().tool}
+      </span>
+      <span class="truncate font-medium text-[var(--fg)]">{agent().name}</span>
+      <Show when={subtitle()}>
+        <span class="truncate text-sm text-[var(--dim)]">{subtitle()}</span>
+      </Show>
+      <Show when={agent().taskTitle}>
+        {(title) => (
+          <span
+            class="truncate rounded border-l-2 border-[var(--accent)] bg-[var(--surface)] px-1.5 text-sm text-[var(--fg-secondary)]"
+            title={title()}
+          >
+            {title()}
+          </span>
+        )}
+      </Show>
+      <span
+        class="ml-auto shrink-0 rounded-full border px-2 py-[1px] text-xs uppercase tracking-wider text-[var(--dim)]"
+        style={{ "border-color": "var(--border)" }}
+        title={`kind: ${agent().kind}`}
+      >
+        {KIND_LABEL[agent().kind]}
+      </span>
+    </div>
+  );
+}
+
+function StatusDot(props: { status: AgentRecord["status"] }): JSX.Element {
+  return (
+    <span
+      aria-label={props.status}
+      class={
+        "inline-block h-2 w-2 shrink-0 rounded-full " +
+        (props.status === "busy" ? "animate-pulse" : "")
+      }
+      style={{ background: STATUS_COLOR[props.status] }}
+    />
+  );
+}

--- a/dashboard/src/components/v2/AgentsView.tsx
+++ b/dashboard/src/components/v2/AgentsView.tsx
@@ -13,12 +13,17 @@
  * Control: controllable agents (non-external with a pane) get an inline
  * send composer that POSTs to `/api/agents/send` — works for local and
  * remote (SSH) agents alike since the daemon routes by id + machineId.
- * External agents stay observe-only. Matches the MissionStatementView
- * polling / Tailwind conventions used by the other v2 views.
+ * Unmanaged tmux agents also get an "Own" control (POST
+ * `/api/agents/claim`, optional name) to adopt them, and managed agents
+ * get a "Release" control (POST `/api/agents/release`) to hand them
+ * back. Both let the 4 s poll reflect the resulting kind change rather
+ * than mutating local state. External agents stay observe-only. Matches
+ * the MissionStatementView polling / Tailwind conventions used by the
+ * other v2 views.
  */
 
 import { createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
-import { Bot, Check, Send } from "lucide-solid";
+import { Anchor, Bot, Check, Send, Unlink } from "lucide-solid";
 import type { AgentRecord } from "@tmux-ide/contracts";
 import { API_BASE } from "@/lib/api";
 
@@ -297,6 +302,21 @@ function AgentRow(props: { agent: () => AgentRecord | undefined }): JSX.Element 
 const SENT_FLASH_MS = 2000;
 const ERROR_FLASH_MS = 5000;
 
+/**
+ * Pulls the daemon's `error` string out of a non-2xx response, falling
+ * back to a status-only message when the body isn't JSON.
+ */
+async function responseErrorText(res: Response): Promise<string> {
+  let detail = `HTTP ${res.status}`;
+  try {
+    const body = (await res.json()) as { error?: string };
+    if (body?.error) detail = body.error;
+  } catch {
+    // Body wasn't JSON; the status-only message stands.
+  }
+  return detail;
+}
+
 function AgentRowBody(props: { agent: () => AgentRecord }): JSX.Element {
   const agent = props.agent;
   const subtitle = createMemo(() => {
@@ -311,17 +331,32 @@ function AgentRowBody(props: { agent: () => AgentRecord }): JSX.Element {
   // messaged through the daemon (which relays to remotes over SSH).
   const controllable = createMemo(() => agent().kind !== "external" && agent().paneId !== null);
 
+  // Ownership controls. Unmanaged tmux agents can be adopted ("Own");
+  // managed agents with a pane can be handed back ("Release"). External
+  // agents have no pane, so neither applies. We never optimistically flip
+  // the record — the 4 s poll re-fetches and the kind/badge updates on
+  // its own after a successful claim/release.
+  const canOwn = createMemo(() => agent().kind === "tmux-unmanaged" && agent().paneId !== null);
+  const canRelease = createMemo(() => agent().kind === "managed" && agent().paneId !== null);
+
   const [composerOpen, setComposerOpen] = createSignal(false);
   const [draft, setDraft] = createSignal("");
   const [sending, setSending] = createSignal(false);
   const [sent, setSent] = createSignal(false);
   const [sendError, setSendError] = createSignal<string | null>(null);
 
+  const [ownOpen, setOwnOpen] = createSignal(false);
+  const [nameDraft, setNameDraft] = createSignal("");
+  const [owning, setOwning] = createSignal(false);
+  const [ownDone, setOwnDone] = createSignal(false);
+
   let sentTimer: ReturnType<typeof setTimeout> | undefined;
   let errorTimer: ReturnType<typeof setTimeout> | undefined;
+  let ownDoneTimer: ReturnType<typeof setTimeout> | undefined;
   onCleanup(() => {
     clearTimeout(sentTimer);
     clearTimeout(errorTimer);
+    clearTimeout(ownDoneTimer);
   });
 
   function showError(message: string): void {
@@ -342,16 +377,7 @@ function AgentRowBody(props: { agent: () => AgentRecord }): JSX.Element {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id: a.id, machineId: a.machineId, message }),
       });
-      if (!res.ok) {
-        let detail = `HTTP ${res.status}`;
-        try {
-          const body = (await res.json()) as { error?: string };
-          if (body?.error) detail = body.error;
-        } catch {
-          // Body wasn't JSON; the status-only message stands.
-        }
-        throw new Error(detail);
-      }
+      if (!res.ok) throw new Error(await responseErrorText(res));
       setDraft("");
       setSent(true);
       clearTimeout(sentTimer);
@@ -360,6 +386,66 @@ function AgentRowBody(props: { agent: () => AgentRecord }): JSX.Element {
       showError(err instanceof Error ? err.message : String(err));
     } finally {
       setSending(false);
+    }
+  }
+
+  function flashOwnDone(): void {
+    setOwnDone(true);
+    clearTimeout(ownDoneTimer);
+    ownDoneTimer = setTimeout(() => setOwnDone(false), SENT_FLASH_MS);
+  }
+
+  async function claim(): Promise<void> {
+    if (owning()) return;
+    const a = agent();
+    const name = nameDraft().trim();
+    setOwning(true);
+    setSendError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/agents/claim`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: a.id, machineId: a.machineId, ...(name ? { name } : {}) }),
+      });
+      if (!res.ok) throw new Error(await responseErrorText(res));
+      setOwnOpen(false);
+      setNameDraft("");
+      flashOwnDone();
+    } catch (err) {
+      showError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setOwning(false);
+    }
+  }
+
+  async function release(): Promise<void> {
+    if (owning()) return;
+    const a = agent();
+    setOwning(true);
+    setSendError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/agents/release`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: a.id, machineId: a.machineId }),
+      });
+      if (!res.ok) throw new Error(await responseErrorText(res));
+      flashOwnDone();
+    } catch (err) {
+      showError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setOwning(false);
+    }
+  }
+
+  function onNameKeyDown(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      void claim();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      setOwnOpen(false);
+      setSendError(null);
     }
   }
 
@@ -411,6 +497,45 @@ function AgentRowBody(props: { agent: () => AgentRecord }): JSX.Element {
         >
           {KIND_LABEL[agent().kind]}
         </span>
+        <Show when={owning()}>
+          <span
+            aria-label="working"
+            class="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-[var(--border)] border-t-[var(--accent)]"
+          />
+        </Show>
+        <Show when={!owning() && ownDone()}>
+          <Check size={14} strokeWidth={2} aria-label="done" class="shrink-0 text-[var(--green)]" />
+        </Show>
+        <Show when={canOwn()}>
+          <button
+            type="button"
+            data-agents-own-toggle
+            aria-label={`Own ${agent().name}`}
+            aria-expanded={ownOpen()}
+            title="Adopt this agent (make it managed)"
+            disabled={owning()}
+            class={
+              "shrink-0 rounded border border-[var(--border)] p-1 transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] disabled:opacity-50 " +
+              (ownOpen() ? "text-[var(--accent)]" : "text-[var(--dim)]")
+            }
+            onClick={() => setOwnOpen(!ownOpen())}
+          >
+            <Anchor size={12} strokeWidth={1.75} aria-hidden="true" />
+          </button>
+        </Show>
+        <Show when={canRelease()}>
+          <button
+            type="button"
+            data-agents-release
+            aria-label={`Release ${agent().name}`}
+            title="Release this agent (make it unmanaged)"
+            disabled={owning()}
+            class="shrink-0 rounded border border-[var(--border)] p-1 text-[var(--dim)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] disabled:opacity-50"
+            onClick={() => void release()}
+          >
+            <Unlink size={12} strokeWidth={1.75} aria-hidden="true" />
+          </button>
+        </Show>
         <Show when={controllable()}>
           <button
             type="button"
@@ -456,6 +581,33 @@ function AgentRowBody(props: { agent: () => AgentRecord }): JSX.Element {
               class="shrink-0 text-[var(--green)]"
             />
           </Show>
+        </div>
+      </Show>
+      <Show when={canOwn() && ownOpen()}>
+        <div class="flex items-center gap-2 border-t border-[var(--border-weak,var(--border))] px-2 py-1.5">
+          <input
+            ref={(el) => requestAnimationFrame(() => el.focus())}
+            type="text"
+            data-agents-own-input
+            value={nameDraft()}
+            disabled={owning()}
+            maxLength={200}
+            placeholder="name (optional) — Enter to own, Esc to close"
+            class="min-w-0 flex-1 bg-transparent text-sm text-[var(--fg)] outline-none placeholder:text-[var(--dim)] disabled:opacity-50"
+            onInput={(e) => setNameDraft(e.currentTarget.value)}
+            onKeyDown={onNameKeyDown}
+          />
+          <button
+            type="button"
+            data-agents-own-confirm
+            aria-label="Confirm own"
+            title="Adopt this agent"
+            disabled={owning()}
+            class="shrink-0 rounded border border-[var(--border)] p-1 text-[var(--dim)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] disabled:opacity-50"
+            onClick={() => void claim()}
+          >
+            <Check size={12} strokeWidth={2} aria-hidden="true" />
+          </button>
         </div>
       </Show>
       <Show when={sendError()}>

--- a/dashboard/src/components/v2/AgentsView.tsx
+++ b/dashboard/src/components/v2/AgentsView.tsx
@@ -1,8 +1,8 @@
 /**
  * AgentsView — fleet-wide agent roster.
  *
- * A single read-only surface that lists every Claude/codex agent across
- * all machines so the user sees their laptop + remote (SSM) boxes and
+ * A single surface that lists every Claude/codex agent across all
+ * machines so the user sees their laptop + remote (SSM) boxes and
  * their sessions in one place.
  *
  * Data flows from `GET /api/hq/agents` (aggregated across machines),
@@ -10,12 +10,15 @@
  * AgentRecord shape comes straight from @tmux-ide/contracts — agents are
  * grouped by machine, then by session (tmux) vs "external".
  *
- * Observe-only for now: no actions. Matches the MissionStatementView
+ * Control: controllable agents (non-external with a pane) get an inline
+ * send composer that POSTs to `/api/agents/send` — works for local and
+ * remote (SSH) agents alike since the daemon routes by id + machineId.
+ * External agents stay observe-only. Matches the MissionStatementView
  * polling / Tailwind conventions used by the other v2 views.
  */
 
 import { createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
-import { Bot } from "lucide-solid";
+import { Bot, Check, Send } from "lucide-solid";
 import type { AgentRecord } from "@tmux-ide/contracts";
 import { API_BASE } from "@/lib/api";
 
@@ -199,7 +202,14 @@ export function AgentsView(_props: AgentsViewProps): JSX.Element {
             }
           >
             <div class="flex flex-col gap-4 p-4">
-              <For each={machines()}>{(machine) => <MachineSection group={machine} />}</For>
+              {/* Keyed on the machine name (a stable primitive) rather than
+                  the group object — the poll rebuilds group objects every
+                  tick, and object-keyed rows would tear down the send
+                  composer (and its focus) mid-typing. Same pattern applies
+                  at the session and agent levels below. */}
+              <For each={machines().map((m) => m.machineName)}>
+                {(name) => <MachineSection name={name} machines={machines} />}
+              </For>
             </div>
           </Show>
         </Show>
@@ -226,44 +236,69 @@ function Header(props: { total: number; busy: number; machines: number }): JSX.E
   );
 }
 
-function MachineSection(props: { group: MachineGroup }): JSX.Element {
+function MachineSection(props: { name: string; machines: () => MachineGroup[] }): JSX.Element {
+  const group = createMemo(() => props.machines().find((m) => m.machineName === props.name));
+  const sessionKeys = createMemo(() => (group()?.sessions ?? []).map((s) => s.key));
   return (
-    <section
-      data-agents-machine={props.group.machineName}
-      class="rounded-md border border-[var(--border)] bg-[var(--surface)]"
-    >
-      <div class="flex items-center gap-2 border-b border-[var(--border-weak,var(--border))] px-3 py-2">
-        <span aria-hidden="true" class="text-[var(--dim)]">
-          ▣
-        </span>
-        <span class="font-medium text-[var(--fg)]">{props.group.machineName}</span>
-        <span class="ml-auto text-sm tabular-nums text-[var(--dim)]">
-          {props.group.agents.length}
-        </span>
-      </div>
-      <div class="flex flex-col gap-3 p-3">
-        <For each={props.group.sessions}>{(session) => <SessionBlock group={session} />}</For>
-      </div>
-    </section>
+    <Show when={group()}>
+      {(g) => (
+        <section
+          data-agents-machine={props.name}
+          class="rounded-md border border-[var(--border)] bg-[var(--surface)]"
+        >
+          <div class="flex items-center gap-2 border-b border-[var(--border-weak,var(--border))] px-3 py-2">
+            <span aria-hidden="true" class="text-[var(--dim)]">
+              ▣
+            </span>
+            <span class="font-medium text-[var(--fg)]">{props.name}</span>
+            <span class="ml-auto text-sm tabular-nums text-[var(--dim)]">{g().agents.length}</span>
+          </div>
+          <div class="flex flex-col gap-3 p-3">
+            <For each={sessionKeys()}>
+              {(key) => <SessionBlock sessionKey={key} group={group} />}
+            </For>
+          </div>
+        </section>
+      )}
+    </Show>
   );
 }
 
-function SessionBlock(props: { group: SessionGroup }): JSX.Element {
+function SessionBlock(props: {
+  sessionKey: string;
+  group: () => MachineGroup | undefined;
+}): JSX.Element {
+  const session = createMemo(() => props.group()?.sessions.find((s) => s.key === props.sessionKey));
+  const agentIds = createMemo(() => (session()?.agents ?? []).map((a) => a.id));
   return (
-    <div data-agents-session={props.group.key}>
-      <div class="mb-1 flex items-center gap-2 text-xs uppercase tracking-wider text-[var(--dim)]">
-        <span aria-hidden="true">{props.group.isExternal ? "◇" : "⊟"}</span>
-        <span>{props.group.label}</span>
-      </div>
-      <div class="flex flex-col gap-1">
-        <For each={props.group.agents}>{(agent) => <AgentRow agent={agent} />}</For>
-      </div>
-    </div>
+    <Show when={session()}>
+      {(s) => (
+        <div data-agents-session={props.sessionKey}>
+          <div class="mb-1 flex items-center gap-2 text-xs uppercase tracking-wider text-[var(--dim)]">
+            <span aria-hidden="true">{s().isExternal ? "◇" : "⊟"}</span>
+            <span>{s().label}</span>
+          </div>
+          <div class="flex flex-col gap-1">
+            <For each={agentIds()}>
+              {(id) => <AgentRow agent={() => s().agents.find((a) => a.id === id)} />}
+            </For>
+          </div>
+        </div>
+      )}
+    </Show>
   );
 }
 
-function AgentRow(props: { agent: AgentRecord }): JSX.Element {
-  const agent = () => props.agent;
+function AgentRow(props: { agent: () => AgentRecord | undefined }): JSX.Element {
+  return <Show when={props.agent()}>{(agent) => <AgentRowBody agent={agent} />}</Show>;
+}
+
+/** How long the success checkmark / inline error stay on screen. */
+const SENT_FLASH_MS = 2000;
+const ERROR_FLASH_MS = 5000;
+
+function AgentRowBody(props: { agent: () => AgentRecord }): JSX.Element {
+  const agent = props.agent;
   const subtitle = createMemo(() => {
     const a = agent();
     if (a.session && a.paneTitle) return `${a.session} · ${a.paneTitle}`;
@@ -271,40 +306,166 @@ function AgentRow(props: { agent: AgentRecord }): JSX.Element {
     return a.cwd ?? null;
   });
 
+  // "External" agents self-report via a hook — there's no pane to type
+  // into, so they stay observe-only. Everything else with a pane can be
+  // messaged through the daemon (which relays to remotes over SSH).
+  const controllable = createMemo(() => agent().kind !== "external" && agent().paneId !== null);
+
+  const [composerOpen, setComposerOpen] = createSignal(false);
+  const [draft, setDraft] = createSignal("");
+  const [sending, setSending] = createSignal(false);
+  const [sent, setSent] = createSignal(false);
+  const [sendError, setSendError] = createSignal<string | null>(null);
+
+  let sentTimer: ReturnType<typeof setTimeout> | undefined;
+  let errorTimer: ReturnType<typeof setTimeout> | undefined;
+  onCleanup(() => {
+    clearTimeout(sentTimer);
+    clearTimeout(errorTimer);
+  });
+
+  function showError(message: string): void {
+    setSendError(message);
+    clearTimeout(errorTimer);
+    errorTimer = setTimeout(() => setSendError(null), ERROR_FLASH_MS);
+  }
+
+  async function submit(): Promise<void> {
+    const message = draft().trim();
+    if (!message || sending()) return;
+    const a = agent();
+    setSending(true);
+    setSendError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/agents/send`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: a.id, machineId: a.machineId, message }),
+      });
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: string };
+          if (body?.error) detail = body.error;
+        } catch {
+          // Body wasn't JSON; the status-only message stands.
+        }
+        throw new Error(detail);
+      }
+      setDraft("");
+      setSent(true);
+      clearTimeout(sentTimer);
+      sentTimer = setTimeout(() => setSent(false), SENT_FLASH_MS);
+    } catch (err) {
+      showError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSending(false);
+    }
+  }
+
+  function onComposerKeyDown(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      void submit();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      setComposerOpen(false);
+      setSendError(null);
+    }
+  }
+
   return (
     <div
       data-agents-row={agent().id}
       data-agents-status={agent().status}
-      class="flex items-center gap-2 rounded border border-[var(--border)] bg-[var(--bg-strong,var(--surface))] px-2 py-1.5"
+      class="rounded border border-[var(--border)] bg-[var(--bg-strong,var(--surface))]"
     >
-      <StatusDot status={agent().status} />
-      <span
-        class="rounded border border-[var(--border)] px-1 text-xs uppercase tracking-wider text-[var(--fg-secondary)]"
-        title={`tool: ${agent().tool}`}
-      >
-        {agent().tool}
-      </span>
-      <span class="truncate font-medium text-[var(--fg)]">{agent().name}</span>
-      <Show when={subtitle()}>
-        <span class="truncate text-sm text-[var(--dim)]">{subtitle()}</span>
-      </Show>
-      <Show when={agent().taskTitle}>
-        {(title) => (
-          <span
-            class="truncate rounded border-l-2 border-[var(--accent)] bg-[var(--surface)] px-1.5 text-sm text-[var(--fg-secondary)]"
-            title={title()}
+      <div class="flex items-center gap-2 px-2 py-1.5">
+        <StatusDot status={agent().status} />
+        <span
+          class="rounded border border-[var(--border)] px-1 text-xs uppercase tracking-wider text-[var(--fg-secondary)]"
+          title={`tool: ${agent().tool}`}
+        >
+          {agent().tool}
+        </span>
+        <span class="truncate font-medium text-[var(--fg)]">{agent().name}</span>
+        <Show when={subtitle()}>
+          <span class="truncate text-sm text-[var(--dim)]">{subtitle()}</span>
+        </Show>
+        <Show when={agent().taskTitle}>
+          {(title) => (
+            <span
+              class="truncate rounded border-l-2 border-[var(--accent)] bg-[var(--surface)] px-1.5 text-sm text-[var(--fg-secondary)]"
+              title={title()}
+            >
+              {title()}
+            </span>
+          )}
+        </Show>
+        <span
+          class="ml-auto shrink-0 rounded-full border px-2 py-[1px] text-xs uppercase tracking-wider text-[var(--dim)]"
+          style={{ "border-color": "var(--border)" }}
+          title={
+            agent().kind === "external" ? "external agent — observe-only" : `kind: ${agent().kind}`
+          }
+        >
+          {KIND_LABEL[agent().kind]}
+        </span>
+        <Show when={controllable()}>
+          <button
+            type="button"
+            data-agents-send-toggle
+            aria-label={`Send a message to ${agent().name}`}
+            aria-expanded={composerOpen()}
+            title="Send a message to this agent"
+            class={
+              "shrink-0 rounded border border-[var(--border)] p-1 transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] " +
+              (composerOpen() ? "text-[var(--accent)]" : "text-[var(--dim)]")
+            }
+            onClick={() => setComposerOpen(!composerOpen())}
           >
-            {title()}
-          </span>
-        )}
+            <Send size={12} strokeWidth={1.75} aria-hidden="true" />
+          </button>
+        </Show>
+      </div>
+      <Show when={controllable() && composerOpen()}>
+        <div class="flex items-center gap-2 border-t border-[var(--border-weak,var(--border))] px-2 py-1.5">
+          <input
+            ref={(el) => requestAnimationFrame(() => el.focus())}
+            type="text"
+            data-agents-send-input
+            value={draft()}
+            disabled={sending()}
+            maxLength={10000}
+            placeholder={`Message ${agent().name}… (Enter to send, Esc to close)`}
+            class="min-w-0 flex-1 bg-transparent text-sm text-[var(--fg)] outline-none placeholder:text-[var(--dim)] disabled:opacity-50"
+            onInput={(e) => setDraft(e.currentTarget.value)}
+            onKeyDown={onComposerKeyDown}
+          />
+          <Show when={sending()}>
+            <span
+              aria-label="sending"
+              class="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-[var(--border)] border-t-[var(--accent)]"
+            />
+          </Show>
+          <Show when={!sending() && sent()}>
+            <Check
+              size={14}
+              strokeWidth={2}
+              aria-label="sent"
+              class="shrink-0 text-[var(--green)]"
+            />
+          </Show>
+        </div>
       </Show>
-      <span
-        class="ml-auto shrink-0 rounded-full border px-2 py-[1px] text-xs uppercase tracking-wider text-[var(--dim)]"
-        style={{ "border-color": "var(--border)" }}
-        title={`kind: ${agent().kind}`}
-      >
-        {KIND_LABEL[agent().kind]}
-      </span>
+      <Show when={sendError()}>
+        <div
+          data-agents-send-error
+          class="border-t border-[var(--border-weak,var(--border))] px-2 py-1 text-xs text-[var(--red,#cc6666)]"
+        >
+          {sendError()}
+        </div>
+      </Show>
     </div>
   );
 }

--- a/dashboard/src/lib/views.ts
+++ b/dashboard/src/lib/views.ts
@@ -18,6 +18,7 @@ import {
   KanbanSquare,
   Search,
   Terminal as TerminalIcon,
+  Bot,
   BarChart3,
   DollarSign,
   Sparkles,
@@ -28,6 +29,7 @@ import {
 export const VIEWS = [
   { id: "mission", label: "Mission", glyph: "◆", Icon: Target },
   { id: "mission-control", label: "Mission Control", glyph: "✦", Icon: Compass },
+  { id: "agents", label: "Agents", glyph: "✲", Icon: Bot },
   { id: "kanban", label: "Kanban", glyph: "⊟", Icon: KanbanSquare },
   { id: "tasks", label: "Tasks", glyph: "≡", Icon: CheckSquare },
   { id: "plans", label: "Plans", glyph: "▦", Icon: ListTodo },

--- a/dashboard/src/routes/project/[name].tsx
+++ b/dashboard/src/routes/project/[name].tsx
@@ -54,6 +54,7 @@ import {
   TasksDashboardView,
 } from "@/components/v2/views";
 import { MissionStatementView } from "@/components/v2/MissionStatementView";
+import { AgentsView } from "@/components/v2/AgentsView";
 import { chrome, useChromeShortcuts } from "@/lib/chrome";
 import { useViewParam } from "@/lib/viewParam";
 import { DEFAULT_VIEW, isViewId, VIEWS, type ViewId } from "@/lib/views";
@@ -69,6 +70,7 @@ const ACTIVITY_BAR_VIEWS = new Set<ActivityBarViewId>([
   "skills",
   "notes",
   "mission",
+  "agents",
   "chat",
   "terminal",
 ]);
@@ -417,6 +419,9 @@ function MainContent(props: { projectName: string; view: ViewId }) {
       </Show>
       <Show when={props.view === "mission-control"}>
         <MissionControlView projectName={props.projectName} />
+      </Show>
+      <Show when={props.view === "agents"}>
+        <AgentsView projectName={props.projectName} />
       </Show>
       <Show when={props.view === "kanban"}>
         <KanbanBoardView projectName={props.projectName} />

--- a/docs/content/docs/commands.mdx
+++ b/docs/content/docs/commands.mdx
@@ -132,7 +132,7 @@ tmux-ide agent hook install
 tmux-ide agent hook install --print   # print the snippet instead of writing
 ```
 
-The installer wires four Claude Code lifecycle events to
+The installer wires the Claude Code lifecycle events to
 `tmux-ide agent report`:
 
 ```json
@@ -144,7 +144,10 @@ The installer wires four Claude Code lifecycle events to
     "UserPromptSubmit": [
       { "hooks": [{ "type": "command", "command": "tmux-ide agent report activity" }] }
     ],
-    "Stop": [{ "hooks": [{ "type": "command", "command": "tmux-ide agent report stop" }] }],
+    "PreToolUse": [
+      { "hooks": [{ "type": "command", "command": "tmux-ide agent report activity" }] }
+    ],
+    "Stop": [{ "hooks": [{ "type": "command", "command": "tmux-ide agent report idle" }] }],
     "SessionEnd": [{ "hooks": [{ "type": "command", "command": "tmux-ide agent report stop" }] }]
   }
 }
@@ -157,15 +160,21 @@ Restart your Claude Code sessions after installing so the hooks load.
 Invoked by the hooks above — you rarely run this by hand. It reads the
 hook JSON payload from **stdin** and POSTs to the local daemon:
 
-| Event      | Claude Code hook     | Daemon action      | Status |
-| ---------- | -------------------- | ------------------ | ------ |
-| `start`    | `SessionStart`       | `agent.register`   | busy   |
-| `activity` | `UserPromptSubmit`   | `agent.heartbeat`  | busy   |
-| `stop`     | `Stop`, `SessionEnd` | `agent.unregister` | —      |
+| Event      | Claude Code hook                 | Daemon action      | Status |
+| ---------- | -------------------------------- | ------------------ | ------ |
+| `start`    | `SessionStart`                   | `agent.register`   | busy   |
+| `activity` | `UserPromptSubmit`, `PreToolUse` | `agent.register`   | busy   |
+| `idle`     | `Stop` (end of a turn)           | `agent.heartbeat`  | idle   |
+| `stop`     | `SessionEnd` (session exit)      | `agent.unregister` | —      |
+
+`Stop` fires at the end of **every turn**, not on session exit — so it maps to
+`idle` (the agent stays on the roster between turns) while `SessionEnd` is the
+real teardown. `PreToolUse` keeps a long-running turn marked live.
 
 The agent `id` is the Claude Code `session_id`; the display name is
-derived as `claude@<basename(cwd)>`. The daemon URL and auth token are
-discovered from `~/.tmux-ide/daemon.json`; an `Authorization: Bearer`
+derived as `<tool>@<basename(cwd)>` (`tool` is `claude` by default, or
+`codex` when `TMUX_IDE_AGENT_TOOL=codex`). The daemon URL and auth token
+are discovered from `~/.tmux-ide/daemon.json`; an `Authorization: Bearer`
 header is sent when a token is present.
 
 `agent report` is best-effort and defensive: if no daemon is running, or

--- a/docs/content/docs/commands.mdx
+++ b/docs/content/docs/commands.mdx
@@ -246,6 +246,27 @@ Failure modes are surfaced clearly:
 - machine unreachable (e.g. the SSH tunnel is down) → the daemon replies
   502 and the CLI prints the error text
 
+### `tmux-ide agents claim` / `release`
+
+An agent is `managed` when tmux-ide owns its tmux session; anything else is
+`tmux-unmanaged` (a Claude/codex session you started yourself). **Claiming**
+adopts a single unmanaged window — it flips that one pane to `managed` and
+optionally names it, without touching the rest of its session:
+
+```bash
+# Own one window and give it a name/role — works locally and over SSH
+tmux-ide agents claim "ssh:boxa:project:%1" --name "API work" --role teammate
+
+# Hand it back (returns to tmux-unmanaged)
+tmux-ide agents release "ssh:boxa:project:%1"
+```
+
+Claiming is non-destructive: it sets a pane-scoped `@ide_owned` tmux option
+(and `@ide_name`/`@ide_role`) — it sends no input and doesn't disturb the
+session. `external` agents have no pane and can't be claimed (409). In the
+dashboard Agents view, unmanaged rows show an **Own** button and managed rows
+a **Release** button.
+
 ## `tmux-ide ls`
 
 List all running tmux sessions.

--- a/docs/content/docs/commands.mdx
+++ b/docs/content/docs/commands.mdx
@@ -94,20 +94,20 @@ from `127.0.0.1:<local-port>` to that remote loopback port.
 
 ```bash
 tmux-ide remote ssh hosts
-tmux-ide remote ssh add atlas --host atlas-evg --path ~/Documents/code/project-atlas
-tmux-ide remote ssh launch atlas
-tmux-ide remote ssh launch atlas --no-open
-tmux-ide remote ssh status atlas
-tmux-ide remote ssh remove atlas
+tmux-ide remote ssh add devbox --host devbox-remote --path ~/projects/my-app
+tmux-ide remote ssh launch devbox
+tmux-ide remote ssh launch devbox --no-open
+tmux-ide remote ssh status devbox
+tmux-ide remote ssh remove devbox
 ```
 
 Use `--local-port` when you want a stable local URL, and `--remote-port`
 when the remote machine already uses the default remote daemon port:
 
 ```bash
-tmux-ide remote ssh add atlas \
-  --host atlas-evg \
-  --path ~/Documents/code/project-atlas \
+tmux-ide remote ssh add devbox \
+  --host devbox-remote \
+  --path ~/projects/my-app \
   --local-port 6061 \
   --remote-port 6060
 ```

--- a/docs/content/docs/commands.mdx
+++ b/docs/content/docs/commands.mdx
@@ -85,6 +85,36 @@ The `tmux-ide` launch command also prints the dashboard URL alongside
 the `Starting <session>` line, so first-time users see it without
 running this subcommand.
 
+## `tmux-ide remote ssh`
+
+Control a tmux-ide project on another machine through SSH without opening
+any public port on the remote host. The remote daemon binds to
+`127.0.0.1` on the remote machine, and the local CLI opens an SSH tunnel
+from `127.0.0.1:<local-port>` to that remote loopback port.
+
+```bash
+tmux-ide remote ssh hosts
+tmux-ide remote ssh add atlas --host atlas-evg --path ~/Documents/code/project-atlas
+tmux-ide remote ssh launch atlas
+tmux-ide remote ssh launch atlas --no-open
+tmux-ide remote ssh status atlas
+tmux-ide remote ssh remove atlas
+```
+
+Use `--local-port` when you want a stable local URL, and `--remote-port`
+when the remote machine already uses the default remote daemon port:
+
+```bash
+tmux-ide remote ssh add atlas \
+  --host atlas-evg \
+  --path ~/Documents/code/project-atlas \
+  --local-port 6061 \
+  --remote-port 6060
+```
+
+The saved config lives in `~/.tmux-ide/ssh-remotes.json` and stores only
+the remote name, SSH host alias, project path, and optional ports.
+
 ## `tmux-ide ls`
 
 List all running tmux sessions.

--- a/docs/content/docs/commands.mdx
+++ b/docs/content/docs/commands.mdx
@@ -115,6 +115,69 @@ tmux-ide remote ssh add atlas \
 The saved config lives in `~/.tmux-ide/ssh-remotes.json` and stores only
 the remote name, SSH host alias, project path, and optional ports.
 
+## `tmux-ide agent`
+
+Let a Claude Code session running in a **plain terminal** — one you did
+not start through tmux-ide — report itself to the local canonical daemon
+so it appears in the central agent view alongside orchestrated agents.
+
+### `tmux-ide agent hook install`
+
+Merge the reporting hooks into `~/.claude/settings.json` (respecting
+`CLAUDE_CONFIG_DIR` when set). Existing hooks are preserved, and
+re-running the installer is idempotent.
+
+```bash
+tmux-ide agent hook install
+tmux-ide agent hook install --print   # print the snippet instead of writing
+```
+
+The installer wires four Claude Code lifecycle events to
+`tmux-ide agent report`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "tmux-ide agent report start" }] }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "tmux-ide agent report activity" }] }
+    ],
+    "Stop": [{ "hooks": [{ "type": "command", "command": "tmux-ide agent report stop" }] }],
+    "SessionEnd": [{ "hooks": [{ "type": "command", "command": "tmux-ide agent report stop" }] }]
+  }
+}
+```
+
+Restart your Claude Code sessions after installing so the hooks load.
+
+### `tmux-ide agent report`
+
+Invoked by the hooks above — you rarely run this by hand. It reads the
+hook JSON payload from **stdin** and POSTs to the local daemon:
+
+| Event      | Claude Code hook     | Daemon action      | Status |
+| ---------- | -------------------- | ------------------ | ------ |
+| `start`    | `SessionStart`       | `agent.register`   | busy   |
+| `activity` | `UserPromptSubmit`   | `agent.heartbeat`  | busy   |
+| `stop`     | `Stop`, `SessionEnd` | `agent.unregister` | —      |
+
+The agent `id` is the Claude Code `session_id`; the display name is
+derived as `claude@<basename(cwd)>`. The daemon URL and auth token are
+discovered from `~/.tmux-ide/daemon.json`; an `Authorization: Bearer`
+header is sent when a token is present.
+
+`agent report` is best-effort and defensive: if no daemon is running, or
+the request fails or times out, it exits 0 silently so it can never break
+your Claude session.
+
+> **Read-only observation.** This feature only _observes_ a plain-terminal
+> agent — it reports the session's existence and lifecycle. It cannot send
+> input to or otherwise control an agent that tmux-ide did not start; there
+> is no pane to drive. Only agents launched inside a tmux-ide session can
+> be dispatched to or messaged.
+
 ## `tmux-ide ls`
 
 List all running tmux sessions.

--- a/docs/content/docs/commands.mdx
+++ b/docs/content/docs/commands.mdx
@@ -187,6 +187,65 @@ your Claude session.
 > is no pane to drive. Only agents launched inside a tmux-ide session can
 > be dispatched to or messaged.
 
+## `tmux-ide agents`
+
+The central fleet surface — list every agent the local canonical daemon
+can see (this machine, HQ-registered machines, and SSH-tunneled remotes)
+and send a message to any of them from here. Not to be confused with
+`tmux-ide agent` (singular), the hook reporter above.
+
+### `tmux-ide agents list`
+
+`tmux-ide agents` (or `tmux-ide agents list`) fetches `/api/hq/agents`
+from the local daemon and prints the fleet grouped by machine, with this
+machine first:
+
+```bash
+tmux-ide agents
+tmux-ide agents list --json   # raw { agents: [...] } response
+```
+
+```
+mac-studio (this machine)
+  ● Lead  claude  managed  dev·%1  — Fix login flow  [dev:%1]
+  ○ claude@side-project  claude  external  /Users/me/side-project  [sess-4f2a]
+boxa
+  ○ Agent 1  claude  managed  project·%1  [ssh:boxa:project:%1]
+```
+
+Each line shows a status glyph (`●` busy, `○` idle, `◌` offline), the
+agent's name, tool, kind, its `session·paneId` (or `cwd` for external
+agents), the current task title when set, and the agent id in brackets —
+you need that id for `agents send`.
+
+If no daemon is running, the command exits non-zero with
+`No tmux-ide daemon running — start one with \`tmux-ide\``.
+
+### `tmux-ide agents send`
+
+Send a message to any agent in the fleet by id. The CLI fetches the
+agent list first and resolves the target machine from the matching
+record, so remote ids work as printed — no manual machine flags:
+
+```bash
+# Local agent (id = session:paneId)
+tmux-ide agents send "dev:%1" "run the tests again"
+
+# SSH-remote agent — works while the `remote ssh launch` tunnel is up
+tmux-ide agents send "ssh:boxa:project:%1" "rebase onto main and rerun CI"
+
+# Send text without pressing Enter
+tmux-ide agents send "dev:%1" --no-enter "draft reply"
+```
+
+Failure modes are surfaced clearly:
+
+- unknown id → error suggesting `tmux-ide agents` to list ids
+- `external` agents (plain-terminal, hook-reported) are **observe-only**
+  — there is no pane to drive, so the daemon replies 409
+- machine unreachable (e.g. the SSH tunnel is down) → the daemon replies
+  502 and the CLI prints the error text
+
 ## `tmux-ide ls`
 
 List all running tmux sessions.

--- a/packages/contracts/src/actions-contract.ts
+++ b/packages/contracts/src/actions-contract.ts
@@ -20,6 +20,8 @@
 import { z } from "zod";
 import { TimelineRowZ } from "./chat-timeline.ts";
 import {
+  AgentHeartbeatPayloadSchemaZ,
+  AgentRegisterPayloadSchemaZ,
   GoalSchemaZ,
   MilestoneSchemaZ,
   MissionSchemaZ,
@@ -461,6 +463,33 @@ export const DaemonShutdownInputZ = z.object({
 });
 export const DaemonShutdownResultZ = z.object({
   stopping: z.literal(true),
+});
+
+// ---------------------------------------------------------------------------
+// agent.* — host-level (NOT project-scoped). A Claude/codex SessionStart hook
+// running in a plain terminal POSTs `agent.register` to self-report, then
+// `agent.heartbeat` on activity and `agent.unregister` on exit. These mutate
+// the daemon's ExternalAgentRegistry; the unified view is read at GET
+// /api/agents (this host) and GET /api/hq/agents (aggregated).
+// ---------------------------------------------------------------------------
+
+export const AgentRegisterInputZ = AgentRegisterPayloadSchemaZ;
+export const AgentRegisterResultZ = z.object({ ok: z.literal(true) });
+
+export const AgentHeartbeatInputZ = AgentHeartbeatPayloadSchemaZ;
+export const AgentHeartbeatResultZ = z.object({
+  ok: z.literal(true),
+  // `false` when no agent with that id was registered (the hook should
+  // re-register). The action still succeeds at the transport level.
+  known: z.boolean(),
+});
+
+export const AgentUnregisterInputZ = z.object({
+  id: z.string().min(1).max(256),
+});
+export const AgentUnregisterResultZ = z.object({
+  ok: z.literal(true),
+  removed: z.boolean(),
 });
 
 // ---------------------------------------------------------------------------
@@ -972,6 +1001,18 @@ export const ActionContractsZ = {
   "daemon.shutdown": {
     input: DaemonShutdownInputZ,
     result: DaemonShutdownResultZ,
+  },
+  "agent.register": {
+    input: AgentRegisterInputZ,
+    result: AgentRegisterResultZ,
+  },
+  "agent.heartbeat": {
+    input: AgentHeartbeatInputZ,
+    result: AgentHeartbeatResultZ,
+  },
+  "agent.unregister": {
+    input: AgentUnregisterInputZ,
+    result: AgentUnregisterResultZ,
   },
   "chat.thread.list": {
     input: ChatThreadListInputZ,

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -423,6 +423,64 @@ export const ProjectDetailSchemaZ = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Agents — a unified, location-agnostic view of every Claude/codex CLI agent,
+// whether spawned by tmux-ide (managed), discovered in another tmux session
+// (tmux-unmanaged), or self-reported from a plain terminal via a hook
+// (external). HQ stamps machineId/machineName when aggregating across hosts.
+// ---------------------------------------------------------------------------
+
+export const AgentToolSchemaZ = z.enum(["claude", "codex", "unknown"]);
+
+export const AgentKindSchemaZ = z.enum(["managed", "tmux-unmanaged", "external"]);
+
+export const AgentStatusSchemaZ = z.enum(["busy", "idle", "offline"]);
+
+export const AgentRecordSchemaZ = z.object({
+  // Stable id. tmux agents: `${machineName}:${session}:${paneId}`.
+  // external agents: the hook-supplied id (typically the Claude session id).
+  id: z.string(),
+  kind: AgentKindSchemaZ,
+  tool: AgentToolSchemaZ,
+  name: z.string(),
+  status: AgentStatusSchemaZ,
+  session: z.string().nullable(),
+  paneId: z.string().nullable(),
+  paneTitle: z.string().nullable(),
+  cwd: z.string().nullable(),
+  taskId: z.string().nullable(),
+  taskTitle: z.string().nullable(),
+  pid: z.number().nullable(),
+  // ISO timestamp of last observed activity / heartbeat.
+  lastActivity: z.string(),
+  // null = this (local) machine; set by HQ when aggregating remotes.
+  machineId: z.string().nullable(),
+  machineName: z.string().nullable(),
+});
+
+// Payload a Claude/codex SessionStart hook POSTs to register itself.
+export const AgentRegisterPayloadSchemaZ = z.object({
+  id: z.string().min(1).max(256),
+  tool: AgentToolSchemaZ.default("claude"),
+  name: z.string().max(256).optional(),
+  cwd: z.string().max(4096).optional(),
+  session: z.string().max(256).optional(),
+  pid: z.number().int().positive().optional(),
+  status: AgentStatusSchemaZ.optional(),
+  taskTitle: z.string().max(512).optional(),
+});
+
+// Payload a hook POSTs on activity (UserPromptSubmit / Stop / Notification).
+export const AgentHeartbeatPayloadSchemaZ = z.object({
+  id: z.string().min(1).max(256),
+  status: AgentStatusSchemaZ.optional(),
+  taskTitle: z.string().max(512).optional(),
+});
+
+export const AgentListSchemaZ = z.object({
+  agents: z.array(AgentRecordSchemaZ),
+});
+
+// ---------------------------------------------------------------------------
 // Inferred types
 // ---------------------------------------------------------------------------
 
@@ -437,3 +495,9 @@ export type AgentDetail = z.infer<typeof AgentDetailSchemaZ>;
 export type PaneInfo = z.infer<typeof PaneInfoSchemaZ>;
 export type SessionOverview = z.infer<typeof SessionOverviewSchemaZ>;
 export type ProjectDetail = z.infer<typeof ProjectDetailSchemaZ>;
+export type AgentTool = z.infer<typeof AgentToolSchemaZ>;
+export type AgentKind = z.infer<typeof AgentKindSchemaZ>;
+export type AgentStatus = z.infer<typeof AgentStatusSchemaZ>;
+export type AgentRecord = z.infer<typeof AgentRecordSchemaZ>;
+export type AgentRegisterPayload = z.infer<typeof AgentRegisterPayloadSchemaZ>;
+export type AgentHeartbeatPayload = z.infer<typeof AgentHeartbeatPayloadSchemaZ>;

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -436,25 +436,27 @@ export const AgentKindSchemaZ = z.enum(["managed", "tmux-unmanaged", "external"]
 export const AgentStatusSchemaZ = z.enum(["busy", "idle", "offline"]);
 
 export const AgentRecordSchemaZ = z.object({
-  // Stable id. tmux agents: `${machineName}:${session}:${paneId}`.
-  // external agents: the hook-supplied id (typically the Claude session id).
-  id: z.string(),
+  // Stable id. tmux agents (local): `${session}:${paneId}`; HQ namespaces
+  // remote ids with `${machineId}:` during aggregation. external agents: the
+  // hook-supplied id (typically the Claude session id). Bounds matter because
+  // HQ validates untrusted remote responses against this same schema.
+  id: z.string().max(512),
   kind: AgentKindSchemaZ,
   tool: AgentToolSchemaZ,
-  name: z.string(),
+  name: z.string().max(256),
   status: AgentStatusSchemaZ,
-  session: z.string().nullable(),
-  paneId: z.string().nullable(),
-  paneTitle: z.string().nullable(),
-  cwd: z.string().nullable(),
-  taskId: z.string().nullable(),
-  taskTitle: z.string().nullable(),
+  session: z.string().max(256).nullable(),
+  paneId: z.string().max(64).nullable(),
+  paneTitle: z.string().max(512).nullable(),
+  cwd: z.string().max(4096).nullable(),
+  taskId: z.string().max(128).nullable(),
+  taskTitle: z.string().max(512).nullable(),
   pid: z.number().nullable(),
   // ISO timestamp of last observed activity / heartbeat.
-  lastActivity: z.string(),
+  lastActivity: z.string().max(64),
   // null = this (local) machine; set by HQ when aggregating remotes.
-  machineId: z.string().nullable(),
-  machineName: z.string().nullable(),
+  machineId: z.string().max(256).nullable(),
+  machineName: z.string().max(256).nullable(),
 });
 
 // Payload a Claude/codex SessionStart hook POSTs to register itself.

--- a/packages/contracts/src/lib-internal/hq.ts
+++ b/packages/contracts/src/lib-internal/hq.ts
@@ -22,10 +22,10 @@ export interface RegistrationPayload {
 }
 
 export const RegistrationPayloadSchema = z.object({
-  id: z.string().min(1),
-  name: z.string().min(1),
-  url: z.string().url(),
-  token: z.string().min(1),
+  id: z.string().min(1).max(256),
+  name: z.string().min(1).max(256),
+  url: z.string().url().max(2048),
+  token: z.string().min(1).max(512),
 });
 
 export const HQConfigSchema = z.object({

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -50,7 +50,7 @@
     "dev": "tsx --watch src/lib/daemon.ts",
     "start": "node dist/lib/daemon.js",
     "lint": "eslint src",
-    "test": "bun test src/chat/thread-store.test.ts src/chat/thread-manager.test.ts src/chat/provider-discovery.test.ts src/chat/context-actions.test.ts src/chat/__tests__/codex-stop-reliability.test.ts src/chat/tools/tmux.test.ts src/chat/reactors/reactor.test.ts src/command-center/actions/handlers/chat-actions.test.ts src/codex/protocol.test.ts src/codex/client.test.ts src/codex/schema.test.ts src/agent-hook.test.ts",
+    "test": "bun test src/chat/thread-store.test.ts src/chat/thread-manager.test.ts src/chat/provider-discovery.test.ts src/chat/context-actions.test.ts src/chat/__tests__/codex-stop-reliability.test.ts src/chat/tools/tmux.test.ts src/chat/reactors/reactor.test.ts src/command-center/actions/handlers/chat-actions.test.ts src/codex/protocol.test.ts src/codex/client.test.ts src/codex/schema.test.ts",
     "test:vitest": "vitest run"
   },
   "dependencies": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -50,7 +50,7 @@
     "dev": "tsx --watch src/lib/daemon.ts",
     "start": "node dist/lib/daemon.js",
     "lint": "eslint src",
-    "test": "bun test src/chat/thread-store.test.ts src/chat/thread-manager.test.ts src/chat/provider-discovery.test.ts src/chat/context-actions.test.ts src/chat/__tests__/codex-stop-reliability.test.ts src/chat/tools/tmux.test.ts src/chat/reactors/reactor.test.ts src/command-center/actions/handlers/chat-actions.test.ts src/codex/protocol.test.ts src/codex/client.test.ts src/codex/schema.test.ts",
+    "test": "bun test src/chat/thread-store.test.ts src/chat/thread-manager.test.ts src/chat/provider-discovery.test.ts src/chat/context-actions.test.ts src/chat/__tests__/codex-stop-reliability.test.ts src/chat/tools/tmux.test.ts src/chat/reactors/reactor.test.ts src/command-center/actions/handlers/chat-actions.test.ts src/codex/protocol.test.ts src/codex/client.test.ts src/codex/schema.test.ts src/agent-hook.test.ts",
     "test:vitest": "vitest run"
   },
   "dependencies": {

--- a/packages/daemon/src/agent-hook.test.ts
+++ b/packages/daemon/src/agent-hook.test.ts
@@ -24,13 +24,20 @@ describe("buildPayload", () => {
     expect((payload as { cwd?: string }).cwd).toBeUndefined();
   });
 
-  it("maps a UserPromptSubmit (activity) event to a heartbeat payload", () => {
+  it("maps a UserPromptSubmit (activity) event to an idempotent register payload", () => {
     const payload = buildPayload("activity", {
       session_id: "sess-2",
       cwd: "/x/y",
       hook_event_name: "UserPromptSubmit",
     });
-    expect(payload).toEqual({ id: "sess-2", status: "busy" });
+    expect(payload).toMatchObject({
+      id: "sess-2",
+      tool: "claude",
+      name: "claude@y",
+      cwd: "/x/y",
+      session: "sess-2",
+      status: "busy",
+    });
   });
 
   it("maps a stop event to an unregister payload (id only)", () => {

--- a/packages/daemon/src/agent-hook.test.ts
+++ b/packages/daemon/src/agent-hook.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "bun:test";
+import { buildPayload, buildHookSnippet, mergeHooks } from "./agent-hook.ts";
+
+describe("buildPayload", () => {
+  it("maps a SessionStart (start) event to a register payload", () => {
+    const payload = buildPayload("start", {
+      session_id: "sess-123",
+      cwd: "/Users/me/code/my-project",
+      hook_event_name: "SessionStart",
+    });
+    expect(payload).toMatchObject({
+      id: "sess-123",
+      tool: "claude",
+      name: "claude@my-project",
+      cwd: "/Users/me/code/my-project",
+      session: "sess-123",
+      status: "busy",
+    });
+  });
+
+  it("falls back to a bare 'claude' name when cwd is missing", () => {
+    const payload = buildPayload("start", { session_id: "sess-1" });
+    expect(payload).toMatchObject({ id: "sess-1", name: "claude", status: "busy" });
+    expect((payload as { cwd?: string }).cwd).toBeUndefined();
+  });
+
+  it("maps a UserPromptSubmit (activity) event to a heartbeat payload", () => {
+    const payload = buildPayload("activity", {
+      session_id: "sess-2",
+      cwd: "/x/y",
+      hook_event_name: "UserPromptSubmit",
+    });
+    expect(payload).toEqual({ id: "sess-2", status: "busy" });
+  });
+
+  it("maps a stop event to an unregister payload (id only)", () => {
+    const payload = buildPayload("stop", {
+      session_id: "sess-3",
+      cwd: "/x/y",
+      hook_event_name: "Stop",
+    });
+    expect(payload).toEqual({ id: "sess-3" });
+  });
+
+  it("returns null when there is no session_id", () => {
+    expect(buildPayload("start", {})).toBeNull();
+    expect(buildPayload("activity", { session_id: "  " })).toBeNull();
+    expect(buildPayload("stop", { cwd: "/x" })).toBeNull();
+  });
+});
+
+describe("buildHookSnippet", () => {
+  it("wires all four lifecycle events to the report command", () => {
+    const snippet = buildHookSnippet();
+    expect(Object.keys(snippet).sort()).toEqual([
+      "SessionEnd",
+      "SessionStart",
+      "Stop",
+      "UserPromptSubmit",
+    ]);
+    expect(snippet.SessionStart![0]!.hooks[0]!.command).toBe("tmux-ide agent report start");
+    expect(snippet.UserPromptSubmit![0]!.hooks[0]!.command).toBe("tmux-ide agent report activity");
+    expect(snippet.Stop![0]!.hooks[0]!.command).toBe("tmux-ide agent report stop");
+    expect(snippet.SessionEnd![0]!.hooks[0]!.command).toBe("tmux-ide agent report stop");
+  });
+});
+
+describe("mergeHooks", () => {
+  it("preserves unrelated hooks while adding ours", () => {
+    const existing = {
+      SessionStart: [{ hooks: [{ type: "command" as const, command: "my-other-tool init" }] }],
+      PreToolUse: [{ hooks: [{ type: "command" as const, command: "guard" }] }],
+    };
+    const merged = mergeHooks(existing, buildHookSnippet());
+    expect(merged.PreToolUse).toEqual(existing.PreToolUse);
+    const startCommands = merged.SessionStart!.flatMap((m) => m.hooks.map((h) => h.command));
+    expect(startCommands).toContain("my-other-tool init");
+    expect(startCommands).toContain("tmux-ide agent report start");
+  });
+
+  it("is idempotent — re-running does not duplicate our entries", () => {
+    const once = mergeHooks(undefined, buildHookSnippet());
+    const twice = mergeHooks(once, buildHookSnippet());
+    const startCommands = twice.SessionStart!.flatMap((m) => m.hooks.map((h) => h.command));
+    expect(startCommands.filter((c) => c === "tmux-ide agent report start")).toHaveLength(1);
+  });
+});

--- a/packages/daemon/src/agent-hook.test.ts
+++ b/packages/daemon/src/agent-hook.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect } from "bun:test";
-import { buildPayload, buildHookSnippet, mergeHooks } from "./agent-hook.ts";
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  buildPayload,
+  buildHookSnippet,
+  buildReportRequest,
+  hostnameForClient,
+  mergeHooks,
+} from "./agent-hook.ts";
+
+afterEach(() => {
+  delete process.env.TMUX_IDE_AGENT_TOOL;
+});
 
 describe("buildPayload", () => {
   it("maps a SessionStart (start) event to a register payload", () => {
@@ -18,7 +28,7 @@ describe("buildPayload", () => {
     });
   });
 
-  it("falls back to a bare 'claude' name when cwd is missing", () => {
+  it("falls back to a bare tool name when cwd is missing", () => {
     const payload = buildPayload("start", { session_id: "sess-1" });
     expect(payload).toMatchObject({ id: "sess-1", name: "claude", status: "busy" });
     expect((payload as { cwd?: string }).cwd).toBeUndefined();
@@ -34,32 +44,44 @@ describe("buildPayload", () => {
       id: "sess-2",
       tool: "claude",
       name: "claude@y",
-      cwd: "/x/y",
-      session: "sess-2",
       status: "busy",
     });
+  });
+
+  it("maps an idle (Stop) event to a status-only heartbeat payload", () => {
+    const payload = buildPayload("idle", { session_id: "sess-9", cwd: "/x/y" });
+    expect(payload).toEqual({ id: "sess-9", status: "idle" });
   });
 
   it("maps a stop event to an unregister payload (id only)", () => {
     const payload = buildPayload("stop", {
       session_id: "sess-3",
       cwd: "/x/y",
-      hook_event_name: "Stop",
+      hook_event_name: "SessionEnd",
     });
     expect(payload).toEqual({ id: "sess-3" });
+  });
+
+  it("honors TMUX_IDE_AGENT_TOOL=codex for tool + name", () => {
+    process.env.TMUX_IDE_AGENT_TOOL = "codex";
+    const payload = buildPayload("start", { session_id: "s", cwd: "/a/proj" });
+    expect(payload).toMatchObject({ tool: "codex", name: "codex@proj" });
   });
 
   it("returns null when there is no session_id", () => {
     expect(buildPayload("start", {})).toBeNull();
     expect(buildPayload("activity", { session_id: "  " })).toBeNull();
     expect(buildPayload("stop", { cwd: "/x" })).toBeNull();
+    // non-string session_id is rejected by the typeof guard
+    expect(buildPayload("start", { session_id: 123 as unknown as string })).toBeNull();
   });
 });
 
 describe("buildHookSnippet", () => {
-  it("wires all four lifecycle events to the report command", () => {
+  it("wires every lifecycle event to the report command", () => {
     const snippet = buildHookSnippet();
     expect(Object.keys(snippet).sort()).toEqual([
+      "PreToolUse",
       "SessionEnd",
       "SessionStart",
       "Stop",
@@ -67,8 +89,30 @@ describe("buildHookSnippet", () => {
     ]);
     expect(snippet.SessionStart![0]!.hooks[0]!.command).toBe("tmux-ide agent report start");
     expect(snippet.UserPromptSubmit![0]!.hooks[0]!.command).toBe("tmux-ide agent report activity");
-    expect(snippet.Stop![0]!.hooks[0]!.command).toBe("tmux-ide agent report stop");
+    expect(snippet.PreToolUse![0]!.hooks[0]!.command).toBe("tmux-ide agent report activity");
+    expect(snippet.Stop![0]!.hooks[0]!.command).toBe("tmux-ide agent report idle");
     expect(snippet.SessionEnd![0]!.hooks[0]!.command).toBe("tmux-ide agent report stop");
+  });
+});
+
+describe("hostnameForClient / buildReportRequest", () => {
+  it("rewrites 0.0.0.0 to loopback", () => {
+    expect(hostnameForClient("0.0.0.0")).toBe("127.0.0.1");
+    expect(hostnameForClient("127.0.0.1")).toBe("127.0.0.1");
+  });
+
+  it("builds the action url and attaches the bearer token when present", () => {
+    const req = buildReportRequest(
+      { bindHostname: "0.0.0.0", port: 6060, authToken: "tok" },
+      "agent.register",
+    );
+    expect(req.url).toBe("http://127.0.0.1:6060/api/v2/action/agent.register");
+    expect(req.headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("omits Authorization when there is no token", () => {
+    const req = buildReportRequest({ bindHostname: "127.0.0.1", port: 7, authToken: null }, "x");
+    expect(req.headers.Authorization).toBeUndefined();
   });
 });
 
@@ -79,10 +123,13 @@ describe("mergeHooks", () => {
       PreToolUse: [{ hooks: [{ type: "command" as const, command: "guard" }] }],
     };
     const merged = mergeHooks(existing, buildHookSnippet());
-    expect(merged.PreToolUse).toEqual(existing.PreToolUse);
     const startCommands = merged.SessionStart!.flatMap((m) => m.hooks.map((h) => h.command));
     expect(startCommands).toContain("my-other-tool init");
     expect(startCommands).toContain("tmux-ide agent report start");
+    // our PreToolUse entry is added without dropping the unrelated guard
+    const preCommands = merged.PreToolUse!.flatMap((m) => m.hooks.map((h) => h.command));
+    expect(preCommands).toContain("guard");
+    expect(preCommands).toContain("tmux-ide agent report activity");
   });
 
   it("is idempotent — re-running does not duplicate our entries", () => {

--- a/packages/daemon/src/agent-hook.ts
+++ b/packages/daemon/src/agent-hook.ts
@@ -1,0 +1,310 @@
+import { readFileSync, mkdirSync, renameSync, existsSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { readCanonicalDaemonInfo } from "./lib/canonical-daemon.ts";
+
+/**
+ * `tmux-ide agent ...` — lets a Claude Code (or Codex) CLI session running in a
+ * plain terminal report itself to the local canonical daemon so it shows up in
+ * the central agent view.
+ *
+ * The reporting path (`agent report <event>`) is invoked by Claude Code hooks.
+ * It MUST be fast and MUST NOT throw to the parent: every failure mode exits 0
+ * so it can never break the user's Claude session. It only OBSERVES the
+ * session — it cannot control a plain-terminal agent.
+ */
+
+type HookEvent = "start" | "activity" | "stop";
+
+const EVENT_TO_ACTION: Record<
+  HookEvent,
+  "agent.register" | "agent.heartbeat" | "agent.unregister"
+> = {
+  start: "agent.register",
+  activity: "agent.heartbeat",
+  stop: "agent.unregister",
+};
+
+/** Shape of the JSON object Claude Code delivers on stdin to a hook command. */
+interface HookStdin {
+  session_id?: string;
+  cwd?: string;
+  hook_event_name?: string;
+  transcript_path?: string;
+}
+
+/** register: { id, tool?, name?, cwd?, session?, pid?, status?, taskTitle? } */
+interface RegisterPayload {
+  id: string;
+  tool?: "claude" | "codex";
+  name?: string;
+  cwd?: string;
+  session?: string;
+  pid?: number;
+  status?: "busy" | "idle" | "offline";
+  taskTitle?: string;
+}
+
+/** heartbeat: { id, status?, taskTitle? } */
+interface HeartbeatPayload {
+  id: string;
+  status?: "busy" | "idle" | "offline";
+  taskTitle?: string;
+}
+
+/** unregister: { id } */
+interface UnregisterPayload {
+  id: string;
+}
+
+type ActionPayload = RegisterPayload | HeartbeatPayload | UnregisterPayload;
+
+function parseStdin(raw: string): HookStdin {
+  if (!raw.trim()) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object") return parsed as HookStdin;
+  } catch {
+    // Malformed stdin — fall through to an empty object.
+  }
+  return {};
+}
+
+/**
+ * Map a hook event + the Claude Code stdin payload onto an agent action body.
+ *
+ * Status mapping:
+ *  - start / activity (UserPromptSubmit, SessionStart) → "busy" — the user just
+ *    handed the agent work.
+ *  - stop (Stop, SessionEnd) → "idle" for the heartbeat-style stop. The actual
+ *    teardown is the `agent.unregister` action which only needs the id.
+ *
+ * `name` is derived as "<tool>@<basename(cwd)>" (e.g. "claude@my-project") so
+ * the central view can show a human-friendly label.
+ */
+export function buildPayload(event: HookEvent, stdin: HookStdin): ActionPayload | null {
+  const id = typeof stdin.session_id === "string" ? stdin.session_id.trim() : "";
+  if (!id) return null;
+
+  if (event === "stop") {
+    return { id } satisfies UnregisterPayload;
+  }
+
+  const cwd = typeof stdin.cwd === "string" && stdin.cwd ? stdin.cwd : undefined;
+  const status: "busy" | "idle" = "busy";
+
+  if (event === "activity") {
+    return { id, status } satisfies HeartbeatPayload;
+  }
+
+  // event === "start" → register
+  const name = cwd ? `claude@${basename(cwd)}` : "claude";
+  return {
+    id,
+    tool: "claude",
+    name,
+    cwd,
+    session: id,
+    pid: typeof process.ppid === "number" ? process.ppid : undefined,
+    status,
+  } satisfies RegisterPayload;
+}
+
+function timeoutSignal(ms: number): AbortSignal {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms).unref?.();
+  return controller.signal;
+}
+
+function hostnameForClient(bindHostname: string): string {
+  return bindHostname === "0.0.0.0" ? "127.0.0.1" : bindHostname;
+}
+
+/**
+ * Read stdin, build the payload, and POST it to the local daemon. Never throws,
+ * always resolves. If no daemon is running, returns silently.
+ */
+async function report(event: HookEvent): Promise<void> {
+  let raw: string;
+  try {
+    raw = readFileSync(0, "utf-8");
+  } catch {
+    // No stdin (e.g. a TTY) — nothing to report.
+    return;
+  }
+
+  const stdin = parseStdin(raw);
+  const payload = buildPayload(event, stdin);
+  if (!payload) return;
+
+  const info = readCanonicalDaemonInfo();
+  if (!info) return;
+
+  const action = EVENT_TO_ACTION[event];
+  const baseUrl = `http://${hostnameForClient(info.bindHostname)}:${info.port}`;
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (info.authToken) headers.Authorization = `Bearer ${info.authToken}`;
+
+  try {
+    await fetch(`${baseUrl}/api/v2/action/${action}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+      signal: timeoutSignal(1500),
+    });
+  } catch {
+    // Daemon unreachable or slow — observing is best-effort.
+  }
+}
+
+/** Claude Code lifecycle hook → reported event. Single source of truth. */
+const HOOK_EVENTS = {
+  SessionStart: "start",
+  UserPromptSubmit: "activity",
+  Stop: "stop",
+  SessionEnd: "stop",
+} as const satisfies Record<string, HookEvent>;
+
+function settingsPath(): string {
+  return process.env.CLAUDE_CONFIG_DIR
+    ? join(process.env.CLAUDE_CONFIG_DIR, "settings.json")
+    : join(homedir(), ".claude", "settings.json");
+}
+
+interface HookCommandEntry {
+  type: "command";
+  command: string;
+}
+
+interface HookMatcher {
+  matcher?: string;
+  hooks: HookCommandEntry[];
+}
+
+type HooksConfig = Record<string, HookMatcher[]>;
+
+/**
+ * Build the `hooks` snippet that wires the four lifecycle events to
+ * `tmux-ide agent report <event>`.
+ */
+export function buildHookSnippet(): HooksConfig {
+  const snippet: HooksConfig = {};
+  for (const [hookName, event] of Object.entries(HOOK_EVENTS)) {
+    snippet[hookName] = [
+      { hooks: [{ type: "command", command: `tmux-ide agent report ${event}` }] },
+    ];
+  }
+  return snippet;
+}
+
+function isOurHookEntry(entry: HookCommandEntry): boolean {
+  return entry.type === "command" && /\btmux-ide agent report\b/.test(entry.command);
+}
+
+/**
+ * Merge our hook matchers into the existing `hooks` config without clobbering
+ * unrelated hooks. Replaces only previously-installed `tmux-ide agent report`
+ * entries so re-running the installer is idempotent.
+ */
+export function mergeHooks(existing: HooksConfig | undefined, snippet: HooksConfig): HooksConfig {
+  const merged: HooksConfig = { ...(existing ?? {}) };
+  for (const [hookName, matchers] of Object.entries(snippet)) {
+    const current = Array.isArray(merged[hookName]) ? merged[hookName] : [];
+    // Strip any prior tmux-ide entries, then drop now-empty matchers.
+    const cleaned = current
+      .map((matcher) => ({
+        ...matcher,
+        hooks: (matcher.hooks ?? []).filter((entry) => !isOurHookEntry(entry)),
+      }))
+      .filter((matcher) => matcher.hooks.length > 0);
+    merged[hookName] = [...cleaned, ...matchers];
+  }
+  return merged;
+}
+
+async function installHooks(opts: { print?: boolean; json?: boolean }): Promise<void> {
+  const snippet = buildHookSnippet();
+
+  if (opts.print) {
+    console.log(JSON.stringify({ hooks: snippet }, null, 2));
+    return;
+  }
+
+  const path = settingsPath();
+  let settings: Record<string, unknown> = {};
+  if (existsSync(path)) {
+    try {
+      settings = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+    } catch {
+      throw new Error(
+        `Could not parse ${path}. Fix the JSON or run "tmux-ide agent hook install --print" and merge manually.`,
+      );
+    }
+  }
+
+  const existingHooks =
+    settings.hooks && typeof settings.hooks === "object"
+      ? (settings.hooks as HooksConfig)
+      : undefined;
+  settings.hooks = mergeHooks(existingHooks, snippet);
+
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmp, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ ok: true, path, events: Object.keys(snippet) }));
+  } else {
+    console.log(`Installed tmux-ide agent hooks into ${path}`);
+    console.log(`Events: ${Object.keys(snippet).join(", ")}`);
+    console.log("Restart your Claude Code sessions for the hooks to take effect.");
+  }
+}
+
+interface AgentCommandOptions {
+  sub?: string;
+  args?: string[];
+  json?: boolean;
+  print?: boolean;
+}
+
+/**
+ * Entry point for `tmux-ide agent ...`.
+ *
+ * - `agent report <start|activity|stop>` — invoked by Claude Code hooks. Always
+ *   exits 0; never throws to the parent process.
+ * - `agent hook install [--print]` — merge the hook config into
+ *   ~/.claude/settings.json (or print the snippet with `--print`).
+ */
+export async function agentCommand(opts: AgentCommandOptions): Promise<void> {
+  const sub = opts.sub;
+
+  if (sub === "report") {
+    const event = opts.args?.[0];
+    if (event === "start" || event === "activity" || event === "stop") {
+      try {
+        await report(event);
+      } catch {
+        // Reporting is best-effort and must never break the parent session.
+      }
+    }
+    // Always succeed for the hook path.
+    process.exit(0);
+  }
+
+  if (sub === "hook") {
+    const hookSub = opts.args?.[0];
+    if (hookSub === "install") {
+      await installHooks({ print: opts.print, json: opts.json });
+      return;
+    }
+    throw new Error("Usage: tmux-ide agent hook install [--print]");
+  }
+
+  throw new Error(
+    "Usage:\n" +
+      "  tmux-ide agent report <start|activity|stop>\n" +
+      "  tmux-ide agent hook install [--print]",
+  );
+}

--- a/packages/daemon/src/agent-hook.ts
+++ b/packages/daemon/src/agent-hook.ts
@@ -314,8 +314,8 @@ interface AgentCommandOptions {
 /**
  * Entry point for `tmux-ide agent ...`.
  *
- * - `agent report <start|activity|stop>` — invoked by Claude Code hooks. Always
- *   exits 0; never throws to the parent process.
+ * - `agent report <start|activity|idle|stop>` — invoked by Claude Code hooks.
+ *   Always exits 0; never throws to the parent process.
  * - `agent hook install [--print]` — merge the hook config into
  *   ~/.claude/settings.json (or print the snippet with `--print`).
  */
@@ -346,7 +346,7 @@ export async function agentCommand(opts: AgentCommandOptions): Promise<void> {
 
   throw new Error(
     "Usage:\n" +
-      "  tmux-ide agent report <start|activity|stop>\n" +
+      "  tmux-ide agent report <start|activity|idle|stop>\n" +
       "  tmux-ide agent hook install [--print]",
   );
 }

--- a/packages/daemon/src/agent-hook.ts
+++ b/packages/daemon/src/agent-hook.ts
@@ -14,15 +14,20 @@ import { readCanonicalDaemonInfo } from "./lib/canonical-daemon.ts";
  * session — it cannot control a plain-terminal agent.
  */
 
-type HookEvent = "start" | "activity" | "stop";
+type HookEvent = "start" | "activity" | "idle" | "stop";
 
-const EVENT_TO_ACTION: Record<HookEvent, "agent.register" | "agent.unregister"> = {
-  // `activity` re-registers (register is an idempotent upsert) so a session that
-  // idled long enough to be evicted reappears on its next prompt — a bare
-  // heartbeat would return known:false and the agent would stay gone until the
-  // session restarts.
+const EVENT_TO_ACTION: Record<
+  HookEvent,
+  "agent.register" | "agent.heartbeat" | "agent.unregister"
+> = {
+  // start/activity re-register (register is an idempotent upsert) so a session
+  // evicted after a long idle reappears on its next prompt or tool call.
+  // idle is a lightweight status-only heartbeat fired when a turn ends — the
+  // agent stays on the roster (just not "busy"), instead of vanishing between
+  // turns. stop is the real teardown (session exit).
   start: "agent.register",
   activity: "agent.register",
+  idle: "agent.heartbeat",
   stop: "agent.unregister",
 };
 
@@ -46,12 +51,19 @@ interface RegisterPayload {
   taskTitle?: string;
 }
 
+/** heartbeat: { id, status?, taskTitle? } */
+interface HeartbeatPayload {
+  id: string;
+  status?: "busy" | "idle" | "offline";
+  taskTitle?: string;
+}
+
 /** unregister: { id } */
 interface UnregisterPayload {
   id: string;
 }
 
-type ActionPayload = RegisterPayload | UnregisterPayload;
+type ActionPayload = RegisterPayload | HeartbeatPayload | UnregisterPayload;
 
 function parseStdin(raw: string): HookStdin {
   if (!raw.trim()) return {};
@@ -65,13 +77,22 @@ function parseStdin(raw: string): HookStdin {
 }
 
 /**
+ * The reporting tool. Defaults to "claude" (this is a Claude Code hook), but a
+ * codex (or other) integration can set TMUX_IDE_AGENT_TOOL so the unified view
+ * labels it correctly rather than always showing "claude".
+ */
+function reportingTool(): "claude" | "codex" {
+  return process.env.TMUX_IDE_AGENT_TOOL === "codex" ? "codex" : "claude";
+}
+
+/**
  * Map a hook event + the Claude Code stdin payload onto an agent action body.
  *
- *  - start / activity (SessionStart, UserPromptSubmit) → an idempotent register
- *    with status "busy" — the user just handed the agent work. Plain-terminal
- *    sessions can't be observed at rest, so there is no "idle" external state;
- *    an agent is busy until it's unregistered.
- *  - stop (Stop, SessionEnd) → unregister (id only).
+ *  - start / activity (SessionStart, UserPromptSubmit, PreToolUse) → an
+ *    idempotent register with status "busy" — work is in flight.
+ *  - idle (Stop) → a status-only heartbeat marking the agent idle at the end of
+ *    a turn, so it stays on the roster between turns instead of disappearing.
+ *  - stop (SessionEnd) → unregister (id only).
  *
  * `name` is derived as "<tool>@<basename(cwd)>" (e.g. "claude@my-project") so
  * the central view can show a human-friendly label.
@@ -84,12 +105,17 @@ export function buildPayload(event: HookEvent, stdin: HookStdin): ActionPayload 
     return { id } satisfies UnregisterPayload;
   }
 
+  if (event === "idle") {
+    return { id, status: "idle" } satisfies HeartbeatPayload;
+  }
+
   // start or activity → register (upsert).
+  const tool = reportingTool();
   const cwd = typeof stdin.cwd === "string" && stdin.cwd ? stdin.cwd : undefined;
-  const name = cwd ? `claude@${basename(cwd)}` : "claude";
+  const name = cwd ? `${tool}@${basename(cwd)}` : tool;
   return {
     id,
-    tool: "claude",
+    tool,
     name,
     cwd,
     session: id,
@@ -104,8 +130,25 @@ function timeoutSignal(ms: number): AbortSignal {
   return controller.signal;
 }
 
-function hostnameForClient(bindHostname: string): string {
+export function hostnameForClient(bindHostname: string): string {
   return bindHostname === "0.0.0.0" ? "127.0.0.1" : bindHostname;
+}
+
+interface DaemonInfoLike {
+  bindHostname: string;
+  port: number;
+  authToken?: string | null;
+}
+
+/** Build the daemon request (url + headers) for an action. Testable seam. */
+export function buildReportRequest(
+  info: DaemonInfoLike,
+  action: string,
+): { url: string; headers: Record<string, string> } {
+  const baseUrl = `http://${hostnameForClient(info.bindHostname)}:${info.port}`;
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (info.authToken) headers.Authorization = `Bearer ${info.authToken}`;
+  return { url: `${baseUrl}/api/v2/action/${action}`, headers };
 }
 
 /**
@@ -135,13 +178,10 @@ async function report(event: HookEvent): Promise<void> {
   const info = readCanonicalDaemonInfo();
   if (!info) return;
 
-  const action = EVENT_TO_ACTION[event];
-  const baseUrl = `http://${hostnameForClient(info.bindHostname)}:${info.port}`;
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (info.authToken) headers.Authorization = `Bearer ${info.authToken}`;
+  const { url, headers } = buildReportRequest(info, EVENT_TO_ACTION[event]);
 
   try {
-    await fetch(`${baseUrl}/api/v2/action/${action}`, {
+    await fetch(url, {
       method: "POST",
       headers,
       body: JSON.stringify(payload),
@@ -152,11 +192,18 @@ async function report(event: HookEvent): Promise<void> {
   }
 }
 
-/** Claude Code lifecycle hook → reported event. Single source of truth. */
+/**
+ * Claude Code lifecycle hook → reported event. Single source of truth.
+ *
+ * Stop fires at the END OF EVERY TURN (not session exit), so it maps to `idle`
+ * — the agent stays on the roster between turns. PreToolUse refreshes liveness
+ * during long turns. SessionEnd is the real teardown.
+ */
 const HOOK_EVENTS = {
   SessionStart: "start",
   UserPromptSubmit: "activity",
-  Stop: "stop",
+  PreToolUse: "activity",
+  Stop: "idle",
   SessionEnd: "stop",
 } as const satisfies Record<string, HookEvent>;
 
@@ -179,7 +226,7 @@ interface HookMatcher {
 type HooksConfig = Record<string, HookMatcher[]>;
 
 /**
- * Build the `hooks` snippet that wires the four lifecycle events to
+ * Build the `hooks` snippet that wires the Claude Code lifecycle events to
  * `tmux-ide agent report <event>`.
  */
 export function buildHookSnippet(): HooksConfig {
@@ -277,7 +324,7 @@ export async function agentCommand(opts: AgentCommandOptions): Promise<void> {
 
   if (sub === "report") {
     const event = opts.args?.[0];
-    if (event === "start" || event === "activity" || event === "stop") {
+    if (event === "start" || event === "activity" || event === "idle" || event === "stop") {
       try {
         await report(event);
       } catch {

--- a/packages/daemon/src/agent-hook.ts
+++ b/packages/daemon/src/agent-hook.ts
@@ -16,12 +16,13 @@ import { readCanonicalDaemonInfo } from "./lib/canonical-daemon.ts";
 
 type HookEvent = "start" | "activity" | "stop";
 
-const EVENT_TO_ACTION: Record<
-  HookEvent,
-  "agent.register" | "agent.heartbeat" | "agent.unregister"
-> = {
+const EVENT_TO_ACTION: Record<HookEvent, "agent.register" | "agent.unregister"> = {
+  // `activity` re-registers (register is an idempotent upsert) so a session that
+  // idled long enough to be evicted reappears on its next prompt — a bare
+  // heartbeat would return known:false and the agent would stay gone until the
+  // session restarts.
   start: "agent.register",
-  activity: "agent.heartbeat",
+  activity: "agent.register",
   stop: "agent.unregister",
 };
 
@@ -45,19 +46,12 @@ interface RegisterPayload {
   taskTitle?: string;
 }
 
-/** heartbeat: { id, status?, taskTitle? } */
-interface HeartbeatPayload {
-  id: string;
-  status?: "busy" | "idle" | "offline";
-  taskTitle?: string;
-}
-
 /** unregister: { id } */
 interface UnregisterPayload {
   id: string;
 }
 
-type ActionPayload = RegisterPayload | HeartbeatPayload | UnregisterPayload;
+type ActionPayload = RegisterPayload | UnregisterPayload;
 
 function parseStdin(raw: string): HookStdin {
   if (!raw.trim()) return {};
@@ -73,11 +67,11 @@ function parseStdin(raw: string): HookStdin {
 /**
  * Map a hook event + the Claude Code stdin payload onto an agent action body.
  *
- * Status mapping:
- *  - start / activity (UserPromptSubmit, SessionStart) → "busy" — the user just
- *    handed the agent work.
- *  - stop (Stop, SessionEnd) → "idle" for the heartbeat-style stop. The actual
- *    teardown is the `agent.unregister` action which only needs the id.
+ *  - start / activity (SessionStart, UserPromptSubmit) → an idempotent register
+ *    with status "busy" — the user just handed the agent work. Plain-terminal
+ *    sessions can't be observed at rest, so there is no "idle" external state;
+ *    an agent is busy until it's unregistered.
+ *  - stop (Stop, SessionEnd) → unregister (id only).
  *
  * `name` is derived as "<tool>@<basename(cwd)>" (e.g. "claude@my-project") so
  * the central view can show a human-friendly label.
@@ -90,14 +84,8 @@ export function buildPayload(event: HookEvent, stdin: HookStdin): ActionPayload 
     return { id } satisfies UnregisterPayload;
   }
 
+  // start or activity → register (upsert).
   const cwd = typeof stdin.cwd === "string" && stdin.cwd ? stdin.cwd : undefined;
-  const status: "busy" | "idle" = "busy";
-
-  if (event === "activity") {
-    return { id, status } satisfies HeartbeatPayload;
-  }
-
-  // event === "start" → register
   const name = cwd ? `claude@${basename(cwd)}` : "claude";
   return {
     id,
@@ -106,7 +94,7 @@ export function buildPayload(event: HookEvent, stdin: HookStdin): ActionPayload 
     cwd,
     session: id,
     pid: typeof process.ppid === "number" ? process.ppid : undefined,
-    status,
+    status: "busy",
   } satisfies RegisterPayload;
 }
 
@@ -125,6 +113,10 @@ function hostnameForClient(bindHostname: string): string {
  * always resolves. If no daemon is running, returns silently.
  */
 async function report(event: HookEvent): Promise<void> {
+  // Sessions running inside tmux are already discovered by the daemon's
+  // tmux-wide scan; reporting here too would double-count them.
+  if (process.env.TMUX) return;
+
   let raw: string;
   try {
     raw = readFileSync(0, "utf-8");
@@ -132,6 +124,9 @@ async function report(event: HookEvent): Promise<void> {
     // No stdin (e.g. a TTY) — nothing to report.
     return;
   }
+
+  // Bound the parse: a hook payload is tiny; anything huge is malformed.
+  if (raw.length > 256 * 1024) return;
 
   const stdin = parseStdin(raw);
   const payload = buildPayload(event, stdin);

--- a/packages/daemon/src/agents-cli.test.ts
+++ b/packages/daemon/src/agents-cli.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import type { AgentRecord } from "@tmux-ide/contracts";
+import {
+  findAgentById,
+  resolveSendTarget,
+  groupAgentsByMachine,
+  formatAgentLine,
+  formatAgentList,
+} from "./agents-cli.ts";
+import { IdeError } from "./lib/errors.ts";
+
+function agent(overrides: Partial<AgentRecord>): AgentRecord {
+  return {
+    id: "dev:%1",
+    kind: "managed",
+    tool: "claude",
+    name: "Agent 1",
+    status: "idle",
+    session: "dev",
+    paneId: "%1",
+    paneTitle: null,
+    cwd: null,
+    taskId: null,
+    taskTitle: null,
+    pid: null,
+    lastActivity: "2026-07-02T00:00:00.000Z",
+    machineId: null,
+    machineName: "local-mac",
+    ...overrides,
+  };
+}
+
+const fleet: AgentRecord[] = [
+  agent({ id: "dev:%1", name: "Lead", status: "busy", taskTitle: "Fix login" }),
+  agent({
+    id: "ssh:boxa:project:%1",
+    name: "Remote 1",
+    status: "idle",
+    session: "project",
+    machineId: "ssh:boxa",
+    machineName: "boxa",
+  }),
+  agent({
+    id: "3c9f0e2a:hq-proj:%2",
+    name: "HQ Agent",
+    status: "offline",
+    session: "hq-proj",
+    paneId: "%2",
+    machineId: "3c9f0e2a",
+    machineName: "studio",
+  }),
+  agent({
+    id: "sess-external-1",
+    name: "claude@side-project",
+    kind: "external",
+    status: "busy",
+    session: null,
+    paneId: null,
+    cwd: "/Users/me/side-project",
+  }),
+];
+
+describe("findAgentById / resolveSendTarget", () => {
+  it("resolves a local agent to machineId null", () => {
+    const { agent: found, machineId } = resolveSendTarget(fleet, "dev:%1");
+    expect(found.name).toBe("Lead");
+    expect(machineId).toBeNull();
+  });
+
+  it("resolves an SSH-remote agent to its ssh machineId verbatim", () => {
+    const { machineId } = resolveSendTarget(fleet, "ssh:boxa:project:%1");
+    expect(machineId).toBe("ssh:boxa");
+  });
+
+  it("resolves an HQ-machine agent to its uuid machineId verbatim", () => {
+    const { machineId } = resolveSendTarget(fleet, "3c9f0e2a:hq-proj:%2");
+    expect(machineId).toBe("3c9f0e2a");
+  });
+
+  it("matches ids exactly — never by prefix or parsing", () => {
+    expect(findAgentById(fleet, "dev:%")).toBeUndefined();
+    expect(findAgentById(fleet, "ssh:boxa")).toBeUndefined();
+    expect(findAgentById(fleet, "dev:%1")?.id).toBe("dev:%1");
+  });
+
+  it("throws a clear not-found error suggesting the list command", () => {
+    expect(() => resolveSendTarget(fleet, "nope")).toThrowError(IdeError);
+    expect(() => resolveSendTarget(fleet, "nope")).toThrowError(
+      /Agent not found: nope.*tmux-ide agents/s,
+    );
+  });
+});
+
+describe("groupAgentsByMachine", () => {
+  it("puts the local machine (machineId null) first", () => {
+    const reversed = [...fleet].reverse();
+    const groups = groupAgentsByMachine(reversed);
+    expect(groups[0]!.machineId).toBeNull();
+    expect(groups[0]!.agents.map((a) => a.id)).toEqual(["sess-external-1", "dev:%1"]);
+  });
+
+  it("keeps one group per machine with its name attached", () => {
+    const groups = groupAgentsByMachine(fleet);
+    expect(groups).toHaveLength(3);
+    expect(groups.map((g) => g.machineName)).toEqual(["local-mac", "boxa", "studio"]);
+  });
+});
+
+describe("formatAgentLine", () => {
+  it("shows glyph, name, tool, kind, session·paneId, task, and id", () => {
+    const line = formatAgentLine(fleet[0]!);
+    expect(line).toContain("●");
+    expect(line).toContain("Lead");
+    expect(line).toContain("claude");
+    expect(line).toContain("managed");
+    expect(line).toContain("dev·%1");
+    expect(line).toContain("— Fix login");
+    expect(line).toContain("[dev:%1]");
+  });
+
+  it("falls back to cwd when there is no pane, and uses status glyphs", () => {
+    const external = formatAgentLine(fleet[3]!);
+    expect(external).toContain("/Users/me/side-project");
+    expect(external).toContain("external");
+    expect(formatAgentLine(fleet[1]!)).toContain("○");
+    expect(formatAgentLine(fleet[2]!)).toContain("◌");
+  });
+});
+
+describe("formatAgentList", () => {
+  it("groups output by machine with the local machine first", () => {
+    const text = formatAgentList(fleet);
+    const lines = text.split("\n");
+    expect(lines[0]).toBe("local-mac (this machine)");
+    const boxaIndex = lines.indexOf("boxa");
+    const studioIndex = lines.indexOf("studio");
+    expect(boxaIndex).toBeGreaterThan(0);
+    expect(studioIndex).toBeGreaterThan(boxaIndex);
+    expect(lines[boxaIndex + 1]).toContain("[ssh:boxa:project:%1]");
+  });
+
+  it("labels the local group generically when machineName is missing", () => {
+    const text = formatAgentList([agent({ machineName: null })]);
+    expect(text.split("\n")[0]).toBe("this machine");
+  });
+
+  it("reports an empty fleet", () => {
+    expect(formatAgentList([])).toBe("No agents found.");
+  });
+});

--- a/packages/daemon/src/agents-cli.ts
+++ b/packages/daemon/src/agents-cli.ts
@@ -219,6 +219,57 @@ async function sendToAgent(opts: {
   console.log(`Sent to ${agent.name} [${agent.id}] on ${where}.`);
 }
 
+async function claimAgent(opts: {
+  id: string;
+  name?: string;
+  role?: string;
+  release?: boolean;
+  json?: boolean;
+}): Promise<void> {
+  const info = requireDaemonInfo();
+  const { agents } = await fetchAgentList(info);
+  const { agent, machineId } = resolveSendTarget(agents, opts.id);
+
+  const path = opts.release ? "/api/agents/release" : "/api/agents/claim";
+  const { url, headers } = daemonRequest(info, path);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(
+        opts.release
+          ? { id: opts.id, machineId }
+          : { id: opts.id, machineId, name: opts.name, role: opts.role },
+      ),
+      signal: timeoutSignal(15_000),
+    });
+  } catch {
+    throw new IdeError(NO_DAEMON_MESSAGE, { code: "DAEMON_UNAVAILABLE", exitCode: 1 });
+  }
+
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) {
+    const detail = typeof body.error === "string" ? body.error : `HTTP ${res.status}`;
+    throw new IdeError(`${opts.release ? "Release" : "Claim"} failed: ${detail}`, {
+      code: opts.release ? "RELEASE_FAILED" : "CLAIM_FAILED",
+      exitCode: 1,
+    });
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify(body));
+    return;
+  }
+  const where = machineId === null ? "this machine" : (agent.machineName ?? machineId);
+  if (opts.release) {
+    console.log(`Released ${agent.name} [${agent.id}] on ${where} (back to unmanaged).`);
+  } else {
+    const label = opts.name ?? agent.name;
+    console.log(`Owned ${label} [${agent.id}] on ${where} — now managed.`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -228,6 +279,8 @@ export interface AgentsCommandOptions {
   args?: string[];
   json?: boolean;
   noEnter?: boolean;
+  name?: string;
+  role?: string;
 }
 
 /**
@@ -259,10 +312,32 @@ export async function agentsCommand(opts: AgentsCommandOptions): Promise<void> {
     return;
   }
 
+  if (sub === "claim" || sub === "release") {
+    const [id] = opts.args ?? [];
+    if (!id) {
+      throw new IdeError(
+        `Usage: tmux-ide agents ${sub} <agent-id>` +
+          (sub === "claim" ? " [--name <name>] [--role <role>]" : "") +
+          "\nRun `tmux-ide agents` to list agent ids.",
+        { code: "USAGE", exitCode: 1 },
+      );
+    }
+    await claimAgent({
+      id,
+      name: opts.name,
+      role: opts.role,
+      release: sub === "release",
+      json: opts.json,
+    });
+    return;
+  }
+
   throw new IdeError(
     "Usage:\n" +
       "  tmux-ide agents [list] [--json]\n" +
       "  tmux-ide agents send <agent-id> <message...> [--no-enter] [--json]\n" +
+      "  tmux-ide agents claim <agent-id> [--name <name>] [--role <role>]\n" +
+      "  tmux-ide agents release <agent-id>\n" +
       "(For the plain-terminal hook reporter, see `tmux-ide agent`.)",
     { code: "USAGE", exitCode: 1 },
   );

--- a/packages/daemon/src/agents-cli.ts
+++ b/packages/daemon/src/agents-cli.ts
@@ -1,0 +1,269 @@
+import { AgentListSchemaZ, type AgentRecord } from "@tmux-ide/contracts";
+import { hostnameForClient } from "./agent-hook.ts";
+import { readCanonicalDaemonInfo, type CanonicalDaemonInfo } from "./lib/canonical-daemon.ts";
+import { IdeError } from "./lib/errors.ts";
+
+/**
+ * `tmux-ide agents ...` — the central fleet surface. Lists every agent the
+ * local canonical daemon can see (this machine, HQ-registered machines, and
+ * SSH-tunneled remotes) and sends input to any of them from here.
+ *
+ * Distinct from `tmux-ide agent` (singular), the hook reporter that lets a
+ * plain-terminal Claude/codex session report itself to the daemon.
+ */
+
+const NO_DAEMON_MESSAGE = "No tmux-ide daemon running — start one with `tmux-ide`";
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+const STATUS_GLYPHS: Record<AgentRecord["status"], string> = {
+  busy: "●",
+  idle: "○",
+  offline: "◌",
+};
+
+/** Exact-match lookup — agent ids are opaque, never parsed or prefix-matched. */
+export function findAgentById(agents: AgentRecord[], id: string): AgentRecord | undefined {
+  return agents.find((agent) => agent.id === id);
+}
+
+/**
+ * Resolve a send target from the fetched fleet list. The machineId is taken
+ * verbatim from the matching record (null = this machine) — the id string is
+ * never parsed to guess it.
+ */
+export function resolveSendTarget(
+  agents: AgentRecord[],
+  id: string,
+): { agent: AgentRecord; machineId: string | null } {
+  const agent = findAgentById(agents, id);
+  if (!agent) {
+    throw new IdeError(`Agent not found: ${id}. Run \`tmux-ide agents\` to list agent ids.`, {
+      code: "AGENT_NOT_FOUND",
+      exitCode: 1,
+    });
+  }
+  return { agent, machineId: agent.machineId };
+}
+
+export interface AgentMachineGroup {
+  machineId: string | null;
+  machineName: string | null;
+  agents: AgentRecord[];
+}
+
+/**
+ * Group agents by machine for display. The local machine (machineId null)
+ * always comes first; remote machines follow in first-seen order.
+ */
+export function groupAgentsByMachine(agents: AgentRecord[]): AgentMachineGroup[] {
+  const groups = new Map<string, AgentMachineGroup>();
+  for (const agent of agents) {
+    const key = agent.machineId ?? "";
+    let group = groups.get(key);
+    if (!group) {
+      group = { machineId: agent.machineId, machineName: agent.machineName, agents: [] };
+      groups.set(key, group);
+    }
+    group.agents.push(agent);
+  }
+  const ordered = [...groups.values()];
+  ordered.sort((a, b) => Number(a.machineId !== null) - Number(b.machineId !== null));
+  return ordered;
+}
+
+/** One display line per agent: glyph, name, tool, kind, location, task, id. */
+export function formatAgentLine(agent: AgentRecord): string {
+  const location =
+    agent.session && agent.paneId ? `${agent.session}·${agent.paneId}` : (agent.cwd ?? "");
+  const parts = [`${STATUS_GLYPHS[agent.status]} ${agent.name}`, agent.tool, agent.kind];
+  if (location) parts.push(location);
+  if (agent.taskTitle) parts.push(`— ${agent.taskTitle}`);
+  parts.push(`[${agent.id}]`);
+  return `  ${parts.join("  ")}`;
+}
+
+/** Human-readable fleet listing, grouped by machine (this machine first). */
+export function formatAgentList(agents: AgentRecord[]): string {
+  if (agents.length === 0) {
+    return "No agents found.";
+  }
+  const lines: string[] = [];
+  for (const group of groupAgentsByMachine(agents)) {
+    const label =
+      group.machineId === null
+        ? group.machineName
+          ? `${group.machineName} (this machine)`
+          : "this machine"
+        : (group.machineName ?? group.machineId);
+    lines.push(label);
+    for (const agent of group.agents) {
+      lines.push(formatAgentLine(agent));
+    }
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Daemon HTTP plumbing
+// ---------------------------------------------------------------------------
+
+function requireDaemonInfo(): CanonicalDaemonInfo {
+  const info = readCanonicalDaemonInfo();
+  if (!info) {
+    throw new IdeError(NO_DAEMON_MESSAGE, { code: "DAEMON_UNAVAILABLE", exitCode: 1 });
+  }
+  return info;
+}
+
+function daemonRequest(
+  info: CanonicalDaemonInfo,
+  path: string,
+): { url: string; headers: Record<string, string> } {
+  const url = `http://${hostnameForClient(info.bindHostname)}:${info.port}${path}`;
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (info.authToken) headers.Authorization = `Bearer ${info.authToken}`;
+  return { url, headers };
+}
+
+function timeoutSignal(ms: number): AbortSignal {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms).unref?.();
+  return controller.signal;
+}
+
+async function fetchAgentList(
+  info: CanonicalDaemonInfo,
+): Promise<{ agents: AgentRecord[]; raw: unknown }> {
+  const { url, headers } = daemonRequest(info, "/api/hq/agents");
+  let res: Response;
+  try {
+    res = await fetch(url, { headers, signal: timeoutSignal(15_000) });
+  } catch {
+    // daemon.json exists but nothing answers — treat as no daemon.
+    throw new IdeError(NO_DAEMON_MESSAGE, { code: "DAEMON_UNAVAILABLE", exitCode: 1 });
+  }
+  if (!res.ok) {
+    throw new IdeError(`Daemon replied ${res.status} to GET /api/hq/agents`, {
+      code: "DAEMON_ERROR",
+      exitCode: 1,
+    });
+  }
+  const raw: unknown = await res.json();
+  const parsed = AgentListSchemaZ.safeParse(raw);
+  if (!parsed.success) {
+    throw new IdeError("Daemon returned an unexpected /api/hq/agents payload", {
+      code: "DAEMON_ERROR",
+      exitCode: 1,
+    });
+  }
+  return { agents: parsed.data.agents, raw };
+}
+
+// ---------------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------------
+
+async function listAgents(opts: { json?: boolean }): Promise<void> {
+  const info = requireDaemonInfo();
+  const { agents, raw } = await fetchAgentList(info);
+  if (opts.json) {
+    console.log(JSON.stringify(raw));
+    return;
+  }
+  console.log(formatAgentList(agents));
+}
+
+async function sendToAgent(opts: {
+  id: string;
+  message: string;
+  noEnter?: boolean;
+  json?: boolean;
+}): Promise<void> {
+  const info = requireDaemonInfo();
+  const { agents } = await fetchAgentList(info);
+  const { agent, machineId } = resolveSendTarget(agents, opts.id);
+
+  const { url, headers } = daemonRequest(info, "/api/agents/send");
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        id: opts.id,
+        machineId,
+        message: opts.message,
+        noEnter: opts.noEnter ? true : undefined,
+      }),
+      signal: timeoutSignal(15_000),
+    });
+  } catch {
+    throw new IdeError(NO_DAEMON_MESSAGE, { code: "DAEMON_UNAVAILABLE", exitCode: 1 });
+  }
+
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) {
+    const detail = typeof body.error === "string" ? body.error : `HTTP ${res.status}`;
+    const code = res.status === 409 ? "AGENT_OBSERVE_ONLY" : "SEND_FAILED";
+    throw new IdeError(`Send failed: ${detail}`, { code, exitCode: 1 });
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify(body));
+    return;
+  }
+  const where = machineId === null ? "this machine" : (agent.machineName ?? machineId);
+  console.log(`Sent to ${agent.name} [${agent.id}] on ${where}.`);
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export interface AgentsCommandOptions {
+  sub?: string;
+  args?: string[];
+  json?: boolean;
+  noEnter?: boolean;
+}
+
+/**
+ * Entry point for `tmux-ide agents ...`.
+ *
+ * - `agents` / `agents list [--json]` — list every agent across machines.
+ * - `agents send <agent-id> <message...> [--no-enter]` — send input to any
+ *   agent by id (external plain-terminal agents are observe-only).
+ */
+export async function agentsCommand(opts: AgentsCommandOptions): Promise<void> {
+  const sub = opts.sub;
+
+  if (sub === undefined || sub === "list") {
+    await listAgents({ json: opts.json });
+    return;
+  }
+
+  if (sub === "send") {
+    const [id, ...messageParts] = opts.args ?? [];
+    const message = messageParts.join(" ");
+    if (!id || !message) {
+      throw new IdeError(
+        "Usage: tmux-ide agents send <agent-id> <message...> [--no-enter]\n" +
+          "Run `tmux-ide agents` to list agent ids.",
+        { code: "USAGE", exitCode: 1 },
+      );
+    }
+    await sendToAgent({ id, message, noEnter: opts.noEnter, json: opts.json });
+    return;
+  }
+
+  throw new IdeError(
+    "Usage:\n" +
+      "  tmux-ide agents [list] [--json]\n" +
+      "  tmux-ide agents send <agent-id> <message...> [--no-enter] [--json]\n" +
+      "(For the plain-terminal hook reporter, see `tmux-ide agent`.)",
+    { code: "USAGE", exitCode: 1 },
+  );
+}

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -71,6 +71,7 @@ interface CliFlags {
   "hq-url"?: string;
   to?: string;
   "no-enter"?: boolean;
+  print?: boolean;
 }
 
 export async function main(): Promise<void> {
@@ -124,6 +125,8 @@ export async function main(): Promise<void> {
       // send command flags
       to: { type: "string" },
       "no-enter": { type: "boolean" },
+      // agent command flags
+      print: { type: "boolean" },
     },
   });
   const values = rawValues as CliFlags;
@@ -151,6 +154,7 @@ export async function main(): Promise<void> {
     "metrics",
     "setup",
     "send",
+    "agent",
     "dispatch",
     "notify",
     "orchestrator",
@@ -237,6 +241,11 @@ ${bold("Pane Messaging:")}
   ${cyan("tmux-ide send")} <target> <message>     ${dim("Send message to a pane")}
   ${cyan("tmux-ide send")} --to <name> <message>   ${dim("Target by name, title, role, or ID")}
   ${cyan("tmux-ide send")} <target> --no-enter msg  ${dim("Send text without pressing Enter")}
+
+${bold("Agent Reporting:")}
+  ${cyan("tmux-ide agent hook install")}              ${dim("Install Claude Code hooks (~/.claude/settings.json)")}
+  ${cyan("tmux-ide agent hook install --print")}      ${dim("Print the hook snippet for manual install")}
+  ${cyan("tmux-ide agent report")} <event>            ${dim("Report start|activity|stop (called by hooks)")}
 
 ${bold("Dispatch:")}
   ${cyan("tmux-ide dispatch")} <id> [--json]        ${dim("Print task context to stdout")}
@@ -636,6 +645,17 @@ ${bold("Flags:")}
             message = readFileSync(0, "utf-8").trim();
           }
           await send(undefined, { json, to: target, message, noEnter: values["no-enter"] });
+          break;
+        }
+
+        case "agent": {
+          const { agentCommand } = await import("./agent-hook.ts");
+          await agentCommand({
+            sub: positionals[1],
+            args: positionals.slice(2),
+            json,
+            print: values.print,
+          });
           break;
         }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -155,6 +155,7 @@ export async function main(): Promise<void> {
     "setup",
     "send",
     "agent",
+    "agents",
     "dispatch",
     "notify",
     "orchestrator",
@@ -245,7 +246,11 @@ ${bold("Pane Messaging:")}
 ${bold("Agent Reporting:")}
   ${cyan("tmux-ide agent hook install")}              ${dim("Install Claude Code hooks (~/.claude/settings.json)")}
   ${cyan("tmux-ide agent hook install --print")}      ${dim("Print the hook snippet for manual install")}
-  ${cyan("tmux-ide agent report")} <event>            ${dim("Report start|activity|stop (called by hooks)")}
+  ${cyan("tmux-ide agent report")} <event>            ${dim("Report start|activity|stop (called by hooks; fleet view: agents)")}
+
+${bold("Agent Fleet:")}
+  ${cyan("tmux-ide agents")} [list] [--json]          ${dim("List agents across all machines (hook reporter: agent)")}
+  ${cyan("tmux-ide agents send")} <id> <message>      ${dim("Send a message to any agent by id [--no-enter]")}
 
 ${bold("Dispatch:")}
   ${cyan("tmux-ide dispatch")} <id> [--json]        ${dim("Print task context to stdout")}
@@ -655,6 +660,17 @@ ${bold("Flags:")}
             args: positionals.slice(2),
             json,
             print: values.print,
+          });
+          break;
+        }
+
+        case "agents": {
+          const { agentsCommand } = await import("./agents-cli.ts");
+          await agentsCommand({
+            sub: positionals[1],
+            args: positionals.slice(2),
+            json,
+            noEnter: values["no-enter"],
           });
           break;
         }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -72,6 +72,7 @@ interface CliFlags {
   to?: string;
   "no-enter"?: boolean;
   print?: boolean;
+  role?: string;
 }
 
 export async function main(): Promise<void> {
@@ -671,6 +672,8 @@ ${bold("Flags:")}
             args: positionals.slice(2),
             json,
             noEnter: values["no-enter"],
+            name: values.name,
+            role: values.role,
           });
           break;
         }

--- a/packages/daemon/src/command-center/actions/handlers/agent-actions.ts
+++ b/packages/daemon/src/command-center/actions/handlers/agent-actions.ts
@@ -1,0 +1,42 @@
+// Host-level agent actions — a Claude/codex SessionStart hook (or any plain
+// terminal session) self-reports here so the daemon can surface it alongside
+// tmux-discovered agents at GET /api/agents. NOT project-scoped: the registry
+// is per-host, keyed by the hook-supplied id (typically the Claude session id).
+import {
+  ExternalAgentRegistry,
+  getDefaultExternalAgentRegistry,
+} from "../../../lib/agent-registry.ts";
+import type { ActionInput, ActionResult } from "../contract.ts";
+
+export interface AgentActionDeps {
+  /** Override the registry (tests). Defaults to the daemon-wide singleton. */
+  registry?: ExternalAgentRegistry;
+}
+
+function registryFrom(deps: AgentActionDeps): ExternalAgentRegistry {
+  return deps.registry ?? getDefaultExternalAgentRegistry();
+}
+
+export function agentRegisterHandler(
+  input: ActionInput<"agent.register">,
+  deps: AgentActionDeps = {},
+): ActionResult<"agent.register"> {
+  registryFrom(deps).register(input);
+  return { ok: true };
+}
+
+export function agentHeartbeatHandler(
+  input: ActionInput<"agent.heartbeat">,
+  deps: AgentActionDeps = {},
+): ActionResult<"agent.heartbeat"> {
+  const known = registryFrom(deps).heartbeat(input);
+  return { ok: true, known };
+}
+
+export function agentUnregisterHandler(
+  input: ActionInput<"agent.unregister">,
+  deps: AgentActionDeps = {},
+): ActionResult<"agent.unregister"> {
+  const removed = registryFrom(deps).unregister(input.id);
+  return { ok: true, removed };
+}

--- a/packages/daemon/src/command-center/actions/registry.ts
+++ b/packages/daemon/src/command-center/actions/registry.ts
@@ -61,6 +61,11 @@ import {
 } from "./handlers/webhook-actions.ts";
 import { appSetRemoteAccessHandler } from "./handlers/app-set-remote-access.ts";
 import { daemonShutdownHandler } from "./handlers/daemon-shutdown.ts";
+import {
+  agentHeartbeatHandler,
+  agentRegisterHandler,
+  agentUnregisterHandler,
+} from "./handlers/agent-actions.ts";
 import { chatContextCaptureTerminalHandler } from "../../chat/context-actions.ts";
 import {
   chatPermissionRespondHandler,
@@ -276,6 +281,21 @@ export const actionRegistry: RegistryShape = {
     inputSchema: ActionContractsZ["daemon.shutdown"].input,
     resultSchema: ActionContractsZ["daemon.shutdown"].result,
     handler: daemonShutdownHandler,
+  },
+  "agent.register": {
+    inputSchema: ActionContractsZ["agent.register"].input,
+    resultSchema: ActionContractsZ["agent.register"].result,
+    handler: agentRegisterHandler,
+  },
+  "agent.heartbeat": {
+    inputSchema: ActionContractsZ["agent.heartbeat"].input,
+    resultSchema: ActionContractsZ["agent.heartbeat"].result,
+    handler: agentHeartbeatHandler,
+  },
+  "agent.unregister": {
+    inputSchema: ActionContractsZ["agent.unregister"].input,
+    resultSchema: ActionContractsZ["agent.unregister"].result,
+    handler: agentUnregisterHandler,
   },
   "chat.thread.list": {
     inputSchema: ActionContractsZ["chat.thread.list"].input,

--- a/packages/daemon/src/command-center/schemas.ts
+++ b/packages/daemon/src/command-center/schemas.ts
@@ -30,6 +30,17 @@ export const sendCommandSchema = z.object({
   noEnter: z.boolean().optional(),
 });
 
+// Send input to an agent from the unified agents view. `machineId` routes the
+// send: null/absent = an agent on this host; `ssh:<name>` or an HQ machine id
+// = proxy one hop to that machine's daemon (the forwarded request carries no
+// machineId, so it cannot loop).
+export const agentSendSchema = z.object({
+  id: z.string().min(1).max(512),
+  machineId: z.string().min(1).max(256).nullish(),
+  message: z.string().min(1, "Message is required").max(10_000),
+  noEnter: z.boolean().optional(),
+});
+
 export const createMilestoneSchema = z.object({
   title: z.string().trim().min(1, "Title is required"),
   sequence: z.number().int().positive(),

--- a/packages/daemon/src/command-center/schemas.ts
+++ b/packages/daemon/src/command-center/schemas.ts
@@ -41,6 +41,20 @@ export const agentSendSchema = z.object({
   noEnter: z.boolean().optional(),
 });
 
+// Adopt ("own") an unmanaged tmux pane, optionally naming it. Same routing
+// rule as send: machineId null = local, ssh:<name>/uuid = one-hop proxy.
+export const agentClaimSchema = z.object({
+  id: z.string().min(1).max(512),
+  machineId: z.string().min(1).max(256).nullish(),
+  name: z.string().min(1).max(200).optional(),
+  role: z.string().min(1).max(64).optional(),
+});
+
+export const agentReleaseSchema = z.object({
+  id: z.string().min(1).max(512),
+  machineId: z.string().min(1).max(256).nullish(),
+});
+
 export const createMilestoneSchema = z.object({
   title: z.string().trim().min(1, "Title is required"),
   sequence: z.number().int().positive(),

--- a/packages/daemon/src/command-center/server.ts
+++ b/packages/daemon/src/command-center/server.ts
@@ -94,6 +94,14 @@ import {
   WorkspaceAlreadyExistsError,
   WorkspaceNotFoundError,
 } from "../lib/workspace-registry.ts";
+import { discoverTmuxAgents } from "../lib/agent-discovery.ts";
+import {
+  aggregateHqAgents,
+  getDefaultExternalAgentRegistry,
+  mergeLocalAgents,
+  type RemoteAgentSource,
+} from "../lib/agent-registry.ts";
+import { AgentListSchemaZ, type AgentRecord } from "@tmux-ide/contracts";
 import { AddWorkspaceRequestSchemaZ } from "@tmux-ide/contracts";
 import {
   updateTaskSchema,
@@ -203,7 +211,7 @@ import {
   OnboardInvalidInputError,
 } from "../lib/project-onboard.ts";
 import { realpathSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, hostname } from "node:os";
 import { isAbsolute, resolve as pathResolve } from "node:path";
 import { getLspClient, getLspClientForFile } from "../lsp/registry.ts";
 import { randomUUID } from "node:crypto";
@@ -239,6 +247,12 @@ export interface CreateAppOptions {
   authConfig?: AuthConfig;
   tunnelManager?: TunnelManager;
   remoteRegistry?: RemoteRegistry;
+  /**
+   * This host's HQ machine name (the name it registers under when acting as
+   * an HQ remote). Used to stamp local agents in GET /api/hq/agents so the
+   * aggregated view labels them by machine. Falls back to os.hostname().
+   */
+  hqMachineName?: string;
   remoteAccess?: {
     bindHostname?: string;
     token?: string | null;
@@ -3792,6 +3806,63 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     const removed = remoteRegistry.unregister(c.req.param("id"));
     if (!removed) return c.json({ error: "Machine not found" }, 404);
     return c.json({ ok: true });
+  });
+
+  // --- Unified agent view ---
+
+  // Every Claude/codex agent on THIS host: tmux-discovered panes (managed +
+  // unmanaged) merged with hook-registered external sessions. machineId/Name
+  // stay null here — HQ stamps them when aggregating across hosts.
+  function localAgents(): AgentRecord[] {
+    const managed = new Set(
+      getDefaultWorkspaceRegistry()
+        .list()
+        .map((w) => w.sessionName),
+    );
+    const tmuxAgents = discoverTmuxAgents(managed);
+    const external = getDefaultExternalAgentRegistry().list();
+    return mergeLocalAgents(tmuxAgents, external);
+  }
+
+  app.get("/api/agents", (c) => {
+    const payload = AgentListSchemaZ.parse({ agents: localAgents() });
+    return c.json(payload);
+  });
+
+  // Aggregated view across HQ-registered machines. Always includes this
+  // host's local agents (stamped with this host's machine name). When acting
+  // as HQ, fans out to each remote's /api/agents and namespaces ids by
+  // machine id. Machines that error or time out are skipped.
+  app.get("/api/hq/agents", async (c) => {
+    const selfName = options.hqMachineName ?? hostname();
+    let remotes: RemoteAgentSource[] = [];
+
+    if (remoteRegistry) {
+      const fanout = remoteRegistry
+        .getMachines()
+        .map(async (machine): Promise<RemoteAgentSource | null> => {
+          try {
+            const controller = new AbortController();
+            const tid = setTimeout(() => controller.abort(), 5_000);
+            const res = await fetch(`${machine.url}/api/agents`, {
+              headers: { Authorization: `Bearer ${machine.token}` },
+              signal: controller.signal,
+            });
+            clearTimeout(tid);
+            if (!res.ok) return null;
+            const parsed = AgentListSchemaZ.safeParse(await res.json());
+            if (!parsed.success) return null;
+            return { machineId: machine.id, machineName: machine.name, agents: parsed.data.agents };
+          } catch {
+            // Skip unreachable / slow machines — don't fail the whole response.
+            return null;
+          }
+        });
+      remotes = (await Promise.all(fanout)).filter((r): r is RemoteAgentSource => r !== null);
+    }
+
+    const agents = aggregateHqAgents(localAgents(), selfName, remotes);
+    return c.json(AgentListSchemaZ.parse({ agents }));
   });
 
   // --- Tunnel endpoints ---

--- a/packages/daemon/src/command-center/server.ts
+++ b/packages/daemon/src/command-center/server.ts
@@ -54,7 +54,7 @@ import {
   TaskActionError,
 } from "../lib/task-actions.ts";
 import { readEvents, appendEvent, eventLogEmitter } from "../lib/event-log.ts";
-import { getLogBuffer, subscribeLogs, type LogEntry } from "../lib/log.ts";
+import { getLogBuffer, subscribeLogs, logger, type LogEntry } from "../lib/log.ts";
 import { extractMarks, calculateStats, tagContent } from "../lib/authorship.ts";
 import {
   loadValidationState,
@@ -3829,6 +3829,17 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     return c.json(payload);
   });
 
+  const MAX_HQ_MACHINES = 50;
+  const MAX_HQ_AGENTS = 2000;
+  const isHttpUrl = (u: string): boolean => {
+    try {
+      const proto = new URL(u).protocol;
+      return proto === "http:" || proto === "https:";
+    } catch {
+      return false;
+    }
+  };
+
   // Aggregated view across HQ-registered machines. Always includes this
   // host's local agents (stamped with this host's machine name). When acting
   // as HQ, fans out to each remote's /api/agents and namespaces ids by
@@ -3838,8 +3849,22 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     let remotes: RemoteAgentSource[] = [];
 
     if (remoteRegistry) {
-      const fanout = remoteRegistry
+      // Bound the fan-out: skip self (a host that also registered itself would
+      // otherwise double-count its agents), reject non-http(s) urls (the url is
+      // only validated as a generic URL at registration), and cap the machine
+      // count so a flood of registrations can't make this call arbitrarily
+      // expensive.
+      const candidates = remoteRegistry
         .getMachines()
+        .filter((m) => m.name !== selfName && isHttpUrl(m.url));
+      if (candidates.length > MAX_HQ_MACHINES) {
+        logger.warn(
+          "hq-agents",
+          `fan-out capped: ${candidates.length} machines, querying first ${MAX_HQ_MACHINES}`,
+        );
+      }
+      const fanout = candidates
+        .slice(0, MAX_HQ_MACHINES)
         .map(async (machine): Promise<RemoteAgentSource | null> => {
           try {
             const controller = new AbortController();
@@ -3847,6 +3872,9 @@ export function createApp(options: CreateAppOptions = {}): Hono {
             const res = await fetch(`${machine.url}/api/agents`, {
               headers: { Authorization: `Bearer ${machine.token}` },
               signal: controller.signal,
+              // Don't chase redirects from a (possibly hostile) remote with the
+              // machine's bearer attached — treat a 3xx as a failed fetch.
+              redirect: "manual",
             });
             clearTimeout(tid);
             if (!res.ok) return null;
@@ -3861,7 +3889,14 @@ export function createApp(options: CreateAppOptions = {}): Hono {
       remotes = (await Promise.all(fanout)).filter((r): r is RemoteAgentSource => r !== null);
     }
 
-    const agents = aggregateHqAgents(localAgents(), selfName, remotes);
+    let agents = aggregateHqAgents(localAgents(), selfName, remotes);
+    if (agents.length > MAX_HQ_AGENTS) {
+      logger.warn(
+        "hq-agents",
+        `response capped: ${agents.length} agents, returning first ${MAX_HQ_AGENTS} (local first)`,
+      );
+      agents = agents.slice(0, MAX_HQ_AGENTS);
+    }
     return c.json(AgentListSchemaZ.parse({ agents }));
   });
 

--- a/packages/daemon/src/command-center/server.ts
+++ b/packages/daemon/src/command-center/server.ts
@@ -95,6 +95,7 @@ import {
   WorkspaceNotFoundError,
 } from "../lib/workspace-registry.ts";
 import { discoverTmuxAgents } from "../lib/agent-discovery.ts";
+import { listSshAgentSources, resolveSshMachineUrl } from "../lib/agent-remotes.ts";
 import {
   aggregateHqAgents,
   getDefaultExternalAgentRegistry,
@@ -109,6 +110,7 @@ import {
   savePlanSchema,
   savePlanContentSchema,
   sendCommandSchema,
+  agentSendSchema,
   createMilestoneSchema,
   updateMilestoneSchema,
   updateAssertionSchema,
@@ -3840,12 +3842,14 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     }
   };
 
-  // Aggregated view across HQ-registered machines. Always includes this
-  // host's local agents (stamped with this host's machine name). When acting
-  // as HQ, fans out to each remote's /api/agents and namespaces ids by
-  // machine id. Machines that error or time out are skipped.
+  // Aggregated view across HQ-registered machines AND SSH-tunneled remotes.
+  // Always includes this host's local agents (stamped with this host's machine
+  // name). HQ machines register themselves inbound; SSH remotes are outbound
+  // tunnels this machine opened (`remote ssh launch`), probed via their
+  // recorded local tunnel port. Machines that error or time out are skipped.
   app.get("/api/hq/agents", async (c) => {
     const selfName = options.hqMachineName ?? hostname();
+    const sshSourcesPromise = listSshAgentSources();
     let remotes: RemoteAgentSource[] = [];
 
     if (remoteRegistry) {
@@ -3889,6 +3893,10 @@ export function createApp(options: CreateAppOptions = {}): Hono {
       remotes = (await Promise.all(fanout)).filter((r): r is RemoteAgentSource => r !== null);
     }
 
+    // SSH tunnel sources ride alongside HQ machines; `ssh:` machine ids can't
+    // collide with HQ's uuid machine ids.
+    remotes = [...remotes, ...(await sshSourcesPromise)];
+
     let agents = aggregateHqAgents(localAgents(), selfName, remotes);
     if (agents.length > MAX_HQ_AGENTS) {
       logger.warn(
@@ -3898,6 +3906,74 @@ export function createApp(options: CreateAppOptions = {}): Hono {
       agents = agents.slice(0, MAX_HQ_AGENTS);
     }
     return c.json(AgentListSchemaZ.parse({ agents }));
+  });
+
+  // Send input to any agent in the unified view — the control half of the
+  // central pane. Local tmux agents get send-keys directly; agents on another
+  // machine are proxied one hop to that machine's daemon (which then treats
+  // the send as local). External (plain-terminal) agents have no pane to
+  // drive and are observe-only.
+  app.post("/api/agents/send", zValidator("json", agentSendSchema), async (c) => {
+    const { id, machineId, message, noEnter } = c.req.valid("json");
+
+    if (machineId) {
+      // Remote hop: resolve the machine's daemon URL, strip the namespace we
+      // stamped during aggregation, and forward WITHOUT machineId (one hop max).
+      const sshUrl = await resolveSshMachineUrl(machineId);
+      const hqMachine = sshUrl ? null : remoteRegistry?.getMachine(machineId);
+      const baseUrl = sshUrl ?? hqMachine?.url;
+      if (!baseUrl || !isHttpUrl(baseUrl)) {
+        return c.json({ error: `Unknown machine: ${machineId}` }, 404);
+      }
+      const prefix = `${machineId}:`;
+      if (!id.startsWith(prefix)) {
+        return c.json({ error: "Agent id does not belong to that machine" }, 400);
+      }
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      if (hqMachine) headers.Authorization = `Bearer ${hqMachine.token}`;
+      try {
+        const controller = new AbortController();
+        const tid = setTimeout(() => controller.abort(), 5_000);
+        const res = await fetch(`${baseUrl}/api/agents/send`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ id: id.slice(prefix.length), message, noEnter }),
+          signal: controller.signal,
+          redirect: "manual",
+        });
+        clearTimeout(tid);
+        const body = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as Record<
+          string,
+          unknown
+        >;
+        if (res.ok) return c.json(body);
+        return c.json({ ...body, remoteStatus: res.status }, 502);
+      } catch {
+        return c.json({ error: `Machine ${machineId} is unreachable` }, 502);
+      }
+    }
+
+    // Local: the agent must be a tmux pane on this host.
+    const agent = localAgents().find((candidate) => candidate.id === id);
+    if (!agent) {
+      return c.json({ error: `Agent not found: ${id}` }, 404);
+    }
+    if (agent.kind === "external" || !agent.session || !agent.paneId) {
+      return c.json({ error: "External agents are observe-only (no pane to drive)" }, 409);
+    }
+
+    const busyStatus = getPaneBusyStatus(agent.session, agent.paneId);
+    // Collapse multiline for agent panes (same semantics as project send).
+    const prepared = busyStatus === "agent" ? message.replace(/\n+/g, " ").trim() : message;
+    if (noEnter) {
+      sendText(agent.session, agent.paneId, prepared);
+    } else {
+      sendCommand(agent.session, agent.paneId, prepared);
+    }
+    return c.json({
+      ok: true,
+      agent: { id: agent.id, session: agent.session, paneId: agent.paneId },
+    });
   });
 
   // --- Tunnel endpoints ---

--- a/packages/daemon/src/command-center/server.ts
+++ b/packages/daemon/src/command-center/server.ts
@@ -94,7 +94,12 @@ import {
   WorkspaceAlreadyExistsError,
   WorkspaceNotFoundError,
 } from "../lib/workspace-registry.ts";
-import { discoverTmuxAgents } from "../lib/agent-discovery.ts";
+import {
+  discoverTmuxAgents,
+  claimPane,
+  releasePane,
+  InvalidPaneIdError,
+} from "../lib/agent-discovery.ts";
 import { listSshAgentSources, resolveSshMachineUrl } from "../lib/agent-remotes.ts";
 import {
   aggregateHqAgents,
@@ -111,6 +116,8 @@ import {
   savePlanContentSchema,
   sendCommandSchema,
   agentSendSchema,
+  agentClaimSchema,
+  agentReleaseSchema,
   createMilestoneSchema,
   updateMilestoneSchema,
   updateAssertionSchema,
@@ -3908,60 +3915,92 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     return c.json(AgentListSchemaZ.parse({ agents }));
   });
 
-  // Send input to any agent in the unified view — the control half of the
-  // central pane. Local tmux agents get send-keys directly; agents on another
-  // machine are proxied one hop to that machine's daemon (which then treats
-  // the send as local). External (plain-terminal) agents have no pane to
-  // drive and are observe-only.
-  app.post("/api/agents/send", zValidator("json", agentSendSchema), async (c) => {
-    const { id, machineId, message, noEnter } = c.req.valid("json");
+  // Resolve an agent id (+ optional machineId) to a control target: either a
+  // local AgentRecord on this host, or a one-hop proxy to the machine that owns
+  // it. Shared by every /api/agents/* control route so the local-vs-remote
+  // routing rule lives in exactly one place.
+  type AgentTarget =
+    | { kind: "local"; agent: AgentRecord }
+    | { kind: "remote"; baseUrl: string; headers: Record<string, string>; forwardId: string }
+    | { kind: "error"; status: 400 | 404; body: Record<string, unknown> };
 
+  async function resolveAgentTarget(
+    id: string,
+    machineId: string | null | undefined,
+  ): Promise<AgentTarget> {
     if (machineId) {
-      // Remote hop: resolve the machine's daemon URL, strip the namespace we
-      // stamped during aggregation, and forward WITHOUT machineId (one hop max).
       const sshUrl = await resolveSshMachineUrl(machineId);
       const hqMachine = sshUrl ? null : remoteRegistry?.getMachine(machineId);
       const baseUrl = sshUrl ?? hqMachine?.url;
       if (!baseUrl || !isHttpUrl(baseUrl)) {
-        return c.json({ error: `Unknown machine: ${machineId}` }, 404);
+        return { kind: "error", status: 404, body: { error: `Unknown machine: ${machineId}` } };
       }
       const prefix = `${machineId}:`;
       if (!id.startsWith(prefix)) {
-        return c.json({ error: "Agent id does not belong to that machine" }, 400);
+        return {
+          kind: "error",
+          status: 400,
+          body: { error: "Agent id does not belong to that machine" },
+        };
       }
       const headers: Record<string, string> = { "Content-Type": "application/json" };
       if (hqMachine) headers.Authorization = `Bearer ${hqMachine.token}`;
-      try {
-        const controller = new AbortController();
-        const tid = setTimeout(() => controller.abort(), 5_000);
-        const res = await fetch(`${baseUrl}/api/agents/send`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({ id: id.slice(prefix.length), message, noEnter }),
-          signal: controller.signal,
-          redirect: "manual",
-        });
-        clearTimeout(tid);
-        const body = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as Record<
-          string,
-          unknown
-        >;
-        if (res.ok) return c.json(body);
-        return c.json({ ...body, remoteStatus: res.status }, 502);
-      } catch {
-        return c.json({ error: `Machine ${machineId} is unreachable` }, 502);
-      }
+      return { kind: "remote", baseUrl, headers, forwardId: id.slice(prefix.length) };
+    }
+    const agent = localAgents().find((candidate) => candidate.id === id);
+    if (!agent) return { kind: "error", status: 404, body: { error: `Agent not found: ${id}` } };
+    return { kind: "local", agent };
+  }
+
+  // Forward a control call one hop to the machine that owns the agent. The
+  // forwarded body carries no machineId, so the far daemon treats it as local
+  // and can't re-proxy (one hop max, no loops). Never chases redirects.
+  // Returns a ready-to-emit status + body; the caller owns the response.
+  async function proxyAgentPost(
+    target: Extract<AgentTarget, { kind: "remote" }>,
+    path: string,
+    body: Record<string, unknown>,
+    machineId: string,
+  ): Promise<{ status: 200 | 502; body: Record<string, unknown> }> {
+    try {
+      const controller = new AbortController();
+      const tid = setTimeout(() => controller.abort(), 5_000);
+      const res = await fetch(`${target.baseUrl}${path}`, {
+        method: "POST",
+        headers: target.headers,
+        body: JSON.stringify({ ...body, id: target.forwardId }),
+        signal: controller.signal,
+        redirect: "manual",
+      });
+      clearTimeout(tid);
+      const respBody = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as Record<
+        string,
+        unknown
+      >;
+      if (res.ok) return { status: 200, body: respBody };
+      return { status: 502, body: { ...respBody, remoteStatus: res.status } };
+    } catch {
+      return { status: 502, body: { error: `Machine ${machineId} is unreachable` } };
+    }
+  }
+
+  // Send input to any agent in the unified view — the control half of the
+  // central pane. Local tmux agents get send-keys directly; agents on another
+  // machine are proxied one hop. External (plain-terminal) agents have no pane
+  // to drive and are observe-only.
+  app.post("/api/agents/send", zValidator("json", agentSendSchema), async (c) => {
+    const { id, machineId, message, noEnter } = c.req.valid("json");
+    const target = await resolveAgentTarget(id, machineId);
+    if (target.kind === "error") return c.json(target.body, target.status);
+    if (target.kind === "remote") {
+      const r = await proxyAgentPost(target, "/api/agents/send", { message, noEnter }, machineId!);
+      return c.json(r.body, r.status);
     }
 
-    // Local: the agent must be a tmux pane on this host.
-    const agent = localAgents().find((candidate) => candidate.id === id);
-    if (!agent) {
-      return c.json({ error: `Agent not found: ${id}` }, 404);
-    }
+    const { agent } = target;
     if (agent.kind === "external" || !agent.session || !agent.paneId) {
       return c.json({ error: "External agents are observe-only (no pane to drive)" }, 409);
     }
-
     const busyStatus = getPaneBusyStatus(agent.session, agent.paneId);
     // Collapse multiline for agent panes (same semantics as project send).
     const prepared = busyStatus === "agent" ? message.replace(/\n+/g, " ").trim() : message;
@@ -3974,6 +4013,52 @@ export function createApp(options: CreateAppOptions = {}): Hono {
       ok: true,
       agent: { id: agent.id, session: agent.session, paneId: agent.paneId },
     });
+  });
+
+  // Adopt ("own") an unmanaged tmux pane: tag the pane so discovery reports it
+  // as `managed`, and optionally give it a name/role. Per-pane, so it doesn't
+  // affect the rest of an unmanaged session.
+  app.post("/api/agents/claim", zValidator("json", agentClaimSchema), async (c) => {
+    const { id, machineId, name, role } = c.req.valid("json");
+    const target = await resolveAgentTarget(id, machineId);
+    if (target.kind === "error") return c.json(target.body, target.status);
+    if (target.kind === "remote") {
+      const r = await proxyAgentPost(target, "/api/agents/claim", { name, role }, machineId!);
+      return c.json(r.body, r.status);
+    }
+
+    const { agent } = target;
+    if (agent.kind === "external" || !agent.paneId) {
+      return c.json({ error: "External agents have no pane to claim" }, 409);
+    }
+    try {
+      claimPane(agent.paneId, { name, role });
+    } catch (err) {
+      if (err instanceof InvalidPaneIdError) return c.json({ error: err.message }, 400);
+      throw err;
+    }
+    return c.json({ ok: true, agent: { id: agent.id, paneId: agent.paneId, name: name ?? null } });
+  });
+
+  // Release a previously claimed pane (back to `tmux-unmanaged`).
+  app.post("/api/agents/release", zValidator("json", agentReleaseSchema), async (c) => {
+    const { id, machineId } = c.req.valid("json");
+    const target = await resolveAgentTarget(id, machineId);
+    if (target.kind === "error") return c.json(target.body, target.status);
+    if (target.kind === "remote") {
+      const r = await proxyAgentPost(target, "/api/agents/release", {}, machineId!);
+      return c.json(r.body, r.status);
+    }
+
+    const { agent } = target;
+    if (!agent.paneId) return c.json({ error: "Agent has no pane to release" }, 409);
+    try {
+      releasePane(agent.paneId);
+    } catch (err) {
+      if (err instanceof InvalidPaneIdError) return c.json({ error: err.message }, 400);
+      throw err;
+    }
+    return c.json({ ok: true, agent: { id: agent.id, paneId: agent.paneId } });
   });
 
   // --- Tunnel endpoints ---

--- a/packages/daemon/src/lib/__tests__/agent-actions.test.ts
+++ b/packages/daemon/src/lib/__tests__/agent-actions.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { AgentRecord } from "@tmux-ide/contracts";
+import { AgentListSchemaZ } from "@tmux-ide/contracts";
+import {
+  aggregateHqAgents,
+  ExternalAgentRegistry,
+  mergeLocalAgents,
+  type RemoteAgentSource,
+} from "../agent-registry.ts";
+import {
+  agentHeartbeatHandler,
+  agentRegisterHandler,
+  agentUnregisterHandler,
+} from "../../command-center/actions/handlers/agent-actions.ts";
+
+// ---------------------------------------------------------------------------
+// Action handlers — mutate the injected ExternalAgentRegistry.
+// ---------------------------------------------------------------------------
+
+describe("agent action handlers", () => {
+  it("register adds an agent observable via list()", () => {
+    const registry = new ExternalAgentRegistry();
+    const result = agentRegisterHandler(
+      { id: "sess-1", tool: "claude", name: "Laptop", cwd: "/w" },
+      { registry },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(registry.list().map((a) => a.id)).toEqual(["sess-1"]);
+  });
+
+  it("heartbeat reports known=true for a registered agent, false otherwise", () => {
+    const registry = new ExternalAgentRegistry();
+    agentRegisterHandler({ id: "sess-1", tool: "claude" }, { registry });
+
+    expect(agentHeartbeatHandler({ id: "sess-1", status: "busy" }, { registry })).toEqual({
+      ok: true,
+      known: true,
+    });
+    expect(registry.list()[0]!.status).toBe("busy");
+
+    expect(agentHeartbeatHandler({ id: "ghost" }, { registry })).toEqual({
+      ok: true,
+      known: false,
+    });
+  });
+
+  it("unregister removes the agent and reports removed", () => {
+    const registry = new ExternalAgentRegistry();
+    agentRegisterHandler({ id: "sess-1", tool: "claude" }, { registry });
+
+    expect(agentUnregisterHandler({ id: "sess-1" }, { registry })).toEqual({
+      ok: true,
+      removed: true,
+    });
+    expect(registry.list()).toHaveLength(0);
+    expect(agentUnregisterHandler({ id: "sess-1" }, { registry })).toEqual({
+      ok: true,
+      removed: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HQ aggregation — the pure stamping/namespacing the /api/hq/agents route
+// applies after fanning out to remotes (the route owns fetch/timeout/skip;
+// errored machines simply never appear in `remotes`).
+// ---------------------------------------------------------------------------
+
+function makeAgent(id: string, overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    id,
+    kind: "external",
+    tool: "claude",
+    name: id,
+    status: "idle",
+    session: null,
+    paneId: null,
+    paneTitle: null,
+    cwd: null,
+    taskId: null,
+    taskTitle: null,
+    pid: null,
+    lastActivity: new Date(0).toISOString(),
+    machineId: null,
+    machineName: null,
+    ...overrides,
+  };
+}
+
+describe("aggregateHqAgents", () => {
+  it("stamps local agents with the self machine name and null machineId", () => {
+    const out = aggregateHqAgents([makeAgent("local-1")], "this-host", []);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ id: "local-1", machineId: null, machineName: "this-host" });
+  });
+
+  it("namespaces remote ids and stamps remote machine id + name", () => {
+    const remotes: RemoteAgentSource[] = [
+      {
+        machineId: "machine-A",
+        machineName: "build-box",
+        agents: [makeAgent("remote-x"), makeAgent("remote-y")],
+      },
+    ];
+    const out = aggregateHqAgents([makeAgent("local-1")], "this-host", remotes);
+
+    expect(out.map((a) => a.id)).toEqual(["local-1", "machine-A:remote-x", "machine-A:remote-y"]);
+    const remote = out.find((a) => a.id === "machine-A:remote-x")!;
+    expect(remote).toMatchObject({ machineId: "machine-A", machineName: "build-box" });
+    // Output conforms to the shared contract.
+    expect(AgentListSchemaZ.safeParse({ agents: out }).success).toBe(true);
+  });
+
+  it("returns only local agents when no remotes are reachable", () => {
+    const out = aggregateHqAgents([makeAgent("local-1")], "this-host", []);
+    expect(out.map((a) => a.id)).toEqual(["local-1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeLocalAgents — what GET /api/agents returns (tmux + external, pid-dedup).
+// ---------------------------------------------------------------------------
+
+describe("mergeLocalAgents in the GET /api/agents path", () => {
+  it("drops an external agent whose pid is already visible as a tmux pane", () => {
+    const tmux = [makeAgent("sess:%1", { kind: "managed", pid: 1234 })];
+    const external = [
+      makeAgent("hook-a", { pid: 1234 }), // duplicate of the tmux pane
+      makeAgent("hook-b", { pid: 5678 }), // genuinely external
+    ];
+    const merged = mergeLocalAgents(tmux, external);
+    expect(merged.map((a) => a.id)).toEqual(["sess:%1", "hook-b"]);
+    expect(AgentListSchemaZ.safeParse({ agents: merged }).success).toBe(true);
+  });
+});

--- a/packages/daemon/src/lib/__tests__/agent-discovery.test.ts
+++ b/packages/daemon/src/lib/__tests__/agent-discovery.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { _setExecutor, discoverTmuxAgents, inferAgentTool, listAllTmuxPanes } from "../agent-discovery.ts";
+
+// session, pane_id, index, title, command, cwd, pid, w, h, active, role, name, type
+function row(fields: Partial<Record<string, string>>): string {
+  return [
+    fields.session ?? "proj",
+    fields.id ?? "%1",
+    fields.index ?? "0",
+    fields.title ?? "Claude Code",
+    fields.cmd ?? "claude",
+    fields.cwd ?? "/work/proj",
+    fields.pid ?? "1234",
+    fields.width ?? "120",
+    fields.height ?? "40",
+    fields.active ?? "1",
+    fields.role ?? "",
+    fields.name ?? "",
+    fields.type ?? "",
+  ].join("\t");
+}
+
+let restore: (() => void) | null = null;
+afterEach(() => {
+  restore?.();
+  restore = null;
+});
+
+describe("inferAgentTool", () => {
+  it("detects claude, codex, version-string, and unknown", () => {
+    expect(inferAgentTool("claude")).toBe("claude");
+    expect(inferAgentTool("codex")).toBe("codex");
+    expect(inferAgentTool("2.1.80")).toBe("claude");
+    expect(inferAgentTool("zsh")).toBe("unknown");
+  });
+});
+
+describe("listAllTmuxPanes", () => {
+  it("parses session/cwd/pid out of list-panes -a", () => {
+    restore = _setExecutor((_cmd, args) => {
+      expect(args).toContain("-a");
+      return row({ session: "alpha", id: "%3", cwd: "/x", pid: "999" }) + "\n";
+    });
+    const panes = listAllTmuxPanes();
+    expect(panes).toHaveLength(1);
+    expect(panes[0]).toMatchObject({ session: "alpha", id: "%3", cwd: "/x", pid: 999 });
+  });
+
+  it("returns [] when no tmux server is running", () => {
+    restore = _setExecutor(() => "");
+    expect(listAllTmuxPanes()).toEqual([]);
+  });
+});
+
+describe("discoverTmuxAgents", () => {
+  it("classifies managed vs unmanaged and skips shells", () => {
+    restore = _setExecutor(() =>
+      [
+        row({ session: "mine", id: "%1", cmd: "claude" }),
+        row({ session: "other", id: "%2", cmd: "codex", title: "codex" }),
+        row({ session: "mine", id: "%3", cmd: "zsh", title: "Shell" }),
+      ].join("\n"),
+    );
+    const agents = discoverTmuxAgents(new Set(["mine"]));
+    expect(agents).toHaveLength(2);
+    const managed = agents.find((a) => a.paneId === "%1")!;
+    const unmanaged = agents.find((a) => a.paneId === "%2")!;
+    expect(managed.kind).toBe("managed");
+    expect(managed.tool).toBe("claude");
+    expect(managed.id).toBe("mine:%1");
+    expect(unmanaged.kind).toBe("tmux-unmanaged");
+    expect(unmanaged.tool).toBe("codex");
+  });
+
+  it("marks spinner-titled panes busy", () => {
+    restore = _setExecutor(() => row({ title: "⠙ Working…", cmd: "claude" }));
+    const [agent] = discoverTmuxAgents(new Set(["proj"]));
+    expect(agent!.status).toBe("busy");
+  });
+});

--- a/packages/daemon/src/lib/__tests__/agent-discovery.test.ts
+++ b/packages/daemon/src/lib/__tests__/agent-discovery.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { _setExecutor, discoverTmuxAgents, inferAgentTool, listAllTmuxPanes } from "../agent-discovery.ts";
+import {
+  _setExecutor,
+  discoverTmuxAgents,
+  inferAgentTool,
+  listAllTmuxPanes,
+} from "../agent-discovery.ts";
 
-// session, pane_id, index, title, command, cwd, pid, w, h, active, role, name, type
+// session, pane_id, index, command, cwd, pid, w, h, active, role, name, type, title
+// (title is LAST so a tab inside it doesn't corrupt the other fields)
 function row(fields: Partial<Record<string, string>>): string {
   return [
     fields.session ?? "proj",
     fields.id ?? "%1",
     fields.index ?? "0",
-    fields.title ?? "Claude Code",
     fields.cmd ?? "claude",
     fields.cwd ?? "/work/proj",
     fields.pid ?? "1234",
@@ -17,6 +22,7 @@ function row(fields: Partial<Record<string, string>>): string {
     fields.role ?? "",
     fields.name ?? "",
     fields.type ?? "",
+    fields.title ?? "Claude Code",
   ].join("\t");
 }
 
@@ -49,6 +55,20 @@ describe("listAllTmuxPanes", () => {
   it("returns [] when no tmux server is running", () => {
     restore = _setExecutor(() => "");
     expect(listAllTmuxPanes()).toEqual([]);
+  });
+
+  it("recovers a tab embedded in the pane title (title is last field)", () => {
+    restore = _setExecutor(() => row({ title: "Claude\tCode\twork" }));
+    const panes = listAllTmuxPanes();
+    expect(panes).toHaveLength(1);
+    expect(panes[0]).toMatchObject({ session: "proj", id: "%1", title: "Claude\tCode\twork" });
+  });
+
+  it("skips malformed short rows instead of emitting NaN garbage", () => {
+    restore = _setExecutor(() => ["proj\t%1", row({ id: "%2" })].join("\n"));
+    const panes = listAllTmuxPanes();
+    expect(panes).toHaveLength(1);
+    expect(panes[0]!.id).toBe("%2");
   });
 });
 

--- a/packages/daemon/src/lib/__tests__/agent-discovery.test.ts
+++ b/packages/daemon/src/lib/__tests__/agent-discovery.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, afterEach } from "vitest";
 import {
   _setExecutor,
+  claimPane,
   discoverTmuxAgents,
   inferAgentTool,
+  InvalidPaneIdError,
   listAllTmuxPanes,
+  releasePane,
 } from "../agent-discovery.ts";
 
-// session, pane_id, index, command, cwd, pid, w, h, active, role, name, type, title
+// session, pane_id, index, command, cwd, pid, w, h, active, role, name, type, owned, title
 // (title is LAST so a tab inside it doesn't corrupt the other fields)
 function row(fields: Partial<Record<string, string>>): string {
   return [
@@ -22,6 +25,7 @@ function row(fields: Partial<Record<string, string>>): string {
     fields.role ?? "",
     fields.name ?? "",
     fields.type ?? "",
+    fields.owned ?? "",
     fields.title ?? "Claude Code",
   ].join("\t");
 }
@@ -96,5 +100,62 @@ describe("discoverTmuxAgents", () => {
     restore = _setExecutor(() => row({ title: "⠙ Working…", cmd: "claude" }));
     const [agent] = discoverTmuxAgents(new Set(["proj"]));
     expect(agent!.status).toBe("busy");
+  });
+
+  it("treats a claimed (@ide_owned) pane as managed even in an unmanaged session", () => {
+    restore = _setExecutor(() =>
+      [
+        row({ session: "other", id: "%2", cmd: "claude", owned: "1", name: "My Agent" }),
+        row({ session: "other", id: "%3", cmd: "claude" }),
+      ].join("\n"),
+    );
+    const agents = discoverTmuxAgents(new Set(["mine"]));
+    const claimed = agents.find((a) => a.paneId === "%2")!;
+    const unclaimed = agents.find((a) => a.paneId === "%3")!;
+    expect(claimed.kind).toBe("managed");
+    expect(claimed.name).toBe("My Agent");
+    expect(unclaimed.kind).toBe("tmux-unmanaged");
+  });
+});
+
+describe("claimPane / releasePane", () => {
+  it("sets @ide_owned (+ name/role) via pane-scoped set-option", () => {
+    const calls: string[][] = [];
+    restore = _setExecutor((_cmd, args) => {
+      calls.push(args);
+      return "";
+    });
+    claimPane("%7", { name: "Politician Trades", role: "teammate" });
+    expect(calls).toContainEqual(["set-option", "-p", "-t", "%7", "@ide_owned", "1"]);
+    expect(calls).toContainEqual([
+      "set-option",
+      "-p",
+      "-t",
+      "%7",
+      "@ide_name",
+      "Politician Trades",
+    ]);
+    expect(calls).toContainEqual(["set-option", "-p", "-t", "%7", "@ide_role", "teammate"]);
+  });
+
+  it("unsets @ide_owned on release", () => {
+    const calls: string[][] = [];
+    restore = _setExecutor((_cmd, args) => {
+      calls.push(args);
+      return "";
+    });
+    releasePane("%7");
+    expect(calls).toContainEqual(["set-option", "-p", "-u", "-t", "%7", "@ide_owned"]);
+  });
+
+  it("rejects a bogus pane id before touching tmux", () => {
+    let called = false;
+    restore = _setExecutor(() => {
+      called = true;
+      return "";
+    });
+    expect(() => claimPane("%7; rm -rf /")).toThrow(InvalidPaneIdError);
+    expect(() => releasePane("not-a-pane")).toThrow(InvalidPaneIdError);
+    expect(called).toBe(false);
   });
 });

--- a/packages/daemon/src/lib/__tests__/agent-registry.test.ts
+++ b/packages/daemon/src/lib/__tests__/agent-registry.test.ts
@@ -135,9 +135,19 @@ describe("aggregateHqAgents", () => {
       cwd: `/x${del}/y`,
     };
     const out = aggregateHqAgents([], "laptop", [
-      { machineId: "m1", machineName: "box-a", agents: [hostile] },
+      { machineId: "m1", machineName: `box${esc}a`, agents: [hostile] },
     ]);
     expect(out[0]!.name).toBe("evil[2Jname");
     expect(out[0]!.cwd).toBe("/x/y");
+    // machineName/machineId come from the (untrusted) registration record too
+    expect(out[0]!.machineName).toBe("boxa");
+  });
+
+  it("re-stamps a remote agent that already carries a machineId (no double-stamp)", () => {
+    const preStamped: AgentRecord = { ...remoteAgent, machineId: "old", machineName: "stale" };
+    const out = aggregateHqAgents([], "laptop", [
+      { machineId: "m2", machineName: "box-b", agents: [preStamped] },
+    ]);
+    expect(out[0]).toMatchObject({ machineId: "m2", machineName: "box-b", id: "m2:proj:%1" });
   });
 });

--- a/packages/daemon/src/lib/__tests__/agent-registry.test.ts
+++ b/packages/daemon/src/lib/__tests__/agent-registry.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import type { AgentRecord } from "@tmux-ide/contracts";
+import { ExternalAgentRegistry, mergeLocalAgents } from "../agent-registry.ts";
+
+describe("ExternalAgentRegistry", () => {
+  it("registers and lists an external agent as idle", () => {
+    const reg = new ExternalAgentRegistry();
+    reg.register({ id: "sess-1", tool: "claude", name: "Laptop Claude", cwd: "/w" }, 1000);
+    const agents = reg.list(1000);
+    expect(agents).toHaveLength(1);
+    expect(agents[0]).toMatchObject({ id: "sess-1", kind: "external", status: "idle", cwd: "/w" });
+  });
+
+  it("heartbeat updates status and refreshes lastSeen", () => {
+    const reg = new ExternalAgentRegistry({ offlineAfterMs: 1000 });
+    reg.register({ id: "a", tool: "claude" }, 0);
+    expect(reg.heartbeat({ id: "a", status: "busy" }, 1500)).toBe(true);
+    expect(reg.list(1500)[0]!.status).toBe("busy");
+  });
+
+  it("heartbeat for unknown id returns false", () => {
+    const reg = new ExternalAgentRegistry();
+    expect(reg.heartbeat({ id: "ghost" }, 0)).toBe(false);
+  });
+
+  it("marks agents offline past the offline window", () => {
+    const reg = new ExternalAgentRegistry({ offlineAfterMs: 1000 });
+    reg.register({ id: "a", tool: "claude", status: "busy" }, 0);
+    expect(reg.list(500)[0]!.status).toBe("busy");
+    expect(reg.list(2000)[0]!.status).toBe("offline");
+  });
+
+  it("evicts agents past the eviction window", () => {
+    const reg = new ExternalAgentRegistry({ evictAfterMs: 1000 });
+    reg.register({ id: "a", tool: "claude" }, 0);
+    expect(reg.list(2000)).toHaveLength(0);
+  });
+
+  it("unregister removes an agent", () => {
+    const reg = new ExternalAgentRegistry();
+    reg.register({ id: "a", tool: "claude" }, 0);
+    expect(reg.unregister("a")).toBe(true);
+    expect(reg.list(0)).toHaveLength(0);
+  });
+});
+
+describe("mergeLocalAgents", () => {
+  const tmuxAgent: AgentRecord = {
+    id: "s:%1",
+    kind: "managed",
+    tool: "claude",
+    name: "François",
+    status: "idle",
+    session: "s",
+    paneId: "%1",
+    paneTitle: "Claude Code",
+    cwd: "/w",
+    taskId: null,
+    taskTitle: null,
+    pid: 4242,
+    lastActivity: "2026-01-01T00:00:00.000Z",
+    machineId: null,
+    machineName: null,
+  };
+  const externalDupe: AgentRecord = { ...tmuxAgent, id: "ext", kind: "external", paneId: null };
+  const externalOther: AgentRecord = { ...externalDupe, id: "ext2", pid: 9999 };
+
+  it("drops external agents that share a pid with a tmux pane", () => {
+    const merged = mergeLocalAgents([tmuxAgent], [externalDupe]);
+    expect(merged.map((a) => a.id)).toEqual(["s:%1"]);
+  });
+
+  it("keeps external agents with distinct or null pids", () => {
+    const merged = mergeLocalAgents([tmuxAgent], [externalOther, { ...externalDupe, pid: null }]);
+    expect(merged).toHaveLength(3);
+  });
+});

--- a/packages/daemon/src/lib/__tests__/agent-registry.test.ts
+++ b/packages/daemon/src/lib/__tests__/agent-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { AgentRecord } from "@tmux-ide/contracts";
-import { ExternalAgentRegistry, mergeLocalAgents } from "../agent-registry.ts";
+import { ExternalAgentRegistry, aggregateHqAgents, mergeLocalAgents } from "../agent-registry.ts";
 
 describe("ExternalAgentRegistry", () => {
   it("registers and lists an external agent as idle", () => {
@@ -73,5 +73,71 @@ describe("mergeLocalAgents", () => {
   it("keeps external agents with distinct or null pids", () => {
     const merged = mergeLocalAgents([tmuxAgent], [externalOther, { ...externalDupe, pid: null }]);
     expect(merged).toHaveLength(3);
+  });
+});
+
+describe("ExternalAgentRegistry maxEntries cap", () => {
+  it("evicts the least-recently-seen entry when full", () => {
+    const reg = new ExternalAgentRegistry({ maxEntries: 2 });
+    reg.register({ id: "a", tool: "claude" }, 100);
+    reg.register({ id: "b", tool: "claude" }, 200);
+    reg.register({ id: "c", tool: "claude" }, 300); // overflow → evicts "a"
+    const ids = reg
+      .list(300)
+      .map((x) => x.id)
+      .sort();
+    expect(ids).toEqual(["b", "c"]);
+  });
+
+  it("re-registering an existing id does not trigger eviction", () => {
+    const reg = new ExternalAgentRegistry({ maxEntries: 2 });
+    reg.register({ id: "a", tool: "claude" }, 100);
+    reg.register({ id: "b", tool: "claude" }, 200);
+    reg.register({ id: "a", tool: "claude", status: "busy" }, 300); // update, not new
+    expect(reg.list(300)).toHaveLength(2);
+  });
+});
+
+describe("aggregateHqAgents", () => {
+  const remoteAgent: AgentRecord = {
+    id: "proj:%1",
+    kind: "managed",
+    tool: "claude",
+    name: "René",
+    status: "busy",
+    session: "proj",
+    paneId: "%1",
+    paneTitle: "Claude Code",
+    cwd: "/srv/proj",
+    taskId: null,
+    taskTitle: null,
+    pid: 7,
+    lastActivity: "2026-01-01T00:00:00.000Z",
+    machineId: null,
+    machineName: null,
+  };
+  const localAgent: AgentRecord = { ...remoteAgent, id: "local:%9", name: "François" };
+
+  it("stamps local agents with self name and namespaces remote ids", () => {
+    const out = aggregateHqAgents([localAgent], "laptop", [
+      { machineId: "m1", machineName: "box-a", agents: [remoteAgent] },
+    ]);
+    expect(out[0]).toMatchObject({ machineName: "laptop", machineId: null, id: "local:%9" });
+    expect(out[1]).toMatchObject({ machineName: "box-a", machineId: "m1", id: "m1:proj:%1" });
+  });
+
+  it("strips control chars from untrusted remote display fields", () => {
+    const esc = String.fromCharCode(27); // ESC (terminal escape lead-in)
+    const del = String.fromCharCode(127); // DEL
+    const hostile: AgentRecord = {
+      ...remoteAgent,
+      name: `evil${esc}[2Jname`,
+      cwd: `/x${del}/y`,
+    };
+    const out = aggregateHqAgents([], "laptop", [
+      { machineId: "m1", machineName: "box-a", agents: [hostile] },
+    ]);
+    expect(out[0]!.name).toBe("evil[2Jname");
+    expect(out[0]!.cwd).toBe("/x/y");
   });
 });

--- a/packages/daemon/src/lib/__tests__/agent-remotes.test.ts
+++ b/packages/daemon/src/lib/__tests__/agent-remotes.test.ts
@@ -102,6 +102,27 @@ describe("listSshAgentSources", () => {
     expect(calls).toHaveLength(2);
   });
 
+  it("dedupes store entries that share a tunnel url, preferring the freshest launch", async () => {
+    writeRemotes([
+      { name: "stale", host: "h", path: "/old", addedAt: "x", localPort: 7001 },
+      {
+        name: "fresh",
+        host: "h",
+        path: "/new",
+        addedAt: "x",
+        localPort: 7001,
+        lastLaunchedAt: "2026-07-02T00:00:00.000Z",
+      },
+    ]);
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ agents: [agent] }), { status: 200 }),
+    ) as typeof fetch;
+    const sources = await listSshAgentSources();
+    expect(sources).toHaveLength(1);
+    expect(sources[0]!.machineName).toBe("fresh");
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
   it("skips a remote whose response fails schema validation", async () => {
     writeRemotes([{ name: "boxa", host: "h", path: "/p", addedAt: "x", lastLocalPort: 7001 }]);
     globalThis.fetch = vi.fn(

--- a/packages/daemon/src/lib/__tests__/agent-remotes.test.ts
+++ b/packages/daemon/src/lib/__tests__/agent-remotes.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentRecord } from "@tmux-ide/contracts";
+import { listSshAgentSources, resolveSshMachineUrl, sshMachineId } from "../agent-remotes.ts";
+
+const agent: AgentRecord = {
+  id: "proj:%1",
+  kind: "managed",
+  tool: "claude",
+  name: "René",
+  status: "busy",
+  session: "proj",
+  paneId: "%1",
+  paneTitle: "Claude Code",
+  cwd: "/srv/proj",
+  taskId: null,
+  taskTitle: null,
+  pid: 7,
+  lastActivity: "2026-01-01T00:00:00.000Z",
+  machineId: null,
+  machineName: null,
+};
+
+let dir: string;
+let storeFile: string;
+const originalFetch = globalThis.fetch;
+
+function writeRemotes(remotes: object[]): void {
+  writeFileSync(storeFile, JSON.stringify({ version: 1, remotes }, null, 2));
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "tmux-ide-remotes-"));
+  storeFile = join(dir, "ssh-remotes.json");
+  process.env.TMUX_IDE_SSH_REMOTES_FILE = storeFile;
+});
+
+afterEach(() => {
+  delete process.env.TMUX_IDE_SSH_REMOTES_FILE;
+  globalThis.fetch = originalFetch;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("sshMachineId / resolveSshMachineUrl", () => {
+  it("resolves a configured remote's tunnel url from lastLocalPort", async () => {
+    writeRemotes([
+      { name: "boxa", host: "boxa-ssm", path: "/srv/p", addedAt: "x", lastLocalPort: 7777 },
+    ]);
+    expect(sshMachineId("boxa")).toBe("ssh:boxa");
+    expect(await resolveSshMachineUrl("ssh:boxa")).toBe("http://127.0.0.1:7777");
+  });
+
+  it("prefers the pinned localPort over lastLocalPort", async () => {
+    writeRemotes([
+      {
+        name: "boxa",
+        host: "h",
+        path: "/p",
+        addedAt: "x",
+        localPort: 6061,
+        lastLocalPort: 7777,
+      },
+    ]);
+    expect(await resolveSshMachineUrl("ssh:boxa")).toBe("http://127.0.0.1:6061");
+  });
+
+  it("returns null for non-ssh machine ids, unknown remotes, and tunnel-less remotes", async () => {
+    writeRemotes([{ name: "no-tunnel", host: "h", path: "/p", addedAt: "x" }]);
+    expect(await resolveSshMachineUrl("some-hq-uuid")).toBeNull();
+    expect(await resolveSshMachineUrl("ssh:ghost")).toBeNull();
+    expect(await resolveSshMachineUrl("ssh:no-tunnel")).toBeNull();
+  });
+});
+
+describe("listSshAgentSources", () => {
+  it("returns reachable tunnels as agent sources and skips dead ones", async () => {
+    writeRemotes([
+      { name: "boxa", host: "h", path: "/p", addedAt: "x", lastLocalPort: 7001 },
+      { name: "boxb", host: "h", path: "/p", addedAt: "x", lastLocalPort: 7002 },
+      { name: "no-tunnel", host: "h", path: "/p", addedAt: "x" },
+    ]);
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("http://127.0.0.1:7001/")) {
+        return new Response(JSON.stringify({ agents: [agent] }), { status: 200 });
+      }
+      throw new Error("connect ECONNREFUSED");
+    }) as typeof fetch;
+
+    const sources = await listSshAgentSources();
+    expect(sources).toHaveLength(1);
+    expect(sources[0]).toMatchObject({ machineId: "ssh:boxa", machineName: "boxa" });
+    expect(sources[0]!.agents[0]!.id).toBe("proj:%1");
+    // the tunnel-less remote is never probed
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) =>
+      String(c[0]),
+    );
+    expect(calls.some((u) => u.includes("7001"))).toBe(true);
+    expect(calls.some((u) => u.includes("7002"))).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("skips a remote whose response fails schema validation", async () => {
+    writeRemotes([{ name: "boxa", host: "h", path: "/p", addedAt: "x", lastLocalPort: 7001 }]);
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ agents: "not-an-array" }), { status: 200 }),
+    ) as typeof fetch;
+    expect(await listSshAgentSources()).toEqual([]);
+  });
+
+  it("skips a remote that answers with a redirect", async () => {
+    writeRemotes([{ name: "boxa", host: "h", path: "/p", addedAt: "x", lastLocalPort: 7001 }]);
+    globalThis.fetch = vi.fn(
+      async () => new Response(null, { status: 302, headers: { Location: "http://evil" } }),
+    ) as typeof fetch;
+    expect(await listSshAgentSources()).toEqual([]);
+  });
+});

--- a/packages/daemon/src/lib/agent-discovery.ts
+++ b/packages/daemon/src/lib/agent-discovery.ts
@@ -14,6 +14,9 @@ export interface TmuxPane extends PaneInfo {
   session: string;
   cwd: string | null;
   pid: number | null;
+  // Set via `claimPane`: this specific pane has been adopted ("owned") even
+  // though tmux-ide didn't create its session.
+  owned: boolean;
 }
 
 // pane_title is free-text and can contain tabs, so it goes LAST — any overflow
@@ -32,6 +35,7 @@ const FIELDS = [
   "#{@ide_role}",
   "#{@ide_name}",
   "#{@ide_type}",
+  "#{@ide_owned}",
   "#{pane_title}",
 ];
 const FIXED_FIELDS = FIELDS.length - 1; // everything before the trailing title
@@ -46,7 +50,8 @@ export function listAllTmuxPanes(): TmuxPane[] {
     const parts = line.split("\t");
     // Skip malformed rows (a tmux format glitch shouldn't crash discovery).
     if (parts.length < FIXED_FIELDS) continue;
-    const [session, id, index, cmd, cwd, pid, width, height, active, role, name, type] = parts;
+    const [session, id, index, cmd, cwd, pid, width, height, active, role, name, type, owned] =
+      parts;
     if (!session || !id) continue;
     panes.push({
       session,
@@ -62,6 +67,7 @@ export function listAllTmuxPanes(): TmuxPane[] {
       role: (role || null) as PaneInfo["role"],
       name: name || null,
       type: type || null,
+      owned: owned === "1",
     } satisfies TmuxPane);
   }
   return panes;
@@ -86,7 +92,9 @@ export function discoverTmuxAgents(managedSessions: Set<string>): AgentRecord[] 
   return listAllTmuxPanes()
     .filter((pane) => isAgentPane(pane))
     .map((pane) => {
-      const managed = managedSessions.has(pane.session);
+      // A pane is managed if tmux-ide owns its whole session OR it was
+      // individually claimed (`@ide_owned`).
+      const managed = managedSessions.has(pane.session) || pane.owned;
       return {
         id: `${pane.session}:${pane.id}`,
         kind: managed ? "managed" : "tmux-unmanaged",
@@ -105,4 +113,45 @@ export function discoverTmuxAgents(managedSessions: Set<string>): AgentRecord[] 
         machineName: null,
       } satisfies AgentRecord;
     });
+}
+
+const PANE_ID_RE = /^%\d+$/;
+
+/** Strip control chars and bound length for a tmux option value. */
+function sanitizeOption(value: string, max: number): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0)!;
+    if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)) continue;
+    out += ch;
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+export class InvalidPaneIdError extends Error {
+  constructor(paneId: string) {
+    super(`Invalid tmux pane id: ${paneId}`);
+    this.name = "InvalidPaneIdError";
+  }
+}
+
+/**
+ * Adopt ("own") a single tmux pane by tagging it with `@ide_owned`, so
+ * discovery reports it as `managed` even though tmux-ide didn't start its
+ * session. Optionally set a display name/role. Pane-scoped tmux options
+ * (`set-option -p`) don't touch the rest of the session.
+ */
+export function claimPane(paneId: string, opts: { name?: string; role?: string } = {}): void {
+  if (!PANE_ID_RE.test(paneId)) throw new InvalidPaneIdError(paneId);
+  tmux("set-option", "-p", "-t", paneId, "@ide_owned", "1");
+  if (opts.name)
+    tmux("set-option", "-p", "-t", paneId, "@ide_name", sanitizeOption(opts.name, 200));
+  if (opts.role) tmux("set-option", "-p", "-t", paneId, "@ide_role", sanitizeOption(opts.role, 64));
+}
+
+/** Release a previously claimed pane. Leaves any custom `@ide_name` intact. */
+export function releasePane(paneId: string): void {
+  if (!PANE_ID_RE.test(paneId)) throw new InvalidPaneIdError(paneId);
+  tmux("set-option", "-p", "-u", "-t", paneId, "@ide_owned");
 }

--- a/packages/daemon/src/lib/agent-discovery.ts
+++ b/packages/daemon/src/lib/agent-discovery.ts
@@ -1,0 +1,123 @@
+// Discover every Claude/codex CLI agent visible on this host's tmux server —
+// not just the panes tmux-ide spawned. Panes living in a managed session are
+// reported as `managed` (we can control them); panes in any other session are
+// `tmux-unmanaged` (observe + best-effort send-keys).
+import { execFileSync } from "node:child_process";
+import type { AgentRecord, AgentTool, PaneInfo } from "@tmux-ide/contracts";
+import { isAgentPane, isAgentBusy, agentIdentifier } from "./orchestrator.ts";
+
+type TmuxExecutor = (cmd: string, args: string[], options?: object) => string;
+
+let _executor: TmuxExecutor = (cmd, args, options) =>
+  execFileSync(cmd, args, { encoding: "utf-8", ...options }).toString();
+
+/** Swap the tmux executor (tests). Returns a restore function. */
+export function _setExecutor(fn: TmuxExecutor): () => void {
+  const prev = _executor;
+  _executor = fn;
+  return () => {
+    _executor = prev;
+  };
+}
+
+function tmux(...args: string[]): string {
+  try {
+    return _executor("tmux", args, { stdio: ["pipe", "pipe", "pipe"] }).trim();
+  } catch (error) {
+    const stderr = (error as { stderr?: Buffer | string })?.stderr?.toString() ?? "";
+    if (stderr.includes("no server running") || stderr.includes("can't find session")) {
+      return "";
+    }
+    throw error;
+  }
+}
+
+export interface TmuxPane extends PaneInfo {
+  session: string;
+  cwd: string | null;
+  pid: number | null;
+}
+
+const FIELDS = [
+  "#{session_name}",
+  "#{pane_id}",
+  "#{pane_index}",
+  "#{pane_title}",
+  "#{pane_current_command}",
+  "#{pane_current_path}",
+  "#{pane_pid}",
+  "#{pane_width}",
+  "#{pane_height}",
+  "#{pane_active}",
+  "#{@ide_role}",
+  "#{@ide_name}",
+  "#{@ide_type}",
+];
+
+/** List panes across every session on the tmux server (`list-panes -a`). */
+export function listAllTmuxPanes(): TmuxPane[] {
+  const output = tmux("list-panes", "-a", "-F", FIELDS.join("\t"));
+  if (!output) return [];
+  return output
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [session, id, index, title, cmd, cwd, pid, width, height, active, role, name, type] =
+        line.split("\t");
+      return {
+        session: session!,
+        id: id!,
+        index: parseInt(index!, 10),
+        title: title!,
+        currentCommand: cmd!,
+        cwd: cwd || null,
+        pid: pid ? parseInt(pid, 10) : null,
+        width: parseInt(width!, 10),
+        height: parseInt(height!, 10),
+        active: active === "1",
+        role: (role || null) as PaneInfo["role"],
+        name: name || null,
+        type: type || null,
+      } satisfies TmuxPane;
+    });
+}
+
+/** Infer which CLI an agent pane is running from its command name. */
+export function inferAgentTool(currentCommand: string): AgentTool {
+  const cmd = currentCommand.toLowerCase();
+  if (cmd.startsWith("codex")) return "codex";
+  if (cmd.startsWith("claude")) return "claude";
+  // Claude Code reports its version string (e.g. "2.1.80") as the command.
+  if (/^\d+\.\d+/.test(cmd)) return "claude";
+  return "unknown";
+}
+
+/**
+ * Discover all tmux agents on this host. `managedSessions` are the session
+ * names tmux-ide owns; panes in those are `managed`, everything else is
+ * `tmux-unmanaged`.
+ */
+export function discoverTmuxAgents(managedSessions: Set<string>): AgentRecord[] {
+  return listAllTmuxPanes()
+    .filter((pane) => isAgentPane(pane))
+    .map((pane) => {
+      const managed = managedSessions.has(pane.session);
+      return {
+        id: `${pane.session}:${pane.id}`,
+        kind: managed ? "managed" : "tmux-unmanaged",
+        tool: inferAgentTool(pane.currentCommand),
+        name: agentIdentifier(pane),
+        status: isAgentBusy(pane) ? "busy" : "idle",
+        session: pane.session,
+        paneId: pane.id,
+        paneTitle: pane.title,
+        cwd: pane.cwd,
+        taskId: null,
+        taskTitle: null,
+        pid: pane.pid,
+        lastActivity: new Date().toISOString(),
+        machineId: null,
+        machineName: null,
+      } satisfies AgentRecord;
+    });
+}

--- a/packages/daemon/src/lib/agent-discovery.ts
+++ b/packages/daemon/src/lib/agent-discovery.ts
@@ -2,35 +2,13 @@
 // not just the panes tmux-ide spawned. Panes living in a managed session are
 // reported as `managed` (we can control them); panes in any other session are
 // `tmux-unmanaged` (observe + best-effort send-keys).
-import { execFileSync } from "node:child_process";
 import type { AgentRecord, AgentTool, PaneInfo } from "@tmux-ide/contracts";
 import { isAgentPane, isAgentBusy, agentIdentifier } from "./orchestrator.ts";
+import { tmux, _setExecutor } from "./tmux-exec.ts";
 
-type TmuxExecutor = (cmd: string, args: string[], options?: object) => string;
-
-let _executor: TmuxExecutor = (cmd, args, options) =>
-  execFileSync(cmd, args, { encoding: "utf-8", ...options }).toString();
-
-/** Swap the tmux executor (tests). Returns a restore function. */
-export function _setExecutor(fn: TmuxExecutor): () => void {
-  const prev = _executor;
-  _executor = fn;
-  return () => {
-    _executor = prev;
-  };
-}
-
-function tmux(...args: string[]): string {
-  try {
-    return _executor("tmux", args, { stdio: ["pipe", "pipe", "pipe"] }).trim();
-  } catch (error) {
-    const stderr = (error as { stderr?: Buffer | string })?.stderr?.toString() ?? "";
-    if (stderr.includes("no server running") || stderr.includes("can't find session")) {
-      return "";
-    }
-    throw error;
-  }
-}
+// Re-exported so existing tests/callers can keep importing the executor seam
+// from here.
+export { _setExecutor };
 
 export interface TmuxPane extends PaneInfo {
   session: string;
@@ -38,11 +16,13 @@ export interface TmuxPane extends PaneInfo {
   pid: number | null;
 }
 
+// pane_title is free-text and can contain tabs, so it goes LAST — any overflow
+// from the tab split is rejoined back into the title rather than corrupting the
+// fields after it.
 const FIELDS = [
   "#{session_name}",
   "#{pane_id}",
   "#{pane_index}",
-  "#{pane_title}",
   "#{pane_current_command}",
   "#{pane_current_path}",
   "#{pane_pid}",
@@ -52,34 +32,39 @@ const FIELDS = [
   "#{@ide_role}",
   "#{@ide_name}",
   "#{@ide_type}",
+  "#{pane_title}",
 ];
+const FIXED_FIELDS = FIELDS.length - 1; // everything before the trailing title
 
 /** List panes across every session on the tmux server (`list-panes -a`). */
 export function listAllTmuxPanes(): TmuxPane[] {
   const output = tmux("list-panes", "-a", "-F", FIELDS.join("\t"));
   if (!output) return [];
-  return output
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => {
-      const [session, id, index, title, cmd, cwd, pid, width, height, active, role, name, type] =
-        line.split("\t");
-      return {
-        session: session!,
-        id: id!,
-        index: parseInt(index!, 10),
-        title: title!,
-        currentCommand: cmd!,
-        cwd: cwd || null,
-        pid: pid ? parseInt(pid, 10) : null,
-        width: parseInt(width!, 10),
-        height: parseInt(height!, 10),
-        active: active === "1",
-        role: (role || null) as PaneInfo["role"],
-        name: name || null,
-        type: type || null,
-      } satisfies TmuxPane;
-    });
+  const panes: TmuxPane[] = [];
+  for (const line of output.split("\n")) {
+    if (!line) continue;
+    const parts = line.split("\t");
+    // Skip malformed rows (a tmux format glitch shouldn't crash discovery).
+    if (parts.length < FIXED_FIELDS) continue;
+    const [session, id, index, cmd, cwd, pid, width, height, active, role, name, type] = parts;
+    if (!session || !id) continue;
+    panes.push({
+      session,
+      id,
+      index: parseInt(index!, 10) || 0,
+      title: parts.slice(FIXED_FIELDS).join("\t"),
+      currentCommand: cmd ?? "",
+      cwd: cwd || null,
+      pid: pid ? parseInt(pid, 10) || null : null,
+      width: parseInt(width!, 10) || 0,
+      height: parseInt(height!, 10) || 0,
+      active: active === "1",
+      role: (role || null) as PaneInfo["role"],
+      name: name || null,
+      type: type || null,
+    } satisfies TmuxPane);
+  }
+  return panes;
 }
 
 /** Infer which CLI an agent pane is running from its command name. */

--- a/packages/daemon/src/lib/agent-registry.ts
+++ b/packages/daemon/src/lib/agent-registry.ts
@@ -101,6 +101,62 @@ export class ExternalAgentRegistry {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Default singleton — the daemon process holds one registry so both the v2
+// action handlers (agent.register / heartbeat / unregister) and the
+// GET /api/agents route observe the same external-agent state.
+// ---------------------------------------------------------------------------
+
+let _default: ExternalAgentRegistry | null = null;
+
+export function getDefaultExternalAgentRegistry(): ExternalAgentRegistry {
+  if (!_default) _default = new ExternalAgentRegistry();
+  return _default;
+}
+
+/** @internal Test hook: replace the singleton. */
+export function _setDefaultExternalAgentRegistryForTests(
+  registry: ExternalAgentRegistry | null,
+): void {
+  _default = registry;
+}
+
+/** A remote machine's agents as fetched by HQ during fan-out. */
+export interface RemoteAgentSource {
+  machineId: string;
+  machineName: string;
+  agents: AgentRecord[];
+}
+
+/**
+ * Build the aggregated HQ view: this host's local agents (stamped with the
+ * self machine name, machineId null) followed by every reachable remote's
+ * agents (stamped with the remote's id/name, ids namespaced by `${id}:` so
+ * they stay globally unique). Pure — the caller owns fetch/timeout/skip.
+ */
+export function aggregateHqAgents(
+  localAgents: AgentRecord[],
+  selfMachineName: string,
+  remotes: RemoteAgentSource[],
+): AgentRecord[] {
+  const out: AgentRecord[] = localAgents.map((a) => ({
+    ...a,
+    machineId: null,
+    machineName: selfMachineName,
+  }));
+  for (const remote of remotes) {
+    for (const a of remote.agents) {
+      out.push({
+        ...a,
+        id: `${remote.machineId}:${a.id}`,
+        machineId: remote.machineId,
+        machineName: remote.machineName,
+      });
+    }
+  }
+  return out;
+}
+
 /**
  * Merge tmux-discovered agents with externally-reported ones, de-duplicating
  * by pid (a hook-registered agent that's also visible in a tmux pane shows up

--- a/packages/daemon/src/lib/agent-registry.ts
+++ b/packages/daemon/src/lib/agent-registry.ts
@@ -154,15 +154,17 @@ export interface RemoteAgentSource {
 // (terminal escape sequences, NULs) from display strings so a remote can't
 // inject into the local UI/terminal when its records are rendered.
 function sanitizeDisplay(value: string): string {
-  let out = "";
+  const chars: string[] = [];
   for (const ch of value) {
     const code = ch.codePointAt(0)!;
     // Drop C0 controls (0x00-0x1F), DEL (0x7F), and C1 controls (0x80-0x9F) —
     // xterm-class terminals can interpret C1 bytes (e.g. 0x9B = CSI).
     if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)) continue;
-    out += ch;
+    chars.push(ch);
+    // Cap by code point (not UTF-16 unit) so we never split an astral pair.
+    if (chars.length >= 512) break;
   }
-  return out.slice(0, 512);
+  return chars.join("");
 }
 
 function sanitizeRemoteAgent(a: AgentRecord, remote: RemoteAgentSource): AgentRecord {

--- a/packages/daemon/src/lib/agent-registry.ts
+++ b/packages/daemon/src/lib/agent-registry.ts
@@ -27,20 +27,39 @@ export interface ExternalAgentRegistryOptions {
   offlineAfterMs?: number;
   // Window without a heartbeat before an agent is dropped entirely.
   evictAfterMs?: number;
+  // Hard cap on tracked agents; protects the long-lived daemon from a flood of
+  // unique-id registrations. On overflow the least-recently-seen entry is
+  // evicted so growth is bounded regardless of how often the list is read.
+  maxEntries?: number;
 }
 
 export class ExternalAgentRegistry {
   private agents = new Map<string, ExternalAgentEntry>();
   private readonly offlineAfterMs: number;
   private readonly evictAfterMs: number;
+  private readonly maxEntries: number;
 
   constructor(opts?: ExternalAgentRegistryOptions) {
     this.offlineAfterMs = opts?.offlineAfterMs ?? 90_000;
     this.evictAfterMs = opts?.evictAfterMs ?? 30 * 60_000;
+    this.maxEntries = opts?.maxEntries ?? 1000;
+  }
+
+  private evictOldest(): void {
+    let oldestId: string | null = null;
+    let oldestSeen = Infinity;
+    for (const [id, entry] of this.agents) {
+      if (entry.lastSeen < oldestSeen) {
+        oldestSeen = entry.lastSeen;
+        oldestId = id;
+      }
+    }
+    if (oldestId !== null) this.agents.delete(oldestId);
   }
 
   register(payload: AgentRegisterPayload, now = Date.now()): void {
     const existing = this.agents.get(payload.id);
+    if (!existing && this.agents.size >= this.maxEntries) this.evictOldest();
     this.agents.set(payload.id, {
       id: payload.id,
       tool: payload.tool,
@@ -128,11 +147,39 @@ export interface RemoteAgentSource {
   agents: AgentRecord[];
 }
 
+// Remote agents come from a possibly-hostile/compromised machine. The response
+// is already Zod-bounded for length; here we additionally strip control chars
+// (terminal escape sequences, NULs) from display strings so a remote can't
+// inject into the local UI/terminal when its records are rendered.
+function sanitizeDisplay(value: string): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0)!;
+    // Drop C0 controls (0x00-0x1F) and DEL (0x7F).
+    if (code >= 0x20 && code !== 0x7f) out += ch;
+  }
+  return out.slice(0, 512);
+}
+
+function sanitizeRemoteAgent(a: AgentRecord, remote: RemoteAgentSource): AgentRecord {
+  return {
+    ...a,
+    id: `${remote.machineId}:${sanitizeDisplay(a.id)}`,
+    name: sanitizeDisplay(a.name),
+    session: a.session === null ? null : sanitizeDisplay(a.session),
+    paneTitle: a.paneTitle === null ? null : sanitizeDisplay(a.paneTitle),
+    cwd: a.cwd === null ? null : sanitizeDisplay(a.cwd),
+    taskTitle: a.taskTitle === null ? null : sanitizeDisplay(a.taskTitle),
+    machineId: remote.machineId,
+    machineName: remote.machineName,
+  };
+}
+
 /**
  * Build the aggregated HQ view: this host's local agents (stamped with the
  * self machine name, machineId null) followed by every reachable remote's
- * agents (stamped with the remote's id/name, ids namespaced by `${id}:` so
- * they stay globally unique). Pure — the caller owns fetch/timeout/skip.
+ * agents (stamped + sanitized, ids namespaced by `${machineId}:` so they stay
+ * globally unique). Pure — the caller owns fetch/timeout/skip/self-exclusion.
  */
 export function aggregateHqAgents(
   localAgents: AgentRecord[],
@@ -146,12 +193,7 @@ export function aggregateHqAgents(
   }));
   for (const remote of remotes) {
     for (const a of remote.agents) {
-      out.push({
-        ...a,
-        id: `${remote.machineId}:${a.id}`,
-        machineId: remote.machineId,
-        machineName: remote.machineName,
-      });
+      out.push(sanitizeRemoteAgent(a, remote));
     }
   }
   return out;

--- a/packages/daemon/src/lib/agent-registry.ts
+++ b/packages/daemon/src/lib/agent-registry.ts
@@ -40,7 +40,9 @@ export class ExternalAgentRegistry {
   private readonly maxEntries: number;
 
   constructor(opts?: ExternalAgentRegistryOptions) {
-    this.offlineAfterMs = opts?.offlineAfterMs ?? 90_000;
+    // 5min: hooks only refresh lastSeen on prompt/tool-use/turn-end, so the
+    // window must tolerate a long turn that makes no tool calls.
+    this.offlineAfterMs = opts?.offlineAfterMs ?? 5 * 60_000;
     this.evictAfterMs = opts?.evictAfterMs ?? 30 * 60_000;
     this.maxEntries = opts?.maxEntries ?? 1000;
   }
@@ -155,23 +157,28 @@ function sanitizeDisplay(value: string): string {
   let out = "";
   for (const ch of value) {
     const code = ch.codePointAt(0)!;
-    // Drop C0 controls (0x00-0x1F) and DEL (0x7F).
-    if (code >= 0x20 && code !== 0x7f) out += ch;
+    // Drop C0 controls (0x00-0x1F), DEL (0x7F), and C1 controls (0x80-0x9F) —
+    // xterm-class terminals can interpret C1 bytes (e.g. 0x9B = CSI).
+    if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)) continue;
+    out += ch;
   }
   return out.slice(0, 512);
 }
 
 function sanitizeRemoteAgent(a: AgentRecord, remote: RemoteAgentSource): AgentRecord {
+  // machineId/machineName come from the remote's registration record, which is
+  // also attacker-influenceable — sanitize them too, not just the agent fields.
+  const machineId = sanitizeDisplay(remote.machineId);
   return {
     ...a,
-    id: `${remote.machineId}:${sanitizeDisplay(a.id)}`,
+    id: `${machineId}:${sanitizeDisplay(a.id)}`,
     name: sanitizeDisplay(a.name),
     session: a.session === null ? null : sanitizeDisplay(a.session),
     paneTitle: a.paneTitle === null ? null : sanitizeDisplay(a.paneTitle),
     cwd: a.cwd === null ? null : sanitizeDisplay(a.cwd),
     taskTitle: a.taskTitle === null ? null : sanitizeDisplay(a.taskTitle),
-    machineId: remote.machineId,
-    machineName: remote.machineName,
+    machineId,
+    machineName: sanitizeDisplay(remote.machineName),
   };
 }
 
@@ -186,10 +193,11 @@ export function aggregateHqAgents(
   selfMachineName: string,
   remotes: RemoteAgentSource[],
 ): AgentRecord[] {
+  const selfName = sanitizeDisplay(selfMachineName);
   const out: AgentRecord[] = localAgents.map((a) => ({
     ...a,
     machineId: null,
-    machineName: selfMachineName,
+    machineName: selfName,
   }));
   for (const remote of remotes) {
     for (const a of remote.agents) {

--- a/packages/daemon/src/lib/agent-registry.ts
+++ b/packages/daemon/src/lib/agent-registry.ts
@@ -1,0 +1,118 @@
+// In-memory registry of externally-reported Claude/codex agents — sessions
+// running in plain terminals (no tmux) that self-report via a hook. Entries go
+// `offline` after a missed-heartbeat window and are evicted once long stale.
+import type {
+  AgentHeartbeatPayload,
+  AgentRecord,
+  AgentRegisterPayload,
+  AgentStatus,
+  AgentTool,
+} from "@tmux-ide/contracts";
+
+interface ExternalAgentEntry {
+  id: string;
+  tool: AgentTool;
+  name: string;
+  cwd: string | null;
+  session: string | null;
+  pid: number | null;
+  status: AgentStatus;
+  taskTitle: string | null;
+  registeredAt: number;
+  lastSeen: number;
+}
+
+export interface ExternalAgentRegistryOptions {
+  // Window without a heartbeat before an agent is reported `offline`.
+  offlineAfterMs?: number;
+  // Window without a heartbeat before an agent is dropped entirely.
+  evictAfterMs?: number;
+}
+
+export class ExternalAgentRegistry {
+  private agents = new Map<string, ExternalAgentEntry>();
+  private readonly offlineAfterMs: number;
+  private readonly evictAfterMs: number;
+
+  constructor(opts?: ExternalAgentRegistryOptions) {
+    this.offlineAfterMs = opts?.offlineAfterMs ?? 90_000;
+    this.evictAfterMs = opts?.evictAfterMs ?? 30 * 60_000;
+  }
+
+  register(payload: AgentRegisterPayload, now = Date.now()): void {
+    const existing = this.agents.get(payload.id);
+    this.agents.set(payload.id, {
+      id: payload.id,
+      tool: payload.tool,
+      name: payload.name ?? existing?.name ?? payload.id.slice(0, 12),
+      cwd: payload.cwd ?? existing?.cwd ?? null,
+      session: payload.session ?? existing?.session ?? null,
+      pid: payload.pid ?? existing?.pid ?? null,
+      status: payload.status ?? existing?.status ?? "idle",
+      taskTitle: payload.taskTitle ?? existing?.taskTitle ?? null,
+      registeredAt: existing?.registeredAt ?? now,
+      lastSeen: now,
+    });
+  }
+
+  heartbeat(payload: AgentHeartbeatPayload, now = Date.now()): boolean {
+    const entry = this.agents.get(payload.id);
+    if (!entry) return false;
+    entry.lastSeen = now;
+    if (payload.status) entry.status = payload.status;
+    if (payload.taskTitle !== undefined) entry.taskTitle = payload.taskTitle;
+    return true;
+  }
+
+  unregister(id: string): boolean {
+    return this.agents.delete(id);
+  }
+
+  /** Drop entries that have been silent past the eviction window. */
+  prune(now = Date.now()): void {
+    for (const [id, entry] of this.agents) {
+      if (now - entry.lastSeen > this.evictAfterMs) this.agents.delete(id);
+    }
+  }
+
+  /** Snapshot as unified AgentRecords; stale entries surface as `offline`. */
+  list(now = Date.now()): AgentRecord[] {
+    this.prune(now);
+    return Array.from(this.agents.values()).map((entry) => {
+      const stale = now - entry.lastSeen > this.offlineAfterMs;
+      return {
+        id: entry.id,
+        kind: "external",
+        tool: entry.tool,
+        name: entry.name,
+        status: stale ? "offline" : entry.status,
+        session: entry.session,
+        paneId: null,
+        paneTitle: null,
+        cwd: entry.cwd,
+        taskId: null,
+        taskTitle: entry.taskTitle,
+        pid: entry.pid,
+        lastActivity: new Date(entry.lastSeen).toISOString(),
+        machineId: null,
+        machineName: null,
+      } satisfies AgentRecord;
+    });
+  }
+}
+
+/**
+ * Merge tmux-discovered agents with externally-reported ones, de-duplicating
+ * by pid (a hook-registered agent that's also visible in a tmux pane shows up
+ * once, preferring the richer live tmux record).
+ */
+export function mergeLocalAgents(
+  tmuxAgents: AgentRecord[],
+  externalAgents: AgentRecord[],
+): AgentRecord[] {
+  const tmuxPids = new Set(
+    tmuxAgents.map((a) => a.pid).filter((pid): pid is number => pid !== null),
+  );
+  const externalOnly = externalAgents.filter((a) => a.pid === null || !tmuxPids.has(a.pid));
+  return [...tmuxAgents, ...externalOnly];
+}

--- a/packages/daemon/src/lib/agent-remotes.ts
+++ b/packages/daemon/src/lib/agent-remotes.ts
@@ -1,0 +1,72 @@
+// Fold SSH-tunneled remotes into the central agents view. Unlike HQ machines
+// (which register themselves inbound), SSH remotes are outbound-only: this
+// machine opened a forward tunnel to the remote daemon's loopback port, so the
+// tunnel endpoint on 127.0.0.1 IS the remote daemon. We treat each configured
+// remote with a recorded tunnel port as an agent source and as a control
+// target — no reverse connectivity required, which matters for SSM-style
+// setups where the remote can't reach back to this machine.
+import { AgentListSchemaZ } from "@tmux-ide/contracts";
+import { readSshRemotes, type SshRemote } from "../ssh-remote.ts";
+import type { RemoteAgentSource } from "./agent-registry.ts";
+
+const SSH_MACHINE_PREFIX = "ssh:";
+const PROBE_TIMEOUT_MS = 2_500;
+
+export function sshMachineId(remoteName: string): string {
+  return `${SSH_MACHINE_PREFIX}${remoteName}`;
+}
+
+function tunnelPort(remote: SshRemote): number | null {
+  return remote.localPort ?? remote.lastLocalPort ?? null;
+}
+
+function tunnelBaseUrl(remote: SshRemote): string | null {
+  const port = tunnelPort(remote);
+  return port ? `http://127.0.0.1:${port}` : null;
+}
+
+/**
+ * Resolve an ssh-machine id (`ssh:<name>`) to the local tunnel base url, or
+ * null when the id isn't an ssh machine / the remote has no recorded tunnel.
+ */
+export async function resolveSshMachineUrl(machineId: string): Promise<string | null> {
+  if (!machineId.startsWith(SSH_MACHINE_PREFIX)) return null;
+  const name = machineId.slice(SSH_MACHINE_PREFIX.length);
+  const remote = (await readSshRemotes()).find((candidate) => candidate.name === name);
+  return remote ? tunnelBaseUrl(remote) : null;
+}
+
+async function fetchAgents(baseUrl: string): Promise<RemoteAgentSource["agents"] | null> {
+  try {
+    const controller = new AbortController();
+    const tid = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    // The tunnel terminates on the remote's loopback, where the daemon runs
+    // token-less; no Authorization needed. Redirects are refused for the same
+    // reason as the HQ fan-out: never chase a hostile 3xx.
+    const res = await fetch(`${baseUrl}/api/agents`, {
+      signal: controller.signal,
+      redirect: "manual",
+    });
+    clearTimeout(tid);
+    if (!res.ok) return null;
+    const parsed = AgentListSchemaZ.safeParse(await res.json());
+    return parsed.success ? parsed.data.agents : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Probe every configured SSH remote with a recorded tunnel port and return the
+ * reachable ones as agent sources. Remotes whose tunnel is down (fetch fails)
+ * are silently skipped — `remote ssh launch` re-records the port next time.
+ */
+export async function listSshAgentSources(): Promise<RemoteAgentSource[]> {
+  const remotes = (await readSshRemotes()).filter((remote) => tunnelPort(remote) !== null);
+  const probes = remotes.map(async (remote): Promise<RemoteAgentSource | null> => {
+    const agents = await fetchAgents(tunnelBaseUrl(remote)!);
+    if (!agents) return null;
+    return { machineId: sshMachineId(remote.name), machineName: remote.name, agents };
+  });
+  return (await Promise.all(probes)).filter((source): source is RemoteAgentSource => !!source);
+}

--- a/packages/daemon/src/lib/agent-remotes.ts
+++ b/packages/daemon/src/lib/agent-remotes.ts
@@ -60,13 +60,26 @@ async function fetchAgents(baseUrl: string): Promise<RemoteAgentSource["agents"]
  * Probe every configured SSH remote with a recorded tunnel port and return the
  * reachable ones as agent sources. Remotes whose tunnel is down (fetch fails)
  * are silently skipped — `remote ssh launch` re-records the port next time.
+ *
+ * Multiple store entries can point at the same tunnel port (e.g. a stale
+ * remote plus a re-added one); probing both would duplicate every agent, so
+ * entries are deduped by resolved URL, keeping the most recently launched.
  */
 export async function listSshAgentSources(): Promise<RemoteAgentSource[]> {
-  const remotes = (await readSshRemotes()).filter((remote) => tunnelPort(remote) !== null);
-  const probes = remotes.map(async (remote): Promise<RemoteAgentSource | null> => {
-    const agents = await fetchAgents(tunnelBaseUrl(remote)!);
-    if (!agents) return null;
-    return { machineId: sshMachineId(remote.name), machineName: remote.name, agents };
-  });
+  const byUrl = new Map<string, SshRemote>();
+  for (const remote of await readSshRemotes()) {
+    const url = tunnelBaseUrl(remote);
+    if (!url) continue;
+    const current = byUrl.get(url);
+    const launched = (candidate: SshRemote) => candidate.lastLaunchedAt ?? "";
+    if (!current || launched(remote) > launched(current)) byUrl.set(url, remote);
+  }
+  const probes = [...byUrl.entries()].map(
+    async ([url, remote]): Promise<RemoteAgentSource | null> => {
+      const agents = await fetchAgents(url);
+      if (!agents) return null;
+      return { machineId: sshMachineId(remote.name), machineName: remote.name, agents };
+    },
+  );
   return (await Promise.all(probes)).filter((source): source is RemoteAgentSource => !!source);
 }

--- a/packages/daemon/src/lib/cli-action-bridge.ts
+++ b/packages/daemon/src/lib/cli-action-bridge.ts
@@ -106,8 +106,17 @@ const requireFromHere = createRequire(import.meta.url);
  *  against the live daemon's advertised version on attach. */
 function expectedDaemonVersion(): string {
   try {
-    const pkg = requireFromHere("../../package.json") as { version?: string };
-    return pkg.version ?? "0.0.0";
+    // Survive both dev layout (../../package.json) and the esbuild-bundled
+    // bin/cli.js layout (../package.json).
+    for (const candidate of ["../../package.json", "../package.json"]) {
+      try {
+        const pkg = requireFromHere(candidate) as { version?: string };
+        if (typeof pkg.version === "string") return pkg.version;
+      } catch {
+        // try the next candidate
+      }
+    }
+    return "0.0.0";
   } catch {
     return "0.0.0";
   }

--- a/packages/daemon/src/lib/daemon-embed.ts
+++ b/packages/daemon/src/lib/daemon-embed.ts
@@ -545,11 +545,13 @@ async function startHttpServer({
         })
       : undefined;
 
+  const { hostname: osHostname } = await import("node:os");
   const app = createApp({
     authService,
     authConfig,
     tunnelManager,
     remoteRegistry,
+    hqMachineName: hqConfig?.machine_name ?? osHostname(),
     remoteAccess: {
       bindHostname,
       token: authToken ?? null,

--- a/packages/daemon/src/lib/daemon-embed.ts
+++ b/packages/daemon/src/lib/daemon-embed.ts
@@ -39,6 +39,22 @@ import {
 } from "./canonical-daemon.ts";
 
 const requireFromHere = createRequire(import.meta.url);
+
+// Version lookup must survive both layouts: dev (this file at
+// packages/daemon/src/lib/ -> ../../package.json) and the esbuild-bundled
+// bin/cli.js (../package.json is the repo/package root). Never crash the
+// daemon over a missing version string.
+function resolveOwnVersion(): string {
+  for (const candidate of ["../../package.json", "../package.json"]) {
+    try {
+      const pkg = requireFromHere(candidate) as { version?: string };
+      if (typeof pkg.version === "string") return pkg.version;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return "0.0.0";
+}
 const DEFAULT_HOSTNAME = "127.0.0.1";
 const DEFAULT_GRACEFUL_MS = 2000;
 const MONITOR_INTERVAL_MS = 1000;
@@ -744,11 +760,10 @@ export async function startEmbeddedDaemon(
     localBypassToken,
     silent: opts.silent,
   });
-  const pkg = requireFromHere("../../package.json") as { version?: string };
   writeCanonicalDaemonInfo({
     pid: process.pid,
     port,
-    version: pkg.version ?? "0.0.0",
+    version: resolveOwnVersion(),
     startedAt: new Date().toISOString(),
     bindHostname,
     authToken,

--- a/packages/daemon/src/lib/hq/registry.test.ts
+++ b/packages/daemon/src/lib/hq/registry.test.ts
@@ -234,4 +234,28 @@ describe("RemoteRegistry", () => {
       expect(registry.getMachine("unknown")).toBeUndefined();
     });
   });
+
+  describe("maxMachines cap", () => {
+    it("rejects new registrations past the cap but allows re-registration", () => {
+      const capped = new RemoteRegistry({
+        healthInterval: 60_000,
+        maxMachines: 2,
+        isShuttingDown: () => shuttingDown,
+      });
+      try {
+        capped.register({ id: "a", name: "a", url: "https://a.example.com", token: "t" });
+        capped.register({ id: "b", name: "b", url: "https://b.example.com", token: "t" });
+        expect(() =>
+          capped.register({ id: "c", name: "c", url: "https://c.example.com", token: "t" }),
+        ).toThrow(/full/);
+        // existing machine re-registers (heartbeat) even at capacity
+        expect(() =>
+          capped.register({ id: "a", name: "a", url: "https://a.example.com", token: "t2" }),
+        ).not.toThrow();
+        expect(capped.getMachines().length).toBe(2);
+      } finally {
+        capped.destroy();
+      }
+    });
+  });
 });

--- a/packages/daemon/src/lib/hq/registry.ts
+++ b/packages/daemon/src/lib/hq/registry.ts
@@ -35,6 +35,9 @@ export class RemoteRegistry {
     // If same ID already registered, update it (heartbeat / re-registration)
     const existing = this.machines.get(remote.id);
     if (existing) {
+      // Drop the stale name→machine index entry on rename so machinesByName
+      // doesn't grow unbounded under repeated same-id renames.
+      if (existing.name !== remote.name) this.machinesByName.delete(existing.name);
       existing.name = remote.name;
       existing.url = remote.url;
       existing.token = remote.token;

--- a/packages/daemon/src/lib/hq/registry.ts
+++ b/packages/daemon/src/lib/hq/registry.ts
@@ -11,15 +11,20 @@ export class RemoteRegistry {
   private healthCheckTimer: ReturnType<typeof setInterval> | null = null;
   private readonly healthInterval: number;
   private readonly healthTimeout: number;
+  private readonly maxMachines: number;
   private isShuttingDown: () => boolean;
 
   constructor(opts?: {
     healthInterval?: number;
     healthTimeout?: number;
+    maxMachines?: number;
     isShuttingDown?: () => boolean;
   }) {
     this.healthInterval = opts?.healthInterval ?? 15_000;
     this.healthTimeout = opts?.healthTimeout ?? 5_000;
+    // Bound registry size — each entry also drives a periodic health-check
+    // fetch, so unbounded registration would be a resource amplifier.
+    this.maxMachines = opts?.maxMachines ?? 256;
     this.isShuttingDown = opts?.isShuttingDown ?? (() => false);
     this.startHealthChecker();
   }
@@ -42,6 +47,12 @@ export class RemoteRegistry {
     // Block duplicate names (different ID)
     if (this.machinesByName.has(remote.name)) {
       throw new Error(`Machine with name '${remote.name}' is already registered`);
+    }
+
+    // Reject new registrations past the cap (existing machines re-register via
+    // the early-return above, so liveness isn't affected).
+    if (this.machines.size >= this.maxMachines) {
+      throw new Error(`HQ registry full (${this.maxMachines} machines)`);
     }
 
     const now = new Date();

--- a/packages/daemon/src/lib/tmux-exec.ts
+++ b/packages/daemon/src/lib/tmux-exec.ts
@@ -1,0 +1,41 @@
+// Shared synchronous tmux invocation primitive with an injectable executor for
+// tests. Used by both widgets/lib/pane-comms (single-session queries) and
+// lib/agent-discovery (all-session scan). The async/spawn-based helpers live
+// elsewhere; this is the lightweight execFileSync path the TUI/discovery use.
+import { execFileSync } from "node:child_process";
+
+export type TmuxExecutor = (cmd: string, args: string[], options?: object) => string;
+
+let _executor: TmuxExecutor = (cmd, args, options) =>
+  execFileSync(cmd, args, { encoding: "utf-8", ...options }).toString();
+
+/** Swap the tmux executor (tests). Returns a restore function. */
+export function _setExecutor(fn: TmuxExecutor): () => void {
+  const prev = _executor;
+  _executor = fn;
+  return () => {
+    _executor = prev;
+  };
+}
+
+/**
+ * Low-level: invoke tmux with explicit child_process options (e.g. custom
+ * stdio/encoding) and no error handling. Callers own the try/catch. Goes
+ * through the same injectable executor so tests can intercept it.
+ */
+export function runTmux(args: string[], options?: object): string {
+  return _executor("tmux", args, options);
+}
+
+/** Run a tmux command, returning trimmed stdout. Returns "" when no server. */
+export function tmux(...args: string[]): string {
+  try {
+    return _executor("tmux", args, { stdio: ["pipe", "pipe", "pipe"] }).trim();
+  } catch (error) {
+    const stderr = (error as { stderr?: Buffer | string })?.stderr?.toString() ?? "";
+    if (stderr.includes("no server running") || stderr.includes("can't find session")) {
+      return "";
+    }
+    throw error;
+  }
+}

--- a/packages/daemon/src/remote.test.ts
+++ b/packages/daemon/src/remote.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "bun:test";
 import { HQConfigSchema, RegistrationPayloadSchema } from "./lib/hq/types.ts";
+import {
+  buildRemoteServeScript,
+  buildSshForwardArgs,
+  parseSshConfigHosts,
+  shellQuote,
+  validateSshAlias,
+} from "./ssh-remote.ts";
 
 describe("remote CLI contracts", () => {
   describe("HQConfigSchema", () => {
@@ -110,6 +117,56 @@ describe("remote CLI contracts", () => {
         rows: [{ panes: [{ title: "Shell" }] }],
       });
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("SSH remotes", () => {
+    it("parses concrete SSH config hosts and skips wildcard entries", () => {
+      expect(
+        parseSshConfigHosts(`
+          Host atlas-evg atlas-linux-box
+            User evg
+
+          Host *
+            ServerAliveInterval 15
+
+          Host !blocked *.example.com
+            User ignored
+        `),
+      ).toEqual(["atlas-evg", "atlas-linux-box"]);
+    });
+
+    it("rejects SSH aliases with shell metacharacters", () => {
+      expect(() => validateSshAlias("atlas-evg")).not.toThrow();
+      expect(() => validateSshAlias("atlas-evg;touch /tmp/pwned")).toThrow();
+      expect(() => validateSshAlias("-oProxyCommand=evil")).toThrow();
+    });
+
+    it("quotes remote paths before passing them to the remote shell", () => {
+      expect(shellQuote("/home/evg/project atlas")).toBe("'/home/evg/project atlas'");
+      expect(shellQuote("/home/evg/it's-here")).toBe("'/home/evg/it'\\''s-here'");
+    });
+
+    it("builds a remote serve script that binds only through localhost tunnel inputs", () => {
+      const script = buildRemoteServeScript("/home/evg/project atlas", 6060);
+      expect(script).toContain("cd '/home/evg/project atlas'");
+      expect(script).toContain("tmux-ide __remote-serve --port 6060");
+      expect(script).not.toContain("0.0.0.0");
+    });
+
+    it("builds SSH forwarding args without invoking a local shell", () => {
+      expect(
+        buildSshForwardArgs({ host: "atlas-evg", localPort: 49152, remotePort: 6060 }),
+      ).toEqual([
+        "-N",
+        "-L",
+        "127.0.0.1:49152:127.0.0.1:6060",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-o",
+        "ServerAliveInterval=15",
+        "atlas-evg",
+      ]);
     });
   });
 });

--- a/packages/daemon/src/remote.test.ts
+++ b/packages/daemon/src/remote.test.ts
@@ -124,8 +124,8 @@ describe("remote CLI contracts", () => {
     it("parses concrete SSH config hosts and skips wildcard entries", () => {
       expect(
         parseSshConfigHosts(`
-          Host atlas-evg atlas-linux-box
-            User evg
+          Host devbox-remote devbox-linux
+            User dev
 
           Host *
             ServerAliveInterval 15
@@ -133,30 +133,30 @@ describe("remote CLI contracts", () => {
           Host !blocked *.example.com
             User ignored
         `),
-      ).toEqual(["atlas-evg", "atlas-linux-box"]);
+      ).toEqual(["devbox-remote", "devbox-linux"]);
     });
 
     it("rejects SSH aliases with shell metacharacters", () => {
-      expect(() => validateSshAlias("atlas-evg")).not.toThrow();
-      expect(() => validateSshAlias("atlas-evg;touch /tmp/pwned")).toThrow();
+      expect(() => validateSshAlias("devbox-remote")).not.toThrow();
+      expect(() => validateSshAlias("devbox-remote;touch /tmp/pwned")).toThrow();
       expect(() => validateSshAlias("-oProxyCommand=evil")).toThrow();
     });
 
     it("quotes remote paths before passing them to the remote shell", () => {
-      expect(shellQuote("/home/evg/project atlas")).toBe("'/home/evg/project atlas'");
-      expect(shellQuote("/home/evg/it's-here")).toBe("'/home/evg/it'\\''s-here'");
+      expect(shellQuote("/home/dev/project alpha")).toBe("'/home/dev/project alpha'");
+      expect(shellQuote("/home/dev/it's-here")).toBe("'/home/dev/it'\\''s-here'");
     });
 
     it("builds a remote serve script that binds only through localhost tunnel inputs", () => {
-      const script = buildRemoteServeScript("/home/evg/project atlas", 6060);
-      expect(script).toContain("cd '/home/evg/project atlas'");
+      const script = buildRemoteServeScript("/home/dev/project alpha", 6060);
+      expect(script).toContain("cd '/home/dev/project alpha'");
       expect(script).toContain("tmux-ide __remote-serve --port 6060");
       expect(script).not.toContain("0.0.0.0");
     });
 
     it("builds SSH forwarding args without invoking a local shell", () => {
       expect(
-        buildSshForwardArgs({ host: "atlas-evg", localPort: 49152, remotePort: 6060 }),
+        buildSshForwardArgs({ host: "devbox-remote", localPort: 49152, remotePort: 6060 }),
       ).toEqual([
         "-N",
         "-L",
@@ -171,7 +171,7 @@ describe("remote CLI contracts", () => {
         "ControlMaster=no",
         "-o",
         "ControlPath=none",
-        "atlas-evg",
+        "devbox-remote",
       ]);
     });
   });

--- a/packages/daemon/src/remote.test.ts
+++ b/packages/daemon/src/remote.test.ts
@@ -165,6 +165,12 @@ describe("remote CLI contracts", () => {
         "ExitOnForwardFailure=yes",
         "-o",
         "ServerAliveInterval=15",
+        // Dedicated connection: mux hand-off would drop the forward when the
+        // -N client exits (ControlMaster + SSM setups).
+        "-o",
+        "ControlMaster=no",
+        "-o",
+        "ControlPath=none",
         "atlas-evg",
       ]);
     });

--- a/packages/daemon/src/remote.test.ts
+++ b/packages/daemon/src/remote.test.ts
@@ -133,7 +133,7 @@ describe("remote CLI contracts", () => {
           Host !blocked *.example.com
             User ignored
         `),
-      ).toEqual(["devbox-remote", "devbox-linux"]);
+      ).toEqual(["devbox-linux", "devbox-remote"]);
     });
 
     it("rejects SSH aliases with shell metacharacters", () => {

--- a/packages/daemon/src/remote.ts
+++ b/packages/daemon/src/remote.ts
@@ -31,6 +31,12 @@ export async function remoteCommand(
   const { json, sub } = opts;
 
   switch (sub) {
+    case "ssh": {
+      const { sshRemoteCommand } = await import("./ssh-remote.ts");
+      await sshRemoteCommand({ ...opts, args: opts.args ?? [] });
+      break;
+    }
+
     case "register": {
       const hqConfig = await loadHQConfig(dir);
       if (!hqConfig || hqConfig.role !== "remote") {
@@ -141,7 +147,7 @@ export async function remoteCommand(
 
     default:
       throw new IdeError(
-        `Unknown remote subcommand: ${sub ?? "(none)"}\nUsage: tmux-ide remote register|machines|status`,
+        `Unknown remote subcommand: ${sub ?? "(none)"}\nUsage: tmux-ide remote register|machines|status|ssh`,
         { code: "USAGE" },
       );
   }

--- a/packages/daemon/src/ssh-remote.ts
+++ b/packages/daemon/src/ssh-remote.ts
@@ -18,6 +18,11 @@ export interface SshRemote {
   localPort?: number;
   remotePort?: number;
   addedAt: string;
+  // Where the most recent `launch` tunnel landed locally. The daemon uses this
+  // to fold tunneled remotes into the central agents view and to proxy control
+  // traffic through the tunnel.
+  lastLocalPort?: number;
+  lastLaunchedAt?: string;
 }
 
 interface SshRemoteStore {
@@ -37,8 +42,13 @@ interface SshTunnel {
   stop(): void;
 }
 
-function remotesFilePath(): string {
+export function remotesFilePath(): string {
   return process.env.TMUX_IDE_SSH_REMOTES_FILE ?? join(homedir(), ".tmux-ide", "ssh-remotes.json");
+}
+
+/** Read the configured SSH remotes (validated; empty on missing/corrupt file). */
+export async function readSshRemotes(): Promise<SshRemote[]> {
+  return (await readStore()).remotes;
 }
 
 function sshConfigPath(): string {
@@ -82,6 +92,9 @@ function isSshRemote(value: unknown): value is SshRemote {
   if (typeof remote.addedAt !== "string") return false;
   if (remote.localPort !== undefined && !isValidPort(remote.localPort)) return false;
   if (remote.remotePort !== undefined && !isValidPort(remote.remotePort)) return false;
+  if (remote.lastLocalPort !== undefined && !isValidPort(remote.lastLocalPort)) return false;
+  if (remote.lastLaunchedAt !== undefined && typeof remote.lastLaunchedAt !== "string")
+    return false;
   return true;
 }
 
@@ -398,6 +411,15 @@ async function launchRemote(opts: SshRemoteOptions): Promise<void> {
   } catch (err) {
     tunnel.stop();
     throw err;
+  }
+  // Record where the tunnel landed so the local daemon can aggregate this
+  // remote's agents and proxy control traffic through the tunnel.
+  const store = await readStore();
+  const stored = store.remotes.find((candidate) => candidate.name === remote.name);
+  if (stored) {
+    stored.lastLocalPort = localPort;
+    stored.lastLaunchedAt = new Date().toISOString();
+    await writeStore(store);
   }
   if (opts.json) {
     console.log(

--- a/packages/daemon/src/ssh-remote.ts
+++ b/packages/daemon/src/ssh-remote.ts
@@ -1,0 +1,501 @@
+import { spawn, execFile } from "node:child_process";
+import { mkdir, readFile, writeFile, chmod } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { createServer } from "node:net";
+import { IdeError } from "./lib/errors.ts";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_REMOTE_PORT = 6060;
+const DEFAULT_LOCAL_HOST = "127.0.0.1";
+
+export interface SshRemote {
+  name: string;
+  host: string;
+  path: string;
+  localPort?: number;
+  remotePort?: number;
+  addedAt: string;
+}
+
+interface SshRemoteStore {
+  version: 1;
+  remotes: SshRemote[];
+}
+
+interface SshRemoteOptions {
+  json?: boolean;
+  sub?: string;
+  args?: string[];
+  values?: Record<string, string | boolean | undefined>;
+}
+
+interface SshTunnel {
+  pid: number;
+  stop(): void;
+}
+
+function remotesFilePath(): string {
+  return process.env.TMUX_IDE_SSH_REMOTES_FILE ?? join(homedir(), ".tmux-ide", "ssh-remotes.json");
+}
+
+function sshConfigPath(): string {
+  return process.env.TMUX_IDE_SSH_CONFIG ?? join(homedir(), ".ssh", "config");
+}
+
+function emptyStore(): SshRemoteStore {
+  return { version: 1, remotes: [] };
+}
+
+async function readStore(): Promise<SshRemoteStore> {
+  const file = remotesFilePath();
+  if (!existsSync(file)) return emptyStore();
+  try {
+    const parsed = JSON.parse(await readFile(file, "utf-8")) as Partial<SshRemoteStore>;
+    if (parsed.version !== 1 || !Array.isArray(parsed.remotes)) return emptyStore();
+    return {
+      version: 1,
+      remotes: parsed.remotes.filter(isSshRemote),
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+
+async function writeStore(store: SshRemoteStore): Promise<void> {
+  const file = remotesFilePath();
+  await mkdir(dirname(file), { recursive: true, mode: 0o700 });
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmp, JSON.stringify(store, null, 2) + "\n", { encoding: "utf-8", mode: 0o600 });
+  await chmod(tmp, 0o600);
+  await import("node:fs/promises").then(({ rename }) => rename(tmp, file));
+}
+
+function isSshRemote(value: unknown): value is SshRemote {
+  if (!value || typeof value !== "object") return false;
+  const remote = value as Partial<SshRemote>;
+  if (typeof remote.name !== "string") return false;
+  if (typeof remote.host !== "string") return false;
+  if (typeof remote.path !== "string") return false;
+  if (typeof remote.addedAt !== "string") return false;
+  if (remote.localPort !== undefined && !isValidPort(remote.localPort)) return false;
+  if (remote.remotePort !== undefined && !isValidPort(remote.remotePort)) return false;
+  return true;
+}
+
+function isValidPort(port: number): boolean {
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
+}
+
+function parsePort(value: string | boolean | undefined, label: string): number | undefined {
+  if (value === undefined || value === false) return undefined;
+  if (value === true || value.trim() === "") {
+    throw new IdeError(`${label} requires a numeric value`, { code: "USAGE" });
+  }
+  const port = Number(value);
+  if (!isValidPort(port)) {
+    throw new IdeError(`${label} must be an integer from 1 to 65535`, { code: "USAGE" });
+  }
+  return port;
+}
+
+export function parseSshConfigHosts(contents: string): string[] {
+  const hosts = new Set<string>();
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const match = line.match(/^Host\s+(.+)$/i);
+    if (!match) continue;
+    for (const host of match[1]!.split(/\s+/)) {
+      if (!host || host.includes("*") || host.includes("?") || host.startsWith("!")) continue;
+      hosts.add(host);
+    }
+  }
+  return [...hosts].sort((a, b) => a.localeCompare(b));
+}
+
+export function validateRemoteName(name: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(name)) {
+    throw new IdeError(
+      "Remote name must start with a letter or number and contain only letters, numbers, dot, underscore, or dash.",
+      { code: "USAGE" },
+    );
+  }
+}
+
+export function validateSshAlias(host: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}$/.test(host)) {
+    throw new IdeError(
+      "SSH host must be a config alias or host string without whitespace or shell metacharacters.",
+      { code: "USAGE" },
+    );
+  }
+  if (host.startsWith("-")) {
+    throw new IdeError("SSH host cannot start with '-'", { code: "USAGE" });
+  }
+}
+
+export function validateRemotePath(path: string): void {
+  if (!path || /[\0\r\n]/.test(path)) {
+    throw new IdeError("Remote path must be a single non-empty path.", { code: "USAGE" });
+  }
+}
+
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function buildRemoteServeScript(remotePath: string, remotePort: number): string {
+  validateRemotePath(remotePath);
+  if (!isValidPort(remotePort)) {
+    throw new IdeError("Remote port must be an integer from 1 to 65535", { code: "USAGE" });
+  }
+  const quotedPath = shellQuote(remotePath);
+  return [
+    `cd ${quotedPath}`,
+    "mkdir -p .tmux-ide",
+    'if ! command -v tmux-ide >/dev/null 2>&1; then echo "tmux-ide not found on remote PATH" >&2; exit 127; fi',
+    `nohup tmux-ide __remote-serve --port ${remotePort} > .tmux-ide/remote-daemon.log 2>&1 < /dev/null &`,
+  ].join(" && ");
+}
+
+export function buildSshForwardArgs(opts: {
+  host: string;
+  localPort: number;
+  remotePort: number;
+}): string[] {
+  validateSshAlias(opts.host);
+  if (!isValidPort(opts.localPort) || !isValidPort(opts.remotePort)) {
+    throw new IdeError("SSH tunnel ports must be integers from 1 to 65535", { code: "USAGE" });
+  }
+  return [
+    "-N",
+    "-L",
+    `${DEFAULT_LOCAL_HOST}:${opts.localPort}:127.0.0.1:${opts.remotePort}`,
+    "-o",
+    "ExitOnForwardFailure=yes",
+    "-o",
+    "ServerAliveInterval=15",
+    opts.host,
+  ];
+}
+
+async function pickFreeLocalPort(): Promise<number> {
+  const server = createServer();
+  return await new Promise<number>((resolvePort, reject) => {
+    server.once("error", reject);
+    server.listen(0, DEFAULT_LOCAL_HOST, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : null;
+      server.close(() => {
+        if (port) resolvePort(port);
+        else reject(new IdeError("Could not allocate a local tunnel port", { code: "PORT_ERROR" }));
+      });
+    });
+  });
+}
+
+async function assertLocalPortFree(port: number): Promise<void> {
+  const server = createServer();
+  await new Promise<void>((resolvePort, reject) => {
+    server.once("error", () =>
+      reject(new IdeError(`Local port ${port} is already in use`, { code: "PORT_IN_USE" })),
+    );
+    server.listen(port, DEFAULT_LOCAL_HOST, () => {
+      server.close(() => resolvePort());
+    });
+  });
+}
+
+function openInBrowser(url: string): void {
+  const cmd =
+    process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+  try {
+    const child = spawn(cmd, [url], { detached: true, stdio: "ignore" });
+    child.unref();
+  } catch {
+    // The printed URL is still useful.
+  }
+}
+
+async function waitForHealth(url: string, timeoutMs = 15_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+  while (Date.now() < deadline) {
+    try {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 750).unref?.();
+      const res = await fetch(`${url}healthz`, { signal: controller.signal });
+      if (res.ok) return;
+      lastError = `HTTP ${res.status}`;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    await new Promise((resolveTimer) => setTimeout(resolveTimer, 250));
+  }
+  throw new IdeError(
+    `Remote dashboard did not become healthy through the SSH tunnel: ${lastError}`,
+    {
+      code: "REMOTE_UNHEALTHY",
+    },
+  );
+}
+
+async function runRemoteServe(remote: SshRemote, remotePort: number): Promise<void> {
+  const script = buildRemoteServeScript(remote.path, remotePort);
+  try {
+    await execFileAsync("ssh", [remote.host, script], { timeout: 10_000 });
+  } catch (err) {
+    const stderr =
+      err instanceof Error && "stderr" in err && typeof err.stderr === "string"
+        ? err.stderr.trim()
+        : "";
+    throw new IdeError(`Failed to start tmux-ide on ${remote.host}${stderr ? `: ${stderr}` : ""}`, {
+      code: "SSH_REMOTE_START_FAILED",
+    });
+  }
+}
+
+async function startTunnel(
+  remote: SshRemote,
+  localPort: number,
+  remotePort: number,
+): Promise<SshTunnel> {
+  const args = buildSshForwardArgs({ host: remote.host, localPort, remotePort });
+  const child = spawn("ssh", args, { detached: true, stdio: "ignore" });
+  child.unref();
+  await new Promise<void>((resolveStart, reject) => {
+    const timer = setTimeout(resolveStart, 500);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      reject(
+        new IdeError(
+          `SSH tunnel exited before it was ready (${signal ?? `code ${code ?? "unknown"}`})`,
+          { code: "SSH_TUNNEL_FAILED" },
+        ),
+      );
+    });
+    child.once("error", (err) => {
+      clearTimeout(timer);
+      reject(
+        new IdeError(`Failed to start ssh tunnel: ${err.message}`, { code: "SSH_TUNNEL_FAILED" }),
+      );
+    });
+  });
+  return {
+    pid: child.pid ?? 0,
+    stop: () => {
+      if (!child.pid) return;
+      try {
+        process.kill(-child.pid, "SIGTERM");
+      } catch {
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          // Already gone.
+        }
+      }
+    },
+  };
+}
+
+function printRemotes(remotes: SshRemote[]): void {
+  if (remotes.length === 0) {
+    console.log("No SSH remotes configured");
+    return;
+  }
+  for (const remote of remotes) {
+    const local = remote.localPort ? ` local:${remote.localPort}` : "";
+    const remotePort = remote.remotePort ? ` remote:${remote.remotePort}` : "";
+    console.log(`  ${remote.name} — ${remote.host}:${remote.path}${local}${remotePort}`);
+  }
+}
+
+async function listHosts(json: boolean | undefined): Promise<void> {
+  const file = sshConfigPath();
+  const hosts = existsSync(file) ? parseSshConfigHosts(await readFile(file, "utf-8")) : [];
+  if (json) {
+    console.log(JSON.stringify({ hosts }));
+  } else if (hosts.length === 0) {
+    console.log("No concrete SSH hosts found");
+  } else {
+    for (const host of hosts) console.log(host);
+  }
+}
+
+async function addRemote(opts: SshRemoteOptions): Promise<void> {
+  const name = opts.args?.[0];
+  const host = opts.values?.host;
+  const path = opts.values?.path;
+  if (!name || typeof host !== "string" || typeof path !== "string") {
+    throw new IdeError(
+      "Usage: tmux-ide remote ssh add <name> --host <ssh-host> --path <remote-project-dir> [--local-port N] [--remote-port N]",
+      { code: "USAGE" },
+    );
+  }
+  validateRemoteName(name);
+  validateSshAlias(host);
+  validateRemotePath(path);
+  const localPort = parsePort(opts.values?.["local-port"], "--local-port");
+  const remotePort = parsePort(opts.values?.["remote-port"], "--remote-port");
+  const store = await readStore();
+  const next: SshRemote = {
+    name,
+    host,
+    path,
+    localPort,
+    remotePort,
+    addedAt: new Date().toISOString(),
+  };
+  const index = store.remotes.findIndex((remote) => remote.name === name);
+  if (index >= 0) store.remotes[index] = next;
+  else store.remotes.push(next);
+  await writeStore(store);
+  if (opts.json) console.log(JSON.stringify({ ok: true, remote: next }));
+  else console.log(`Saved SSH remote ${name} (${host}:${path})`);
+}
+
+async function removeRemote(opts: SshRemoteOptions): Promise<void> {
+  const name = opts.args?.[0];
+  if (!name) {
+    throw new IdeError("Usage: tmux-ide remote ssh remove <name>", { code: "USAGE" });
+  }
+  const store = await readStore();
+  const before = store.remotes.length;
+  store.remotes = store.remotes.filter((remote) => remote.name !== name);
+  await writeStore(store);
+  const removed = store.remotes.length !== before;
+  if (opts.json) console.log(JSON.stringify({ ok: true, removed }));
+  else
+    console.log(removed ? `Removed SSH remote ${name}` : `SSH remote ${name} was not configured`);
+}
+
+async function getConfiguredRemote(name: string | undefined): Promise<SshRemote> {
+  if (!name) {
+    throw new IdeError("Usage: tmux-ide remote ssh launch <name>", { code: "USAGE" });
+  }
+  validateRemoteName(name);
+  const store = await readStore();
+  const remote = store.remotes.find((candidate) => candidate.name === name);
+  if (!remote) {
+    throw new IdeError(`SSH remote ${name} is not configured`, { code: "REMOTE_NOT_FOUND" });
+  }
+  return remote;
+}
+
+async function launchRemote(opts: SshRemoteOptions): Promise<void> {
+  const remote = await getConfiguredRemote(opts.args?.[0]);
+  const remotePort = remote.remotePort ?? DEFAULT_REMOTE_PORT;
+  const localPort = remote.localPort ?? (await pickFreeLocalPort());
+  if (remote.localPort) await assertLocalPortFree(localPort);
+  await runRemoteServe(remote, remotePort);
+  const tunnel = await startTunnel(remote, localPort, remotePort);
+  const url = `http://${DEFAULT_LOCAL_HOST}:${localPort}/`;
+  try {
+    await waitForHealth(url);
+  } catch (err) {
+    tunnel.stop();
+    throw err;
+  }
+  if (opts.json) {
+    console.log(
+      JSON.stringify({ ok: true, url, localPort, remotePort, tunnelPid: tunnel.pid, remote }),
+    );
+  } else {
+    console.log(`Dashboard: ${url}`);
+    console.log(`Tunnel: ${remote.host} 127.0.0.1:${localPort} -> 127.0.0.1:${remotePort}`);
+  }
+  if (opts.values?.["no-open"] !== true) openInBrowser(url);
+}
+
+async function statusRemote(opts: SshRemoteOptions): Promise<void> {
+  const remote = await getConfiguredRemote(opts.args?.[0]);
+  const localPort = remote.localPort;
+  const url = localPort ? `http://${DEFAULT_LOCAL_HOST}:${localPort}/` : null;
+  let healthy = false;
+  if (url) {
+    try {
+      const res = await fetch(`${url}healthz`);
+      healthy = res.ok;
+    } catch {
+      healthy = false;
+    }
+  }
+  if (opts.json) {
+    console.log(JSON.stringify({ remote, url, healthy }));
+  } else {
+    console.log(`Remote: ${remote.name}`);
+    console.log(`SSH host: ${remote.host}`);
+    console.log(`Path: ${remote.path}`);
+    console.log(`Remote daemon bind: 127.0.0.1:${remote.remotePort ?? DEFAULT_REMOTE_PORT}`);
+    if (url) console.log(`Local URL: ${url} (${healthy ? "healthy" : "not reachable"})`);
+    else console.log("Local URL: dynamic; run launch to allocate a tunnel port");
+  }
+}
+
+export async function sshRemoteCommand(opts: SshRemoteOptions): Promise<void> {
+  const sub = opts.args?.[0];
+  const args = opts.args?.slice(1) ?? [];
+  switch (sub) {
+    case "hosts":
+      await listHosts(opts.json);
+      break;
+    case "list": {
+      const store = await readStore();
+      if (opts.json) console.log(JSON.stringify({ remotes: store.remotes }));
+      else printRemotes(store.remotes);
+      break;
+    }
+    case "add":
+      await addRemote({ ...opts, args });
+      break;
+    case "remove":
+      await removeRemote({ ...opts, args });
+      break;
+    case "launch":
+    case "dashboard":
+      await launchRemote({ ...opts, args });
+      break;
+    case "status":
+      await statusRemote({ ...opts, args });
+      break;
+    default:
+      throw new IdeError(
+        "Usage: tmux-ide remote ssh hosts|list|add|remove|launch|dashboard|status",
+        { code: "USAGE" },
+      );
+  }
+}
+
+export async function remoteServeCommand(opts: { port?: string | boolean }): Promise<void> {
+  const port = parsePort(opts.port, "--port") ?? DEFAULT_REMOTE_PORT;
+  const dir = resolve(".");
+  const { readConfig, getSessionName } = await import("./lib/yaml-io.ts");
+  const { launch } = await import("./launch.ts");
+  const { startEmbeddedDaemon } = await import("./lib/daemon-embed.ts");
+  const { readCanonicalDaemonInfo, isCanonicalDaemonAlive } =
+    await import("./lib/canonical-daemon.ts");
+
+  const existing = readCanonicalDaemonInfo();
+  if (existing && existing.port === port && existing.bindHostname === "127.0.0.1") {
+    if (await isCanonicalDaemonAlive(existing)) return;
+  }
+
+  const { config } = readConfig(dir);
+  const { name: fallbackName } = getSessionName(dir);
+  const sessionName = config.name ?? fallbackName;
+  await launch(dir, { attach: false });
+  const handle = await startEmbeddedDaemon({
+    sessionName,
+    port,
+    bindHostname: "127.0.0.1",
+  });
+  const stop = async () => {
+    await handle.stop({ gracefulMs: 500 });
+  };
+  process.once("SIGINT", () => void stop().finally(() => process.exit(0)));
+  process.once("SIGTERM", () => void stop().finally(() => process.exit(0)));
+  await new Promise<void>(() => undefined);
+}

--- a/packages/daemon/src/ssh-remote.ts
+++ b/packages/daemon/src/ssh-remote.ts
@@ -191,6 +191,14 @@ export function buildSshForwardArgs(opts: {
     "ExitOnForwardFailure=yes",
     "-o",
     "ServerAliveInterval=15",
+    // The tunnel must be a dedicated connection we own. Under ControlMaster
+    // multiplexing (common with SSM ProxyCommand setups) the `-N` client can
+    // exit immediately after handing off to the persistent master, taking its
+    // forward down with it. Disable mux for this one connection.
+    "-o",
+    "ControlMaster=no",
+    "-o",
+    "ControlPath=none",
     opts.host,
   ];
 }

--- a/packages/daemon/src/widgets/lib/pane-comms.ts
+++ b/packages/daemon/src/widgets/lib/pane-comms.ts
@@ -1,34 +1,9 @@
-import { execFileSync } from "node:child_process";
 import type { PaneInfo } from "@tmux-ide/contracts";
+import { tmux, runTmux, _setExecutor } from "../../lib/tmux-exec.ts";
 
 export type { PaneInfo };
-
-type TmuxExecutor = (cmd: string, args: string[], options?: object) => string;
-
-let _executor: TmuxExecutor = (cmd, args, options) =>
-  execFileSync(cmd, args, { encoding: "utf-8", ...options }).toString();
-
-export function _setExecutor(fn: TmuxExecutor): () => void {
-  const prev = _executor;
-  _executor = fn;
-  return () => {
-    _executor = prev;
-  };
-}
-
-function tmux(...args: string[]): string {
-  try {
-    return _executor("tmux", args, {
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
-  } catch (error) {
-    const stderr = (error as { stderr?: Buffer | string })?.stderr?.toString() ?? "";
-    if (stderr.includes("no server running") || stderr.includes("can't find session")) {
-      return "";
-    }
-    throw error;
-  }
-}
+// Re-exported so existing callers/tests keep importing the executor seam here.
+export { _setExecutor };
 
 export function listSessionPanes(session: string): PaneInfo[] {
   const format = [
@@ -199,7 +174,7 @@ export function resolveTarget(session: string, opts: TargetOptions): string | nu
  */
 export function captureLastLine(paneId: string): string {
   try {
-    return _executor("tmux", ["capture-pane", "-t", paneId, "-p", "-S", "-1"], {
+    return runTmux(["capture-pane", "-t", paneId, "-p", "-S", "-1"], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       "src/git/__tests__/*.test.ts",
       "src/lib/__tests__/*.test.ts",
       "src/lsp/__tests__/*.test.ts",
+      "src/agent-hook.test.ts",
     ],
     coverage: {
       provider: "v8",

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       "src/lib/__tests__/*.test.ts",
       "src/lsp/__tests__/*.test.ts",
       "src/agent-hook.test.ts",
+      "src/agents-cli.test.ts",
     ],
     coverage: {
       provider: "v8",

--- a/packages/tmux-bridge/src/panes.ts
+++ b/packages/tmux-bridge/src/panes.ts
@@ -54,8 +54,10 @@ export function splitPane(
         direction === "vertical" ? "-v" : "-h",
         "-c",
         cwd,
-        "-p",
-        String(percent),
+        // `-l N%` (tmux ≥3.1) — the old `-p N` percentage flag is gone from
+        // some builds (e.g. 3.4 fails with "size missing").
+        "-l",
+        `${percent}%`,
       ],
       { encoding: "utf-8" },
     ) as string

--- a/packages/tmux-bridge/src/runner.test.ts
+++ b/packages/tmux-bridge/src/runner.test.ts
@@ -218,12 +218,13 @@ describe("splitPane", () => {
     expect(!args.includes("-v")).toBeTruthy();
   });
 
-  it("passes percent correctly", () => {
+  it("passes percent as -l N% (portable across tmux >=3.1)", () => {
     mockExec.mockImplementation(() => "%3\n");
     splitPane("%0", "vertical", "/workspace", 42);
     const args = mockExec.mock.calls[0][1];
-    const pIdx = args.indexOf("-p");
-    expect(args[pIdx + 1]).toBe("42");
+    const lIdx = args.indexOf("-l");
+    expect(args[lIdx + 1]).toBe("42%");
+    expect(args.includes("-p")).toBeFalsy();
   });
 
   it("returns trimmed pane ID", () => {


### PR DESCRIPTION
## What this does

Turns tmux-ide into a single pane of glass for **every Claude/codex CLI agent** — sessions tmux-ide spawned, sessions in other tmux windows, plain-terminal sessions, and sessions on **other machines reached over SSH/SSM** — with the ability to send input to any of them from the central dashboard, CLI, or API.

## The pieces (11 commits, in dependency order)

**1. SSH remote control (`tmux-ide remote ssh`)**
Launch and tunnel a remote machine's daemon to local loopback without opening any public port: `remote ssh add/launch/status/remove`, `__remote-serve` on the remote binds 127.0.0.1 only. Input validation on host/path/name, atomic 0600 store writes.

**2. Unified agent model + discovery**
`AgentRecord` (managed / tmux-unmanaged / external) in contracts; the daemon scans **all** tmux sessions (`list-panes -a`, tab-safe parsing), merges hook-registered plain-terminal sessions, and serves `GET /api/agents`.

**3. Self-report hook for plain terminals**
`tmux-ide agent hook install` wires Claude Code lifecycle hooks (SessionStart/UserPromptSubmit/PreToolUse → register-busy, Stop → idle heartbeat, SessionEnd → unregister). Always exits 0; skips inside tmux (already discovered); `TMUX_IDE_AGENT_TOOL=codex` labels codex sessions.

**4. Cross-machine aggregation — `GET /api/hq/agents`**
Fans out to HQ-registered machines **and SSH-tunneled remotes** (outbound-only — works over SSM where the remote can't call back). Remote responses are schema-bounded, control-char-sanitized, id-namespaced (`ssh:<name>:...`), machine-stamped, capped, and fetched with `redirect:"manual"`.

**5. Central control — `POST /api/agents/send`**
Send input to any agent in the unified view: local tmux agents via send-keys, remote agents proxied exactly one hop through the tunnel (forwarded request carries no machineId → no loops). External agents are observe-only (409).

**6. Surfaces**
- Dashboard **Agents view**: fleet grouped machine → session, status/tool/kind badges, inline send composer per controllable row.
- CLI: `tmux-ide agents [list] [--json]` and `tmux-ide agents send <agent-id> <message...>`.

## Verification

- **Live end-to-end**: two real daemons + a real tmux pane simulating the SSH topology — the central daemon aggregated the remote's agent and `POST /api/agents/send` executed a command in the remote pane; 404/400/409 guard paths exercised.
- 65 vitest + 53 bun tests green (new suites gated in CI); `tsc` clean across contracts/daemon/dashboard; eslint 0 errors; prettier clean; docs build passes.
- Two dedicated security review rounds (SSRF/redirect handling, untrusted-remote field sanitization incl. C1 controls, registry caps/LRU, bounded schemas, no token leakage in the hook). Deferred by design (loopback/tunnel trust model): per-id ownership tokens, HQ registration-secret enforcement, CORS hardening — flagged in commit messages.

## Notes for reviewers

- Remote daemons bind 127.0.0.1 only; the only path in is an SSH tunnel, so the trust boundary is SSH access itself.
- `remote ssh launch` now persists `lastLocalPort` in `~/.tmux-ide/ssh-remotes.json` — that's how the local daemon knows where each tunnel lands.
- Docs: `docs/content/docs/commands.mdx` covers `remote ssh`, `agent` (hook), and `agents` (fleet).