### PR TITLE
fix(publish): 351 kB npm package — exclude platform binary + stale dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "scripts",
     "skill",
     "templates",
-    "packages/daemon/dist"
+    "packages/daemon/dist",
+    "!packages/daemon/dist/tui"
   ],
   "scripts": {
     "build": "pnpm build:cli",


### PR DESCRIPTION
Pre-publish audit caught the tarball at 26.7 MB: the darwin-arm64 compiled TUI binary (76 MB, useless cross-platform) and stale pre-trim dist artifacts were shipping. files[] now excludes dist/tui; dist rebuilt clean. Package: 351.5 kB / 275 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)