### PR TITLE
feat: agent lifecycle verbs — spawn/restart/stop from the app (M23.1)

### DIFF
--- a/packages/daemon/src/tui/mirror/agent-lifecycle.test.ts
+++ b/packages/daemon/src/tui/mirror/agent-lifecycle.test.ts
@@ -186,13 +186,7 @@ describe("respawnArgs", () => {
       "/proj",
       "claude",
     ]);
-    expect(respawnArgs("%7", "claude", null)).toEqual([
-      "respawn-pane",
-      "-k",
-      "-t",
-      "%7",
-      "claude",
-    ]);
+    expect(respawnArgs("%7", "claude", null)).toEqual(["respawn-pane", "-k", "-t", "%7", "claude"]);
   });
 });
 

--- a/packages/daemon/src/tui/mirror/agent-lifecycle.test.ts
+++ b/packages/daemon/src/tui/mirror/agent-lifecycle.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import type { AgentManifest } from "../detect/manifest.ts";
+import { BUNDLED_MANIFESTS } from "../detect/manifests.ts";
+import {
+  AGENT_LAUNCH_COMMANDS,
+  CUSTOM_KIND_ID,
+  agentKindItems,
+  clearAuthorityArgs,
+  interruptArgs,
+  isShellCommand,
+  launchCommandFor,
+  paneHostsShell,
+  placementItems,
+  relaunchArgs,
+  respawnArgs,
+  spawnAgentArgs,
+  spawnSessionArgs,
+} from "./agent-lifecycle.ts";
+
+const manifest = (id: string, commands: string[]): AgentManifest => ({
+  id,
+  commands,
+  states: {},
+});
+
+describe("launchCommandFor", () => {
+  it("uses the shipped map for bundled kinds", () => {
+    expect(launchCommandFor("claude", BUNDLED_MANIFESTS)).toBe("claude");
+    // cursor's manifest matches `cursor-agent`/`cursor`; the launch binary is cursor-agent.
+    expect(launchCommandFor("cursor", BUNDLED_MANIFESTS)).toBe("cursor-agent");
+  });
+
+  it("falls back to a user-override manifest's first command token", () => {
+    const custom = manifest("my-agent", ["my-agent-cli", "my-agent"]);
+    expect(launchCommandFor("my-agent", [...BUNDLED_MANIFESTS, custom])).toBe("my-agent-cli");
+  });
+
+  it("falls back to the kind itself when nothing else is known", () => {
+    expect(launchCommandFor("mystery", [])).toBe("mystery");
+  });
+
+  it("covers every bundled agent kind in the launch map (shell excluded)", () => {
+    for (const m of BUNDLED_MANIFESTS) {
+      if (m.id === "shell") continue;
+      expect(AGENT_LAUNCH_COMMANDS[m.id], m.id).toBeTruthy();
+    }
+  });
+});
+
+describe("agentKindItems", () => {
+  it("lists every manifest id except the shell catch-all, then the custom row last", () => {
+    const items = agentKindItems(BUNDLED_MANIFESTS);
+    const ids = items.map((i) => i.id);
+    expect(ids).not.toContain("shell");
+    expect(ids[ids.length - 1]).toBe(CUSTOM_KIND_ID);
+    expect(ids).toContain("claude");
+    expect(ids).toContain("codex");
+    expect(items).toHaveLength(BUNDLED_MANIFESTS.length - 1 + 1);
+  });
+
+  it("shows the launch command as the row detail", () => {
+    const items = agentKindItems(BUNDLED_MANIFESTS);
+    expect(items.find((i) => i.id === "cursor")?.detail).toBe("cursor-agent");
+  });
+
+  it("includes user-override manifests (the loader's merged list is the source)", () => {
+    const items = agentKindItems([...BUNDLED_MANIFESTS, manifest("my-agent", ["my-agent"])]);
+    expect(items.map((i) => i.id)).toContain("my-agent");
+  });
+});
+
+describe("placementItems", () => {
+  it("offers splits only when there is a pane to split", () => {
+    expect(placementItems({ split: false }).map((i) => i.id)).toEqual(["window"]);
+    expect(placementItems({ split: true }).map((i) => i.id)).toEqual([
+      "window",
+      "split-h",
+      "split-v",
+    ]);
+  });
+});
+
+describe("spawnAgentArgs", () => {
+  it("spawns a new window in the session, with -c when the dir is known", () => {
+    expect(spawnAgentArgs("window", { session: "web" }, "/proj", "claude")).toEqual([
+      "new-window",
+      "-t",
+      "web:",
+      "-c",
+      "/proj",
+      "claude",
+    ]);
+    expect(spawnAgentArgs("window", { session: "web" }, null, "claude")).toEqual([
+      "new-window",
+      "-t",
+      "web:",
+      "claude",
+    ]);
+  });
+
+  it("splits the concrete pane when one is given, else the session's active pane", () => {
+    expect(spawnAgentArgs("split-h", { session: "web", paneId: "%3" }, "/proj", "codex")).toEqual([
+      "split-window",
+      "-h",
+      "-t",
+      "%3",
+      "-c",
+      "/proj",
+      "codex",
+    ]);
+    expect(spawnAgentArgs("split-v", { session: "web" }, null, "codex")).toEqual([
+      "split-window",
+      "-v",
+      "-t",
+      "web:",
+      "codex",
+    ]);
+  });
+});
+
+describe("spawnSessionArgs", () => {
+  it("creates a detached session running the command in the project dir", () => {
+    expect(spawnSessionArgs("api", "/proj", "claude")).toEqual([
+      "new-session",
+      "-d",
+      "-s",
+      "api",
+      "-c",
+      "/proj",
+      "claude",
+    ]);
+    expect(spawnSessionArgs("api", null, "claude")).toEqual([
+      "new-session",
+      "-d",
+      "-s",
+      "api",
+      "claude",
+    ]);
+  });
+});
+
+describe("isShellCommand", () => {
+  it("recognizes the shell manifest's commands plus common extras", () => {
+    for (const sh of ["zsh", "bash", "sh", "fish", "nu", "dash", "ksh", "tcsh"]) {
+      expect(isShellCommand(sh, BUNDLED_MANIFESTS), sh).toBe(true);
+    }
+  });
+
+  it("strips login-shell dashes and paths", () => {
+    expect(isShellCommand("-zsh", BUNDLED_MANIFESTS)).toBe(true);
+    expect(isShellCommand("/bin/bash", BUNDLED_MANIFESTS)).toBe(true);
+  });
+
+  it("says no for agent processes (they ARE the pane command — respawn path)", () => {
+    expect(isShellCommand("claude", BUNDLED_MANIFESTS)).toBe(false);
+    expect(isShellCommand("python3.13", BUNDLED_MANIFESTS)).toBe(false);
+    expect(isShellCommand("node", BUNDLED_MANIFESTS)).toBe(false);
+  });
+});
+
+describe("paneHostsShell", () => {
+  it("an empty start command is tmux's default shell — every plain user pane", () => {
+    expect(paneHostsShell("", BUNDLED_MANIFESTS)).toBe(true);
+    expect(paneHostsShell("  ", BUNDLED_MANIFESTS)).toBe(true);
+  });
+
+  it("an explicit shell start command still hosts a shell", () => {
+    expect(paneHostsShell("zsh", BUNDLED_MANIFESTS)).toBe(true);
+    expect(paneHostsShell("/bin/zsh -l", BUNDLED_MANIFESTS)).toBe(true);
+  });
+
+  it("an agent start command means the pane dies with the process — respawn path", () => {
+    expect(paneHostsShell("aider", BUNDLED_MANIFESTS)).toBe(false);
+    expect(paneHostsShell("claude --resume abc123", BUNDLED_MANIFESTS)).toBe(false);
+  });
+});
+
+describe("respawnArgs", () => {
+  it("kills and relaunches the pane in place, pinning the cwd explicitly", () => {
+    expect(respawnArgs("%7", "claude", "/proj")).toEqual([
+      "respawn-pane",
+      "-k",
+      "-t",
+      "%7",
+      "-c",
+      "/proj",
+      "claude",
+    ]);
+    expect(respawnArgs("%7", "claude", null)).toEqual([
+      "respawn-pane",
+      "-k",
+      "-t",
+      "%7",
+      "claude",
+    ]);
+  });
+});
+
+describe("stop/restart argv", () => {
+  it("interrupts via send-keys C-c", () => {
+    expect(interruptArgs("%7")).toEqual(["send-keys", "-t", "%7", "C-c"]);
+  });
+
+  it("relaunches as literal text then a real Enter key (two calls — -l must not eat Enter)", () => {
+    expect(relaunchArgs("%7", "claude --resume")).toEqual([
+      ["send-keys", "-t", "%7", "-l", "claude --resume"],
+      ["send-keys", "-t", "%7", "Enter"],
+    ]);
+  });
+
+  it("clears BOTH authority stamps pane-locally (the SessionEnd-equivalent hygiene)", () => {
+    expect(clearAuthorityArgs("%7")).toEqual([
+      ["set-option", "-p", "-t", "%7", "-u", "@agent_state"],
+      ["set-option", "-p", "-t", "%7", "-u", "@agent_session_id"],
+    ]);
+  });
+});

--- a/packages/daemon/src/tui/mirror/agent-lifecycle.ts
+++ b/packages/daemon/src/tui/mirror/agent-lifecycle.ts
@@ -81,9 +81,7 @@ export type SpawnPlacement = "window" | "split-h" | "split-v";
  * agent will land before anything runs.
  */
 export function placementItems(opts: { split: boolean }): DialogSelectItem[] {
-  const items: DialogSelectItem[] = [
-    { id: "window", label: "New window", detail: "its own tab" },
-  ];
+  const items: DialogSelectItem[] = [{ id: "window", label: "New window", detail: "its own tab" }];
   if (opts.split) {
     items.push({ id: "split-h", label: "Split right", detail: "beside this pane" });
     items.push({ id: "split-v", label: "Split below", detail: "under this pane" });

--- a/packages/daemon/src/tui/mirror/agent-lifecycle.ts
+++ b/packages/daemon/src/tui/mirror/agent-lifecycle.ts
@@ -1,0 +1,208 @@
+/**
+ * Agent lifecycle verbs — the PURE model (M23.1). The app can finally MANAGE
+ * the fleet it watches: spawn a new agent (home chips / palette / sidebar
+ * session menu / Terminal split), restart one, stop one, close its pane. The
+ * kind list, the kind→launch-command map, the placement rows, and the exact
+ * tmux argv every verb runs all live here so they unit-test without OpenTUI;
+ * app.tsx supplies the dialog flows and the async execFile calls.
+ *
+ * KIND SOURCING: the detection manifests (manifest-loader) are the single
+ * source of WHICH kinds exist — a user override manifest automatically shows
+ * up in the "New agent" picker. Manifests carry `commands` (process names to
+ * MATCH, e.g. `codex.exe`), not a command to LAUNCH, so the launch command is
+ * a small map here keyed by manifest id, falling back to the manifest's first
+ * command token (right for every current bundle and for user overrides).
+ *
+ * CONTRACT HYGIENE: the claude integration's SessionEnd hook stamps
+ * `@agent_state idle:<epoch>` when the agent exits on its own. When WE kill it
+ * out-of-band (stop/restart) no hook fires, and a `working`/`blocked` stamp
+ * would keep lying for AUTHORITY_STALE_SECONDS (10 min) before the staleness
+ * guard falls back to scraping. So stop/restart UNSET the pane's authority
+ * options (`@agent_state`, `@agent_session_id`) — the same end state as a
+ * clean exit, without inventing a fake idle epoch.
+ */
+import type { AgentManifest } from "../detect/manifest.ts";
+import type { DialogSelectItem } from "./dialog-model.ts";
+
+/** The "Custom command…" picker row — resolves to a DialogPrompt, not a kind. */
+export const CUSTOM_KIND_ID = "custom-command";
+
+/**
+ * Launch command per manifest id. Manifest `commands` are process-match
+ * tokens; this is what actually gets typed/executed to START the agent. Only
+ * ids whose launch spelling differs from (or shouldn't trust) the first match
+ * token need an entry — {@link launchCommandFor} falls back for the rest.
+ */
+export const AGENT_LAUNCH_COMMANDS: Record<string, string> = {
+  claude: "claude",
+  codex: "codex",
+  opencode: "opencode",
+  gemini: "gemini",
+  aider: "aider",
+  copilot: "copilot",
+  cursor: "cursor-agent",
+  goose: "goose",
+  amp: "amp",
+};
+
+/**
+ * PURE — the command that launches an agent of `kind`: the map entry when we
+ * ship one, else the kind's manifest's first `commands` token (user-override
+ * manifests land here), else the kind itself.
+ */
+export function launchCommandFor(kind: string, manifests: readonly AgentManifest[]): string {
+  const mapped = AGENT_LAUNCH_COMMANDS[kind];
+  if (mapped) return mapped;
+  const m = manifests.find((x) => x.id === kind);
+  return m?.commands[0] ?? kind;
+}
+
+/**
+ * PURE — the "New agent" picker rows: one per manifest id (the `shell`
+ * catch-all is not an agent and is excluded), detail showing the command that
+ * will run, then the "Custom command…" escape hatch last.
+ */
+export function agentKindItems(manifests: readonly AgentManifest[]): DialogSelectItem[] {
+  const items: DialogSelectItem[] = manifests
+    .filter((m) => m.id !== "shell")
+    .map((m) => ({ id: m.id, label: m.id, detail: launchCommandFor(m.id, manifests) }));
+  items.push({ id: CUSTOM_KIND_ID, label: "Custom command…", detail: "type your own" });
+  return items;
+}
+
+/** Where a spawned agent lands, relative to the target session/pane. */
+export type SpawnPlacement = "window" | "split-h" | "split-v";
+
+/**
+ * PURE — the "where should it run" rows. Splits are offered only when there is
+ * a concrete pane to split (the Terminal surface's focused pane); the home /
+ * sidebar entry points target a session, where a new window is the honest
+ * placement. A single-row list still shows, so the flow always says where the
+ * agent will land before anything runs.
+ */
+export function placementItems(opts: { split: boolean }): DialogSelectItem[] {
+  const items: DialogSelectItem[] = [
+    { id: "window", label: "New window", detail: "its own tab" },
+  ];
+  if (opts.split) {
+    items.push({ id: "split-h", label: "Split right", detail: "beside this pane" });
+    items.push({ id: "split-v", label: "Split below", detail: "under this pane" });
+  }
+  return items;
+}
+
+/** The spawn target: the owning session, plus the concrete pane for splits. */
+export interface SpawnTarget {
+  session: string;
+  /** Required for `split-h`/`split-v`; ignored for `window`. */
+  paneId?: string;
+}
+
+/**
+ * PURE — the tmux argv that spawns `command` at `placement`. New windows
+ * target `<session>:` (tmux appends); splits target the pane. `dir` becomes
+ * `-c` when known. The command is passed as tmux's shell-command argument —
+ * a bare binary is exec'd directly, so `pane_current_command` is the agent
+ * itself and detection picks it up with no extra wiring.
+ */
+export function spawnAgentArgs(
+  placement: SpawnPlacement,
+  target: SpawnTarget,
+  dir: string | null,
+  command: string,
+): string[] {
+  const cd = dir ? ["-c", dir] : [];
+  if (placement === "window") return ["new-window", "-t", `${target.session}:`, ...cd, command];
+  const flag = placement === "split-h" ? "-h" : "-v";
+  return ["split-window", flag, "-t", target.paneId ?? `${target.session}:`, ...cd, command];
+}
+
+/**
+ * PURE — the tmux argv that creates a fresh detached session running
+ * `command` (the home PROJECT-row spawn: no live session exists yet, so the
+ * agent gets one, named for the project).
+ */
+export function spawnSessionArgs(name: string, dir: string | null, command: string): string[] {
+  return ["new-session", "-d", "-s", name, ...(dir ? ["-c", dir] : []), command];
+}
+
+/** Interactive shells beyond the shell manifest's `commands` — a login shell
+ *  hosting an agent can surface as any of these in `pane_current_command`. */
+const EXTRA_SHELLS = ["dash", "ksh", "tcsh", "csh"];
+
+/**
+ * PURE — is `command` an interactive shell? Login-shell dashes and paths are
+ * stripped (`-zsh`, `/bin/zsh` → `zsh`); sourced from the `shell` manifest's
+ * command list plus a few shells it doesn't track.
+ */
+export function isShellCommand(command: string, manifests: readonly AgentManifest[]): boolean {
+  const name = command.replace(/^-/, "").split("/").pop() ?? command;
+  const shell = manifests.find((m) => m.id === "shell");
+  return [...(shell?.commands ?? []), ...EXTRA_SHELLS].includes(name);
+}
+
+/**
+ * PURE — does the pane HOST A SHELL underneath whatever runs in it? Decides
+ * the RESTART strategy: shell-hosted agents are ctrl-c'd and relaunched via
+ * send-keys (the shell survives to type into); an agent that IS the pane's
+ * own process (our spawn verb's panes) has no shell underneath — ctrl-c would
+ * end the pane — so it is respawned in place instead.
+ *
+ * The input is `#{pane_start_command}`, NOT `pane_current_command`: the
+ * current command reflects the FOREGROUND process, so a user-typed `claude`
+ * under zsh reads as `claude` too — indistinguishable from a pane-command
+ * agent (measured). The start command is the pane's ROOT: empty means tmux's
+ * default shell (every plain user pane), a shell word means an explicit shell
+ * pane, anything else means the pane dies with that process.
+ */
+export function paneHostsShell(startCommand: string, manifests: readonly AgentManifest[]): boolean {
+  const first = startCommand.trim().split(/\s+/)[0] ?? "";
+  if (first.length === 0) return true; // default-shell pane
+  return isShellCommand(first, manifests);
+}
+
+/**
+ * PURE — the tmux argv that relaunches `command` as the pane's own process:
+ * `respawn-pane -k` kills what runs there and restarts IN PLACE — same pane
+ * id, same geometry. `dir` rides as an explicit `-c` (the flow reads the
+ * pane's current path first) so the cwd is preserved on every tmux version.
+ */
+export function respawnArgs(paneId: string, command: string, dir: string | null): string[] {
+  return ["respawn-pane", "-k", "-t", paneId, ...(dir ? ["-c", dir] : []), command];
+}
+
+/** PURE — one interrupt (ctrl-c) to the pane. Sent TWICE by the flows: TUI
+ *  agents (claude, codex) treat a single ctrl-c as "clear input / cancel turn"
+ *  and only a quick second one as "exit"; a plain process ignores the repeat. */
+export function interruptArgs(paneId: string): string[] {
+  return ["send-keys", "-t", paneId, "C-c"];
+}
+
+/** PURE — relaunch `command` in the pane's (still-running) shell: the literal
+ *  command text, then Enter as a key. Two calls — `-l` must not eat "Enter". */
+export function relaunchArgs(paneId: string, command: string): string[][] {
+  return [
+    ["send-keys", "-t", paneId, "-l", command],
+    ["send-keys", "-t", paneId, "Enter"],
+  ];
+}
+
+/**
+ * PURE — unset the pane's authority stamps after an out-of-band stop/restart
+ * (see the header: no hook fires, so a stale `working:<epoch>` would lie for
+ * 10 minutes). `-u` on a pane-local (`-p`) option removes it, which is exactly
+ * the "no authority present" state the classifier falls back to scraping from.
+ */
+export function clearAuthorityArgs(paneId: string): string[][] {
+  return [
+    ["set-option", "-p", "-t", paneId, "-u", "@agent_state"],
+    ["set-option", "-p", "-t", paneId, "-u", "@agent_session_id"],
+  ];
+}
+
+/** Gap between the two interrupts — inside claude/codex's "press again to
+ *  exit" window, long enough for the first ^c to be processed. */
+export const INTERRUPT_TAP_GAP_MS = 250;
+/** Grace after the interrupts before relaunching in the same pane — lets the
+ *  agent process die and its shell repaint the prompt. */
+export const RESTART_GRACE_MS = 1000;

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -309,6 +309,23 @@ import {
   type RawEntry,
 } from "./file-tree.ts";
 import { spans, spanHit, spansFromRight, type Span } from "./spans.ts";
+import {
+  CUSTOM_KIND_ID,
+  INTERRUPT_TAP_GAP_MS,
+  RESTART_GRACE_MS,
+  agentKindItems,
+  clearAuthorityArgs,
+  interruptArgs,
+  launchCommandFor,
+  paneHostsShell,
+  placementItems,
+  relaunchArgs,
+  respawnArgs,
+  spawnAgentArgs,
+  spawnSessionArgs,
+  type SpawnPlacement,
+} from "./agent-lifecycle.ts";
+import { getManifests } from "../detect/manifest-loader.ts";
 import { agentsByPane, chipLabel } from "./agent-chip.ts";
 import { focusStrips } from "./focus-border.ts";
 import { scrollThumb, trackZone, pageTop, dragTop } from "./scrollbar-model.ts";
@@ -454,6 +471,7 @@ type HoverRegion =
   | "button"
   | "tabbtn"
   | "homechip"
+  | "homeagentchip"
   | "welcomeopen"
   | "sidebtn";
 
@@ -545,6 +563,9 @@ const PALETTE_ROWS = 10;
 const HOME_CHIP_SESSION = "[± diff] ";
 const HOME_CHIP_PROJECT = "[▸ launch] ";
 const HOME_CHIP_RECENT = "[▸ open] ";
+// The spawn verb's home entry (M23.1): session/project rows carry a second
+// chip left of the primary one; `a` is its keyboard twin.
+const HOME_CHIP_AGENT = "[+ agent] ";
 const TABBAR_PALETTE_LABEL = "F5 ⌘ palette ";
 // ── M22.5 first-run welcome ─────────────────────────────────────────────────
 // A centered greeting shown only on a truly empty fleet (no sessions, no
@@ -859,6 +880,8 @@ render(
       diffPath?: string;
       paneId?: string;
       windowIndex?: number;
+      /** The sidebar agent row a menu targets (M23.1 lifecycle verbs). */
+      agent?: AgentRowInput;
     }
     const [menu, setMenu] = createSignal<MenuState | null>(null);
     const [menuSel, setMenuSel] = createSignal(0);
@@ -1416,6 +1439,185 @@ render(
       });
     };
 
+    // ── AGENT LIFECYCLE (M23.1) — spawn / restart / stop / close ────────────
+    // The verbs go to tmux DIRECTLY (async execFile — the render-loop law, and
+    // the target agent may live in a session the mirror isn't attached to).
+    // The kind list / launch commands / exact argv are pure in
+    // agent-lifecycle.ts; only the dialog flows and the io live here.
+    const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+    /** One awaited tmux call; errors are swallowed (a dead pane target is a
+     *  normal race — the fleet poll shows the truth moments later). */
+    const tmuxRun = (args: string[]) =>
+      new Promise<void>((resolve) => execFile("tmux", args, () => resolve()));
+
+    /** Out-of-band stop hygiene: killing an agent ourselves fires NO lifecycle
+     *  hook (a clean exit's SessionEnd stamps idle), so a working/blocked
+     *  authority stamp would keep lying until the 10-minute staleness guard.
+     *  Unset both pane options — the same "no authority" end state. */
+    const clearAgentAuthority = async (paneId: string) => {
+      for (const args of clearAuthorityArgs(paneId)) await tmuxRun(args);
+    };
+
+    /** ctrl-c TWICE: TUI agents (claude, codex) treat a single ^c as "clear
+     *  input / cancel turn" and only a quick second one as exit; a plain
+     *  process ignores the repeat. */
+    const interruptAgent = async (paneId: string) => {
+      await tmuxRun(interruptArgs(paneId));
+      await sleep(INTERRUPT_TAP_GAP_MS);
+      await tmuxRun(interruptArgs(paneId));
+    };
+
+    const stopAgentFlow = async (a: Pick<AgentRowInput, "paneId" | "kind">) => {
+      const ok = await DialogConfirm.show({
+        title: `Stop ${a.kind}?`,
+        body: "Interrupts the agent (ctrl-c). The pane and its shell stay open.",
+        yesLabel: "Stop it",
+        noLabel: "Cancel",
+        defaultNo: true,
+      });
+      if (!ok) return;
+      await interruptAgent(a.paneId);
+      await clearAgentAuthority(a.paneId);
+      setStatusNote(`stopped ${a.kind}`);
+      setTimeout(() => fleetRefresh?.(), 500);
+    };
+
+    /** The pane's `pane_start_command` (its ROOT: "" = default shell) +
+     *  `pane_current_path`, or null when the pane is gone. One async display
+     *  call (tab-joined). NOT pane_current_command — that is the FOREGROUND
+     *  process, so a user-typed `claude` under zsh would read as `claude` too
+     *  and be indistinguishable from a pane-command agent (measured). */
+    const paneStartAndPath = (paneId: string) =>
+      new Promise<{ start: string; path: string } | null>((resolve) =>
+        execFile(
+          "tmux",
+          ["display", "-p", "-t", paneId, "#{pane_start_command}\t#{pane_current_path}"],
+          (err, stdout) => {
+            if (err) return resolve(null);
+            const [start = "", path = ""] = stdout.trimEnd().split("\t");
+            resolve({ start, path });
+          },
+        ),
+      );
+
+    /** Two restart strategies, picked by what the pane's ROOT process is:
+     *  shell-hosted agents get ctrl-c + relaunch via send-keys (the shell
+     *  survives to type into); when the agent IS the pane's own process (our
+     *  spawn verb's panes), ctrl-c would end the pane — respawn it in place
+     *  instead (same pane id, cwd pinned explicitly). Both paths clear the
+     *  authority stamps. */
+    const restartAgentFlow = async (a: Pick<AgentRowInput, "paneId" | "kind">) => {
+      const manifests = getManifests();
+      const command = launchCommandFor(a.kind, manifests);
+      const live = await paneStartAndPath(a.paneId);
+      if (!live) {
+        setStatusNote("that pane is gone — refreshing");
+        setTimeout(() => fleetRefresh?.(), 300);
+        return;
+      }
+      const underShell = paneHostsShell(live.start, manifests);
+      const ok = await DialogConfirm.show({
+        title: `Restart ${a.kind}?`,
+        body: underShell
+          ? `Stops it with ctrl-c, waits a moment, then runs "${command}" again in the same pane.`
+          : `The agent is this pane's own process, so the pane is relaunched in place running "${command}".`,
+        yesLabel: "Restart it",
+        noLabel: "Cancel",
+        defaultNo: true,
+      });
+      if (!ok) return;
+      if (underShell) {
+        await interruptAgent(a.paneId);
+        await clearAgentAuthority(a.paneId);
+        await sleep(RESTART_GRACE_MS);
+        for (const args of relaunchArgs(a.paneId, command)) await tmuxRun(args);
+      } else {
+        await clearAgentAuthority(a.paneId);
+        await tmuxRun(respawnArgs(a.paneId, command, live.path || null));
+      }
+      setStatusNote(`restarted ${a.kind}`);
+      setTimeout(() => fleetRefresh?.(), 1500);
+    };
+
+    /** The destructive twin of stop: kill the agent's pane. Confirmation is the
+     *  caller's job (the menu's armed "confirm: y" state). The pane's options
+     *  die with it, so no authority cleanup is needed. */
+    const closeAgentPane = (a: Pick<AgentRowInput, "paneId" | "kind">) => {
+      execFile("tmux", ["kill-pane", "-t", a.paneId], () =>
+        setTimeout(() => fleetRefresh?.(), 300),
+      );
+      setStatusNote(`closed ${a.kind}'s pane`);
+    };
+
+    /** The spawn flow: WHAT runs (manifest kinds + a custom command) → WHERE
+     *  (splits only when a concrete pane exists) → run it. Without a live
+     *  session (a home project row) the agent gets a fresh detached session in
+     *  the project dir. Detection needs no extra wiring: the spawned pane's
+     *  command IS the agent, so the next fleet poll classifies it. */
+    interface NewAgentContext {
+      session?: string;
+      dir: string | null;
+      paneId?: string;
+      /** Names the fresh session when there is no live one (project rows). */
+      sessionName?: string;
+    }
+    const newAgentFlow = async (ctx: NewAgentContext) => {
+      setHoverIf(null); // the overlay owns the pointer, like the palette
+      const manifests = getManifests();
+      const kind = await DialogSelect.show({
+        title: "New agent — what should run?",
+        items: agentKindItems(manifests),
+        footerHint: "pick an agent, or type your own command",
+      });
+      if (!kind) return;
+      let command: string;
+      if (kind.item.id === CUSTOM_KIND_ID) {
+        const typed = await DialogPrompt.show({
+          title: "Custom command",
+          placeholder: "my-agent --flag",
+          footerHint: "runs as the new pane's command",
+          validate: (v) => (v.trim().length > 0 ? null : "Type a command, or press esc to go back"),
+        });
+        if (typed === null) return;
+        command = typed.trim();
+      } else {
+        command = launchCommandFor(kind.item.id, manifests);
+      }
+      if (!ctx.session) {
+        const base = ctx.sessionName ?? basename(ctx.dir ?? invokeCwd);
+        const name = sessionNameFor(base || "agents");
+        execFile("tmux", spawnSessionArgs(name, ctx.dir, command), (err) => {
+          setStatusNote(err ? `couldn't start ${command}` : `started ${command} in ${name}`);
+          if (!err) execFile("tmux", ["set-environment", "-t", name, "TMUX_IDE", "1"], () => {});
+          setTimeout(() => fleetRefresh?.(), 300);
+        });
+        return;
+      }
+      const where = await DialogSelect.show({
+        title: "Where should it run?",
+        items: placementItems({ split: ctx.paneId !== undefined }),
+        filterable: false,
+      });
+      if (!where) return;
+      const placement = where.item.id as SpawnPlacement;
+      const target = { session: ctx.session, paneId: ctx.paneId };
+      execFile("tmux", spawnAgentArgs(placement, target, ctx.dir, command), (err) => {
+        setStatusNote(err ? `couldn't start ${command}` : `started ${command} in ${ctx.session}`);
+        setTimeout(() => fleetRefresh?.(), 300);
+      });
+    };
+
+    /** "New agent…" for a home row (the [+ agent] chip, the `a` key, the home
+     *  palette command): a session row spawns into that session, a project/
+     *  recent row into a fresh session in its dir; with nothing useful selected
+     *  fall back to the working directory. */
+    const newAgentFromHome = (it: HomeItem | undefined) => {
+      if (it?.kind === "session") void newAgentFlow({ session: it.session, dir: it.dir });
+      else if (it?.kind === "project") void newAgentFlow({ dir: it.dir, sessionName: it.name });
+      else if (it?.kind === "recent") void newAgentFlow({ dir: it.dir });
+      else void newAgentFlow({ dir: invokeCwd });
+    };
+
     // ── OPEN A FOLDER (M22.5) — the non-technicals' front door ───────────────
     // A filesystem picker (a DialogSelect browse loop over ASYNC readdir) →
     // create-or-attach a session in the chosen dir → openWorkspace, then two
@@ -1701,6 +1903,32 @@ render(
           break;
         case "jump-agent":
           jumpToAgent(a);
+          break;
+        case "new-agent":
+          // Contextual target: the Terminal surface spawns into the mirrored
+          // session (splits offered — a focused pane exists); home uses the
+          // selected row; anywhere else the workspace session, else a fresh one.
+          if (mode() === "mirror") {
+            // The mirrored session's OWN dir first: contextDir can be a stale
+            // persisted workspace when the app booted straight to --target.
+            void newAgentFlow({
+              session: curTarget(),
+              dir: dirForSession(curTarget()) ?? (contextDir() || null),
+              paneId: mirror?.focusedPane() ?? undefined,
+            });
+          } else if (mode() === "home") {
+            newAgentFromHome(selectedHomeItem());
+          } else if (contextSession()) {
+            void newAgentFlow({ session: contextSession(), dir: contextDir() || null });
+          } else {
+            void newAgentFlow({ dir: workspaceDir() });
+          }
+          break;
+        case "restart-agent":
+          void restartAgentFlow({ paneId: a.paneId, kind: a.agentKind });
+          break;
+        case "stop-agent":
+          void stopAgentFlow({ paneId: a.paneId, kind: a.agentKind });
           break;
         case "open-file":
           openEditor(a.path);
@@ -2728,10 +2956,21 @@ render(
       if (y === 0) return null; // the surface tab bar owns row 0
       const gy = y - TABBAR_H;
       if (x < sidebarW()) {
-        // Only SESSION rows carry a context menu; agent rows (left-click jumps),
-        // the gap, header, and empty-state line have none. Route through the same
-        // sidebarHit the click/hover resolvers use so the ranges never diverge.
+        // SESSION rows carry the session menu; AGENT rows carry the lifecycle
+        // menu (M23.1 — left-click still jumps). The gap, header, and
+        // empty-state line have none. Route through the same sidebarHit the
+        // click/hover resolvers use so the ranges never diverge.
         const hit = sidebarHit(gy, fleet().length, fleetAgents().length);
+        if (hit?.kind === "agent") {
+          const a = fleetAgents()[hit.index];
+          if (!a) return null;
+          return {
+            region: "agent",
+            title: `${a.kind} · ${a.session}`,
+            items: MENU_ITEMS.agent,
+            agent: a,
+          };
+        }
         if (hit?.kind !== "session") return null;
         const s = fleet()[hit.index];
         if (!s) return null;
@@ -2895,11 +3134,28 @@ render(
       const m = menu();
       if (!m) return;
       const val = (input ?? "").trim();
+      if (m.region === "agent") {
+        // The sidebar agent row's lifecycle verbs (M23.1). restart/stop confirm
+        // via DialogConfirm inside their flows; close fired through the menu's
+        // armed "confirm: y" state (danger), so it runs immediately here.
+        const a = m.agent!;
+        closeMenu();
+        if (id === "jump") jumpToAgent(a);
+        else if (id === "restart") void restartAgentFlow(a);
+        else if (id === "stop") void stopAgentFlow(a);
+        else if (id === "close") closeAgentPane(a);
+        return;
+      }
       if (m.region === "session") {
         const name = m.session!;
         if (id === "attach") {
           closeMenu();
           openWorkspace(name, m.sessionDir ?? null);
+          return;
+        }
+        if (id === "new-agent") {
+          closeMenu();
+          void newAgentFlow({ session: name, dir: m.sessionDir ?? null });
           return;
         }
         if (id === "kill") {
@@ -3273,6 +3529,12 @@ render(
           setSessionPrompt("");
           return;
         }
+        // `a` — the row [+ agent] chip's keyboard twin (M23.1): spawn an agent
+        // for the selected row (or a fresh session when nothing is selected).
+        if (evt.name === "a") {
+          newAgentFromHome(selectedHomeItem());
+          return;
+        }
         // `d` — open the diff panel for the selected row's project dir (the
         // home item carries it via the team payload), adopting it as context.
         if (evt.name === "d") {
@@ -3416,6 +3678,7 @@ render(
           ? [
               { id: "home-openfolder", label: "[f open folder]" },
               { id: "home-new", label: "[n new session]" },
+              { id: "home-agent", label: "[a new agent]" },
               { id: "home-open", label: "[o open]" },
               { id: "home-diff", label: "[d diff]" },
             ]
@@ -3470,6 +3733,7 @@ render(
         const pid = mirror?.focusedPane();
         if (pid) void mirror?.command(`resize-pane -Z -t ${pid}`).catch(() => {});
       } else if (id === "home-openfolder") void openFolderFlow();
+      else if (id === "home-agent") newAgentFromHome(selectedHomeItem());
       else if (id === "home-open") setPathPrompt("");
       else if (id === "home-new") setSessionPrompt("");
       else if (id === "home-diff") {
@@ -3537,10 +3801,32 @@ render(
           : it?.kind === "recent"
             ? HOME_CHIP_RECENT
             : "";
-    const homeChipHit = (it: HomeItem | undefined, x: number): boolean => {
-      const label = homeChipLabel(it);
-      if (!label) return false;
-      return spanHit(spansFromRight([label], buttonRightEdge(), 0), x) === 0;
+    /** A home row's chip list, left to right: session/project rows lead with
+     *  the [+ agent] spawn chip (M23.1), then every row's PRIMARY verb chip.
+     *  The render walks these defs and the hit-test lays the SAME labels out
+     *  from the right edge, so clicks land exactly on what's drawn. */
+    const homeRowChips = (it: HomeItem | undefined): { id: "agent" | "primary"; label: string }[] => {
+      const defs: { id: "agent" | "primary"; label: string }[] = [];
+      if (it?.kind === "session" || it?.kind === "project") {
+        defs.push({ id: "agent", label: HOME_CHIP_AGENT });
+      }
+      const primary = homeChipLabel(it);
+      if (primary) defs.push({ id: "primary", label: primary });
+      return defs;
+    };
+    /** Which chip (if any) column `x` hits on the row for `it`. */
+    const homeChipAt = (it: HomeItem | undefined, x: number): "agent" | "primary" | null => {
+      const defs = homeRowChips(it);
+      if (defs.length === 0) return null;
+      const i = spanHit(
+        spansFromRight(
+          defs.map((d) => d.label),
+          buttonRightEdge(),
+          0,
+        ),
+        x,
+      );
+      return i >= 0 ? defs[i]!.id : null;
     };
     /** A home row's muted meta text — sessions keep the exact `3w · project`
      *  string the panel always showed; projects show their dir + origin. */
@@ -3600,7 +3886,11 @@ render(
           setHoverIf(null);
           return;
         }
-        setHoverIf({ region: homeChipHit(it, x) ? "homechip" : "home", index: idx });
+        const chip = homeChipAt(it, x);
+        setHoverIf({
+          region: chip === "agent" ? "homeagentchip" : chip === "primary" ? "homechip" : "home",
+          index: idx,
+        });
         return;
       }
       if (m === "editor") {
@@ -3990,12 +4280,17 @@ render(
           void openFolderFlow();
           return;
         }
-        // A row click: the right-aligned verb chip wins over the row body;
+        // A row click: the right-aligned verb chips win over the row body
+        // ([+ agent] spawns — M23.1; the primary chip diffs/launches/reopens);
         // header rows are inert. Sessions open, projects launch, recents reopen.
         const idx = homeItemIndexAt(gy);
         const it = homeItems()[idx];
         if (!it || it.kind === "header") return;
-        if (homeChipHit(it, x)) runHomeChip(idx);
+        const chip = homeChipAt(it, x);
+        if (chip === "agent") {
+          setSel(idx);
+          newAgentFromHome(it);
+        } else if (chip === "primary") runHomeChip(idx);
         else activateHomeItem(idx);
         return;
       }
@@ -4490,12 +4785,23 @@ render(
                         </text>
                         <text fg={MUTED}>{homeRowMeta(it)}</text>
                         <box flexGrow={1} />
-                        <text
-                          fg={BUTTON_FG}
-                          bg={isHovered("homechip", i()) ? BUTTON_HOVER_BG : BUTTON_BG}
-                        >
-                          {homeChipLabel(it)}
-                        </text>
+                        {/* The row's chips (M23.1: [+ agent] before the primary
+                          verb) — the SAME defs homeChipAt lays out from the
+                          right edge, so hover/click match cell-for-cell. */}
+                        <For each={homeRowChips(it)}>
+                          {(c) => (
+                            <text
+                              fg={BUTTON_FG}
+                              bg={
+                                isHovered(c.id === "agent" ? "homeagentchip" : "homechip", i())
+                                  ? BUTTON_HOVER_BG
+                                  : BUTTON_BG
+                              }
+                            >
+                              {c.label}
+                            </text>
+                          )}
+                        </For>
                       </box>
                     </Show>
                   )}

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -3805,7 +3805,9 @@ render(
      *  the [+ agent] spawn chip (M23.1), then every row's PRIMARY verb chip.
      *  The render walks these defs and the hit-test lays the SAME labels out
      *  from the right edge, so clicks land exactly on what's drawn. */
-    const homeRowChips = (it: HomeItem | undefined): { id: "agent" | "primary"; label: string }[] => {
+    const homeRowChips = (
+      it: HomeItem | undefined,
+    ): { id: "agent" | "primary"; label: string }[] => {
       const defs: { id: "agent" | "primary"; label: string }[] = [];
       if (it?.kind === "session" || it?.kind === "project") {
         defs.push({ id: "agent", label: HOME_CHIP_AGENT });

--- a/packages/daemon/src/tui/mirror/menu-model.test.ts
+++ b/packages/daemon/src/tui/mirror/menu-model.test.ts
@@ -13,7 +13,8 @@ import {
 
 describe("MENU_ITEMS", () => {
   it("names one fixed list per region", () => {
-    expect(MENU_ITEMS.session.map((i) => i.id)).toEqual(["attach", "rename", "kill"]);
+    expect(MENU_ITEMS.session.map((i) => i.id)).toEqual(["attach", "new-agent", "rename", "kill"]);
+    expect(MENU_ITEMS.agent.map((i) => i.id)).toEqual(["jump", "restart", "stop", "close"]);
     expect(MENU_ITEMS.file.map((i) => i.id)).toEqual(["open", "newfile", "rename", "delete"]);
     expect(MENU_ITEMS.difffile.map((i) => i.id)).toEqual(["open", "copypath"]);
     expect(MENU_ITEMS.pane.map((i) => i.id)).toEqual([
@@ -47,6 +48,10 @@ describe("MENU_ITEMS", () => {
     expect(MENU_ITEMS.pane.find((i) => i.id === "kill")?.danger).toBe(true);
     expect(MENU_ITEMS.file.find((i) => i.id === "delete")?.danger).toBe(true);
     expect(MENU_ITEMS.window.find((i) => i.id === "kill")?.danger).toBe(true);
+    // "Close pane" kills the agent's pane — destructive; "Stop agent" (an
+    // interrupt, pane survives) confirms via DialogConfirm instead.
+    expect(MENU_ITEMS.agent.find((i) => i.id === "close")?.danger).toBe(true);
+    expect(MENU_ITEMS.agent.find((i) => i.id === "stop")?.danger).toBeUndefined();
     expect(MENU_ITEMS.session.find((i) => i.id === "rename")?.input).toBe("rename to");
     expect(MENU_ITEMS.file.find((i) => i.id === "newfile")?.input).toBe("new file");
     expect(MENU_ITEMS.window.find((i) => i.id === "rename")?.input).toBe("rename to");

--- a/packages/daemon/src/tui/mirror/menu-model.ts
+++ b/packages/daemon/src/tui/mirror/menu-model.ts
@@ -16,7 +16,7 @@
 /** The surfaces a right-click can target. Each maps to a fixed item list; the
  *  concrete payload (session name, file path, pane id) rides in the app's menu
  *  state, not here. */
-export type MenuRegion = "session" | "file" | "difffile" | "pane" | "window";
+export type MenuRegion = "session" | "agent" | "file" | "difffile" | "pane" | "window";
 
 /** One menu entry. `id` is what the app dispatches on; `danger` items rearm to
  *  a "confirm: y" state instead of firing immediately; `input` items open an
@@ -36,8 +36,20 @@ export interface MenuItem {
 export const MENU_ITEMS: Record<MenuRegion, MenuItem[]> = {
   session: [
     { id: "attach", label: "Attach" },
+    { id: "new-agent", label: "New agent…" },
     { id: "rename", label: "Rename", input: "rename to" },
     { id: "kill", label: "Kill session", danger: true },
+  ],
+  // Sidebar AGENT rows (M23.1): a left-click jumps; the context menu carries
+  // the lifecycle verbs. "Stop agent" only interrupts (the pane survives);
+  // "Close pane" is the destructive twin that also kills the pane. restart/
+  // stop confirm via DialogConfirm in the app (plain-language body), so only
+  // close — where there is no dialog — uses the inline confirm rearm.
+  agent: [
+    { id: "jump", label: "Go to agent" },
+    { id: "restart", label: "Restart agent" },
+    { id: "stop", label: "Stop agent" },
+    { id: "close", label: "Close pane", danger: true },
   ],
   file: [
     { id: "open", label: "Open" },

--- a/packages/daemon/src/tui/mirror/palette.test.ts
+++ b/packages/daemon/src/tui/mirror/palette.test.ts
@@ -10,6 +10,7 @@ describe("staticPaletteActions", () => {
       "Switch tab: Files",
       "Switch tab: Diff",
       "Open folder…",
+      "New agent…",
       "Attach session: alpha",
       "Attach session: beta",
       "Save file",
@@ -36,6 +37,34 @@ describe("staticPaletteActions", () => {
   it("typing 'set' surfaces the settings umbrella (the battery's palette entry)", () => {
     const filtered = filterPaletteActions("set", []);
     expect(filtered.some((a) => a.kind === "settings" && a.id === "settings")).toBe(true);
+  });
+
+  it("offers new-agent on every surface, and per-agent lifecycle verbs after the jumps (M23.1)", () => {
+    expect(staticPaletteActions([]).some((a) => a.kind === "new-agent")).toBe(true);
+    const agent = {
+      paneId: "%4",
+      windowIndex: 1,
+      session: "web",
+      kind: "claude",
+      state: "working" as const,
+      since: null,
+    };
+    const actions = staticPaletteActions(["web"], { agents: [agent] });
+    const labels = actions.map((a) => a.label);
+    const jump = labels.indexOf("Agent: claude · web (working)");
+    const restart = labels.indexOf("Restart agent: claude · web");
+    const stop = labels.indexOf("Stop agent: claude · web");
+    expect(jump).toBeGreaterThanOrEqual(0);
+    expect(restart).toBeGreaterThan(jump);
+    expect(stop).toBeGreaterThan(restart);
+    const r = actions[restart]!;
+    expect(r.kind === "restart-agent" && r.paneId === "%4" && r.agentKind === "claude").toBe(true);
+    // typing "restart" narrows straight to the verb
+    expect(
+      filterPaletteActions("restart", ["web"], { agents: [agent] }).some(
+        (a) => a.kind === "restart-agent",
+      ),
+    ).toBe(true);
   });
 
   it("offers the paste-buffer action on every surface (no terminal gate)", () => {
@@ -69,7 +98,7 @@ describe("filterPaletteActions", () => {
   it("returns every static action for an empty query, no open-file entry", () => {
     const actions = filterPaletteActions("", ["alpha"]);
     expect(actions.some((a) => a.kind === "open-file")).toBe(false);
-    expect(actions).toHaveLength(18);
+    expect(actions).toHaveLength(19);
   });
 
   it("fuzzy-ranks matches and appends an open-file action for a plain word", () => {

--- a/packages/daemon/src/tui/mirror/palette.ts
+++ b/packages/daemon/src/tui/mirror/palette.ts
@@ -23,6 +23,13 @@ export type PaletteAction =
   | { kind: "open-folder"; label: string }
   | { kind: "attach"; session: string; label: string }
   | { kind: "jump-agent"; paneId: string; session: string; windowIndex: number; label: string }
+  // The lifecycle verbs (M23.1) — `agentKind` (not `kind`, taken by the action
+  // discriminant) is the manifest id the restart flow resolves a launch
+  // command from. Each fleet agent gets one restart + one stop row; "New
+  // agent…" opens the spawn flow (kind → placement → run) on the dialog stack.
+  | { kind: "new-agent"; label: string }
+  | { kind: "restart-agent"; paneId: string; agentKind: string; session: string; label: string }
+  | { kind: "stop-agent"; paneId: string; agentKind: string; session: string; label: string }
   | { kind: "open-file"; path: string; label: string }
   | { kind: "save"; label: string }
   | { kind: "refresh-diff"; label: string }
@@ -93,6 +100,9 @@ export function staticPaletteActions(
   // The non-technicals' front door (M22.5): a filesystem picker → create-or-
   // attach a session in the chosen folder. Offered on every surface.
   actions.push({ kind: "open-folder", label: "Open folder…" });
+  // Spawn an agent (M23.1) — offered on every surface; the flow's placement
+  // step is what's contextual (splits only where a focused pane exists).
+  actions.push({ kind: "new-agent", label: "New agent…" });
   for (const s of sessions) {
     actions.push({ kind: "attach", session: s, label: `Attach session: ${s}` });
   }
@@ -106,6 +116,25 @@ export function staticPaletteActions(
       session: a.session,
       windowIndex: a.windowIndex,
       label: `Agent: ${a.kind} · ${a.session} (${a.state})`,
+    });
+  }
+  // The per-agent lifecycle verbs (M23.1), grouped after the jumps so an empty
+  // query reads jump-first; the fuzzy filter finds "restart"/"stop" directly.
+  for (const a of ctx.agents ?? []) {
+    const who = `${a.kind} · ${a.session}`;
+    actions.push({
+      kind: "restart-agent",
+      paneId: a.paneId,
+      agentKind: a.kind,
+      session: a.session,
+      label: `Restart agent: ${who}`,
+    });
+    actions.push({
+      kind: "stop-agent",
+      paneId: a.paneId,
+      agentKind: a.kind,
+      session: a.session,
+      label: `Stop agent: ${who}`,
     });
   }
   actions.push({ kind: "save", label: "Save file" });


### PR DESCRIPTION
Card #94: the app now manages the fleet, not just watches it. Spawn with manifest-sourced kinds, restart branched on pane_start_command (the measured discriminator — foreground command lies), stop with authority-stamp hygiene. Full injected battery on both restart strategies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)