### PR TITLE
feat: event-driven geometry — resize goes fully native (M23.5)

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -204,9 +204,10 @@ import { registerProject, ProjectAlreadyRegisteredError } from "../../lib/projec
 import { separatorAt, resizedSize, resizeCommand, type Separator } from "./resize-model.ts";
 import {
   effectiveWindowSize,
-  detectSizeMismatch,
+  detectSizeMismatchWithRepin,
   letterboxOffset,
   formatSizeHint,
+  type RepinState,
   type Size,
 } from "./size-truth.ts";
 import {
@@ -1269,15 +1270,33 @@ render(
     };
 
     let mirror: SessionMirror | null = null;
+    // ── EVENT-DRIVEN RE-PIN (M23.5) ──────────────────────────────────────────
+    // The 200ms canvas size poll is gone: a createEffect on the renderer dims
+    // signal (canvasCols/canvasRows read dims() + sidebarW()) re-pins the
+    // mirror the moment the size actually changes. `lastPin` is what we last
+    // asked tmux for; `repinInFlight` gates the size-truth hint while tmux
+    // confirms (D4b — see the tick).
+    let lastPin: Size = { cols: canvasCols(), rows: canvasRows() };
+    let repinInFlight: RepinState | null = null;
+    createEffect(() => {
+      const next: Size = { cols: canvasCols(), rows: canvasRows() };
+      if (next.cols === lastPin.cols && next.rows === lastPin.rows) return;
+      repinInFlight = { prev: lastPin, at: performance.now() };
+      lastPin = next;
+      void mirror?.resize(next.cols, next.rows);
+    });
     const attach = (name: string) => {
       mirror?.dispose();
       scrollOffsets.clear();
       setPanes([]);
       setStatus(`attaching ${name}…`);
+      // A fresh mirror pins at the current canvas size — no re-pin in flight.
+      lastPin = { cols: canvasCols(), rows: canvasRows() };
+      repinInFlight = null;
       const m = new SessionMirror({
         target: name,
-        cols: canvasCols(),
-        rows: canvasRows(),
+        cols: lastPin.cols,
+        rows: lastPin.rows,
         onDirty: markDirty,
         onStatus: () => {
           markDirty();
@@ -2421,15 +2440,28 @@ render(
         // styled-row rebuild) — the <pane_surface> reads cells via the blit and
         // gates its walk on the version, so unchanged panes cost nothing.
         const raw = mirror.panes(scrollOffsets, !FB_PANES);
-        // Size truth (M22.8): the RAW pane bounding box is the effective window
-        // size. When a co-attached terminal shrank it below our pinned canvas we
-        // surface the honest hint AND center the grid — the offset is baked into
+        // Size truth (M22.8, event-driven M23.5): the effective window size is
+        // the layout ROOT's WxH pushed by %layout-change (the pane bounding
+        // box only seeds it before the first layout lands). When a co-attached
+        // terminal sized the window away from our pinned canvas we surface the
+        // honest hint AND center the grid — the offset is baked into
         // pane.left/top HERE (one place), so every render and pointer-routing
         // read (all expressed relative to pane.left/top or `inside(pane,…)`)
-        // stays consistent for free without touching the mouse math.
+        // stays consistent for free without touching the mouse math. A re-pin
+        // in flight suppresses the mismatch (D4b): between our refresh-client
+        // -C and tmux's %layout-change the stale size is expected, and honest-
+        // hinting it flashed "window sized by another terminal" + a letterbox
+        // jump on every grow (measured).
         const pinned: Size = { cols: canvasCols(), rows: canvasRows() };
-        const effective = effectiveWindowSize(raw);
-        const mm = effective ? detectSizeMismatch(pinned, effective) : null;
+        const effective = mirror.windowSize() ?? effectiveWindowSize(raw);
+        const mm = effective
+          ? detectSizeMismatchWithRepin(pinned, effective, repinInFlight, performance.now())
+          : null;
+        // The transition completed (sizes agree) — retire the grace so a LATER
+        // genuine co-attach shrink to exactly the old size still surfaces.
+        if (effective && effective.cols === pinned.cols && effective.rows === pinned.rows) {
+          repinInFlight = null;
+        }
         setWindowMismatch(mm);
         const off = mm ? letterboxOffset(pinned, mm) : { x: 0, y: 0 };
         setPanes(
@@ -2486,20 +2518,10 @@ render(
       const diffTimer = setInterval(() => {
         if (mode() === "diff") refreshStatus();
       }, 3000);
-      let lastW = canvasCols();
-      let lastH = canvasRows();
-      const sizeTimer = setInterval(() => {
-        if (canvasCols() !== lastW || canvasRows() !== lastH) {
-          lastW = canvasCols();
-          lastH = canvasRows();
-          void mirror?.resize(lastW, lastH);
-        }
-      }, 200);
       onCleanup(() => {
         clearInterval(t);
         clearInterval(fleetTimer);
         clearInterval(diffTimer);
-        clearInterval(sizeTimer);
         if (saveTimer) clearTimeout(saveTimer);
         if (noteTimer) clearTimeout(noteTimer);
         mirror?.dispose();
@@ -5592,5 +5614,13 @@ render(
   },
   // targetFps stays EXPLICIT: @opentui 0.4.3 still silently defaults it to 30
   // (maxFps already defaults to 60). Re-confirmed on the 0.4.3 bump (M21.2).
-  { targetFps: 60, maxFps: 60 },
+  // consoleMode: OpenTUI's error console is an in-app OVERLAY that pops over
+  // the canvas on any console.error (a runtime exception mid-render flashed it
+  // during the M23.5 resize battery). Off in production; the mirror debug flag
+  // keeps it for development, where it is genuinely useful.
+  {
+    targetFps: 60,
+    maxFps: 60,
+    consoleMode: process.env.TMUX_IDE_MIRROR_DEBUG ? "console-overlay" : "disabled",
+  },
 );

--- a/packages/daemon/src/tui/mirror/layout-parse.test.ts
+++ b/packages/daemon/src/tui/mirror/layout-parse.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseLayout,
+  parseLayoutChange,
+  parseWindowPaneChanged,
+  parseSessionWindowChanged,
+  parseMouseSubscription,
+} from "./layout-parse.ts";
+
+// Every layout string below was captured from a live tmux 3.7b server
+// (zz-m235: a left pane + a right column split in two; resize/zoom/storm).
+
+const THREE_PANE = "468e,120x40,0,0{60x40,0,0,443,59x40,61,0[59x20,61,0,444,59x19,61,21,445]}";
+const ZOOMED = "6a6f,100x30,0,0,445";
+const SINGLE = "6e38,282x90,0,0,446";
+const STORM_STEP = "0bd6,90x28,0,0{45x28,0,0,443,44x28,46,0[44x14,46,0,444,44x13,46,15,445]}";
+
+describe("parseLayout", () => {
+  it("parses a nested horizontal+vertical split (real capture)", () => {
+    const p = parseLayout(THREE_PANE)!;
+    expect(p.width).toBe(120);
+    expect(p.height).toBe(40);
+    expect(p.leaves).toEqual([
+      { id: "%443", left: 0, top: 0, width: 60, height: 40 },
+      { id: "%444", left: 61, top: 0, width: 59, height: 20 },
+      { id: "%445", left: 61, top: 21, width: 59, height: 19 },
+    ]);
+  });
+
+  it("parses the zoomed visible layout — a single collapsed leaf", () => {
+    const p = parseLayout(ZOOMED)!;
+    expect(p.width).toBe(100);
+    expect(p.height).toBe(30);
+    expect(p.leaves).toEqual([{ id: "%445", left: 0, top: 0, width: 100, height: 30 }]);
+  });
+
+  it("parses a single-pane window", () => {
+    const p = parseLayout(SINGLE)!;
+    expect(p.width).toBe(282);
+    expect(p.height).toBe(90);
+    expect(p.leaves).toEqual([{ id: "%446", left: 0, top: 0, width: 282, height: 90 }]);
+  });
+
+  it("parses a resize-storm step (same shape, new sizes)", () => {
+    const p = parseLayout(STORM_STEP)!;
+    expect(p.width).toBe(90);
+    expect(p.height).toBe(28);
+    expect(p.leaves.map((l) => l.id)).toEqual(["%443", "%444", "%445"]);
+    expect(p.leaves[2]).toEqual({ id: "%445", left: 46, top: 15, width: 44, height: 13 });
+  });
+
+  it("parses a vertical-only split", () => {
+    // Hand-derived from the grammar: two stacked panes in an 80x24 window.
+    const p = parseLayout("abcd,80x24,0,0[80x12,0,0,1,80x11,0,13,2]")!;
+    expect(p.leaves).toEqual([
+      { id: "%1", left: 0, top: 0, width: 80, height: 12 },
+      { id: "%2", left: 0, top: 13, width: 80, height: 11 },
+    ]);
+  });
+
+  it("rejects malformed input instead of throwing", () => {
+    expect(parseLayout("")).toBeNull();
+    expect(parseLayout("no-checksum,80x24,0,0,1")).toBeNull();
+    expect(parseLayout("abcd,80x24,0,0")).toBeNull(); // no leaf id, no children
+    expect(parseLayout("abcd,80x24,0,0{80x24,0,0,1")).toBeNull(); // unclosed brace
+    expect(parseLayout("abcd,80x24,0,0,1trailing")).toBeNull(); // junk after root
+    expect(parseLayout("abcd,80xx24,0,0,1")).toBeNull();
+  });
+});
+
+describe("parseLayoutChange", () => {
+  it("parses the real notification body incl. the zoom flag", () => {
+    const ev = parseLayoutChange(`@387 ${THREE_PANE} ${ZOOMED} *Z`)!;
+    expect(ev.windowId).toBe("@387");
+    expect(ev.layout).toBe(THREE_PANE);
+    expect(ev.visible).toBe(ZOOMED);
+    expect(ev.zoomed).toBe(true);
+  });
+  it("unzoomed flags carry no Z", () => {
+    expect(parseLayoutChange(`@387 ${THREE_PANE} ${THREE_PANE} *`)!.zoomed).toBe(false);
+    expect(parseLayoutChange(`@387 ${THREE_PANE} ${THREE_PANE} -`)!.zoomed).toBe(false);
+  });
+  it("rejects off shapes", () => {
+    expect(parseLayoutChange("")).toBeNull();
+    expect(parseLayoutChange("%443 x y")).toBeNull();
+    expect(parseLayoutChange("@387 onlylayout")).toBeNull();
+  });
+});
+
+describe("parseWindowPaneChanged", () => {
+  it("parses the real body", () => {
+    expect(parseWindowPaneChanged("@387 %443")).toEqual({ windowId: "@387", paneId: "%443" });
+  });
+  it("rejects off shapes", () => {
+    expect(parseWindowPaneChanged("@387")).toBeNull();
+    expect(parseWindowPaneChanged("%443 @387")).toBeNull();
+  });
+});
+
+describe("parseSessionWindowChanged", () => {
+  it("parses the real body", () => {
+    expect(parseSessionWindowChanged("$353 @388")).toEqual({ windowId: "@388" });
+  });
+  it("rejects off shapes", () => {
+    expect(parseSessionWindowChanged("$353")).toBeNull();
+  });
+});
+
+describe("parseMouseSubscription", () => {
+  it("parses the real subscription line (on and off)", () => {
+    expect(parseMouseSubscription("mouse $353 @387 0 %445 : 1")).toEqual({
+      paneId: "%445",
+      on: true,
+    });
+    expect(parseMouseSubscription("mouse $353 @387 0 %443 : 0")).toEqual({
+      paneId: "%443",
+      on: false,
+    });
+  });
+  it("ignores other subscription names and off shapes", () => {
+    expect(parseMouseSubscription("other $353 @387 0 %445 : 1")).toBeNull();
+    expect(parseMouseSubscription("mouse $353 @387 0")).toBeNull();
+  });
+});

--- a/packages/daemon/src/tui/mirror/layout-parse.ts
+++ b/packages/daemon/src/tui/mirror/layout-parse.ts
@@ -1,0 +1,154 @@
+/**
+ * PURE — tmux layout-string and control-notification parsing (M23.5).
+ *
+ * `%layout-change` arrives sub-millisecond after the server applies a layout
+ * and ALWAYS precedes the first new-size `%output` (measured on tmux 3.7b:
+ * the follow-up output can trail by as little as 0.2ms). The mirror therefore
+ * derives pane geometry from the notification PAYLOAD itself instead of a
+ * debounced `list-panes` round-trip — these parsers are that push path.
+ *
+ * The layout grammar mirrors tmux's `layout_parse.c`: a 4-hex-digit checksum,
+ * a comma, then a cell. A cell is `WxH,X,Y` followed by either `,<paneId>`
+ * (a leaf; the numeric pane id sans `%`), `{…}` (horizontal split) or `[…]`
+ * (vertical split) with comma-separated child cells. The ROOT cell's WxH is
+ * the authoritative window size. Parse the VISIBLE layout — the THIRD field
+ * of `%layout-change @win <layout> <visible-layout> <flags>` — because zoom
+ * collapses it to the single zoomed pane (`*Z` in flags = zoomed); the second
+ * field keeps reporting the saved multi-pane layout.
+ *
+ * Everything here is unit-tested against layout strings captured from a real
+ * tmux 3.7b server (splits, zoom, storms) — no tmux at test time.
+ */
+
+/** One visible pane rectangle, in window cells. `id` is `%`-prefixed. */
+export interface LayoutLeaf {
+  id: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** A parsed (visible) layout: the window size + the leaves in layout order. */
+export interface ParsedLayout {
+  /** The root cell's WxH — the authoritative window size. */
+  width: number;
+  height: number;
+  leaves: LayoutLeaf[];
+}
+
+/** Parse a tmux layout string (`csum,WxH,X,Y…`). Null on any malformed input
+ *  (the caller falls back to the slow list-panes path — never throw here). */
+export function parseLayout(layout: string): ParsedLayout | null {
+  if (!/^[0-9a-fA-F]{4},/.test(layout)) return null;
+  const s = layout.slice(5);
+  const leaves: LayoutLeaf[] = [];
+  const root = parseCell(s, 0, leaves);
+  if (!root || root.pos !== s.length) return null;
+  return { width: root.width, height: root.height, leaves };
+}
+
+/** Recursive-descent cell parse from `pos`; appends leaves in layout order. */
+function parseCell(
+  s: string,
+  pos: number,
+  leaves: LayoutLeaf[],
+): { width: number; height: number; pos: number } | null {
+  const dims = readDims(s, pos);
+  if (!dims) return null;
+  const { width, height, left, top } = dims;
+  pos = dims.pos;
+  const ch = s[pos];
+  if (ch === ",") {
+    // Leaf: the numeric pane id.
+    const id = readInt(s, pos + 1);
+    if (!id) return null;
+    leaves.push({ id: `%${id.value}`, left, top, width, height });
+    return { width, height, pos: id.pos };
+  }
+  if (ch === "{" || ch === "[") {
+    const close = ch === "{" ? "}" : "]";
+    pos++;
+    for (;;) {
+      const child = parseCell(s, pos, leaves);
+      if (!child) return null;
+      pos = child.pos;
+      if (s[pos] === ",") {
+        pos++;
+        continue;
+      }
+      if (s[pos] === close) return { width, height, pos: pos + 1 };
+      return null;
+    }
+  }
+  // A bare root leaf ends the string (`…,0,0,445`): ch is undefined only when
+  // the leaf id was consumed above, so anything else here is malformed.
+  return null;
+}
+
+/** Read `WxH,X,Y` at `pos`. */
+function readDims(
+  s: string,
+  pos: number,
+): { width: number; height: number; left: number; top: number; pos: number } | null {
+  const w = readInt(s, pos);
+  if (!w || s[w.pos] !== "x") return null;
+  const h = readInt(s, w.pos + 1);
+  if (!h || s[h.pos] !== ",") return null;
+  const x = readInt(s, h.pos + 1);
+  if (!x || s[x.pos] !== ",") return null;
+  const y = readInt(s, x.pos + 1);
+  if (!y) return null;
+  return { width: w.value, height: h.value, left: x.value, top: y.value, pos: y.pos };
+}
+
+/** Read a decimal integer at `pos` (at least one digit). */
+function readInt(s: string, pos: number): { value: number; pos: number } | null {
+  let end = pos;
+  while (end < s.length && s.charCodeAt(end) >= 0x30 && s.charCodeAt(end) <= 0x39) end++;
+  if (end === pos) return null;
+  return { value: Number(s.slice(pos, end)), pos: end };
+}
+
+/** A parsed `%layout-change` notification body. */
+export interface LayoutChange {
+  windowId: string;
+  /** The saved (full) layout — kept for debugging; geometry uses `visible`. */
+  layout: string;
+  /** The VISIBLE layout — collapses to the single zoomed pane under zoom. */
+  visible: string;
+  /** `Z` present in the flags field (`*Z`). */
+  zoomed: boolean;
+}
+
+/** Parse the body after `%layout-change ` (tmux 3.7b:
+ *  `@387 <layout> <visible-layout> *Z`). Null when the shape is off. */
+export function parseLayoutChange(rest: string): LayoutChange | null {
+  const parts = rest.trim().split(/\s+/);
+  const [windowId = "", layout = "", visible = "", flags = ""] = parts;
+  if (parts.length < 3 || !windowId.startsWith("@")) return null;
+  return { windowId, layout, visible, zoomed: flags.includes("Z") };
+}
+
+/** Parse the body after `%window-pane-changed ` (`@387 %443`). */
+export function parseWindowPaneChanged(rest: string): { windowId: string; paneId: string } | null {
+  const [windowId = "", paneId = ""] = rest.trim().split(/\s+/);
+  if (!windowId.startsWith("@") || !paneId.startsWith("%")) return null;
+  return { windowId, paneId };
+}
+
+/** Parse the body after `%session-window-changed ` (`$353 @388`). */
+export function parseSessionWindowChanged(rest: string): { windowId: string } | null {
+  const [, windowId = ""] = rest.trim().split(/\s+/);
+  if (!windowId.startsWith("@")) return null;
+  return { windowId };
+}
+
+/** Parse the body after `%subscription-changed ` for the mirror's `mouse`
+ *  subscription (tmux 3.7b: `mouse $353 @387 0 %445 : 1`). Null for other
+ *  subscription names or an off shape. */
+export function parseMouseSubscription(rest: string): { paneId: string; on: boolean } | null {
+  const m = /^mouse\s+\$\S+\s+@\S+\s+\S+\s+(%\S+)\s*:\s*(.*)$/.exec(rest.trim());
+  if (!m) return null;
+  return { paneId: m[1]!, on: m[2]!.trim() === "1" };
+}

--- a/packages/daemon/src/tui/mirror/pane-mirror.test.ts
+++ b/packages/daemon/src/tui/mirror/pane-mirror.test.ts
@@ -126,4 +126,27 @@ describe("PaneMirror.blit — incremental (M21.4)", () => {
     expect(dirtyRows).toEqual([2]);
     m.dispose();
   });
+
+  it("a mismatched-length row is bounds-guarded: always dirty, never RangeError (D5)", async () => {
+    const W = 10,
+      H = 4;
+    const m = new PaneMirror(W, H);
+    m.write("A\r\nB\r\nC\r\nD");
+    await flushed(m, "D");
+    const buffers = arrays(W, H);
+    blit(m, buffers, W, H, true);
+    // Force the xterm internal into the post-shrink shape the guard exists for:
+    // a line whose raw cell data is NOT cols×3 u32 long. Writing it into the
+    // rowLen-strided shadow used to throw RangeError (measured after rapid
+    // shrinks over wrapped content).
+    const line = m["term"].buffer.active.getLine(1) as unknown as {
+      _line: { _data: Uint32Array };
+    };
+    line._line._data = new Uint32Array(W * 3 + 6); // longer than the stride
+    expect(() => blit(m, buffers, W, H, false)).not.toThrow();
+    // Shadow-less rows repaint every walk — the guarded row stays dirty.
+    expect(blit(m, buffers, W, H, false)).toContain(1);
+    expect(blit(m, buffers, W, H, false)).toContain(1);
+    m.dispose();
+  });
 });

--- a/packages/daemon/src/tui/mirror/pane-mirror.ts
+++ b/packages/daemon/src/tui/mirror/pane-mirror.ts
@@ -420,7 +420,12 @@ export class PaneMirror {
     const forceRows = opts.forceRows && opts.forceRows.length ? opts.forceRows : null;
 
     for (let y = 0; y < height; y++) {
-      const data = this._incremental ? this.rowData(baseY, y) : null;
+      const raw = this._incremental ? this.rowData(baseY, y) : null;
+      // Bounds guard (M23.5, D5): after a shrink xterm's reflow can leave a
+      // line's `_data` at a length ≠ cols×3; comparing or `set`ting it against
+      // the rowLen-strided shadow would read garbage / throw RangeError. Treat
+      // such a row as shadow-less: always repaint it, never write the shadow.
+      const data = raw !== null && raw.length === rowLen ? raw : null;
       let dirty = full || y >= bottomDirtyFrom || data === null; // no shadow info for this row → always repaint
       if (!dirty && this._shadow) dirty = !shadowMatches(this._shadow, y * rowLen, data!);
       if (!dirty && forceRows) {

--- a/packages/daemon/src/tui/mirror/perf-tap.ts
+++ b/packages/daemon/src/tui/mirror/perf-tap.ts
@@ -103,9 +103,10 @@ export function tapInputTick(): void {
 // ── size re-pin tap (M22.8) ─────────────────────────────────────────────────
 // Every canvas-area change (terminal resize, sidebar drag) funnels through the
 // mirror's `resize()` — the ONE re-pin chokepoint. This tap records each re-pin
-// so a live drag/resize burst can be asserted to collapse to the expected count
-// (the 200ms size poll coalesces a burst to one re-pin per settled size). Gated
-// behind TMUX_IDE_ZZ_PERF, appending `cols rows` lines to /tmp/zz-repin.log.
+// so a live drag/resize burst can be asserted against the expected count (since
+// M23.5 the renderer dims signal re-pins per actual size change — no more 200ms
+// poll). Gated behind TMUX_IDE_ZZ_PERF, appending `cols rows` lines to
+// /tmp/zz-repin.log.
 
 const REPIN_LOG = "/tmp/zz-repin.log";
 
@@ -114,6 +115,31 @@ export function tapRepin(cols: number, rows: number): void {
   if (!process.env.TMUX_IDE_ZZ_PERF) return;
   try {
     appendFileSync(REPIN_LOG, `${cols} ${rows}\n`);
+  } catch {
+    /* perf tap only */
+  }
+}
+
+// ── resize tap (M23.5) ──────────────────────────────────────────────────────
+// The event-driven geometry pipeline's flight recorder: one timestamped line
+// per hop — %layout-change received (`notify`), geometry applied into the
+// mirrors (`geometry-applied`), a canvas re-pin (`repin`), a per-pane term
+// resize (`pane-resize`), and per-%output mirror dims (`output`) — so a resize
+// battery can assert "geometry applied <5ms after the notify" and "no %output
+// parsed into stale dims" straight from the log. Own env gate
+// (TMUX_IDE_ZZ_RESIZE_TAP): the per-output line is too chatty for the general
+// TMUX_IDE_ZZ_PERF sessions.
+
+const RESIZE_LOG = "/tmp/zz-resize-tap.log";
+
+/** Append one `<t> <event> <detail>` line. No-op unless TMUX_IDE_ZZ_RESIZE_TAP. */
+export function tapResize(event: string, detail = ""): void {
+  if (!process.env.TMUX_IDE_ZZ_RESIZE_TAP) return;
+  try {
+    appendFileSync(
+      RESIZE_LOG,
+      `${performance.now().toFixed(2)} ${event}${detail ? ` ${detail}` : ""}\n`,
+    );
   } catch {
     /* perf tap only */
   }

--- a/packages/daemon/src/tui/mirror/session-mirror.test.ts
+++ b/packages/daemon/src/tui/mirror/session-mirror.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { parsePaneGeometry, diffPanes, type PaneGeometry } from "./session-mirror.ts";
+import { parsePaneGeometry, geometryFromLeaves, type PaneGeometry } from "./session-mirror.ts";
+import { parseLayout } from "./layout-parse.ts";
 
 const g = (id: string, left: number, top: number, w: number, h: number, active = false) =>
   ({ id, left, top, width: w, height: h, active, appMouse: false, zoomed: false }) as PaneGeometry;
@@ -21,24 +22,81 @@ describe("parsePaneGeometry", () => {
     expect(a).toMatchObject({ id: "%1", active: true, appMouse: false, zoomed: true });
     expect(b).toMatchObject({ id: "%2", active: false, appMouse: true, zoomed: false });
   });
+  it("ignores extra trailing fields (the sync format appends window_id)", () => {
+    expect(parsePaneGeometry(["%1 0 0 80 20 1 0 0 @387"])).toEqual([g("%1", 0, 0, 80, 20, true)]);
+  });
 });
 
-describe("diffPanes", () => {
-  const prev = [g("%1", 0, 0, 80, 20), g("%2", 81, 0, 79, 20)];
-  it("detects adds and removes", () => {
-    const d = diffPanes(prev, [g("%1", 0, 0, 80, 20), g("%3", 0, 21, 160, 10)]);
-    expect(d.added.map((p) => p.id)).toEqual(["%3"]);
-    expect(d.removed).toEqual(["%2"]);
+describe("geometryFromLeaves", () => {
+  // A real captured visible layout feeds the leaves, as in production.
+  const leaves = parseLayout(
+    "468e,120x40,0,0{60x40,0,0,443,59x40,61,0[59x20,61,0,444,59x19,61,21,445]}",
+  )!.leaves;
+
+  it("builds geometry from leaves with tracked active + appMouse flags", () => {
+    const out = geometryFromLeaves(leaves, [], "%444", new Map([["%444", true]]), false);
+    expect(out).toEqual([
+      {
+        id: "%443",
+        left: 0,
+        top: 0,
+        width: 60,
+        height: 40,
+        active: false,
+        appMouse: false,
+        zoomed: false,
+      },
+      {
+        id: "%444",
+        left: 61,
+        top: 0,
+        width: 59,
+        height: 20,
+        active: true,
+        appMouse: true,
+        zoomed: false,
+      },
+      {
+        id: "%445",
+        left: 61,
+        top: 21,
+        width: 59,
+        height: 19,
+        active: false,
+        appMouse: false,
+        zoomed: false,
+      },
+    ]);
   });
-  it("detects resizes and pure moves separately", () => {
-    const d = diffPanes(prev, [g("%1", 0, 0, 100, 20), g("%2", 101, 0, 79, 20)]);
-    expect(d.resized.map((p) => p.id)).toEqual(["%1"]);
-    expect(d.moved.map((p) => p.id)).toEqual(["%2"]);
+
+  it("falls back to the previous geometry's flags while trackers are silent", () => {
+    const prev = [{ ...g("%443", 0, 0, 60, 40, true), appMouse: true }];
+    const out = geometryFromLeaves(leaves, prev, "", new Map(), false);
+    expect(out[0]).toMatchObject({ id: "%443", active: true, appMouse: true });
+    expect(out[1]).toMatchObject({ id: "%444", active: false, appMouse: false });
   });
-  it("empty diff when identical", () => {
-    const d = diffPanes(prev, prev);
-    expect(d.added).toEqual([]);
-    expect(d.removed).toEqual([]);
-    expect(d.resized).toEqual([]);
+
+  it("the tracked active pane overrides a stale previous flag", () => {
+    const prev = [g("%443", 0, 0, 60, 40, true)];
+    const out = geometryFromLeaves(leaves, prev, "%445", new Map(), false);
+    expect(out.find((p) => p.id === "%443")!.active).toBe(false);
+    expect(out.find((p) => p.id === "%445")!.active).toBe(true);
+  });
+
+  it("stamps the zoom flag on every visible pane", () => {
+    const zoomedLeaves = parseLayout("6a6f,100x30,0,0,445")!.leaves;
+    const out = geometryFromLeaves(zoomedLeaves, [], "%445", new Map(), true);
+    expect(out).toEqual([
+      {
+        id: "%445",
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 30,
+        active: true,
+        appMouse: false,
+        zoomed: true,
+      },
+    ]);
   });
 });

--- a/packages/daemon/src/tui/mirror/session-mirror.ts
+++ b/packages/daemon/src/tui/mirror/session-mirror.ts
@@ -5,14 +5,24 @@
  * {@link ControlModeClient} attaches to the session, `refresh-client -C`
  * pins the virtual client size to our render area (so tmux computes pane
  * layout for OUR grid), and every pane of the active window gets a
- * {@link PaneMirror} fed by routed `%output` bytes. Layout notifications
- * (`%layout-change`, `%window-pane-changed`, …) trigger a re-sync that
- * diffs geometry and creates/resizes/disposes mirrors incrementally.
+ * {@link PaneMirror} fed by routed `%output` bytes.
+ *
+ * GEOMETRY IS EVENT-DRIVEN (M23.5). `%layout-change` arrives sub-ms after the
+ * server applies a layout and ALWAYS precedes the first new-size `%output`
+ * (measured on 3.7b: as little as 0.2ms ahead) — so the notification PAYLOAD
+ * itself (the visible-layout string, parsed by layout-parse.ts) resizes the
+ * PaneMirrors SYNCHRONOUSLY in the same event-loop turn. The old 40ms-debounced
+ * `list-panes` hop let new-size redraws parse into stale-sized xterms, which
+ * corrupted redraw-once apps (vim/less/shells) PERMANENTLY. A slow list-panes
+ * `sync` remains as the attach seed, the reconciler behind uncertain events,
+ * the flag source, and the ONLY owner of mirror disposal. `%window-pane-changed`
+ * drives the active pane; one `refresh-client -B` subscription pushes per-pane
+ * `mouse_any_flag` (~1s cadence, `%subscription-changed`).
  *
  * tmux remains the multiplexer, PTY owner, and source of layout truth —
  * this class owns nothing but mirrors and routing. The pure helpers
- * ({@link parsePaneGeometry}, {@link diffPanes}) carry the logic and are
- * unit-tested without tmux.
+ * ({@link parsePaneGeometry}, {@link geometryFromLeaves}, layout-parse.ts)
+ * carry the logic and are unit-tested without tmux.
  */
 import { appendFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
@@ -25,7 +35,16 @@ import {
   type CursorState,
 } from "./pane-mirror.ts";
 import type { CellArrays } from "./blit.ts";
-import { tapInputOutput, tapRepin } from "./perf-tap.ts";
+import { tapInputOutput, tapRepin, tapResize } from "./perf-tap.ts";
+import {
+  parseLayout,
+  parseLayoutChange,
+  parseWindowPaneChanged,
+  parseSessionWindowChanged,
+  parseMouseSubscription,
+  type LayoutLeaf,
+} from "./layout-parse.ts";
+import { effectiveWindowSize, type Size } from "./size-truth.ts";
 
 /** One pane's geometry inside the window, in cells (tmux coordinates). */
 export interface PaneGeometry {
@@ -45,7 +64,8 @@ export interface PaneGeometry {
 
 /** PURE — parse `list-panes -F "#{pane_id} #{pane_left} …"` reply lines. The
  *  trailing `window_zoomed_flag` field is optional (absent lines parse as not
- *  zoomed) so older format strings and fixtures stay valid. */
+ *  zoomed) so older format strings and fixtures stay valid; any further
+ *  trailing fields (sync appends `window_id`) are ignored here. */
 export function parsePaneGeometry(lines: string[]): PaneGeometry[] {
   const panes: PaneGeometry[] = [];
   for (const line of lines) {
@@ -78,28 +98,33 @@ export function parsePaneGeometry(lines: string[]): PaneGeometry[] {
   return panes;
 }
 
-/** PURE — what changed between two layouts, keyed by pane id. */
-export function diffPanes(
-  prev: PaneGeometry[],
-  next: PaneGeometry[],
-): { added: PaneGeometry[]; removed: string[]; resized: PaneGeometry[]; moved: PaneGeometry[] } {
+/** PURE — visible geometry from parsed layout leaves (M23.5). A layout string
+ *  carries rects only, so the flags it can't encode merge in from elsewhere:
+ *  `active` from the tracked active pane (falling back to the previous
+ *  geometry's flag while it is still unknown), `appMouse` from the
+ *  subscription-fed map (then the previous flag, then false for a brand-new
+ *  pane), `zoomed` from the notification's flags field. */
+export function geometryFromLeaves(
+  leaves: readonly LayoutLeaf[],
+  prev: readonly PaneGeometry[],
+  activePane: string,
+  appMouse: ReadonlyMap<string, boolean>,
+  zoomed: boolean,
+): PaneGeometry[] {
   const prevById = new Map(prev.map((p) => [p.id, p]));
-  const nextIds = new Set(next.map((p) => p.id));
-  const added: PaneGeometry[] = [];
-  const resized: PaneGeometry[] = [];
-  const moved: PaneGeometry[] = [];
-  for (const pane of next) {
-    const was = prevById.get(pane.id);
-    if (!was) {
-      added.push(pane);
-    } else if (was.width !== pane.width || was.height !== pane.height) {
-      resized.push(pane);
-    } else if (was.left !== pane.left || was.top !== pane.top) {
-      moved.push(pane);
-    }
-  }
-  const removed = prev.filter((p) => !nextIds.has(p.id)).map((p) => p.id);
-  return { added, removed, resized, moved };
+  return leaves.map((l) => {
+    const was = prevById.get(l.id);
+    return {
+      id: l.id,
+      left: l.left,
+      top: l.top,
+      width: l.width,
+      height: l.height,
+      active: activePane ? l.id === activePane : (was?.active ?? false),
+      appMouse: appMouse.get(l.id) ?? was?.appMouse ?? false,
+      zoomed,
+    };
+  });
 }
 
 /** A live pane: geometry + its mirror snapshot. */
@@ -123,14 +148,14 @@ export interface SessionMirrorOptions {
   onExit?: () => void;
 }
 
-/** Control-mode notifications (sans `%`) that mean "the layout changed". */
+/** Control-mode notifications (sans `%`) that still fall back to the slow
+ *  re-sync — structure changed but the notification body doesn't carry enough
+ *  to apply it directly (layout-change / window-pane-changed /
+ *  session-window-changed have their own push handlers now). */
 const STRUCTURAL_NOTIFICATIONS = new Set([
-  "layout-change",
   "window-add",
   "window-close",
   "window-renamed",
-  "window-pane-changed",
-  "session-window-changed",
   "unlinked-window-close",
 ]);
 
@@ -140,6 +165,30 @@ export class SessionMirror {
   private geometry: PaneGeometry[] = [];
   private focused = "";
   private syncQueued = false;
+  // ── Push-geometry state (M23.5) ─────────────────────────────────────────
+  /** The mirrored session's active window id (`@N`) — gates which
+   *  `%layout-change` events apply. Learned by sync, updated by
+   *  `%session-window-changed`. Empty until the first sync lands. */
+  private activeWindow = "";
+  /** tmux's active pane (`%N`) — from `%window-pane-changed` and sync. */
+  private activePane = "";
+  /** The active window is zoomed (flags `*Z` / `window_zoomed_flag`). */
+  private zoomedNow = false;
+  /** Last APPLIED visible-layout string — dedupes notification bursts (every
+   *  payload of a burst carries the final layout; the checksum differs iff the
+   *  layout does). Reset on window switch so the new window's first layout
+   *  always applies. */
+  private lastVisibleLayout = "";
+  /** The window's authoritative size: the latest layout root's WxH
+   *  (event-driven), seeded/reconciled by sync's pane bounding box. */
+  private winSize: Size | null = null;
+  /** Per-pane `mouse_any_flag`, pushed by the control-mode subscription and
+   *  reconciled by sync — the fix for the latent missed-toggle (a pane
+   *  flipping mouse mode between two syncs was never re-read). */
+  private readonly appMouseByPane = new Map<string, boolean>();
+  /** Mirrors created (at correct size) whose CONTENT seed (capture-pane
+   *  history + screen + cursor) hasn't run yet — sync drains this. */
+  private readonly unseeded = new Set<string>();
   /** Size policy (M22.8). "auto" (default): we pin our virtual client size via
    *  `refresh-client -C` and let tmux's `window-size latest` cooperate — a
    *  co-attached terminal may win, which we surface honestly rather than fight.
@@ -168,10 +217,14 @@ export class SessionMirror {
       attachTarget: opts.target,
       onOutput: (pane, data) => {
         tapInputOutput(pane); // t1: first echo back for a key we just forwarded
-        this.mirrors.get(pane)?.write(data);
+        const mirror = this.mirrors.get(pane);
+        if (process.env.TMUX_IDE_ZZ_RESIZE_TAP && mirror) {
+          tapResize("output", `${pane} ${mirror.cols}x${mirror.rows} ${data.length}b`);
+        }
+        mirror?.write(data);
         opts.onDirty?.();
       },
-      onNotify: (name) => {
+      onNotify: (name, rest) => {
         if (process.env.TMUX_IDE_MIRROR_DEBUG) {
           try {
             appendFileSync("/tmp/zz-notify.log", name + "\n");
@@ -179,12 +232,15 @@ export class SessionMirror {
             // debug tap only
           }
         }
-        // Any structural notification re-syncs the layout; the debounce keeps
-        // bursts (e.g. a resize storm) to one list-panes round-trip. NOTE:
-        // parseControlLine strips the leading `%` from notification names.
-        if (STRUCTURAL_NOTIFICATIONS.has(name)) {
-          this.queueSync();
-        }
+        // NOTE: parseControlLine strips the leading `%` from notification
+        // names. Geometry-bearing notifications apply DIRECTLY from their
+        // payload (the M23.5 push path — see each handler); everything else
+        // structural falls back to the debounced re-sync.
+        if (name === "layout-change") this.onLayoutChange(rest);
+        else if (name === "window-pane-changed") this.onWindowPaneChanged(rest);
+        else if (name === "subscription-changed") this.onSubscriptionChanged(rest);
+        else if (name === "session-window-changed") this.onSessionWindowChanged(rest);
+        else if (STRUCTURAL_NOTIFICATIONS.has(name)) this.queueSync();
       },
       onExit: () => opts.onExit?.(),
     });
@@ -193,7 +249,154 @@ export class SessionMirror {
   async start(): Promise<void> {
     await this.client.start();
     await this.client.command(`refresh-client -C ${this.opts.cols}x${this.opts.rows}`);
+    // ONE control-mode subscription (M23.5): tmux re-evaluates the format on
+    // its ~1s tick and pushes `%subscription-changed` per pane on change — the
+    // push source for appMouse. The argument is DOUBLE-QUOTED on the control
+    // channel (the measured working form; see layout-parse.ts for the reply
+    // shape). Best-effort: an old tmux without -B just degrades to sync-only.
+    await this.client.command(`refresh-client -B "mouse:%*:#{mouse_any_flag}"`).catch(() => {});
     await this.sync();
+  }
+
+  /** The mirrored window's authoritative size (layout root WxH), or null
+   *  before the first layout/sync — the app's event-driven size truth. */
+  windowSize(): Size | null {
+    return this.winSize;
+  }
+
+  // ── The push-geometry handlers (M23.5) ─────────────────────────────────
+
+  /**
+   * `%layout-change` → parse the VISIBLE layout and resize mirrors NOW —
+   * synchronously, in the same event-loop turn, BEFORE the control client
+   * feeds any subsequent `%output` line (resize-first is safe: bytes emitted
+   * for the OLD size clamp into the new grid, exactly as a native terminal
+   * treats a process writing across a resize; the app repaints on its own
+   * SIGWINCH an instant later).
+   *
+   * AckWriter interaction: {@link PaneMirror.write} is ack-PACED, so `%output`
+   * bytes that arrived BEFORE this notification may still sit unparsed in the
+   * writer's queue while `term.resize()` applies immediately — those old-size
+   * bytes then parse into the new grid and clamp, which is the same
+   * native-terminal behavior as above. The invariant that matters is that the
+   * resize is ordered by the CONTROL-CLIENT READ ORDER (never held for
+   * content): everything the server sent for the new size parses at the new
+   * size.
+   */
+  private onLayoutChange(rest: string): void {
+    const ev = parseLayoutChange(rest);
+    if (!ev) return;
+    tapResize("notify", `${ev.windowId} ${ev.visible}`);
+    // Before the first sync the active window is unknown — reconcile slowly.
+    if (!this.activeWindow) {
+      this.queueSync();
+      return;
+    }
+    if (ev.windowId !== this.activeWindow) return; // a background window
+    if (ev.visible === this.lastVisibleLayout) return; // burst dedupe
+    const parsed = parseLayout(ev.visible);
+    if (!parsed) {
+      this.queueSync(); // never guess from a failed parse
+      return;
+    }
+    this.lastVisibleLayout = ev.visible;
+    this.zoomedNow = ev.zoomed;
+    this.winSize = { cols: parsed.width, rows: parsed.height };
+    this.applyLayout(parsed.leaves, ev.zoomed);
+    tapResize(
+      "geometry-applied",
+      `${parsed.width}x${parsed.height} panes=${parsed.leaves.length}${ev.zoomed ? " Z" : ""}`,
+    );
+  }
+
+  /** Create/resize mirrors for the visible leaves and swap the geometry — all
+   *  synchronous. Mirror DISPOSAL stays with sync: a pane missing from the
+   *  visible layout is hidden under zoom (keep it warm — unzoom is instant and
+   *  scrollback survives), or genuinely closed (the queued sync checks against
+   *  list-panes truth and disposes there). */
+  private applyLayout(leaves: readonly LayoutLeaf[], zoomed: boolean): void {
+    let needSync = false;
+    for (const leaf of leaves) {
+      const mirror = this.mirrors.get(leaf.id);
+      if (!mirror) {
+        // A brand-new pane (split) in the layout: create the mirror at the
+        // right size NOW so its very first %output parses into correct
+        // geometry; the content seed rides the queued slow sync.
+        const created = new PaneMirror(leaf.width, leaf.height);
+        // Dirty must re-arm when bytes have PARSED, not just when they were
+        // enqueued (onOutput) — with ack-paced writes an enqueue-time dirty can
+        // be consumed by the tick before the grid changed, dropping the frame.
+        created.onParsed = () => this.opts.onDirty?.();
+        this.mirrors.set(leaf.id, created);
+        this.unseeded.add(leaf.id);
+        needSync = true;
+      } else if (mirror.cols !== leaf.width || mirror.rows !== leaf.height) {
+        mirror.resize(leaf.width, leaf.height);
+        tapResize("pane-resize", `${leaf.id} ${leaf.width}x${leaf.height}`);
+      }
+    }
+    if (!zoomed) {
+      const visible = new Set(leaves.map((l) => l.id));
+      for (const id of this.mirrors.keys()) {
+        if (!visible.has(id)) {
+          needSync = true; // a pane closed — let sync dispose against truth
+          break;
+        }
+      }
+    }
+    this.geometry = geometryFromLeaves(
+      leaves,
+      this.geometry,
+      this.activePane,
+      this.appMouseByPane,
+      zoomed,
+    );
+    this.opts.onDirty?.();
+    if (needSync) this.queueSync();
+  }
+
+  /** `%window-pane-changed` — tmux's active pane moved (fires immediately,
+   *  ahead of any sync). Track it and re-flag the geometry in place. */
+  private onWindowPaneChanged(rest: string): void {
+    const ev = parseWindowPaneChanged(rest);
+    if (!ev || (this.activeWindow && ev.windowId !== this.activeWindow)) return;
+    this.activePane = ev.paneId;
+    // Converge the LOCAL focus to tmux truth too: a select-pane we issued
+    // echoes back as this notification, and an external change (menu verb,
+    // another client) should move our focus the same way.
+    if (this.geometry.some((g) => g.id === ev.paneId)) this.focused = ev.paneId;
+    let changed = false;
+    this.geometry = this.geometry.map((g) => {
+      if (g.active === (g.id === ev.paneId)) return g;
+      changed = true;
+      return { ...g, active: g.id === ev.paneId };
+    });
+    if (changed) this.opts.onDirty?.();
+  }
+
+  /** `%subscription-changed` for the `mouse` subscription — a pane's app
+   *  turned mouse reporting on/off (~1s cadence; see {@link start}). */
+  private onSubscriptionChanged(rest: string): void {
+    const ev = parseMouseSubscription(rest);
+    if (!ev || this.appMouseByPane.get(ev.paneId) === ev.on) return;
+    this.appMouseByPane.set(ev.paneId, ev.on);
+    let changed = false;
+    this.geometry = this.geometry.map((g) => {
+      if (g.id !== ev.paneId || g.appMouse === ev.on) return g;
+      changed = true;
+      return { ...g, appMouse: ev.on };
+    });
+    if (changed) this.opts.onDirty?.();
+  }
+
+  /** `%session-window-changed` — the mirrored session switched windows: a new
+   *  pane set, so the slow path reseeds everything. */
+  private onSessionWindowChanged(rest: string): void {
+    const ev = parseSessionWindowChanged(rest);
+    if (!ev) return;
+    this.activeWindow = ev.windowId;
+    this.lastVisibleLayout = "";
+    this.queueSync();
   }
 
   /**
@@ -328,6 +531,7 @@ export class SessionMirror {
     this.opts.cols = cols;
     this.opts.rows = rows;
     tapRepin(cols, rows); // debug tap: assert one re-pin per settled size change
+    tapResize("repin", `${cols}x${rows}`);
     await this.client.command(`refresh-client -C ${cols}x${rows}`).catch(() => {});
     // Under the manual policy `refresh-client -C` no longer drives the window
     // size, so a terminal/sidebar resize after a reclaim must resize the window
@@ -386,6 +590,10 @@ export class SessionMirror {
     this.mirrors.clear();
   }
 
+  /** Queue the SLOW path (M23.5: reconciler, flag source, seed driver, sole
+   *  mirror disposer — geometry itself is pushed by {@link onLayoutChange}).
+   *  The 40ms debounce coalesces notification bursts to one round-trip; it no
+   *  longer gates any resize. */
   private queueSync(): void {
     if (this.syncQueued) return;
     this.syncQueued = true;
@@ -397,47 +605,96 @@ export class SessionMirror {
 
   private async sync(): Promise<void> {
     const lines = await this.client.command(
-      `list-panes -t ${this.opts.target} -F "#{pane_id} #{pane_left} #{pane_top} #{pane_width} #{pane_height} #{pane_active} #{mouse_any_flag} #{window_zoomed_flag}"`,
+      `list-panes -t ${this.opts.target} -F "#{pane_id} #{pane_left} #{pane_top} #{pane_width} #{pane_height} #{pane_active} #{mouse_any_flag} #{window_zoomed_flag} #{window_id}"`,
     );
-    const next = parsePaneGeometry(lines);
-    const { added, removed, resized } = diffPanes(this.geometry, next);
+    // `list-panes` on a session target lists the CURRENT window — every pane
+    // of it, including the ones zoom hides. The trailing window id is the
+    // active-window gate for %layout-change (parsePaneGeometry ignores it).
+    const all = parsePaneGeometry(lines);
+    const win = lines[0]?.trim().split(/\s+/)[8];
+    if (win?.startsWith("@")) this.activeWindow = win;
 
-    for (const id of removed) {
-      this.mirrors.get(id)?.dispose();
+    // Everything from here to the geometry swap is SYNCHRONOUS. The reply
+    // reflects server state at least as new as any notification already
+    // processed (control mode serializes both on one channel), and nothing
+    // interleaves before the swap — so a sync can never clobber a NEWER
+    // pushed layout with stale rects.
+    const listed = new Set(all.map((p) => p.id));
+    for (const [id, mirror] of this.mirrors) {
+      if (listed.has(id)) continue;
+      mirror.dispose();
       this.mirrors.delete(id);
+      this.unseeded.delete(id);
+      this.appMouseByPane.delete(id);
       if (this.focused === id) this.focused = "";
     }
-    for (const pane of added) {
-      const mirror = new PaneMirror(pane.width, pane.height);
-      // Dirty must re-arm when bytes have PARSED, not just when they were
-      // enqueued (onOutput) — with ack-paced writes an enqueue-time dirty can
-      // be consumed by the tick before the grid changed, dropping the frame.
-      mirror.onParsed = () => this.opts.onDirty?.();
-      this.mirrors.set(pane.id, mirror);
-      // Seed with history + current screen (-e keeps colors, -S reaches back
-      // into tmux's scrollback, 2000 lines. The old 300 cap guarded a SYNC seed
-      // write that blocked the event loop; with ack-paced writes (M21.5) the
-      // write just enqueues (~0.01ms) and xterm parses async — 2000 lines parse
-      // in ~8ms off the render loop (measured), so the deeper history is free.
-      // -J joins wrapped lines so re-wrapping stays sane.
-      const seed = await this.client
+    for (const pane of all) {
+      const mirror = this.mirrors.get(pane.id);
+      if (!mirror) {
+        const created = new PaneMirror(pane.width, pane.height);
+        // Dirty must re-arm when bytes have PARSED, not just when they were
+        // enqueued (onOutput) — with ack-paced writes an enqueue-time dirty can
+        // be consumed by the tick before the grid changed, dropping the frame.
+        created.onParsed = () => this.opts.onDirty?.();
+        this.mirrors.set(pane.id, created);
+        this.unseeded.add(pane.id);
+      } else if (mirror.cols !== pane.width || mirror.rows !== pane.height) {
+        mirror.resize(pane.width, pane.height);
+        tapResize("pane-resize", `${pane.id} ${pane.width}x${pane.height} sync`);
+      }
+      this.appMouseByPane.set(pane.id, pane.appMouse);
+    }
+    this.zoomedNow = all.some((p) => p.zoomed);
+    const active = all.find((p) => p.active);
+    if (active) this.activePane = active.id;
+    // Visible geometry: under zoom list-panes still reports the HIDDEN panes
+    // at their unzoomed rects (measured on 3.7b: they overlap the zoomed pane
+    // and would steal first-match hit-tests — D3). Only the active (= zoomed)
+    // pane is visible, and its listed rect is the full window.
+    this.geometry = this.zoomedNow ? all.filter((p) => p.active) : all;
+    this.winSize = effectiveWindowSize(all) ?? this.winSize;
+    this.opts.onStatus?.(`${this.geometry.length} panes`);
+    this.opts.onDirty?.();
+
+    // CONTENT seeds last — the awaits below can span chunks, so nothing after
+    // this point touches geometry. Seed with history + current screen (-e
+    // keeps colors, -S reaches back into tmux's scrollback, 2000 lines. The
+    // old 300 cap guarded a SYNC seed write that blocked the event loop; with
+    // ack-paced writes (M21.5) the write just enqueues (~0.01ms) and xterm
+    // parses async — 2000 lines parse in ~8ms off the render loop (measured),
+    // so the deeper history is free. -J joins wrapped lines so re-wrapping
+    // stays sane.)
+    for (const pane of all) {
+      if (!this.unseeded.has(pane.id)) continue;
+      this.unseeded.delete(pane.id);
+      const mirror = this.mirrors.get(pane.id);
+      if (!mirror) continue;
+      const seedReply = this.client
         .command(`capture-pane -p -e -J -S -2000 -t ${pane.id}`)
-        .catch(() => []);
+        .catch(() => [] as string[]);
+      // The pane's REAL cursor (D2): the seed replay leaves xterm's cursor
+      // wherever the last captured byte fell — and the trailing CRLF the seed
+      // used to append scrolled one extra row on a full viewport, drifting
+      // the whole grid up. Dropped now; instead read tmux's cursor and CUP it
+      // home (CUP is viewport-relative — the same coordinates
+      // #{cursor_x}/#{cursor_y} report). Issued back-to-back with the capture
+      // so both ride one round-trip.
+      const cursorReply = this.client
+        .command(`display-message -p -t ${pane.id} "#{cursor_x} #{cursor_y}"`)
+        .catch(() => [] as string[]);
+      const seed = await seedReply;
       // The control client reads replies as latin1 (one JS char per byte —
       // required for the protocol), so the seed is a byte string in disguise:
       // re-encode latin1 → bytes before feeding the VT parser, or every
       // multibyte glyph shatters into mojibake (…→â¦, ⇡→â¡ — user-reported,
       // "weird a's with a roof"). The live %output path already decodes bytes.
       if (seed.length > 0) {
-        mirror.write(Buffer.from(seed.join("\r\n") + "\r\n", "latin1"));
+        mirror.write(Buffer.from(seed.join("\r\n"), "latin1"));
+      }
+      const [cx, cy] = ((await cursorReply)[0] ?? "").trim().split(/\s+/).map(Number);
+      if (Number.isInteger(cx) && Number.isInteger(cy)) {
+        mirror.write(`\x1b[${cy! + 1};${cx! + 1}H`);
       }
     }
-    for (const pane of resized) {
-      this.mirrors.get(pane.id)?.resize(pane.width, pane.height);
-    }
-
-    this.geometry = next;
-    this.opts.onStatus?.(`${next.length} panes`);
-    this.opts.onDirty?.();
   }
 }

--- a/packages/daemon/src/tui/mirror/size-truth.test.ts
+++ b/packages/daemon/src/tui/mirror/size-truth.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from "vitest";
 import {
   effectiveWindowSize,
   detectSizeMismatch,
+  detectSizeMismatchWithRepin,
+  REPIN_GRACE_MS,
+  REPIN_STALE_GRACE_MS,
   letterboxOffset,
   formatSizeHint,
   type Rect,
@@ -59,6 +62,40 @@ describe("detectSizeMismatch", () => {
       cols: 200,
       rows: 55,
     });
+  });
+});
+
+describe("detectSizeMismatchWithRepin", () => {
+  const prev = { cols: 120, rows: 40 };
+  const pinned = { cols: 160, rows: 50 }; // the NEW pin (a grow)
+  const repin = { prev, at: 1000 };
+
+  it("passes mismatches through with no re-pin in flight", () => {
+    expect(detectSizeMismatchWithRepin(pinned, prev, null, 99_999)).toEqual(prev);
+  });
+
+  it("is null when sizes agree (and regardless of any re-pin)", () => {
+    expect(detectSizeMismatchWithRepin(pinned, pinned, repin, 1001)).toBeNull();
+  });
+
+  it("suppresses ANY mismatch within the re-pin grace (the grow flash)", () => {
+    expect(detectSizeMismatchWithRepin(pinned, prev, repin, 1000 + REPIN_GRACE_MS - 1)).toBeNull();
+    // Even a size that is neither pin (mid-transition on a storm).
+    expect(detectSizeMismatchWithRepin(pinned, { cols: 130, rows: 44 }, repin, 1100)).toBeNull();
+  });
+
+  it("keeps suppressing the exact pre-repin size up to the stale grace", () => {
+    expect(
+      detectSizeMismatchWithRepin(pinned, prev, repin, 1000 + REPIN_STALE_GRACE_MS - 1),
+    ).toBeNull();
+    expect(detectSizeMismatchWithRepin(pinned, prev, repin, 1000 + REPIN_STALE_GRACE_MS)).toEqual(
+      prev,
+    );
+  });
+
+  it("surfaces a DIFFERENT size once the short grace passed (a real co-attach)", () => {
+    const other = { cols: 100, rows: 30 };
+    expect(detectSizeMismatchWithRepin(pinned, other, repin, 1000 + REPIN_GRACE_MS)).toEqual(other);
   });
 });
 

--- a/packages/daemon/src/tui/mirror/size-truth.ts
+++ b/packages/daemon/src/tui/mirror/size-truth.ts
@@ -66,6 +66,47 @@ export function letterboxOffset(canvas: Size, content: Size): { x: number; y: nu
   };
 }
 
+/** An in-flight re-pin (M23.5): we changed our pinned size and tmux has not
+ *  confirmed the new layout yet. `prev` is the pin BEFORE this re-pin. */
+export interface RepinState {
+  prev: Size;
+  at: number;
+}
+
+/** How long any mismatch is suppressed after a re-pin (server round-trip +
+ *  layout-change latency is sub-ms; the margin covers a loaded machine). */
+export const REPIN_GRACE_MS = 400;
+/** How long a mismatch that still equals the PRE-repin pin is suppressed — the
+ *  unambiguous "tmux hasn't applied our new pin yet" signature can wait longer
+ *  before we call it another terminal's doing. */
+export const REPIN_STALE_GRACE_MS = 1500;
+
+/**
+ * PURE — {@link detectSizeMismatch}, gated for the re-pin transition (M23.5,
+ * D4b): between our `refresh-client -C` and tmux's `%layout-change` the
+ * effective size is legitimately stale, and surfacing it flashed a false
+ * "window sized by another terminal" hint plus a letterbox jump-to-center on
+ * EVERY grow (measured). Suppress the mismatch while a re-pin is in flight:
+ * any mismatch within {@link REPIN_GRACE_MS}, and — for longer, up to
+ * {@link REPIN_STALE_GRACE_MS} — one whose effective size still equals the
+ * pre-repin pin exactly (that shape can only be the old pin, not a co-attached
+ * terminal's choice). Past the grace the honest hint returns.
+ */
+export function detectSizeMismatchWithRepin(
+  pinned: Size,
+  effective: Size,
+  repin: RepinState | null,
+  now: number,
+): Size | null {
+  const mm = detectSizeMismatch(pinned, effective);
+  if (!mm || !repin) return mm;
+  const age = now - repin.at;
+  if (age < REPIN_GRACE_MS) return null;
+  const isPrevPin = effective.cols === repin.prev.cols && effective.rows === repin.prev.rows;
+  if (isPrevPin && age < REPIN_STALE_GRACE_MS) return null;
+  return mm;
+}
+
 /**
  * PURE — the quiet, plain-language hint for a size mismatch: the honest answer
  * ("here is the size another terminal chose"), dimensions in the terminal-native


### PR DESCRIPTION
Card #101, from a two-probe investigation: parse %layout-change's own layout payload and resize mirrors synchronously before subsequent output — geometry lag 40-240ms → 0.32ms measured. Kills the 200ms size poll, fixes zoom-overlay/hit-steal, seed cursor, false mismatch flash, a blit RangeError, and the missed mouse-toggle bug. Full resize battery green at both mirror and hosted-app levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)