### PR TITLE
feat: new-agent flow v2 — one dialog, the button, a team console (M24.1)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3149,6 +3149,9 @@ function pickBool(value, fallback) {
 function pickPosInt(value, fallback) {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
 }
+function pickEnum(value, allowed, fallback) {
+  return typeof value === "string" && allowed.includes(value) ? value : fallback;
+}
 function parseAppConfig(input) {
   const D = DEFAULT_APP_CONFIG;
   const root = asObject(input);
@@ -3209,7 +3212,8 @@ function parseAppConfig(input) {
     worktrees: { dir: pickString(worktrees.dir, D.worktrees.dir) },
     app: {
       frontDoor: pickBool(app.frontDoor, D.app.frontDoor),
-      detachable: pickBool(app.detachable, D.app.detachable)
+      detachable: pickBool(app.detachable, D.app.detachable),
+      newAgentCwd: pickEnum(app.newAgentCwd, ["pane", "session"], D.app.newAgentCwd)
     }
   };
 }
@@ -3304,7 +3308,7 @@ var init_app_config = __esm({
       welcome: { show: true },
       integrations: { offer: true },
       worktrees: { dir: "" },
-      app: { frontDoor: false, detachable: false }
+      app: { frontDoor: false, detachable: false, newAgentCwd: "pane" }
     };
     DEFAULT_THEME = DEFAULT_APP_CONFIG.theme;
     DEFAULT_KEYS = DEFAULT_APP_CONFIG.keys;
@@ -12079,6 +12083,32 @@ var init_wait = __esm({
   }
 });
 
+// packages/daemon/src/tui/team/home.ts
+var ROLLUP_ORDER;
+var init_home = __esm({
+  "packages/daemon/src/tui/team/home.ts"() {
+    "use strict";
+    init_grammar();
+    init_panels();
+    ROLLUP_ORDER = ["blocked", "working", "done", "idle"];
+  }
+});
+
+// packages/daemon/src/tui/mirror/agent-rows.ts
+var STATE_RANK;
+var init_agent_rows = __esm({
+  "packages/daemon/src/tui/mirror/agent-rows.ts"() {
+    "use strict";
+    init_home();
+    STATE_RANK = (() => {
+      const rank = {};
+      ROLLUP_ORDER.forEach((s, i) => rank[s] = i);
+      rank.unknown = ROLLUP_ORDER.length;
+      return rank;
+    })();
+  }
+});
+
 // packages/daemon/src/tui/mirror/agent-lifecycle.ts
 function launchCommandFor(kind, manifests) {
   const mapped = AGENT_LAUNCH_COMMANDS[kind];
@@ -12088,12 +12118,22 @@ function launchCommandFor(kind, manifests) {
 }
 function spawnAgentArgs(placement, target, dir, command2) {
   const cd = dir ? ["-c", dir] : [];
-  if (placement === "window") return ["new-window", "-t", `${target.session}:`, ...cd, command2];
+  if (placement === "window") {
+    return ["new-window", "-t", `${target.session}:`, ...PRINT_PANE_ID, ...cd, command2];
+  }
   const flag = placement === "split-h" ? "-h" : "-v";
-  return ["split-window", flag, "-t", target.paneId ?? `${target.session}:`, ...cd, command2];
+  return [
+    "split-window",
+    flag,
+    "-t",
+    target.paneId ?? `${target.session}:`,
+    ...PRINT_PANE_ID,
+    ...cd,
+    command2
+  ];
 }
 function spawnSessionArgs(name, dir, command2) {
-  return ["new-session", "-d", "-s", name, ...dir ? ["-c", dir] : [], command2];
+  return ["new-session", "-d", "-s", name, ...PRINT_PANE_ID, ...dir ? ["-c", dir] : [], command2];
 }
 function isShellCommand(command2, manifests) {
   const name = command2.replace(/^-/, "").split("/").pop() ?? command2;
@@ -12123,10 +12163,11 @@ function clearAuthorityArgs(paneId) {
     ["set-option", "-p", "-t", paneId, "-u", "@agent_session_id"]
   ];
 }
-var AGENT_LAUNCH_COMMANDS, EXTRA_SHELLS, INTERRUPT_TAP_GAP_MS, RESTART_GRACE_MS;
+var AGENT_LAUNCH_COMMANDS, PRINT_PANE_ID, EXTRA_SHELLS, INTERRUPT_TAP_GAP_MS, RESTART_GRACE_MS;
 var init_agent_lifecycle = __esm({
   "packages/daemon/src/tui/mirror/agent-lifecycle.ts"() {
     "use strict";
+    init_agent_rows();
     AGENT_LAUNCH_COMMANDS = {
       claude: "claude",
       codex: "codex",
@@ -12138,6 +12179,7 @@ var init_agent_lifecycle = __esm({
       goose: "goose",
       amp: "amp"
     };
+    PRINT_PANE_ID = ["-P", "-F", "#{pane_id}"];
     EXTRA_SHELLS = ["dash", "ksh", "tcsh", "csh"];
     INTERRUPT_TAP_GAP_MS = 250;
     RESTART_GRACE_MS = 1e3;
@@ -13614,13 +13656,21 @@ function buildRestorePlan(snapshot, liveSessionNames, ideProjects = /* @__PURE__
   }
   return { actions, paneCount };
 }
-var SAFE_SESSION_ID = /^[A-Za-z0-9-]+$/;
+var SAFE_SESSION_ID = /^[A-Za-z0-9_-]+$/;
+var AGENT_RESUME_COMMANDS = {
+  claude: (id) => `claude --resume ${id}`,
+  codex: (id) => `codex resume ${id}`,
+  opencode: (id) => `opencode --session ${id}`,
+  cursor: (id) => `cursor-agent --resume ${id}`,
+  copilot: (id) => `copilot --resume=${id}`
+};
 function paneResumeCommand(pane, opts) {
   if (!opts.resumeAgents) return null;
-  if (pane.agent !== "claude") return null;
+  const resume = pane.agent ? AGENT_RESUME_COMMANDS[pane.agent] : void 0;
+  if (!resume) return null;
   const id = pane.agentSessionId;
   if (!id || !SAFE_SESSION_ID.test(id)) return null;
-  return `claude --resume ${id}`;
+  return resume(id);
 }
 function countResumableAgents(session, resumeAgents) {
   let n = 0;

--- a/packages/daemon/src/lib/app-config.test.ts
+++ b/packages/daemon/src/lib/app-config.test.ts
@@ -191,6 +191,15 @@ describe("parseAppConfig — mistyped fields fall back to default", () => {
     // An explicit true makes bare `tmux-ide app` run hosted (M23.2).
     expect(parseAppConfig({ app: { detachable: true } }).app.detachable).toBe(true);
   });
+
+  it("app.newAgentCwd — defaults to pane, accepts session, coerces junk back (M24.1)", () => {
+    expect(DEFAULT_APP_CONFIG.app.newAgentCwd).toBe("pane");
+    expect(parseAppConfig(undefined).app.newAgentCwd).toBe("pane");
+    expect(parseAppConfig({ app: { newAgentCwd: "session" } }).app.newAgentCwd).toBe("session");
+    expect(parseAppConfig({ app: { newAgentCwd: "pane" } }).app.newAgentCwd).toBe("pane");
+    expect(parseAppConfig({ app: { newAgentCwd: "window" } }).app.newAgentCwd).toBe("pane");
+    expect(parseAppConfig({ app: { newAgentCwd: true } }).app.newAgentCwd).toBe("pane");
+  });
 });
 
 describe("loadAppConfig / getAppConfig / TMUX_IDE_CONFIG", () => {

--- a/packages/daemon/src/lib/app-config.ts
+++ b/packages/daemon/src/lib/app-config.ts
@@ -151,7 +151,18 @@ export interface AppApp {
    * single run.
    */
   detachable: boolean;
+  /**
+   * Where a Terminal-surface "New agent" spawn starts (M24.1): `"pane"`
+   * (default) inherits the FOCUSED pane's current working directory —
+   * `#{pane_current_path}`, so the agent lands where you are — while
+   * `"session"` keeps the session/project directory. Home/sidebar spawns
+   * always use the session/project dir (no focused pane exists there).
+   */
+  newAgentCwd: NewAgentCwd;
 }
+
+/** The two Terminal-spawn cwd policies (see {@link AppApp.newAgentCwd}). */
+export type NewAgentCwd = "pane" | "session";
 
 /** Worktree flow config (`tmux-ide worktree`). */
 export interface AppWorktrees {
@@ -211,7 +222,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   welcome: { show: true },
   integrations: { offer: true },
   worktrees: { dir: "" },
-  app: { frontDoor: false, detachable: false },
+  app: { frontDoor: false, detachable: false, newAgentCwd: "pane" },
 };
 
 /** The default theme tokens — the fallback threaded into the pure builders. */
@@ -244,6 +255,13 @@ function pickBool(value: unknown, fallback: boolean): boolean {
 /** A positive integer, else the default. */
 function pickPosInt(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+/** One of `allowed`, else the default. */
+function pickEnum<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : fallback;
 }
 
 /**
@@ -313,6 +331,7 @@ export function parseAppConfig(input: unknown): AppConfig {
     app: {
       frontDoor: pickBool(app.frontDoor, D.app.frontDoor),
       detachable: pickBool(app.detachable, D.app.detachable),
+      newAgentCwd: pickEnum(app.newAgentCwd, ["pane", "session"], D.app.newAgentCwd),
     },
   };
 }

--- a/packages/daemon/src/restore.test.ts
+++ b/packages/daemon/src/restore.test.ts
@@ -117,9 +117,41 @@ describe("paneResumeCommand", () => {
       resumeAgents: true,
       want: null,
     },
+    // The M24.1 table extensions — each spelling VERIFIED against the CLI's
+    // own --help (codex/opencode/cursor) or the official docs (copilot).
     {
-      name: "other agent + session id → null (no resume story)",
+      name: "codex + session id → codex resume <id>",
       pane: pane({ agent: "codex", agentSessionId: id }),
+      resumeAgents: true,
+      want: `codex resume ${id}`,
+    },
+    {
+      name: "opencode + its ses_… id → opencode --session <id> (underscore is safe)",
+      pane: pane({ agent: "opencode", agentSessionId: "ses_8f2ab91ccd" }),
+      resumeAgents: true,
+      want: "opencode --session ses_8f2ab91ccd",
+    },
+    {
+      name: "cursor + chat id → cursor-agent --resume <id> (launch binary, not the kind)",
+      pane: pane({ agent: "cursor", agentSessionId: id }),
+      resumeAgents: true,
+      want: `cursor-agent --resume ${id}`,
+    },
+    {
+      name: "copilot + session id → copilot --resume=<id> (the optional-value = form)",
+      pane: pane({ agent: "copilot", agentSessionId: id }),
+      resumeAgents: true,
+      want: `copilot --resume=${id}`,
+    },
+    {
+      name: "unverified agent (gemini) + session id → null (no VERIFIED resume story)",
+      pane: pane({ agent: "gemini", agentSessionId: id }),
+      resumeAgents: true,
+      want: null,
+    },
+    {
+      name: "codex id with shell metacharacters → null (same guard as claude)",
+      pane: pane({ agent: "codex", agentSessionId: "abc;rm -rf" }),
       resumeAgents: true,
       want: null,
     },

--- a/packages/daemon/src/restore.ts
+++ b/packages/daemon/src/restore.ts
@@ -13,9 +13,11 @@
  *
  * `--resume-agents` (or `{ "restore": { "resumeAgents": true } }` in
  * `~/.tmux-ide/config.json`) layers native agent-resume on top: a rebuilt
- * claude pane that carries a recorded `@agent_session_id` relaunches as
- * `claude --resume <id>`, reviving the actual conversation rather than opening
- * a fresh shell. See {@link paneResumeCommand} for the exact decision table.
+ * agent pane that carries a recorded `@agent_session_id` relaunches with its
+ * kind's VERIFIED resume invocation (`claude --resume <id>`, `codex resume
+ * <id>`, … — {@link AGENT_RESUME_COMMANDS}), reviving the actual conversation
+ * rather than opening a fresh shell. See {@link paneResumeCommand} for the
+ * exact decision table.
  *
  * {@link buildRestorePlan} + {@link paneResumeCommand} + {@link restorePrefs}
  * are PURE (unit-tested); {@link restore} is the thin io wrapper that reads the
@@ -92,22 +94,51 @@ export function buildRestorePlan(
 // Pure — agent resume decision
 // ---------------------------------------------------------------------------
 
-/** A session id is trusted only if it's the uuid alphabet — nothing shell-active. */
-const SAFE_SESSION_ID = /^[A-Za-z0-9-]+$/;
+/** A session id is trusted only if it's uuid-ish (`[A-Za-z0-9_-]` — underscore
+ *  covers opencode's `ses_…` ids) — nothing shell-active. */
+const SAFE_SESSION_ID = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * The native session-resume invocation per agent kind (M24.1 — the table was
+ * claude-only until then). ONLY VERIFIED entries ship; each spelling's source:
+ *  - `claude --resume <id>`: the shipped integration (its hooks record the id).
+ *  - `codex resume <id>`: `codex resume --help` — "Usage: codex resume
+ *    [OPTIONS] [SESSION_ID]  … Session id (UUID) or session name".
+ *  - `opencode --session <id>`: `opencode --help` — "-s, --session  session id
+ *    to continue".
+ *  - `cursor-agent --resume <id>`: `cursor-agent --help` — "--resume [chatId]
+ *    Select a session to resume".
+ *  - `copilot --resume=<id>`: GitHub Copilot CLI command reference —
+ *    "--resume[=VALUE]  Resume a previous interactive session … Optionally
+ *    specify a session ID" (the `=` form, since the value is optional).
+ * Unverified (no entry): gemini, aider, goose, amp — no confirmed native
+ * per-session resume invocation at the time of writing.
+ *
+ * Only claude's hooks record `@agent_session_id` automatically today; the
+ * other entries fire for panes whose agent self-reported the id per the agent
+ * contract (`tmux set-option -p @agent_session_id <id>`).
+ */
+export const AGENT_RESUME_COMMANDS: Record<string, (id: string) => string> = {
+  claude: (id) => `claude --resume ${id}`,
+  codex: (id) => `codex resume ${id}`,
+  opencode: (id) => `opencode --session ${id}`,
+  cursor: (id) => `cursor-agent --resume ${id}`,
+  copilot: (id) => `copilot --resume=${id}`,
+};
 
 /**
  * PURE — the command to relaunch a pane so its agent conversation is revived,
  * or `null` for "no resume — leave it a plain shell (or replay `command`)".
  *
  * Decision table (only fires when `resumeAgents` is on):
- *  - claude + a recorded `@agent_session_id` → `claude --resume <id>`. The id is
- *    a uuid, but we don't trust the snapshot: unless it matches
- *    {@link SAFE_SESSION_ID} (`[A-Za-z0-9-]`) we bail to `null` rather than risk
- *    feeding shell metacharacters into send-keys.
- *  - claude with NO session id → `null`. `claude --continue` would be too
- *    magical here (it resumes the most-recent conversation in the cwd, which may
- *    belong to a different pane); a fresh shell is the safe, predictable default.
- *  - any other agent → `null`. No native resume story yet.
+ *  - a kind in {@link AGENT_RESUME_COMMANDS} + a recorded `@agent_session_id` →
+ *    that kind's resume invocation. The id is uuid-ish, but we don't trust the
+ *    snapshot: unless it matches {@link SAFE_SESSION_ID} we bail to `null`
+ *    rather than risk feeding shell metacharacters into send-keys.
+ *  - a known kind with NO session id → `null`. A "continue most recent" flag
+ *    would be too magical here (it resumes the cwd's most-recent conversation,
+ *    which may belong to a different pane); a fresh shell is the safe default.
+ *  - any other agent → `null`. No VERIFIED resume story.
  *  - `resumeAgents` off → always `null`.
  */
 export function paneResumeCommand(
@@ -115,10 +146,11 @@ export function paneResumeCommand(
   opts: { resumeAgents: boolean },
 ): string | null {
   if (!opts.resumeAgents) return null;
-  if (pane.agent !== "claude") return null;
+  const resume = pane.agent ? AGENT_RESUME_COMMANDS[pane.agent] : undefined;
+  if (!resume) return null;
   const id = pane.agentSessionId;
   if (!id || !SAFE_SESSION_ID.test(id)) return null;
-  return `claude --resume ${id}`;
+  return resume(id);
 }
 
 /** PURE — how many of a session's panes would resume under `resumeAgents`. */

--- a/packages/daemon/src/tui/mirror/agent-lifecycle.test.ts
+++ b/packages/daemon/src/tui/mirror/agent-lifecycle.test.ts
@@ -2,20 +2,39 @@ import { describe, expect, it } from "vitest";
 import type { AgentManifest } from "../detect/manifest.ts";
 import { BUNDLED_MANIFESTS } from "../detect/manifests.ts";
 import {
+  AGAIN_ID,
   AGENT_LAUNCH_COMMANDS,
   CUSTOM_KIND_ID,
+  TEAM_ACTIONS,
+  TEAM_NEW_ID,
   agentKindItems,
   clearAuthorityArgs,
+  compatiblePlacement,
+  customRecentId,
+  customRecentIndex,
+  defaultSpawnPlacement,
   interruptArgs,
   isShellCommand,
+  isSpawnWhere,
+  labelPaneArgs,
+  labelWindowArgs,
+  lastSpawnName,
   launchCommandFor,
+  newAgentItems,
   paneHostsShell,
-  placementItems,
+  placementActions,
+  placementLabel,
   relaunchArgs,
+  resolvePlacement,
   respawnArgs,
   spawnAgentArgs,
+  spawnLabelFor,
   spawnSessionArgs,
+  stampLaunchArgs,
+  teamAgentIndex,
+  teamItems,
 } from "./agent-lifecycle.ts";
+import type { AgentRowInput } from "./agent-rows.ts";
 
 const manifest = (id: string, commands: string[]): AgentManifest => ({
   id,
@@ -69,23 +88,131 @@ describe("agentKindItems", () => {
   });
 });
 
-describe("placementItems", () => {
-  it("offers splits only when there is a pane to split", () => {
-    expect(placementItems({ split: false }).map((i) => i.id)).toEqual(["window"]);
-    expect(placementItems({ split: true }).map((i) => i.id)).toEqual([
-      "window",
-      "split-h",
-      "split-v",
-    ]);
+describe("defaultSpawnPlacement", () => {
+  it("splits right of a focused pane, else a window in the session, else a fresh session", () => {
+    expect(defaultSpawnPlacement({ pane: true, session: true })).toBe("split-h");
+    expect(defaultSpawnPlacement({ pane: false, session: true })).toBe("window");
+    expect(defaultSpawnPlacement({ pane: false, session: false })).toBe("session");
+  });
+});
+
+describe("compatiblePlacement", () => {
+  it("splits need a pane, windows a session, a fresh session always works", () => {
+    expect(compatiblePlacement("split-h", { pane: true, session: true })).toBe(true);
+    expect(compatiblePlacement("split-h", { pane: false, session: true })).toBe(false);
+    expect(compatiblePlacement("split-v", { pane: false, session: false })).toBe(false);
+    expect(compatiblePlacement("window", { pane: false, session: true })).toBe(true);
+    expect(compatiblePlacement("window", { pane: false, session: false })).toBe(false);
+    expect(compatiblePlacement("session", { pane: false, session: false })).toBe(true);
+  });
+});
+
+describe("placementActions", () => {
+  it("offers ^w window / ^d split-below only where a pane exists (the default is split-right)", () => {
+    expect(placementActions({ pane: true, session: true }).map((a) => a.key)).toEqual(["w", "d"]);
+    expect(placementActions({ pane: false, session: true })).toEqual([]);
+    expect(placementActions({ pane: false, session: false })).toEqual([]);
+  });
+});
+
+describe("resolvePlacement", () => {
+  it("maps the footer action keys, and keeps the fallback on plain enter", () => {
+    expect(resolvePlacement("split-h", "w")).toBe("window");
+    expect(resolvePlacement("split-h", "d")).toBe("split-v");
+    expect(resolvePlacement("split-h", undefined)).toBe("split-h");
+    expect(resolvePlacement("session", undefined)).toBe("session");
+  });
+});
+
+describe("placementLabel", () => {
+  it("names every placement in plain language", () => {
+    expect(placementLabel("split-h")).toBe("split right");
+    expect(placementLabel("split-v")).toBe("split below");
+    expect(placementLabel("window")).toBe("new window");
+    expect(placementLabel("session")).toBe("new session");
+  });
+});
+
+describe("isSpawnWhere", () => {
+  it("accepts the four placements and rejects everything else", () => {
+    for (const p of ["window", "split-h", "split-v", "session"]) expect(isSpawnWhere(p)).toBe(true);
+    expect(isSpawnWhere("pane")).toBe(false);
+    expect(isSpawnWhere(3)).toBe(false);
+    expect(isSpawnWhere(undefined)).toBe(false);
+  });
+});
+
+describe("newAgentItems", () => {
+  const last = { kind: "claude", command: "claude", placement: "split-h" as const };
+
+  it("front-loads the again row (pre-selected at index 0) when a spawn is remembered", () => {
+    const items = newAgentItems({ manifests: BUNDLED_MANIFESTS, last, customRecents: [] });
+    expect(items[0]!.id).toBe(AGAIN_ID);
+    expect(items[0]!.label).toBe("claude — again");
+    expect(items[0]!.detail).toBe("split right");
+  });
+
+  it("labels a remembered custom spawn by its argv and shows the checked placement", () => {
+    const items = newAgentItems({
+      manifests: BUNDLED_MANIFESTS,
+      last: { kind: CUSTOM_KIND_ID, command: "my-agent --x", placement: "split-h" },
+      againPlacement: "window", // context lost its pane — the row says where it will REALLY go
+      customRecents: [],
+    });
+    expect(items[0]!.label).toBe("my-agent --x — again");
+    expect(items[0]!.detail).toBe("new window");
+  });
+
+  it("omits the again row without memory and keeps the kind list + custom row", () => {
+    const items = newAgentItems({ manifests: BUNDLED_MANIFESTS, last: null, customRecents: [] });
+    expect(items[0]!.id).not.toBe(AGAIN_ID);
+    expect(items.map((i) => i.id)).toContain("claude");
+    expect(items.map((i) => i.id)).toContain(CUSTOM_KIND_ID);
+  });
+
+  it("lists custom recents as selectable rows beneath the custom row", () => {
+    const items = newAgentItems({
+      manifests: BUNDLED_MANIFESTS,
+      last: null,
+      customRecents: ["my-agent --x", "other --y"],
+    });
+    const ids = items.map((i) => i.id);
+    const customIdx = ids.indexOf(CUSTOM_KIND_ID);
+    expect(ids[customIdx + 1]).toBe(customRecentId(0));
+    expect(ids[customIdx + 2]).toBe(customRecentId(1));
+    expect(items[customIdx + 1]!.label).toBe("my-agent --x");
+    expect(customRecentIndex(customRecentId(1))).toBe(1);
+    expect(customRecentIndex("claude")).toBeNull();
+    expect(customRecentIndex(`${customRecentId(0)}x`)).toBeNull();
+  });
+});
+
+describe("lastSpawnName", () => {
+  it("names a kind spawn by kind and a custom spawn by its argv", () => {
+    expect(lastSpawnName({ kind: "codex", command: "codex", placement: "window" })).toBe("codex");
+    expect(lastSpawnName({ kind: CUSTOM_KIND_ID, command: "m --f", placement: "window" })).toBe(
+      "m --f",
+    );
+  });
+});
+
+describe("spawnLabelFor", () => {
+  it("labels kind spawns by kind and custom spawns by the command's basename", () => {
+    expect(spawnLabelFor("claude", "claude")).toBe("claude");
+    expect(spawnLabelFor(CUSTOM_KIND_ID, "/usr/local/bin/my-agent --flag")).toBe("my-agent");
+    expect(spawnLabelFor(CUSTOM_KIND_ID, "  ")).toBe("agent");
   });
 });
 
 describe("spawnAgentArgs", () => {
-  it("spawns a new window in the session, with -c when the dir is known", () => {
+  it("spawns a new window in the session (printing the pane id), with -c when the dir is known", () => {
     expect(spawnAgentArgs("window", { session: "web" }, "/proj", "claude")).toEqual([
       "new-window",
       "-t",
       "web:",
+      "-P",
+      "-F",
+      "#{pane_id}",
       "-c",
       "/proj",
       "claude",
@@ -94,6 +221,9 @@ describe("spawnAgentArgs", () => {
       "new-window",
       "-t",
       "web:",
+      "-P",
+      "-F",
+      "#{pane_id}",
       "claude",
     ]);
   });
@@ -104,6 +234,9 @@ describe("spawnAgentArgs", () => {
       "-h",
       "-t",
       "%3",
+      "-P",
+      "-F",
+      "#{pane_id}",
       "-c",
       "/proj",
       "codex",
@@ -113,18 +246,24 @@ describe("spawnAgentArgs", () => {
       "-v",
       "-t",
       "web:",
+      "-P",
+      "-F",
+      "#{pane_id}",
       "codex",
     ]);
   });
 });
 
 describe("spawnSessionArgs", () => {
-  it("creates a detached session running the command in the project dir", () => {
+  it("creates a detached session running the command in the project dir, printing the pane id", () => {
     expect(spawnSessionArgs("api", "/proj", "claude")).toEqual([
       "new-session",
       "-d",
       "-s",
       "api",
+      "-P",
+      "-F",
+      "#{pane_id}",
       "-c",
       "/proj",
       "claude",
@@ -134,8 +273,52 @@ describe("spawnSessionArgs", () => {
       "-d",
       "-s",
       "api",
+      "-P",
+      "-F",
+      "#{pane_id}",
       "claude",
     ]);
+  });
+});
+
+describe("label + stamp argv (M24.1 auto-label)", () => {
+  it("titles the spawned pane / names the spawned window after the agent", () => {
+    expect(labelPaneArgs("%7", "claude")).toEqual(["select-pane", "-t", "%7", "-T", "claude"]);
+    expect(labelWindowArgs("%7", "codex")).toEqual(["rename-window", "-t", "%7", "codex"]);
+  });
+
+  it("stamps the exact launch argv as a pane-local option", () => {
+    expect(stampLaunchArgs("%7", "claude --resume abc")).toEqual([
+      "set-option",
+      "-p",
+      "-t",
+      "%7",
+      "@agent_launch",
+      "claude --resume abc",
+    ]);
+  });
+});
+
+describe("teamItems", () => {
+  const agents: AgentRowInput[] = [
+    { paneId: "%1", windowIndex: 0, session: "web", kind: "claude", state: "working", since: 970 },
+    { paneId: "%2", windowIndex: 1, session: "api", kind: "codex", state: "blocked", since: null },
+  ];
+
+  it("pins + new agent first, then one row per fleet agent with state (+ dwell) detail", () => {
+    const items = teamItems(agents, 1000);
+    expect(items[0]!.id).toBe(TEAM_NEW_ID);
+    expect(items[1]!.label).toBe("claude · web");
+    expect(items[1]!.detail).toBe("working 30s"); // stamped → dwell shown
+    expect(items[2]!.label).toBe("codex · api");
+    expect(items[2]!.detail).toBe("blocked"); // scraped → bare state
+    expect(teamAgentIndex(items[1]!.id)).toBe(0);
+    expect(teamAgentIndex(items[2]!.id)).toBe(1);
+    expect(teamAgentIndex(TEAM_NEW_ID)).toBeNull();
+  });
+
+  it("offers restart/stop as the footer ctrl-actions", () => {
+    expect(TEAM_ACTIONS.map((a) => a.key)).toEqual(["r", "s"]);
   });
 });
 

--- a/packages/daemon/src/tui/mirror/agent-lifecycle.ts
+++ b/packages/daemon/src/tui/mirror/agent-lifecycle.ts
@@ -22,10 +22,18 @@
  * clean exit, without inventing a fake idle epoch.
  */
 import type { AgentManifest } from "../detect/manifest.ts";
-import type { DialogSelectItem } from "./dialog-model.ts";
+import type { DialogRowAction, DialogSelectItem } from "./dialog-model.ts";
+import { agentAgeLabel, type AgentRowInput } from "./agent-rows.ts";
 
 /** The "Custom command…" picker row — resolves to a DialogPrompt, not a kind. */
 export const CUSTOM_KIND_ID = "custom-command";
+
+/** The kind picker's front-loaded repeat row (M24.1) — pre-selected, so a
+ *  repeat spawn is Enter·Enter from the palette. */
+export const AGAIN_ID = "again";
+
+/** Prefix for the custom-command RECENTS rows beneath "Custom command…". */
+const CUSTOM_RECENT_PREFIX = "custom-recent:";
 
 /**
  * Launch command per manifest id. Manifest `commands` are process-match
@@ -73,20 +81,145 @@ export function agentKindItems(manifests: readonly AgentManifest[]): DialogSelec
 /** Where a spawned agent lands, relative to the target session/pane. */
 export type SpawnPlacement = "window" | "split-h" | "split-v";
 
+/** Every place a spawn can land — the pane placements plus a fresh detached
+ *  session (home project rows). The "again" memory remembers one of these. */
+export type SpawnWhere = SpawnPlacement | "session";
+
+const SPAWN_WHERES: readonly SpawnWhere[] = ["window", "split-h", "split-v", "session"];
+
+/** PURE — is `x` a persistable spawn placement? (app-state sanitizing). */
+export function isSpawnWhere(x: unknown): x is SpawnWhere {
+  return typeof x === "string" && (SPAWN_WHERES as readonly string[]).includes(x);
+}
+
+/** One remembered spawn — enough to repeat it exactly (M24.1). Persisted per
+ *  project/session-dir in app-state; `command` carries custom argv verbatim. */
+export interface LastSpawn {
+  /** Manifest id, or {@link CUSTOM_KIND_ID} for a typed command. */
+  kind: string;
+  /** The exact command the spawn ran (the resolved launch command / custom argv). */
+  command: string;
+  /** Where it landed. */
+  placement: SpawnWhere;
+}
+
+/** What the spawn flow knows about its entry point: is there a concrete pane
+ *  to split (Terminal surface), and is there a live session at all? */
+export interface SpawnContextShape {
+  pane: boolean;
+  session: boolean;
+}
+
 /**
- * PURE — the "where should it run" rows. Splits are offered only when there is
- * a concrete pane to split (the Terminal surface's focused pane); the home /
- * sidebar entry points target a session, where a new window is the honest
- * placement. A single-row list still shows, so the flow always says where the
- * agent will land before anything runs.
+ * PURE — where a spawn lands when the user just presses Enter (M24.1: the flow
+ * never ASKS where). Terminal surface (a focused pane exists) → split right of
+ * it; a live session without a concrete pane (home/sidebar session rows) → a
+ * new window in it; no session (home project rows) → a fresh detached session.
  */
-export function placementItems(opts: { split: boolean }): DialogSelectItem[] {
-  const items: DialogSelectItem[] = [{ id: "window", label: "New window", detail: "its own tab" }];
-  if (opts.split) {
-    items.push({ id: "split-h", label: "Split right", detail: "beside this pane" });
-    items.push({ id: "split-v", label: "Split below", detail: "under this pane" });
+export function defaultSpawnPlacement(ctx: SpawnContextShape): SpawnWhere {
+  if (ctx.pane) return "split-h";
+  if (ctx.session) return "window";
+  return "session";
+}
+
+/** PURE — can a remembered placement replay in this context? Splits need a
+ *  concrete pane; window needs a live session; a fresh session always can. */
+export function compatiblePlacement(placement: SpawnWhere, ctx: SpawnContextShape): boolean {
+  if (placement === "session") return true;
+  if (placement === "window") return ctx.session;
+  return ctx.pane;
+}
+
+/** PURE — plain language for a placement (footer hints, the again row). */
+export function placementLabel(placement: SpawnWhere): string {
+  if (placement === "split-h") return "split right";
+  if (placement === "split-v") return "split below";
+  if (placement === "window") return "new window";
+  return "new session";
+}
+
+/**
+ * PURE — the kind picker's footer ACTIONS: placement ALTERNATIVES as ctrl-key
+ * chords, never a second dialog (M24.1). Offered only where they differ from
+ * the default and are honest in this context: with a focused pane the default
+ * is split-right, so ^w (new window) and ^d (split below) are the escapes; a
+ * session-only context defaults to a new window with nothing else honest to
+ * offer; no session means a fresh one — no alternatives.
+ */
+export function placementActions(ctx: SpawnContextShape): DialogRowAction[] {
+  if (ctx.pane) {
+    return [
+      { key: "w", label: "in a new window" },
+      { key: "d", label: "split below" },
+    ];
   }
+  return [];
+}
+
+/** PURE — the placement a dialog result maps to: an action key overrides the
+ *  default (`^w` → window, `^d` → split below); Enter keeps the default. */
+export function resolvePlacement(fallback: SpawnWhere, actionKey?: string): SpawnWhere {
+  if (actionKey === "w") return "window";
+  if (actionKey === "d") return "split-v";
+  return fallback;
+}
+
+/** PURE — a custom-recent row id for `index` into the recents list. */
+export function customRecentId(index: number): string {
+  return `${CUSTOM_RECENT_PREFIX}${index}`;
+}
+
+/** PURE — the recents index a row id encodes, or null for any other row. */
+export function customRecentIndex(id: string): number | null {
+  if (!id.startsWith(CUSTOM_RECENT_PREFIX)) return null;
+  const n = Number(id.slice(CUSTOM_RECENT_PREFIX.length));
+  return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
+/** PURE — what a remembered spawn is called: the kind, or the custom argv
+ *  verbatim (labels for the again row + the palette's again action). */
+export function lastSpawnName(last: LastSpawn): string {
+  return last.kind === CUSTOM_KIND_ID ? last.command : last.kind;
+}
+
+/**
+ * PURE — the ONE dialog's rows (M24.1): the "again" repeat row FIRST (when a
+ * spawn is remembered for this context — pre-selected, so repeat = Enter), then
+ * the manifest kinds, then "Custom command…", then the recent custom commands
+ * as directly selectable rows beneath it. The again row names what it repeats
+ * and where it will land.
+ */
+export function newAgentItems(opts: {
+  manifests: readonly AgentManifest[];
+  last: LastSpawn | null;
+  /** The placement the again row will actually use (memory, context-checked). */
+  againPlacement?: SpawnWhere;
+  customRecents: readonly string[];
+}): DialogSelectItem[] {
+  const items: DialogSelectItem[] = [];
+  if (opts.last) {
+    const where = opts.againPlacement ?? opts.last.placement;
+    items.push({
+      id: AGAIN_ID,
+      label: `${lastSpawnName(opts.last)} — again`,
+      detail: placementLabel(where),
+    });
+  }
+  items.push(...agentKindItems(opts.manifests));
+  opts.customRecents.forEach((cmd, i) => {
+    items.push({ id: customRecentId(i), label: cmd, detail: "recent" });
+  });
   return items;
+}
+
+/** PURE — the label a spawned pane/window gets: the kind, or a custom
+ *  command's first token stripped to its basename (`/us/bin/my-agent -x` →
+ *  `my-agent`). Empty input falls back to "agent". */
+export function spawnLabelFor(kind: string, command: string): string {
+  if (kind !== CUSTOM_KIND_ID) return kind;
+  const first = command.trim().split(/\s+/)[0] ?? "";
+  const base = first.split("/").pop() ?? "";
+  return base.length > 0 ? base : "agent";
 }
 
 /** The spawn target: the owning session, plus the concrete pane for splits. */
@@ -96,12 +229,17 @@ export interface SpawnTarget {
   paneId?: string;
 }
 
+/** `-P -F` — every spawn PRINTS its new pane id, so the flow can label the
+ *  pane/window and stamp `@agent_launch` without a lookup race. */
+const PRINT_PANE_ID = ["-P", "-F", "#{pane_id}"];
+
 /**
  * PURE — the tmux argv that spawns `command` at `placement`. New windows
  * target `<session>:` (tmux appends); splits target the pane. `dir` becomes
  * `-c` when known. The command is passed as tmux's shell-command argument —
  * a bare binary is exec'd directly, so `pane_current_command` is the agent
- * itself and detection picks it up with no extra wiring.
+ * itself and detection picks it up with no extra wiring. `-P -F "#{pane_id}"`
+ * prints the spawned pane's id (M24.1 — the label/stamp follow-ups target it).
  */
 export function spawnAgentArgs(
   placement: SpawnPlacement,
@@ -110,19 +248,96 @@ export function spawnAgentArgs(
   command: string,
 ): string[] {
   const cd = dir ? ["-c", dir] : [];
-  if (placement === "window") return ["new-window", "-t", `${target.session}:`, ...cd, command];
+  if (placement === "window") {
+    return ["new-window", "-t", `${target.session}:`, ...PRINT_PANE_ID, ...cd, command];
+  }
   const flag = placement === "split-h" ? "-h" : "-v";
-  return ["split-window", flag, "-t", target.paneId ?? `${target.session}:`, ...cd, command];
+  return [
+    "split-window",
+    flag,
+    "-t",
+    target.paneId ?? `${target.session}:`,
+    ...PRINT_PANE_ID,
+    ...cd,
+    command,
+  ];
 }
 
 /**
  * PURE — the tmux argv that creates a fresh detached session running
  * `command` (the home PROJECT-row spawn: no live session exists yet, so the
- * agent gets one, named for the project).
+ * agent gets one, named for the project). Prints the new pane id like
+ * {@link spawnAgentArgs}.
  */
 export function spawnSessionArgs(name: string, dir: string | null, command: string): string[] {
-  return ["new-session", "-d", "-s", name, ...(dir ? ["-c", dir] : []), command];
+  return ["new-session", "-d", "-s", name, ...PRINT_PANE_ID, ...(dir ? ["-c", dir] : []), command];
 }
+
+/** PURE — title the spawned pane after its agent (`select-pane -T`), so the
+ *  pane is named without the user being asked (M24.1 auto-label). */
+export function labelPaneArgs(paneId: string, label: string): string[] {
+  return ["select-pane", "-t", paneId, "-T", label];
+}
+
+/** PURE — name a spawned WINDOW after its agent. Targets the spawned pane's
+ *  id, which tmux resolves to the window that holds it. */
+export function labelWindowArgs(paneId: string, label: string): string[] {
+  return ["rename-window", "-t", paneId, label];
+}
+
+/** PURE — stamp the spawned pane with the exact command that launched it
+ *  (`@agent_launch`, pane-local) — restart's preferred relaunch source (better
+ *  than `pane_start_command`, which tmux rewrites for respawned panes). */
+export function stampLaunchArgs(paneId: string, command: string): string[] {
+  return ["set-option", "-p", "-t", paneId, "@agent_launch", command];
+}
+
+// ── The team dialog (M24.1 — "manage your team" in one surface) ─────────────
+
+/** The team dialog's pinned "+ new agent" row id. */
+export const TEAM_NEW_ID = "team-new";
+
+/** Prefix for the team dialog's per-agent rows: `agent:<index>` into the
+ *  caller's (already sorted) fleet agent list. */
+const TEAM_AGENT_PREFIX = "agent:";
+
+/** PURE — a team row id for `index` into the fleet agent list. */
+export function teamAgentId(index: number): string {
+  return `${TEAM_AGENT_PREFIX}${index}`;
+}
+
+/** PURE — the fleet-agent index a team row id encodes, or null. */
+export function teamAgentIndex(id: string): number | null {
+  if (!id.startsWith(TEAM_AGENT_PREFIX)) return null;
+  const n = Number(id.slice(TEAM_AGENT_PREFIX.length));
+  return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
+/**
+ * PURE — the Team dialog rows: a pinned "+ new agent" first (the same one-
+ * dialog kind picker), then one row per fleet agent — "<kind> · <session>",
+ * detail its state (+ dwell when stamped). Enter/click jumps; the footer's
+ * ctrl-actions (restart/stop) ride the DialogRowAction channel.
+ */
+export function teamItems(agents: readonly AgentRowInput[], nowSec: number): DialogSelectItem[] {
+  const items: DialogSelectItem[] = [
+    { id: TEAM_NEW_ID, label: "+ new agent", detail: "kind picker" },
+  ];
+  agents.forEach((a, i) => {
+    items.push({
+      id: teamAgentId(i),
+      label: `${a.kind} · ${a.session}`,
+      detail: agentAgeLabel(a.state, a.since, nowSec) ?? a.state,
+    });
+  });
+  return items;
+}
+
+/** The Team dialog's footer ctrl-actions (restart/stop the selected agent). */
+export const TEAM_ACTIONS: DialogRowAction[] = [
+  { key: "r", label: "restart" },
+  { key: "s", label: "stop" },
+];
 
 /** Interactive shells beyond the shell manifest's `commands` — a login shell
  *  hosting an agent can surface as any of these in `pane_current_command`. */

--- a/packages/daemon/src/tui/mirror/agent-rows.test.ts
+++ b/packages/daemon/src/tui/mirror/agent-rows.test.ts
@@ -136,7 +136,7 @@ describe("sidebarHit", () => {
     expect(sidebarHit(4, 2, 3)).toBeNull();
   });
 
-  it("maps the agents header row (inert)", () => {
+  it("maps the agents header row (the Team dialog / [+ agent] chip target)", () => {
     expect(sidebarHit(5, 2, 3)).toEqual({ kind: "agents-header" });
   });
 
@@ -151,10 +151,11 @@ describe("sidebarHit", () => {
     expect(sidebarHit(20, 2, 3)).toBeNull();
   });
 
-  it("treats the empty-state row (agentCount 0) as inert", () => {
-    // gy2..3 sessions, gy4 gap, gy5 header, gy6 is the empty-state line → null.
+  it("addresses the empty-state row (agentCount 0) so its [+ agent] chip can hit (M24.1)", () => {
+    // gy2..3 sessions, gy4 gap, gy5 header, gy6 the empty-state line, then null.
     expect(sidebarHit(5, 2, 0)).toEqual({ kind: "agents-header" });
-    expect(sidebarHit(6, 2, 0)).toBeNull();
+    expect(sidebarHit(6, 2, 0)).toEqual({ kind: "agents-empty" });
+    expect(sidebarHit(7, 2, 0)).toBeNull();
   });
 
   it("works with zero sessions (gap then agents section after the rule)", () => {

--- a/packages/daemon/src/tui/mirror/agent-rows.ts
+++ b/packages/daemon/src/tui/mirror/agent-rows.ts
@@ -78,6 +78,11 @@ export function agentsHeaderLabel(count: number, maxChars: number): string {
 /** The quiet empty-state line shown under the header when no agents are running. */
 export const AGENTS_EMPTY_LINE = "no agents running — panes running claude or codex show up here";
 
+/** The always-present spawn chip on the AGENTS header row (and the empty-state
+ *  row) — THE discoverable "start a new agent" entry (M24.1). Right-aligned;
+ *  the render and the router share its span via `spansFromRight`. */
+export const AGENTS_ADD_CHIP = "[+ agent]";
+
 /**
  * PURE — a compact state-age like `"blocked 4m"` from a `since` epoch-seconds
  * stamp, for the hovered row. Returns null when there is no timestamp (a scraped
@@ -103,12 +108,15 @@ export function agentAgeLabel(
  *  agree on the row the header sits on — a mismatch lands clicks one row off. */
 export const AGENTS_GAP_ROWS = 1;
 
-/** What a sidebar content row (a tab-bar-adjusted `gy`) targets. `agents-header`,
- *  the gap row(s), and the empty-state row are inert (the router does nothing). */
+/** What a sidebar content row (a tab-bar-adjusted `gy`) targets. The gap
+ *  row(s) are inert; `agents-header` opens the Team dialog (its right-aligned
+ *  `[+ agent]` chip spawns — the router x-tests the chip span first), and
+ *  `agents-empty` is the empty-state row (inert except its chip). */
 export type SidebarHit =
   | { kind: "session"; index: number }
   | { kind: "agent"; index: number }
   | { kind: "agents-header" }
+  | { kind: "agents-empty" }
   | null;
 
 /**
@@ -117,8 +125,8 @@ export type SidebarHit =
  * never land where a row isn't drawn. Layout, top to bottom: `gy 0` title,
  * `gy 1` rule, then `sessionCount` session rows from `gy 2`, then
  * `AGENTS_GAP_ROWS` blank row(s), then the agents section — one header row, then
- * `agentCount` agent rows (or a single inert empty-state row when
- * `agentCount === 0`).
+ * `agentCount` agent rows (or a single empty-state row when `agentCount === 0`,
+ * hit-tested as `agents-empty` so its `[+ agent]` chip stays clickable).
  */
 export function sidebarHit(gy: number, sessionCount: number, agentCount: number): SidebarHit {
   if (gy < 2) return null;
@@ -128,6 +136,7 @@ export function sidebarHit(gy: number, sessionCount: number, agentCount: number)
   if (gy < headerGy) return null; // the gap row(s) between sessions and agents
   if (gy === headerGy) return { kind: "agents-header" };
   const ai = gy - headerGy - 1;
-  if (agentCount === 0 || ai < 0 || ai >= agentCount) return null;
+  if (agentCount === 0) return ai === 0 ? { kind: "agents-empty" } : null;
+  if (ai < 0 || ai >= agentCount) return null;
   return { kind: "agent", index: ai };
 }

--- a/packages/daemon/src/tui/mirror/app-state.test.ts
+++ b/packages/daemon/src/tui/mirror/app-state.test.ts
@@ -1,17 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  CUSTOM_COMMANDS_CAP,
   DEFAULT_APP_STATE,
   RECENTS_CAP,
   SIDEBAR_W_DEFAULT,
+  SPAWN_MEMORY_CAP,
+  addCustomCommand,
   addRecentFolder,
   appStateHome,
   appStatePath,
   clampSidebarWidth,
   isTab,
   parseAppState,
+  rememberSpawn,
   serializeAppState,
+  spawnMemoryKey,
   type AppState,
 } from "./app-state.ts";
+import type { LastSpawn } from "./agent-lifecycle.ts";
 
 describe("isTab", () => {
   it("accepts the four surface keys and rejects anything else", () => {
@@ -34,6 +40,11 @@ describe("parseAppState", () => {
       diffFile: "src/x.ts",
       sidebarW: 30,
       recentFolders: ["/tmp/one", "/tmp/two"],
+      lastSpawns: {
+        "/tmp/one": { kind: "claude", command: "claude", placement: "split-h" },
+        "session:web": { kind: "custom-command", command: "my-agent --x", placement: "window" },
+      },
+      customCommands: ["my-agent --x", "other --y"],
     };
     expect(parseAppState(serializeAppState(state))).toEqual(state);
   });
@@ -55,6 +66,8 @@ describe("parseAppState", () => {
       diffFile: "d",
       sidebarW: SIDEBAR_W_DEFAULT,
       recentFolders: [],
+      lastSpawns: {},
+      customCommands: [],
     });
   });
 
@@ -69,7 +82,33 @@ describe("parseAppState", () => {
       diffFile: null,
       sidebarW: SIDEBAR_W_DEFAULT,
       recentFolders: [],
+      lastSpawns: {},
+      customCommands: [],
     });
+  });
+
+  it("drops malformed spawn-memory entries and keeps clean ones (order preserved)", () => {
+    const parsed = parseAppState(
+      JSON.stringify({
+        lastSpawns: {
+          "/good": { kind: "claude", command: "claude", placement: "window" },
+          "/bad-placement": { kind: "claude", command: "claude", placement: "pane" },
+          "/bad-kind": { kind: "", command: "claude", placement: "window" },
+          "/bad-shape": "claude",
+          "": { kind: "claude", command: "claude", placement: "window" },
+          "/good2": { kind: "custom-command", command: "m --x", placement: "session" },
+        },
+        customCommands: ["a", "", 5, "a", "b"],
+      }),
+    );
+    expect(Object.keys(parsed.lastSpawns)).toEqual(["/good", "/good2"]);
+    expect(parsed.customCommands).toEqual(["a", "b"]);
+  });
+
+  it("yields empty spawn memory for a non-object value", () => {
+    expect(parseAppState(JSON.stringify({ lastSpawns: ["x"], customCommands: "y" }))).toEqual(
+      DEFAULT_APP_STATE,
+    );
   });
 
   it("keeps only clean, deduped, capped recent folders", () => {
@@ -111,18 +150,64 @@ describe("serializeAppState", () => {
         diffFile: null,
         sidebarW: SIDEBAR_W_DEFAULT,
         recentFolders: [],
+        lastSpawns: {},
+        customCommands: [],
         // @ts-expect-error — runtime extra keys must not leak into the file
         junk: "x",
       }),
     );
     expect(Object.keys(parsed).sort()).toEqual([
       "contextSession",
+      "customCommands",
       "diffFile",
+      "lastSpawns",
       "lastTab",
       "openFile",
       "recentFolders",
       "sidebarW",
     ]);
+  });
+});
+
+describe("spawnMemoryKey", () => {
+  it("prefers the dir, falls back to a namespaced session, else null", () => {
+    expect(spawnMemoryKey("/proj", "web")).toBe("/proj");
+    expect(spawnMemoryKey(null, "web")).toBe("session:web");
+    expect(spawnMemoryKey("", "web")).toBe("session:web");
+    expect(spawnMemoryKey(null, undefined)).toBeNull();
+    expect(spawnMemoryKey(null, "")).toBeNull();
+  });
+});
+
+describe("rememberSpawn", () => {
+  const spawn = (kind: string): LastSpawn => ({ kind, command: kind, placement: "window" });
+
+  it("re-inserts an existing key as newest (LRU order) without touching the input", () => {
+    const map = { "/a": spawn("claude"), "/b": spawn("codex") };
+    const out = rememberSpawn(map, "/a", spawn("opencode"));
+    expect(Object.keys(out)).toEqual(["/b", "/a"]);
+    expect(out["/a"]!.kind).toBe("opencode");
+    expect(Object.keys(map)).toEqual(["/a", "/b"]); // input untouched
+  });
+
+  it("drops the oldest entries past the cap", () => {
+    let map: Record<string, LastSpawn> = {};
+    for (let i = 0; i < SPAWN_MEMORY_CAP + 3; i++) {
+      map = rememberSpawn(map, `/p${i}`, spawn("claude"));
+    }
+    const keys = Object.keys(map);
+    expect(keys.length).toBe(SPAWN_MEMORY_CAP);
+    expect(keys[0]).toBe("/p3"); // /p0../p2 fell off
+    expect(keys[keys.length - 1]).toBe(`/p${SPAWN_MEMORY_CAP + 2}`);
+  });
+});
+
+describe("addCustomCommand", () => {
+  it("moves a command to the front, dedupes, caps, and ignores blanks", () => {
+    expect(addCustomCommand(["a", "b"], "b")).toEqual(["b", "a"]);
+    expect(addCustomCommand(["a", "b", "c", "d", "e"], "f")).toEqual(["f", "a", "b", "c", "d"]);
+    expect(addCustomCommand(["a"], "  ")).toEqual(["a"]);
+    expect(addCustomCommand([], "x --y").length).toBeLessThanOrEqual(CUSTOM_COMMANDS_CAP);
   });
 });
 

--- a/packages/daemon/src/tui/mirror/app-state.ts
+++ b/packages/daemon/src/tui/mirror/app-state.ts
@@ -19,6 +19,7 @@ import { existsSync, readFileSync, mkdirSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { isSpawnWhere, type LastSpawn } from "./agent-lifecycle.ts";
 
 /** The four top-level surfaces. `terminal` is the SessionMirror, `files` the
  *  editor + file list, `diff` the git panel, `home` the fleet cockpit. */
@@ -48,6 +49,12 @@ export function clampSidebarWidth(w: number): number {
 /** How many recently-opened folders home remembers (M22.5). Oldest fall off. */
 export const RECENTS_CAP = 8;
 
+/** How many per-context "again" spawn memories persist (M24.1). Oldest fall off. */
+export const SPAWN_MEMORY_CAP = 20;
+
+/** How many custom spawn commands the recents list keeps (M24.1, global). */
+export const CUSTOM_COMMANDS_CAP = 5;
+
 /** The persisted shape. `null` means "nothing remembered" for that slot. */
 export interface AppState {
   /** The tab the app was showing when it last saved. */
@@ -63,6 +70,13 @@ export interface AppState {
   /** Recently-opened folder paths (M22.5), most-recent first, deduped and
    *  capped at {@link RECENTS_CAP}. Home renders these under a "recent" header. */
   recentFolders: string[];
+  /** The "again" memory (M24.1): spawn-context key (a project/session dir, or
+   *  `session:<name>` when no dir is known) → the last spawn there. Insertion-
+   *  ordered LRU capped at {@link SPAWN_MEMORY_CAP}. */
+  lastSpawns: Record<string, LastSpawn>;
+  /** Recent CUSTOM spawn commands (M24.1), most-recent first, deduped, global
+   *  (not per-project), capped at {@link CUSTOM_COMMANDS_CAP}. */
+  customCommands: string[];
 }
 
 export const DEFAULT_APP_STATE: AppState = {
@@ -72,7 +86,88 @@ export const DEFAULT_APP_STATE: AppState = {
   diffFile: null,
   sidebarW: SIDEBAR_W_DEFAULT,
   recentFolders: [],
+  lastSpawns: {},
+  customCommands: [],
 };
+
+/** PURE — the "again" memory key for a spawn context: the concrete dir when
+ *  known, else the session name (namespaced so a dirless session can't collide
+ *  with a path), else null — nothing stable to remember under. */
+export function spawnMemoryKey(dir: string | null, session?: string): string | null {
+  if (dir && dir.length > 0) return dir;
+  if (session && session.length > 0) return `session:${session}`;
+  return null;
+}
+
+/**
+ * PURE — the spawn-memory map after remembering `spawn` under `key`: the key
+ * moves to newest (re-inserted last), and when the map outgrows `cap` the
+ * OLDEST entries drop (JS objects preserve string-key insertion order — the
+ * same order JSON round-trips, so the LRU survives restarts).
+ */
+export function rememberSpawn(
+  map: Readonly<Record<string, LastSpawn>>,
+  key: string,
+  spawn: LastSpawn,
+  cap: number = SPAWN_MEMORY_CAP,
+): Record<string, LastSpawn> {
+  const out: Record<string, LastSpawn> = {};
+  for (const [k, v] of Object.entries(map)) if (k !== key) out[k] = v;
+  out[key] = spawn;
+  const keys = Object.keys(out);
+  for (let i = 0; i < keys.length - cap; i++) delete out[keys[i]!];
+  return out;
+}
+
+/** PURE — the custom-command recents after running `command`: moved to the
+ *  front, deduped, capped. Blank commands leave the list unchanged. */
+export function addCustomCommand(
+  list: readonly string[],
+  command: string,
+  cap: number = CUSTOM_COMMANDS_CAP,
+): string[] {
+  const cmd = command.trim();
+  if (cmd.length === 0) return [...list];
+  return [cmd, ...list.filter((c) => c !== cmd)].slice(0, cap);
+}
+
+/** PURE — one persisted spawn coerced to a clean {@link LastSpawn}, or null
+ *  when any field is missing/mistyped (the whole entry drops). */
+function sanitizeSpawn(v: unknown): LastSpawn | null {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return null;
+  const o = v as Record<string, unknown>;
+  if (typeof o.kind !== "string" || o.kind.length === 0) return null;
+  if (typeof o.command !== "string" || o.command.length === 0) return null;
+  if (!isSpawnWhere(o.placement)) return null;
+  return { kind: o.kind, command: o.command, placement: o.placement };
+}
+
+/** PURE — a persisted spawn-memory value coerced clean: non-object → {},
+ *  malformed entries drop, order kept, capped from the OLD end. */
+function sanitizeSpawns(v: unknown): Record<string, LastSpawn> {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return {};
+  const out: Record<string, LastSpawn> = {};
+  for (const [key, raw] of Object.entries(v as Record<string, unknown>)) {
+    if (key.length === 0) continue;
+    const spawn = sanitizeSpawn(raw);
+    if (spawn) out[key] = spawn;
+  }
+  const keys = Object.keys(out);
+  for (let i = 0; i < keys.length - SPAWN_MEMORY_CAP; i++) delete out[keys[i]!];
+  return out;
+}
+
+/** PURE — a persisted string list coerced clean: non-empty, deduped (first
+ *  wins), capped at `cap`. Anything not a string[] yields []. */
+function sanitizeStringList(v: unknown, cap: number): string[] {
+  if (!Array.isArray(v)) return [];
+  const out: string[] = [];
+  for (const item of v) {
+    if (typeof item === "string" && item.length > 0 && !out.includes(item)) out.push(item);
+    if (out.length >= cap) break;
+  }
+  return out;
+}
 
 /** PURE — the recents list after opening `dir`: it moves to the front,
  *  any earlier occurrence is removed (dedupe), and the tail past `cap` drops.
@@ -89,13 +184,7 @@ export function addRecentFolder(
 /** PURE — a persisted recents value coerced to clean strings: non-empty,
  *  deduped (first wins), capped. Anything not a string[] yields []. */
 function sanitizeRecents(v: unknown): string[] {
-  if (!Array.isArray(v)) return [];
-  const out: string[] = [];
-  for (const item of v) {
-    if (typeof item === "string" && item.length > 0 && !out.includes(item)) out.push(item);
-    if (out.length >= RECENTS_CAP) break;
-  }
-  return out;
+  return sanitizeStringList(v, RECENTS_CAP);
 }
 
 /** The tmux-ide home dir: `TMUX_IDE_HOME` when set, else `~/.tmux-ide`. */
@@ -137,10 +226,12 @@ export function parseAppState(raw: string): AppState {
         ? clampSidebarWidth(obj.sidebarW)
         : DEFAULT_APP_STATE.sidebarW,
     recentFolders: sanitizeRecents(obj.recentFolders),
+    lastSpawns: sanitizeSpawns(obj.lastSpawns),
+    customCommands: sanitizeStringList(obj.customCommands, CUSTOM_COMMANDS_CAP),
   };
 }
 
-/** PURE — serialize an {@link AppState} to the exact four-key JSON we persist
+/** PURE — serialize an {@link AppState} to the exact JSON shape we persist
  *  (extra runtime keys are dropped; stable key order for tidy diffs). */
 export function serializeAppState(state: AppState): string {
   const clean: AppState = {
@@ -150,6 +241,8 @@ export function serializeAppState(state: AppState): string {
     diffFile: optString(state.diffFile),
     sidebarW: clampSidebarWidth(state.sidebarW),
     recentFolders: sanitizeRecents(state.recentFolders),
+    lastSpawns: sanitizeSpawns(state.lastSpawns),
+    customCommands: sanitizeStringList(state.customCommands, CUSTOM_COMMANDS_CAP),
   };
   return JSON.stringify(clean, null, 2);
 }

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -180,8 +180,11 @@ import {
   loadAppState,
   saveAppState,
   addRecentFolder,
+  addCustomCommand,
   clampSidebarWidth,
   isTab,
+  rememberSpawn,
+  spawnMemoryKey,
   type AppState,
   type Tab,
 } from "./app-state.ts";
@@ -294,6 +297,7 @@ import {
   agentsHeaderLabel,
   agentAgeLabel,
   sidebarHit,
+  AGENTS_ADD_CHIP,
   AGENTS_EMPTY_LINE,
   AGENTS_GAP_ROWS,
   type AgentRowInput,
@@ -315,20 +319,37 @@ import {
 } from "./file-tree.ts";
 import { spans, spanHit, spansFromRight, type Span } from "./spans.ts";
 import {
+  AGAIN_ID,
   CUSTOM_KIND_ID,
   INTERRUPT_TAP_GAP_MS,
   RESTART_GRACE_MS,
-  agentKindItems,
+  TEAM_ACTIONS,
+  TEAM_NEW_ID,
   clearAuthorityArgs,
+  compatiblePlacement,
+  customRecentIndex,
+  defaultSpawnPlacement,
   interruptArgs,
+  labelPaneArgs,
+  labelWindowArgs,
+  lastSpawnName,
   launchCommandFor,
+  newAgentItems,
   paneHostsShell,
-  placementItems,
+  placementActions,
+  placementLabel,
   relaunchArgs,
+  resolvePlacement,
   respawnArgs,
   spawnAgentArgs,
+  spawnLabelFor,
   spawnSessionArgs,
+  stampLaunchArgs,
+  teamAgentIndex,
+  teamItems,
+  type LastSpawn,
   type SpawnPlacement,
+  type SpawnWhere,
 } from "./agent-lifecycle.ts";
 import { getManifests } from "../detect/manifest-loader.ts";
 import { agentsByPane, chipLabel } from "./agent-chip.ts";
@@ -478,7 +499,11 @@ type HoverRegion =
   | "homechip"
   | "homeagentchip"
   | "welcomeopen"
-  | "sidebtn";
+  | "sidebtn"
+  // M24.1: the AGENTS header row (click → Team dialog) and its right-aligned
+  // [+ agent] chip (index 0 = header row, 1 = the empty-state row's twin).
+  | "agentshdr"
+  | "agentschip";
 
 /** The one pointer-event shape the central `route` reads. `button` distinguishes
  *  left (0) / right (2) presses; `stopPropagation` (present on the real OpenTUI
@@ -674,6 +699,12 @@ render(
     // every folder open, persisted with the rest of the app state. Home renders
     // them under a "recent" header (deduped against sessions + the registry).
     const [recentFolders, setRecentFolders] = createSignal<string[]>(persisted.recentFolders);
+    // The "again" spawn memory + custom-command recents (M24.1) — restored from
+    // app-state, updated on every spawn, persisted with the rest.
+    const [lastSpawns, setLastSpawns] = createSignal<Record<string, LastSpawn>>(
+      persisted.lastSpawns,
+    );
+    const [customCommands, setCustomCommands] = createSignal<string[]>(persisted.customCommands);
     // The first-run tip line — the user's ACTUAL keybindings, read once at launch
     // (loadAppConfig honors TMUX_IDE_CONFIG). Cheap + pure, computed once.
     const welcomeTip = firstRunTip(loadAppConfig().keys);
@@ -1512,19 +1543,28 @@ render(
     };
 
     /** The pane's `pane_start_command` (its ROOT: "" = default shell) +
-     *  `pane_current_path`, or null when the pane is gone. One async display
-     *  call (tab-joined). NOT pane_current_command — that is the FOREGROUND
-     *  process, so a user-typed `claude` under zsh would read as `claude` too
-     *  and be indistinguishable from a pane-command agent (measured). */
+     *  `pane_current_path` + our `@agent_launch` stamp (M24.1 — the exact argv
+     *  our spawn verb ran, the preferred relaunch source), or null when the
+     *  pane is gone. One async display call (tab-joined; the stamp rides LAST
+     *  and re-joins, so a command containing tabs survives). NOT
+     *  pane_current_command — that is the FOREGROUND process, so a user-typed
+     *  `claude` under zsh would read as `claude` too and be indistinguishable
+     *  from a pane-command agent (measured). */
     const paneStartAndPath = (paneId: string) =>
-      new Promise<{ start: string; path: string } | null>((resolve) =>
+      new Promise<{ start: string; path: string; launch: string } | null>((resolve) =>
         execFile(
           "tmux",
-          ["display", "-p", "-t", paneId, "#{pane_start_command}\t#{pane_current_path}"],
+          [
+            "display",
+            "-p",
+            "-t",
+            paneId,
+            "#{pane_start_command}\t#{pane_current_path}\t#{@agent_launch}",
+          ],
           (err, stdout) => {
             if (err) return resolve(null);
-            const [start = "", path = ""] = stdout.trimEnd().split("\t");
-            resolve({ start, path });
+            const [start = "", path = "", ...rest] = stdout.trimEnd().split("\t");
+            resolve({ start, path, launch: rest.join("\t") });
           },
         ),
       );
@@ -1537,13 +1577,15 @@ render(
      *  authority stamps. */
     const restartAgentFlow = async (a: Pick<AgentRowInput, "paneId" | "kind">) => {
       const manifests = getManifests();
-      const command = launchCommandFor(a.kind, manifests);
       const live = await paneStartAndPath(a.paneId);
       if (!live) {
         setStatusNote("that pane is gone — refreshing");
         setTimeout(() => fleetRefresh?.(), 300);
         return;
       }
+      // The @agent_launch stamp (our own spawn's exact argv — flags included)
+      // beats the kind's generic launch command when present (M24.1).
+      const command = live.launch || launchCommandFor(a.kind, manifests);
       const underShell = paneHostsShell(live.start, manifests);
       const ok = await DialogConfirm.show({
         title: `Restart ${a.kind}?`,
@@ -1578,11 +1620,16 @@ render(
       setStatusNote(`closed ${a.kind}'s pane`);
     };
 
-    /** The spawn flow: WHAT runs (manifest kinds + a custom command) → WHERE
-     *  (splits only when a concrete pane exists) → run it. Without a live
-     *  session (a home project row) the agent gets a fresh detached session in
-     *  the project dir. Detection needs no extra wiring: the spawned pane's
-     *  command IS the agent, so the next fleet poll classifies it. */
+    // ── THE SPAWN FLOW (M24.1 — one dialog, defaults everywhere) ─────────────
+    // The flow never ASKS what it can default: ONE kind picker whose Enter
+    // spawns at the context's default placement (split right of a focused
+    // pane / a new window in the session / a fresh session for project rows);
+    // placement ALTERNATIVES are footer ctrl-actions, never a second dialog.
+    // The picker's TOP row repeats the last spawn remembered for this context
+    // (per project/session-dir, app-state), custom commands keep a global
+    // recents list, and DialogPrompt only ever appears for a brand-new custom
+    // command. Detection needs no extra wiring: the spawned pane's command IS
+    // the agent, so the next fleet poll classifies it.
     interface NewAgentContext {
       session?: string;
       dir: string | null;
@@ -1590,17 +1637,106 @@ render(
       /** Names the fresh session when there is no live one (project rows). */
       sessionName?: string;
     }
+    /** The context's shape for the pure placement decisions. */
+    const spawnShape = (ctx: NewAgentContext) => ({
+      pane: ctx.paneId !== undefined,
+      session: ctx.session !== undefined,
+    });
+    /** The context's "again"-memory key + remembered spawn (null when none). */
+    const spawnMemoryFor = (
+      ctx: NewAgentContext,
+    ): { key: string | null; last: LastSpawn | null } => {
+      const key = spawnMemoryKey(ctx.dir, ctx.session ?? ctx.sessionName);
+      return { key, last: key ? (lastSpawns()[key] ?? null) : null };
+    };
+    /** ASYNC — a pane's `#{pane_current_path}`, or null when unreadable. */
+    const paneCurrentPath = (paneId: string) =>
+      new Promise<string | null>((resolve) =>
+        execFile("tmux", ["display", "-p", "-t", paneId, "#{pane_current_path}"], (err, stdout) =>
+          resolve(err ? null : stdout.trim() || null),
+        ),
+      );
+    /** Run ONE spawn: resolve the cwd policy (Terminal-surface spawns inherit
+     *  the FOCUSED pane's cwd under `app.newAgentCwd: "pane"`, the default),
+     *  build the argv (`-P -F` returns the new pane id), then — in the same
+     *  breath — auto-label the pane/window after the agent and stamp
+     *  `@agent_launch` with the exact command, and remember the spawn for the
+     *  again row / palette action / custom recents. */
+    const runSpawn = async (
+      ctx: NewAgentContext,
+      choice: { kind: string; command: string; placement: SpawnWhere },
+    ) => {
+      const { kind, command, placement } = choice;
+      let dir = ctx.dir;
+      if (ctx.paneId && loadAppConfig().app.newAgentCwd === "pane") {
+        dir = (await paneCurrentPath(ctx.paneId)) ?? ctx.dir;
+      }
+      const label = spawnLabelFor(kind, command);
+      // Remember FIRST (fire-and-forget spawn callbacks shouldn't gate it):
+      // the again memory is keyed per project/session-dir, custom argv joins
+      // the global recents.
+      const { key } = spawnMemoryFor(ctx);
+      if (key) setLastSpawns((m) => rememberSpawn(m, key, { kind, command, placement }));
+      if (kind === CUSTOM_KIND_ID) setCustomCommands((l) => addCustomCommand(l, command));
+      /** Post-spawn follow-ups against the printed pane id: title the pane
+       *  (or its window), stamp the launch argv. Best-effort, async. */
+      const decorate = (stdout: string) => {
+        const paneId = stdout.trim();
+        if (!paneId.startsWith("%")) return;
+        const labelArgs =
+          placement === "window" ? labelWindowArgs(paneId, label) : labelPaneArgs(paneId, label);
+        execFile("tmux", labelArgs, () => {});
+        execFile("tmux", stampLaunchArgs(paneId, command), () => {});
+      };
+      if (placement === "session" || !ctx.session) {
+        const base = ctx.sessionName ?? basename(ctx.dir ?? invokeCwd);
+        const name = sessionNameFor(base || "agents");
+        execFile("tmux", spawnSessionArgs(name, dir, command), (err, stdout) => {
+          setStatusNote(err ? `couldn't start ${command}` : `started ${command} in ${name}`);
+          if (!err) {
+            execFile("tmux", ["set-environment", "-t", name, "TMUX_IDE", "1"], () => {});
+            decorate(stdout);
+          }
+          setTimeout(() => fleetRefresh?.(), 300);
+        });
+        return;
+      }
+      const target = { session: ctx.session, paneId: ctx.paneId };
+      const args = spawnAgentArgs(placement as SpawnPlacement, target, dir, command);
+      execFile("tmux", args, (err, stdout) => {
+        setStatusNote(err ? `couldn't start ${command}` : `started ${command} in ${ctx.session}`);
+        if (!err) decorate(stdout);
+        setTimeout(() => fleetRefresh?.(), 300);
+      });
+    };
     const newAgentFlow = async (ctx: NewAgentContext) => {
       setHoverIf(null); // the overlay owns the pointer, like the palette
       const manifests = getManifests();
-      const kind = await DialogSelect.show({
-        title: "New agent — what should run?",
-        items: agentKindItems(manifests),
-        footerHint: "pick an agent, or type your own command",
+      const shape = spawnShape(ctx);
+      const fallback = defaultSpawnPlacement(shape);
+      const { last } = spawnMemoryFor(ctx);
+      // The again row replays its remembered placement where the context still
+      // allows it (a remembered split needs a focused pane); else the default.
+      const againPlacement =
+        last && compatiblePlacement(last.placement, shape) ? last.placement : fallback;
+      const res = await DialogSelect.show({
+        title: "New agent",
+        items: newAgentItems({ manifests, last, againPlacement, customRecents: customCommands() }),
+        actions: placementActions(shape),
+        footerHint: `enter: ${placementLabel(fallback)}`,
       });
-      if (!kind) return;
+      if (!res) return;
+      let kind: string;
       let command: string;
-      if (kind.item.id === CUSTOM_KIND_ID) {
+      const recentIdx = customRecentIndex(res.item.id);
+      if (res.item.id === AGAIN_ID && last) {
+        kind = last.kind;
+        command = last.command;
+      } else if (recentIdx !== null) {
+        kind = CUSTOM_KIND_ID;
+        command = customCommands()[recentIdx] ?? "";
+        if (!command) return;
+      } else if (res.item.id === CUSTOM_KIND_ID) {
         const typed = await DialogPrompt.show({
           title: "Custom command",
           placeholder: "my-agent --flag",
@@ -1608,32 +1744,32 @@ render(
           validate: (v) => (v.trim().length > 0 ? null : "Type a command, or press esc to go back"),
         });
         if (typed === null) return;
+        kind = CUSTOM_KIND_ID;
         command = typed.trim();
       } else {
-        command = launchCommandFor(kind.item.id, manifests);
+        kind = res.item.id;
+        command = launchCommandFor(res.item.id, manifests);
       }
-      if (!ctx.session) {
-        const base = ctx.sessionName ?? basename(ctx.dir ?? invokeCwd);
-        const name = sessionNameFor(base || "agents");
-        execFile("tmux", spawnSessionArgs(name, ctx.dir, command), (err) => {
-          setStatusNote(err ? `couldn't start ${command}` : `started ${command} in ${name}`);
-          if (!err) execFile("tmux", ["set-environment", "-t", name, "TMUX_IDE", "1"], () => {});
-          setTimeout(() => fleetRefresh?.(), 300);
-        });
+      // WHERE: Enter keeps the default (the again row: its remembered
+      // placement); a footer ctrl-action (^w / ^d) overrides.
+      const base = res.item.id === AGAIN_ID ? againPlacement : fallback;
+      await runSpawn(ctx, { kind, command, placement: resolvePlacement(base, res.action) });
+    };
+    /** Repeat the current context's remembered spawn DIRECTLY — the palette's
+     *  "New agent: <kind> (again)" action (no dialog). Falls through to the
+     *  full flow when nothing is remembered (shouldn't happen — the action is
+     *  only offered with memory). */
+    const newAgentAgain = (ctx: NewAgentContext) => {
+      const { last } = spawnMemoryFor(ctx);
+      if (!last) {
+        void newAgentFlow(ctx);
         return;
       }
-      const where = await DialogSelect.show({
-        title: "Where should it run?",
-        items: placementItems({ split: ctx.paneId !== undefined }),
-        filterable: false,
-      });
-      if (!where) return;
-      const placement = where.item.id as SpawnPlacement;
-      const target = { session: ctx.session, paneId: ctx.paneId };
-      execFile("tmux", spawnAgentArgs(placement, target, ctx.dir, command), (err) => {
-        setStatusNote(err ? `couldn't start ${command}` : `started ${command} in ${ctx.session}`);
-        setTimeout(() => fleetRefresh?.(), 300);
-      });
+      const shape = spawnShape(ctx);
+      const placement = compatiblePlacement(last.placement, shape)
+        ? last.placement
+        : defaultSpawnPlacement(shape);
+      void runSpawn(ctx, { kind: last.kind, command: last.command, placement });
     };
 
     /** "New agent…" for a home row (the [+ agent] chip, the `a` key, the home
@@ -1641,10 +1777,66 @@ render(
      *  recent row into a fresh session in its dir; with nothing useful selected
      *  fall back to the working directory. */
     const newAgentFromHome = (it: HomeItem | undefined) => {
-      if (it?.kind === "session") void newAgentFlow({ session: it.session, dir: it.dir });
-      else if (it?.kind === "project") void newAgentFlow({ dir: it.dir, sessionName: it.name });
-      else if (it?.kind === "recent") void newAgentFlow({ dir: it.dir });
-      else void newAgentFlow({ dir: invokeCwd });
+      void newAgentFlow(homeAgentContext(it));
+    };
+    /** The spawn context a home row implies (shared by the row chips and the
+     *  contextual resolver below). */
+    const homeAgentContext = (it: HomeItem | undefined): NewAgentContext => {
+      if (it?.kind === "session") return { session: it.session, dir: it.dir };
+      if (it?.kind === "project") return { dir: it.dir, sessionName: it.name };
+      if (it?.kind === "recent") return { dir: it.dir };
+      return { dir: invokeCwd };
+    };
+    /** THE contextual spawn target — one resolver shared by the palette's
+     *  new-agent actions, the sidebar's [+ agent] chip, and the Team dialog:
+     *  the Terminal surface spawns beside its focused pane, home uses the
+     *  selected row, anywhere else the workspace session, else a fresh one. */
+    const currentNewAgentContext = (): NewAgentContext => {
+      if (mode() === "mirror") {
+        // The mirrored session's OWN dir first: contextDir can be a stale
+        // persisted workspace when the app booted straight to --target.
+        return {
+          session: curTarget(),
+          dir: dirForSession(curTarget()) ?? (contextDir() || null),
+          paneId: mirror?.focusedPane() ?? undefined,
+        };
+      }
+      if (mode() === "home") return homeAgentContext(selectedHomeItem());
+      if (contextSession()) return { session: contextSession(), dir: contextDir() || null };
+      return { dir: workspaceDir() };
+    };
+    /** What the current context's remembered spawn is called, or null — drives
+     *  the palette's pinned "New agent: <name> (again)" action. */
+    const currentAgainName = (): string | null => {
+      const { last } = spawnMemoryFor(currentNewAgentContext());
+      return last ? lastSpawnName(last) : null;
+    };
+
+    /** The TEAM dialog (M24.1): every fleet agent in one surface — Enter/click
+     *  JUMPS to the agent, ^r restarts, ^s stops (both confirm via their own
+     *  flows), and a pinned "+ new agent" row opens the one-dialog kind picker.
+     *  Opened from the sidebar's agents-header click and the palette's
+     *  "Manage team…". */
+    const manageTeamFlow = async () => {
+      setHoverIf(null); // the overlay owns the pointer, like the palette
+      const agents = fleetAgents();
+      const res = await DialogSelect.show({
+        title: `Team — ${agents.length} agent${agents.length === 1 ? "" : "s"}`,
+        items: teamItems(agents, Math.floor(Date.now() / 1000)),
+        actions: TEAM_ACTIONS,
+        footerHint: "enter jumps",
+      });
+      if (!res) return;
+      if (res.item.id === TEAM_NEW_ID) {
+        void newAgentFlow(currentNewAgentContext());
+        return;
+      }
+      const idx = teamAgentIndex(res.item.id);
+      const a = idx !== null ? agents[idx] : undefined;
+      if (!a) return;
+      if (res.action === "r") void restartAgentFlow(a);
+      else if (res.action === "s") void stopAgentFlow(a);
+      else jumpToAgent(a);
     };
 
     // ── OPEN A FOLDER (M22.5) — the non-technicals' front door ───────────────
@@ -1887,6 +2079,9 @@ render(
           agents: fleetAgents(),
           sizeMismatch: windowMismatch() !== null,
           appMousePane: panes().find((p) => p.active)?.appMouse === true,
+          // Pins "New agent: <name> (again)" FIRST when this context has spawn
+          // memory (M24.1) — F5 → Enter repeats the last spawn.
+          againName: currentAgainName(),
         },
       ),
     );
@@ -1934,24 +2129,18 @@ render(
           jumpToAgent(a);
           break;
         case "new-agent":
-          // Contextual target: the Terminal surface spawns into the mirrored
-          // session (splits offered — a focused pane exists); home uses the
-          // selected row; anywhere else the workspace session, else a fresh one.
-          if (mode() === "mirror") {
-            // The mirrored session's OWN dir first: contextDir can be a stale
-            // persisted workspace when the app booted straight to --target.
-            void newAgentFlow({
-              session: curTarget(),
-              dir: dirForSession(curTarget()) ?? (contextDir() || null),
-              paneId: mirror?.focusedPane() ?? undefined,
-            });
-          } else if (mode() === "home") {
-            newAgentFromHome(selectedHomeItem());
-          } else if (contextSession()) {
-            void newAgentFlow({ session: contextSession(), dir: contextDir() || null });
-          } else {
-            void newAgentFlow({ dir: workspaceDir() });
-          }
+          // Contextual target (currentNewAgentContext): the Terminal surface
+          // spawns beside its focused pane; home uses the selected row;
+          // anywhere else the workspace session, else a fresh one.
+          void newAgentFlow(currentNewAgentContext());
+          break;
+        case "new-agent-again":
+          // Repeat the remembered spawn directly — no dialog (M24.1: the
+          // pinned action makes F5 → Enter the whole repeat gesture).
+          newAgentAgain(currentNewAgentContext());
+          break;
+        case "manage-team":
+          void manageTeamFlow();
           break;
         case "restart-agent":
           void restartAgentFlow({ paneId: a.paneId, kind: a.agentKind });
@@ -2407,6 +2596,8 @@ render(
         diffFile: diffFiles()[diffSel()]?.path ?? null,
         sidebarW: sidebarW(),
         recentFolders: recentFolders(),
+        lastSpawns: lastSpawns(),
+        customCommands: customCommands(),
       };
       if (saveTimer) clearTimeout(saveTimer);
       saveTimer = setTimeout(() => void saveAppState(snapshot), 400);
@@ -3875,6 +4066,10 @@ render(
       );
       return i >= 0 ? defs[i]!.id : null;
     };
+    /** The `[+ agent]` chip's x-span on the sidebar's AGENTS header row and the
+     *  empty-state row (M24.1) — right-anchored flush to the sidebar's edge; the
+     *  render (label · flexGrow spacer · chip) lays out the same cells. */
+    const agentsChipSpans = createMemo(() => spansFromRight([AGENTS_ADD_CHIP], sidebarW(), 0));
     /** A home row's muted meta text — sessions keep the exact `3w · project`
      *  string the panel always showed; projects show their dir + origin. */
     const homeRowMeta = (it: HomeItem): string =>
@@ -3913,7 +4108,19 @@ render(
         const hit = sidebarHit(gy, fleet().length, fleetAgents().length);
         if (hit?.kind === "session") setHoverIf({ region: "sidebar", index: hit.index });
         else if (hit?.kind === "agent") setHoverIf({ region: "sidebaragent", index: hit.index });
-        else setHoverIf(null);
+        else if (hit?.kind === "agents-header") {
+          // The [+ agent] chip lifts on its own; the rest of the header row
+          // tints as the Team-dialog target (M24.1).
+          setHoverIf(
+            spanHit(agentsChipSpans(), x) === 0
+              ? { region: "agentschip", index: 0 }
+              : { region: "agentshdr", index: 0 },
+          );
+        } else if (hit?.kind === "agents-empty") {
+          setHoverIf(
+            spanHit(agentsChipSpans(), x) === 0 ? { region: "agentschip", index: 1 } : null,
+          );
+        } else setHoverIf(null);
         return;
       }
       const m = mode();
@@ -4299,7 +4506,9 @@ render(
           return;
         }
         // Session rows switch the workspace; agent rows JUMP to their exact pane
-        // (M22.2). The agents-header row and the empty-state line are inert.
+        // (M22.2). The agents-header row opens the TEAM dialog — its [+ agent]
+        // chip (also on the empty-state row) spawns via the one-dialog kind
+        // picker (M24.1).
         const hit = sidebarHit(gy, fleet().length, fleetAgents().length);
         if (hit?.kind === "session") {
           const s = fleet()[hit.index];
@@ -4307,6 +4516,11 @@ render(
         } else if (hit?.kind === "agent") {
           const a = fleetAgents()[hit.index];
           if (a) jumpToAgent(a);
+        } else if (hit?.kind === "agents-header") {
+          if (spanHit(agentsChipSpans(), x) === 0) void newAgentFlow(currentNewAgentContext());
+          else void manageTeamFlow();
+        } else if (hit?.kind === "agents-empty") {
+          if (spanHit(agentsChipSpans(), x) === 0) void newAgentFlow(currentNewAgentContext());
         }
         return;
       }
@@ -4681,12 +4895,42 @@ render(
               starts right after the session <For>, one header row then the agent
               rows (or one quiet empty-state line). Hover reveals the state age. */}
             <box flexDirection="column" marginTop={AGENTS_GAP_ROWS}>
-              <text fg={MUTED} attributes={1}>
-                {agentsHeaderLabel(fleetAgents().length, sidebarW() - 2)}
-              </text>
+              {/* Header row (M24.1): label + a right-aligned [+ agent] chip.
+                The row body opens the TEAM dialog, the chip spawns; the router
+                x-tests `agentsChipSpans` — the flexGrow spacer here lays the
+                chip on exactly those cells. The empty state keeps a chip twin
+                so spawning is discoverable before any agent runs. */}
+              <box
+                flexDirection="row"
+                backgroundColor={isHovered("agentshdr", 0) ? HOVER_BG : SIDEBAR_BG}
+              >
+                <text fg={MUTED} attributes={1}>
+                  {agentsHeaderLabel(
+                    fleetAgents().length,
+                    Math.max(1, sidebarW() - AGENTS_ADD_CHIP.length - 2),
+                  )}
+                </text>
+                <box flexGrow={1} />
+                <text fg={MUTED} bg={isHovered("agentschip", 0) ? BUTTON_HOVER_BG : SIDEBAR_BG}>
+                  {AGENTS_ADD_CHIP}
+                </text>
+              </box>
               <Show
                 when={fleetAgents().length > 0}
-                fallback={<text fg={MUTED}>{AGENTS_EMPTY_LINE.slice(0, sidebarW() - 2)}</text>}
+                fallback={
+                  <box flexDirection="row">
+                    <text fg={MUTED}>
+                      {AGENTS_EMPTY_LINE.slice(
+                        0,
+                        Math.max(1, sidebarW() - AGENTS_ADD_CHIP.length - 2),
+                      )}
+                    </text>
+                    <box flexGrow={1} />
+                    <text fg={MUTED} bg={isHovered("agentschip", 1) ? BUTTON_HOVER_BG : SIDEBAR_BG}>
+                      {AGENTS_ADD_CHIP}
+                    </text>
+                  </box>
+                }
               >
                 <For each={fleetAgents()}>
                   {(a, i) => {

--- a/packages/daemon/src/tui/mirror/dialog-stack.test.ts
+++ b/packages/daemon/src/tui/mirror/dialog-stack.test.ts
@@ -107,6 +107,15 @@ describe("select behavior", () => {
     expect(stack.top()!.state.query).toBe("");
   });
 
+  it('the space key (OpenTUI name "space") types a real space into the filter (M24.1)', () => {
+    const stack = createDialogStack();
+    void stack.push({ kind: "select", title: "Pick", items });
+    dialogKey(stack, key("a"));
+    dialogKey(stack, key("space"));
+    dialogKey(stack, key("b"));
+    expect(stack.top()!.state.query).toBe("a b");
+  });
+
   it("a danger row arms to press-again-to-confirm; a second enter resolves; moving disarms", async () => {
     const danger: DialogSelectItem[] = [
       { id: "keep", label: "Keep" },
@@ -193,6 +202,15 @@ describe("prompt behavior", () => {
     stack.setBusy(true);
     dialogKey(stack, key("d"));
     expect(stack.top()!.state.input).toBe("abC");
+  });
+
+  it("types spaces (a custom command's flags depend on it — M24.1)", async () => {
+    const stack = createDialogStack();
+    const p = stack.push({ kind: "prompt", title: "Custom command" });
+    for (const n of ["m", "y", "space", "-", "x"]) dialogKey(stack, key(n));
+    expect(stack.top()!.state.input).toBe("my -x");
+    dialogKey(stack, key("return"));
+    await expect(p).resolves.toBe("my -x");
   });
 });
 

--- a/packages/daemon/src/tui/mirror/dialog-stack.ts
+++ b/packages/daemon/src/tui/mirror/dialog-stack.ts
@@ -279,6 +279,17 @@ export interface DialogKeyEvent {
   shift: boolean;
 }
 
+/** The typed character a key event contributes to a filter/prompt, or null.
+ *  OpenTUI names the space key `"space"` (not a 1-char name), so the bare
+ *  length-1 check silently DROPPED every space — a custom command with flags
+ *  could never be typed (measured live, M24.1). */
+function typedChar(evt: DialogKeyEvent): string | null {
+  if (evt.ctrl || evt.meta) return null;
+  if (evt.name === "space") return " ";
+  if (evt.name.length === 1) return evt.shift ? evt.name.toUpperCase() : evt.name;
+  return null;
+}
+
 /**
  * Feed one key to the stack's top dialog. Centralized ESCAPE lives here: it
  * pops exactly one level. The caller must treat EVERY key as consumed while
@@ -313,8 +324,9 @@ export function dialogKey(stack: DialogStack, evt: DialogKeyEvent): void {
       state.armed = null;
       return stack.touch();
     }
-    if (evt.name.length === 1 && !evt.ctrl && !evt.meta) {
-      state.query += evt.shift ? evt.name.toUpperCase() : evt.name;
+    const ch = typedChar(evt);
+    if (ch !== null) {
+      state.query += ch;
       state.sel = 0;
       state.top = 0;
       state.armed = null;
@@ -338,8 +350,9 @@ export function dialogKey(stack: DialogStack, evt: DialogKeyEvent): void {
       state.error = null;
       return stack.touch();
     }
-    if (evt.name.length === 1 && !evt.ctrl && !evt.meta) {
-      state.input += evt.shift ? evt.name.toUpperCase() : evt.name;
+    const ch = typedChar(evt);
+    if (ch !== null) {
+      state.input += ch;
       state.error = null;
       return stack.touch();
     }

--- a/packages/daemon/src/tui/mirror/palette.test.ts
+++ b/packages/daemon/src/tui/mirror/palette.test.ts
@@ -11,6 +11,7 @@ describe("staticPaletteActions", () => {
       "Switch tab: Diff",
       "Open folder…",
       "New agent…",
+      "Manage team…",
       "Attach session: alpha",
       "Attach session: beta",
       "Save file",
@@ -27,6 +28,28 @@ describe("staticPaletteActions", () => {
       "Settings: Reset to defaults",
       "Quit",
     ]);
+  });
+
+  it("pins 'New agent: <name> (again)' FIRST when the context has spawn memory (M24.1)", () => {
+    const actions = staticPaletteActions(["alpha"], { againName: "claude" });
+    expect(actions[0]).toMatchObject({
+      kind: "new-agent-again",
+      label: "New agent: claude (again)",
+    });
+    // Empty-query Enter therefore repeats the spawn: F5 → Enter (≤2 Enters).
+    expect(filterPaletteActions("", ["alpha"], { againName: "claude" })[0]!.kind).toBe(
+      "new-agent-again",
+    );
+    // …and the action ranks above "New agent…" by construction.
+    const labels = actions.map((a) => a.label);
+    expect(labels.indexOf("New agent: claude (again)")).toBeLessThan(labels.indexOf("New agent…"));
+    // Without memory it is absent entirely.
+    expect(staticPaletteActions([]).some((a) => a.kind === "new-agent-again")).toBe(false);
+  });
+
+  it("offers the team console on every surface (M24.1)", () => {
+    expect(staticPaletteActions([]).some((a) => a.kind === "manage-team")).toBe(true);
+    expect(filterPaletteActions("team", []).some((a) => a.kind === "manage-team")).toBe(true);
   });
 
   it("offers the open-folder command on every surface", () => {
@@ -98,7 +121,7 @@ describe("filterPaletteActions", () => {
   it("returns every static action for an empty query, no open-file entry", () => {
     const actions = filterPaletteActions("", ["alpha"]);
     expect(actions.some((a) => a.kind === "open-file")).toBe(false);
-    expect(actions).toHaveLength(19);
+    expect(actions).toHaveLength(20);
   });
 
   it("fuzzy-ranks matches and appends an open-file action for a plain word", () => {

--- a/packages/daemon/src/tui/mirror/palette.ts
+++ b/packages/daemon/src/tui/mirror/palette.ts
@@ -28,6 +28,10 @@ export type PaletteAction =
   // command from. Each fleet agent gets one restart + one stop row; "New
   // agent…" opens the spawn flow (kind → placement → run) on the dialog stack.
   | { kind: "new-agent"; label: string }
+  // Repeat the current context's remembered spawn directly — no dialog (M24.1).
+  | { kind: "new-agent-again"; label: string }
+  // The one-surface team console (M24.1): jump/restart/stop + "+ new agent".
+  | { kind: "manage-team"; label: string }
   | { kind: "restart-agent"; paneId: string; agentKind: string; session: string; label: string }
   | { kind: "stop-agent"; paneId: string; agentKind: string; session: string; label: string }
   | { kind: "open-file"; path: string; label: string }
@@ -76,6 +80,10 @@ export interface PaletteContext {
    *  "Select text in pane" offered (ordinary panes drag-select directly, so the
    *  action would be a no-op that clutters the list). */
   appMousePane?: boolean;
+  /** What the current context's remembered spawn is called (`claude`, a custom
+   *  argv, …) — when set, a direct "New agent: <name> (again)" action is PINNED
+   *  FIRST, so a repeat spawn is F5 → Enter (M24.1's ≤2-Enters bar). */
+  againName?: string | null;
 }
 
 const TAB_LABELS: { tab: Tab; label: string }[] = [
@@ -92,17 +100,24 @@ export function staticPaletteActions(
   sessions: string[],
   ctx: PaletteContext = {},
 ): PaletteAction[] {
-  const actions: PaletteAction[] = TAB_LABELS.map((t) => ({
-    kind: "tab" as const,
-    tab: t.tab,
-    label: t.label,
-  }));
+  const actions: PaletteAction[] = [];
+  // The repeat spawn (M24.1) — FIRST, above everything: with memory for the
+  // current context, an empty-query Enter repeats the last spawn, making
+  // F5 → Enter the whole gesture (the card's ≤2-Enters acceptance bar).
+  if (ctx.againName) {
+    actions.push({ kind: "new-agent-again", label: `New agent: ${ctx.againName} (again)` });
+  }
+  for (const t of TAB_LABELS) actions.push({ kind: "tab", tab: t.tab, label: t.label });
   // The non-technicals' front door (M22.5): a filesystem picker → create-or-
   // attach a session in the chosen folder. Offered on every surface.
   actions.push({ kind: "open-folder", label: "Open folder…" });
-  // Spawn an agent (M23.1) — offered on every surface; the flow's placement
-  // step is what's contextual (splits only where a focused pane exists).
+  // Spawn an agent (M23.1/M24.1) — offered on every surface; ONE dialog whose
+  // default placement is contextual (split beside a focused pane, else a new
+  // window in the session, else a fresh session).
   actions.push({ kind: "new-agent", label: "New agent…" });
+  // The team console (M24.1): every fleet agent in one dialog — jump, restart,
+  // stop, spawn. The sidebar agents-header click's keyboard twin.
+  actions.push({ kind: "manage-team", label: "Manage team…" });
   for (const s of sessions) {
     actions.push({ kind: "attach", session: s, label: `Attach session: ${s}` });
   }


### PR DESCRIPTION
Card #102 + addendum: placement dialog removed (contextual defaults + footer actions), per-project again-memory (repeat = 1 Enter), pane-cwd inheritance, auto-labels, @agent_launch stamps feeding restart + a verified resume table (codex/opencode/cursor/copilot), the sidebar [+ agent] button, the Manage-team dialog, and a load-bearing dialog space-key fix. Merged with M24.2 (app-config union). 1222 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)