### PR TITLE
feat: drag selects in agent panes by default (M24.2)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3149,6 +3149,9 @@ function pickBool(value, fallback) {
 function pickPosInt(value, fallback) {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
 }
+function pickChoice(value, allowed, fallback) {
+  return typeof value === "string" && allowed.includes(value) ? value : fallback;
+}
 function parseAppConfig(input) {
   const D = DEFAULT_APP_CONFIG;
   const root = asObject(input);
@@ -3209,7 +3212,8 @@ function parseAppConfig(input) {
     worktrees: { dir: pickString(worktrees.dir, D.worktrees.dir) },
     app: {
       frontDoor: pickBool(app.frontDoor, D.app.frontDoor),
-      detachable: pickBool(app.detachable, D.app.detachable)
+      detachable: pickBool(app.detachable, D.app.detachable),
+      dragSelect: pickChoice(app.dragSelect, ["agents", "always", "never"], D.app.dragSelect)
     }
   };
 }
@@ -3304,7 +3308,7 @@ var init_app_config = __esm({
       welcome: { show: true },
       integrations: { offer: true },
       worktrees: { dir: "" },
-      app: { frontDoor: false, detachable: false }
+      app: { frontDoor: false, detachable: false, dragSelect: "agents" }
     };
     DEFAULT_THEME = DEFAULT_APP_CONFIG.theme;
     DEFAULT_KEYS = DEFAULT_APP_CONFIG.keys;

--- a/packages/daemon/src/lib/app-config.test.ts
+++ b/packages/daemon/src/lib/app-config.test.ts
@@ -191,6 +191,16 @@ describe("parseAppConfig — mistyped fields fall back to default", () => {
     // An explicit true makes bare `tmux-ide app` run hosted (M23.2).
     expect(parseAppConfig({ app: { detachable: true } }).app.detachable).toBe(true);
   });
+
+  it("app.dragSelect — defaults to 'agents' and coerces anything off the enum back to it", () => {
+    expect(DEFAULT_APP_CONFIG.app.dragSelect).toBe("agents");
+    expect(parseAppConfig(undefined).app.dragSelect).toBe("agents");
+    expect(parseAppConfig({ app: { dragSelect: "sometimes" } }).app.dragSelect).toBe("agents");
+    expect(parseAppConfig({ app: { dragSelect: true } }).app.dragSelect).toBe("agents");
+    expect(parseAppConfig({ app: "nope" }).app.dragSelect).toBe("agents");
+    expect(parseAppConfig({ app: { dragSelect: "always" } }).app.dragSelect).toBe("always");
+    expect(parseAppConfig({ app: { dragSelect: "never" } }).app.dragSelect).toBe("never");
+  });
 });
 
 describe("loadAppConfig / getAppConfig / TMUX_IDE_CONFIG", () => {

--- a/packages/daemon/src/lib/app-config.ts
+++ b/packages/daemon/src/lib/app-config.ts
@@ -151,6 +151,17 @@ export interface AppApp {
    * single run.
    */
   detachable: boolean;
+  /**
+   * When a plain left drag on an app-mouse pane SELECTS locally instead of
+   * forwarding to the pane's app (M24.2). "agents" (default): panes our own
+   * detection matches to a fleet agent entry select; other app-mouse panes
+   * (vim/htop) forward. "always": every app-mouse pane selects on drag.
+   * "never": every app-mouse pane forwards (the pre-M24.2 behavior). A genuine
+   * click (press+release in one cell) is still forwarded on select-default
+   * panes; shift inverts a pane's default; the right-click pane menu overrides
+   * per pane for the session.
+   */
+  dragSelect: "agents" | "always" | "never";
 }
 
 /** Worktree flow config (`tmux-ide worktree`). */
@@ -211,7 +222,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   welcome: { show: true },
   integrations: { offer: true },
   worktrees: { dir: "" },
-  app: { frontDoor: false, detachable: false },
+  app: { frontDoor: false, detachable: false, dragSelect: "agents" },
 };
 
 /** The default theme tokens — the fallback threaded into the pure builders. */
@@ -244,6 +255,13 @@ function pickBool(value: unknown, fallback: boolean): boolean {
 /** A positive integer, else the default. */
 function pickPosInt(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+/** One of the allowed literals, else the default. */
+function pickChoice<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : fallback;
 }
 
 /**
@@ -313,6 +331,7 @@ export function parseAppConfig(input: unknown): AppConfig {
     app: {
       frontDoor: pickBool(app.frontDoor, D.app.frontDoor),
       detachable: pickBool(app.detachable, D.app.detachable),
+      dragSelect: pickChoice(app.dragSelect, ["agents", "always", "never"], D.app.dragSelect),
     },
   };
 }

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -22,6 +22,19 @@
  * passes shift through to us (SGR button+4; many terminals keep shift+drag
  * for native selection — measured: see the card notes).
  *
+ * DRAG SELECTS ON AGENT PANES (M24.2): the implicit default now follows the
+ * pane. Where the fleet's agent join (agentByPane) matches, a plain left
+ * press is DEFERRED (`pendingPress`): motion off the press cell starts a
+ * normal selection (the app sees NOTHING — no stray down), a release in
+ * place forwards the owed SGR press/release pair (agents are click-driven).
+ * Other app-mouse panes (vim/htop) forward as before. SHIFT inverts a pane's
+ * default (so shift+drag on an agent pane forwards; on vim it selects, as in
+ * M22.9); the right-click pane menu carries a per-pane session override; the
+ * `app.dragSelect` policy ("agents"|"always"|"never", app-config) is read
+ * once at boot. Wheel routing is UNTOUCHED (agent panes still forward the
+ * wheel outside select mode); pure logic in selection.ts (paneDragDefault /
+ * routePanePress).
+ *
  * SURFACE TABS (M18.4): a persistent top row — [⌂ Home][❯ Terminal][▤ Files]
  * [± Diff] — makes the app a real IDE. F1..F4 switch (F-keys encode reliably;
  * ctrl+digit/alt do NOT — measured); the tab bar is also clickable (fixed x-span
@@ -358,11 +371,13 @@ import {
   tintRunsInverse,
   tintRunsBg,
   osc52Sequence,
-  pressStartsSelection,
+  paneDragDefault,
+  routePanePress,
   wheelScrollsLocal,
   selectBadgeLabel,
   ATTR_INVERSE,
   type Cell,
+  type PaneDragDefault,
   type Selection,
 } from "./selection.ts";
 
@@ -810,6 +825,39 @@ render(
       if (focused && focused !== sm && mirror?.focusedPane() !== sm) exitSelectMode();
     });
 
+    // ── IMPLICIT DRAG-SELECT DEFAULT (M24.2) ─────────────────────────────────
+    // Select mode is the explicit escape hatch; the DEFAULT now follows the
+    // pane. Where the fleet says an agent runs (the M22.3 agentByPane join), a
+    // plain left drag SELECTS — the press is DEFERRED (`pendingPress`) so a
+    // genuine click still reaches the app as one SGR press/release pair, and
+    // NOTHING is forwarded once motion starts a selection. Other app-mouse
+    // panes keep forwarding; shift inverts a pane's default (routePanePress);
+    // the right-click toggle overrides per pane for the session (pruned when
+    // the pane dies); `app.dragSelect` sets the policy, read once at boot like
+    // the rest of the app config.
+    const dragSelectPolicy = loadAppConfig().app.dragSelect;
+    const dragOverrides = new Map<string, PaneDragDefault>();
+    const paneDrag = (paneId: string): PaneDragDefault =>
+      paneDragDefault(
+        agentByPane().get(paneId),
+        dragSelectPolicy,
+        dragOverrides.get(paneId) ?? null,
+      );
+    /** Drop overrides for panes that no longer exist anywhere on the server
+     *  (pane ids are server-global and never recycled, so a miss is a death,
+     *  not a window switch). Piggybacks on the 3s fleet tick; one control-mode
+     *  round-trip, only while overrides exist at all. */
+    const pruneDragOverrides = () => {
+      if (dragOverrides.size === 0 || !mirror) return;
+      void mirror
+        .command('list-panes -a -F "#{pane_id}"')
+        .then((lines) => {
+          const alive = new Set(lines.map((l) => l.trim()));
+          for (const id of [...dragOverrides.keys()]) if (!alive.has(id)) dragOverrides.delete(id);
+        })
+        .catch(() => {});
+    };
+
     // ── SCROLLBACK SEARCH (M20.3) ────────────────────────────────────────────
     // copy-mode's `/` finder, app-native. `search` is the live search SESSION: a
     // bottom-of-canvas input line owning the keyboard while open. `editing:true`
@@ -864,6 +912,23 @@ render(
           surface: ScrollSurface;
         };
     let dragging: DragState | null = null;
+
+    // ── DEFERRED PRESS (M24.2) ───────────────────────────────────────────────
+    // A left press on a select-default app-mouse pane is WITHHELD: if the
+    // pointer leaves the press cell before release, the press becomes the
+    // anchor of a normal selection (the app never sees any of it); if the
+    // release lands in the same cell, the owed SGR press/release pair is
+    // forwarded then — a click, which is how agents like claude are driven.
+    // Coordinates are frozen at press so the forwarded pair is exactly the
+    // cell the user pressed. Only one of {pendingPress, selecting, dragging}
+    // is ever live.
+    let pendingPress: { paneId: string; x: number; gy: number; cell: Cell } | null = null;
+    // The pane whose app is OWED a release because its press was forwarded.
+    // OpenTUI synthesizes SEVERAL release-type events per physical release
+    // (drag-end, up, drop, up — measured live), so the release forward must be
+    // debt-tracked: paid exactly ONCE, to the pane that got the down (wherever
+    // the pointer is at release), and never for gestures we consumed locally.
+    let forwardedDown: string | null = null;
 
     // ── RIGHT-CLICK CONTEXT MENU (M19.2) ─────────────────────────────────────
     // A small overlay opened at the pointer on a right-button press (SGR button
@@ -2486,6 +2551,7 @@ render(
       // input (mouse events die during the storm). The child does the work.
       let fleetInFlight = false;
       const refreshFleet = () => {
+        pruneDragOverrides();
         if (fleetInFlight) return;
         fleetInFlight = true;
         execFile("node", [cliPath, "team", "--json"], { timeout: 10_000 }, (err, stdout) => {
@@ -3090,8 +3156,9 @@ render(
       return {
         region: "pane",
         title: pane.id,
-        // App-mouse panes lead with "Select text…" / "Stop selecting" (M22.9).
-        items: paneMenuItems(pane.appMouse, selectModePane() === pane.id),
+        // App-mouse panes lead with "Select text…" / "Stop selecting" (M22.9)
+        // and the per-pane drag-default toggle (M24.2).
+        items: paneMenuItems(pane.appMouse, selectModePane() === pane.id, paneDrag(pane.id)),
         paneId: pane.id,
       };
     };
@@ -3278,6 +3345,17 @@ render(
         }
         if (id === "select-text-off") {
           exitSelectMode();
+          closeMenu();
+          return;
+        }
+        // The drag-default toggle (M24.2): a session-scoped per-pane override
+        // (pruned when the pane dies) flipping whether a plain drag selects
+        // locally or forwards to the pane's app.
+        if (id === "drag-select" || id === "drag-forward") {
+          dragOverrides.set(pid, id === "drag-select" ? "select" : "forward");
+          setStatusNote(
+            id === "drag-select" ? "drag selects in this pane" : "drags forward to the app",
+          );
           closeMenu();
           return;
         }
@@ -4246,6 +4324,41 @@ render(
         // suppressed until the gesture ends.
         return;
       }
+      // A DEFERRED press (M24.2) resolves on the next event: a drag that leaves
+      // the press cell starts the selection the press was withheld for (nothing
+      // is ever forwarded, no stray down); a release still in that cell forwards
+      // the owed SGR press/release pair — the click the pane's app was due.
+      // Everything else mid-press is swallowed, like the resize gestures above;
+      // a second down without a release (never seen live) just drops the debt.
+      if (pendingPress) {
+        const pp = pendingPress;
+        const pane = panesById().get(pp.paneId);
+        if (type === "drag") {
+          if (!pane) {
+            pendingPress = null; // the pane died mid-press — nothing is owed
+            return;
+          }
+          const cell = paneCell(pane, x, y - TABBAR_H);
+          if (cell.row !== pp.cell.row || cell.col !== pp.cell.col) {
+            pendingPress = null;
+            selAnchor = pp.cell;
+            selecting = { surface: "mirror", paneId: pane.id };
+            setSelection({ surface: "mirror", paneId: pane.id, anchor: pp.cell, head: cell });
+          }
+          return;
+        }
+        if (type === "up" || type === "drag-end" || type === "drop") {
+          pendingPress = null;
+          if (pane) {
+            forwardPress(pane, pp.x, pp.gy, false);
+            forwardPress(pane, pp.x, pp.gy, true);
+          }
+          return;
+        }
+        if (type === "down")
+          pendingPress = null; // drop the debt, route the press
+        else return;
+      }
       // Motion (bubbled from child text runs) drives hover only; "out" clears it.
       // Handled first so every click branch below stays a pure down/up/scroll path.
       if (type === "out") {
@@ -4264,14 +4377,22 @@ render(
       }
       // Release ends a live selection: the mirror copies what was dragged; the
       // editor keeps its selection for ^c. Discrete word/line selections leave
-      // `selecting` null, so their trailing release passes straight through — as
-      // does any release on an appMouse pane (which never starts a selection).
+      // `selecting` null, so their trailing release passes straight through.
       if (type === "up" || type === "drag-end" || type === "drop") {
         if (selecting) {
           const s = selection();
           if (s && s.surface === "mirror" && selecting.surface === "mirror")
             commitMirrorCopy(s.paneId, s.anchor, s.head);
           selecting = null;
+          return;
+        }
+        // A FORWARDED press's release: pay the debt to the pane that got the
+        // down — at the pointer's release cell, clamped into that pane — and
+        // only once (the synthesized duplicates find no debt and stay local).
+        if (forwardedDown) {
+          const pane = panesById().get(forwardedDown);
+          forwardedDown = null;
+          if (pane && selectModePane() !== pane.id) forwardPress(pane, x, y - TABBAR_H, true);
           return;
         }
       }
@@ -4458,17 +4579,24 @@ render(
       if (!pane) return;
       if (type === "down") {
         mirror?.focus(pane.id);
-        // App-mouse panes forward the press UNLESS this pane's select mode is
-        // on or the press is shift-modified (M22.9) — then the normal selection
-        // machine below runs instead (non-app-mouse panes are unchanged).
-        if (
-          !pressStartsSelection(
-            pane.appMouse,
-            selectModePane() === pane.id,
-            e.modifiers?.shift === true,
-          )
-        ) {
+        // Where the press goes (M22.9 + M24.2): plain panes and select mode run
+        // the selection machine below; app-mouse panes follow the pane's drag
+        // default (agents select, others forward; shift inverts) — a select
+        // default DEFERS the press so a genuine click still reaches the app
+        // (see the pendingPress resolution above).
+        const routing = routePanePress(
+          pane.appMouse,
+          selectModePane() === pane.id,
+          e.modifiers?.shift === true,
+          paneDrag(pane.id),
+        );
+        if (routing === "forward") {
+          forwardedDown = pane.id;
           forwardPress(pane, x, gy, false);
+          return;
+        }
+        if (routing === "defer") {
+          pendingPress = { paneId: pane.id, x, gy, cell: paneCell(pane, x, gy) };
           return;
         }
         // Begin a drag selection, or on a repeat click select
@@ -4490,11 +4618,11 @@ render(
           selecting = { surface: "mirror", paneId: pane.id };
           setSelection(null);
         }
-      } else if (type === "up") {
-        // Releases of a local selection gesture never reach here (the
-        // `selecting` branch above returns); select mode suppresses the rest.
-        if (pane.appMouse && selectModePane() !== pane.id) forwardPress(pane, x, gy, true);
       } else if (type === "scroll") {
+        // (Releases never reach here: local gestures are consumed by the
+        // selecting/pendingPress branches above and a forwarded press's
+        // release is paid via the `forwardedDown` debt — never re-derived
+        // from whichever pane happens to sit under the pointer.)
         const dir = e.scroll?.direction;
         if (dir === "up" || dir === "down") {
           const { col, row } = paneCell(pane, x, gy);

--- a/packages/daemon/src/tui/mirror/menu-model.test.ts
+++ b/packages/daemon/src/tui/mirror/menu-model.test.ts
@@ -164,18 +164,24 @@ describe("submenuPos", () => {
   });
 });
 
-describe("paneMenuItems (M22.9 — select mode entry)", () => {
+describe("paneMenuItems (M22.9 select mode + M24.2 drag-default toggle)", () => {
   it("keeps the fixed pane list byte-identical for non-app-mouse panes", () => {
-    expect(paneMenuItems(false, false)).toBe(MENU_ITEMS.pane);
+    expect(paneMenuItems(false, false, "select")).toBe(MENU_ITEMS.pane);
+    expect(paneMenuItems(false, false, "forward")).toBe(MENU_ITEMS.pane);
   });
-  it("leads with Select text… on an app-mouse pane", () => {
-    const items = paneMenuItems(true, false);
+  it("leads with Select text… then the drag toggle on an app-mouse pane", () => {
+    const items = paneMenuItems(true, false, "forward");
     expect(items[0]).toEqual({ id: "select-text", label: "Select text…" });
-    expect(items.slice(1)).toEqual(MENU_ITEMS.pane);
+    expect(items[1]).toEqual({ id: "drag-select", label: "Select on drag" });
+    expect(items.slice(2)).toEqual(MENU_ITEMS.pane);
   });
   it("flips to the exit verb while the pane's select mode is on", () => {
-    const items = paneMenuItems(true, true);
+    const items = paneMenuItems(true, true, "forward");
     expect(items[0]).toEqual({ id: "select-text-off", label: "Stop selecting" });
-    expect(items.slice(1)).toEqual(MENU_ITEMS.pane);
+    expect(items.slice(2)).toEqual(MENU_ITEMS.pane);
+  });
+  it("offers the OTHER default: a select-default (agent) pane gets Forward mouse drags", () => {
+    const items = paneMenuItems(true, false, "select");
+    expect(items[1]).toEqual({ id: "drag-forward", label: "Forward mouse drags" });
   });
 });

--- a/packages/daemon/src/tui/mirror/menu-model.ts
+++ b/packages/daemon/src/tui/mirror/menu-model.ts
@@ -93,13 +93,24 @@ export const MENU_ITEMS: Record<MenuRegion, MenuItem[]> = {
  *  panes (the app turned mouse reporting on — presses are forwarded, so a drag
  *  can't start a selection) get a leading "Select text…" verb that pauses
  *  forwarding for that pane; while its select mode is active the entry flips to
- *  the exit verb. Ordinary panes keep the fixed list untouched. */
-export function paneMenuItems(appMouse: boolean, selectModeOn: boolean): MenuItem[] {
+ *  the exit verb. They also get the drag-default toggle (M24.2): the label is
+ *  always the OTHER default (`dragDefault` is the pane's current one, override
+ *  and config applied), so picking it flips the pane for the session. Ordinary
+ *  panes keep the fixed list untouched. */
+export function paneMenuItems(
+  appMouse: boolean,
+  selectModeOn: boolean,
+  dragDefault: "select" | "forward",
+): MenuItem[] {
   if (!appMouse) return MENU_ITEMS.pane;
   const entry: MenuItem = selectModeOn
     ? { id: "select-text-off", label: "Stop selecting" }
     : { id: "select-text", label: "Select text…" };
-  return [entry, ...MENU_ITEMS.pane];
+  const dragToggle: MenuItem =
+    dragDefault === "select"
+      ? { id: "drag-forward", label: "Forward mouse drags" }
+      : { id: "drag-select", label: "Select on drag" };
+  return [entry, dragToggle, ...MENU_ITEMS.pane];
 }
 
 /** The overlay's border (1) + horizontal padding (1 each side). The header row

--- a/packages/daemon/src/tui/mirror/selection.test.ts
+++ b/packages/daemon/src/tui/mirror/selection.test.ts
@@ -10,7 +10,8 @@ import {
   tintRunsBg,
   osc52Sequence,
   tmuxPassthrough,
-  pressStartsSelection,
+  paneDragDefault,
+  routePanePress,
   wheelScrollsLocal,
   selectBadgeLabel,
   chunkByBytes,
@@ -232,20 +233,45 @@ describe("chunkByBytes", () => {
 });
 
 describe("select mode on app-mouse panes (M22.9)", () => {
-  describe("pressStartsSelection", () => {
-    it("always selects on a non-app-mouse pane (byte-identical old behavior)", () => {
-      expect(pressStartsSelection(false, false, false)).toBe(true);
-      expect(pressStartsSelection(false, false, true)).toBe(true);
-      expect(pressStartsSelection(false, true, false)).toBe(true);
+  describe("paneDragDefault (M24.2)", () => {
+    const agent = { paneId: "%7" };
+    it("selects on an agent pane, forwards on a plain one, under the default policy", () => {
+      expect(paneDragDefault(agent, "agents", null)).toBe("select");
+      expect(paneDragDefault(undefined, "agents", null)).toBe("forward");
     });
-    it("forwards a plain press on an app-mouse pane", () => {
-      expect(pressStartsSelection(true, false, false)).toBe(false);
+    it("'always' selects and 'never' forwards regardless of the agent join", () => {
+      expect(paneDragDefault(undefined, "always", null)).toBe("select");
+      expect(paneDragDefault(agent, "never", null)).toBe("forward");
     });
-    it("selects on an app-mouse pane while its select mode is on", () => {
-      expect(pressStartsSelection(true, true, false)).toBe(true);
+    it("a per-pane override beats both the policy and the join", () => {
+      expect(paneDragDefault(agent, "agents", "forward")).toBe("forward");
+      expect(paneDragDefault(undefined, "agents", "select")).toBe("select");
+      expect(paneDragDefault(agent, "never", "select")).toBe("select");
+      expect(paneDragDefault(undefined, "always", "forward")).toBe("forward");
     });
-    it("selects on an app-mouse pane when the press is shift-modified", () => {
-      expect(pressStartsSelection(true, false, true)).toBe(true);
+  });
+
+  describe("routePanePress (M22.9 + M24.2)", () => {
+    it("always selects immediately on a non-app-mouse pane", () => {
+      expect(routePanePress(false, false, false, "forward")).toBe("select");
+      expect(routePanePress(false, false, true, "select")).toBe("select");
+      expect(routePanePress(false, true, false, "forward")).toBe("select");
+    });
+    it("selects immediately while the pane's select mode is on", () => {
+      expect(routePanePress(true, true, false, "forward")).toBe("select");
+      expect(routePanePress(true, true, true, "select")).toBe("select");
+    });
+    it("forwards a plain press on a forward-default pane (old behavior)", () => {
+      expect(routePanePress(true, false, false, "forward")).toBe("forward");
+    });
+    it("defers a plain press on a select-default pane (agent panes)", () => {
+      expect(routePanePress(true, false, false, "select")).toBe("defer");
+    });
+    it("shift inverts the default: selects immediately on a forward-default pane", () => {
+      expect(routePanePress(true, false, true, "forward")).toBe("select");
+    });
+    it("shift inverts the default: forwards on a select-default (agent) pane", () => {
+      expect(routePanePress(true, false, true, "select")).toBe("forward");
     });
   });
 

--- a/packages/daemon/src/tui/mirror/selection.ts
+++ b/packages/daemon/src/tui/mirror/selection.ts
@@ -198,14 +198,60 @@ export function tintRunsBg<T extends { text: string; bg: number | null }>(
 // through (SGR encodes it as +4 on the button code; many terminals keep
 // shift+drag for native selection instead — then only select mode applies).
 
-/** PURE — whether a left press on a pane begins a LOCAL drag selection
- *  (vs. being forwarded to the pane's app as an SGR press). */
-export function pressStartsSelection(
+// ── Implicit drag-select default (M24.2) ─────────────────────────────────────
+// Every agent pane (claude/codex) is app-mouse, so "forwarding wins" meant a
+// user's whole fleet couldn't drag-select. The DEFAULT now follows the pane:
+// where our own detection says an agent runs there, a plain drag selects and
+// only a genuine click (press+release in one cell) is forwarded — deferred
+// until motion or release decides. Shift INVERTS the pane's default (so on an
+// agent pane shift+drag forwards; on a vim pane it selects, as in M22.9), the
+// right-click toggle overrides per pane for the session, and `app.dragSelect`
+// ("agents"|"always"|"never") sets the policy.
+
+/** Where a plain left drag on a pane goes by default. */
+export type PaneDragDefault = "select" | "forward";
+/** The `app.dragSelect` policy values (app-config). */
+export type DragSelectSetting = "agents" | "always" | "never";
+
+/** PURE — a pane's drag default. Precedence: the session's per-pane override
+ *  (the right-click toggle) > the config policy ("always"/"never") > the agent
+ *  join ("agents": a pane matching a fleet agent entry selects; every other
+ *  app-mouse pane forwards). */
+export function paneDragDefault(
+  agentEntry: { paneId: string } | undefined,
+  config: DragSelectSetting,
+  override: PaneDragDefault | null,
+): PaneDragDefault {
+  if (override !== null) return override;
+  if (config === "always") return "select";
+  if (config === "never") return "forward";
+  return agentEntry !== undefined ? "select" : "forward";
+}
+
+/** What a left press on a pane does: run the selection machine NOW, forward
+ *  the SGR press NOW, or DEFER (withhold the press until motion starts a
+ *  selection or a release-in-place forwards the owed click pair). */
+export type PressRouting = "select" | "forward" | "defer";
+
+/** PURE — route a left press. Plain panes and select mode keep the immediate
+ *  selection machine. Otherwise the pane's drag default decides, with shift
+ *  inverting it: a shift press that lands on "select" stays IMMEDIATE (the
+ *  M22.9 behavior — a shift-click was never forwarded), while an unshifted
+ *  "select" defers so the pane's app still gets genuine clicks. */
+export function routePanePress(
   appMouse: boolean,
   selectModeOn: boolean,
   shift: boolean,
-): boolean {
-  return !appMouse || selectModeOn || shift;
+  dragDefault: PaneDragDefault,
+): PressRouting {
+  if (!appMouse || selectModeOn) return "select";
+  const effective: PaneDragDefault = shift
+    ? dragDefault === "select"
+      ? "forward"
+      : "select"
+    : dragDefault;
+  if (effective === "forward") return "forward";
+  return shift ? "select" : "defer";
 }
 
 /** PURE — whether the wheel scrolls the LOCAL mirror scrollback (vs. being


### PR DESCRIPTION
Card #103: detection-driven drag default (agents select, mouse-apps forward), shift inverts, per-pane toggle, config escape. Deferred-press design keeps claude's clicks intact; fixes a pre-existing quadruple-release forwarding bug. Full recorder-asserted battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)