### PR TITLE
feat: local socket API — tmux-ide serve (M23.3)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1360,6 +1360,109 @@ var init_terminals = __esm({
   }
 });
 
+// packages/contracts/src/control.ts
+import { z as z9 } from "zod";
+var CONTROL_PROTOCOL_VERSION, controlIdSchema, agentStatusSchema, controlRequestSchema, controlErrorSchema, controlResponseSchema, controlEventSchema, agentStatusEventSchema, agentsParamsSchema, sendParamsSchema, CONTROL_WAIT_MAX_TIMEOUT_MS, waitTimeoutSchema, waitParamsSchema, spawnPlacementSchema, spawnParamsSchema, restartAgentParamsSchema, stopAgentParamsSchema, explainParamsSchema, subscribeParamsSchema;
+var init_control = __esm({
+  "packages/contracts/src/control.ts"() {
+    "use strict";
+    CONTROL_PROTOCOL_VERSION = 1;
+    controlIdSchema = z9.union([z9.string(), z9.number()]);
+    agentStatusSchema = z9.enum(["blocked", "working", "done", "idle", "unknown"]);
+    controlRequestSchema = z9.object({
+      v: z9.literal(CONTROL_PROTOCOL_VERSION),
+      id: controlIdSchema,
+      verb: z9.string().min(1),
+      params: z9.record(z9.string(), z9.unknown()).optional()
+    });
+    controlErrorSchema = z9.object({
+      code: z9.string(),
+      message: z9.string()
+    });
+    controlResponseSchema = z9.discriminatedUnion("ok", [
+      z9.object({
+        v: z9.literal(CONTROL_PROTOCOL_VERSION),
+        id: controlIdSchema.nullable(),
+        ok: z9.literal(true),
+        data: z9.unknown()
+      }),
+      z9.object({
+        v: z9.literal(CONTROL_PROTOCOL_VERSION),
+        id: controlIdSchema.nullable(),
+        ok: z9.literal(false),
+        error: controlErrorSchema
+      })
+    ]);
+    controlEventSchema = z9.object({
+      v: z9.literal(CONTROL_PROTOCOL_VERSION),
+      event: z9.string().min(1),
+      data: z9.unknown()
+    });
+    agentStatusEventSchema = z9.object({
+      ts: z9.string(),
+      session: z9.string(),
+      from: agentStatusSchema.nullable(),
+      to: agentStatusSchema
+    });
+    agentsParamsSchema = z9.object({
+      session: z9.string().optional()
+    });
+    sendParamsSchema = z9.object({
+      session: z9.string().min(1),
+      target: z9.string().min(1),
+      message: z9.string().min(1),
+      noEnter: z9.boolean().optional(),
+      dir: z9.string().optional()
+    });
+    CONTROL_WAIT_MAX_TIMEOUT_MS = 6e5;
+    waitTimeoutSchema = z9.number().int().positive().max(CONTROL_WAIT_MAX_TIMEOUT_MS).optional();
+    waitParamsSchema = z9.discriminatedUnion("kind", [
+      z9.object({
+        kind: z9.literal("agent-status"),
+        session: z9.string().min(1),
+        status: agentStatusSchema,
+        timeoutMs: waitTimeoutSchema
+      }),
+      z9.object({
+        kind: z9.literal("output"),
+        target: z9.string().min(1),
+        match: z9.string().min(1),
+        timeoutMs: waitTimeoutSchema
+      })
+    ]);
+    spawnPlacementSchema = z9.enum(["window", "split-h", "split-v"]);
+    spawnParamsSchema = z9.object({
+      kind: z9.string().min(1).optional(),
+      command: z9.string().min(1).optional(),
+      session: z9.string().min(1).optional(),
+      sessionName: z9.string().min(1).optional(),
+      dir: z9.string().optional(),
+      placement: spawnPlacementSchema.optional(),
+      paneId: z9.string().optional()
+    }).refine((p) => Boolean(p.kind) !== Boolean(p.command), {
+      message: "exactly one of `kind` or `command` is required"
+    }).refine((p) => Boolean(p.session) || Boolean(p.sessionName), {
+      message: "`session` (spawn into it) or `sessionName` (create it) is required"
+    }).refine((p) => !(p.placement && p.placement !== "window") || Boolean(p.paneId), {
+      message: "split placements need `paneId`"
+    });
+    restartAgentParamsSchema = z9.object({
+      paneId: z9.string().min(1),
+      kind: z9.string().min(1).optional(),
+      command: z9.string().min(1).optional()
+    }).refine((p) => Boolean(p.kind) || Boolean(p.command), {
+      message: "`kind` or `command` is required"
+    });
+    stopAgentParamsSchema = z9.object({
+      paneId: z9.string().min(1)
+    });
+    explainParamsSchema = z9.object({
+      target: z9.string().min(1)
+    });
+    subscribeParamsSchema = z9.object({}).loose();
+  }
+});
+
 // packages/contracts/src/index.ts
 var init_src2 = __esm({
   "packages/contracts/src/index.ts"() {
@@ -1373,6 +1476,7 @@ var init_src2 = __esm({
     init_actions_contract();
     init_actions_errors();
     init_terminals();
+    init_control();
   }
 });
 
@@ -3932,37 +4036,37 @@ var init_kitty_keys = __esm({
 });
 
 // packages/daemon/src/schemas/registry.ts
-import { z as z9 } from "zod";
+import { z as z10 } from "zod";
 var RegisteredProjectSchemaZ, RegisterProjectRequestSchemaZ, InitProjectRequestSchemaZ, ProjectTemplateSchemaZ;
 var init_registry = __esm({
   "packages/daemon/src/schemas/registry.ts"() {
     "use strict";
-    RegisteredProjectSchemaZ = z9.object({
+    RegisteredProjectSchemaZ = z10.object({
       /** Unique registry key. Defaults to `basename(dir)`; collisions resolved by appending `-2`, `-3`, … */
-      name: z9.string(),
+      name: z10.string(),
       /** Absolute path to the project directory. */
-      dir: z9.string(),
+      dir: z10.string(),
       /** Whether `<dir>/ide.yml` exists; refreshed on register and on `probe()`. */
-      hasIdeYml: z9.boolean(),
+      hasIdeYml: z10.boolean(),
       /** Git remote origin URL, or `null` if not a git repo / no origin / probe failed. */
-      gitOrigin: z9.string().nullable(),
+      gitOrigin: z10.string().nullable(),
       /** Current git branch, or `null` if not a git repo / detached HEAD / probe failed. */
-      gitBranch: z9.string().nullable(),
+      gitBranch: z10.string().nullable(),
       /** ISO-8601 timestamp the project was first registered. */
-      registeredAt: z9.string()
+      registeredAt: z10.string()
     });
-    RegisterProjectRequestSchemaZ = z9.object({
-      dir: z9.string().min(1),
-      name: z9.string().min(1).optional()
+    RegisterProjectRequestSchemaZ = z10.object({
+      dir: z10.string().min(1),
+      name: z10.string().min(1).optional()
     });
-    InitProjectRequestSchemaZ = z9.object({
-      dir: z9.string().min(1),
-      template: z9.string().min(1).optional()
+    InitProjectRequestSchemaZ = z10.object({
+      dir: z10.string().min(1),
+      template: z10.string().min(1).optional()
     });
-    ProjectTemplateSchemaZ = z9.object({
-      id: z9.string(),
-      label: z9.string(),
-      description: z9.string()
+    ProjectTemplateSchemaZ = z10.object({
+      id: z10.string(),
+      label: z10.string(),
+      description: z10.string()
     });
   }
 });
@@ -4024,7 +4128,7 @@ import { EventEmitter } from "node:events";
 import { existsSync as existsSync12, mkdirSync as mkdirSync7, readFileSync as readFileSync7, renameSync as renameSync3, writeFileSync as writeFileSync8 } from "node:fs";
 import { homedir as homedir9 } from "node:os";
 import { dirname as dirname10, isAbsolute as isAbsolute2, join as join9, resolve as resolve8 } from "node:path";
-import { z as z10 } from "zod";
+import { z as z11 } from "zod";
 function applyAction(state, action) {
   switch (action.type) {
     case "register":
@@ -4159,9 +4263,9 @@ var init_project_registry = __esm({
     init_registry();
     init_project_probe();
     REGISTRY_DIR_ENV = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ = z10.object({
-      version: z10.literal(1),
-      projects: z10.array(RegisteredProjectSchemaZ)
+    RegistryFileSchemaZ = z11.object({
+      version: z11.literal(1),
+      projects: z11.array(RegisteredProjectSchemaZ)
     });
     ProjectRegistryError = class extends Error {
       code;
@@ -4551,7 +4655,7 @@ var init_notify = __esm({
 import { existsSync as existsSync15, mkdirSync as mkdirSync9, readFileSync as readFileSync9, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir11 } from "node:os";
 import { dirname as dirname11, join as join11 } from "node:path";
-import { z as z11 } from "zod";
+import { z as z12 } from "zod";
 function isBareShell(cmd) {
   return /^-?(zsh|bash|sh|fish|dash|ksh|tcsh|csh|nu)$/.test(cmd.trim());
 }
@@ -4723,32 +4827,32 @@ var init_snapshot2 = __esm({
     init_src();
     init_process_tree();
     init_sessions2();
-    PaneSnapshotSchemaZ = z11.object({
-      index: z11.number(),
-      cwd: z11.string(),
-      command: z11.string().nullable(),
-      agent: z11.string().nullable(),
-      agentSessionId: z11.string().nullable(),
-      agentState: z11.string().nullable(),
-      title: z11.string()
+    PaneSnapshotSchemaZ = z12.object({
+      index: z12.number(),
+      cwd: z12.string(),
+      command: z12.string().nullable(),
+      agent: z12.string().nullable(),
+      agentSessionId: z12.string().nullable(),
+      agentState: z12.string().nullable(),
+      title: z12.string()
     });
-    WindowSnapshotSchemaZ = z11.object({
-      index: z11.number(),
-      name: z11.string(),
-      active: z11.boolean(),
-      layout: z11.string(),
-      panes: z11.array(PaneSnapshotSchemaZ)
+    WindowSnapshotSchemaZ = z12.object({
+      index: z12.number(),
+      name: z12.string(),
+      active: z12.boolean(),
+      layout: z12.string(),
+      panes: z12.array(PaneSnapshotSchemaZ)
     });
-    SessionSnapshotSchemaZ = z11.object({
-      name: z11.string(),
-      cwd: z11.string(),
-      adopted: z11.boolean(),
-      windows: z11.array(WindowSnapshotSchemaZ)
+    SessionSnapshotSchemaZ = z12.object({
+      name: z12.string(),
+      cwd: z12.string(),
+      adopted: z12.boolean(),
+      windows: z12.array(WindowSnapshotSchemaZ)
     });
-    FleetSnapshotSchemaZ = z11.object({
-      version: z11.literal(1),
-      savedAt: z11.string(),
-      sessions: z11.array(SessionSnapshotSchemaZ)
+    FleetSnapshotSchemaZ = z12.object({
+      version: z12.literal(1),
+      savedAt: z12.string(),
+      sessions: z12.array(SessionSnapshotSchemaZ)
     });
     SNAPSHOT_PANE_FORMAT = [
       "#{session_name}",
@@ -4785,6 +4889,7 @@ __export(updater_exports, {
   UPDATER_SESSION: () => UPDATER_SESSION,
   adoptedSessionsFrom: () => adoptedSessionsFrom,
   enrichEvents: () => enrichEvents,
+  fleetStatuses: () => fleetStatuses,
   listAdoptedSessions: () => listAdoptedSessions,
   paneLocation: () => paneLocation,
   pickRepresentativePane: () => pickRepresentativePane,
@@ -5441,7 +5546,7 @@ function waitForPaneCommand(targetPane, expectedCommands, {
   attempts = 20,
   delayMs = 100,
   getCurrentCommand = getPaneCurrentCommand,
-  sleep = sleepMs
+  sleep: sleep2 = sleepMs
 } = {}) {
   const allowed = new Set(expectedCommands.map((command2) => command2.toLowerCase()));
   for (let attempt = 0; attempt < attempts; attempt++) {
@@ -5451,7 +5556,7 @@ function waitForPaneCommand(targetPane, expectedCommands, {
     } catch {
     }
     if (attempt < attempts - 1) {
-      sleep(delayMs);
+      sleep2(delayMs);
     }
   }
   return false;
@@ -7141,7 +7246,7 @@ import { EventEmitter as EventEmitter3 } from "node:events";
 import { existsSync as existsSync23, mkdirSync as mkdirSync13, readFileSync as readFileSync14, renameSync as renameSync8, writeFileSync as writeFileSync13 } from "node:fs";
 import { homedir as homedir14 } from "node:os";
 import { dirname as dirname17, join as join16 } from "node:path";
-import { z as z12 } from "zod";
+import { z as z13 } from "zod";
 function getDefaultWorkspaceRegistry() {
   if (!_default) _default = new WorkspaceRegistry();
   return _default;
@@ -7164,9 +7269,9 @@ var init_workspace_registry = __esm({
     "use strict";
     init_src2();
     REGISTRY_DIR_ENV3 = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ2 = z12.object({
-      version: z12.literal(1),
-      workspaces: z12.array(WorkspaceSchemaZ)
+    RegistryFileSchemaZ2 = z13.object({
+      version: z13.literal(1),
+      workspaces: z13.array(WorkspaceSchemaZ)
     });
     WorkspaceAlreadyExistsError = class extends Error {
       code = "ALREADY_EXISTS";
@@ -7814,6 +7919,57 @@ function prepareMessage(message, busyStatus) {
   }
   return message;
 }
+function deliverMessage(opts) {
+  const { session, target, noEnter, dir } = opts;
+  const state = getSessionState(session);
+  if (!state.running) {
+    throw new IdeError(`Session "${session}" is not running`, {
+      code: "SESSION_NOT_FOUND"
+    });
+  }
+  const panes = listSessionPanes(session);
+  const pane = resolvePane(panes, target);
+  if (!pane) {
+    const available = panes.map((p) => {
+      const label = p.name ?? p.title;
+      return `  ${p.id}  ${label}${p.role ? ` (${p.role})` : ""}`;
+    }).join("\n");
+    throw new IdeError(`Pane "${target}" not found.
+
+Available panes:
+${available}`, {
+      code: "PANE_NOT_FOUND"
+    });
+  }
+  const busyStatus = getPaneBusyStatus(session, pane.id);
+  const message = prepareMessage(opts.message, busyStatus);
+  let sentViaFile = false;
+  if (noEnter) {
+    sendText(session, pane.id, message);
+  } else {
+    const dispatch = dir ? writeDispatchFile(dir, pane.id, message) : null;
+    if (dispatch) {
+      sendCommand(session, pane.id, dispatch.triggerCmd);
+      sentViaFile = true;
+    } else {
+      sendCommand(session, pane.id, message);
+    }
+  }
+  return {
+    ok: true,
+    session,
+    target: {
+      paneId: pane.id,
+      name: pane.name,
+      title: pane.title,
+      role: pane.role
+    },
+    message,
+    busyStatus,
+    sentViaFile,
+    ...busyStatus === "agent" ? { warning: "agent_busy" } : {}
+  };
+}
 async function send(targetDir, opts) {
   const dir = resolve17(targetDir ?? ".");
   const { name: session } = getSessionName(dir);
@@ -7828,61 +7984,16 @@ async function send(targetDir, opts) {
       code: "USAGE"
     });
   }
-  const state = getSessionState(session);
-  if (!state.running) {
-    throw new IdeError(`Session "${session}" is not running`, {
-      code: "SESSION_NOT_FOUND"
-    });
-  }
-  const panes = listSessionPanes(session);
-  const pane = resolvePane(panes, target);
-  if (!pane) {
-    const available = panes.map((p) => {
-      const label2 = p.name ?? p.title;
-      return `  ${p.id}  ${label2}${p.role ? ` (${p.role})` : ""}`;
-    }).join("\n");
-    throw new IdeError(`Pane "${target}" not found.
-
-Available panes:
-${available}`, {
-      code: "PANE_NOT_FOUND"
-    });
-  }
-  const busyStatus = getPaneBusyStatus(session, pane.id);
-  const message = prepareMessage(rawMessage, busyStatus);
-  let sentViaFile = false;
-  if (noEnter) {
-    sendText(session, pane.id, message);
-  } else {
-    const dispatch = writeDispatchFile(dir, pane.id, message);
-    if (dispatch) {
-      sendCommand(session, pane.id, dispatch.triggerCmd);
-      sentViaFile = true;
-    } else {
-      sendCommand(session, pane.id, message);
-    }
-  }
-  const result = {
-    ok: true,
-    session,
-    target: {
-      paneId: pane.id,
-      name: pane.name,
-      title: pane.title,
-      role: pane.role
-    },
-    message,
-    busyStatus,
-    sentViaFile,
-    ...busyStatus === "agent" ? { warning: "agent_busy" } : {}
-  };
+  const result = deliverMessage({ session, target, message: rawMessage, noEnter, dir });
+  const { message, busyStatus } = result;
+  const pane = result.target;
   if (json2) {
     console.log(JSON.stringify(result, null, 2));
     return;
   }
   const label = pane.name ?? pane.title;
   const preview = message.length > 60 ? message.slice(0, 60) + "..." : message;
-  console.log(`Sent to "${label}" (${pane.id}): ${preview}`);
+  console.log(`Sent to "${label}" (${pane.paneId}): ${preview}`);
   if (busyStatus === "agent") {
     console.log("Warning: agent appears busy. Message sent anyway.");
   }
@@ -7959,74 +8070,74 @@ var init_log = __esm({
 });
 
 // packages/daemon/src/command-center/schemas.ts
-import { z as z13 } from "zod";
+import { z as z14 } from "zod";
 var updateTaskSchema, createTaskSchema, savePlanSchema, savePlanContentSchema, sendCommandSchema, createMilestoneSchema, updateMilestoneSchema, updateAssertionSchema, triggerResearchSchema, launchSchema, stopSchema, skillNameRegex, createSkillSchema, updateSkillSchema;
 var init_schemas = __esm({
   "packages/daemon/src/command-center/schemas.ts"() {
     "use strict";
-    updateTaskSchema = z13.object({
-      status: z13.enum(["todo", "in-progress", "review", "done"]).optional(),
-      assignee: z13.string().optional(),
-      title: z13.string().optional(),
-      description: z13.string().optional(),
-      priority: z13.number().optional()
+    updateTaskSchema = z14.object({
+      status: z14.enum(["todo", "in-progress", "review", "done"]).optional(),
+      assignee: z14.string().optional(),
+      title: z14.string().optional(),
+      description: z14.string().optional(),
+      priority: z14.number().optional()
     });
-    createTaskSchema = z13.object({
-      title: z13.string().trim().min(1, "Title is required"),
-      description: z13.string().optional(),
-      priority: z13.number().optional(),
-      goal: z13.string().optional(),
-      tags: z13.array(z13.string()).optional()
+    createTaskSchema = z14.object({
+      title: z14.string().trim().min(1, "Title is required"),
+      description: z14.string().optional(),
+      priority: z14.number().optional(),
+      goal: z14.string().optional(),
+      tags: z14.array(z14.string()).optional()
     });
-    savePlanSchema = z13.object({
-      content: z13.string().max(1e6, "Plan content is too large")
+    savePlanSchema = z14.object({
+      content: z14.string().max(1e6, "Plan content is too large")
     });
-    savePlanContentSchema = z13.object({
-      content: z13.string().max(1e6, "Plan content is too large")
+    savePlanContentSchema = z14.object({
+      content: z14.string().max(1e6, "Plan content is too large")
     });
-    sendCommandSchema = z13.object({
-      target: z13.string().min(1, "Target pane is required"),
-      message: z13.string().min(1, "Message is required"),
-      noEnter: z13.boolean().optional()
+    sendCommandSchema = z14.object({
+      target: z14.string().min(1, "Target pane is required"),
+      message: z14.string().min(1, "Message is required"),
+      noEnter: z14.boolean().optional()
     });
-    createMilestoneSchema = z13.object({
-      title: z13.string().trim().min(1, "Title is required"),
-      sequence: z13.number().int().positive(),
-      description: z13.string().optional()
+    createMilestoneSchema = z14.object({
+      title: z14.string().trim().min(1, "Title is required"),
+      sequence: z14.number().int().positive(),
+      description: z14.string().optional()
     });
-    updateMilestoneSchema = z13.object({
-      status: z13.enum(["locked", "active", "done", "validating"]).optional(),
-      title: z13.string().optional(),
-      description: z13.string().optional()
+    updateMilestoneSchema = z14.object({
+      status: z14.enum(["locked", "active", "done", "validating"]).optional(),
+      title: z14.string().optional(),
+      description: z14.string().optional()
     });
-    updateAssertionSchema = z13.object({
-      status: z13.enum(["pending", "passing", "failing", "blocked"]),
-      evidence: z13.string().optional(),
-      verifiedBy: z13.string().optional()
+    updateAssertionSchema = z14.object({
+      status: z14.enum(["pending", "passing", "failing", "blocked"]),
+      evidence: z14.string().optional(),
+      verifiedBy: z14.string().optional()
     });
-    triggerResearchSchema = z13.object({
-      type: z13.string().trim().min(1, "Research type is required")
+    triggerResearchSchema = z14.object({
+      type: z14.string().trim().min(1, "Research type is required")
     });
-    launchSchema = z13.object({
-      attach: z13.boolean().optional()
+    launchSchema = z14.object({
+      attach: z14.boolean().optional()
     }).optional();
-    stopSchema = z13.object({}).optional();
+    stopSchema = z14.object({}).optional();
     skillNameRegex = /^[A-Za-z0-9._ -]+$/;
-    createSkillSchema = z13.object({
-      name: z13.string().trim().min(1, "Skill name is required").regex(
+    createSkillSchema = z14.object({
+      name: z14.string().trim().min(1, "Skill name is required").regex(
         skillNameRegex,
         "Skill name may only contain letters, digits, dot, dash, underscore, or space"
       ),
-      role: z13.string().trim().optional(),
-      description: z13.string().optional(),
-      specialties: z13.array(z13.string()).optional(),
-      body: z13.string().optional()
+      role: z14.string().trim().optional(),
+      description: z14.string().optional(),
+      specialties: z14.array(z14.string()).optional(),
+      body: z14.string().optional()
     });
-    updateSkillSchema = z13.object({
-      role: z13.string().trim().optional(),
-      description: z13.string().optional(),
-      specialties: z13.array(z13.string()).optional(),
-      body: z13.string().optional()
+    updateSkillSchema = z14.object({
+      role: z14.string().trim().optional(),
+      description: z14.string().optional(),
+      specialties: z14.array(z14.string()).optional(),
+      body: z14.string().optional()
     });
   }
 });
@@ -8630,8 +8741,8 @@ var init_terminal_respawn = __esm({
 // packages/daemon/src/command-center/actions/handlers/terminal-stop.ts
 function terminalStopHandler(input, deps2 = {}) {
   const registry = deps2.registry ?? defaultPtyBridgeRegistry;
-  const ok = registry.delete(input.terminalId);
-  if (!ok) {
+  const ok2 = registry.delete(input.terminalId);
+  if (!ok2) {
     throw new ActionError({
       code: "terminal_not_found",
       message: `No terminal bridge for id "${input.terminalId}"`,
@@ -9039,56 +9150,56 @@ var init_project_init_runner = __esm({
 });
 
 // packages/daemon/src/schemas/inspect.ts
-import { z as z14 } from "zod";
+import { z as z15 } from "zod";
 var ProjectInspectDetectedSchemaZ, ProjectInspectSchemaZ, InspectFilesystemRequestSchemaZ, OnboardProjectRequestSchemaZ;
 var init_inspect = __esm({
   "packages/daemon/src/schemas/inspect.ts"() {
     "use strict";
-    ProjectInspectDetectedSchemaZ = z14.object({
+    ProjectInspectDetectedSchemaZ = z15.object({
       /** Detected package manager from lockfile, or `null`. */
-      packageManager: z14.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
+      packageManager: z15.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
       /** Detected frameworks (e.g. `["next", "convex"]`). Empty array when none. */
-      frameworks: z14.array(z14.string()),
+      frameworks: z15.array(z15.string()),
       /** Suggested dev command (e.g. `pnpm dev`). `null` if no dev script found. */
-      devCommand: z14.string().nullable(),
+      devCommand: z15.string().nullable(),
       /** Suggested test command (e.g. `pnpm test`). `null` if no test script found. */
-      testCommand: z14.string().nullable()
+      testCommand: z15.string().nullable()
     });
-    ProjectInspectSchemaZ = z14.object({
+    ProjectInspectSchemaZ = z15.object({
       /** Sanitized basename of the directory — safe to use as a tmux session name. */
-      name: z14.string(),
+      name: z15.string(),
       /** Absolute, canonical path to the directory. */
-      dir: z14.string(),
+      dir: z15.string(),
       /** Whether `<dir>/ide.yml` exists. */
-      hasIdeYml: z14.boolean(),
+      hasIdeYml: z15.boolean(),
       /** Git remote origin URL, or `null` if not a git repo / no origin / probe failed. */
-      gitOrigin: z14.string().nullable(),
+      gitOrigin: z15.string().nullable(),
       /** Current git branch, or `null` if not a git repo / detached HEAD / probe failed. */
-      gitBranch: z14.string().nullable(),
+      gitBranch: z15.string().nullable(),
       /** Detected stack signals (reuses `tmux-ide detect` logic). */
       detected: ProjectInspectDetectedSchemaZ
     });
-    InspectFilesystemRequestSchemaZ = z14.object({
-      dir: z14.string().min(1)
+    InspectFilesystemRequestSchemaZ = z15.object({
+      dir: z15.string().min(1)
     });
-    OnboardProjectRequestSchemaZ = z14.object({
-      dir: z14.string().min(1),
+    OnboardProjectRequestSchemaZ = z15.object({
+      dir: z15.string().min(1),
       /** Optional override for the project name — defaults to inspect.name. */
-      name: z14.string().min(1).optional(),
+      name: z15.string().min(1).optional(),
       /** 1, 2, or 3 — how many Claude panes to scaffold in the top row. */
-      agents: z14.number().int().min(1).max(3),
+      agents: z15.number().int().min(1).max(3),
       /**
        * Optional per-agent pane titles. When provided, length must equal
        * `agents`; the server uses these as `title:` for the Claude panes
        * instead of the canonical `Lead`/`Teammate N`/`Claude N` defaults.
        */
-      agentNames: z14.array(z14.string().min(1)).optional(),
+      agentNames: z15.array(z15.string().min(1)).optional(),
       /** Dev server command (e.g. `pnpm dev`). Omit / null to skip the dev pane. */
-      devCommand: z14.string().min(1).nullable().optional(),
+      devCommand: z15.string().min(1).nullable().optional(),
       /** Test command (e.g. `pnpm test`). Currently informational; stored for later. */
-      testCommand: z14.string().min(1).nullable().optional(),
+      testCommand: z15.string().min(1).nullable().optional(),
       /** Lint command (e.g. `pnpm lint`). Currently informational; stored for later. */
-      lintCommand: z14.string().min(1).nullable().optional()
+      lintCommand: z15.string().min(1).nullable().optional()
     });
   }
 });
@@ -10819,7 +10930,7 @@ var init_daemon_embed = __esm({
 
 // packages/daemon/src/lib/cli-action-bridge.ts
 import { createRequire as createRequire3 } from "node:module";
-import { z as z15 } from "zod";
+import { z as z16 } from "zod";
 function timeoutSignal3(ms) {
   const controller = new AbortController();
   setTimeout(() => controller.abort(), ms).unref?.();
@@ -10922,7 +11033,7 @@ async function tryDispatchAction(name, input, options = {}) {
       details: failure.data.error.details
     });
   }
-  const success = z15.object({ ok: z15.literal(true), result: contract.result }).safeParse(body);
+  const success = z16.object({ ok: z16.literal(true), result: contract.result }).safeParse(body);
   if (!success.success) return null;
   return success.data.result;
 }
@@ -10933,12 +11044,12 @@ var init_cli_action_bridge = __esm({
     init_contract();
     init_canonical_daemon();
     init_daemon_embed();
-    FailureEnvelopeZ = z15.object({
-      ok: z15.literal(false),
-      error: z15.object({
-        code: z15.string(),
-        message: z15.string(),
-        details: z15.unknown().optional()
+    FailureEnvelopeZ = z16.object({
+      ok: z16.literal(false),
+      error: z16.object({
+        code: z16.string(),
+        message: z16.string(),
+        details: z16.unknown().optional()
       })
     });
     deps = {
@@ -11574,6 +11685,130 @@ var init_report = __esm({
   }
 });
 
+// packages/daemon/src/control/frames.ts
+function encodeFrame(message) {
+  return `${JSON.stringify(message)}
+`;
+}
+function createFrameSplitter() {
+  let buffer = "";
+  return (chunk) => {
+    buffer += chunk;
+    const parts = buffer.split("\n");
+    buffer = parts.pop() ?? "";
+    if (buffer.length > MAX_FRAME_BYTES) {
+      buffer = "";
+      throw new Error(`frame exceeds ${MAX_FRAME_BYTES} bytes without a newline`);
+    }
+    return parts.filter((line) => line.trim().length > 0);
+  };
+}
+var MAX_FRAME_BYTES;
+var init_frames = __esm({
+  "packages/daemon/src/control/frames.ts"() {
+    "use strict";
+    MAX_FRAME_BYTES = 4 * 1024 * 1024;
+  }
+});
+
+// packages/daemon/src/control/dispatch.ts
+function extractId(value) {
+  if (typeof value === "object" && value !== null && "id" in value) {
+    const id = value.id;
+    if (typeof id === "string" || typeof id === "number") return id;
+  }
+  return null;
+}
+async function dispatchLine(line, handlers, ctx) {
+  let raw;
+  try {
+    raw = JSON.parse(line);
+  } catch {
+    return fail(null, "bad-request", "frame is not valid JSON");
+  }
+  const parsed = controlRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return fail(
+      extractId(raw),
+      "bad-request",
+      `invalid request envelope (need {v:${CONTROL_PROTOCOL_VERSION}, id, verb})`
+    );
+  }
+  const { id, verb, params } = parsed.data;
+  const handler = handlers[verb];
+  if (!handler) {
+    return fail(id, "unknown-verb", `unknown verb "${verb}"`);
+  }
+  try {
+    return ok(id, await handler(params ?? {}, ctx));
+  } catch (err) {
+    if (err instanceof ControlVerbError) return fail(id, err.code, err.message);
+    if (err instanceof IdeError) {
+      const code = err.code === "USAGE" ? "bad-request" : "not-found";
+      return fail(id, code, err.message);
+    }
+    return fail(id, "internal", err?.message ?? "internal error");
+  }
+}
+var ControlVerbError, ok, fail;
+var init_dispatch = __esm({
+  "packages/daemon/src/control/dispatch.ts"() {
+    "use strict";
+    init_src2();
+    init_errors2();
+    ControlVerbError = class extends Error {
+      code;
+      constructor(code, message) {
+        super(message);
+        this.code = code;
+      }
+    };
+    ok = (id, data) => ({
+      v: CONTROL_PROTOCOL_VERSION,
+      id,
+      ok: true,
+      data
+    });
+    fail = (id, code, message) => ({
+      v: CONTROL_PROTOCOL_VERSION,
+      id,
+      ok: false,
+      error: { code, message }
+    });
+  }
+});
+
+// packages/daemon/src/control/fanout.ts
+function createFanout(edges = {}) {
+  const sinks = /* @__PURE__ */ new Set();
+  const remove = (sink) => {
+    if (!sinks.delete(sink)) return;
+    if (sinks.size === 0) edges.onLast?.();
+  };
+  return {
+    add(sink) {
+      sinks.add(sink);
+      if (sinks.size === 1) edges.onFirst?.();
+      return () => remove(sink);
+    },
+    emit(event) {
+      for (const sink of [...sinks]) {
+        try {
+          sink(event);
+        } catch {
+          remove(sink);
+        }
+      }
+    },
+    size: () => sinks.size
+  };
+}
+var init_fanout = __esm({
+  "packages/daemon/src/control/fanout.ts"() {
+    "use strict";
+  }
+});
+
 // packages/daemon/src/agent-explain.ts
 var agent_explain_exports = {};
 __export(agent_explain_exports, {
@@ -11769,6 +12004,578 @@ var init_agent_explain = __esm({
   }
 });
 
+// packages/daemon/src/tui/team/wait.ts
+var wait_exports = {};
+__export(wait_exports, {
+  WAIT_DEFAULT_TIMEOUT_MS: () => WAIT_DEFAULT_TIMEOUT_MS,
+  WAIT_OUTPUT_POLL_MS: () => WAIT_OUTPUT_POLL_MS,
+  WAIT_STATUS_POLL_MS: () => WAIT_STATUS_POLL_MS,
+  matchOutput: () => matchOutput,
+  waitForAgentStatus: () => waitForAgentStatus,
+  waitForOutputMatch: () => waitForOutputMatch
+});
+function matchOutput(text, pattern) {
+  const lines = text.split("\n");
+  for (const line of lines) {
+    if (new RegExp(pattern).test(line)) return line;
+  }
+  if (new RegExp(pattern).test(text)) return lines[lines.length - 1] ?? "";
+  return null;
+}
+async function waitForAgentStatus(session, want, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? WAIT_DEFAULT_TIMEOUT_MS;
+  const pollMs = opts.pollMs ?? WAIT_STATUS_POLL_MS;
+  const tracker = opts.tracker ?? createStatusTracker();
+  const list = opts.listSessions ?? listTeamSessions;
+  const now = opts.now ?? Date.now;
+  const sleep2 = opts.sleep ?? sleepMs3;
+  const started = now();
+  for (; ; ) {
+    const status2 = findSessionStatus(list(tracker), session);
+    if (status2 === want) return { ok: true, session, want, status: status2 };
+    if (now() - started >= timeoutMs) {
+      return { ok: false, session, want, status: status2, timedOutAfterMs: timeoutMs };
+    }
+    await sleep2(pollMs);
+  }
+}
+async function waitForOutputMatch(target, pattern, opts = {}) {
+  new RegExp(pattern);
+  const timeoutMs = opts.timeoutMs ?? WAIT_DEFAULT_TIMEOUT_MS;
+  const pollMs = opts.pollMs ?? WAIT_OUTPUT_POLL_MS;
+  const capture = opts.capture ?? defaultCapture;
+  const now = opts.now ?? Date.now;
+  const sleep2 = opts.sleep ?? sleepMs3;
+  const started = now();
+  for (; ; ) {
+    let text = "";
+    try {
+      text = capture(target);
+    } catch {
+    }
+    const matched = matchOutput(text, pattern);
+    if (matched !== null) return { ok: true, target, pattern, matched };
+    if (now() - started >= timeoutMs) {
+      return { ok: false, target, pattern, matched: null, timedOutAfterMs: timeoutMs };
+    }
+    await sleep2(pollMs);
+  }
+}
+function defaultCapture(target) {
+  return capturePane(target, { lines: 200 });
+}
+var WAIT_DEFAULT_TIMEOUT_MS, WAIT_STATUS_POLL_MS, WAIT_OUTPUT_POLL_MS, sleepMs3;
+var init_wait = __esm({
+  "packages/daemon/src/tui/team/wait.ts"() {
+    "use strict";
+    init_src();
+    init_classify();
+    init_report();
+    init_sessions2();
+    WAIT_DEFAULT_TIMEOUT_MS = 6e4;
+    WAIT_STATUS_POLL_MS = 750;
+    WAIT_OUTPUT_POLL_MS = 500;
+    sleepMs3 = (ms) => new Promise((r) => setTimeout(r, ms));
+  }
+});
+
+// packages/daemon/src/tui/mirror/agent-lifecycle.ts
+function launchCommandFor(kind, manifests) {
+  const mapped = AGENT_LAUNCH_COMMANDS[kind];
+  if (mapped) return mapped;
+  const m = manifests.find((x) => x.id === kind);
+  return m?.commands[0] ?? kind;
+}
+function spawnAgentArgs(placement, target, dir, command2) {
+  const cd = dir ? ["-c", dir] : [];
+  if (placement === "window") return ["new-window", "-t", `${target.session}:`, ...cd, command2];
+  const flag = placement === "split-h" ? "-h" : "-v";
+  return ["split-window", flag, "-t", target.paneId ?? `${target.session}:`, ...cd, command2];
+}
+function spawnSessionArgs(name, dir, command2) {
+  return ["new-session", "-d", "-s", name, ...dir ? ["-c", dir] : [], command2];
+}
+function isShellCommand(command2, manifests) {
+  const name = command2.replace(/^-/, "").split("/").pop() ?? command2;
+  const shell = manifests.find((m) => m.id === "shell");
+  return [...shell?.commands ?? [], ...EXTRA_SHELLS].includes(name);
+}
+function paneHostsShell(startCommand, manifests) {
+  const first = startCommand.trim().split(/\s+/)[0] ?? "";
+  if (first.length === 0) return true;
+  return isShellCommand(first, manifests);
+}
+function respawnArgs(paneId, command2, dir) {
+  return ["respawn-pane", "-k", "-t", paneId, ...dir ? ["-c", dir] : [], command2];
+}
+function interruptArgs(paneId) {
+  return ["send-keys", "-t", paneId, "C-c"];
+}
+function relaunchArgs(paneId, command2) {
+  return [
+    ["send-keys", "-t", paneId, "-l", command2],
+    ["send-keys", "-t", paneId, "Enter"]
+  ];
+}
+function clearAuthorityArgs(paneId) {
+  return [
+    ["set-option", "-p", "-t", paneId, "-u", "@agent_state"],
+    ["set-option", "-p", "-t", paneId, "-u", "@agent_session_id"]
+  ];
+}
+var AGENT_LAUNCH_COMMANDS, EXTRA_SHELLS, INTERRUPT_TAP_GAP_MS, RESTART_GRACE_MS;
+var init_agent_lifecycle = __esm({
+  "packages/daemon/src/tui/mirror/agent-lifecycle.ts"() {
+    "use strict";
+    AGENT_LAUNCH_COMMANDS = {
+      claude: "claude",
+      codex: "codex",
+      opencode: "opencode",
+      gemini: "gemini",
+      aider: "aider",
+      copilot: "copilot",
+      cursor: "cursor-agent",
+      goose: "goose",
+      amp: "amp"
+    };
+    EXTRA_SHELLS = ["dash", "ksh", "tcsh", "csh"];
+    INTERRUPT_TAP_GAP_MS = 250;
+    RESTART_GRACE_MS = 1e3;
+  }
+});
+
+// packages/daemon/src/control/lifecycle.ts
+import { execFile as execFile3 } from "node:child_process";
+function tmuxRun(args) {
+  return new Promise((resolve24, reject) => {
+    execFile3("tmux", args, (err, stdout) => err ? reject(err) : resolve24(stdout.trimEnd()));
+  });
+}
+async function tmuxTry(args) {
+  await tmuxRun(args).catch(() => {
+  });
+}
+function resolveLaunchCommand(params) {
+  if (params.command) return params.command;
+  return launchCommandFor(params.kind, getManifests());
+}
+async function spawnAgent(params) {
+  const dir = params.dir ?? null;
+  const argv = params.session ? spawnAgentArgs(
+    params.placement ?? "window",
+    { session: params.session, paneId: params.paneId },
+    dir,
+    params.command
+  ) : spawnSessionArgs(params.sessionName, dir, params.command);
+  const [subcommand, ...rest] = argv;
+  let paneId;
+  try {
+    paneId = await tmuxRun([subcommand, "-P", "-F", "#{pane_id}", ...rest]);
+  } catch (err) {
+    throw new ControlVerbError("not-found", `tmux refused to spawn: ${err.message}`);
+  }
+  const session = params.session ?? params.sessionName;
+  if (!params.session) await tmuxTry(["set-environment", "-t", session, "TMUX_IDE", "1"]);
+  return {
+    paneId,
+    session,
+    command: params.command,
+    placement: params.session ? params.placement ?? "window" : "new-session"
+  };
+}
+async function interruptAgent(paneId) {
+  await tmuxTry(interruptArgs(paneId));
+  await sleep(INTERRUPT_TAP_GAP_MS);
+  await tmuxTry(interruptArgs(paneId));
+}
+async function clearAgentAuthority(paneId) {
+  for (const args of clearAuthorityArgs(paneId)) await tmuxTry(args);
+}
+function paneStartAndPath(paneId) {
+  return tmuxRun(["display", "-p", "-t", paneId, "#{pane_start_command}	#{pane_current_path}"]).then((out) => {
+    const [start2 = "", path2 = ""] = out.split("	");
+    return { start: start2, path: path2 };
+  }).catch(() => null);
+}
+async function stopAgent(paneId) {
+  const live = await paneStartAndPath(paneId);
+  if (!live) throw new ControlVerbError("not-found", `no pane "${paneId}"`);
+  await interruptAgent(paneId);
+  await clearAgentAuthority(paneId);
+  return { paneId, stopped: true };
+}
+async function restartAgent(paneId, command2) {
+  const live = await paneStartAndPath(paneId);
+  if (!live) throw new ControlVerbError("not-found", `no pane "${paneId}"`);
+  if (paneHostsShell(live.start, getManifests())) {
+    await interruptAgent(paneId);
+    await clearAgentAuthority(paneId);
+    await sleep(RESTART_GRACE_MS);
+    for (const args of relaunchArgs(paneId, command2)) await tmuxTry(args);
+    return { paneId, command: command2, strategy: "relaunch" };
+  }
+  await clearAgentAuthority(paneId);
+  await tmuxTry(respawnArgs(paneId, command2, live.path || null));
+  return { paneId, command: command2, strategy: "respawn" };
+}
+var sleep;
+var init_lifecycle = __esm({
+  "packages/daemon/src/control/lifecycle.ts"() {
+    "use strict";
+    init_agent_lifecycle();
+    init_manifest_loader();
+    init_dispatch();
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  }
+});
+
+// packages/daemon/src/control/verbs.ts
+function parse(schema, params) {
+  const result = schema.safeParse(params);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const at = issue?.path?.length ? ` at ${issue.path.join(".")}` : "";
+    throw new ControlVerbError("bad-request", `invalid params${at}: ${issue?.message ?? "?"}`);
+  }
+  return result.data;
+}
+function createVerbHandlers(ctx) {
+  return {
+    fleet: () => toFleetJson(listTeamProjects(ctx.tracker)),
+    agents: (params) => {
+      const p = parse(agentsParamsSchema, params);
+      const sessions = listTeamSessions(ctx.tracker);
+      const scoped = p.session ? sessions.filter((s) => s.name === p.session) : sessions;
+      if (p.session && scoped.length === 0) {
+        throw new ControlVerbError("not-found", `no session "${p.session}"`);
+      }
+      return { agents: scoped.flatMap((s) => s.agents ?? []) };
+    },
+    send: (params) => {
+      const p = parse(sendParamsSchema, params);
+      return deliverMessage(p);
+    },
+    wait: async (params) => {
+      const p = parse(waitParamsSchema, params);
+      if (p.kind === "output") {
+        try {
+          new RegExp(p.match);
+        } catch (err) {
+          throw new ControlVerbError(
+            "bad-request",
+            `invalid match regex: ${err.message}`
+          );
+        }
+      }
+      const result = p.kind === "agent-status" ? await waitForAgentStatus(p.session, p.status, { timeoutMs: p.timeoutMs }) : await waitForOutputMatch(p.target, p.match, { timeoutMs: p.timeoutMs });
+      if (!result.ok) {
+        const what = p.kind === "agent-status" ? `"${p.session}" to reach status "${p.status}"` : `${p.target} output to match /${p.match}/`;
+        throw new ControlVerbError(
+          "timeout",
+          `timed out after ${result.timedOutAfterMs}ms waiting for ${what}`
+        );
+      }
+      return result;
+    },
+    spawn: (params) => {
+      const p = parse(spawnParamsSchema, params);
+      return spawnAgent({ ...p, command: resolveLaunchCommand(p) });
+    },
+    "restart-agent": (params) => {
+      const p = parse(restartAgentParamsSchema, params);
+      return restartAgent(p.paneId, resolveLaunchCommand(p));
+    },
+    "stop-agent": (params) => {
+      const p = parse(stopAgentParamsSchema, params);
+      return stopAgent(p.paneId);
+    },
+    explain: (params) => {
+      const p = parse(explainParamsSchema, params);
+      return buildReport(p.target);
+    },
+    subscribe: (_params, verbCtx) => {
+      verbCtx.subscribe();
+      return { subscribed: true, events: ["agent-status"] };
+    }
+  };
+}
+var init_verbs = __esm({
+  "packages/daemon/src/control/verbs.ts"() {
+    "use strict";
+    init_src2();
+    init_agent_explain();
+    init_send();
+    init_report();
+    init_projects();
+    init_sessions2();
+    init_wait();
+    init_dispatch();
+    init_lifecycle();
+  }
+});
+
+// packages/daemon/src/control/server.ts
+var server_exports2 = {};
+__export(server_exports2, {
+  defaultControlSocketPath: () => defaultControlSocketPath,
+  startControlServer: () => startControlServer
+});
+import { chmodSync as chmodSync4, existsSync as existsSync32, mkdirSync as mkdirSync17, statSync as statSync5, unlinkSync } from "node:fs";
+import { createServer as createServer2, connect } from "node:net";
+import { dirname as dirname21, join as join25 } from "node:path";
+function defaultControlSocketPath() {
+  return join25(tuiStateHome(), "control.sock");
+}
+async function claimSocketPath(path2) {
+  if (!existsSync32(path2)) return;
+  if (!statSync5(path2).isSocket()) {
+    throw new IdeError(
+      `${path2} exists and is not a socket \u2014 refusing to remove it. Pass a different --socket path.`,
+      { code: "USAGE", exitCode: 1 }
+    );
+  }
+  const alive = await new Promise((resolve24) => {
+    const probe = connect(path2);
+    const done = (result) => {
+      probe.destroy();
+      resolve24(result);
+    };
+    probe.once("connect", () => done(true));
+    probe.once("error", () => done(false));
+    probe.setTimeout(500, () => done(false));
+  });
+  if (alive) {
+    throw new IdeError(`another server is already listening on ${path2}`, {
+      code: "USAGE",
+      exitCode: 1
+    });
+  }
+  unlinkSync(path2);
+}
+async function startControlServer(opts = {}) {
+  const socketPath = opts.socketPath ?? defaultControlSocketPath();
+  const log = opts.log ?? (() => {
+  });
+  const tickMs = opts.tickMs ?? TICK_MS;
+  mkdirSync17(dirname21(socketPath), { recursive: true });
+  await claimSocketPath(socketPath);
+  const tracker = createStatusTracker();
+  const handlers = createVerbHandlers({ tracker });
+  const prevState = /* @__PURE__ */ new Map();
+  let timer = null;
+  const tick = () => {
+    try {
+      const { events, state } = diffFleet(prevState, fleetStatuses(listTeamProjects(tracker)));
+      prevState.clear();
+      for (const [name, status2] of state) prevState.set(name, status2);
+      const ts = (/* @__PURE__ */ new Date()).toISOString();
+      for (const ev of events) fanout.emit({ ts, ...ev });
+    } catch (err) {
+      log(`event tick failed: ${err.message}`);
+    }
+  };
+  const fanout = createFanout({
+    onFirst: () => {
+      tick();
+      timer = setInterval(tick, tickMs);
+    },
+    onLast: () => {
+      if (timer) clearInterval(timer);
+      timer = null;
+      prevState.clear();
+    }
+  });
+  const connections = /* @__PURE__ */ new Set();
+  const server = createServer2((conn) => {
+    connections.add(conn);
+    conn.setEncoding("utf8");
+    const split = createFrameSplitter();
+    let unsubscribe = null;
+    const push = (ev) => {
+      conn.write(encodeFrame({ v: CONTROL_PROTOCOL_VERSION, event: "agent-status", data: ev }));
+    };
+    const ctx = {
+      subscribe: () => {
+        unsubscribe ??= fanout.add(push);
+      }
+    };
+    conn.on("data", (chunk) => {
+      let lines;
+      try {
+        lines = split(chunk);
+      } catch {
+        conn.destroy();
+        return;
+      }
+      for (const line of lines) {
+        void dispatchLine(line, handlers, ctx).then((response) => {
+          if (!conn.destroyed) conn.write(encodeFrame(response));
+        });
+      }
+    });
+    conn.on("close", () => {
+      unsubscribe?.();
+      connections.delete(conn);
+    });
+    conn.on("error", () => {
+    });
+  });
+  await new Promise((resolve24, reject) => {
+    server.once("error", (err) => {
+      if ((err.code === "EINVAL" || err.code === "ENAMETOOLONG") && socketPath.length > 100) {
+        reject(
+          new IdeError(
+            `socket path is too long for a Unix socket (${socketPath.length} chars; the OS caps it around 104): ${socketPath}
+Pass a shorter path: tmux-ide serve --socket /tmp/tmux-ide-control.sock`,
+            { code: "USAGE", exitCode: 1 }
+          )
+        );
+        return;
+      }
+      reject(err);
+    });
+    server.listen(socketPath, () => {
+      server.removeAllListeners("error");
+      resolve24();
+    });
+  });
+  chmodSync4(socketPath, 384);
+  log(`listening on ${socketPath}`);
+  return {
+    socketPath,
+    close: () => new Promise((resolve24) => {
+      if (timer) clearInterval(timer);
+      timer = null;
+      for (const conn of connections) conn.destroy();
+      server.close(() => {
+        try {
+          unlinkSync(socketPath);
+        } catch {
+        }
+        resolve24();
+      });
+    })
+  };
+}
+var init_server2 = __esm({
+  "packages/daemon/src/control/server.ts"() {
+    "use strict";
+    init_src2();
+    init_errors2();
+    init_tui_binary();
+    init_classify();
+    init_events();
+    init_updater();
+    init_projects();
+    init_dispatch();
+    init_fanout();
+    init_frames();
+    init_verbs();
+  }
+});
+
+// packages/daemon/src/control/client.ts
+var client_exports = {};
+__export(client_exports, {
+  ControlRequestError: () => ControlRequestError,
+  connectControl: () => connectControl
+});
+import { connect as connect2 } from "node:net";
+function connectControl(opts = {}) {
+  const path2 = opts.socketPath ?? defaultControlSocketPath();
+  return new Promise((resolve24, reject) => {
+    const socket = connect2(path2);
+    socket.once("error", reject);
+    socket.once("connect", () => {
+      socket.removeListener("error", reject);
+      resolve24(wrap(socket));
+    });
+  });
+}
+function wrap(socket) {
+  socket.setEncoding("utf8");
+  const split = createFrameSplitter();
+  const pending = /* @__PURE__ */ new Map();
+  const eventSinks = [];
+  let nextId = 1;
+  let markDone;
+  const done = new Promise((r) => {
+    markDone = r;
+  });
+  socket.on("data", (chunk) => {
+    for (const line of split(chunk)) {
+      let raw;
+      try {
+        raw = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const event = controlEventSchema.safeParse(raw);
+      if (event.success) {
+        for (const sink of eventSinks) sink(event.data);
+        continue;
+      }
+      const response = controlResponseSchema.safeParse(raw);
+      if (!response.success || response.data.id === null) continue;
+      const waiter = pending.get(response.data.id);
+      if (!waiter) continue;
+      pending.delete(response.data.id);
+      if (response.data.ok) waiter.resolve(response.data.data);
+      else {
+        waiter.reject(
+          new ControlRequestError(response.data.error.code, response.data.error.message)
+        );
+      }
+    }
+  });
+  const teardown = () => {
+    for (const { reject } of pending.values()) {
+      reject(new ControlRequestError("disconnected", "control socket closed"));
+    }
+    pending.clear();
+    markDone();
+  };
+  socket.on("close", teardown);
+  socket.on("error", () => {
+  });
+  const request = (verb, params) => {
+    const id = nextId++;
+    return new Promise((resolve24, reject) => {
+      if (socket.destroyed) {
+        reject(new ControlRequestError("disconnected", "control socket closed"));
+        return;
+      }
+      pending.set(id, { resolve: resolve24, reject });
+      socket.write(encodeFrame({ v: CONTROL_PROTOCOL_VERSION, id, verb, params }));
+    });
+  };
+  return {
+    request,
+    subscribe: async (onEvent) => {
+      eventSinks.push(onEvent);
+      await request("subscribe");
+    },
+    close: () => socket.destroy(),
+    done
+  };
+}
+var ControlRequestError;
+var init_client = __esm({
+  "packages/daemon/src/control/client.ts"() {
+    "use strict";
+    init_src2();
+    init_frames();
+    init_server2();
+    ControlRequestError = class extends Error {
+      code;
+      constructor(code, message) {
+        super(message);
+        this.code = code;
+      }
+    };
+  }
+});
+
 // packages/daemon/src/lib/worktree.ts
 var worktree_exports = {};
 __export(worktree_exports, {
@@ -11784,7 +12591,7 @@ __export(worktree_exports, {
   worktreeSessionName: () => worktreeSessionName
 });
 import { execFileSync as execFileSync13 } from "node:child_process";
-import { basename as basename9, dirname as dirname21, isAbsolute as isAbsolute6, join as join25, resolve as resolve22 } from "node:path";
+import { basename as basename9, dirname as dirname22, isAbsolute as isAbsolute6, join as join26, resolve as resolve22 } from "node:path";
 function sanitizeForTmux(part) {
   return part.replace(/[.:/\s]+/g, "-");
 }
@@ -11793,11 +12600,11 @@ function worktreeSessionName(project, branch) {
 }
 function defaultWorktreeBaseDir(repoDir) {
   const abs = resolve22(repoDir);
-  return join25(dirname21(abs), `${basename9(abs)}-worktrees`);
+  return join26(dirname22(abs), `${basename9(abs)}-worktrees`);
 }
 function worktreePath(repoDir, branch, configuredDir) {
   const base = configuredDir && configuredDir.length > 0 ? isAbsolute6(configuredDir) ? configuredDir : resolve22(repoDir, configuredDir) : defaultWorktreeBaseDir(repoDir);
-  return join25(base, branch);
+  return join26(base, branch);
 }
 function parseWorktreeList(porcelain) {
   const entries = [];
@@ -11941,8 +12748,8 @@ __export(update_exports, {
   runUpdate: () => runUpdate
 });
 import { execSync as execSync4 } from "node:child_process";
-import { existsSync as existsSync32 } from "node:fs";
-import { dirname as dirname22, join as join26 } from "node:path";
+import { existsSync as existsSync33 } from "node:fs";
+import { dirname as dirname23, join as join27 } from "node:path";
 function detectPackageManager(cliPath) {
   const p = cliPath.toLowerCase();
   if (/(^|\/)\.?bun(\/|$)/.test(p)) return "bun";
@@ -11988,8 +12795,8 @@ function renderPlan(plan, { current, latest, dryRun }) {
 function findGitCheckoutRoot(startDir) {
   let dir = startDir;
   for (; ; ) {
-    if (existsSync32(join26(dir, ".git"))) return dir;
-    const parent = dirname22(dir);
+    if (existsSync33(join27(dir, ".git"))) return dir;
+    const parent = dirname23(dir);
     if (parent === dir) return null;
     dir = parent;
   }
@@ -12024,7 +12831,7 @@ var command_center_exports = {};
 __export(command_center_exports, {
   startCommandCenter: () => startCommandCenter
 });
-import { createServer as createServer2 } from "node:http";
+import { createServer as createServer3 } from "node:http";
 import { getRequestListener } from "@hono/node-server";
 async function startCommandCenter(options = {}) {
   const port = options.port ?? 6060;
@@ -12034,7 +12841,7 @@ async function startCommandCenter(options = {}) {
   if (options.authConfig) appOpts.authConfig = options.authConfig;
   const app = createApp(appOpts);
   const listener = getRequestListener(app.fetch);
-  const server = createServer2(listener);
+  const server = createServer3(listener);
   return new Promise((resolve24) => {
     server.listen(port, hostname2, () => {
       console.log(`Command Center API on http://${hostname2}:${port}`);
@@ -12050,14 +12857,14 @@ var init_command_center = __esm({
 });
 
 // packages/daemon/src/server/index.ts
-var server_exports2 = {};
-__export(server_exports2, {
+var server_exports3 = {};
+__export(server_exports3, {
   createApp: () => createApp2,
   resolvePort: () => resolvePort,
   start: () => start
 });
-import { createServer as createServer3 } from "node:http";
-import { parse } from "node:url";
+import { createServer as createServer4 } from "node:http";
+import { parse as parse2 } from "node:url";
 import { Hono as Hono2 } from "hono";
 import { getRequestListener as getRequestListener2 } from "@hono/node-server";
 import { WebSocketServer as WebSocketServer3 } from "ws";
@@ -12077,10 +12884,10 @@ function createApp2() {
 async function start(port) {
   const resolvedPort = resolvePort(port);
   const app = createApp2();
-  const server = createServer3(getRequestListener2(app.fetch));
+  const server = createServer4(getRequestListener2(app.fetch));
   const ptyWss = new WebSocketServer3({ noServer: true });
   server.on("upgrade", (req, socket, head3) => {
-    const { pathname } = parse(req.url ?? "/", true);
+    const { pathname } = parse2(req.url ?? "/", true);
     const match = pathname?.match(/^\/ws\/pty\/([^/]+)$/);
     if (!match) {
       socket.destroy();
@@ -12110,7 +12917,7 @@ async function start(port) {
   };
 }
 var DEFAULT_PORT;
-var init_server2 = __esm({
+var init_server3 = __esm({
   "packages/daemon/src/server/index.ts"() {
     "use strict";
     init_ws_route();
@@ -12121,9 +12928,9 @@ var init_server2 = __esm({
 // bin/cli.ts
 init_launch();
 import { parseArgs } from "node:util";
-import { resolve as resolve23, dirname as dirname23, join as join27 } from "node:path";
+import { resolve as resolve23, dirname as dirname24, join as join28 } from "node:path";
 import { execFileSync as execFileSync14 } from "node:child_process";
-import { existsSync as existsSync33 } from "node:fs";
+import { existsSync as existsSync34 } from "node:fs";
 import { fileURLToPath as fileURLToPath9 } from "node:url";
 
 // packages/daemon/src/tui/team/entry.ts
@@ -12960,8 +13767,8 @@ async function restore({
   for (const action of plan.actions) {
     if (action.kind === "skip") continue;
     if (action.kind === "launch") {
-      const ok = await launchProject(action.dir, json2);
-      if (ok) launched.push(action.session);
+      const ok2 = await launchProject(action.dir, json2);
+      if (ok2) launched.push(action.session);
       else {
         const snap = snapshot.sessions.find((s) => s.name === action.session);
         if (snap) {
@@ -13113,7 +13920,7 @@ function hostAttachArgv(insideTmux) {
 }
 
 // bin/cli.ts
-var __dirname6 = dirname23(fileURLToPath9(import.meta.url));
+var __dirname6 = dirname24(fileURLToPath9(import.meta.url));
 var selfPath = fileURLToPath9(import.meta.url);
 var nodeCliPath = selfPath.endsWith(".js") ? selfPath : resolve23(__dirname6, "cli.js");
 var { positionals, values } = parseArgs({
@@ -13215,6 +14022,7 @@ var knownCommands = /* @__PURE__ */ new Set([
   "worktree",
   "update",
   "skill-sync",
+  "serve",
   "command-center",
   "server",
   "help"
@@ -13265,7 +14073,8 @@ ${bold3("Usage:")}
                               ${dim3("Block until a session reaches a status (exit 0 match / 1 timeout)")}
   ${cyan2("tmux-ide wait output")} <pane|session> --match <regex> [--timeout <ms>]
                               ${dim3("Block until a pane's output matches a regex (exit 0 match / 1 timeout)")}
-  ${cyan2("tmux-ide events")} [--follow] [--json]  ${dim3("Stream agent-status transitions (needs an adopted session)")}
+  ${cyan2("tmux-ide events")} [--follow] [--json] [--socket]  ${dim3("Stream agent-status transitions (--socket: push from a running serve)")}
+  ${cyan2("tmux-ide serve")} [--socket <path>]  ${dim3("Local control socket: NDJSON verbs + pushed events (~/.tmux-ide/control.sock)")}
   ${cyan2("tmux-ide adopt")} <session>    ${dim3("Add the live tmux-ide status bar to a session")}
   ${cyan2("tmux-ide adopt --all")}        ${dim3("Adopt every live (non-internal) session")}
   ${cyan2("tmux-ide unadopt")} <session>  ${dim3("Remove the status bar")}
@@ -13327,7 +14136,7 @@ function execBunWidget(surface, scriptPath, args, commandLabel, extraEnv = {}) {
     surface,
     scriptPath,
     args,
-    checkoutExists: existsSync33(scriptPath),
+    checkoutExists: existsSync34(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui()
   });
@@ -13359,7 +14168,7 @@ function launchHostedApp(scriptPath, appArgs) {
     surface: "app",
     scriptPath,
     args: appArgs,
-    checkoutExists: existsSync33(scriptPath),
+    checkoutExists: existsSync34(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui()
   });
@@ -13401,6 +14210,28 @@ async function printFleetJson() {
   const { toFleetJson: toFleetJson2 } = await Promise.resolve().then(() => (init_report(), report_exports));
   console.log(JSON.stringify(toFleetJson2(listTeamProjects2(createStatusTracker2())), null, 2));
 }
+var socketFlag = values.socket;
+async function waitOverSocket(params) {
+  if (!socketFlag) return null;
+  const { connectControl: connectControl2, ControlRequestError: ControlRequestError2 } = await Promise.resolve().then(() => (init_client(), client_exports));
+  let client;
+  try {
+    client = await connectControl2({
+      socketPath: typeof socketFlag === "string" ? socketFlag : void 0
+    });
+  } catch {
+    return null;
+  }
+  try {
+    const data = await client.request("wait", params);
+    return { timedOut: false, data };
+  } catch (err) {
+    if (err instanceof ControlRequestError2 && err.code === "timeout") return { timedOut: true };
+    return null;
+  } finally {
+    client.close();
+  }
+}
 var teamScriptPath = resolve23(__dirname6, "../packages/daemon/src/tui/team/index.tsx");
 var appScriptPath = resolve23(__dirname6, "../packages/daemon/src/tui/mirror/app.tsx");
 function launchTeamCockpit() {
@@ -13436,7 +14267,7 @@ try {
         }
       }
       const targetDir = resolve23(startTargetDir || ".");
-      const hasIdeYml = existsSync33(join27(targetDir, "ide.yml"));
+      const hasIdeYml = existsSync34(join28(targetDir, "ide.yml"));
       const entry = resolveEntry({
         hasIdeYml,
         teamFlag: values.team === true,
@@ -13592,7 +14423,7 @@ try {
         const pattern = values.match;
         if (!target || typeof pattern !== "string" || pattern.length === 0) {
           console.error(
-            "Usage: tmux-ide wait output <pane|session> --match <regex> [--timeout <ms>]"
+            "Usage: tmux-ide wait output <pane|session> --match <regex> [--timeout <ms>] [--socket[=path]]"
           );
           process.exit(1);
         }
@@ -13602,83 +14433,88 @@ try {
           console.error(`Invalid --match regex: ${err.message}`);
           process.exit(1);
         }
-        const { capturePane: capturePane2 } = await Promise.resolve().then(() => (init_src(), src_exports));
         const outTimeout = Number(values.timeout ?? "60000");
-        const outStart = Date.now();
-        const nap = (ms) => new Promise((r) => setTimeout(r, ms));
-        while (true) {
-          let text = "";
-          try {
-            text = capturePane2(target, { lines: 200 });
-          } catch {
-          }
-          const lines = text.split("\n");
-          let hit = null;
-          for (const line of lines) {
-            if (new RegExp(pattern).test(line)) {
-              hit = line;
-              break;
-            }
-          }
-          if (hit === null && new RegExp(pattern).test(text)) hit = lines[lines.length - 1] ?? "";
-          if (hit !== null) {
-            if (json) console.log(JSON.stringify({ matched: hit }));
-            else console.log(hit);
-            process.exit(0);
-          }
-          if (Date.now() - outStart >= outTimeout) {
+        const viaSocket2 = await waitOverSocket({
+          kind: "output",
+          target,
+          match: pattern,
+          timeoutMs: outTimeout
+        });
+        if (viaSocket2) {
+          if (viaSocket2.timedOut) {
             console.error(
               `Timed out after ${outTimeout}ms waiting for ${target} output to match /${pattern}/`
             );
             process.exit(1);
           }
-          await nap(500);
+          const hit = viaSocket2.data.matched;
+          if (json) console.log(JSON.stringify({ matched: hit }));
+          else console.log(hit);
+          process.exit(0);
         }
+        const { waitForOutputMatch: waitForOutputMatch2 } = await Promise.resolve().then(() => (init_wait(), wait_exports));
+        const result2 = await waitForOutputMatch2(target, pattern, { timeoutMs: outTimeout });
+        if (!result2.ok) {
+          console.error(
+            `Timed out after ${outTimeout}ms waiting for ${target} output to match /${pattern}/`
+          );
+          process.exit(1);
+        }
+        if (json) console.log(JSON.stringify({ matched: result2.matched }));
+        else console.log(result2.matched);
+        process.exit(0);
       }
-      const { createStatusTracker: createStatusTracker2 } = await Promise.resolve().then(() => (init_classify(), classify_exports));
-      const { listTeamSessions: listTeamSessions2 } = await Promise.resolve().then(() => (init_sessions2(), sessions_exports));
-      const { findSessionStatus: findSessionStatus2 } = await Promise.resolve().then(() => (init_report(), report_exports));
       const VALID = /* @__PURE__ */ new Set(["blocked", "working", "done", "idle", "unknown"]);
       const sessionName = positionals[2];
       const want = values.status;
       if (sub !== "agent-status" || !sessionName || typeof want !== "string" || !VALID.has(want)) {
         console.error(
-          "Usage: tmux-ide wait agent-status <session> --status <blocked|working|done|idle|unknown> [--timeout <ms>]"
+          "Usage: tmux-ide wait agent-status <session> --status <blocked|working|done|idle|unknown> [--timeout <ms>] [--socket[=path]]"
         );
         process.exit(1);
       }
       const timeout = Number(values.timeout ?? "60000");
-      const started = Date.now();
-      const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-      const tracker = createStatusTracker2();
-      while (true) {
-        const sessions = listTeamSessions2(tracker);
-        const status2 = findSessionStatus2(sessions, sessionName);
-        if (status2 === want) {
-          if (json) {
-            console.log(JSON.stringify({ session: sessionName, status: status2, ok: true }));
-          } else {
-            console.log(`${sessionName} reached status: ${status2}`);
-          }
-          process.exit(0);
-        }
-        if (Date.now() - started >= timeout) {
+      const viaSocket = await waitOverSocket({
+        kind: "agent-status",
+        session: sessionName,
+        status: want,
+        timeoutMs: timeout
+      });
+      if (viaSocket) {
+        if (viaSocket.timedOut) {
           console.error(
-            `Timed out after ${timeout}ms waiting for ${sessionName} to reach status "${want}" (last: ${status2 ?? "absent"})`
+            `Timed out after ${timeout}ms waiting for ${sessionName} to reach status "${want}"`
           );
           process.exit(1);
         }
-        await sleep(750);
+        if (json) console.log(JSON.stringify({ session: sessionName, status: want, ok: true }));
+        else console.log(`${sessionName} reached status: ${want}`);
+        process.exit(0);
       }
+      const { waitForAgentStatus: waitForAgentStatus2 } = await Promise.resolve().then(() => (init_wait(), wait_exports));
+      const result = await waitForAgentStatus2(
+        sessionName,
+        want,
+        { timeoutMs: timeout }
+      );
+      if (!result.ok) {
+        console.error(
+          `Timed out after ${timeout}ms waiting for ${sessionName} to reach status "${want}" (last: ${result.status ?? "absent"})`
+        );
+        process.exit(1);
+      }
+      if (json) {
+        console.log(JSON.stringify({ session: sessionName, status: result.status, ok: true }));
+      } else {
+        console.log(`${sessionName} reached status: ${result.status}`);
+      }
+      process.exit(0);
+      break;
     }
     case "events": {
-      const { readFileSync: readFileSync19, existsSync: existsSync34, statSync: statSync5, openSync, readSync, closeSync } = await import("node:fs");
+      const { readFileSync: readFileSync19, existsSync: existsSync35, statSync: statSync6, openSync, readSync, closeSync } = await import("node:fs");
       const { eventsPath: eventsPath2, formatEventLine: formatEventLine2 } = await Promise.resolve().then(() => (init_events(), events_exports));
       const path2 = eventsPath2();
-      if (!existsSync34(path2)) {
-        console.log("no events yet \u2014 is a session adopted? (the chrome updater writes events)");
-        break;
-      }
       const paintStatus = (status2, text) => {
         if (noColor || status2 === null) return text;
         const code = status2 === "blocked" ? "203" : status2 === "working" ? "221" : status2 === "done" ? "111" : status2 === "idle" ? "114" : "244";
@@ -13695,15 +14531,40 @@ try {
         } catch {
         }
       };
+      if (values.follow && socketFlag) {
+        const { connectControl: connectControl2 } = await Promise.resolve().then(() => (init_client(), client_exports));
+        const client = await connectControl2({
+          socketPath: typeof socketFlag === "string" ? socketFlag : void 0
+        }).catch(() => null);
+        if (client) {
+          if (existsSync35(path2)) {
+            const backlog = readFileSync19(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
+            for (const line of backlog.slice(-50)) printLine(line);
+          }
+          await client.subscribe((frame) => {
+            if (frame.event === "agent-status") printLine(JSON.stringify(frame.data));
+          });
+          process.on("SIGINT", () => {
+            client.close();
+            process.exit(0);
+          });
+          await client.done;
+          break;
+        }
+      }
+      if (!existsSync35(path2)) {
+        console.log("no events yet \u2014 is a session adopted? (the chrome updater writes events)");
+        break;
+      }
       const allLines = readFileSync19(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
       for (const line of allLines.slice(-50)) printLine(line);
       if (!values.follow) break;
-      let offset = statSync5(path2).size;
+      let offset = statSync6(path2).size;
       let leftover = "";
       const timer = setInterval(() => {
         let size;
         try {
-          size = statSync5(path2).size;
+          size = statSync6(path2).size;
         } catch {
           return;
         }
@@ -14102,7 +14963,7 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
       const mainPath = worktrees[0]?.path ?? repoDir;
       const projectName = getSessionName2(mainPath).name;
       async function openWorktreeSession(wtPath, name) {
-        if (existsSync33(join27(wtPath, "ide.yml"))) {
+        if (existsSync34(join28(wtPath, "ide.yml"))) {
           await launch(wtPath, { attach: false, sessionName: name });
         } else {
           if (!hasSession2(name)) createDetachedSession2(name, wtPath);
@@ -14276,6 +15137,25 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
       }
       break;
     }
+    case "serve": {
+      const { startControlServer: startControlServer2, defaultControlSocketPath: defaultControlSocketPath2 } = await Promise.resolve().then(() => (init_server2(), server_exports2));
+      const socketPath = typeof socketFlag === "string" ? socketFlag : positionals[1] ?? defaultControlSocketPath2();
+      const server = await startControlServer2({
+        socketPath,
+        log: (m) => console.error(`[serve] ${m}`)
+      });
+      let closing = false;
+      const shutdown = () => {
+        if (closing) return;
+        closing = true;
+        void server.close().then(() => process.exit(0));
+      };
+      process.on("SIGTERM", shutdown);
+      process.on("SIGINT", shutdown);
+      await new Promise(() => {
+      });
+      break;
+    }
     case "command-center": {
       const { startCommandCenter: startCommandCenter2 } = await Promise.resolve().then(() => (init_command_center(), command_center_exports));
       await startCommandCenter2({ port: parseInt(values.port ?? "4000") });
@@ -14288,7 +15168,7 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
         if (values.port) serverArgs.push("--port", values.port);
         execFileSync14("node", serverArgs, { stdio: "inherit" });
       } else {
-        const { start: start2 } = await Promise.resolve().then(() => (init_server2(), server_exports2));
+        const { start: start2 } = await Promise.resolve().then(() => (init_server3(), server_exports3));
         await start2(values.port ? parseInt(values.port, 10) : void 0);
       }
       break;

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -151,6 +151,7 @@ const knownCommands = new Set([
   "worktree",
   "update",
   "skill-sync",
+  "serve",
   "command-center",
   "server",
   "help",
@@ -208,7 +209,8 @@ ${bold("Usage:")}
                               ${dim("Block until a session reaches a status (exit 0 match / 1 timeout)")}
   ${cyan("tmux-ide wait output")} <pane|session> --match <regex> [--timeout <ms>]
                               ${dim("Block until a pane's output matches a regex (exit 0 match / 1 timeout)")}
-  ${cyan("tmux-ide events")} [--follow] [--json]  ${dim("Stream agent-status transitions (needs an adopted session)")}
+  ${cyan("tmux-ide events")} [--follow] [--json] [--socket]  ${dim("Stream agent-status transitions (--socket: push from a running serve)")}
+  ${cyan("tmux-ide serve")} [--socket <path>]  ${dim("Local control socket: NDJSON verbs + pushed events (~/.tmux-ide/control.sock)")}
   ${cyan("tmux-ide adopt")} <session>    ${dim("Add the live tmux-ide status bar to a session")}
   ${cyan("tmux-ide adopt --all")}        ${dim("Adopt every live (non-internal) session")}
   ${cyan("tmux-ide unadopt")} <session>  ${dim("Remove the status bar")}
@@ -382,6 +384,41 @@ async function printFleetJson(): Promise<void> {
   const { listTeamProjects } = await import("../packages/daemon/src/tui/team/projects.ts");
   const { toFleetJson } = await import("../packages/daemon/src/tui/team/report.ts");
   console.log(JSON.stringify(toFleetJson(listTeamProjects(createStatusTracker())), null, 2));
+}
+
+// The `--socket[=path]` opt-in (undeclared in parseArgs on purpose: bare
+// `--socket` parses to `true`, `--socket=/path` to the path — strict:false
+// gives optional-value semantics parseArgs can't declare). `true | string |
+// undefined`; string overrides the default socket path.
+const socketFlag = values.socket as string | boolean | undefined;
+
+// Run a `wait` on a live `tmux-ide serve` (connect once, the server holds the
+// wait — no local polling). Returns null when the flag is off, no server
+// answers, or the connection drops mid-wait — callers fall back SILENTLY to
+// the local polling implementation (same shared logic, tui/team/wait.ts).
+async function waitOverSocket(
+  params: Record<string, unknown>,
+): Promise<{ timedOut: boolean; data?: unknown } | null> {
+  if (!socketFlag) return null;
+  const { connectControl, ControlRequestError } =
+    await import("../packages/daemon/src/control/client.ts");
+  let client: Awaited<ReturnType<typeof connectControl>>;
+  try {
+    client = await connectControl({
+      socketPath: typeof socketFlag === "string" ? socketFlag : undefined,
+    });
+  } catch {
+    return null; // no server listening — poll locally instead
+  }
+  try {
+    const data = await client.request("wait", params);
+    return { timedOut: false, data };
+  } catch (err) {
+    if (err instanceof ControlRequestError && err.code === "timeout") return { timedOut: true };
+    return null; // dropped/errored mid-wait — fall back to polling
+  } finally {
+    client.close();
+  }
 }
 
 const teamScriptPath = resolve(__dirname, "../packages/daemon/src/tui/team/index.tsx");
@@ -644,7 +681,7 @@ try {
         const pattern = values.match;
         if (!target || typeof pattern !== "string" || pattern.length === 0) {
           console.error(
-            "Usage: tmux-ide wait output <pane|session> --match <regex> [--timeout <ms>]",
+            "Usage: tmux-ide wait output <pane|session> --match <regex> [--timeout <ms>] [--socket[=path]]",
           );
           process.exit(1);
         }
@@ -654,46 +691,42 @@ try {
           console.error(`Invalid --match regex: ${(err as Error).message}`);
           process.exit(1);
         }
-        const { capturePane } = await import("../packages/tmux-bridge/src/index.ts");
         const outTimeout = Number(values.timeout ?? "60000");
-        const outStart = Date.now();
-        const nap = (ms: number) => new Promise((r) => setTimeout(r, ms));
-        while (true) {
-          let text = "";
-          try {
-            text = capturePane(target!, { lines: 200 });
-          } catch {
-            // pane/session not (yet) available — keep polling until timeout
-          }
-          const lines = text.split("\n");
-          // Fresh regex per test so a user-supplied /g flag can't carry lastIndex
-          // between calls. Report the specific matching line when we can.
-          let hit: string | null = null;
-          for (const line of lines) {
-            if (new RegExp(pattern!).test(line)) {
-              hit = line;
-              break;
-            }
-          }
-          if (hit === null && new RegExp(pattern!).test(text)) hit = lines[lines.length - 1] ?? "";
-          if (hit !== null) {
-            if (json) console.log(JSON.stringify({ matched: hit }));
-            else console.log(hit);
-            process.exit(0);
-          }
-          if (Date.now() - outStart >= outTimeout) {
+
+        // `--socket` fast path: let a running `tmux-ide serve` hold the wait
+        // (one process, no spawn-per-poll). Falls back silently when no server
+        // is listening — the polling below is exactly the same implementation.
+        const viaSocket = await waitOverSocket({
+          kind: "output",
+          target,
+          match: pattern,
+          timeoutMs: outTimeout,
+        });
+        if (viaSocket) {
+          if (viaSocket.timedOut) {
             console.error(
               `Timed out after ${outTimeout}ms waiting for ${target} output to match /${pattern}/`,
             );
             process.exit(1);
           }
-          await nap(500);
+          const hit = (viaSocket.data as { matched: string }).matched;
+          if (json) console.log(JSON.stringify({ matched: hit }));
+          else console.log(hit);
+          process.exit(0);
         }
-      }
 
-      const { createStatusTracker } = await import("../packages/daemon/src/tui/detect/classify.ts");
-      const { listTeamSessions } = await import("../packages/daemon/src/tui/team/sessions.ts");
-      const { findSessionStatus } = await import("../packages/daemon/src/tui/team/report.ts");
+        const { waitForOutputMatch } = await import("../packages/daemon/src/tui/team/wait.ts");
+        const result = await waitForOutputMatch(target!, pattern!, { timeoutMs: outTimeout });
+        if (!result.ok) {
+          console.error(
+            `Timed out after ${outTimeout}ms waiting for ${target} output to match /${pattern}/`,
+          );
+          process.exit(1);
+        }
+        if (json) console.log(JSON.stringify({ matched: result.matched }));
+        else console.log(result.matched);
+        process.exit(0);
+      }
 
       const VALID = new Set(["blocked", "working", "done", "idle", "unknown"]);
       const sessionName = positionals[2];
@@ -701,37 +734,50 @@ try {
 
       if (sub !== "agent-status" || !sessionName || typeof want !== "string" || !VALID.has(want)) {
         console.error(
-          "Usage: tmux-ide wait agent-status <session> --status <blocked|working|done|idle|unknown> [--timeout <ms>]",
+          "Usage: tmux-ide wait agent-status <session> --status <blocked|working|done|idle|unknown> [--timeout <ms>] [--socket[=path]]",
         );
         process.exit(1);
       }
 
       const timeout = Number(values.timeout ?? "60000");
-      const started = Date.now();
-      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-      // One tracker persists across polls so the working→idle `done` transition
-      // can be observed (it's inherently cross-tick).
-      const tracker = createStatusTracker();
 
-      while (true) {
-        const sessions = listTeamSessions(tracker);
-        const status = findSessionStatus(sessions, sessionName!);
-        if (status === want) {
-          if (json) {
-            console.log(JSON.stringify({ session: sessionName, status, ok: true }));
-          } else {
-            console.log(`${sessionName} reached status: ${status}`);
-          }
-          process.exit(0);
-        }
-        if (Date.now() - started >= timeout) {
+      const viaSocket = await waitOverSocket({
+        kind: "agent-status",
+        session: sessionName,
+        status: want,
+        timeoutMs: timeout,
+      });
+      if (viaSocket) {
+        if (viaSocket.timedOut) {
           console.error(
-            `Timed out after ${timeout}ms waiting for ${sessionName} to reach status "${want}" (last: ${status ?? "absent"})`,
+            `Timed out after ${timeout}ms waiting for ${sessionName} to reach status "${want}"`,
           );
           process.exit(1);
         }
-        await sleep(750);
+        if (json) console.log(JSON.stringify({ session: sessionName, status: want, ok: true }));
+        else console.log(`${sessionName} reached status: ${want}`);
+        process.exit(0);
       }
+
+      const { waitForAgentStatus } = await import("../packages/daemon/src/tui/team/wait.ts");
+      const result = await waitForAgentStatus(
+        sessionName!,
+        want as import("../packages/daemon/src/tui/detect/classify.ts").AgentStatus,
+        { timeoutMs: timeout },
+      );
+      if (!result.ok) {
+        console.error(
+          `Timed out after ${timeout}ms waiting for ${sessionName} to reach status "${want}" (last: ${result.status ?? "absent"})`,
+        );
+        process.exit(1);
+      }
+      if (json) {
+        console.log(JSON.stringify({ session: sessionName, status: result.status, ok: true }));
+      } else {
+        console.log(`${sessionName} reached status: ${result.status}`);
+      }
+      process.exit(0);
+      break;
     }
 
     case "events": {
@@ -744,10 +790,6 @@ try {
       type EventLike = { ts: string; session: string; from: Status | null; to: Status };
 
       const path = eventsPath();
-      if (!existsSync(path)) {
-        console.log("no events yet — is a session adopted? (the chrome updater writes events)");
-        break;
-      }
 
       // Status → ANSI color, matching the chrome bar's palette in spirit.
       const paintStatus = (status: Status | null, text: string): string => {
@@ -776,6 +818,40 @@ try {
           // skip malformed line
         }
       };
+
+      // `--follow --socket` fast path: a running `tmux-ide serve` PUSHES
+      // transitions the moment its detection tick sees them — no file polling.
+      // The last-50 backlog still comes from the log (the server has no
+      // history); falls back silently to the polling path when no server is up.
+      if (values.follow && socketFlag) {
+        const { connectControl } = await import("../packages/daemon/src/control/client.ts");
+        const client = await connectControl({
+          socketPath: typeof socketFlag === "string" ? socketFlag : undefined,
+        }).catch(() => null);
+        if (client) {
+          if (existsSync(path)) {
+            const backlog = readFileSync(path, "utf8")
+              .split("\n")
+              .filter((l) => l.trim().length > 0);
+            for (const line of backlog.slice(-50)) printLine(line);
+          }
+          await client.subscribe((frame) => {
+            if (frame.event === "agent-status") printLine(JSON.stringify(frame.data));
+          });
+          process.on("SIGINT", () => {
+            client.close();
+            process.exit(0);
+          });
+          // Ends when the server shuts down (EOF) — exit cleanly then.
+          await client.done;
+          break;
+        }
+      }
+
+      if (!existsSync(path)) {
+        console.log("no events yet — is a session adopted? (the chrome updater writes events)");
+        break;
+      }
 
       const allLines = readFileSync(path, "utf8")
         .split("\n")
@@ -1522,6 +1598,34 @@ try {
             : ` (v${result.to})`;
         console.log(`skill ${result.action}${detail}: ${result.path}`);
       }
+      break;
+    }
+
+    case "serve": {
+      // The local control socket (M23.3): NDJSON verbs + pushed agent-status
+      // events over a 0600 Unix socket. Foreground on purpose — the process
+      // the user (or their agent loop) started is the process they own; see
+      // the host tradeoff in control/server.ts.
+      const { startControlServer, defaultControlSocketPath } =
+        await import("../packages/daemon/src/control/server.ts");
+      const socketPath =
+        typeof socketFlag === "string"
+          ? socketFlag
+          : (positionals[1] ?? defaultControlSocketPath());
+      const server = await startControlServer({
+        socketPath,
+        log: (m) => console.error(`[serve] ${m}`),
+      });
+      let closing = false;
+      const shutdown = () => {
+        if (closing) return;
+        closing = true;
+        // Unlinks the socket and EOFs every client before exiting.
+        void server.close().then(() => process.exit(0));
+      };
+      process.on("SIGTERM", shutdown);
+      process.on("SIGINT", shutdown);
+      await new Promise(() => {}); // the server owns the process lifetime
       break;
     }
 

--- a/packages/contracts/src/__tests__/control.test.ts
+++ b/packages/contracts/src/__tests__/control.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Schema tests for the control-socket protocol (M23.3): the versioned
+ * envelope and the per-verb params. These pin the WIRE contract — a change
+ * that breaks one of these breaks every connected agent loop.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  CONTROL_PROTOCOL_VERSION,
+  CONTROL_WAIT_MAX_TIMEOUT_MS,
+  agentStatusEventSchema,
+  controlEventSchema,
+  controlRequestSchema,
+  controlResponseSchema,
+  restartAgentParamsSchema,
+  sendParamsSchema,
+  spawnParamsSchema,
+  waitParamsSchema,
+} from "../control";
+
+describe("controlRequestSchema", () => {
+  it("accepts a minimal request (params optional)", () => {
+    const r = controlRequestSchema.parse({ v: 1, id: 1, verb: "fleet" });
+    expect(r.verb).toBe("fleet");
+    expect(r.params).toBeUndefined();
+  });
+
+  it("accepts string ids and object params", () => {
+    const r = controlRequestSchema.parse({
+      v: 1,
+      id: "req-7",
+      verb: "send",
+      params: { session: "s", target: "%1", message: "hi" },
+    });
+    expect(r.id).toBe("req-7");
+  });
+
+  it("keeps verb an OPEN string — unknown verbs parse (dispatch answers them)", () => {
+    expect(controlRequestSchema.parse({ v: 1, id: 1, verb: "verb-from-the-future" }).verb).toBe(
+      "verb-from-the-future",
+    );
+  });
+
+  it("rejects a wrong or missing version", () => {
+    expect(() => controlRequestSchema.parse({ v: 2, id: 1, verb: "fleet" })).toThrow();
+    expect(() => controlRequestSchema.parse({ id: 1, verb: "fleet" })).toThrow();
+  });
+
+  it("rejects a missing id or empty verb", () => {
+    expect(() => controlRequestSchema.parse({ v: 1, verb: "fleet" })).toThrow();
+    expect(() => controlRequestSchema.parse({ v: 1, id: 1, verb: "" })).toThrow();
+  });
+});
+
+describe("controlResponseSchema", () => {
+  it("accepts an ok response with arbitrary data", () => {
+    const r = controlResponseSchema.parse({ v: 1, id: 3, ok: true, data: { projects: [] } });
+    expect(r.ok).toBe(true);
+  });
+
+  it("accepts an error response with a null id (uncorrelatable frame)", () => {
+    const r = controlResponseSchema.parse({
+      v: 1,
+      id: null,
+      ok: false,
+      error: { code: "bad-request", message: "unparseable frame" },
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects an error response without the error object", () => {
+    expect(() => controlResponseSchema.parse({ v: 1, id: 1, ok: false })).toThrow();
+  });
+});
+
+describe("controlEventSchema + agentStatusEventSchema", () => {
+  it("accepts an event frame and its agent-status payload", () => {
+    const frame = controlEventSchema.parse({
+      v: CONTROL_PROTOCOL_VERSION,
+      event: "agent-status",
+      data: { ts: "2026-07-10T12:00:00Z", session: "zz-x", from: null, to: "working" },
+    });
+    const ev = agentStatusEventSchema.parse(frame.data);
+    expect(ev.from).toBeNull();
+    expect(ev.to).toBe("working");
+  });
+
+  it("rejects an unknown status in the payload", () => {
+    expect(() =>
+      agentStatusEventSchema.parse({ ts: "t", session: "s", from: null, to: "sleeping" }),
+    ).toThrow();
+  });
+});
+
+describe("waitParamsSchema", () => {
+  it("accepts both kinds", () => {
+    expect(
+      waitParamsSchema.parse({ kind: "agent-status", session: "s", status: "done" }).kind,
+    ).toBe("agent-status");
+    expect(waitParamsSchema.parse({ kind: "output", target: "%1", match: "ok" }).kind).toBe(
+      "output",
+    );
+  });
+
+  it("caps timeoutMs", () => {
+    expect(() =>
+      waitParamsSchema.parse({
+        kind: "output",
+        target: "%1",
+        match: "ok",
+        timeoutMs: CONTROL_WAIT_MAX_TIMEOUT_MS + 1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("spawnParamsSchema", () => {
+  it("requires exactly one of kind/command", () => {
+    expect(() => spawnParamsSchema.parse({ session: "s" })).toThrow();
+    expect(() => spawnParamsSchema.parse({ session: "s", kind: "claude", command: "x" })).toThrow();
+    expect(spawnParamsSchema.parse({ session: "s", kind: "claude" }).kind).toBe("claude");
+  });
+
+  it("requires a session or a sessionName", () => {
+    expect(() => spawnParamsSchema.parse({ kind: "claude" })).toThrow();
+    expect(spawnParamsSchema.parse({ sessionName: "zz-new", kind: "claude" }).sessionName).toBe(
+      "zz-new",
+    );
+  });
+
+  it("requires paneId for split placements only", () => {
+    expect(() =>
+      spawnParamsSchema.parse({ session: "s", kind: "claude", placement: "split-h" }),
+    ).toThrow();
+    expect(
+      spawnParamsSchema.parse({ session: "s", kind: "claude", placement: "window" }).placement,
+    ).toBe("window");
+  });
+});
+
+describe("sendParamsSchema / restartAgentParamsSchema", () => {
+  it("send requires session, target and a non-empty message", () => {
+    expect(() => sendParamsSchema.parse({ session: "s", target: "%1", message: "" })).toThrow();
+    expect(sendParamsSchema.parse({ session: "s", target: "%1", message: "go" }).noEnter).toBe(
+      undefined,
+    );
+  });
+
+  it("restart requires kind or command", () => {
+    expect(() => restartAgentParamsSchema.parse({ paneId: "%1" })).toThrow();
+    expect(restartAgentParamsSchema.parse({ paneId: "%1", command: "claude" }).command).toBe(
+      "claude",
+    );
+  });
+});

--- a/packages/contracts/src/control.ts
+++ b/packages/contracts/src/control.ts
@@ -1,0 +1,217 @@
+/**
+ * The local control-socket protocol (M23.3) — newline-delimited JSON frames
+ * over a Unix socket (`~/.tmux-ide/control.sock` by default). This is the
+ * scriptable surface for agent loops: connect once, drive the fleet, get
+ * events PUSHED instead of spawning a CLI per poll.
+ *
+ * Every frame is one JSON object on one line. Three frame shapes:
+ *
+ *   request   {v:1, id, verb, params?}          client → server
+ *   response  {v:1, id, ok, data|error}         server → client (id-correlated)
+ *   event     {v:1, event, data}                server → client (after `subscribe`)
+ *
+ * The envelope is VERSIONED from day one (`v: 1`) and `verb` is an open
+ * string in the envelope (unknown verbs are answered with an `unknown-verb`
+ * error, not a parse failure) so a v2 can add verbs without breaking v1
+ * clients. The future native-app bridge (#90) layers on mechanically: each
+ * NDJSON frame maps 1:1 to a WebSocket text message — id correlation and the
+ * unsolicited event channel already match WS semantics, so the bridge is a
+ * transport swap, not a protocol change.
+ *
+ * Params schemas are per-verb and STRICT about types but tolerant of absence
+ * (`params` may be omitted for verbs that need none).
+ */
+import { z } from "zod";
+
+/** The protocol version every frame carries. Bump only on breaking changes. */
+export const CONTROL_PROTOCOL_VERSION = 1;
+
+/** Request ids are client-chosen; responses echo them verbatim. */
+export const controlIdSchema = z.union([z.string(), z.number()]);
+export type ControlId = z.infer<typeof controlIdSchema>;
+
+/** The agent statuses the detection layer produces (mirrors the daemon's `AgentStatus`). */
+export const agentStatusSchema = z.enum(["blocked", "working", "done", "idle", "unknown"]);
+export type ControlAgentStatus = z.infer<typeof agentStatusSchema>;
+
+/** The verbs a v1 server understands (dispatch also answers unknown strings honestly). */
+export const CONTROL_VERBS = [
+  "fleet",
+  "agents",
+  "send",
+  "wait",
+  "spawn",
+  "restart-agent",
+  "stop-agent",
+  "explain",
+  "subscribe",
+] as const;
+export type ControlVerb = (typeof CONTROL_VERBS)[number];
+
+/**
+ * The request envelope. `verb` stays an open string here — verb existence is
+ * a DISPATCH concern (answered with `unknown-verb`), not a parse failure, so
+ * newer clients get an honest error from an older server.
+ */
+export const controlRequestSchema = z.object({
+  v: z.literal(CONTROL_PROTOCOL_VERSION),
+  id: controlIdSchema,
+  verb: z.string().min(1),
+  params: z.record(z.string(), z.unknown()).optional(),
+});
+export type ControlRequest = z.infer<typeof controlRequestSchema>;
+
+/** Machine-readable error codes a response can carry. */
+export const controlErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+});
+export type ControlError = z.infer<typeof controlErrorSchema>;
+
+/**
+ * The response envelope. `id` is null only for frames the server could not
+ * correlate (unparseable JSON / envelope) — everything else echoes the
+ * request id.
+ */
+export const controlResponseSchema = z.discriminatedUnion("ok", [
+  z.object({
+    v: z.literal(CONTROL_PROTOCOL_VERSION),
+    id: controlIdSchema.nullable(),
+    ok: z.literal(true),
+    data: z.unknown(),
+  }),
+  z.object({
+    v: z.literal(CONTROL_PROTOCOL_VERSION),
+    id: controlIdSchema.nullable(),
+    ok: z.literal(false),
+    error: controlErrorSchema,
+  }),
+]);
+export type ControlResponse = z.infer<typeof controlResponseSchema>;
+
+/** An unsolicited push frame (only sent to connections that ran `subscribe`). */
+export const controlEventSchema = z.object({
+  v: z.literal(CONTROL_PROTOCOL_VERSION),
+  event: z.string().min(1),
+  data: z.unknown(),
+});
+export type ControlEventFrame = z.infer<typeof controlEventSchema>;
+
+/** The one v1 event stream: session-level agent-status transitions
+ *  (`from` is null the first time the subscriber's server sees a session). */
+export const agentStatusEventSchema = z.object({
+  ts: z.string(),
+  session: z.string(),
+  from: agentStatusSchema.nullable(),
+  to: agentStatusSchema,
+});
+export type AgentStatusEvent = z.infer<typeof agentStatusEventSchema>;
+
+// ---------------------------------------------------------------------------
+// Per-verb params
+// ---------------------------------------------------------------------------
+
+/** `agents` — flat per-pane agent entries, optionally scoped to one session. */
+export const agentsParamsSchema = z.object({
+  session: z.string().optional(),
+});
+export type AgentsParams = z.infer<typeof agentsParamsSchema>;
+
+/**
+ * `send` — deliver text to a pane in `session`. `target` accepts the same
+ * forms as `tmux-ide send`: a pane id (%N), an @ide_name, a title, a role, or
+ * a partial title. `dir` (optional) is the project dir long messages are
+ * dispatched through as a file; without it long text is sent directly.
+ */
+export const sendParamsSchema = z.object({
+  session: z.string().min(1),
+  target: z.string().min(1),
+  message: z.string().min(1),
+  noEnter: z.boolean().optional(),
+  dir: z.string().optional(),
+});
+export type SendParams = z.infer<typeof sendParamsSchema>;
+
+/** Server-side cap on a single `wait` — protects the resident process. */
+export const CONTROL_WAIT_MAX_TIMEOUT_MS = 600_000;
+
+const waitTimeoutSchema = z.number().int().positive().max(CONTROL_WAIT_MAX_TIMEOUT_MS).optional();
+
+/** `wait` — block (server-side) until a condition holds. Two kinds, mirroring
+ *  `tmux-ide wait agent-status` and `tmux-ide wait output`. */
+export const waitParamsSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("agent-status"),
+    session: z.string().min(1),
+    status: agentStatusSchema,
+    timeoutMs: waitTimeoutSchema,
+  }),
+  z.object({
+    kind: z.literal("output"),
+    target: z.string().min(1),
+    match: z.string().min(1),
+    timeoutMs: waitTimeoutSchema,
+  }),
+]);
+export type WaitParams = z.infer<typeof waitParamsSchema>;
+
+/** Where a spawned agent lands (mirrors the app's lifecycle placements). */
+export const spawnPlacementSchema = z.enum(["window", "split-h", "split-v"]);
+
+/**
+ * `spawn` — start an agent via the SAME lifecycle argv builders the app uses.
+ * Exactly one of `kind` (a detection-manifest id, resolved to its launch
+ * command) or `command` (verbatim) must be given. With `session` the agent
+ * lands in that live session (`placement`, default a new window; splits need
+ * `paneId`); without it a fresh detached session named `sessionName` is
+ * created in `dir`.
+ */
+export const spawnParamsSchema = z
+  .object({
+    kind: z.string().min(1).optional(),
+    command: z.string().min(1).optional(),
+    session: z.string().min(1).optional(),
+    sessionName: z.string().min(1).optional(),
+    dir: z.string().optional(),
+    placement: spawnPlacementSchema.optional(),
+    paneId: z.string().optional(),
+  })
+  .refine((p) => Boolean(p.kind) !== Boolean(p.command), {
+    message: "exactly one of `kind` or `command` is required",
+  })
+  .refine((p) => Boolean(p.session) || Boolean(p.sessionName), {
+    message: "`session` (spawn into it) or `sessionName` (create it) is required",
+  })
+  .refine((p) => !(p.placement && p.placement !== "window") || Boolean(p.paneId), {
+    message: "split placements need `paneId`",
+  });
+export type SpawnParams = z.infer<typeof spawnParamsSchema>;
+
+/** `restart-agent` — restart the agent in `paneId`, relaunching `command`
+ *  (or `kind`'s launch command). One of the two is required. */
+export const restartAgentParamsSchema = z
+  .object({
+    paneId: z.string().min(1),
+    kind: z.string().min(1).optional(),
+    command: z.string().min(1).optional(),
+  })
+  .refine((p) => Boolean(p.kind) || Boolean(p.command), {
+    message: "`kind` or `command` is required",
+  });
+export type RestartAgentParams = z.infer<typeof restartAgentParamsSchema>;
+
+/** `stop-agent` — interrupt the agent in `paneId` (the pane stays open). */
+export const stopAgentParamsSchema = z.object({
+  paneId: z.string().min(1),
+});
+export type StopAgentParams = z.infer<typeof stopAgentParamsSchema>;
+
+/** `explain` — the detection debugger for one pane (or a session's active pane). */
+export const explainParamsSchema = z.object({
+  target: z.string().min(1),
+});
+export type ExplainParams = z.infer<typeof explainParamsSchema>;
+
+/** `subscribe` — flip this connection into receiving event frames. */
+export const subscribeParamsSchema = z.object({}).loose();
+export type SubscribeParams = z.infer<typeof subscribeParamsSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -22,3 +22,4 @@ export * from "./workspace.ts";
 export * from "./actions-contract.ts";
 export * from "./actions-errors.ts";
 export * from "./terminals.ts";
+export * from "./control.ts";

--- a/packages/daemon/src/control/client.ts
+++ b/packages/daemon/src/control/client.ts
@@ -1,0 +1,128 @@
+/**
+ * A minimal control-socket client — what the CLI's `--socket` fast-paths
+ * (`events --follow --socket`, `wait … --socket`) ride on. Connect, send
+ * id-correlated requests, optionally receive pushed event frames. Kept
+ * dependency-light on purpose: this is also the reference for "how would an
+ * agent drive the socket from node" (see skill/SKILL.md).
+ */
+import { connect, type Socket } from "node:net";
+import {
+  CONTROL_PROTOCOL_VERSION,
+  controlEventSchema,
+  controlResponseSchema,
+  type ControlEventFrame,
+} from "@tmux-ide/contracts";
+import { createFrameSplitter, encodeFrame } from "./frames.ts";
+import { defaultControlSocketPath } from "./server.ts";
+
+/** A failed verb, carrying the server's machine-readable error code. */
+export class ControlRequestError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export interface ControlClient {
+  /** Send one verb; resolves with the response `data`, rejects with
+   *  {@link ControlRequestError} on an error response or a dropped socket. */
+  request(verb: string, params?: Record<string, unknown>): Promise<unknown>;
+  /** Receive pushed event frames (also sends the `subscribe` verb). */
+  subscribe(onEvent: (event: ControlEventFrame) => void): Promise<void>;
+  close(): void;
+  /** Resolves when the connection ends (server shutdown → EOF). */
+  done: Promise<void>;
+}
+
+/**
+ * Connect to a control server. Rejects (quickly) when nothing is listening —
+ * callers treat that as "no server, fall back to polling".
+ */
+export function connectControl(opts: { socketPath?: string } = {}): Promise<ControlClient> {
+  const path = opts.socketPath ?? defaultControlSocketPath();
+  return new Promise((resolve, reject) => {
+    const socket: Socket = connect(path);
+    socket.once("error", reject);
+    socket.once("connect", () => {
+      socket.removeListener("error", reject);
+      resolve(wrap(socket));
+    });
+  });
+}
+
+function wrap(socket: Socket): ControlClient {
+  socket.setEncoding("utf8");
+  const split = createFrameSplitter();
+  const pending = new Map<
+    string | number,
+    { resolve: (data: unknown) => void; reject: (err: Error) => void }
+  >();
+  const eventSinks: Array<(event: ControlEventFrame) => void> = [];
+  let nextId = 1;
+
+  let markDone: () => void;
+  const done = new Promise<void>((r) => {
+    markDone = r;
+  });
+
+  socket.on("data", (chunk: string) => {
+    for (const line of split(chunk)) {
+      let raw: unknown;
+      try {
+        raw = JSON.parse(line);
+      } catch {
+        continue; // a malformed server frame — skip, ids keep us honest
+      }
+      const event = controlEventSchema.safeParse(raw);
+      if (event.success) {
+        for (const sink of eventSinks) sink(event.data);
+        continue;
+      }
+      const response = controlResponseSchema.safeParse(raw);
+      if (!response.success || response.data.id === null) continue;
+      const waiter = pending.get(response.data.id);
+      if (!waiter) continue;
+      pending.delete(response.data.id);
+      if (response.data.ok) waiter.resolve(response.data.data);
+      else {
+        waiter.reject(
+          new ControlRequestError(response.data.error.code, response.data.error.message),
+        );
+      }
+    }
+  });
+  const teardown = (): void => {
+    for (const { reject } of pending.values()) {
+      reject(new ControlRequestError("disconnected", "control socket closed"));
+    }
+    pending.clear();
+    markDone();
+  };
+  socket.on("close", teardown);
+  socket.on("error", () => {
+    // 'close' follows and runs the teardown
+  });
+
+  const request = (verb: string, params?: Record<string, unknown>): Promise<unknown> => {
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      if (socket.destroyed) {
+        reject(new ControlRequestError("disconnected", "control socket closed"));
+        return;
+      }
+      pending.set(id, { resolve, reject });
+      socket.write(encodeFrame({ v: CONTROL_PROTOCOL_VERSION, id, verb, params }));
+    });
+  };
+
+  return {
+    request,
+    subscribe: async (onEvent) => {
+      eventSinks.push(onEvent);
+      await request("subscribe");
+    },
+    close: () => socket.destroy(),
+    done,
+  };
+}

--- a/packages/daemon/src/control/dispatch.test.ts
+++ b/packages/daemon/src/control/dispatch.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Dispatch: every failure mode is an ANSWER (a response frame), never a
+ * throw — plus routing, params passthrough, and the subscribe context.
+ */
+import { describe, expect, it } from "vitest";
+import { IdeError } from "../lib/errors.ts";
+import { ControlVerbError, dispatchLine, type VerbContext } from "./dispatch.ts";
+
+const ctx: VerbContext = { subscribe: () => {} };
+
+describe("dispatchLine", () => {
+  it("answers unparseable JSON with bad-request and a null id", async () => {
+    const res = await dispatchLine("not json", {}, ctx);
+    expect(res).toMatchObject({ v: 1, id: null, ok: false, error: { code: "bad-request" } });
+  });
+
+  it("answers a bad envelope with bad-request, recovering the id when possible", async () => {
+    const res = await dispatchLine('{"id":42,"verb":"fleet"}', {}, ctx); // missing v
+    expect(res).toMatchObject({ id: 42, ok: false, error: { code: "bad-request" } });
+  });
+
+  it("answers an unknown verb honestly", async () => {
+    const res = await dispatchLine('{"v":1,"id":1,"verb":"launch-missiles"}', {}, ctx);
+    expect(res).toMatchObject({ id: 1, ok: false, error: { code: "unknown-verb" } });
+  });
+
+  it("routes to the handler and wraps its return in an ok envelope", async () => {
+    const res = await dispatchLine(
+      '{"v":1,"id":"a","verb":"echo","params":{"x":1}}',
+      { echo: (params) => ({ got: params }) },
+      ctx,
+    );
+    expect(res).toEqual({ v: 1, id: "a", ok: true, data: { got: { x: 1 } } });
+  });
+
+  it("defaults missing params to an empty object", async () => {
+    let seen: unknown;
+    await dispatchLine(
+      '{"v":1,"id":1,"verb":"echo"}',
+      {
+        echo: (params) => {
+          seen = params;
+          return null;
+        },
+      },
+      ctx,
+    );
+    expect(seen).toEqual({});
+  });
+
+  it("maps ControlVerbError to its code", async () => {
+    const res = await dispatchLine(
+      '{"v":1,"id":1,"verb":"w"}',
+      {
+        w: () => {
+          throw new ControlVerbError("timeout", "took too long");
+        },
+      },
+      ctx,
+    );
+    expect(res).toMatchObject({ ok: false, error: { code: "timeout", message: "took too long" } });
+  });
+
+  it("maps IdeError codes: USAGE → bad-request, others → not-found", async () => {
+    const usage = await dispatchLine(
+      '{"v":1,"id":1,"verb":"u"}',
+      {
+        u: () => {
+          throw new IdeError("bad usage", { code: "USAGE" });
+        },
+      },
+      ctx,
+    );
+    expect(usage).toMatchObject({ ok: false, error: { code: "bad-request" } });
+
+    const missing = await dispatchLine(
+      '{"v":1,"id":1,"verb":"m"}',
+      {
+        m: () => {
+          throw new IdeError("no such session", { code: "SESSION_NOT_FOUND" });
+        },
+      },
+      ctx,
+    );
+    expect(missing).toMatchObject({ ok: false, error: { code: "not-found" } });
+  });
+
+  it("maps an unexpected throw to internal", async () => {
+    const res = await dispatchLine(
+      '{"v":1,"id":1,"verb":"boom"}',
+      {
+        boom: () => {
+          throw new Error("nope");
+        },
+      },
+      ctx,
+    );
+    expect(res).toMatchObject({ ok: false, error: { code: "internal", message: "nope" } });
+  });
+
+  it("hands the verb context through (subscribe)", async () => {
+    let flipped = false;
+    const res = await dispatchLine(
+      '{"v":1,"id":1,"verb":"subscribe"}',
+      { subscribe: (_p, c) => (c.subscribe(), { subscribed: true }) },
+      { subscribe: () => (flipped = true) },
+    );
+    expect(flipped).toBe(true);
+    expect(res).toMatchObject({ ok: true, data: { subscribed: true } });
+  });
+});

--- a/packages/daemon/src/control/dispatch.ts
+++ b/packages/daemon/src/control/dispatch.ts
@@ -1,0 +1,107 @@
+/**
+ * Request dispatch for the control socket — PURE given its handler map.
+ *
+ * Takes one raw frame line, parses + validates the versioned envelope,
+ * routes to the verb's handler, and shapes the response envelope — including
+ * every failure mode (unparseable JSON, bad envelope, unknown verb, invalid
+ * params, handler error). Handlers are injected, so this whole layer unit-
+ * tests without a socket or a tmux server.
+ *
+ * Error codes on the wire:
+ *   bad-request    unparseable frame / envelope / params (message says which)
+ *   unknown-verb   the verb isn't in this server's handler map
+ *   not-found      the named pane/session/target doesn't exist
+ *   timeout        a `wait` ran out of time
+ *   internal       the handler threw something unexpected
+ */
+import {
+  CONTROL_PROTOCOL_VERSION,
+  controlRequestSchema,
+  type ControlResponse,
+} from "@tmux-ide/contracts";
+import { IdeError } from "../lib/errors.ts";
+
+/** Thrown by handlers to reach the wire with a specific code. */
+export class ControlVerbError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+/** What a handler gets besides its (already unknown-typed) params. */
+export interface VerbContext {
+  /** Flip this connection into receiving event frames (the `subscribe` verb). */
+  subscribe: () => void;
+}
+
+export type VerbHandler = (params: unknown, ctx: VerbContext) => Promise<unknown> | unknown;
+
+const ok = (id: string | number, data: unknown): ControlResponse => ({
+  v: CONTROL_PROTOCOL_VERSION,
+  id,
+  ok: true,
+  data,
+});
+
+const fail = (id: string | number | null, code: string, message: string): ControlResponse => ({
+  v: CONTROL_PROTOCOL_VERSION,
+  id,
+  ok: false,
+  error: { code, message },
+});
+
+/** Best-effort id recovery from a frame that failed envelope validation. */
+function extractId(value: unknown): string | number | null {
+  if (typeof value === "object" && value !== null && "id" in value) {
+    const id = (value as { id: unknown }).id;
+    if (typeof id === "string" || typeof id === "number") return id;
+  }
+  return null;
+}
+
+/**
+ * Dispatch one raw line to `handlers`. ALWAYS resolves to a response frame —
+ * a protocol error is an answer, never a dropped request or a thrown error
+ * (only the transport decides to drop connections).
+ */
+export async function dispatchLine(
+  line: string,
+  handlers: Record<string, VerbHandler>,
+  ctx: VerbContext,
+): Promise<ControlResponse> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(line);
+  } catch {
+    return fail(null, "bad-request", "frame is not valid JSON");
+  }
+
+  const parsed = controlRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return fail(
+      extractId(raw),
+      "bad-request",
+      `invalid request envelope (need {v:${CONTROL_PROTOCOL_VERSION}, id, verb})`,
+    );
+  }
+
+  const { id, verb, params } = parsed.data;
+  const handler = handlers[verb];
+  if (!handler) {
+    return fail(id, "unknown-verb", `unknown verb "${verb}"`);
+  }
+
+  try {
+    return ok(id, await handler(params ?? {}, ctx));
+  } catch (err) {
+    if (err instanceof ControlVerbError) return fail(id, err.code, err.message);
+    if (err instanceof IdeError) {
+      // Data-layer errors carry honest codes already (SESSION_NOT_FOUND, …).
+      const code = err.code === "USAGE" ? "bad-request" : "not-found";
+      return fail(id, code, err.message);
+    }
+    return fail(id, "internal", (err as Error)?.message ?? "internal error");
+  }
+}

--- a/packages/daemon/src/control/fanout.test.ts
+++ b/packages/daemon/src/control/fanout.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Fan-out bookkeeping: delivery to every sink, idempotent unsubscribe, and
+ * the 0→1 / 1→0 edges the server's event tick starts and stops on.
+ */
+import { describe, expect, it } from "vitest";
+import { createFanout } from "./fanout.ts";
+
+describe("createFanout", () => {
+  it("delivers each event to every sink", () => {
+    const fanout = createFanout<number>();
+    const a: number[] = [];
+    const b: number[] = [];
+    fanout.add((n) => a.push(n));
+    fanout.add((n) => b.push(n));
+    fanout.emit(1);
+    fanout.emit(2);
+    expect(a).toEqual([1, 2]);
+    expect(b).toEqual([1, 2]);
+  });
+
+  it("unsubscribe removes only that sink and is idempotent", () => {
+    const fanout = createFanout<number>();
+    const a: number[] = [];
+    const b: number[] = [];
+    const offA = fanout.add((n) => a.push(n));
+    fanout.add((n) => b.push(n));
+    offA();
+    offA();
+    fanout.emit(7);
+    expect(a).toEqual([]);
+    expect(b).toEqual([7]);
+    expect(fanout.size()).toBe(1);
+  });
+
+  it("fires onFirst on 0→1 and onLast on 1→0 (and again on the next cycle)", () => {
+    const edges: string[] = [];
+    const fanout = createFanout<number>({
+      onFirst: () => edges.push("first"),
+      onLast: () => edges.push("last"),
+    });
+    const off1 = fanout.add(() => {});
+    const off2 = fanout.add(() => {});
+    off1();
+    off2();
+    const off3 = fanout.add(() => {});
+    off3();
+    expect(edges).toEqual(["first", "last", "first", "last"]);
+  });
+
+  it("drops a throwing sink instead of failing the emit", () => {
+    const fanout = createFanout<number>();
+    const good: number[] = [];
+    fanout.add(() => {
+      throw new Error("torn down");
+    });
+    fanout.add((n) => good.push(n));
+    fanout.emit(1);
+    fanout.emit(2);
+    expect(good).toEqual([1, 2]);
+    expect(fanout.size()).toBe(1);
+  });
+});

--- a/packages/daemon/src/control/fanout.ts
+++ b/packages/daemon/src/control/fanout.ts
@@ -1,0 +1,44 @@
+/**
+ * Subscriber fan-out bookkeeping for the control server — PURE.
+ *
+ * Tracks the set of live subscribers and delivers each emitted event to all
+ * of them. The `onFirst`/`onLast` edges let the server run its detection
+ * tick ONLY while someone is listening (0→1 starts it, 1→0 stops it), so an
+ * idle `tmux-ide serve` costs nothing between requests.
+ */
+
+export interface Fanout<T> {
+  /** Register a sink. Returns its unsubscribe (idempotent). */
+  add(sink: (event: T) => void): () => void;
+  /** Deliver `event` to every sink. A throwing sink is dropped, not fatal. */
+  emit(event: T): void;
+  size(): number;
+}
+
+export function createFanout<T>(
+  edges: { onFirst?: () => void; onLast?: () => void } = {},
+): Fanout<T> {
+  const sinks = new Set<(event: T) => void>();
+  const remove = (sink: (event: T) => void): void => {
+    if (!sinks.delete(sink)) return;
+    if (sinks.size === 0) edges.onLast?.();
+  };
+  return {
+    add(sink) {
+      sinks.add(sink);
+      if (sinks.size === 1) edges.onFirst?.();
+      return () => remove(sink);
+    },
+    emit(event) {
+      for (const sink of [...sinks]) {
+        try {
+          sink(event);
+        } catch {
+          // A sink that throws (a torn-down connection) removes itself.
+          remove(sink);
+        }
+      }
+    },
+    size: () => sinks.size,
+  };
+}

--- a/packages/daemon/src/control/frames.test.ts
+++ b/packages/daemon/src/control/frames.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Frame splitting is the wire's foundation: partial frames buffer, multiple
+ * frames per chunk all surface, and encode/split round-trips exactly.
+ */
+import { describe, expect, it } from "vitest";
+import { MAX_FRAME_BYTES, createFrameSplitter, encodeFrame } from "./frames.ts";
+
+describe("encodeFrame", () => {
+  it("emits one newline-terminated JSON line", () => {
+    expect(encodeFrame({ v: 1, id: 1, verb: "fleet" })).toBe('{"v":1,"id":1,"verb":"fleet"}\n');
+  });
+
+  it("never contains a raw newline inside the payload", () => {
+    const frame = encodeFrame({ text: "line one\nline two" });
+    expect(frame.slice(0, -1)).not.toContain("\n");
+  });
+});
+
+describe("createFrameSplitter", () => {
+  it("buffers a partial frame across chunks", () => {
+    const split = createFrameSplitter();
+    expect(split('{"id":')).toEqual([]);
+    expect(split("1}\n")).toEqual(['{"id":1}']);
+  });
+
+  it("returns multiple complete frames from one chunk", () => {
+    const split = createFrameSplitter();
+    expect(split('{"id":1}\n{"id":2}\n{"id":3}\n')).toEqual(['{"id":1}', '{"id":2}', '{"id":3}']);
+  });
+
+  it("holds the trailing partial while yielding the complete ones", () => {
+    const split = createFrameSplitter();
+    expect(split('{"id":1}\n{"id"')).toEqual(['{"id":1}']);
+    expect(split(":2}\n")).toEqual(['{"id":2}']);
+  });
+
+  it("drops blank lines", () => {
+    const split = createFrameSplitter();
+    expect(split('\n\n  \n{"id":1}\n\n')).toEqual(['{"id":1}']);
+  });
+
+  it("round-trips encodeFrame output byte-split at every position", () => {
+    const frame = encodeFrame({ v: 1, id: "x", verb: "send", params: { message: "a\nb" } });
+    for (let cut = 1; cut < frame.length; cut++) {
+      const split = createFrameSplitter();
+      const first = split(frame.slice(0, cut));
+      const second = split(frame.slice(cut));
+      expect([...first, ...second]).toEqual([frame.trimEnd()]);
+    }
+  });
+
+  it("throws when a partial line exceeds MAX_FRAME_BYTES", () => {
+    const split = createFrameSplitter();
+    const half = "x".repeat(MAX_FRAME_BYTES);
+    expect(() => {
+      split(half);
+      split(half); // still no newline — over the limit
+    }).toThrow(/exceeds/);
+  });
+});

--- a/packages/daemon/src/control/frames.ts
+++ b/packages/daemon/src/control/frames.ts
@@ -1,0 +1,40 @@
+/**
+ * NDJSON framing for the control socket — PURE.
+ *
+ * One frame = one JSON object on one `\n`-terminated line. TCP-style streams
+ * deliver arbitrary chunk boundaries, so the splitter buffers a partial
+ * trailing line across feeds and hands back only COMPLETE lines. Encoding is
+ * the trivial inverse; it lives here so every writer produces identical
+ * frames (a `JSON.stringify` can never contain a raw newline, so one write
+ * call per frame is atomic on the wire).
+ */
+
+/** Refuse to buffer a partial line beyond this — a client streaming an
+ *  unterminated megabyte is broken or hostile, not slow. */
+export const MAX_FRAME_BYTES = 4 * 1024 * 1024;
+
+/** Serialize one frame: the JSON line plus its terminator. */
+export function encodeFrame(message: unknown): string {
+  return `${JSON.stringify(message)}\n`;
+}
+
+/**
+ * A stateful chunk → complete-lines splitter. Feed it raw socket data; it
+ * returns every COMPLETE line received so far (blank lines are dropped) and
+ * keeps the trailing partial line buffered for the next feed. Throws when the
+ * partial line outgrows {@link MAX_FRAME_BYTES} — the caller should drop the
+ * connection.
+ */
+export function createFrameSplitter(): (chunk: string) => string[] {
+  let buffer = "";
+  return (chunk: string): string[] => {
+    buffer += chunk;
+    const parts = buffer.split("\n");
+    buffer = parts.pop() ?? "";
+    if (buffer.length > MAX_FRAME_BYTES) {
+      buffer = "";
+      throw new Error(`frame exceeds ${MAX_FRAME_BYTES} bytes without a newline`);
+    }
+    return parts.filter((line) => line.trim().length > 0);
+  };
+}

--- a/packages/daemon/src/control/lifecycle.ts
+++ b/packages/daemon/src/control/lifecycle.ts
@@ -1,0 +1,151 @@
+/**
+ * Agent lifecycle io for the control socket — spawn / restart / stop.
+ *
+ * The MODEL (kind → launch command, exact tmux argv, the shell-vs-own-process
+ * restart decision, interrupt timing) is the pure `tui/mirror/agent-lifecycle`
+ * module the unified app already runs on; this file is only the async tmux
+ * plumbing around it, so the socket drives the SAME lifecycle path as the app.
+ */
+import { execFile } from "node:child_process";
+import {
+  INTERRUPT_TAP_GAP_MS,
+  RESTART_GRACE_MS,
+  clearAuthorityArgs,
+  interruptArgs,
+  launchCommandFor,
+  paneHostsShell,
+  relaunchArgs,
+  respawnArgs,
+  spawnAgentArgs,
+  spawnSessionArgs,
+  type SpawnPlacement,
+} from "../tui/mirror/agent-lifecycle.ts";
+import { getManifests } from "../tui/detect/manifest-loader.ts";
+import { ControlVerbError } from "./dispatch.ts";
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** One tmux call; resolves stdout, rejects on a tmux error. */
+function tmuxRun(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("tmux", args, (err, stdout) => (err ? reject(err) : resolve(stdout.trimEnd())));
+  });
+}
+
+/** Like {@link tmuxRun} but errors are swallowed — for best-effort steps
+ *  (a dead pane target is a normal race, the fleet shows the truth later). */
+async function tmuxTry(args: string[]): Promise<void> {
+  await tmuxRun(args).catch(() => {});
+}
+
+/** Resolve `kind`/`command` params to the command that actually launches. */
+export function resolveLaunchCommand(params: { kind?: string; command?: string }): string {
+  if (params.command) return params.command;
+  return launchCommandFor(params.kind!, getManifests());
+}
+
+export interface SpawnOutcome {
+  paneId: string;
+  session: string;
+  command: string;
+  placement: SpawnPlacement | "new-session";
+}
+
+/**
+ * Spawn an agent. With `session` the shared placement argv is used (window /
+ * split); without it a fresh detached session named `sessionName` starts in
+ * `dir`. `-P -F #{pane_id}` is threaded right after the tmux subcommand so
+ * the caller learns WHICH pane the agent got (the argv builders stay
+ * untouched — the app's flows don't want the print).
+ */
+export async function spawnAgent(params: {
+  command: string;
+  session?: string;
+  sessionName?: string;
+  dir?: string;
+  placement?: SpawnPlacement;
+  paneId?: string;
+}): Promise<SpawnOutcome> {
+  const dir = params.dir ?? null;
+  const argv = params.session
+    ? spawnAgentArgs(
+        params.placement ?? "window",
+        { session: params.session, paneId: params.paneId },
+        dir,
+        params.command,
+      )
+    : spawnSessionArgs(params.sessionName!, dir, params.command);
+  const [subcommand, ...rest] = argv;
+  let paneId: string;
+  try {
+    paneId = await tmuxRun([subcommand!, "-P", "-F", "#{pane_id}", ...rest]);
+  } catch (err) {
+    throw new ControlVerbError("not-found", `tmux refused to spawn: ${(err as Error).message}`);
+  }
+  const session = params.session ?? params.sessionName!;
+  // Mark a fresh session as ours (mirrors the app's spawn flow).
+  if (!params.session) await tmuxTry(["set-environment", "-t", session, "TMUX_IDE", "1"]);
+  return {
+    paneId,
+    session,
+    command: params.command,
+    placement: params.session ? (params.placement ?? "window") : "new-session",
+  };
+}
+
+/** The double ctrl-c (see agent-lifecycle: one taps, the quick second exits). */
+async function interruptAgent(paneId: string): Promise<void> {
+  await tmuxTry(interruptArgs(paneId));
+  await sleep(INTERRUPT_TAP_GAP_MS);
+  await tmuxTry(interruptArgs(paneId));
+}
+
+/** Out-of-band stop hygiene: no hook fires, so unset the authority stamps. */
+async function clearAgentAuthority(paneId: string): Promise<void> {
+  for (const args of clearAuthorityArgs(paneId)) await tmuxTry(args);
+}
+
+/** The pane's root command + cwd, or null when the pane is gone. */
+function paneStartAndPath(paneId: string): Promise<{ start: string; path: string } | null> {
+  return tmuxRun(["display", "-p", "-t", paneId, "#{pane_start_command}\t#{pane_current_path}"])
+    .then((out) => {
+      const [start = "", path = ""] = out.split("\t");
+      return { start, path };
+    })
+    .catch(() => null);
+}
+
+/** Stop the agent in `paneId`: interrupt + authority cleanup. The pane (and
+ *  its shell, if any) stays open — `kill-pane` is deliberately NOT offered
+ *  over the socket; that is a human, confirmed-destructive verb. */
+export async function stopAgent(paneId: string): Promise<{ paneId: string; stopped: true }> {
+  const live = await paneStartAndPath(paneId);
+  if (!live) throw new ControlVerbError("not-found", `no pane "${paneId}"`);
+  await interruptAgent(paneId);
+  await clearAgentAuthority(paneId);
+  return { paneId, stopped: true };
+}
+
+/**
+ * Restart the agent in `paneId` running `command`, using the app's two
+ * strategies: a SHELL-hosted agent is interrupted and relaunched via
+ * send-keys (the shell survives to type into); an agent that IS the pane's
+ * own process is respawned in place (ctrl-c would end the pane).
+ */
+export async function restartAgent(
+  paneId: string,
+  command: string,
+): Promise<{ paneId: string; command: string; strategy: "relaunch" | "respawn" }> {
+  const live = await paneStartAndPath(paneId);
+  if (!live) throw new ControlVerbError("not-found", `no pane "${paneId}"`);
+  if (paneHostsShell(live.start, getManifests())) {
+    await interruptAgent(paneId);
+    await clearAgentAuthority(paneId);
+    await sleep(RESTART_GRACE_MS);
+    for (const args of relaunchArgs(paneId, command)) await tmuxTry(args);
+    return { paneId, command, strategy: "relaunch" };
+  }
+  await clearAgentAuthority(paneId);
+  await tmuxTry(respawnArgs(paneId, command, live.path || null));
+  return { paneId, command, strategy: "respawn" };
+}

--- a/packages/daemon/src/control/server.ts
+++ b/packages/daemon/src/control/server.ts
@@ -1,0 +1,237 @@
+/**
+ * The control-socket server — `tmux-ide serve` (M23.3).
+ *
+ * NDJSON frames over a local Unix socket (default `~/.tmux-ide/control.sock`,
+ * mode 0600). Agent loops connect once and drive the fleet — request/response
+ * verbs plus PUSHED agent-status events after `subscribe` — instead of
+ * spawning a CLI process per call. Protocol schemas live in
+ * `@tmux-ide/contracts` (control.ts); verb handlers in `./verbs.ts` call the
+ * SAME data layer the CLI cases do.
+ *
+ * HOST DECISION (the tradeoff, considered before building):
+ *   (a) `tmux-ide serve` — an EXPLICIT foreground process. Costs the user a
+ *       deliberate start, dies with them, trivially restartable after a code
+ *       change, and its lifetime states its purpose.
+ *   (b) piggyback on the `_tmux-ide-chrome` updater tick — always running for
+ *       adopted fleets, but chrome-lifecycle-coupled: unadopting the last
+ *       session would kill the API mid-conversation, `adopt` would grow a
+ *       network-ish responsibility, and the updater's contract ("never let a
+ *       bad tick break the bars") is the wrong place for a protocol surface.
+ *   (c) socket-activated per-connection handlers — zero resident cost, but
+ *       every connection pays a full node boot (the latency the socket exists
+ *       to remove) and no resident process means no push events and no
+ *       persistent status tracker (the cross-tick `done` needs history).
+ *   CHOSEN: (a), deliberately WITHOUT auto-start. The old command-center HTTP
+ *   server is the cautionary tale: an implicitly-running daemon accretes
+ *   scope. This surface stays minimal — session-control verbs only, no feed,
+ *   no chat, no network listener — and the CLI only uses the socket
+ *   OPPORTUNISTICALLY (`--socket` fast-paths fall back to polling when no
+ *   server is up). An agent that wants the socket runs `tmux-ide serve`
+ *   itself; the process it spawned is the process it owns.
+ *
+ * SECURITY: local user only. The socket is chmod 0600, there is no network
+ * transport, no tokens (filesystem permissions ARE the auth). The #90 bridge
+ * that exposes this to a native app layers a WS server ON TOP later — each
+ * NDJSON frame maps 1:1 to a WS text message, so that bridge is mechanical
+ * and this file never grows remote scope.
+ *
+ * EVENTS: while at least one connection is subscribed, a detection tick
+ * (same cadence and diff as the chrome updater, one persistent tracker)
+ * computes the fleet and pushes session-level status transitions. No
+ * subscribers → no tick → an idle server does nothing. The tick does NOT
+ * write events.jsonl — the chrome updater owns the log; this stream is
+ * transport, not history.
+ */
+import { chmodSync, existsSync, mkdirSync, statSync, unlinkSync } from "node:fs";
+import { createServer, connect, type Server, type Socket } from "node:net";
+import { dirname, join } from "node:path";
+import { CONTROL_PROTOCOL_VERSION, type AgentStatusEvent } from "@tmux-ide/contracts";
+import { IdeError } from "../lib/errors.ts";
+import { tuiStateHome } from "../lib/tui-binary.ts";
+import { createStatusTracker, type AgentStatus } from "../tui/detect/classify.ts";
+import { diffFleet } from "../tui/chrome/events.ts";
+import { fleetStatuses, TICK_MS } from "../tui/chrome/updater.ts";
+import { listTeamProjects } from "../tui/team/projects.ts";
+import { dispatchLine } from "./dispatch.ts";
+import { createFanout } from "./fanout.ts";
+import { createFrameSplitter, encodeFrame } from "./frames.ts";
+import { createVerbHandlers } from "./verbs.ts";
+
+/** The default socket path — under the state home so `TMUX_IDE_HOME` scopes
+ *  tests away from the real user socket. */
+export function defaultControlSocketPath(): string {
+  return join(tuiStateHome(), "control.sock");
+}
+
+export interface ControlServerOptions {
+  socketPath?: string;
+  /** Diagnostics sink (the CLI passes stderr). Default: silent. */
+  log?: (message: string) => void;
+  /** Event-tick cadence override (tests); defaults to the updater's TICK_MS. */
+  tickMs?: number;
+}
+
+export interface ControlServer {
+  socketPath: string;
+  close(): Promise<void>;
+}
+
+/**
+ * Claim `path`: refuse anything that exists and is not a socket (NEVER
+ * unlink a foreign file), refuse a socket another live server answers on,
+ * and unlink a stale socket left by a dead server.
+ */
+async function claimSocketPath(path: string): Promise<void> {
+  if (!existsSync(path)) return;
+  if (!statSync(path).isSocket()) {
+    throw new IdeError(
+      `${path} exists and is not a socket — refusing to remove it. ` +
+        `Pass a different --socket path.`,
+      { code: "USAGE", exitCode: 1 },
+    );
+  }
+  const alive = await new Promise<boolean>((resolve) => {
+    const probe: Socket = connect(path);
+    const done = (result: boolean) => {
+      probe.destroy();
+      resolve(result);
+    };
+    probe.once("connect", () => done(true));
+    probe.once("error", () => done(false));
+    probe.setTimeout(500, () => done(false));
+  });
+  if (alive) {
+    throw new IdeError(`another server is already listening on ${path}`, {
+      code: "USAGE",
+      exitCode: 1,
+    });
+  }
+  unlinkSync(path); // stale socket from a dead server — safe to rebind
+}
+
+/** Start the server. Resolves once the socket is listening (mode 0600). */
+export async function startControlServer(opts: ControlServerOptions = {}): Promise<ControlServer> {
+  const socketPath = opts.socketPath ?? defaultControlSocketPath();
+  const log = opts.log ?? (() => {});
+  const tickMs = opts.tickMs ?? TICK_MS;
+
+  mkdirSync(dirname(socketPath), { recursive: true });
+  await claimSocketPath(socketPath);
+
+  // ONE tracker for the server's lifetime, shared by the verbs and the event
+  // tick — cross-tick `done` (working→idle) is only observable with history.
+  const tracker = createStatusTracker();
+  const handlers = createVerbHandlers({ tracker });
+
+  // The event tick: runs ONLY while subscribers exist (fanout edges), diffs
+  // the fleet exactly like the chrome updater, pushes transitions.
+  const prevState = new Map<string, AgentStatus>();
+  let timer: ReturnType<typeof setInterval> | null = null;
+  const tick = (): void => {
+    try {
+      const { events, state } = diffFleet(prevState, fleetStatuses(listTeamProjects(tracker)));
+      prevState.clear();
+      for (const [name, status] of state) prevState.set(name, status);
+      const ts = new Date().toISOString();
+      for (const ev of events) fanout.emit({ ts, ...ev });
+    } catch (err) {
+      log(`event tick failed: ${(err as Error).message}`);
+    }
+  };
+  const fanout = createFanout<AgentStatusEvent>({
+    onFirst: () => {
+      tick(); // seed immediately — the first events carry the current fleet (from: null)
+      timer = setInterval(tick, tickMs);
+    },
+    onLast: () => {
+      if (timer) clearInterval(timer);
+      timer = null;
+      prevState.clear();
+    },
+  });
+
+  const connections = new Set<Socket>();
+  const server: Server = createServer((conn) => {
+    connections.add(conn);
+    conn.setEncoding("utf8");
+    const split = createFrameSplitter();
+    let unsubscribe: (() => void) | null = null;
+
+    const push = (ev: AgentStatusEvent): void => {
+      // One write per frame — JSON.stringify never contains a raw newline,
+      // so frames from concurrent requests can never interleave mid-message.
+      conn.write(encodeFrame({ v: CONTROL_PROTOCOL_VERSION, event: "agent-status", data: ev }));
+    };
+    const ctx = {
+      subscribe: () => {
+        unsubscribe ??= fanout.add(push);
+      },
+    };
+
+    conn.on("data", (chunk: string) => {
+      let lines: string[];
+      try {
+        lines = split(chunk);
+      } catch {
+        conn.destroy(); // frame overflow — a broken client, not a slow one
+        return;
+      }
+      for (const line of lines) {
+        // Handled CONCURRENTLY: a long `wait` must not block this
+        // connection's other requests (responses correlate by id).
+        void dispatchLine(line, handlers, ctx).then((response) => {
+          if (!conn.destroyed) conn.write(encodeFrame(response));
+        });
+      }
+    });
+    conn.on("close", () => {
+      unsubscribe?.();
+      connections.delete(conn);
+    });
+    conn.on("error", () => {
+      // close follows; nothing to do — never let a client error kill serve
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", (err: NodeJS.ErrnoException) => {
+      // Unix sockets cap the path at ~104 bytes (macOS sun_path) — surfaced
+      // as a bare EINVAL. Say what actually went wrong and how to fix it.
+      if ((err.code === "EINVAL" || err.code === "ENAMETOOLONG") && socketPath.length > 100) {
+        reject(
+          new IdeError(
+            `socket path is too long for a Unix socket (${socketPath.length} chars; the OS caps it around 104): ${socketPath}\n` +
+              `Pass a shorter path: tmux-ide serve --socket /tmp/tmux-ide-control.sock`,
+            { code: "USAGE", exitCode: 1 },
+          ),
+        );
+        return;
+      }
+      reject(err);
+    });
+    server.listen(socketPath, () => {
+      server.removeAllListeners("error");
+      resolve();
+    });
+  });
+  chmodSync(socketPath, 0o600);
+  log(`listening on ${socketPath}`);
+
+  return {
+    socketPath,
+    close: () =>
+      new Promise<void>((resolve) => {
+        if (timer) clearInterval(timer);
+        timer = null;
+        for (const conn of connections) conn.destroy(); // clients see EOF
+        server.close(() => {
+          try {
+            unlinkSync(socketPath);
+          } catch {
+            // already gone
+          }
+          resolve();
+        });
+      }),
+  };
+}

--- a/packages/daemon/src/control/verbs.ts
+++ b/packages/daemon/src/control/verbs.ts
@@ -1,0 +1,118 @@
+/**
+ * The v1 verb handlers — each one a THIN adapter from validated params to
+ * the SAME data-layer functions the CLI cases call (report/sessions/wait/
+ * send/agent-explain/lifecycle). No fleet logic lives here; if a verb needs
+ * logic a CLI case has inline, the logic moves to the data layer and both
+ * point at it (that's how `wait` and `send` got their shared cores).
+ */
+import {
+  agentsParamsSchema,
+  explainParamsSchema,
+  restartAgentParamsSchema,
+  sendParamsSchema,
+  spawnParamsSchema,
+  stopAgentParamsSchema,
+  waitParamsSchema,
+} from "@tmux-ide/contracts";
+import type { ZodType } from "zod";
+import { buildReport } from "../agent-explain.ts";
+import { deliverMessage } from "../send.ts";
+import type { StatusTracker } from "../tui/detect/classify.ts";
+import { toFleetJson } from "../tui/team/report.ts";
+import { listTeamProjects } from "../tui/team/projects.ts";
+import { listTeamSessions } from "../tui/team/sessions.ts";
+import { waitForAgentStatus, waitForOutputMatch } from "../tui/team/wait.ts";
+import { ControlVerbError, type VerbHandler } from "./dispatch.ts";
+import { resolveLaunchCommand, restartAgent, spawnAgent, stopAgent } from "./lifecycle.ts";
+
+/** Validate `params` against a verb's schema, or answer `bad-request`. */
+function parse<T>(schema: ZodType<T>, params: unknown): T {
+  const result = schema.safeParse(params);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const at = issue?.path?.length ? ` at ${issue.path.join(".")}` : "";
+    throw new ControlVerbError("bad-request", `invalid params${at}: ${issue?.message ?? "?"}`);
+  }
+  return result.data;
+}
+
+/**
+ * Build the handler map. `tracker` is the server's ONE persistent status
+ * tracker (shared with the event tick) so `fleet`/`agents` see the
+ * cross-tick `done` transition exactly like the chrome updater does —
+ * a fresh tracker per call could never observe working→idle.
+ */
+export function createVerbHandlers(ctx: { tracker: StatusTracker }): Record<string, VerbHandler> {
+  return {
+    fleet: () => toFleetJson(listTeamProjects(ctx.tracker)),
+
+    agents: (params) => {
+      const p = parse(agentsParamsSchema, params);
+      const sessions = listTeamSessions(ctx.tracker);
+      const scoped = p.session ? sessions.filter((s) => s.name === p.session) : sessions;
+      if (p.session && scoped.length === 0) {
+        throw new ControlVerbError("not-found", `no session "${p.session}"`);
+      }
+      return { agents: scoped.flatMap((s) => s.agents ?? []) };
+    },
+
+    send: (params) => {
+      const p = parse(sendParamsSchema, params);
+      return deliverMessage(p);
+    },
+
+    wait: async (params) => {
+      const p = parse(waitParamsSchema, params);
+      if (p.kind === "output") {
+        try {
+          new RegExp(p.match);
+        } catch (err) {
+          throw new ControlVerbError(
+            "bad-request",
+            `invalid match regex: ${(err as Error).message}`,
+          );
+        }
+      }
+      const result =
+        p.kind === "agent-status"
+          ? await waitForAgentStatus(p.session, p.status, { timeoutMs: p.timeoutMs })
+          : await waitForOutputMatch(p.target, p.match, { timeoutMs: p.timeoutMs });
+      if (!result.ok) {
+        const what =
+          p.kind === "agent-status"
+            ? `"${p.session}" to reach status "${p.status}"`
+            : `${p.target} output to match /${p.match}/`;
+        throw new ControlVerbError(
+          "timeout",
+          `timed out after ${result.timedOutAfterMs}ms waiting for ${what}`,
+        );
+      }
+      return result;
+    },
+
+    spawn: (params) => {
+      const p = parse(spawnParamsSchema, params);
+      return spawnAgent({ ...p, command: resolveLaunchCommand(p) });
+    },
+
+    "restart-agent": (params) => {
+      const p = parse(restartAgentParamsSchema, params);
+      return restartAgent(p.paneId, resolveLaunchCommand(p));
+    },
+
+    "stop-agent": (params) => {
+      const p = parse(stopAgentParamsSchema, params);
+      return stopAgent(p.paneId);
+    },
+
+    explain: (params) => {
+      const p = parse(explainParamsSchema, params);
+      return buildReport(p.target);
+    },
+
+    subscribe: (_params, verbCtx) => {
+      verbCtx.subscribe();
+      return { subscribed: true, events: ["agent-status"] };
+    },
+  };
+}

--- a/packages/daemon/src/send.ts
+++ b/packages/daemon/src/send.ts
@@ -86,24 +86,36 @@ function prepareMessage(message: string, busyStatus: PaneBusyStatus): string {
   return message;
 }
 
-export async function send(targetDir: string | undefined, opts: SendOptions): Promise<void> {
-  const dir = resolve(targetDir ?? ".");
-  const { name: session } = getSessionName(dir);
-  const { json, to: target, message: rawMessage, noEnter } = opts;
+/** What a delivery reports back (the `send --json` payload, and the control
+ *  socket's `send` verb data). */
+export interface DeliverResult {
+  ok: true;
+  session: string;
+  target: { paneId: string; name: string | null; title: string; role: string | null };
+  message: string;
+  busyStatus: PaneBusyStatus;
+  sentViaFile: boolean;
+  warning?: "agent_busy";
+}
 
-  if (!target) {
-    throw new IdeError("Missing target. Usage: tmux-ide send <target> <message>", {
-      code: "USAGE",
-    });
-  }
+/**
+ * Deliver `message` to a pane of `session` — the SHARED core behind the
+ * `tmux-ide send` CLI case and the control socket's `send` verb. Resolves
+ * `target` (pane id / @ide_name / title / role / partial title), adapts to
+ * the pane's busy status, and routes long messages through a dispatch file
+ * under `dir` when one is given (without a `dir` the text is sent directly).
+ * Throws `IdeError` (SESSION_NOT_FOUND / PANE_NOT_FOUND) — no printing here.
+ */
+export function deliverMessage(opts: {
+  session: string;
+  target: string;
+  message: string;
+  noEnter?: boolean;
+  /** The project dir long messages are dispatched through as a file. */
+  dir?: string;
+}): DeliverResult {
+  const { session, target, noEnter, dir } = opts;
 
-  if (!rawMessage) {
-    throw new IdeError("Missing message. Usage: tmux-ide send <target> <message>", {
-      code: "USAGE",
-    });
-  }
-
-  // Verify session is running
   const state = getSessionState(session);
   if (!state.running) {
     throw new IdeError(`Session "${session}" is not running`, {
@@ -126,13 +138,13 @@ export async function send(targetDir: string | undefined, opts: SendOptions): Pr
   }
 
   const busyStatus = getPaneBusyStatus(session, pane.id);
-  const message = prepareMessage(rawMessage, busyStatus);
+  const message = prepareMessage(opts.message, busyStatus);
 
   let sentViaFile = false;
   if (noEnter) {
     sendText(session, pane.id, message);
   } else {
-    const dispatch = writeDispatchFile(dir, pane.id, message);
+    const dispatch = dir ? writeDispatchFile(dir, pane.id, message) : null;
     if (dispatch) {
       sendCommand(session, pane.id, dispatch.triggerCmd);
       sentViaFile = true;
@@ -141,7 +153,7 @@ export async function send(targetDir: string | undefined, opts: SendOptions): Pr
     }
   }
 
-  const result = {
+  return {
     ok: true,
     session,
     target: {
@@ -153,8 +165,30 @@ export async function send(targetDir: string | undefined, opts: SendOptions): Pr
     message,
     busyStatus,
     sentViaFile,
-    ...(busyStatus === "agent" ? { warning: "agent_busy" } : {}),
+    ...(busyStatus === "agent" ? { warning: "agent_busy" as const } : {}),
   };
+}
+
+export async function send(targetDir: string | undefined, opts: SendOptions): Promise<void> {
+  const dir = resolve(targetDir ?? ".");
+  const { name: session } = getSessionName(dir);
+  const { json, to: target, message: rawMessage, noEnter } = opts;
+
+  if (!target) {
+    throw new IdeError("Missing target. Usage: tmux-ide send <target> <message>", {
+      code: "USAGE",
+    });
+  }
+
+  if (!rawMessage) {
+    throw new IdeError("Missing message. Usage: tmux-ide send <target> <message>", {
+      code: "USAGE",
+    });
+  }
+
+  const result = deliverMessage({ session, target, message: rawMessage, noEnter, dir });
+  const { message, busyStatus } = result;
+  const pane = result.target;
 
   if (json) {
     console.log(JSON.stringify(result, null, 2));
@@ -163,7 +197,7 @@ export async function send(targetDir: string | undefined, opts: SendOptions): Pr
 
   const label = pane.name ?? pane.title;
   const preview = message.length > 60 ? message.slice(0, 60) + "..." : message;
-  console.log(`Sent to "${label}" (${pane.id}): ${preview}`);
+  console.log(`Sent to "${label}" (${pane.paneId}): ${preview}`);
 
   if (busyStatus === "agent") {
     console.log("Warning: agent appears busy. Message sent anyway.");

--- a/packages/daemon/src/tui/chrome/updater.ts
+++ b/packages/daemon/src/tui/chrome/updater.ts
@@ -181,8 +181,11 @@ export function updateSegment(status: UpdateStatus, theme: AppTheme): string {
   return `#[range=user|update]#[fg=${theme.accent}]⬆ v${status.latest}#[default]#[norange]`;
 }
 
-/** Flatten the project view to a flat per-session status list for {@link diffFleet}. */
-function fleetStatuses(projects: TeamProject[]): Array<{ name: string; status: AgentStatus }> {
+/** Flatten the project view to a flat per-session status list for {@link diffFleet}.
+ *  Exported: the control server's event tick diffs the same projection. */
+export function fleetStatuses(
+  projects: TeamProject[],
+): Array<{ name: string; status: AgentStatus }> {
   return projects.flatMap((p) => p.sessions.map((s) => ({ name: s.name, status: s.status })));
 }
 

--- a/packages/daemon/src/tui/team/wait.test.ts
+++ b/packages/daemon/src/tui/team/wait.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The extracted wait loops (`tmux-ide wait` + the socket's `wait` verb):
+ * deps-injected polling, so success, timeout, and the matching rules pin
+ * down without a tmux server.
+ */
+import { describe, expect, it } from "vitest";
+import { createStatusTracker, type AgentStatus } from "../detect/classify.ts";
+import type { TeamSession } from "./sessions.ts";
+import { matchOutput, waitForAgentStatus, waitForOutputMatch } from "./wait.ts";
+
+const session = (name: string, status: AgentStatus): TeamSession => ({
+  name,
+  attached: false,
+  windows: 1,
+  panes: 1,
+  status,
+  windowList: [],
+});
+
+/** A fake clock + instant sleep: each sleep advances time by the slept ms. */
+function fakeTime() {
+  let now = 0;
+  return {
+    now: () => now,
+    sleep: (ms: number) => {
+      now += ms;
+      return Promise.resolve();
+    },
+  };
+}
+
+describe("matchOutput", () => {
+  it("reports the first matching LINE", () => {
+    expect(matchOutput("alpha\nbeta ok\ngamma", "ok")).toBe("beta ok");
+  });
+
+  it("falls back to whole-text matching (multi-line patterns)", () => {
+    expect(matchOutput("one\ntwo", "one[\\s\\S]two")).toBe("two");
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(matchOutput("nothing here", "absent")).toBeNull();
+  });
+
+  it("a /g-style sticky pattern cannot carry lastIndex between calls", () => {
+    expect(matchOutput("ok ok", "ok")).toBe("ok ok");
+    expect(matchOutput("ok ok", "ok")).toBe("ok ok");
+  });
+});
+
+describe("waitForAgentStatus", () => {
+  it("resolves ok once the session reaches the wanted status", async () => {
+    const t = fakeTime();
+    let polls = 0;
+    const result = await waitForAgentStatus("s1", "done", {
+      tracker: createStatusTracker(),
+      listSessions: () => [session("s1", ++polls >= 3 ? "done" : "working")],
+      now: t.now,
+      sleep: t.sleep,
+    });
+    expect(result).toMatchObject({ ok: true, session: "s1", status: "done" });
+    expect(polls).toBe(3);
+  });
+
+  it("times out with the last observed status (null when absent)", async () => {
+    const t = fakeTime();
+    const result = await waitForAgentStatus("ghost", "done", {
+      timeoutMs: 3000,
+      tracker: createStatusTracker(),
+      listSessions: () => [session("other", "idle")],
+      now: t.now,
+      sleep: t.sleep,
+    });
+    expect(result).toMatchObject({ ok: false, status: null, timedOutAfterMs: 3000 });
+  });
+});
+
+describe("waitForOutputMatch", () => {
+  it("resolves with the matching line, tolerating capture failures", async () => {
+    const t = fakeTime();
+    let calls = 0;
+    const result = await waitForOutputMatch("%9", "ready", {
+      capture: () => {
+        calls++;
+        if (calls === 1) throw new Error("pane not up yet");
+        return calls < 3 ? "booting" : "server ready on :3000";
+      },
+      now: t.now,
+      sleep: t.sleep,
+    });
+    expect(result).toMatchObject({ ok: true, matched: "server ready on :3000" });
+  });
+
+  it("times out when nothing ever matches", async () => {
+    const t = fakeTime();
+    const result = await waitForOutputMatch("%9", "never", {
+      timeoutMs: 2000,
+      capture: () => "still nothing",
+      now: t.now,
+      sleep: t.sleep,
+    });
+    expect(result).toMatchObject({ ok: false, matched: null, timedOutAfterMs: 2000 });
+  });
+
+  it("throws up front on an invalid regex", async () => {
+    await expect(waitForOutputMatch("%9", "([", { capture: () => "" })).rejects.toThrow();
+  });
+});

--- a/packages/daemon/src/tui/team/wait.ts
+++ b/packages/daemon/src/tui/team/wait.ts
@@ -1,0 +1,144 @@
+/**
+ * The `wait` conditions — the SHARED implementation behind `tmux-ide wait
+ * agent-status` / `tmux-ide wait output` (bin/cli.ts) and the control
+ * socket's `wait` verb (src/control/). Extracted from the CLI case so the
+ * socket is a transport over the same logic, not a second implementation.
+ *
+ * Both loops are deps-injected (fleet lister / pane capture, clock, sleep)
+ * so the polling logic unit-tests without tmux; the exported defaults wire
+ * the real io.
+ */
+import { capturePane } from "@tmux-ide/tmux-bridge";
+import type { AgentStatus, StatusTracker } from "../detect/classify.ts";
+import { createStatusTracker } from "../detect/classify.ts";
+import { findSessionStatus } from "./report.ts";
+import { listTeamSessions, type TeamSession } from "./sessions.ts";
+
+/** Default overall timeout (matches the CLI's historical default). */
+export const WAIT_DEFAULT_TIMEOUT_MS = 60_000;
+/** Poll cadence for the agent-status wait. */
+export const WAIT_STATUS_POLL_MS = 750;
+/** Poll cadence for the output-match wait. */
+export const WAIT_OUTPUT_POLL_MS = 500;
+
+const sleepMs = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * PURE — test `text` (a pane capture) against `pattern`, line by line, and
+ * report the first matching LINE; falls back to whole-text matching (with the
+ * last line reported) so multi-line patterns still hit. A fresh RegExp per
+ * test so a user-supplied /g flag can't carry `lastIndex` between calls.
+ * Returns null when nothing matches.
+ */
+export function matchOutput(text: string, pattern: string): string | null {
+  const lines = text.split("\n");
+  for (const line of lines) {
+    if (new RegExp(pattern).test(line)) return line;
+  }
+  if (new RegExp(pattern).test(text)) return lines[lines.length - 1] ?? "";
+  return null;
+}
+
+export interface WaitAgentStatusResult {
+  ok: boolean;
+  session: string;
+  want: AgentStatus;
+  /** The session's last observed status (null = session absent). */
+  status: AgentStatus | null;
+  /** Set when `ok` is false: how long we waited. */
+  timedOutAfterMs?: number;
+}
+
+export interface WaitAgentStatusOpts {
+  timeoutMs?: number;
+  pollMs?: number;
+  /**
+   * The tracker threaded across polls (one PERSISTS per wait so the
+   * cross-tick working→idle `done` transition can be observed). Injected by
+   * tests; defaults to a fresh tracker.
+   */
+  tracker?: StatusTracker;
+  listSessions?: (tracker: StatusTracker) => TeamSession[];
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Block until `session` reaches `want`, or time out. Never throws. */
+export async function waitForAgentStatus(
+  session: string,
+  want: AgentStatus,
+  opts: WaitAgentStatusOpts = {},
+): Promise<WaitAgentStatusResult> {
+  const timeoutMs = opts.timeoutMs ?? WAIT_DEFAULT_TIMEOUT_MS;
+  const pollMs = opts.pollMs ?? WAIT_STATUS_POLL_MS;
+  const tracker = opts.tracker ?? createStatusTracker();
+  const list = opts.listSessions ?? listTeamSessions;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? sleepMs;
+  const started = now();
+
+  for (;;) {
+    const status = findSessionStatus(list(tracker), session);
+    if (status === want) return { ok: true, session, want, status };
+    if (now() - started >= timeoutMs) {
+      return { ok: false, session, want, status, timedOutAfterMs: timeoutMs };
+    }
+    await sleep(pollMs);
+  }
+}
+
+export interface WaitOutputResult {
+  ok: boolean;
+  target: string;
+  pattern: string;
+  /** The matching line when `ok`; null on timeout. */
+  matched: string | null;
+  timedOutAfterMs?: number;
+}
+
+export interface WaitOutputOpts {
+  timeoutMs?: number;
+  pollMs?: number;
+  /** Pane capture (defaults to tmux-bridge's `capturePane`, 200 lines). */
+  capture?: (target: string) => string;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Block until `target`'s captured output matches `pattern`, or time out.
+ * A capture failure (pane/session not (yet) available) keeps polling until
+ * the timeout. Throws only on an invalid regex — validate before looping.
+ */
+export async function waitForOutputMatch(
+  target: string,
+  pattern: string,
+  opts: WaitOutputOpts = {},
+): Promise<WaitOutputResult> {
+  new RegExp(pattern); // an invalid pattern is a usage error, surfaced up front
+  const timeoutMs = opts.timeoutMs ?? WAIT_DEFAULT_TIMEOUT_MS;
+  const pollMs = opts.pollMs ?? WAIT_OUTPUT_POLL_MS;
+  const capture = opts.capture ?? defaultCapture;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? sleepMs;
+  const started = now();
+
+  for (;;) {
+    let text = "";
+    try {
+      text = capture(target);
+    } catch {
+      // not capturable yet — keep polling
+    }
+    const matched = matchOutput(text, pattern);
+    if (matched !== null) return { ok: true, target, pattern, matched };
+    if (now() - started >= timeoutMs) {
+      return { ok: false, target, pattern, matched: null, timedOutAfterMs: timeoutMs };
+    }
+    await sleep(pollMs);
+  }
+}
+
+function defaultCapture(target: string): string {
+  return capturePane(target, { lines: 200 });
+}

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       "src/terminal/__tests__/*.test.ts",
       "src/lib/app-config.test.ts",
       "src/lib/__tests__/*.test.ts",
+      "src/control/*.test.ts",
       "src/tui/*.test.ts",
       "src/tui/detect/*.test.ts",
       "src/tui/team/*.test.ts",

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -102,6 +102,69 @@ tmux-ide update --dry-run                  # detect install method (dev checkout
 tmux-ide doctor                            # system + integration health (tmux version, TUI surfaces, skill freshness)
 ```
 
+## Drive tmux-ide over the socket (agent loops)
+
+The CLI above spawns a process per call. If you are driving the fleet in a
+loop — polling status, waiting on agents, reacting to transitions — start the
+control server once and keep ONE connection open instead:
+
+```bash
+tmux-ide serve &   # local Unix socket at ~/.tmux-ide/control.sock (0600, this user only)
+```
+
+**Frame format:** newline-delimited JSON, one object per line. Send
+`{"v":1,"id":<any>,"verb":"<verb>","params":{…}}`; you get back
+`{"v":1,"id":<same>,"ok":true,"data":…}` or
+`{"v":1,"id":<same>,"ok":false,"error":{"code","message"}}`. Responses
+correlate by `id` (they may arrive out of order — a long `wait` doesn't block
+other verbs on the same connection). After the `subscribe` verb the server
+also PUSHES unsolicited `{"v":1,"event":"agent-status","data":{ts,session,from,to}}`
+frames the moment its detection tick sees a session change state — no polling.
+
+**Verbs:** `fleet` (the `team --json` payload) · `agents` (per-pane entries,
+optional `{session}`) · `send` (`{session,target,message,noEnter?,dir?}`) ·
+`wait` (`{kind:"agent-status",session,status,timeoutMs?}` or
+`{kind:"output",target,match,timeoutMs?}`; a timeout is an error response with
+code `timeout`) · `spawn` (`{kind|command, session?|sessionName, dir?,
+placement?, paneId?}` → the new `paneId`) · `restart-agent` / `stop-agent`
+(`{paneId, kind|command}`) · `explain` (`{target}`) · `subscribe`.
+
+One-shot from a shell (nc keeps the pipe open for the response):
+
+```bash
+printf '{"v":1,"id":1,"verb":"fleet"}\n' | nc -U ~/.tmux-ide/control.sock | head -1
+```
+
+A subscribe loop from node:
+
+```js
+const net = require("node:net");
+const os = require("node:os");
+const sock = net.connect(`${os.homedir()}/.tmux-ide/control.sock`);
+let buf = "";
+sock.on("data", (chunk) => {
+  buf += chunk;
+  const lines = buf.split("\n");
+  buf = lines.pop();
+  for (const line of lines.filter(Boolean)) {
+    const frame = JSON.parse(line);
+    if (frame.event === "agent-status") console.log(frame.data); // react here
+  }
+});
+sock.write('{"v":1,"id":1,"verb":"subscribe"}\n');
+```
+
+Right after `subscribe`, the first tick reports every session once with
+`from:null` (a snapshot of where the fleet stands); real transitions follow.
+
+**Socket vs CLI:** prefer the socket for anything event-driven or repeated
+(subscribe replaces an `events --follow` poll; a server-held `wait` costs no
+spawn-per-poll). Prefer the CLI for one-shot reads and anything a human might
+re-run — it needs no server. With a server running, `tmux-ide events --follow
+--socket` and `tmux-ide wait … --socket` use it automatically and fall back to
+polling silently when it's gone. The server is local-only by design: no
+network listener, no tokens — filesystem permissions are the auth.
+
 ## Keys & surfaces to tell USERS about
 
 Once a session is adopted, the whole UI is a keystroke away. **Lead with the


### PR DESCRIPTION
Card #96, the milestone closer: NDJSON unix-socket control API with push subscribe, strict data-layer reuse (wait/send extracted, lifecycle builders shared), explicit-start-only host decision documented against the command-center cautionary tale. Live-verified: no-polling subscribe, concurrent framing, full socket lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)