### PR TITLE
feat: detachable cockpit — reattach the app from anywhere (M23.2)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3103,7 +3103,10 @@ function parseAppConfig(input) {
     welcome: { show: pickBool(welcome.show, D.welcome.show) },
     integrations: { offer: pickBool(integrations.offer, D.integrations.offer) },
     worktrees: { dir: pickString(worktrees.dir, D.worktrees.dir) },
-    app: { frontDoor: pickBool(app.frontDoor, D.app.frontDoor) }
+    app: {
+      frontDoor: pickBool(app.frontDoor, D.app.frontDoor),
+      detachable: pickBool(app.detachable, D.app.detachable)
+    }
   };
 }
 function appConfigPath() {
@@ -3197,7 +3200,7 @@ var init_app_config = __esm({
       welcome: { show: true },
       integrations: { offer: true },
       worktrees: { dir: "" },
-      app: { frontDoor: false }
+      app: { frontDoor: false, detachable: false }
     };
     DEFAULT_THEME = DEFAULT_APP_CONFIG.theme;
     DEFAULT_KEYS = DEFAULT_APP_CONFIG.keys;
@@ -13066,6 +13069,50 @@ function reportPlan(plan, snapshot, { json: json2, dryRun, restored, launched, r
 init_send();
 init_errors2();
 init_output();
+
+// packages/daemon/src/tui/mirror/hosted.ts
+var APP_HOST_SESSION = "_tmux-ide-app";
+var HOSTED_ENV = "TMUX_IDE_HOSTED";
+function wantsHostedApp(input) {
+  if (input.hostedEnv) return false;
+  return input.flagDetachable || input.flagHosted || input.configDetachable;
+}
+function shellQuote(word) {
+  return `'${word.replaceAll("'", `'\\''`)}'`;
+}
+function hostedEnvVars(base) {
+  const env = {
+    [HOSTED_ENV]: "1",
+    TMUX_IDE_CWD: base.cwd,
+    TMUX_IDE_CLI: base.cli
+  };
+  if (base.path) env.PATH = base.path;
+  if (base.home) env.TMUX_IDE_HOME = base.home;
+  if (base.config) env.TMUX_IDE_CONFIG = base.config;
+  if (base.tuiBin) env.TMUX_IDE_TUI_BIN = base.tuiBin;
+  return env;
+}
+function hostedCommandLine(bin, argv, env) {
+  const assigns = Object.entries(env).map(([k, v]) => `${k}=${shellQuote(v)}`);
+  return ["exec", "env", ...assigns, shellQuote(bin), ...argv.map(shellQuote)].join(" ");
+}
+function hostExistsArgv() {
+  return ["has-session", "-t", `=${APP_HOST_SESSION}`];
+}
+function hostCreateArgv(opts) {
+  return ["new-session", "-d", "-s", APP_HOST_SESSION, "-c", opts.cwd, opts.commandLine];
+}
+function hostSetupArgvs() {
+  return [
+    ["set-option", "-t", APP_HOST_SESSION, "status", "off"],
+    ["set-option", "-w", "-t", `${APP_HOST_SESSION}:`, "window-size", "latest"]
+  ];
+}
+function hostAttachArgv(insideTmux) {
+  return insideTmux ? ["switch-client", "-t", `=${APP_HOST_SESSION}`] : ["attach-session", "-t", `=${APP_HOST_SESSION}`];
+}
+
+// bin/cli.ts
 var __dirname6 = dirname23(fileURLToPath9(import.meta.url));
 var selfPath = fileURLToPath9(import.meta.url);
 var nodeCliPath = selfPath.endsWith(".js") ? selfPath : resolve23(__dirname6, "cli.js");
@@ -13120,6 +13167,10 @@ var { positionals, values } = parseArgs({
     // actions menu opens at the pointer instead of centered (see `menu` case)
     x: { type: "string" },
     y: { type: "string" },
+    // app: host the cockpit in the internal `_tmux-ide-app` session and attach
+    // to it (M23.2) — `--detachable` is the primary name, `--hosted` the alias
+    detachable: { type: "boolean" },
+    hosted: { type: "boolean" },
     // worktree: base ref for a new branch, the worktree checkout dir override,
     // skip creating a session, and force-remove a dirty worktree (see `worktree`)
     from: { type: "string" },
@@ -13208,6 +13259,7 @@ ${bold3("Usage:")}
   ${cyan2("tmux-ide attach")}             ${dim3("Reattach to a running session")}
   ${cyan2("tmux-ide team")} [--json]      ${dim3("TUI over all tmux sessions (--json prints fleet state)")}
   ${cyan2("tmux-ide app")} [session]      ${dim3("Unified app: fleet home + live session mirror (bare = home)")}
+  ${cyan2("tmux-ide app --detachable")}   ${dim3("Host the app in tmux and attach \u2014 survives the terminal, ^q detaches")}
   ${cyan2("tmux-ide switcher")}           ${dim3("Compact session picker (opens in the M-p popup on adopted sessions)")}
   ${cyan2("tmux-ide wait agent-status")} <session> --status <s> [--timeout <ms>]
                               ${dim3("Block until a session reaches a status (exit 0 match / 1 timeout)")}
@@ -13302,6 +13354,47 @@ Install bun (https://bun.sh) \u2014 the TUI surfaces run on it. Sources ship wit
   }
   execFileSync14(launch2.bin, launch2.argv, { stdio: "inherit", env });
 }
+function launchHostedApp(scriptPath, appArgs) {
+  const launch2 = resolveTuiLaunch({
+    surface: "app",
+    scriptPath,
+    args: appArgs,
+    checkoutExists: existsSync33(scriptPath),
+    bunAvailable: isBunAvailable(),
+    compiledBinary: findCompiledTui()
+  });
+  if (launch2.mode === "unavailable") {
+    throw new IdeError(
+      `\`tmux-ide app --detachable\` is unavailable because ${launch2.reasons.join(" and ")}.
+Install bun (https://bun.sh) \u2014 the TUI surfaces run on it. Sources ship with the npm package since v2.6.1.`,
+      { code: "USAGE", exitCode: 1 }
+    );
+  }
+  let exists = true;
+  try {
+    execFileSync14("tmux", hostExistsArgv(), { stdio: "ignore" });
+  } catch {
+    exists = false;
+  }
+  if (!exists) {
+    const cwd = launch2.mode === "bun" ? resolve23(__dirname6, "..") : process.cwd();
+    const commandLine = hostedCommandLine(
+      launch2.bin,
+      launch2.argv,
+      hostedEnvVars({
+        cwd: process.cwd(),
+        cli: nodeCliPath,
+        path: process.env.PATH,
+        home: process.env.TMUX_IDE_HOME,
+        config: process.env.TMUX_IDE_CONFIG,
+        tuiBin: process.env.TMUX_IDE_TUI_BIN
+      })
+    );
+    execFileSync14("tmux", hostCreateArgv({ cwd, commandLine }), { stdio: "ignore" });
+    for (const args of hostSetupArgvs()) execFileSync14("tmux", args, { stdio: "ignore" });
+  }
+  execFileSync14("tmux", hostAttachArgv(Boolean(process.env.TMUX)), { stdio: "inherit" });
+}
 async function printFleetJson() {
   const { createStatusTracker: createStatusTracker2 } = await Promise.resolve().then(() => (init_classify(), classify_exports));
   const { listTeamProjects: listTeamProjects2 } = await Promise.resolve().then(() => (init_projects(), projects_exports));
@@ -13313,8 +13406,18 @@ var appScriptPath = resolve23(__dirname6, "../packages/daemon/src/tui/mirror/app
 function launchTeamCockpit() {
   execBunWidget("team", teamScriptPath, [], "team");
 }
+function runApp(appArgs) {
+  const hosted = wantsHostedApp({
+    flagDetachable: values.detachable === true,
+    flagHosted: values.hosted === true,
+    configDetachable: loadAppConfig().app.detachable,
+    hostedEnv: process.env[HOSTED_ENV] === "1"
+  });
+  if (hosted) launchHostedApp(appScriptPath, appArgs);
+  else execBunWidget("app", appScriptPath, appArgs, "app");
+}
 function launchApp() {
-  execBunWidget("app", appScriptPath, [], "app");
+  runApp([]);
 }
 try {
   switch (command) {
@@ -13474,7 +13577,7 @@ try {
     case "app": {
       const session = positionals[1];
       const appArgs = session ? [`--target=${session}`] : [];
-      execBunWidget("app", appScriptPath, appArgs, "app");
+      runApp(appArgs);
       break;
     }
     case "switcher": {

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -40,6 +40,16 @@ import { restore } from "../packages/daemon/src/restore.ts";
 import { send } from "../packages/daemon/src/send.ts";
 import { IdeError } from "../packages/daemon/src/lib/errors.ts";
 import { printCommandError } from "../packages/daemon/src/lib/output.ts";
+import {
+  wantsHostedApp,
+  hostedEnvVars,
+  hostedCommandLine,
+  hostExistsArgv,
+  hostCreateArgv,
+  hostSetupArgvs,
+  hostAttachArgv,
+  HOSTED_ENV,
+} from "../packages/daemon/src/tui/mirror/hosted.ts";
 
 const { positionals, values } = parseArgs({
   allowPositionals: true,
@@ -92,6 +102,10 @@ const { positionals, values } = parseArgs({
     // actions menu opens at the pointer instead of centered (see `menu` case)
     x: { type: "string" },
     y: { type: "string" },
+    // app: host the cockpit in the internal `_tmux-ide-app` session and attach
+    // to it (M23.2) — `--detachable` is the primary name, `--hosted` the alias
+    detachable: { type: "boolean" },
+    hosted: { type: "boolean" },
     // worktree: base ref for a new branch, the worktree checkout dir override,
     // skip creating a session, and force-remove a dirty worktree (see `worktree`)
     from: { type: "string" },
@@ -188,6 +202,7 @@ ${bold("Usage:")}
   ${cyan("tmux-ide attach")}             ${dim("Reattach to a running session")}
   ${cyan("tmux-ide team")} [--json]      ${dim("TUI over all tmux sessions (--json prints fleet state)")}
   ${cyan("tmux-ide app")} [session]      ${dim("Unified app: fleet home + live session mirror (bare = home)")}
+  ${cyan("tmux-ide app --detachable")}   ${dim("Host the app in tmux and attach — survives the terminal, ^q detaches")}
   ${cyan("tmux-ide switcher")}           ${dim("Compact session picker (opens in the M-p popup on adopted sessions)")}
   ${cyan("tmux-ide wait agent-status")} <session> --status <s> [--timeout <ms>]
                               ${dim("Block until a session reaches a status (exit 0 match / 1 timeout)")}
@@ -306,6 +321,58 @@ function execBunWidget(
   execFileSync(launch.bin, launch.argv, { stdio: "inherit", env });
 }
 
+// The detachable cockpit (M23.2): instead of running the app in THIS terminal,
+// ensure the internal `_tmux-ide-app` session exists running it full-screen
+// (status off, window-size latest — see hostSetupArgvs), then attach here.
+// Re-invocation from any terminal reattaches the SAME cockpit; ^q inside a
+// hosted app detaches (the HOSTED_ENV marker on the pane command flips it).
+// Inside tmux the client switch-clients instead of nesting an attach.
+function launchHostedApp(scriptPath: string, appArgs: string[]): void {
+  const launch = resolveTuiLaunch({
+    surface: "app",
+    scriptPath,
+    args: appArgs,
+    checkoutExists: existsSync(scriptPath),
+    bunAvailable: isBunAvailable(),
+    compiledBinary: findCompiledTui(),
+  });
+  if (launch.mode === "unavailable") {
+    throw new IdeError(
+      `\`tmux-ide app --detachable\` is unavailable because ${launch.reasons.join(" and ")}.\n` +
+        `Install bun (https://bun.sh) — the TUI surfaces run on it. Sources ship with the npm package since v2.6.1.`,
+      { code: "USAGE", exitCode: 1 },
+    );
+  }
+
+  let exists = true;
+  try {
+    execFileSync("tmux", hostExistsArgv(), { stdio: "ignore" });
+  } catch {
+    exists = false; // also covers "no server yet" — new-session starts one
+  }
+  if (!exists) {
+    // Same cwd rule as execBunWidget: bun needs the repo root (bunfig preload),
+    // the compiled binary must NOT run from it. The app's real env travels on
+    // the pane command line — the tmux server's environment is not ours.
+    const cwd = launch.mode === "bun" ? resolve(__dirname, "..") : process.cwd();
+    const commandLine = hostedCommandLine(
+      launch.bin,
+      launch.argv,
+      hostedEnvVars({
+        cwd: process.cwd(),
+        cli: nodeCliPath,
+        path: process.env.PATH,
+        home: process.env.TMUX_IDE_HOME,
+        config: process.env.TMUX_IDE_CONFIG,
+        tuiBin: process.env.TMUX_IDE_TUI_BIN,
+      }),
+    );
+    execFileSync("tmux", hostCreateArgv({ cwd, commandLine }), { stdio: "ignore" });
+    for (const args of hostSetupArgvs()) execFileSync("tmux", args, { stdio: "ignore" });
+  }
+  execFileSync("tmux", hostAttachArgv(Boolean(process.env.TMUX)), { stdio: "inherit" });
+}
+
 // The scriptable control surface for the cockpit: print the fleet state as JSON
 // and exit without spawning the (bun/OpenTUI) TUI. Shared by `tmux-ide team
 // --json` and bare `tmux-ide --json` when there's no ide.yml to launch. Dynamic
@@ -327,11 +394,27 @@ function launchTeamCockpit(): void {
   execBunWidget("team", teamScriptPath, [], "team");
 }
 
+// The one entry for the unified app: `--detachable`/`--hosted` (or
+// `app.detachable` in config) route through the hosted launcher, everything
+// else runs the app in this terminal as before. The HOSTED_ENV guard keeps the
+// app INSIDE the host session from re-hosting itself.
+function runApp(appArgs: string[]): void {
+  const hosted = wantsHostedApp({
+    flagDetachable: values.detachable === true,
+    flagHosted: values.hosted === true,
+    configDetachable: loadAppConfig().app.detachable,
+    hostedEnv: process.env[HOSTED_ENV] === "1",
+  });
+  if (hosted) launchHostedApp(appScriptPath, appArgs);
+  else execBunWidget("app", appScriptPath, appArgs, "app");
+}
+
 // The unified app as the front door (M22.6): bare `tmux-ide` opens `tmux-ide
 // app`'s HOME panel when `app.frontDoor` is on and there's nothing else to
-// launch. Same entry as the explicit `app` command with no session positional.
+// launch. Same entry as the explicit `app` command with no session positional
+// — including the hosted flip when `app.detachable` is set (M23.2).
 function launchApp(): void {
-  execBunWidget("app", appScriptPath, [], "app");
+  runApp([]);
 }
 
 try {
@@ -528,10 +611,14 @@ try {
     case "app": {
       // The unified app (M18.1): sidebar fleet + a live tmux-session mirror.
       // Bare `tmux-ide app` opens the HOME panel (fleet cards); an optional
-      // session positional boots straight into that session's mirror.
+      // session positional boots straight into that session's mirror. With
+      // `--detachable` (alias `--hosted`, or `app.detachable` in config) the
+      // app runs in the internal `_tmux-ide-app` session instead and this
+      // terminal attaches to it (M23.2) — the positional only shapes the
+      // cockpit at CREATE time; a reattach finds the app exactly as left.
       const session = positionals[1];
       const appArgs = session ? [`--target=${session}`] : [];
-      execBunWidget("app", appScriptPath, appArgs, "app");
+      runApp(appArgs);
       break;
     }
 

--- a/docs/content/docs/app-surfaces.mdx
+++ b/docs/content/docs/app-surfaces.mdx
@@ -126,6 +126,34 @@ as a project. Recently opened folders are one click away, and the optional
 `app.frontDoor` config flag makes bare `tmux-ide` open the app. See
 [Getting started](/docs/getting-started#start-anywhere-with-the-app).
 
+### Keep it running — even from your phone
+
+Your sessions already survive everything; with `--detachable`, the cockpit does
+too:
+
+```bash
+tmux-ide app --detachable   # or --hosted — same thing
+```
+
+Instead of running in your terminal, the app lives in a tmux session of its own
+and your terminal attaches to it. Close the terminal, lose the ssh connection,
+switch machines — the cockpit keeps running exactly where you left it: same
+tab, same scroll position, same open dialogs. Run the command again from any
+terminal (including your phone: ssh in, run it) and you're back in the same
+cockpit.
+
+Two things change in this mode:
+
+- **^q detaches** instead of quitting — the app keeps running in the
+  background. If you launched from inside tmux, ^q returns you to the session
+  you came from. To actually stop the cockpit, press **F5** and run **Quit**.
+- If two terminals of different sizes are attached at once, tmux sizes the
+  cockpit to the one you used last (the smaller view wins while you're on it —
+  standard tmux behavior).
+
+Set `app.detachable: true` in `~/.tmux-ide/config.json` to make plain
+`tmux-ide app` (and the `app.frontDoor` entry) always work this way.
+
 ### Settings without JSON
 
 There's no settings screen and no JSON to hand-edit for the common cases. Press

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -126,6 +126,11 @@ file that holds the shared theme. Two things worth knowing for 2.7:
   bare `tmux-ide` launches the unified app (`tmux-ide app`) instead of the home
   cockpit. Default `false`; `ide.yml` auto-launch and `tmux-ide team` are
   unaffected.
+- **`app.detachable`** makes plain `tmux-ide app` run hosted: the app lives in
+  a tmux session of its own and your terminal attaches to it, so the cockpit
+  survives the terminal and reattaches from anywhere (`^q` detaches instead of
+  quitting). Default `false` — same as passing `--detachable` every time. See
+  [the app surfaces](/docs/app-surfaces#keep-it-running--even-from-your-phone).
 - **Settings are editable in the app.** Inside `tmux-ide app`, press **F5** and
   type "settings" for a palette command per setting — no JSON required. Edits
   write back to `~/.tmux-ide/config.json` atomically:

--- a/packages/daemon/src/lib/app-config.test.ts
+++ b/packages/daemon/src/lib/app-config.test.ts
@@ -182,6 +182,15 @@ describe("parseAppConfig — mistyped fields fall back to default", () => {
     // An explicit true opts into the front-door flip.
     expect(parseAppConfig({ app: { frontDoor: true } }).app.frontDoor).toBe(true);
   });
+
+  it("app.detachable — defaults to false and coerces a mistyped value back to it", () => {
+    expect(DEFAULT_APP_CONFIG.app.detachable).toBe(false);
+    expect(parseAppConfig(undefined).app.detachable).toBe(false);
+    expect(parseAppConfig({ app: { detachable: "yes" } }).app.detachable).toBe(false);
+    expect(parseAppConfig({ app: "nope" }).app.detachable).toBe(false);
+    // An explicit true makes bare `tmux-ide app` run hosted (M23.2).
+    expect(parseAppConfig({ app: { detachable: true } }).app.detachable).toBe(true);
+  });
 });
 
 describe("loadAppConfig / getAppConfig / TMUX_IDE_CONFIG", () => {

--- a/packages/daemon/src/lib/app-config.ts
+++ b/packages/daemon/src/lib/app-config.ts
@@ -142,6 +142,15 @@ export interface AppApp {
    * (the explicit cockpit) and a project's `ide.yml` auto-launch are unaffected.
    */
   frontDoor: boolean;
+  /**
+   * Whether `tmux-ide app` runs HOSTED by default (M23.2): the app lives in an
+   * internal `_tmux-ide-app` tmux session and the invoking terminal attaches to
+   * it, so the cockpit survives the terminal and reattaches from anywhere (^q
+   * detaches instead of quitting). Default false — the same behavior as the
+   * explicit `--detachable` flag; `--detachable`/`--hosted` still force it on a
+   * single run.
+   */
+  detachable: boolean;
 }
 
 /** Worktree flow config (`tmux-ide worktree`). */
@@ -202,7 +211,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   welcome: { show: true },
   integrations: { offer: true },
   worktrees: { dir: "" },
-  app: { frontDoor: false },
+  app: { frontDoor: false, detachable: false },
 };
 
 /** The default theme tokens — the fallback threaded into the pure builders. */
@@ -301,7 +310,10 @@ export function parseAppConfig(input: unknown): AppConfig {
     welcome: { show: pickBool(welcome.show, D.welcome.show) },
     integrations: { offer: pickBool(integrations.offer, D.integrations.offer) },
     worktrees: { dir: pickString(worktrees.dir, D.worktrees.dir) },
-    app: { frontDoor: pickBool(app.frontDoor, D.app.frontDoor) },
+    app: {
+      frontDoor: pickBool(app.frontDoor, D.app.frontDoor),
+      detachable: pickBool(app.detachable, D.app.detachable),
+    },
   };
 }
 

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -6,7 +6,11 @@
  * scrollback (wheel; ↑n/depth badge; any key snaps live), real SGR mouse
  * forwarding into panes whose app enabled mouse mode, 60fps-paced (8ms state tick + targetFps 60 paint)
  * rendering, ^o pane focus cycle, ^t window cycle, ^q quits (session
- * untouched).
+ * untouched) — except HOSTED (M23.2): launched by `tmux-ide app --detachable`
+ * inside the internal `_tmux-ide-app` session (TMUX_IDE_HOSTED=1), ^q puts the
+ * cockpit away and the app keeps running (switch-client -l back to where the
+ * client came from, else detach); the palette's "Quit" verb remains the real
+ * exit (ending the pane command ends the host session).
  *
  * SELECT MODE (M22.9): forwarding normally wins on app-mouse panes, so those
  * panes (exactly the agent panes users copy from) could never drag-select.
@@ -576,11 +580,17 @@ const WELCOME_LINE = "Welcome to tmux-ide — a cockpit for the tmux sessions yo
 const WELCOME_ACTION_LABEL = "▸ open a folder — press f";
 const WELCOME_ROWS = 6;
 const WELCOME_ACTION_ROW = 3; // 0-based within the welcome block
+// HOSTED mode (M23.2): the detachable-cockpit launcher stamps this marker on
+// the app's pane command inside `_tmux-ide-app`. ^q then detaches the tmux
+// client instead of exiting (the cockpit survives the terminal); every "^q
+// quit" hint reads "detach" so the keycap tells the truth.
+const HOSTED = process.env.TMUX_IDE_HOSTED === "1";
+const QUIT_HINT = HOSTED ? "^q detach" : "^q quit";
 // The sidebar footer hint, split so its "F5 palette" segment is a chip: the
 // span starts after paddingLeft (1) + the pre text.
 const SIDEBAR_HINT_PRE = "F1-4 tabs · ";
 const SIDEBAR_HINT_BTN = "F5 palette";
-const SIDEBAR_HINT_POST = " · ^q quit";
+const SIDEBAR_HINT_POST = ` · ${QUIT_HINT}`;
 const SIDEBAR_HINT_SPAN = { start: 1 + SIDEBAR_HINT_PRE.length, width: SIDEBAR_HINT_BTN.length };
 // Scrollback-search highlight backgrounds (M20.3), packed 0xRRGGBB to sit in a
 // run's `bg` (search paints a bg, distinct from selection's inverse video, so
@@ -3380,6 +3390,19 @@ render(
 
     useKeyboard((evt) => {
       if (evt.ctrl && evt.name === "q") {
+        // HOSTED (M23.2): put the cockpit away and keep running — the palette's
+        // "Quit" verb is the real exit. A client that came here via
+        // switch-client (launched inside tmux) bounces BACK to its last
+        // session; a client that attached from a plain terminal has no last
+        // session, so `switch-client -l` fails and it detaches instead. No -t:
+        // tmux resolves "current client" from the pane's $TMUX to the most
+        // recently active client on our session — the presser.
+        if (HOSTED) {
+          execFile("tmux", ["switch-client", "-l"], (err) => {
+            if (err) execFile("tmux", ["detach-client"], () => {});
+          });
+          return;
+        }
         mirror?.dispose();
         editBuffer?.destroy();
         process.exit(0);
@@ -3404,7 +3427,7 @@ render(
         return;
       }
       // The scrollback-search session owns the keyboard while open (the bottom input
-      // line + n/N navigation), so no key leaks to the pane; ^q above still quits.
+      // line + n/N navigation), so no key leaks to the pane; ^q above still works.
       if (search()) {
         searchKey(evt);
         return;
@@ -5164,7 +5187,7 @@ render(
               </box>
               <box paddingLeft={1}>
                 <text fg={MUTED}>
-                  {"j/k file · enter open · ^s save · esc list · ^g home · ^q quit"}
+                  {`j/k file · enter open · ^s save · esc list · ^g home · ${QUIT_HINT}`}
                 </text>
               </box>
             </Show>
@@ -5227,7 +5250,7 @@ render(
               </box>
               <box paddingLeft={1}>
                 <text fg={MUTED}>
-                  {"j/k file · wheel scroll · ^e edit · r refresh · ^g home · ^q quit"}
+                  {`j/k file · wheel scroll · ^e edit · r refresh · ^g home · ${QUIT_HINT}`}
                 </text>
               </box>
             </Show>

--- a/packages/daemon/src/tui/mirror/hosted.test.ts
+++ b/packages/daemon/src/tui/mirror/hosted.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  APP_HOST_SESSION,
+  HOSTED_ENV,
+  wantsHostedApp,
+  shellQuote,
+  hostedEnvVars,
+  hostedCommandLine,
+  hostExistsArgv,
+  hostCreateArgv,
+  hostSetupArgvs,
+  hostAttachArgv,
+} from "./hosted.ts";
+
+const noEntry = {
+  flagDetachable: false,
+  flagHosted: false,
+  configDetachable: false,
+  hostedEnv: false,
+};
+
+describe("wantsHostedApp", () => {
+  it("is off by default", () => {
+    expect(wantsHostedApp(noEntry)).toBe(false);
+  });
+
+  it("either flag opts in", () => {
+    expect(wantsHostedApp({ ...noEntry, flagDetachable: true })).toBe(true);
+    expect(wantsHostedApp({ ...noEntry, flagHosted: true })).toBe(true);
+  });
+
+  it("config opts bare `app` in", () => {
+    expect(wantsHostedApp({ ...noEntry, configDetachable: true })).toBe(true);
+  });
+
+  it("the hosted env marker vetoes everything (recursion guard)", () => {
+    expect(
+      wantsHostedApp({
+        flagDetachable: true,
+        flagHosted: true,
+        configDetachable: true,
+        hostedEnv: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shellQuote", () => {
+  it("wraps plain words", () => {
+    expect(shellQuote("bun")).toBe("'bun'");
+  });
+
+  it("passes spaces and metacharacters literally", () => {
+    expect(shellQuote("/Users/t h/$HOME;rm")).toBe("'/Users/t h/$HOME;rm'");
+  });
+
+  it("escapes embedded single quotes", () => {
+    expect(shellQuote("it's")).toBe(`'it'\\''s'`);
+  });
+});
+
+describe("hostedEnvVars", () => {
+  it("always carries the marker, cwd, and cli", () => {
+    const env = hostedEnvVars({ cwd: "/work", cli: "/repo/bin/cli.js" });
+    expect(env).toEqual({
+      [HOSTED_ENV]: "1",
+      TMUX_IDE_CWD: "/work",
+      TMUX_IDE_CLI: "/repo/bin/cli.js",
+    });
+  });
+
+  it("passes PATH and the state/config/binary overrides through when set", () => {
+    const env = hostedEnvVars({
+      cwd: "/work",
+      cli: "/repo/bin/cli.js",
+      path: "/usr/local/bin:/usr/bin",
+      home: "/scratch/home",
+      config: "/scratch/config.json",
+      tuiBin: "/scratch/tui",
+    });
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin");
+    expect(env.TMUX_IDE_HOME).toBe("/scratch/home");
+    expect(env.TMUX_IDE_CONFIG).toBe("/scratch/config.json");
+    expect(env.TMUX_IDE_TUI_BIN).toBe("/scratch/tui");
+  });
+});
+
+describe("hostedCommandLine", () => {
+  it("builds exec env assigns + quoted bin and argv", () => {
+    const line = hostedCommandLine("bun", ["/repo/app.tsx", "--target=web"], {
+      [HOSTED_ENV]: "1",
+      TMUX_IDE_CWD: "/work dir",
+    });
+    expect(line).toBe(
+      `exec env TMUX_IDE_HOSTED='1' TMUX_IDE_CWD='/work dir' 'bun' '/repo/app.tsx' '--target=web'`,
+    );
+  });
+});
+
+describe("tmux argv builders", () => {
+  it("existence probe exact-matches the host name", () => {
+    expect(hostExistsArgv()).toEqual(["has-session", "-t", `=${APP_HOST_SESSION}`]);
+  });
+
+  it("create is detached, named, cwd-pinned, and runs the command line", () => {
+    expect(hostCreateArgv({ cwd: "/repo", commandLine: "exec env A='1' 'bun'" })).toEqual([
+      "new-session",
+      "-d",
+      "-s",
+      APP_HOST_SESSION,
+      "-c",
+      "/repo",
+      "exec env A='1' 'bun'",
+    ]);
+  });
+
+  it("setup turns status off and pins window-size latest (no `=` — set-option rejects it)", () => {
+    expect(hostSetupArgvs()).toEqual([
+      ["set-option", "-t", APP_HOST_SESSION, "status", "off"],
+      ["set-option", "-w", "-t", `${APP_HOST_SESSION}:`, "window-size", "latest"],
+    ]);
+  });
+
+  it("attach from a plain terminal, switch-client from inside tmux", () => {
+    expect(hostAttachArgv(false)).toEqual(["attach-session", "-t", `=${APP_HOST_SESSION}`]);
+    expect(hostAttachArgv(true)).toEqual(["switch-client", "-t", `=${APP_HOST_SESSION}`]);
+  });
+});
+
+describe("the fleet/snapshot contract", () => {
+  it("the host session name is _-prefixed (internal to every listing filter)", () => {
+    expect(APP_HOST_SESSION.startsWith("_")).toBe(true);
+  });
+});

--- a/packages/daemon/src/tui/mirror/hosted.ts
+++ b/packages/daemon/src/tui/mirror/hosted.ts
@@ -1,0 +1,145 @@
+/**
+ * The detachable cockpit (M23.2) — tmux keeps the app itself alive.
+ *
+ * `tmux-ide app --detachable` (alias `--hosted`) doesn't run the app in the
+ * invoking terminal: it ensures an internal `_tmux-ide-app` session exists
+ * running the app full-screen, then attaches the terminal to it. ^q under
+ * hosting DETACHES the client (the app keeps running); re-invocation from any
+ * terminal — including a phone over ssh — reattaches the SAME cockpit with
+ * scroll positions, dialogs, and workspace context intact.
+ *
+ * These are the PURE pieces of that contract: the entry decision, the tmux
+ * argv builders, and the shell quoting for the host pane's command line. The
+ * io (spawning tmux, resolving bun vs the compiled binary) stays in the CLI;
+ * the app side only reads {@link HOSTED_ENV} to flip ^q from quit to detach.
+ */
+
+/** The internal host session. `_`-prefixed so every fleet surface (team --json,
+ *  sidebar, home) and the snapshot/restore path already filter it out. */
+export const APP_HOST_SESSION = "_tmux-ide-app";
+
+/** The env marker the launcher sets on the hosted app process. The app flips
+ *  ^q from "quit" to "detach the client" when it sees `=1`; the CLI treats it
+ *  as a recursion guard (a hosted app never re-hosts). */
+export const HOSTED_ENV = "TMUX_IDE_HOSTED";
+
+/** Everything the entry decision reads — flags, config, and the guard. */
+export interface HostedEntryInput {
+  /** `--detachable` (the primary flag). */
+  flagDetachable: boolean;
+  /** `--hosted` (the alias). */
+  flagHosted: boolean;
+  /** `app.detachable` from the typed config — makes bare `tmux-ide app` (and
+   *  the frontDoor entry) hosted without the flag. */
+  configDetachable: boolean;
+  /** Whether WE are already the hosted app ({@link HOSTED_ENV} set). */
+  hostedEnv: boolean;
+}
+
+/**
+ * PURE — should this `tmux-ide app` invocation run hosted? Flags and config
+ * both opt in; the env marker vetoes everything (the app inside the host
+ * session must launch plain, or it would try to attach to itself).
+ */
+export function wantsHostedApp(input: HostedEntryInput): boolean {
+  if (input.hostedEnv) return false;
+  return input.flagDetachable || input.flagHosted || input.configDetachable;
+}
+
+/**
+ * PURE — POSIX single-quote a word for a tmux `new-session` shell command
+ * (tmux hands the string to `sh -c`). Single quotes pass everything literally;
+ * an embedded `'` closes, escapes, and reopens.
+ */
+export function shellQuote(word: string): string {
+  return `'${word.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * PURE — the env vars the host pane's app process needs, assembled for the
+ * command line rather than tmux's session environment: the tmux server may
+ * have been started elsewhere with a different environment, so nothing can be
+ * assumed to inherit. PATH rides along for the same reason (the `bun` launch
+ * mode resolves the binary by name).
+ */
+export function hostedEnvVars(base: {
+  /** The user's real invocation dir (in-app prompts default here). */
+  cwd: string;
+  /** The node-runnable CLI path (`TMUX_IDE_CLI`) for in-app subprocesses. */
+  cli: string;
+  /** The invoking shell's PATH. */
+  path?: string;
+  /** `TMUX_IDE_HOME` / `TMUX_IDE_CONFIG` / `TMUX_IDE_TUI_BIN` pass-throughs
+   *  (set in test rigs; must reach the hosted app or it reads real state). */
+  home?: string;
+  config?: string;
+  tuiBin?: string;
+}): Record<string, string> {
+  const env: Record<string, string> = {
+    [HOSTED_ENV]: "1",
+    TMUX_IDE_CWD: base.cwd,
+    TMUX_IDE_CLI: base.cli,
+  };
+  if (base.path) env.PATH = base.path;
+  if (base.home) env.TMUX_IDE_HOME = base.home;
+  if (base.config) env.TMUX_IDE_CONFIG = base.config;
+  if (base.tuiBin) env.TMUX_IDE_TUI_BIN = base.tuiBin;
+  return env;
+}
+
+/**
+ * PURE — the shell command the host pane runs: `exec env K=V… bin args…`,
+ * every value quoted. `exec` replaces the pane's shell with the app so a quit
+ * (the palette verb) ends the pane — and with it the single-window session.
+ */
+export function hostedCommandLine(
+  bin: string,
+  argv: readonly string[],
+  env: Record<string, string>,
+): string {
+  const assigns = Object.entries(env).map(([k, v]) => `${k}=${shellQuote(v)}`);
+  return ["exec", "env", ...assigns, shellQuote(bin), ...argv.map(shellQuote)].join(" ");
+}
+
+/** PURE — exact-match existence probe (`=` prefix: `has-session -t` would
+ *  otherwise PREFIX-match, e.g. a user session named `_tmux-ide-app-notes`). */
+export function hostExistsArgv(): string[] {
+  return ["has-session", "-t", `=${APP_HOST_SESSION}`];
+}
+
+/** PURE — create the detached host session running the app command line. */
+export function hostCreateArgv(opts: { cwd: string; commandLine: string }): string[] {
+  return ["new-session", "-d", "-s", APP_HOST_SESSION, "-c", opts.cwd, opts.commandLine];
+}
+
+/**
+ * PURE — the post-create session setup: status OFF so the app owns every row
+ * (under `status on` the host steals the bottom row and the app renders one
+ * short), and `window-size latest` pinned explicitly so the most recently
+ * active client dictates the size — a smaller second client letterboxes the
+ * larger one (tmux's own dot-fill), which is the documented behavior.
+ *
+ * No `=` exact-match prefix here: tmux (measured on 3.7b) rejects it on
+ * `set-option` session targets ("no such session") even though has-session
+ * and attach accept it. Plain names are safe in THIS builder only because
+ * setup runs right after create — the exact session exists, and tmux prefers
+ * an exact match over a prefix match when one does.
+ */
+export function hostSetupArgvs(): string[][] {
+  return [
+    ["set-option", "-t", APP_HOST_SESSION, "status", "off"],
+    ["set-option", "-w", "-t", `${APP_HOST_SESSION}:`, "window-size", "latest"],
+  ];
+}
+
+/**
+ * PURE — how the invoking terminal reaches the cockpit: inside tmux the
+ * client is already attached to a server, so `switch-client` moves it (a
+ * nested `attach` would complain and double-render); a plain terminal
+ * attaches. Both exact-match the host name.
+ */
+export function hostAttachArgv(insideTmux: boolean): string[] {
+  return insideTmux
+    ? ["switch-client", "-t", `=${APP_HOST_SESSION}`]
+    : ["attach-session", "-t", `=${APP_HOST_SESSION}`];
+}


### PR DESCRIPTION
Card #95: the app hosted in an internal tmux session — ssh from any terminal (or phone) and reattach the same live cockpit. ^q bounces back or detaches; Quit exits; fleet/snapshot/restore verified to ignore the host session. Full battery on an isolated server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)