### PR TITLE
feat: brew install path — formula, tap auto-bump, doctor (M23.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,96 @@ jobs:
         run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Push the just-released version into the Homebrew tap
+  # (wavyrai/homebrew-tap → Formula/tmux-ide.rb). The formula's source of
+  # truth is packaging/homebrew/Formula/tmux-ide.rb in THIS repo; this job
+  # rewrites its url + sha256 to the fresh npm tarball and pushes the result.
+  #
+  # Gated to a graceful no-op until two one-time setup steps exist:
+  #   1. the `wavyrai/homebrew-tap` GitHub repo (empty is fine — this job
+  #      creates Formula/tmux-ide.rb on first run), and
+  #   2. a `TAP_PUSH_TOKEN` repo secret: a fine-grained PAT with contents
+  #      read/write on wavyrai/homebrew-tap.
+  bump_tap:
+    name: Bump Homebrew tap
+    needs: publish_npm
+    runs-on: ubuntu-24.04
+    env:
+      TAP_PUSH_TOKEN: ${{ secrets.TAP_PUSH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Gate on tap secret
+        id: gate
+        run: |
+          if [[ -z "${TAP_PUSH_TOKEN}" ]]; then
+            echo "TAP_PUSH_TOKEN not set — skipping tap bump (create wavyrai/homebrew-tap and add the secret to enable)."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve release version
+        if: steps.gate.outputs.enabled == 'true'
+        id: release
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            raw="${{ github.event.inputs.version }}"
+          else
+            raw="${GITHUB_REF_NAME}"
+          fi
+          version="${raw#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release version: $raw" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the npm tarball and compute its sha256
+        if: steps.gate.outputs.enabled == 'true'
+        id: tarball
+        shell: bash
+        run: |
+          version="${{ steps.release.outputs.version }}"
+          url="https://registry.npmjs.org/tmux-ide/-/tmux-ide-${version}.tgz"
+          # The registry can lag the publish by a little; poll up to 5 minutes.
+          for i in $(seq 1 30); do
+            if curl -fsSL -o tmux-ide.tgz "$url"; then break; fi
+            echo "tarball not visible yet (attempt $i/30) — retrying in 10s"
+            sleep 10
+          done
+          [[ -s tmux-ide.tgz ]] || { echo "npm tarball never appeared: $url" >&2; exit 1; }
+          sha="$(sha256sum tmux-ide.tgz | cut -d' ' -f1)"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "sha256=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Update formula and push to the tap
+        if: steps.gate.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.release.outputs.version }}"
+          url="${{ steps.tarball.outputs.url }}"
+          sha="${{ steps.tarball.outputs.sha256 }}"
+          if ! git clone --depth 1 "https://x-access-token:${TAP_PUSH_TOKEN}@github.com/wavyrai/homebrew-tap.git" tap; then
+            echo "wavyrai/homebrew-tap does not exist (or the token cannot read it) — skipping tap bump."
+            exit 0
+          fi
+          mkdir -p tap/Formula
+          sed -E \
+            -e "s#^(  url \").*(\")\$#\\1${url}\\2#" \
+            -e "s#^(  sha256 \").*(\")\$#\\1${sha}\\2#" \
+            packaging/homebrew/Formula/tmux-ide.rb > tap/Formula/tmux-ide.rb
+          cd tap
+          git add Formula/tmux-ide.rb
+          if git diff --cached --quiet; then
+            echo "Formula already at v${version} — nothing to push."
+            exit 0
+          fi
+          git -c user.name="tmux-ide release bot" \
+              -c user.email="noreply@wavyr.com" \
+              commit -m "tmux-ide ${version}"
+          git push origin HEAD

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -12396,8 +12396,9 @@ init_update_check();
 init_skill_sync();
 init_agent_discovery();
 init_compiled();
+init_claude();
 import { execSync as execSync3 } from "node:child_process";
-import { existsSync as existsSync20 } from "node:fs";
+import { accessSync, constants, existsSync as existsSync20 } from "node:fs";
 import { resolve as resolve14, dirname as dirname15 } from "node:path";
 import { fileURLToPath as fileURLToPath7 } from "node:url";
 function agentIntegrationRows(agents) {
@@ -12419,6 +12420,23 @@ function agentIntegrationRows(agents) {
     };
   });
 }
+function hooksTargetRow(facts) {
+  const label = "Claude hooks target writable";
+  if (facts.writable) {
+    return {
+      label,
+      pass: true,
+      detail: facts.fileExists ? facts.settingsPath : `${facts.settingsPath} (will be created)`,
+      optional: true
+    };
+  }
+  return {
+    label,
+    pass: false,
+    detail: `cannot write ${facts.settingsPath} \u2014 fix its permissions (chown/chmod), or point TMUX_IDE_CLAUDE_SETTINGS at a writable path`,
+    optional: true
+  };
+}
 function check(label, fn, { optional = false } = {}) {
   try {
     const result = fn();
@@ -12433,7 +12451,13 @@ async function doctor({
   const checks = [];
   checks.push(
     check("tmux installed", () => {
-      execSync3("which tmux", { stdio: "ignore" });
+      try {
+        execSync3("which tmux", { stdio: "ignore" });
+      } catch {
+        throw new Error(
+          "not found on PATH \u2014 install it (macOS: `brew install tmux`; Debian/Ubuntu: `sudo apt install tmux`)"
+        );
+      }
       return "found";
     })
   );
@@ -12503,35 +12527,38 @@ async function doctor({
       { optional: true }
     )
   );
-  checks.push(
-    check(
-      "tailscale CLI",
-      () => {
-        const version = execSync3("tailscale version", { encoding: "utf-8" }).trim().split("\n")[0];
-        return version;
-      },
-      { optional: true }
-    )
+  const tunnelCli = (label, cmd) => check(
+    label,
+    () => {
+      try {
+        return execSync3(cmd, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim().split("\n")[0];
+      } catch {
+        throw new Error("not found (optional \u2014 used for remote access tunnels)");
+      }
+    },
+    { optional: true }
   );
+  checks.push(tunnelCli("tailscale CLI", "tailscale version"));
+  checks.push(tunnelCli("ngrok CLI", "ngrok version"));
+  checks.push(tunnelCli("cloudflared CLI", "cloudflared --version"));
   checks.push(
-    check(
-      "ngrok CLI",
-      () => {
-        const version = execSync3("ngrok version", { encoding: "utf-8" }).trim();
-        return version;
-      },
-      { optional: true }
-    )
-  );
-  checks.push(
-    check(
-      "cloudflared CLI",
-      () => {
-        const version = execSync3("cloudflared --version", { encoding: "utf-8" }).trim();
-        return version;
-      },
-      { optional: true }
-    )
+    (() => {
+      const settingsPath = claudeSettingsPath();
+      const fileExists2 = existsSync20(settingsPath);
+      let probe = fileExists2 ? settingsPath : dirname15(settingsPath);
+      while (!existsSync20(probe)) {
+        const parent = dirname15(probe);
+        if (parent === probe) break;
+        probe = parent;
+      }
+      let writable = false;
+      try {
+        accessSync(probe, constants.W_OK);
+        writable = true;
+      } catch {
+      }
+      return hooksTargetRow({ settingsPath, fileExists: fileExists2, writable });
+    })()
   );
   checks.push(
     check(

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -9,6 +9,9 @@ description: Install tmux-ide and adopt your first session in under a minute
 - **Node.js** — ≥ 20
 - **Bun** — only needed for the TUI surfaces (home cockpit, sidebar, floating panels)
 
+The Homebrew install resolves tmux and Node.js for you — with it, there are no
+prerequisites to install by hand.
+
 Check everything at once:
 
 ```bash
@@ -16,6 +19,29 @@ tmux-ide doctor
 ```
 
 ## Install
+
+{/* PENDING TAP PUBLICATION — the `wavyrai/homebrew-tap` repo is not published yet. */}
+{/* The formula (packaging/homebrew/Formula/tmux-ide.rb) and the seeding script */}
+{/* (scripts/publish-tap.sh) are ready; once the tap exists, this Homebrew block */}
+{/* is the lead install path — delete this comment then. */}
+
+### Homebrew (macOS and Linux)
+
+One command — tmux and Node.js are resolved as dependencies, nothing to
+install first:
+
+```bash
+brew install wavyrai/tap/tmux-ide
+```
+
+Homebrew skips npm lifecycle scripts, so wire the Claude Code pieces once
+after installing (the npm path below does this automatically):
+
+```bash
+tmux-ide integration install claude   # Claude Code hooks + skill sync
+```
+
+### npm
 
 ```bash
 npm i -g tmux-ide

--- a/packages/daemon/src/doctor.test.ts
+++ b/packages/daemon/src/doctor.test.ts
@@ -3,7 +3,7 @@
  * text depends only on a DiscoveredAgent[], so no io is needed here.
  */
 import { describe, expect, it } from "vitest";
-import { agentIntegrationRows } from "./doctor.ts";
+import { agentIntegrationRows, hooksTargetRow } from "./doctor.ts";
 import type { DiscoveredAgent } from "./lib/agent-discovery.ts";
 
 const agent = (over: Partial<DiscoveredAgent>): DiscoveredAgent => ({
@@ -60,5 +60,37 @@ describe("agentIntegrationRows", () => {
       agent({ id: "codex", integration: false, path: "/bin/codex" }),
     ]);
     expect(rows.every((r) => r.optional)).toBe(true);
+  });
+});
+
+describe("hooksTargetRow", () => {
+  const path = "/home/u/.claude/settings.json";
+
+  it("passes with the bare path when the file exists and is writable", () => {
+    const row = hooksTargetRow({ settingsPath: path, fileExists: true, writable: true });
+    expect(row.pass).toBe(true);
+    expect(row.detail).toBe(path);
+  });
+
+  it("passes with a 'will be created' note when the file is absent but creatable", () => {
+    const row = hooksTargetRow({ settingsPath: path, fileExists: false, writable: true });
+    expect(row.pass).toBe(true);
+    expect(row.detail).toContain("will be created");
+  });
+
+  it("fails with a plain fix hint (permissions + env override) when not writable", () => {
+    const row = hooksTargetRow({ settingsPath: path, fileExists: true, writable: false });
+    expect(row.pass).toBe(false);
+    expect(row.detail).toContain(path);
+    expect(row.detail).toContain("chown/chmod");
+    expect(row.detail).toContain("TMUX_IDE_CLAUDE_SETTINGS");
+  });
+
+  it("never fails doctor overall (always optional)", () => {
+    for (const fileExists of [true, false]) {
+      for (const writable of [true, false]) {
+        expect(hooksTargetRow({ settingsPath: path, fileExists, writable }).optional).toBe(true);
+      }
+    }
   });
 });

--- a/packages/daemon/src/doctor.ts
+++ b/packages/daemon/src/doctor.ts
@@ -1,11 +1,12 @@
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { accessSync, constants, existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getCurrentVersion, getUpdateStatus } from "./lib/update-check.ts";
 import { installedSkillVersion } from "./lib/skill-sync.ts";
 import { discoverAgents, presentAgents, type DiscoveredAgent } from "./lib/agent-discovery.ts";
 import { findCompiledTui, isBunAvailable } from "./tui/compiled.ts";
+import { claudeSettingsPath } from "./tui/integrations/claude.ts";
 
 interface CheckResult {
   label: string;
@@ -45,6 +46,34 @@ export function agentIntegrationRows(agents: DiscoveredAgent[]): CheckResult[] {
   });
 }
 
+/**
+ * PURE — the "Claude hooks target writable" row from observed facts. Both
+ * `integration install claude` and the npm postinstall write the settings
+ * file; surface a permissions problem BEFORE an install fails halfway.
+ * Optional: a machine without Claude Code shouldn't fail doctor over this.
+ */
+export function hooksTargetRow(facts: {
+  settingsPath: string;
+  fileExists: boolean;
+  writable: boolean;
+}): CheckResult {
+  const label = "Claude hooks target writable";
+  if (facts.writable) {
+    return {
+      label,
+      pass: true,
+      detail: facts.fileExists ? facts.settingsPath : `${facts.settingsPath} (will be created)`,
+      optional: true,
+    };
+  }
+  return {
+    label,
+    pass: false,
+    detail: `cannot write ${facts.settingsPath} — fix its permissions (chown/chmod), or point TMUX_IDE_CLAUDE_SETTINGS at a writable path`,
+    optional: true,
+  };
+}
+
 function check(
   label: string,
   fn: () => string,
@@ -67,7 +96,13 @@ export async function doctor({
 
   checks.push(
     check("tmux installed", () => {
-      execSync("which tmux", { stdio: "ignore" });
+      try {
+        execSync("which tmux", { stdio: "ignore" });
+      } catch {
+        throw new Error(
+          "not found on PATH — install it (macOS: `brew install tmux`; Debian/Ubuntu: `sudo apt install tmux`)",
+        );
+      }
       return "found";
     }),
   );
@@ -153,37 +188,49 @@ export async function doctor({
     ),
   );
 
-  checks.push(
+  // Optional tunnel CLIs: probe quietly (a missing binary must not leak
+  // "command not found" stderr into doctor's own output) and fail with a
+  // plain hint rather than execSync's raw error.
+  const tunnelCli = (label: string, cmd: string): CheckResult =>
     check(
-      "tailscale CLI",
+      label,
       () => {
-        const version = execSync("tailscale version", { encoding: "utf-8" }).trim().split("\n")[0]!;
-        return version;
+        try {
+          return execSync(cmd, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] })
+            .trim()
+            .split("\n")[0]!;
+        } catch {
+          throw new Error("not found (optional — used for remote access tunnels)");
+        }
       },
       { optional: true },
-    ),
-  );
+    );
+  checks.push(tunnelCli("tailscale CLI", "tailscale version"));
+  checks.push(tunnelCli("ngrok CLI", "ngrok version"));
+  checks.push(tunnelCli("cloudflared CLI", "cloudflared --version"));
 
   checks.push(
-    check(
-      "ngrok CLI",
-      () => {
-        const version = execSync("ngrok version", { encoding: "utf-8" }).trim();
-        return version;
-      },
-      { optional: true },
-    ),
-  );
-
-  checks.push(
-    check(
-      "cloudflared CLI",
-      () => {
-        const version = execSync("cloudflared --version", { encoding: "utf-8" }).trim();
-        return version;
-      },
-      { optional: true },
-    ),
+    (() => {
+      // Claude hooks target: the settings file `integration install claude`
+      // (and the npm postinstall) will write. Writability of the file itself
+      // when it exists, else of its nearest existing ancestor directory.
+      const settingsPath = claudeSettingsPath();
+      const fileExists = existsSync(settingsPath);
+      let probe = fileExists ? settingsPath : dirname(settingsPath);
+      while (!existsSync(probe)) {
+        const parent = dirname(probe);
+        if (parent === probe) break;
+        probe = parent;
+      }
+      let writable = false;
+      try {
+        accessSync(probe, constants.W_OK);
+        writable = true;
+      } catch {
+        // leave writable=false — the row explains the fix
+      }
+      return hooksTargetRow({ settingsPath, fileExists, writable });
+    })(),
   );
 
   checks.push(

--- a/packaging/homebrew/Formula/tmux-ide.rb
+++ b/packaging/homebrew/Formula/tmux-ide.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# The source-of-truth Homebrew formula for tmux-ide. It lives in this repo and
+# is published to `wavyrai/homebrew-tap` (as Formula/tmux-ide.rb) by
+# scripts/publish-tap.sh, then kept current by the `bump_tap` job in
+# .github/workflows/release.yml on every release.
+#
+# Strategy: standard Homebrew Node formula — the published npm tarball is
+# installed global-style into the Cellar with Homebrew's own `node`, so
+# `brew install wavyrai/tap/tmux-ide` needs no preexisting Node or tmux.
+class TmuxIde < Formula
+  desc "Terminal-native IDE and agent cockpit built around tmux"
+  homepage "https://github.com/wavyrai/tmux-ide"
+  url "https://registry.npmjs.org/tmux-ide/-/tmux-ide-2.7.0.tgz"
+  sha256 "fbef6a0040a90770e772e2c3c6144dce238dfb77300415126aaab6ad43110a02"
+  license "MIT"
+
+  depends_on "node"
+  depends_on "tmux"
+
+  def install
+    # std_npm_args passes --ignore-scripts, so the package's npm postinstall
+    # never runs here. That is deliberate (its Claude-integration steps write
+    # to $HOME, which the build sandbox forbids — see caveats), but two things
+    # it would have done inside the package itself are recreated below.
+    system "npm", "install", *std_npm_args
+
+    pkg = libexec/"lib/node_modules/tmux-ide"
+
+    # 1. The TUI surfaces run from the shipped sources via bun and import the
+    #    shipped workspace packages by name; the postinstall would have linked
+    #    them into node_modules (see scripts/postinstall.js in the package).
+    scope = pkg/"node_modules/@tmux-ide"
+    scope.mkpath
+    (scope/"tmux-bridge").make_symlink "../../packages/tmux-bridge"
+    (scope/"contracts").make_symlink "../../packages/contracts"
+
+    # 2. node-pty loads its bundled prebuild directly on common platforms
+    #    (verified: no rebuild needed on macOS); `npm rebuild` is insurance
+    #    that compiles the binding wherever no prebuild is shipped.
+    cd pkg do
+      system "npm", "rebuild", "node-pty", "--#{Language::Node.npm_cache_config}"
+    end
+
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  def caveats
+    <<~EOS
+      An npm global install runs tmux-ide's postinstall (Claude Code skill
+      sync); Homebrew skips package lifecycle scripts, so run once:
+        tmux-ide integration install claude   # Claude Code hooks + skill sync
+      (or `tmux-ide skill-sync` for the skill alone).
+
+      The full-screen app (`tmux-ide app`) runs from source when `bun` is on
+      PATH; otherwise fetch the compiled TUI binary with:
+        tmux-ide update --tui-binary
+    EOS
+  end
+
+  test do
+    assert_match "tmux-ide v#{version}", shell_output("#{bin}/tmux-ide --version")
+    # doctor exits 1 in an empty dir (no ide.yml) — the checks still render.
+    assert_match "tmux installed", shell_output("#{bin}/tmux-ide doctor 2>&1", 1)
+  end
+end

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,59 @@
+# Homebrew packaging
+
+`brew install wavyrai/tap/tmux-ide` — no preexisting Node or tmux needed.
+
+## Strategy (decided M23.4)
+
+**Standard Homebrew Node formula**: the published npm tarball is installed
+global-style into the Cellar with Homebrew's own `node` (`std_npm_args`, the
+same pattern homebrew-core uses for renovate/gemini-cli/etc.).
+
+The alternative — shipping the bun-compiled TUI binary plus a thin CLI — was
+rejected: the compiled artifact covers only the TUI surfaces (the CLI itself
+is Node), it would need per-platform release assets and sha blocks in the
+formula, and it diverges from the tested npm artifact. With the Node formula,
+`node` is a brew-resolved dependency rather than a user prerequisite, which
+is what the "one-command install" goal actually requires.
+
+Two details the formula handles because Homebrew installs with
+`--ignore-scripts` (so the package's npm postinstall never runs):
+
+1. it recreates the `@tmux-ide/{tmux-bridge,contracts}` symlinks the
+   postinstall would have made (the bun-run TUI surfaces resolve them), and
+2. it runs `npm rebuild node-pty` (a no-op where the bundled prebuild exists;
+   compiles the binding elsewhere).
+
+The per-user Claude steps the postinstall would have done (skill sync, agent
+teams flag) are covered by the formula's caveats: run
+`tmux-ide integration install claude` once.
+
+## One-time publication (owner: PM/user)
+
+1. Create the GitHub repo `wavyrai/homebrew-tap` (empty; the name must be
+   exactly `homebrew-tap`).
+2. Seed it: `scripts/publish-tap.sh` (clones the tap, copies
+   `packaging/homebrew/Formula/tmux-ide.rb` → `Formula/tmux-ide.rb`, pushes).
+3. Add a repo secret `TAP_PUSH_TOKEN` to wavyrai/tmux-ide: a fine-grained PAT
+   with contents read/write on `wavyrai/homebrew-tap`. From then on the
+   `bump_tap` job in `.github/workflows/release.yml` rewrites the formula's
+   url + sha256 on every release and pushes it (it no-ops gracefully while
+   the secret or the repo is missing).
+4. Flip the install docs: `docs/content/docs/getting-started.mdx` already
+   contains the Homebrew section, marked with a "PENDING TAP PUBLICATION"
+   comment — delete the comment.
+
+## Editing the formula
+
+`packaging/homebrew/Formula/tmux-ide.rb` in this repo is the source of truth;
+structural edits flow to the tap on the next release (or via
+`scripts/publish-tap.sh`). Check before shipping:
+
+```bash
+brew style packaging/homebrew/Formula/tmux-ide.rb
+# full audit + install needs a tap context:
+brew tap-new <user>/zz-audit --no-git
+cp packaging/homebrew/Formula/tmux-ide.rb "$(brew --repo <user>/zz-audit)/Formula/"
+brew audit --strict --online <user>/zz-audit/tmux-ide
+brew install --build-from-source <user>/zz-audit/tmux-ide && brew test tmux-ide
+brew uninstall tmux-ide && brew untap <user>/zz-audit
+```

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -91,7 +91,14 @@ const nextSettings = {
   },
 };
 
-writeFileSync(settingsPath, `${JSON.stringify(nextSettings, null, 2)}\n`);
+try {
+  writeFileSync(settingsPath, `${JSON.stringify(nextSettings, null, 2)}\n`);
+} catch (error) {
+  // Best-effort like everything above: sandboxed installs (e.g. a package
+  // manager building in a $HOME-restricted sandbox) may deny this write —
+  // that must never fail the install itself.
+  console.warn(`[tmux-ide] Skipping Claude settings update: ${error.message}`);
+}
 
 function shouldInstallClaudeIntegration() {
   return process.env.npm_config_global === "true";

--- a/scripts/publish-tap.sh
+++ b/scripts/publish-tap.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Publish packaging/homebrew/Formula/tmux-ide.rb to the Homebrew tap repo
+# (wavyrai/homebrew-tap), i.e. the one-time seeding the CI `bump_tap` job
+# assumes. After this, every release keeps the tap current automatically
+# (given the TAP_PUSH_TOKEN secret — see .github/workflows/release.yml).
+#
+# Usage:
+#   scripts/publish-tap.sh [path-to-tap-checkout]
+#
+# With no argument, clones git@github.com:wavyrai/homebrew-tap.git into a
+# temp dir. The tap repo must already exist on GitHub (create it empty —
+# the name MUST be exactly `homebrew-tap` for `brew install
+# wavyrai/tap/tmux-ide` to resolve).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+formula="$repo_root/packaging/homebrew/Formula/tmux-ide.rb"
+[[ -f "$formula" ]] || {
+  echo "formula not found: $formula" >&2
+  exit 1
+}
+
+tap_dir="${1:-}"
+cleanup=""
+if [[ -z "$tap_dir" ]]; then
+  tap_dir="$(mktemp -d)/homebrew-tap"
+  cleanup="$(dirname "$tap_dir")"
+  git clone git@github.com:wavyrai/homebrew-tap.git "$tap_dir"
+fi
+[[ -d "$tap_dir/.git" ]] || {
+  echo "not a git checkout: $tap_dir" >&2
+  exit 1
+}
+
+version="$(sed -nE 's#^  url ".*/tmux-ide-([0-9][^"]*)\.tgz"$#\1#p' "$formula")"
+[[ -n "$version" ]] || {
+  echo "could not read the version from the formula url" >&2
+  exit 1
+}
+
+mkdir -p "$tap_dir/Formula"
+cp "$formula" "$tap_dir/Formula/tmux-ide.rb"
+
+cd "$tap_dir"
+git add Formula/tmux-ide.rb
+if git diff --cached --quiet; then
+  echo "tap already has this formula version (v$version) — nothing to push."
+else
+  git commit -m "tmux-ide $version"
+  git push origin HEAD
+  echo "pushed tmux-ide v$version to $(git remote get-url origin)"
+fi
+
+[[ -n "$cleanup" ]] && rm -rf "$cleanup"
+echo "install with: brew install wavyrai/tap/tmux-ide"


### PR DESCRIPTION
Card #97: Homebrew Node formula (packaging/homebrew as source of truth), one-time tap seed script, gated CI tap-bump on release, doctor additions, docs. Verified by a real sandboxed install through a scratch tap, fully cleaned up. Requires (once): create wavyrai/homebrew-tap, run scripts/publish-tap.sh, set TAP_PUSH_TOKEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)