### PR TITLE
docs: v2.7.0 release page + topical refresh

### DIFF
--- a/docs/content/docs/agent-detection.mdx
+++ b/docs/content/docs/agent-detection.mdx
@@ -99,6 +99,29 @@ applied and which manifest it forced. For authoritative control, prefer the
 [self-report contract](#the-self-report-contract) above: a fresh `@agent_state`
 always wins.
 
+## Per-pane agents in `team --json`
+
+Whatever the detector resolves is exposed programmatically. `tmux-ide team --json`
+carries a per-pane `agents[]` array on each session — one entry per pane that
+classified to a real agent, flat across the session's windows:
+
+| Field         | What it is                                                          |
+| ------------- | ------------------------------------------------------------------- |
+| `paneId`      | tmux pane id, e.g. `%5`                                             |
+| `windowIndex` | the window (tab) the pane lives in                                  |
+| `session`     | owning session name (repeated per entry so a flat list stays keyed) |
+| `kind`        | resolved agent — the manifest id (`claude`, `codex`, …)             |
+| `state`       | final status (`blocked` / `working` / `done` / `idle`)              |
+| `confidence`  | the manifest's evidence confidence                                  |
+| `since`       | authority-state epoch stamp, or `null` for a scraped/tracked pane   |
+| `title`       | `pane_title`                                                        |
+| `command`     | `pane_current_command` — the immediate process (often node/bun/sh)  |
+| `dir`         | `pane_current_path` — the pane's working directory                  |
+
+This is the same data the unified app reads: the sidebar's agents section and the
+Terminal surface's per-pane chips both render from it. See
+[Home, sidebar & panels](/docs/app-surfaces#the-terminal-surface).
+
 ## See also
 
 - [The dock & keys](/docs/the-dock) — where the glyphs and chips appear

--- a/docs/content/docs/app-surfaces.mdx
+++ b/docs/content/docs/app-surfaces.mdx
@@ -93,7 +93,49 @@ any time to see the full sheet, or print it:
 tmux-ide cheatsheet
 ```
 
+## The unified app — `tmux-ide app`
+
+The surfaces above float over your real session. `tmux-ide app` is the other
+shape: a full-screen IDE over the whole fleet, with tabs across the top
+(**F1 Home** · **F2 Terminal** · **F3 Files** · **F4 Diff** · **F5 palette**).
+tmux still owns the PTYs and layout; the app renders them. See
+[What's new in 2.7](/docs/release-2-7-0) for the full tour.
+
+### The Terminal surface
+
+The Terminal tab is a live mirror of your panes, and it's agent-aware:
+
+- **Status chips** — an agent pane wears a chip (`● claude`); a blocked agent
+  turns bold red with its wait time (`● claude · blocked 4m`).
+- **A focus hairline** — the focused pane gets a quiet accent border, so you
+  always know where keystrokes land.
+- **Select & copy in agent panes** — a pane running a full-screen app (Claude
+  Code, vim) captures the mouse. Right-click → **"Select text…"** pauses mouse
+  forwarding so you can drag-select and copy (via SSH-transparent OSC52); the
+  wheel scrolls history while you select.
+- **Size honesty** — when another attached terminal sizes the shared window
+  smaller, the app centers the view and says so; the palette's **"Resize to fit
+  this window"** reclaims the full canvas.
+
+### Home v2
+
+The app's Home tab greets first-run users with a plain-language welcome instead
+of an empty grid. **Open folder…** is a real filesystem picker — choose a
+directory and the app opens it as a terminal workspace, optionally remembering it
+as a project. Recently opened folders are one click away, and the optional
+`app.frontDoor` config flag makes bare `tmux-ide` open the app. See
+[Getting started](/docs/getting-started#start-anywhere-with-the-app).
+
+### Settings without JSON
+
+There's no settings screen and no JSON to hand-edit for the common cases. Press
+**F5** and type "settings" for a palette command per setting — accent color (with
+a live preview), notifications and quiet hours, update cadence, crash restore, a
+keyboard-shortcut viewer, and a guarded reset. Changes persist atomically to
+`~/.tmux-ide/config.json`. See [ide.yml & configuration](/docs/configuration).
+
 ## See also
 
+- [What's new in 2.7](/docs/release-2-7-0) — the unified app in full
 - [The dock & keys](/docs/the-dock) — the triggers that open these surfaces
 - [Theming & config](/docs/theming) — rebind every key

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -116,6 +116,34 @@ theme:
 For the product-wide palette that colors the dock, chips, panels, and widgets,
 use `~/.tmux-ide/config.json` instead — see [Theming & config](/docs/theming).
 
+## The global config & in-app settings
+
+`ide.yml` describes one project's layout. Product-wide behavior lives in
+`~/.tmux-ide/config.json` (override the path with `TMUX_IDE_CONFIG`) — the same
+file that holds the shared theme. Two things worth knowing for 2.7:
+
+- **`app.frontDoor`** flips the default entry point: with `{ "app": { "frontDoor": true } }`,
+  bare `tmux-ide` launches the unified app (`tmux-ide app`) instead of the home
+  cockpit. Default `false`; `ide.yml` auto-launch and `tmux-ide team` are
+  unaffected.
+- **Settings are editable in the app.** Inside `tmux-ide app`, press **F5** and
+  type "settings" for a palette command per setting — no JSON required. Edits
+  write back to `~/.tmux-ide/config.json` atomically:
+
+  | Setting        | Config field                             |
+  | -------------- | ---------------------------------------- |
+  | Accent color   | `theme.accent`                           |
+  | Notifications  | `notifications` (channels & transitions) |
+  | Quiet hours    | `notifications.quietHours`               |
+  | Update cadence | `updater`, `updates`                     |
+  | Crash restore  | `restore`                                |
+
+  Keyboard shortcuts have a read-only viewer, and a guarded "reset to defaults"
+  removes your overrides so the built-in defaults take over.
+
+See [Theming & config](/docs/theming) for the full palette, and
+[What's new in 2.7](/docs/release-2-7-0#settings-without-json).
+
 ## Editing config programmatically
 
 Every field is reachable from the CLI with `--json` output, e.g.:

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -62,6 +62,30 @@ uninstall removes exactly the tmux-ide entries). It takes effect for **new**
 Claude Code sessions. See [Agent detection](/docs/agent-detection) for the two
 detection layers and the self-report contract any agent can use.
 
+## Start anywhere with the app
+
+`tmux-ide app` opens the unified app — a full-screen IDE over your fleet. It works
+from **any folder with no tmux server running**, a genuine cold start:
+
+```bash
+tmux-ide app          # from any directory
+```
+
+A first-run welcome greets you, and **Open folder…** is a real filesystem picker:
+choose a directory and the app opens it as a terminal workspace, optionally
+remembering it as a project. Recently opened folders stay one click away.
+
+If you'd like bare `tmux-ide` to open the app instead of the home cockpit, set
+the optional front-door flag in `~/.tmux-ide/config.json`:
+
+```json
+{ "app": { "frontDoor": true } }
+```
+
+It's opt-in — `ide.yml` auto-launch and `tmux-ide team` are unaffected. See
+[Home, sidebar & panels](/docs/app-surfaces#the-unified-app--tmux-ide-app) and
+[What's new in 2.7](/docs/release-2-7-0).
+
 ## Optional: describe a layout with ide.yml
 
 Adopt works on sessions you launch however you like. If you'd rather have

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -2,6 +2,7 @@
   "title": "Docs",
   "pages": [
     "index",
+    "release-2-7-0",
     "release-2-6-0",
     "getting-started",
     "the-dock",

--- a/docs/content/docs/release-2-7-0.mdx
+++ b/docs/content/docs/release-2-7-0.mdx
@@ -1,0 +1,115 @@
+---
+title: What's New in 2.7
+description: tmux-ide 2.7 — the unified app becomes a real terminal IDE over your fleet
+---
+
+# tmux-ide 2.7
+
+2.7 is the unified-app release. `tmux-ide app` was a proven spike in 2.6; now
+it's a real terminal IDE over your fleet — panes that feel native, agents you can
+see at a glance, and a front door you can open from anywhere. tmux still owns the
+PTYs, the layout, and persistence; the app just renders them. If it dies, your
+sessions are ordinary tmux, exactly as before.
+
+```bash
+tmux-ide app          # from any folder — no tmux server required
+```
+
+Tabs across the top: **F1 Home** · **F2 Terminal** · **F3 Files** · **F4 Diff** ·
+**F5 palette**. It's mouse-native throughout, and `^q` detaches clean.
+
+## Panes that feel native
+
+The Terminal surface renders a live mirror of your real panes, and in 2.7 that
+mirror stopped feeling like a mirror:
+
+- **Much faster pane rendering** — pane content blits straight into the
+  framebuffer and repaints only the rows that actually changed, so a busy log
+  scrolls smoothly and a quiet pane costs nothing.
+- **A crisp input fast path** — keystrokes are fire-and-forget and coalesced
+  instead of waiting for a round-trip per key, so typing into a pane feels local
+  even over the control-mode hop. Large pastes land byte-perfect and fast.
+- **A hardware cursor** — the focused pane drives the terminal's real cursor:
+  shape, blink, and hide/show follow the application, so vim and Claude Code
+  behave exactly as they do outside the app. Unfocused panes show a quiet marker.
+
+You don't configure any of this — it's just how the Terminal surface behaves now.
+
+## Agents at a glance
+
+The fleet's agent state is now visible without opening anything:
+
+- **A sidebar agents section** lists every agent across every session, blocked
+  ones first. Click one and the app jumps straight to its pane.
+- **Per-pane status chips** — an agent pane wears a small chip (`● claude`); a
+  blocked agent turns bold red and shows how long it's been waiting
+  (`● claude · blocked 4m`).
+- **A focus hairline** — the focused pane gets a quiet accent border so you
+  always know where your keystrokes are going.
+
+Under the hood, `tmux-ide team --json` now carries a per-pane `agents[]` array,
+the same data the sidebar and chips read. → [Agent detection](/docs/agent-detection)
+
+## Start it anywhere
+
+The app no longer assumes you already have a session running. `tmux-ide app`
+works from any folder with **no tmux server at all** — a genuine cold start.
+
+- **A first-run welcome** greets new users in plain language instead of an empty
+  grid.
+- **Open folder…** is a real filesystem picker: choose a directory and the app
+  opens it as a terminal workspace, with the option to remember it as a project
+  and set up a layout. Recently opened folders are one click away.
+- **The front door, optionally.** Set `app.frontDoor: true` in
+  `~/.tmux-ide/config.json` and bare `tmux-ide` launches the unified app instead
+  of the classic home cockpit. It's opt-in; `ide.yml` auto-launch and
+  `tmux-ide team` are unaffected. → [Getting started](/docs/getting-started)
+
+## Settings without JSON
+
+There's no settings screen and no JSON to hand-edit for the common cases. Every
+setting is a palette command — press **F5** and type "settings":
+
+- **Accent color** with a live preview as you move the cursor.
+- **Notifications** — channels, which transitions alert you, and **quiet hours**
+  (a daily window where banners stay silent).
+- **Updates & background refresh** cadence.
+- **Crash restore** — whether restore revives agents or rebuilds sessions only.
+- **Keyboard shortcuts** — a read-only viewer of your current binds.
+- **Reset to defaults**, guarded by a confirm.
+
+Changes persist atomically to `~/.tmux-ide/config.json` and the status line tells
+you where they landed. → [ide.yml & configuration](/docs/configuration)
+
+## Select & copy inside agent panes
+
+Panes running a full-screen app (Claude Code, vim, htop) capture the mouse, so
+you couldn't drag to select text in them. Now you can: right-click →
+**"Select text…"** (or the palette's **"Select text in pane"**) pauses mouse
+forwarding so you can select and copy, with the wheel scrolling history while you
+do. Ordinary shell panes drag-select directly, as before. Copies use
+SSH-transparent OSC52, so the text lands on your local clipboard even across a
+remote session.
+
+## Size honesty with co-attached terminals
+
+If another terminal is attached to the same window and sizes it smaller, the app
+no longer pretends. It centers the view and says so, and the palette offers
+**"Resize to fit this window"** to reclaim the full canvas when you want it.
+Detaching always leaves the other terminal's size intact.
+
+## Per-platform release binaries
+
+The app used to need a dev checkout to run. 2.7 ships **per-platform TUI
+binaries** with download-on-demand, so a plain `npm i -g tmux-ide` gets you a
+working `tmux-ide app` without a repo. → [Getting started](/docs/getting-started)
+
+## Also in 2.7
+
+- Right-click context menus everywhere — pane, window, and session verbs
+  including layout presets and synchronize-panes, with destructive actions
+  confirmed.
+- Scrollback search (`/`), a paste-buffer picker, and pane-zoom fast paths.
+- Notification polish: deduped banners, quiet hours, and richer content.
+- Broader agent detection: six more screen manifests, with detection confidence
+  now surfaced.


### PR DESCRIPTION
Website update for the 2.7.0 release — new What's-New page and surgical refreshes of the four affected topical pages. docs:build green; all keys/labels verified against source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)