### PR TITLE
feat: palette v2 (⌘K), diff v2 (verbs), files v2 (signal) + slash unhijack (M24.4–6)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3214,7 +3214,8 @@ function parseAppConfig(input) {
       frontDoor: pickBool(app.frontDoor, D.app.frontDoor),
       detachable: pickBool(app.detachable, D.app.detachable),
       dragSelect: pickChoice(app.dragSelect, ["agents", "always", "never"], D.app.dragSelect),
-      newAgentCwd: pickChoice(app.newAgentCwd, ["pane", "session"], D.app.newAgentCwd)
+      newAgentCwd: pickChoice(app.newAgentCwd, ["pane", "session"], D.app.newAgentCwd),
+      kittyKeys: pickBool(app.kittyKeys, D.app.kittyKeys)
     }
   };
 }
@@ -3309,7 +3310,13 @@ var init_app_config = __esm({
       welcome: { show: true },
       integrations: { offer: true },
       worktrees: { dir: "" },
-      app: { frontDoor: false, detachable: false, dragSelect: "agents", newAgentCwd: "pane" }
+      app: {
+        frontDoor: false,
+        detachable: false,
+        dragSelect: "agents",
+        newAgentCwd: "pane",
+        kittyKeys: true
+      }
     };
     DEFAULT_THEME = DEFAULT_APP_CONFIG.theme;
     DEFAULT_KEYS = DEFAULT_APP_CONFIG.keys;

--- a/packages/daemon/src/lib/app-config.test.ts
+++ b/packages/daemon/src/lib/app-config.test.ts
@@ -210,6 +210,14 @@ describe("parseAppConfig — mistyped fields fall back to default", () => {
     expect(parseAppConfig({ app: { newAgentCwd: "window" } }).app.newAgentCwd).toBe("pane");
     expect(parseAppConfig({ app: { newAgentCwd: true } }).app.newAgentCwd).toBe("pane");
   });
+
+  it("app.kittyKeys — defaults ON, accepts an explicit opt-out, coerces junk (M24.4)", () => {
+    expect(DEFAULT_APP_CONFIG.app.kittyKeys).toBe(true);
+    expect(parseAppConfig(undefined).app.kittyKeys).toBe(true);
+    expect(parseAppConfig({ app: { kittyKeys: false } }).app.kittyKeys).toBe(false);
+    expect(parseAppConfig({ app: { kittyKeys: "off" } }).app.kittyKeys).toBe(true);
+    expect(parseAppConfig({ app: "nope" }).app.kittyKeys).toBe(true);
+  });
 });
 
 describe("loadAppConfig / getAppConfig / TMUX_IDE_CONFIG", () => {

--- a/packages/daemon/src/lib/app-config.ts
+++ b/packages/daemon/src/lib/app-config.ts
@@ -170,6 +170,15 @@ export interface AppApp {
    * always use the session/project dir (no focused pane exists there).
    */
   newAgentCwd: NewAgentCwd;
+  /**
+   * Whether the unified app enables the kitty keyboard protocol on its host
+   * terminal (M24.4). On (default), kitty-capable terminals deliver ⌘-modified
+   * keys — ⌘K opens the command palette — and disambiguated escapes; the app
+   * re-encodes every key for the mirrored panes either way, and terminals
+   * without the protocol ignore the request entirely. Off restores the legacy
+   * key encoding for hosts where the protocol misbehaves.
+   */
+  kittyKeys: boolean;
 }
 
 /** The two Terminal-spawn cwd policies (see {@link AppApp.newAgentCwd}). */
@@ -233,7 +242,13 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   welcome: { show: true },
   integrations: { offer: true },
   worktrees: { dir: "" },
-  app: { frontDoor: false, detachable: false, dragSelect: "agents", newAgentCwd: "pane" },
+  app: {
+    frontDoor: false,
+    detachable: false,
+    dragSelect: "agents",
+    newAgentCwd: "pane",
+    kittyKeys: true,
+  },
 };
 
 /** The default theme tokens — the fallback threaded into the pure builders. */
@@ -344,6 +359,7 @@ export function parseAppConfig(input: unknown): AppConfig {
       detachable: pickBool(app.detachable, D.app.detachable),
       dragSelect: pickChoice(app.dragSelect, ["agents", "always", "never"], D.app.dragSelect),
       newAgentCwd: pickChoice(app.newAgentCwd, ["pane", "session"], D.app.newAgentCwd),
+      kittyKeys: pickBool(app.kittyKeys, D.app.kittyKeys),
     },
   };
 }

--- a/packages/daemon/src/tui/mirror/app-state.test.ts
+++ b/packages/daemon/src/tui/mirror/app-state.test.ts
@@ -45,6 +45,8 @@ describe("parseAppState", () => {
         "session:web": { kind: "custom-command", command: "my-agent --x", placement: "window" },
       },
       customCommands: ["my-agent --x", "other --y"],
+      filesShowHidden: true,
+      filesShowIgnored: false,
     };
     expect(parseAppState(serializeAppState(state))).toEqual(state);
   });
@@ -68,6 +70,8 @@ describe("parseAppState", () => {
       recentFolders: [],
       lastSpawns: {},
       customCommands: [],
+      filesShowHidden: false,
+      filesShowIgnored: false,
     });
   });
 
@@ -84,6 +88,8 @@ describe("parseAppState", () => {
       recentFolders: [],
       lastSpawns: {},
       customCommands: [],
+      filesShowHidden: false,
+      filesShowIgnored: false,
     });
   });
 
@@ -152,6 +158,8 @@ describe("serializeAppState", () => {
         recentFolders: [],
         lastSpawns: {},
         customCommands: [],
+        filesShowHidden: false,
+        filesShowIgnored: false,
         // @ts-expect-error — runtime extra keys must not leak into the file
         junk: "x",
       }),
@@ -160,6 +168,8 @@ describe("serializeAppState", () => {
       "contextSession",
       "customCommands",
       "diffFile",
+      "filesShowHidden",
+      "filesShowIgnored",
       "lastSpawns",
       "lastTab",
       "openFile",
@@ -254,5 +264,19 @@ describe("appStateHome / appStatePath", () => {
 
   it("defaults under the user home when unset", () => {
     expect(appStatePath().endsWith("/.tmux-ide/app-state.json")).toBe(true);
+  });
+});
+
+describe("files toggles (M24.6)", () => {
+  it("default hidden, parse tolerates absence/mistypes, round-trips", () => {
+    expect(parseAppState("{}").filesShowHidden).toBe(false);
+    expect(parseAppState("{}").filesShowIgnored).toBe(false);
+    expect(parseAppState('{"filesShowHidden":"yes"}').filesShowHidden).toBe(false);
+    const s = parseAppState('{"filesShowHidden":true,"filesShowIgnored":true}');
+    expect(s.filesShowHidden).toBe(true);
+    expect(s.filesShowIgnored).toBe(true);
+    const round = parseAppState(serializeAppState(s));
+    expect(round.filesShowHidden).toBe(true);
+    expect(round.filesShowIgnored).toBe(true);
   });
 });

--- a/packages/daemon/src/tui/mirror/app-state.test.ts
+++ b/packages/daemon/src/tui/mirror/app-state.test.ts
@@ -2,11 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   CUSTOM_COMMANDS_CAP,
   DEFAULT_APP_STATE,
+  PALETTE_USAGE_CAP,
   RECENTS_CAP,
   SIDEBAR_W_DEFAULT,
   SPAWN_MEMORY_CAP,
   addCustomCommand,
   addRecentFolder,
+  recordPaletteUse,
   appStateHome,
   appStatePath,
   clampSidebarWidth,
@@ -45,6 +47,10 @@ describe("parseAppState", () => {
         "session:web": { kind: "custom-command", command: "my-agent --x", placement: "window" },
       },
       customCommands: ["my-agent --x", "other --y"],
+      paletteUsage: {
+        save: { count: 3, lastUsed: 1700000100 },
+        "attach:web": { count: 1, lastUsed: 1700000200 },
+      },
     };
     expect(parseAppState(serializeAppState(state))).toEqual(state);
   });
@@ -68,6 +74,7 @@ describe("parseAppState", () => {
       recentFolders: [],
       lastSpawns: {},
       customCommands: [],
+      paletteUsage: {},
     });
   });
 
@@ -84,6 +91,7 @@ describe("parseAppState", () => {
       recentFolders: [],
       lastSpawns: {},
       customCommands: [],
+      paletteUsage: {},
     });
   });
 
@@ -152,6 +160,7 @@ describe("serializeAppState", () => {
         recentFolders: [],
         lastSpawns: {},
         customCommands: [],
+        paletteUsage: {},
         // @ts-expect-error — runtime extra keys must not leak into the file
         junk: "x",
       }),
@@ -163,6 +172,7 @@ describe("serializeAppState", () => {
       "lastSpawns",
       "lastTab",
       "openFile",
+      "paletteUsage",
       "recentFolders",
       "sidebarW",
     ]);
@@ -233,6 +243,57 @@ describe("addRecentFolder", () => {
 
   it("ignores a blank path", () => {
     expect(addRecentFolder(["/a"], "")).toEqual(["/a"]);
+  });
+});
+
+describe("recordPaletteUse (M24.4)", () => {
+  it("bumps count, stamps lastUsed, and moves the key to newest", () => {
+    const m0 = recordPaletteUse({}, "save", 100);
+    expect(m0).toEqual({ save: { count: 1, lastUsed: 100 } });
+    const m1 = recordPaletteUse(m0, "quit", 200);
+    const m2 = recordPaletteUse(m1, "save", 300);
+    expect(m2.save).toEqual({ count: 2, lastUsed: 300 });
+    // re-use re-inserts LAST — the LRU order JSON round-trips
+    expect(Object.keys(m2)).toEqual(["quit", "save"]);
+  });
+
+  it("caps at the limit, dropping the least-recently-used", () => {
+    let m: Record<string, { count: number; lastUsed: number }> = {};
+    for (let i = 0; i < PALETTE_USAGE_CAP + 3; i++) m = recordPaletteUse(m, `k${i}`, i);
+    expect(Object.keys(m)).toHaveLength(PALETTE_USAGE_CAP);
+    expect(m.k0).toBeUndefined();
+    expect(m.k2).toBeUndefined();
+    expect(m.k3).toBeDefined();
+  });
+
+  it("ignores a blank key and never mutates the input", () => {
+    const orig = { save: { count: 1, lastUsed: 1 } };
+    expect(recordPaletteUse(orig, "", 9)).toEqual(orig);
+    const next = recordPaletteUse(orig, "save", 9);
+    expect(orig.save.count).toBe(1);
+    expect(next.save.count).toBe(2);
+  });
+});
+
+describe("paletteUsage sanitization", () => {
+  it("drops malformed entries and non-object values on parse", () => {
+    const parsed = parseAppState(
+      JSON.stringify({
+        paletteUsage: {
+          good: { count: 2, lastUsed: 123 },
+          floats: { count: 2.9, lastUsed: 456.2 },
+          negative: { count: 0, lastUsed: 1 },
+          mistyped: { count: "3", lastUsed: 1 },
+          missing: { count: 1 },
+          notObject: 7,
+        },
+      }),
+    );
+    expect(parsed.paletteUsage).toEqual({
+      good: { count: 2, lastUsed: 123 },
+      floats: { count: 2, lastUsed: 456 },
+    });
+    expect(parseAppState(JSON.stringify({ paletteUsage: [1] })).paletteUsage).toEqual({});
   });
 });
 

--- a/packages/daemon/src/tui/mirror/app-state.ts
+++ b/packages/daemon/src/tui/mirror/app-state.ts
@@ -77,6 +77,10 @@ export interface AppState {
   /** Recent CUSTOM spawn commands (M24.1), most-recent first, deduped, global
    *  (not per-project), capped at {@link CUSTOM_COMMANDS_CAP}. */
   customCommands: string[];
+  /** Files surface (M24.6): show dotfiles (H toggle). Default hidden. */
+  filesShowHidden: boolean;
+  /** Files surface (M24.6): show gitignored entries (I toggle). Default hidden. */
+  filesShowIgnored: boolean;
 }
 
 export const DEFAULT_APP_STATE: AppState = {
@@ -88,6 +92,8 @@ export const DEFAULT_APP_STATE: AppState = {
   recentFolders: [],
   lastSpawns: {},
   customCommands: [],
+  filesShowHidden: false,
+  filesShowIgnored: false,
 };
 
 /** PURE — the "again" memory key for a spawn context: the concrete dir when
@@ -228,6 +234,8 @@ export function parseAppState(raw: string): AppState {
     recentFolders: sanitizeRecents(obj.recentFolders),
     lastSpawns: sanitizeSpawns(obj.lastSpawns),
     customCommands: sanitizeStringList(obj.customCommands, CUSTOM_COMMANDS_CAP),
+    filesShowHidden: obj.filesShowHidden === true,
+    filesShowIgnored: obj.filesShowIgnored === true,
   };
 }
 
@@ -243,6 +251,8 @@ export function serializeAppState(state: AppState): string {
     recentFolders: sanitizeRecents(state.recentFolders),
     lastSpawns: sanitizeSpawns(state.lastSpawns),
     customCommands: sanitizeStringList(state.customCommands, CUSTOM_COMMANDS_CAP),
+    filesShowHidden: state.filesShowHidden === true,
+    filesShowIgnored: state.filesShowIgnored === true,
   };
   return JSON.stringify(clean, null, 2);
 }

--- a/packages/daemon/src/tui/mirror/app-state.ts
+++ b/packages/daemon/src/tui/mirror/app-state.ts
@@ -55,6 +55,19 @@ export const SPAWN_MEMORY_CAP = 20;
 /** How many custom spawn commands the recents list keeps (M24.1, global). */
 export const CUSTOM_COMMANDS_CAP = 5;
 
+/** How many palette actions the usage history remembers (M24.4). LRU by
+ *  last use — the map is insertion-ordered oldest-first, like lastSpawns. */
+export const PALETTE_USAGE_CAP = 50;
+
+/** One palette action's usage record (M24.4): how often it ran and when last.
+ *  Keyed by the STABLE action key ({@link ./palette.ts}'s paletteActionKey) so
+ *  a relabeled action keeps its history. */
+export interface PaletteUsageEntry {
+  count: number;
+  /** Epoch seconds of the most recent run. */
+  lastUsed: number;
+}
+
 /** The persisted shape. `null` means "nothing remembered" for that slot. */
 export interface AppState {
   /** The tab the app was showing when it last saved. */
@@ -77,6 +90,10 @@ export interface AppState {
   /** Recent CUSTOM spawn commands (M24.1), most-recent first, deduped, global
    *  (not per-project), capped at {@link CUSTOM_COMMANDS_CAP}. */
   customCommands: string[];
+  /** Palette usage history (M24.4): stable action key → {count, lastUsed}.
+   *  Insertion-ordered LRU (oldest first) capped at {@link PALETTE_USAGE_CAP};
+   *  drives the empty-query "recent" group and the ranking tie-break. */
+  paletteUsage: Record<string, PaletteUsageEntry>;
 }
 
 export const DEFAULT_APP_STATE: AppState = {
@@ -88,6 +105,7 @@ export const DEFAULT_APP_STATE: AppState = {
   recentFolders: [],
   lastSpawns: {},
   customCommands: [],
+  paletteUsage: {},
 };
 
 /** PURE — the "again" memory key for a spawn context: the concrete dir when
@@ -116,6 +134,46 @@ export function rememberSpawn(
   out[key] = spawn;
   const keys = Object.keys(out);
   for (let i = 0; i < keys.length - cap; i++) delete out[keys[i]!];
+  return out;
+}
+
+/**
+ * PURE — the palette-usage map after running the action keyed `key` at
+ * `nowSec`: count bumps, lastUsed updates, and the key moves to newest
+ * (re-inserted last — the rememberSpawn LRU idiom, so JSON round-trips keep the
+ * eviction order). Past `cap`, the OLDEST-used entries drop. Blank keys no-op.
+ */
+export function recordPaletteUse(
+  map: Readonly<Record<string, PaletteUsageEntry>>,
+  key: string,
+  nowSec: number,
+  cap: number = PALETTE_USAGE_CAP,
+): Record<string, PaletteUsageEntry> {
+  if (key.length === 0) return { ...map };
+  const out: Record<string, PaletteUsageEntry> = {};
+  for (const [k, v] of Object.entries(map)) if (k !== key) out[k] = v;
+  out[key] = { count: (map[key]?.count ?? 0) + 1, lastUsed: nowSec };
+  const keys = Object.keys(out);
+  for (let i = 0; i < keys.length - cap; i++) delete out[keys[i]!];
+  return out;
+}
+
+/** PURE — a persisted palette-usage value coerced clean: non-object → {},
+ *  entries with a mistyped/non-finite count or lastUsed drop, order kept,
+ *  capped from the OLD end (like sanitizeSpawns). */
+function sanitizePaletteUsage(v: unknown): Record<string, PaletteUsageEntry> {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return {};
+  const out: Record<string, PaletteUsageEntry> = {};
+  for (const [key, raw] of Object.entries(v as Record<string, unknown>)) {
+    if (key.length === 0) continue;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const o = raw as Record<string, unknown>;
+    if (typeof o.count !== "number" || !Number.isFinite(o.count) || o.count < 1) continue;
+    if (typeof o.lastUsed !== "number" || !Number.isFinite(o.lastUsed)) continue;
+    out[key] = { count: Math.floor(o.count), lastUsed: Math.floor(o.lastUsed) };
+  }
+  const keys = Object.keys(out);
+  for (let i = 0; i < keys.length - PALETTE_USAGE_CAP; i++) delete out[keys[i]!];
   return out;
 }
 
@@ -228,6 +286,7 @@ export function parseAppState(raw: string): AppState {
     recentFolders: sanitizeRecents(obj.recentFolders),
     lastSpawns: sanitizeSpawns(obj.lastSpawns),
     customCommands: sanitizeStringList(obj.customCommands, CUSTOM_COMMANDS_CAP),
+    paletteUsage: sanitizePaletteUsage(obj.paletteUsage),
   };
 }
 
@@ -243,6 +302,7 @@ export function serializeAppState(state: AppState): string {
     recentFolders: sanitizeRecents(state.recentFolders),
     lastSpawns: sanitizeSpawns(state.lastSpawns),
     customCommands: sanitizeStringList(state.customCommands, CUSTOM_COMMANDS_CAP),
+    paletteUsage: sanitizePaletteUsage(state.paletteUsage),
   };
   return JSON.stringify(clean, null, 2);
 }

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -55,6 +55,21 @@
  * openFile, diffFile } — persists to `~/.tmux-ide/app-state.json`
  * (TMUX_IDE_HOME override), debounced, restored on launch.
  *
+ * PALETTE V2 (M24.4): the overlay renders ROWS (palette.ts's PaletteRow) —
+ * an empty query groups "recent" (persisted usage in app-state's paletteUsage,
+ * keyed by paletteActionKey so relabels keep history) · "suggested" (surface
+ * verbs; BLOCKED agents' jumps first) · "commands"; a typed query is one flat
+ * list ranked by the label-start-weighted fuzzy score with a frequency/recency
+ * tie-break. Headers are inert rows: keyboard (stepPaletteRow) and the router
+ * both skip them. Action rows right-align their app keycap (settings-model's
+ * PALETTE_KEYCAPS — the keybind viewer's single source). ⌘K is a third opener
+ * beside F5/^p, delivered ONLY under the kitty keyboard protocol: the renderer
+ * requests it (useKittyKeyboard, app.kittyKeys config, default on), the stdin
+ * parser maps CSI-u keys to the SAME names as legacy so pane re-encoding is
+ * untouched, and ALL super-modified keys are consumed at the top of the key
+ * handler (never typed into a query/prompt/editor, never forwarded — pane
+ * forwarding of modifier-rich keys is card #83's scope).
+ *
  * SETTINGS (M22.4): no settings screen — every setting is a palette COMMAND
  * ("Settings…" is the categorized umbrella) executed via three DIALOG
  * primitives on ONE global stack (dialog-stack.ts; pure model in
@@ -194,11 +209,13 @@ import {
   saveAppState,
   addRecentFolder,
   addCustomCommand,
+  recordPaletteUse,
   clampSidebarWidth,
   isTab,
   rememberSpawn,
   spawnMemoryKey,
   type AppState,
+  type PaletteUsageEntry,
   type Tab,
 } from "./app-state.ts";
 import {
@@ -227,13 +244,18 @@ import {
   type Size,
 } from "./size-truth.ts";
 import {
-  filterPaletteActions,
+  paletteRows,
+  paletteActionKey,
+  paletteRowText,
+  firstPaletteAction,
+  stepPaletteRow,
   parseBufferList,
   palettePos,
   paletteRowAt,
   paletteContains,
   clampPaletteTop,
   type PaletteAction,
+  type PaletteRow,
   type PaletteGeom,
   type TmuxBuffer,
 } from "./palette.ts";
@@ -288,6 +310,7 @@ import {
   validateQuietTime,
   validateSnapshotEvery,
   validateTickMs,
+  PALETTE_KEYCAPS,
   type NotificationToggleId,
   type SettingsCommandId,
 } from "./settings-model.ts";
@@ -611,7 +634,23 @@ const HOME_CHIP_RECENT = "[▸ open] ";
 // The spawn verb's home entry (M23.1): session/project rows carry a second
 // chip left of the primary one; `a` is its keyboard twin.
 const HOME_CHIP_AGENT = "[+ agent] ";
-const TABBAR_PALETTE_LABEL = "F5 ⌘ palette ";
+// ── M24.4 kitty keyboard protocol ───────────────────────────────────────────
+// One config read at boot (the dragSelect discipline): when on, the renderer
+// requests kitty's disambiguated key encoding from the host terminal, which is
+// what delivers ⌘-modified keys at all — ⌘K opens the palette. Hosts without
+// the protocol ignore the request (legacy encoding, no behavior change);
+// `app.kittyKeys: false` opts out entirely. The ⌘K hint only shows while the
+// request is actually made.
+const KITTY_KEYS = loadAppConfig().app.kittyKeys;
+const TABBAR_PALETTE_LABEL = KITTY_KEYS ? "F5 ⌘K palette " : "F5 ⌘ palette ";
+// The palette rows' right-aligned keycaps (M24.4) — the settings keybind
+// viewer's enumeration, minus `quit` when HOSTED (^q detaches there; the
+// palette's Quit is the real exit, so the keycap would lie).
+const PALETTE_ROW_KEYCAPS: Readonly<Record<string, string>> = Object.fromEntries(
+  Object.entries(PALETTE_KEYCAPS).filter(
+    ([key]) => !(key === "quit" && process.env.TMUX_IDE_HOSTED === "1"),
+  ),
+);
 // ── M22.5 first-run welcome ─────────────────────────────────────────────────
 // A centered greeting shown only on a truly empty fleet (no sessions, no
 // registered projects). WELCOME_ROWS rows in the content area (gy 2…); the
@@ -720,6 +759,12 @@ render(
       persisted.lastSpawns,
     );
     const [customCommands, setCustomCommands] = createSignal<string[]>(persisted.customCommands);
+    // Palette usage history (M24.4) — restored from app-state, bumped on every
+    // dispatched palette action, persisted with the rest. Drives the empty-query
+    // "recent" group and the typed-query tie-break.
+    const [paletteUsage, setPaletteUsage] = createSignal<Record<string, PaletteUsageEntry>>(
+      persisted.paletteUsage,
+    );
     // The first-run tip line — the user's ACTUAL keybindings, read once at launch
     // (loadAppConfig honors TMUX_IDE_CONFIG). Cheap + pure, computed once.
     const welcomeTip = firstRunTip(loadAppConfig().keys);
@@ -2135,23 +2180,30 @@ render(
     // before). Reset wherever the list identity changes (query edits, level
     // swaps, reopen).
     const [paletteTop, setPaletteTop] = createSignal(0);
-    const paletteActions = createMemo(() =>
-      filterPaletteActions(
+    // ROWS, not bare actions (M24.4): an empty query opens grouped — "recent"
+    // (persisted usage), "suggested" (surface verbs; BLOCKED agents' jumps
+    // first), then "commands" — a typed query is one flat ranked list. Headers
+    // are real, non-selectable rows; the selection helpers below skip them.
+    const paletteRowList = createMemo(() =>
+      paletteRows(
         paletteQuery(),
         fleet().map((s) => s.name),
         {
           terminal: mode() === "mirror",
+          surface: tab(),
           agents: fleetAgents(),
           sizeMismatch: windowMismatch() !== null,
           appMousePane: panes().find((p) => p.active)?.appMouse === true,
           // Pins "New agent: <name> (again)" FIRST when this context has spawn
           // memory (M24.1) — F5 → Enter repeats the last spawn.
           againName: currentAgainName(),
+          usage: paletteUsage(),
+          keycaps: PALETTE_ROW_KEYCAPS,
         },
       ),
     );
-    /** The current palette LIST length — buffers level when open, else actions. */
-    const paletteCount = () => paletteBuffers()?.length ?? paletteActions().length;
+    /** The current palette LIST length — buffers level when open, else rows. */
+    const paletteCount = () => paletteBuffers()?.length ?? paletteRowList().length;
     /** The palette box geometry as placed by the render, for the router. */
     const paletteGeom = (): PaletteGeom => {
       const { left, top } = palettePos(dims().width, dims().height, PALETTE_W);
@@ -2164,13 +2216,20 @@ render(
     };
     const openPalette = () => {
       setPaletteQuery("");
-      setPaletteSel(0);
       setPaletteTop(0);
       setPaletteBuffers(null); // always open on the action list, never mid-picker
+      // The selection starts on the first ACTION row — under grouping that is
+      // the row after the "recent" header, keeping F5 → Enter one gesture.
+      setPaletteSel(Math.max(0, firstPaletteAction(paletteRowList())));
       setHoverIf(null); // the overlay owns the pointer; drop any underlying tint
       setPaletteOpen(true);
     };
     const runPaletteAction = (a: PaletteAction) => {
+      // Usage history (M24.4): every dispatched action bumps its stable key —
+      // count + lastUsed feed the "recent" group and the ranking tie-break.
+      setPaletteUsage((u) =>
+        recordPaletteUse(u, paletteActionKey(a), Math.floor(Date.now() / 1e3)),
+      );
       // "Paste buffer…" descends into the second-level picker instead of
       // dispatching — keep the palette open and load the buffer list.
       if (a.kind === "paste-buffer") {
@@ -2341,23 +2400,23 @@ render(
         }
         return;
       }
-      const actions = paletteActions();
+      const rows = paletteRowList();
       if (evt.name === "escape") {
         setPaletteOpen(false);
       } else if (evt.name === "return") {
-        const a = actions[Math.min(paletteSel(), actions.length - 1)];
-        if (a) runPaletteAction(a);
+        const r = rows[Math.min(paletteSel(), rows.length - 1)];
+        if (r?.type === "action") runPaletteAction(r.action);
       } else if (evt.name === "up") {
-        setPaletteSel((s) => Math.max(0, s - 1));
+        setPaletteSel((s) => stepPaletteRow(rows, s, -1));
       } else if (evt.name === "down") {
-        setPaletteSel((s) => Math.min(Math.max(0, actions.length - 1), s + 1));
+        setPaletteSel((s) => stepPaletteRow(rows, s, 1));
       } else if (evt.name === "backspace") {
         setPaletteQuery((q) => q.slice(0, -1));
-        setPaletteSel(0);
+        setPaletteSel(Math.max(0, firstPaletteAction(paletteRowList())));
         setPaletteTop(0);
       } else if (evt.name.length === 1 && !evt.ctrl && !evt.meta) {
         setPaletteQuery((q) => q + (evt.shift ? evt.name.toUpperCase() : evt.name));
-        setPaletteSel(0);
+        setPaletteSel(Math.max(0, firstPaletteAction(paletteRowList())));
         setPaletteTop(0);
       }
     };
@@ -2585,7 +2644,7 @@ render(
     const runKeybindViewer = async (): Promise<boolean> => {
       await DialogSelect.show({
         title: "Keyboard shortcuts",
-        items: keybindingItems(freshCfg().keys),
+        items: keybindingItems(freshCfg().keys, KITTY_KEYS),
         footerHint: "read-only — edit keys.* in ~/.tmux-ide/config.json",
       });
       return false; // viewing commits nothing; the umbrella reopens
@@ -2663,6 +2722,7 @@ render(
         recentFolders: recentFolders(),
         lastSpawns: lastSpawns(),
         customCommands: customCommands(),
+        paletteUsage: paletteUsage(),
       };
       if (saveTimer) clearTimeout(saveTimer);
       saveTimer = setTimeout(() => void saveAppState(snapshot), 400);
@@ -3698,6 +3758,25 @@ render(
         editBuffer?.destroy();
         process.exit(0);
       }
+      // SUPER-modified keys arrive only under the kitty keyboard protocol
+      // (M24.4). ⌘K opens the palette — suppressed while any overlay owns the
+      // keyboard (dialog/menu/palette/search), mirroring F5. Every OTHER super
+      // combo is consumed here: it must never type into a prompt/editor/query
+      // and never reach a pane (forwarding modifier-rich keys into panes is a
+      // separate card — #83).
+      if (evt.super) {
+        if (
+          evt.name === "k" &&
+          !evt.ctrl &&
+          dialogStack.depth() === 0 &&
+          !menu() &&
+          !paletteOpen() &&
+          !search()
+        ) {
+          openPalette();
+        }
+        return;
+      }
       // A DIALOG owns the keyboard while open (M22.4) — topmost overlay, so it
       // is checked before the menu and the palette. EVERY key is consumed here
       // (escape pops one stack level inside dialogKey): nothing may leak to the
@@ -3723,7 +3802,8 @@ render(
         searchKey(evt);
         return;
       }
-      // F5 (and ^p when it arrives) open the command palette.
+      // F5 (and ^p when it arrives) open the command palette; ⌘K is the kitty
+      // fast path handled above.
       if (evt.name === "f5" || (evt.ctrl && evt.name === "p")) {
         openPalette();
         return;
@@ -4409,7 +4489,14 @@ render(
         }
         if (type === "move" || type === "over" || type === "drag") {
           const ri = paletteRowAt(g, x, y);
-          if (ri >= 0) setPaletteSel(paletteTop() + ri);
+          // A header row is not selectable (M24.4) — motion over it keeps the
+          // selection where it was, like the box chrome.
+          if (ri >= 0) {
+            const abs = paletteTop() + ri;
+            if (paletteBuffers() !== null || paletteRowList()[abs]?.type === "action") {
+              setPaletteSel(abs);
+            }
+          }
           return;
         }
         if (type !== "down") return;
@@ -4417,14 +4504,17 @@ render(
         if (ri >= 0) {
           if (e.button === 2) return; // right press on a row: no-op, stay open
           const abs = paletteTop() + ri;
-          setPaletteSel(abs);
           const bufs = paletteBuffers();
           if (bufs !== null) {
+            setPaletteSel(abs);
             const b = bufs[abs];
             if (b) pasteBuffer(b.name);
           } else {
-            const a = paletteActions()[abs];
-            if (a) runPaletteAction(a);
+            const r = paletteRowList()[abs];
+            if (r?.type === "action") {
+              setPaletteSel(abs);
+              runPaletteAction(r.action);
+            } // a header click is a no-op — the palette stays open
           }
           return;
         }
@@ -5684,21 +5774,40 @@ render(
                     <text fg={DEFAULT_FG}>{`${paletteQuery()}▏`}</text>
                   </box>
                   <text fg={MUTED}>{"─".repeat(PALETTE_W - 4)}</text>
-                  <For each={paletteActions().slice(paletteTop(), paletteTop() + PALETTE_ROWS)}>
-                    {(a, i) => (
+                  {/* Rows (M24.4): group headers render as inert muted lines;
+                    action rows carry the selection prefix + a right-aligned
+                    keycap (paletteRowText keeps the keycap inside the width
+                    however long the label). Hit-testing stays row-level — the
+                    router skips headers by row type. */}
+                  <For each={paletteRowList().slice(paletteTop(), paletteTop() + PALETTE_ROWS)}>
+                    {(r, i) => (
                       <box
                         height={1}
                         backgroundColor={
-                          paletteTop() + i() === paletteSel() ? TAB_ACTIVE_BG : PALETTE_BG
+                          r.type === "action" && paletteTop() + i() === paletteSel()
+                            ? TAB_ACTIVE_BG
+                            : PALETTE_BG
                         }
                       >
-                        <text fg={paletteTop() + i() === paletteSel() ? DEFAULT_FG : MUTED}>
-                          {(paletteTop() + i() === paletteSel() ? "› " : "  ") + a.label}
-                        </text>
+                        <Show
+                          when={r.type === "action"}
+                          fallback={
+                            <text fg={MUTED}>{`— ${r.type === "header" ? r.label : ""}`}</text>
+                          }
+                        >
+                          <text fg={paletteTop() + i() === paletteSel() ? DEFAULT_FG : MUTED}>
+                            {(paletteTop() + i() === paletteSel() ? "› " : "  ") +
+                              paletteRowText(
+                                r.type === "action" ? r.action.label : "",
+                                r.type === "action" ? r.shortcut : null,
+                                PALETTE_W - 6,
+                              )}
+                          </text>
+                        </Show>
                       </box>
                     )}
                   </For>
-                  <Show when={paletteActions().length === 0}>
+                  <Show when={paletteRowList().length === 0}>
                     <text fg={MUTED}>{"  no matches"}</text>
                   </Show>
                 </>
@@ -5990,9 +6099,17 @@ render(
   // the canvas on any console.error (a runtime exception mid-render flashed it
   // during the M23.5 resize battery). Off in production; the mirror debug flag
   // keeps it for development, where it is genuinely useful.
+  // useKittyKeyboard (M24.4): `{}` requests the protocol with OpenTUI's
+  // defaults (disambiguate + alternateKeys; NO events/allKeysAsEscapes — no
+  // release events, printables still arrive as plain text). Kitty-capable
+  // hosts then deliver ⌘K (super+k) and CSI-u escapes the stdin parser maps to
+  // the SAME key names the legacy parser does, so the pane re-encode path
+  // (KEYMAP/sendKey/sendText) is unchanged; hosts without the protocol ignore
+  // the request. `app.kittyKeys: false` opts out.
   {
     targetFps: 60,
     maxFps: 60,
+    useKittyKeyboard: KITTY_KEYS ? {} : null,
     consoleMode: process.env.TMUX_IDE_MIRROR_DEBUG ? "console-overlay" : "disabled",
   },
 );

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -2240,6 +2240,11 @@ render(
       }
       setPaletteOpen(false);
       switch (a.kind) {
+        case "search-scrollback":
+          // The live-prompt entry to scrollback search — `/` only works while
+          // scrolled (it belongs to the pane's agent at the bottom).
+          openSearch();
+          break;
         case "tab":
           selectTab(a.tab);
           break;
@@ -3973,10 +3978,18 @@ render(
         setStatusNote("select mode off");
         return;
       }
-      // `/` opens scrollback search on the focused pane (copy-mode's finder). Only
-      // in Terminal mode (home/editor/diff returned above); a raw `/` still reaches
-      // the pane once search is open, since search then owns the keyboard.
-      if (evt.name === "/" && !evt.ctrl && !evt.meta) {
+      // `/` opens scrollback search ONLY when the focused pane is scrolled into
+      // history — at the live prompt `/` belongs to the PANE (agents' slash
+      // commands; user report 2026-07-11: "we cannot hijack that"). Scrolled up,
+      // you're reading, not talking, so `/` means find. At the live bottom the
+      // palette's "Search scrollback" action is the entry. Once search is open
+      // it owns the keyboard as before.
+      if (
+        evt.name === "/" &&
+        !evt.ctrl &&
+        !evt.meta &&
+        (scrollOffsets.get(mirror.focusedPane()) ?? 0) > 0
+      ) {
         openSearch();
         return;
       }

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -81,15 +81,26 @@
  * persisted tab; `--edit <file>` opens Files; `--diff <dir>` opens Diff. On home,
  * `o` opens a path prompt, `d` opens the Diff tab for the selected session's dir.
  *
- * DIFF (M18.3): a two-column panel — left is the changed-file list (status letter
- * + path, selected row highlighted), right is the unified diff of the selected
- * file (add/del/hunk/context colored). Git runs via ASYNC execFile ONLY (the
- * landmine: no sync execs near the render loop; the one exception is reading a
- * single untracked file to show it as additions). `git status --porcelain` +
- * `git diff --no-color -- <file>` refresh on a 3s timer while mode=diff and on
- * manual `r`. j/k move the file selection; the wheel scrolls the diff (or the
- * file list when over the left column); a left-column click selects a file; `^e`
- * opens the selected file in the EDITOR at its repo-relative path. Pure parsing +
+ * DIFF (M18.3; v2 M24.5): a two-column panel — left is the changed-file list
+ * GROUPED into Staged / Unstaged / Untracked sections (counted headers are
+ * non-selectable rows; an `MM` file appears in BOTH stage groups, each side
+ * diffing its own half of the index), right is the unified diff of the selected
+ * row (add/del/hunk/context colored, add/del lines carry background fills).
+ * Git runs via ASYNC execFile ONLY (the landmine: no sync execs near the render
+ * loop; the one exception is reading a single untracked file to show it as
+ * additions). `git status --porcelain` + both `--numstat`s (per-file ± counts,
+ * header totals) refresh on a 3s timer while mode=diff and on manual `r`.
+ * j/k move the file selection (headers skipped — the row/selection math is the
+ * shared buildDiffRows pass, the AGENTS_GAP_ROWS lesson); s/u stage/unstage the
+ * selected file and S/U everything (reversible, so no confirms — each verb
+ * notes what it did and follows the file into its new group); the footer verbs
+ * and a selected/hovered row's [s stage]/[u unstage] chip are their span-routed
+ * mouse twins; `/` filters the list live (escape clears — diff surface only,
+ * Terminal's `/` scrollback search is untouched); ]/[ jump the diff view
+ * between hunks; the wheel scrolls the diff (or the file list when over the
+ * left column); a left-column click selects a file row; `^e` opens the selected
+ * file in the EDITOR at the first changed line of the top-visible hunk (pure
+ * hunk math from the `@@ -a,b +c,d` header). Pure parsing + grouping +
  * classification live in diff-model.ts (unit-tested).
  *
  * EDITOR (M18.2): the editing ENGINE is a native `EditBuffer` (bun:ffi —
@@ -157,7 +168,7 @@ import {
   writeSync,
   closeSync,
 } from "node:fs";
-import { readdir, writeFile, rename, rm, stat } from "node:fs/promises";
+import { readdir, readFile, writeFile, rename, rm, stat } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { render, useKeyboard, usePaste, useTerminalDimensions } from "@opentui/solid";
@@ -182,11 +193,21 @@ import {
   type ReadOnlyReason,
 } from "./editor-buffer.ts";
 import {
-  parseStatusPorcelain,
   classifyDiff,
   untrackedDiffText,
   clampSel,
-  type StatusEntry,
+  parseStatusGroups,
+  filterEntries,
+  buildDiffRows,
+  rowIndexOfFile,
+  parseNumstat,
+  untrackedLineCount,
+  applyCounts,
+  totalCounts,
+  nextHunkTop,
+  hunkEditTarget,
+  type DiffEntry,
+  type DiffGroup,
   type DiffLineKind,
 } from "./diff-model.ts";
 import {
@@ -509,6 +530,9 @@ type HoverRegion =
   | "windowtab"
   | "files"
   | "diff"
+  // M24.5: the diff footer's clickable [s stage]/[u unstage]/[S all]/[U all]
+  // verb chips (index into DIFF_VERBS).
+  | "diffverb"
   | "button"
   | "tabbtn"
   | "homechip"
@@ -578,6 +602,27 @@ const STATUS_LETTER_FG: Record<string, RGBA> = {
   C: ACCENT,
   "?": MUTED,
 };
+// Add/del BACKGROUND fills layered UNDER the DIFF_FG classes (M24.5). Values
+// mirror the widget theme's diffAddedBg/diffRemovedBg (widgets/lib/theme.ts:27-34)
+// — that theme is the future token source once the app's const surface colors
+// move onto the theming pipeline.
+const DIFF_ADD_BG = RGBA.fromInts(20, 60, 30, 255);
+const DIFF_DEL_BG = RGBA.fromInts(60, 20, 20, 255);
+const DIFF_LINE_BG: Partial<Record<DiffLineKind, RGBA>> = { add: DIFF_ADD_BG, del: DIFF_DEL_BG };
+// The diff footer's clickable stage/unstage verbs (M24.5) — fixed labels so
+// the x-span math is constant. Laid out from the main column's first content
+// cell (sidebarW()+paddingLeft 1) with the render's gap={1}; the spans memo and
+// the footer render walk this SAME list, so a click lands where it's drawn.
+const DIFF_VERBS: { id: "stage" | "unstage" | "stage-all" | "unstage-all"; label: string }[] = [
+  { id: "stage", label: "[s stage]" },
+  { id: "unstage", label: "[u unstage]" },
+  { id: "stage-all", label: "[S all]" },
+  { id: "unstage-all", label: "[U all]" },
+];
+// A diff file row's right-anchored stage/unstage chip (shown on the selected
+// and hovered rows) — trailing space = a 1-cell inset from the list edge.
+const DIFF_ROW_CHIP_STAGE = "[s stage] ";
+const DIFF_ROW_CHIP_UNSTAGE = "[u unstage] ";
 const HEADER_ROWS = 2;
 // The persistent surface-tab row is one screen row at the very top (above the
 // sidebar + main region). Its height offsets every region's global y, so the
@@ -1138,7 +1183,7 @@ render(
       },
     );
 
-    const openEditor = (rawPath: string) => {
+    const openEditor = (rawPath: string, line?: number) => {
       const path = rawPath.startsWith("~/")
         ? `${process.env.HOME ?? ""}${rawPath.slice(1)}`
         : rawPath;
@@ -1156,11 +1201,20 @@ render(
       editBuffer = EditBuffer.create("wcwidth");
       editBuffer.setText(text);
       editBuffer.setCursor(0, 0);
+      // Jump target (M24.5: ^e from a diff hunk): clamp into the buffer, put
+      // the cursor there, and scroll it into view.
+      let top = 0;
+      if (line !== undefined) {
+        const lineCount = text.split("\n").length;
+        const target = Math.max(0, Math.min(line, lineCount - 1));
+        editBuffer.setCursor(target, 0);
+        top = scrollToCursor(target, 0, editorRows(), lineCount);
+      }
       if (mode() !== "editor") prevMode = mode() === "mirror" ? "mirror" : "home";
       setEditorPath(path);
       setEditorReadOnly(reason);
       setEditorModified(false);
-      setEditorTop(0);
+      setEditorTop(top);
       setEditorMsg("");
       setEditorRev((r) => r + 1);
       setFilesFocus("editor");
@@ -1235,27 +1289,48 @@ render(
       setEditorRev((r) => r + 1);
     };
 
-    // ── DIFF (M18.3) ────────────────────────────────────────────────────────
-    // The working-tree diff of `diffDir`, rendered natively. Git runs via async
-    // execFile (`runGit`); the only sync io is reading a single untracked file to
-    // show it as additions. `diffText` holds the raw diff for the selected file;
-    // `diffLoadToken` discards a slow diff whose selection has since moved on.
+    // ── DIFF (M18.3; grouped + stage-aware M24.5) ───────────────────────────
+    // The working-tree diff of `diffDir`, rendered natively as a GROUPED list
+    // (Staged / Unstaged / Untracked; an MM file appears in both stage groups,
+    // each side diffing its own half of the index). Git runs via async execFile
+    // (`runGit`); the only sync io is reading a single untracked file to show it
+    // as additions. `diffText` holds the raw diff for the selected file;
+    // `diffLoadToken` discards a slow diff whose selection has since moved on,
+    // `diffStatusToken` a stale status/numstat merge (same race discipline).
     const [diffDir, setDiffDir] = createSignal(values.diff ?? invokeCwd);
-    const [diffFiles, setDiffFiles] = createSignal<StatusEntry[]>([]);
+    const [diffEntries, setDiffEntries] = createSignal<DiffEntry[]>([]);
     const [diffSel, setDiffSel] = createSignal(0);
     const [diffText, setDiffText] = createSignal("");
     const [diffTop, setDiffTop] = createSignal(0); // diff-pane scroll (right)
-    const [diffFileTop, setDiffFileTop] = createSignal(0); // file-list scroll (left)
+    const [diffFileTop, setDiffFileTop] = createSignal(0); // file-list scroll (left, in ROWS)
     const [diffMsg, setDiffMsg] = createSignal("");
+    // The `/` filter over the grouped file list (diff surface only — Terminal's
+    // `/` scrollback search is a different mode branch). null = off; while
+    // non-null every printable key narrows live, escape/return clear + exit.
+    const [diffFilter, setDiffFilter] = createSignal<string | null>(null);
     let diffLoadToken = 0;
-    // A diff file to re-select once `git status` repopulates the list (restore).
+    let diffStatusToken = 0;
+    // A diff file to re-select once `git status` repopulates the list: the
+    // persisted path on restore, or a verb's follow target — path + preferred
+    // group, so a just-staged file is re-selected in its NEW section.
     let pendingDiffFile: string | null = persisted.diffFile;
+    let pendingDiffGroup: DiffGroup | null = null;
 
     // Body rows below header (1) + rule (1), above the footer (1) — shared by both
     // columns. The left column width is a capped fraction of the canvas.
     const diffBodyRows = () => Math.max(1, dims().height - 3 - TABBAR_H);
     const diffListW = () => Math.max(20, Math.min(48, Math.floor(canvasCols() * 0.34)));
     const diffLines = createMemo(() => classifyDiff(diffText()));
+    // Grouped rows (section headers + files) and the flat selectable-file order,
+    // both from ONE buildDiffRows pass over the filtered entries: the render,
+    // the mouse router, and the selection all walk the SAME rows, so the hit
+    // math cannot drift from what's drawn (the AGENTS_GAP_ROWS lesson).
+    const diffRowsData = createMemo(() =>
+      buildDiffRows(filterEntries(diffEntries(), diffFilter() ?? "")),
+    );
+    const diffRows = () => diffRowsData().rows;
+    const diffVisibleFiles = () => diffRowsData().files;
+    const diffTotals = createMemo(() => totalCounts(diffVisibleFiles()));
     const diffVisible = createMemo(() => {
       const lines = diffLines();
       const rows = diffBodyRows();
@@ -1263,10 +1338,10 @@ render(
       return lines.slice(top, top + rows);
     });
     const fileVisible = createMemo(() => {
-      const files = diffFiles();
-      const rows = diffBodyRows();
-      const top = clampTop(diffFileTop(), files.length, rows);
-      return files.slice(top, top + rows).map((entry, i) => ({ entry, index: top + i }));
+      const rows = diffRows();
+      const view = diffBodyRows();
+      const top = clampTop(diffFileTop(), rows.length, view);
+      return rows.slice(top, top + view).map((row, i) => ({ row, rowIndex: top + i }));
     });
 
     const runGit = (args: string[], cb: (out: string) => void) => {
@@ -1277,14 +1352,15 @@ render(
         (err, stdout) => cb(err ? "" : stdout),
       );
     };
+    const runGitP = (args: string[]) => new Promise<string>((resolve) => runGit(args, resolve));
 
-    /** Load the diff for one file: async `git diff` for tracked paths (falling
-     *  back to `--cached` when the change is staged-only), or the untracked file's
-     *  contents rendered as additions. Guarded by `diffLoadToken` against races. */
-    const loadDiff = (entry: StatusEntry) => {
+    /** Load the diff for one entry, by its GROUP: staged rows diff `--cached`,
+     *  unstaged rows the worktree, and an untracked file's contents render as
+     *  additions. Guarded by `diffLoadToken` against races. */
+    const loadDiff = (entry: DiffEntry) => {
       const token = ++diffLoadToken;
       setDiffMsg("");
-      if (entry.status === "?") {
+      if (entry.group === "untracked") {
         try {
           const bytes = readFileSync(join(diffDir(), entry.path));
           if (isBinary(bytes)) {
@@ -1299,57 +1375,180 @@ render(
         }
         return;
       }
-      runGit(["diff", "--no-color", "--", entry.path], (out) => {
+      const args =
+        entry.group === "staged"
+          ? ["diff", "--no-color", "--cached", "--", entry.path]
+          : ["diff", "--no-color", "--", entry.path];
+      runGit(args, (out) => {
         if (token !== diffLoadToken) return;
-        if (out.trim()) {
-          setDiffText((p) => (p === out ? p : out));
-          return;
-        }
-        runGit(["diff", "--no-color", "--cached", "--", entry.path], (cached) => {
-          if (token !== diffLoadToken) return;
-          setDiffText((p) => (p === cached ? p : cached));
-        });
+        setDiffText((p) => (p === out ? p : out));
       });
     };
 
-    /** Select file `i`: highlight it, reset the diff scroll, keep it in view in the
-     *  file list, and (re)load its diff. */
+    /** Select FILE `i` (an index into the flat selectable order — section
+     *  headers are not selectable): highlight it, reset the diff scroll, keep
+     *  its ROW in view in the file list, and (re)load its diff. */
     const selectDiffFile = (i: number) => {
-      const files = diffFiles();
+      const files = diffVisibleFiles();
       if (files.length === 0) return;
       const idx = clampSel(i, files.length);
       setDiffSel(idx);
       setDiffTop(0);
-      setDiffFileTop((t) => scrollToCursor(idx, t, diffBodyRows(), files.length));
+      const rows = diffRows();
+      const rowIdx = rowIndexOfFile(rows, idx);
+      if (rowIdx !== -1)
+        setDiffFileTop((t) => scrollToCursor(rowIdx, t, diffBodyRows(), rows.length));
       loadDiff(files[idx]!);
     };
     const moveDiffSel = (delta: number) => selectDiffFile(diffSel() + delta);
 
-    /** Re-run `git status --porcelain`, reconcile the selection, and reload the
-     *  selected file's diff (so an external edit is reflected). */
+    /** After a filter mutation: select the first match (reloading its diff), or
+     *  clear the diff pane when nothing matches. */
+    const diffFilterReselect = () => {
+      if (diffVisibleFiles().length === 0) {
+        setDiffSel(0);
+        setDiffText("");
+      } else {
+        selectDiffFile(0);
+      }
+    };
+
+    /** Re-run `git status --porcelain` + both `--numstat`s (and untracked line
+     *  counts via async reads), merge counts into the grouped entries, reconcile
+     *  the selection, and reload the selected file's diff (so an external edit
+     *  is reflected). Fully async; one race token guards the whole merge. */
     const refreshStatus = () => {
-      runGit(["status", "--porcelain"], (out) => {
-        const files = parseStatusPorcelain(out);
-        setDiffFiles(files);
+      const token = ++diffStatusToken;
+      const dir = diffDir();
+      void (async () => {
+        const [statusOut, unstagedOut, stagedOut] = await Promise.all([
+          runGitP(["status", "--porcelain"]),
+          runGitP(["diff", "--numstat"]),
+          runGitP(["diff", "--numstat", "--cached"]),
+        ]);
+        if (token !== diffStatusToken) return;
+        let entries = parseStatusGroups(statusOut);
+        // Untracked ± = the file's line count (binaries skipped; the reads are
+        // capped so a giant fresh tree can't fan out thousands of opens).
+        const untrackedCounts = new Map<string, number>();
+        await Promise.all(
+          entries
+            .filter((e) => e.group === "untracked")
+            .slice(0, 200)
+            .map(async (e) => {
+              try {
+                const bytes = await readFile(join(dir, e.path));
+                if (!isBinary(bytes))
+                  untrackedCounts.set(e.path, untrackedLineCount(bytes.toString("utf8")));
+              } catch {
+                /* unreadable: counts stay null */
+              }
+            }),
+        );
+        if (token !== diffStatusToken) return;
+        entries = applyCounts(
+          entries,
+          parseNumstat(stagedOut),
+          parseNumstat(unstagedOut),
+          untrackedCounts,
+        );
+        setDiffEntries(entries);
+        const files = diffVisibleFiles();
         if (files.length === 0) {
           setDiffText("");
           setDiffSel(0);
-          setDiffMsg("working tree clean");
+          if (entries.length === 0) setDiffMsg("working tree clean");
           return;
         }
-        // Restore: re-select the persisted diff file once it appears in the list.
+        // Re-select a followed file: a verb's target in its NEW group (a staged
+        // file moves to Staged), or the persisted path on restore.
         if (pendingDiffFile) {
-          const restored = files.findIndex((f) => f.path === pendingDiffFile);
+          const path = pendingDiffFile;
+          const group = pendingDiffGroup;
           pendingDiffFile = null;
-          if (restored !== -1) {
-            selectDiffFile(restored);
+          pendingDiffGroup = null;
+          const exact = group ? files.findIndex((f) => f.path === path && f.group === group) : -1;
+          const found = exact !== -1 ? exact : files.findIndex((f) => f.path === path);
+          if (found !== -1) {
+            selectDiffFile(found);
             return;
           }
         }
         const idx = clampSel(diffSel(), files.length);
         setDiffSel(idx);
         loadDiff(files[idx]!);
+      })();
+    };
+
+    // ── Stage/unstage verbs (M24.5) ─────────────────────────────────────────
+    // Reversible operations, so no confirms — each verb notes what it did,
+    // follows the file into its new group, and refreshes (git is the truth).
+    const stageEntry = (e: DiffEntry) => {
+      if (e.group === "staged") {
+        setStatusNote("already staged");
+        return;
+      }
+      runGit(["add", "--", e.path], () => {
+        pendingDiffFile = e.path;
+        pendingDiffGroup = "staged";
+        setStatusNote(`staged ${e.path}`);
+        refreshStatus();
       });
+    };
+    const unstageEntry = (e: DiffEntry) => {
+      if (e.group !== "staged") {
+        setStatusNote("not staged");
+        return;
+      }
+      runGit(["reset", "HEAD", "--", e.path], () => {
+        pendingDiffFile = e.path;
+        pendingDiffGroup = "unstaged";
+        setStatusNote(`unstaged ${e.path}`);
+        refreshStatus();
+      });
+    };
+    const toggleStageEntry = (e: DiffEntry) =>
+      e.group === "staged" ? unstageEntry(e) : stageEntry(e);
+    const stageAll = () => {
+      const cur = diffVisibleFiles()[diffSel()];
+      runGit(["add", "-A"], () => {
+        if (cur) {
+          pendingDiffFile = cur.path;
+          pendingDiffGroup = "staged";
+        }
+        setStatusNote("staged all changes");
+        refreshStatus();
+      });
+    };
+    const unstageAll = () => {
+      const cur = diffVisibleFiles()[diffSel()];
+      runGit(["reset", "HEAD"], () => {
+        if (cur) {
+          pendingDiffFile = cur.path;
+          pendingDiffGroup = cur.group === "staged" ? "unstaged" : cur.group;
+        }
+        setStatusNote("unstaged all");
+        refreshStatus();
+      });
+    };
+
+    /** `]`/`[` — jump the diff view to the next/previous hunk header. */
+    const jumpHunk = (dir: 1 | -1) => {
+      const lines = diffLines();
+      const cur = clampTop(diffTop(), lines.length, diffBodyRows());
+      const next = nextHunkTop(lines, cur, dir);
+      if (next !== null) setDiffTop(clampTop(next, lines.length, diffBodyRows()));
+    };
+
+    /** ^e from the diff panel: open the selected file in the editor AT the
+     *  first changed line of the selected (top-visible) hunk — pure math in
+     *  hunkEditTarget; diffs without hunks (binary/untracked) open at 0. */
+    const openSelectedInEditor = () => {
+      const entry = diffVisibleFiles()[diffSel()];
+      if (!entry) return;
+      const lines = diffLines();
+      const target = hunkEditTarget(lines, clampTop(diffTop(), lines.length, diffBodyRows()));
+      openEditor(join(diffDir(), entry.path), target ?? undefined);
     };
 
     /** Enter the diff panel for `dir` (from home `d`, the Diff tab, or `--diff`
@@ -1361,8 +1560,45 @@ render(
       setDiffFileTop(0);
       setDiffText("");
       setDiffMsg("");
+      setDiffFilter(null);
       setTab("diff");
       refreshStatus();
+    };
+
+    /** The diff footer's clickable verb chips — laid out from the main column's
+     *  first content cell, exactly matching the rendered `paddingLeft={1}
+     *  gap={1}` row (shared render↔router). */
+    const diffVerbSpans = createMemo(() =>
+      spans(
+        DIFF_VERBS.map((v) => v.label),
+        sidebarW() + 1,
+        1,
+      ),
+    );
+    const runDiffVerb = (id: (typeof DIFF_VERBS)[number]["id"]) => {
+      const cur = diffVisibleFiles()[diffSel()];
+      if (id === "stage-all") stageAll();
+      else if (id === "unstage-all") unstageAll();
+      else if (cur && id === "stage") stageEntry(cur);
+      else if (cur && id === "unstage") unstageEntry(cur);
+    };
+    /** A diff file row's right-anchored [s stage]/[u unstage] chip: label by
+     *  group, span pinned to the list column's right edge — the same
+     *  spansFromRight math the render's flexGrow spacer produces. */
+    const diffRowChipLabel = (e: DiffEntry) =>
+      e.group === "staged" ? DIFF_ROW_CHIP_UNSTAGE : DIFF_ROW_CHIP_STAGE;
+    const diffRowChipSpan = (e: DiffEntry): Span =>
+      spansFromRight([diffRowChipLabel(e)], sidebarW() + diffListW(), 0)[0]!;
+    /** Truncate a diff row's path (keeping the tail — the filename is the
+     *  signal) so status + ± counts + the chip (when shown) fit the column. */
+    const diffRowPath = (e: DiffEntry, chip: boolean): string => {
+      const addW = (e.additions ?? 0) > 0 ? `+${e.additions}`.length + 1 : 0;
+      const delW = (e.deletions ?? 0) > 0 ? `-${e.deletions}`.length + 1 : 0;
+      const budget = Math.max(
+        4,
+        diffListW() - 4 - addW - delW - (chip ? diffRowChipLabel(e).length + 1 : 0),
+      );
+      return e.path.length > budget ? "…" + e.path.slice(-(budget - 1)) : e.path;
     };
 
     let mirror: SessionMirror | null = null;
@@ -2109,7 +2345,7 @@ render(
     const selectTab = (t: Tab) => {
       clearSelection();
       if (t === "diff") {
-        if (diffFiles().length === 0) enterDiff(workspaceDir());
+        if (diffEntries().length === 0) enterDiff(workspaceDir());
         else setTab("diff");
         return;
       }
@@ -2658,7 +2894,7 @@ render(
         lastTab: tab(),
         contextSession: contextSession() || null,
         openFile: editorPath(),
-        diffFile: diffFiles()[diffSel()]?.path ?? null,
+        diffFile: diffVisibleFiles()[diffSel()]?.path ?? null,
         sidebarW: sidebarW(),
         recentFolders: recentFolders(),
         lastSpawns: lastSpawns(),
@@ -3307,15 +3543,15 @@ render(
         const overList = x < sidebarW() + diffListW();
         const contentY = gy - HEADER_ROWS;
         if (!overList || contentY < 0) return null;
-        const top = clampTop(diffFileTop(), diffFiles().length, diffBodyRows());
-        const idx = top + contentY;
-        const entry = diffFiles()[idx];
-        if (!entry) return null;
+        const rows = diffRows();
+        const top = clampTop(diffFileTop(), rows.length, diffBodyRows());
+        const row = rows[top + contentY];
+        if (!row || row.kind !== "file") return null;
         return {
           region: "difffile",
-          title: basename(entry.path),
+          title: basename(row.entry.path),
           items: MENU_ITEMS.difffile,
-          diffPath: join(diffDir(), entry.path),
+          diffPath: join(diffDir(), row.entry.path),
         };
       }
       // mirror: gy=0 is the target/status row (no menu); gy=1 is the WINDOW STRIP —
@@ -3735,16 +3971,13 @@ render(
         selectTab(fTab.key);
         return;
       }
-      // ^e — from the diff panel, open the SELECTED file in the editor at its
-      // repo-relative path; elsewhere toggle the editor against the previous mode
-      // (no-op until a file is opened via `o`/`--edit`).
+      // ^e — from the diff panel, open the SELECTED file in the editor at the
+      // first changed line of the top-visible hunk (M24.5); elsewhere toggle the
+      // editor against the previous mode (no-op until a file is opened via
+      // `o`/`--edit`).
       if (evt.ctrl && evt.name === "e") {
-        if (mode() === "diff") {
-          const entry = diffFiles()[diffSel()];
-          if (entry) openEditor(join(diffDir(), entry.path));
-        } else {
-          toggleEditor();
-        }
+        if (mode() === "diff") openSelectedInEditor();
+        else toggleEditor();
         return;
       }
       // ^g, not ^h: legacy encoding makes ctrl+h indistinguishable from
@@ -3799,10 +4032,40 @@ render(
         return;
       }
       if (mode() === "diff") {
-        // ^e / ^g / ^q are handled above; here j/k move the file selection and `r`
-        // forces a status+diff refresh.
+        // The `/` filter owns the keyboard while active (M24.5): printable keys
+        // narrow the grouped list live, escape/return clear + exit (widget
+        // semantics), arrows still move the (filtered) selection.
+        if (diffFilter() !== null) {
+          if (evt.name === "escape" || evt.name === "return") {
+            setDiffFilter(null);
+            diffFilterReselect();
+          } else if (evt.name === "backspace") {
+            setDiffFilter((q) => (q ?? "").slice(0, -1));
+            diffFilterReselect();
+          } else if (evt.name === "up") moveDiffSel(-1);
+          else if (evt.name === "down") moveDiffSel(1);
+          else if (evt.name.length === 1 && !evt.ctrl && !evt.meta) {
+            setDiffFilter((q) => (q ?? "") + (evt.shift ? evt.name.toUpperCase() : evt.name));
+            diffFilterReselect();
+          }
+          return;
+        }
+        // ^e / ^g / ^q are handled above; j/k move the file selection, s/u
+        // stage/unstage the selected file (S/U everything), ]/[ jump between
+        // hunks, `/` filters, and `r` forces a status+diff refresh.
         if (evt.name === "j" || evt.name === "down") moveDiffSel(1);
         else if (evt.name === "k" || evt.name === "up") moveDiffSel(-1);
+        else if (evt.name === "s" && evt.shift) stageAll();
+        else if (evt.name === "u" && evt.shift) unstageAll();
+        else if (evt.name === "s") {
+          const cur = diffVisibleFiles()[diffSel()];
+          if (cur) stageEntry(cur);
+        } else if (evt.name === "u") {
+          const cur = diffVisibleFiles()[diffSel()];
+          if (cur) unstageEntry(cur);
+        } else if (evt.name === "]") jumpHunk(1);
+        else if (evt.name === "[") jumpHunk(-1);
+        else if (evt.name === "/" && !evt.ctrl && !evt.meta) setDiffFilter("");
         else if (evt.name === "r") refreshStatus();
         return;
       }
@@ -4248,15 +4511,24 @@ render(
           setHoverIf(i >= 0 ? { region: "button", index: i } : null);
           return;
         }
+        // The footer's stage/unstage verb chips (last screen row).
+        if (y === dims().height - 1) {
+          const i = spanHit(diffVerbSpans(), x);
+          setHoverIf(i >= 0 ? { region: "diffverb", index: i } : null);
+          return;
+        }
         const contentY = gy - HEADER_ROWS;
         const overList = x < sidebarW() + diffListW();
         if (!overList || contentY < 0) {
           setHoverIf(null);
           return;
         }
-        const top = clampTop(diffFileTop(), diffFiles().length, diffBodyRows());
+        // Only FILE rows are hoverable (section headers are inert); the hover
+        // index is the ROW index, matching the render's slice.
+        const rows = diffRows();
+        const top = clampTop(diffFileTop(), rows.length, diffBodyRows());
         const idx = top + contentY;
-        setHoverIf(idx >= 0 && idx < diffFiles().length ? { region: "diff", index: idx } : null);
+        setHoverIf(rows[idx]?.kind === "file" ? { region: "diff", index: idx } : null);
         return;
       }
       // mirror mode: the per-window strip lives on gy=1, with the [+ split] button
@@ -4737,9 +5009,11 @@ render(
         setEditorRev((r) => r + 1);
         return;
       }
-      // DIFF mode: header (gy=0) + rule (gy=1), body from gy=2. Left column
-      // [0,listW) is the file list, the rest is the diff. Wheel scrolls whichever
-      // column the pointer is over; a left-column click selects that file row.
+      // DIFF mode: header (gy=0) + rule (gy=1), body from gy=2, footer verbs on
+      // the last screen row. Left column [0,listW) is the grouped file list, the
+      // rest is the diff. Wheel scrolls whichever column the pointer is over; a
+      // left-column click selects that file ROW (headers are inert), and the
+      // row's right-anchored [s stage]/[u unstage] chip wins over selection.
       if (mode() === "diff") {
         const overList = x < sidebarW() + diffListW();
         if (type === "scroll") {
@@ -4747,7 +5021,7 @@ render(
           if (dir !== "up" && dir !== "down") return;
           const step = dir === "up" ? -SCROLL_STEP : SCROLL_STEP;
           if (overList) {
-            setDiffFileTop((t) => clampTop(t + step, diffFiles().length, diffBodyRows()));
+            setDiffFileTop((t) => clampTop(t + step, diffRows().length, diffBodyRows()));
           } else {
             setDiffTop((t) => clampTop(t + step, diffLines().length, diffBodyRows()));
           }
@@ -4761,11 +5035,24 @@ render(
           if (i >= 0) runButton(hb.defs[i]!.id);
           return;
         }
+        // The footer's stage/unstage verb chips (same spans the render draws).
+        if (y === dims().height - 1) {
+          const i = spanHit(diffVerbSpans(), x);
+          if (i >= 0) runDiffVerb(DIFF_VERBS[i]!.id);
+          return;
+        }
         const contentY = gy - HEADER_ROWS;
         if (contentY < 0 || !overList) return;
-        const top = clampTop(diffFileTop(), diffFiles().length, diffBodyRows());
-        const idx = top + contentY;
-        if (idx >= 0 && idx < diffFiles().length) selectDiffFile(idx);
+        const rows = diffRows();
+        const top = clampTop(diffFileTop(), rows.length, diffBodyRows());
+        const row = rows[top + contentY];
+        if (!row || row.kind !== "file") return;
+        const chip = diffRowChipSpan(row.entry);
+        if (x >= chip.start && x < chip.start + chip.width) {
+          toggleStageEntry(row.entry);
+          return;
+        }
+        selectDiffFile(row.fileIndex);
         return;
       }
       // The per-window strip (gy=1) — resolved by the SAME x-span math the render
@@ -5586,14 +5873,25 @@ render(
               </box>
             </Show>
             <Show when={mode() === "diff"}>
-              {/* header (y=0) · rule (y=1) · two-column body (y=2+). `route` reverses
-              this geometry: left column = file list, right = diff. NO onMouse on
-              the rows — the main column container routes everything. */}
+              {/* header (y=0) · rule (y=1) · two-column body (y=2+) · footer
+              verbs (last row). `route` reverses this geometry: left column =
+              grouped file list (headers + rows from the SAME buildDiffRows the
+              router walks), right = diff. NO onMouse on the rows — the main
+              column container routes everything. */}
               <box paddingLeft={1} flexDirection="row" gap={1}>
                 <text fg={ACCENT} attributes={1}>
                   {basename(diffDir()) || "diff"}
                 </text>
-                <text fg={MUTED}>{`${diffFiles().length} changed`}</text>
+                <text fg={MUTED}>{`${diffVisibleFiles().length} files`}</text>
+                <Show when={diffTotals().additions > 0}>
+                  <text fg={DIFF_ADD_FG}>{`+${diffTotals().additions}`}</text>
+                </Show>
+                <Show when={diffTotals().deletions > 0}>
+                  <text fg={DIFF_DEL_FG}>{`-${diffTotals().deletions}`}</text>
+                </Show>
+                <Show when={diffFilter() !== null}>
+                  <text fg={ACCENT}>{`/${diffFilter()}▏`}</text>
+                </Show>
                 <Show when={diffMsg()}>
                   <text fg={MUTED}>{`· ${diffMsg()}`}</text>
                 </Show>
@@ -5601,50 +5899,89 @@ render(
               </box>
               <text fg={MUTED}>{"─".repeat(Math.max(4, canvasCols() - 2))}</text>
               <box flexDirection="row" flexGrow={1}>
-                {/* Left: changed-file list. */}
+                {/* Left: the grouped changed-file list (Staged / Unstaged /
+                  Untracked). Section headers are inert; file rows show ±
+                  counts and, when selected or hovered, a right-anchored
+                  stage/unstage chip the router hit-tests with the SAME
+                  spansFromRight math. */}
                 <box width={diffListW()} flexDirection="column" backgroundColor={GUTTER_BG}>
                   <For each={fileVisible()}>
-                    {(row) => (
-                      <box
-                        flexDirection="row"
-                        gap={1}
-                        paddingLeft={1}
-                        backgroundColor={
-                          row.index === diffSel()
-                            ? TAB_ACTIVE_BG
-                            : isHovered("diff", row.index)
-                              ? HOVER_BG
-                              : GUTTER_BG
-                        }
-                      >
-                        <text fg={STATUS_LETTER_FG[row.entry.status] ?? DEFAULT_FG}>
-                          {row.entry.status}
-                        </text>
-                        <text fg={row.index === diffSel() ? DEFAULT_FG : MUTED}>
-                          {row.entry.path.length > diffListW() - 4
-                            ? "…" + row.entry.path.slice(-(diffListW() - 5))
-                            : row.entry.path}
-                        </text>
-                      </box>
-                    )}
+                    {({ row, rowIndex }) =>
+                      row.kind === "header" ? (
+                        <box height={1} paddingLeft={1} backgroundColor={GUTTER_BG}>
+                          <text fg={ACCENT} attributes={1}>
+                            {row.label}
+                          </text>
+                        </box>
+                      ) : (
+                        <box
+                          height={1}
+                          flexDirection="row"
+                          gap={1}
+                          paddingLeft={1}
+                          backgroundColor={
+                            row.fileIndex === diffSel()
+                              ? TAB_ACTIVE_BG
+                              : isHovered("diff", rowIndex)
+                                ? HOVER_BG
+                                : GUTTER_BG
+                          }
+                        >
+                          <text fg={STATUS_LETTER_FG[row.entry.status] ?? DEFAULT_FG}>
+                            {row.entry.status}
+                          </text>
+                          <text fg={row.fileIndex === diffSel() ? DEFAULT_FG : MUTED}>
+                            {diffRowPath(
+                              row.entry,
+                              row.fileIndex === diffSel() || isHovered("diff", rowIndex),
+                            )}
+                          </text>
+                          <Show when={(row.entry.additions ?? 0) > 0}>
+                            <text fg={DIFF_ADD_FG}>{`+${row.entry.additions}`}</text>
+                          </Show>
+                          <Show when={(row.entry.deletions ?? 0) > 0}>
+                            <text fg={DIFF_DEL_FG}>{`-${row.entry.deletions}`}</text>
+                          </Show>
+                          <Show when={row.fileIndex === diffSel() || isHovered("diff", rowIndex)}>
+                            <box flexGrow={1} />
+                            <text fg={BUTTON_FG} bg={BUTTON_BG}>
+                              {diffRowChipLabel(row.entry)}
+                            </text>
+                          </Show>
+                        </box>
+                      )
+                    }
                   </For>
                 </box>
-                {/* Right: unified diff of the selected file, with a right-edge
-                  scrollbar overlaid on the last column. */}
+                {/* Right: unified diff of the selected file — add/del rows carry
+                  the widget-derived background fills under the fg classes — with
+                  a right-edge scrollbar overlaid on the last column. */}
                 <box position="relative" flexGrow={1} flexDirection="column" paddingLeft={1}>
                   {scrollbarOverlay(diffScrollGeom)}
                   <For each={diffVisible()}>
                     {(ln) => (
-                      <box height={1}>
+                      <box height={1} backgroundColor={DIFF_LINE_BG[ln.kind] ?? DEFAULT_BG}>
                         <text fg={DIFF_FG[ln.kind]}>{ln.text || " "}</text>
                       </box>
                     )}
                   </For>
                 </box>
               </box>
-              <box paddingLeft={1}>
+              {/* Footer: clickable stage/unstage verbs (the spans the router
+                hit-tests) followed by plain keyboard hints. */}
+              <box paddingLeft={1} flexDirection="row" gap={1}>
+                <For each={DIFF_VERBS}>
+                  {(v, i) => (
+                    <text
+                      fg={BUTTON_FG}
+                      bg={isHovered("diffverb", i()) ? BUTTON_HOVER_BG : BUTTON_BG}
+                    >
+                      {v.label}
+                    </text>
+                  )}
+                </For>
                 <text fg={MUTED}>
-                  {`j/k file · wheel scroll · ^e edit · r refresh · ^g home · ${QUIT_HINT}`}
+                  {`]/[ hunk · ^e edit · / filter · r refresh · ^g home · ${QUIT_HINT}`}
                 </text>
               </box>
             </Show>

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -157,7 +157,7 @@ import {
   writeSync,
   closeSync,
 } from "node:fs";
-import { readdir, writeFile, rename, rm, stat } from "node:fs/promises";
+import { readdir, readFile, writeFile, rename, rm, stat } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { render, useKeyboard, usePaste, useTerminalDimensions } from "@opentui/solid";
@@ -324,12 +324,24 @@ import {
   type SearchMatch,
 } from "./search-model.ts";
 import {
+  ALWAYS_IGNORE,
+  ancestorDirs,
   buildNodes,
+  changedFileWalk,
+  filterEntries,
+  filterView,
+  indexOfPath,
   insertChildrenAt,
+  nextChangedPath,
+  rebuildTree,
+  relPath,
   removeSubtreeAt,
+  statusMapFromEntries,
   type FileNode,
   type RawEntry,
 } from "./file-tree.ts";
+import ignore, { type Ignore } from "ignore";
+import { watchDirectory } from "../../widgets/lib/watcher.ts";
 import { spans, spanHit, spansFromRight, type Span } from "./spans.ts";
 import {
   AGAIN_ID,
@@ -1437,14 +1449,29 @@ render(
       setTab("home");
     };
 
-    // ── FILES TAB (M18.4) ────────────────────────────────────────────────────
-    // A minimal, one-level-expandable file list (left) beside the M18.2 editor
-    // (right), rooted at the workspace dir. `fs.readdir` is ALWAYS async (the
-    // render-loop landmine); the flat-tree splice/prune math is pure in
-    // file-tree.ts.
+    // ── FILES TAB (M18.4, uplifted M24.6) ────────────────────────────────────
+    // An expandable file list (left) beside the M18.2 editor (right), rooted at
+    // the workspace dir. `fs.readdir` and every git call are ALWAYS async (the
+    // render-loop landmine); ordering, ignore/hidden filtering, git-status
+    // decoration, the changed-file walk, the `/` filter view and the expansion-
+    // preserving rebuild are all pure in file-tree.ts. Ignore rules come from
+    // the workspace's .gitignore via the `ignore` package (matching is pure;
+    // only the file read is io). SELECTION indexes the VISIBLE (filtered) rows;
+    // expansion math maps back to the underlying flat list via FilteredRow.index.
     const [fileNodes, setFileNodes] = createSignal<FileNode[]>([]);
     const [fileSel, setFileSel] = createSignal(0);
     const [fileTop, setFileTop] = createSignal(0);
+    // The H / I visibility toggles — persisted in app-state (default: hidden).
+    const [showHiddenFiles, setShowHiddenFiles] = createSignal(persisted.filesShowHidden);
+    const [showIgnoredFiles, setShowIgnoredFiles] = createSignal(persisted.filesShowIgnored);
+    // Git decoration: porcelain entries for the workspace repo + its toplevel
+    // (status paths are REPO-relative — the workspace dir may sit deeper).
+    const [fileStatusEntries, setFileStatusEntries] = createSignal<StatusEntry[]>([]);
+    const [filesGitTop, setFilesGitTop] = createSignal<string | null>(null);
+    // The `/` filter: null = off, "" = filter mode just opened. The selection
+    // to restore when the filter is escaped lives beside it (not reactive).
+    const [filesQuery, setFilesQuery] = createSignal<string | null>(null);
+    let filesPreFilterPath: string | null = null;
     // Which half of the Files tab has the keyboard: the file LIST (j/k/enter) or
     // the EDITOR (typing). Opening a file hands focus to the editor; esc hands it
     // back to the list.
@@ -1452,59 +1479,277 @@ render(
     const filesListW = () => Math.max(20, Math.min(44, Math.floor(canvasCols() * 0.34)));
     /** The workspace directory driving both the file list and the diff panel. */
     const workspaceDir = () => contextDir() || invokeCwd;
+    const fileStatusMap = createMemo(() => statusMapFromEntries(fileStatusEntries()));
+    const changedWalk = createMemo(() =>
+      changedFileWalk(fileStatusEntries(), { showHidden: showHiddenFiles() }),
+    );
+    /** The rows the list actually shows: the flat tree through the `/` filter. */
+    const visibleFiles = createMemo(() => filterView(fileNodes(), filesQuery()));
     const fileListVisible = createMemo(() => {
-      const nodes = fileNodes();
-      const rows = editorRows();
-      const top = clampTop(fileTop(), nodes.length, rows);
-      return nodes.slice(top, top + rows).map((node, i) => ({ node, index: top + i }));
+      const rows = visibleFiles();
+      const view = editorRows();
+      const top = clampTop(fileTop(), rows.length, view);
+      return rows.slice(top, top + view).map((row, i) => ({ node: row.node, index: top + i }));
     });
+    /** The status letter for a node (repo-relative lookup incl. propagated
+     *  ancestor letters), or null outside a repo / for a clean path. */
+    const fileStatusFor = (n: FileNode): string | null => {
+      const top = filesGitTop();
+      if (!top) return null;
+      const rel = relPath(top, n.path);
+      return rel ? (fileStatusMap().get(rel) ?? null) : null;
+    };
 
-    const toRaw = (e: { name: string; isDirectory: () => boolean }): RawEntry => ({
-      name: e.name,
-      isDir: e.isDirectory(),
-    });
-    /** (Re)load the top-level listing for `dir` (async). Directories that were
-     *  expanded collapse back to the fresh root — a lean v1 (deep re-expansion is
-     *  a later nicety). */
+    // The gitignore matcher for the CURRENT workspace root (reloaded when the
+    // root changes or the tree refreshes — cheap: one small file read).
+    let filesIg: Ignore = ignore();
+    let filesIgDir = "";
+    const loadIgnoreRules = async (root: string): Promise<void> => {
+      const ig = ignore();
+      try {
+        ig.add(await readFile(join(root, ".gitignore"), "utf8"));
+      } catch {
+        // no .gitignore — everything passes
+      }
+      filesIg = ig;
+      filesIgDir = root;
+    };
+    /** Async list of `dir`, annotated with the gitignore verdict and filtered
+     *  through the current H/I toggles (pure filterEntries). */
+    const listDir = async (dir: string): Promise<RawEntry[]> => {
+      const root = workspaceDir();
+      if (filesIgDir !== root) await loadIgnoreRules(root);
+      const ents = await readdir(dir, { withFileTypes: true });
+      const raw: RawEntry[] = ents.map((e) => {
+        const isDir = e.isDirectory();
+        const rel = relPath(root, join(dir, e.name));
+        let ignored = false;
+        if (rel) {
+          try {
+            ignored = filesIg.ignores(isDir ? `${rel}/` : rel);
+          } catch {
+            // malformed path for the matcher — treat as not ignored
+          }
+        }
+        return { name: e.name, isDir, ignored };
+      });
+      return filterEntries(raw, {
+        showHidden: showHiddenFiles(),
+        showIgnored: showIgnoredFiles(),
+      });
+    };
+
+    /** Re-run `git status --porcelain` for the workspace (async; also resolves
+     *  the repo toplevel the porcelain paths are relative to). */
+    const runGitFiles = (args: string[], cb: (out: string) => void) => {
+      execFile(
+        "git",
+        ["-C", workspaceDir(), "-c", "core.quotepath=false", "-c", "core.fsmonitor=false", ...args],
+        { timeout: 10_000, maxBuffer: 16_000_000 },
+        (err, stdout) => cb(err ? "" : stdout),
+      );
+    };
+    const refreshFileStatus = () => {
+      runGitFiles(["rev-parse", "--show-toplevel"], (top) => {
+        const t = top.trim();
+        setFilesGitTop(t || null);
+        if (!t) {
+          setFileStatusEntries([]);
+          return;
+        }
+        runGitFiles(["status", "--porcelain"], (out) =>
+          setFileStatusEntries(parseStatusPorcelain(out)),
+        );
+      });
+    };
+
+    /** (Re)load the top-level listing for `dir` (async), reset the filter and
+     *  selection, refresh the git decoration, and (re)arm the watcher. */
     const loadFileList = (dir: string) => {
-      void readdir(dir, { withFileTypes: true })
-        .then((ents) => {
-          setFileNodes(buildNodes(dir, ents.map(toRaw), 0));
-          setFileSel(0);
-          setFileTop(0);
+      void loadIgnoreRules(workspaceDir()).then(() =>
+        listDir(dir)
+          .then((ents) => {
+            setFileNodes(buildNodes(dir, ents, 0));
+            setFileSel(0);
+            setFileTop(0);
+            setFilesQuery(null);
+          })
+          .catch(() => setFileNodes([])),
+      );
+      refreshFileStatus();
+      ensureFilesWatch(workspaceDir());
+    };
+
+    /** Expansion-preserving refresh: re-read the root + every expanded dir with
+     *  the CURRENT toggles, rebuild the flat tree (pure), keep the selection on
+     *  the same path where it survived. Used by the watcher push, the H/I
+     *  toggles, `r`, and the file-mutation menu verbs. */
+    let treeRefreshBusy = false;
+    const refreshTree = () => {
+      if (treeRefreshBusy) return;
+      treeRefreshBusy = true;
+      const root = workspaceDir();
+      const keepPath = visibleFiles()[fileSel()]?.node.path ?? null;
+      const expanded = new Set(
+        fileNodes()
+          .filter((n) => n.isDir && n.expanded)
+          .map((n) => n.path),
+      );
+      // Fresh rules first (the .gitignore itself may have changed), then every
+      // still-relevant dir in parallel; failed reads (vanished dirs) drop out.
+      void loadIgnoreRules(root)
+        .then(() =>
+          Promise.all(
+            [root, ...expanded].map(async (d) => [d, await listDir(d).catch(() => null)] as const),
+          ),
+        )
+        .then((pairs) => {
+          if (root !== workspaceDir()) return; // workspace moved on mid-flight
+          const listing = new Map<string, RawEntry[]>();
+          for (const [d, ents] of pairs) if (ents) listing.set(d, ents);
+          setFileNodes(rebuildTree(root, listing, expanded));
+          const rows = visibleFiles();
+          const idx = keepPath ? rows.findIndex((r) => r.node.path === keepPath) : -1;
+          const sel = idx !== -1 ? idx : clampSel(fileSel(), Math.max(1, rows.length));
+          setFileSel(sel);
+          setFileTop((t) => scrollToCursor(sel, t, editorRows(), rows.length));
         })
-        .catch(() => {
-          setFileNodes([]);
+        .finally(() => {
+          treeRefreshBusy = false;
         });
+      refreshFileStatus();
     };
+
+    const toggleHiddenFiles = () => {
+      setShowHiddenFiles((v) => !v);
+      refreshTree();
+    };
+    const toggleIgnoredFiles = () => {
+      setShowIgnoredFiles((v) => !v);
+      refreshTree();
+    };
+
     const moveFileSel = (delta: number) => {
-      const nodes = fileNodes();
-      if (nodes.length === 0) return;
-      const idx = clampSel(fileSel() + delta, nodes.length);
+      const rows = visibleFiles();
+      if (rows.length === 0) return;
+      const idx = clampSel(fileSel() + delta, rows.length);
       setFileSel(idx);
-      setFileTop((t) => scrollToCursor(idx, t, editorRows(), nodes.length));
+      setFileTop((t) => scrollToCursor(idx, t, editorRows(), rows.length));
     };
-    /** Enter on a row: open a file in the editor, or toggle a directory (async
-     *  readdir → splice children in, or prune the subtree). */
-    const activateFile = (index: number) => {
-      const node = fileNodes()[index];
-      if (!node) return;
-      setFileSel(index);
+    /** Enter on a VISIBLE row: open a file in the editor, or toggle a directory
+     *  (async readdir → splice children in, or prune the subtree). Expansion
+     *  applies at the row's UNDERLYING index, re-resolved by path at apply time
+     *  (a watcher refresh may have reshaped the list under a slow readdir). */
+    const activateFile = (visIndex: number) => {
+      const row = visibleFiles()[visIndex];
+      if (!row) return;
+      setFileSel(visIndex);
+      const node = row.node;
       if (!node.isDir) {
         openEditor(node.path);
         return;
       }
       if (node.expanded) {
-        setFileNodes((list) => removeSubtreeAt(list, index));
+        setFileNodes((list) => removeSubtreeAt(list, indexOfPath(list, node.path)));
         return;
       }
-      void readdir(node.path, { withFileTypes: true })
+      void listDir(node.path)
         .then((ents) => {
-          const children = buildNodes(node.path, ents.map(toRaw), node.depth + 1);
-          setFileNodes((list) => insertChildrenAt(list, index, children));
+          const children = buildNodes(node.path, ents, node.depth + 1);
+          setFileNodes((list) => insertChildrenAt(list, indexOfPath(list, node.path), children));
         })
         .catch(() => {});
     };
+
+    /** Reveal `absPath` in the tree: expand each collapsed ancestor in turn
+     *  (async readdirs), then select the row. Bails silently when a segment is
+     *  filtered out of view (the changed walk pre-filters what it offers). */
+    const revealPath = async (absPath: string): Promise<void> => {
+      const root = workspaceDir();
+      const rel = relPath(root, absPath);
+      if (!rel) return;
+      for (const anc of ancestorDirs(rel)) {
+        const ancAbs = join(root, anc);
+        const idx = indexOfPath(fileNodes(), ancAbs);
+        const node = fileNodes()[idx];
+        if (!node || !node.isDir) return;
+        if (!node.expanded) {
+          const ents = await listDir(ancAbs).catch(() => null);
+          if (!ents) return;
+          const children = buildNodes(ancAbs, ents, node.depth + 1);
+          setFileNodes((list) => insertChildrenAt(list, indexOfPath(list, ancAbs), children));
+        }
+      }
+      const idx = indexOfPath(fileNodes(), absPath);
+      if (idx === -1) return;
+      setFileSel(idx);
+      setFileTop((t) => scrollToCursor(idx, t, editorRows(), visibleFiles().length));
+    };
+
+    /** `[` / `]` — hop the selection to the prev/next CHANGED file (tree display
+     *  order, wrapping), auto-expanding collapsed ancestors. Clears the `/`
+     *  filter first: the hop is defined on the whole tree. */
+    const hopChanged = (dir: 1 | -1) => {
+      const top = filesGitTop();
+      const walk = changedWalk();
+      if (!top || walk.length === 0) return;
+      if (filesQuery() !== null) setFilesQuery(null);
+      const cur = visibleFiles()[fileSel()]?.node ?? null;
+      const curRel = cur ? relPath(top, cur.path) || null : null;
+      const next = nextChangedPath(walk, curRel, dir);
+      if (next) void revealPath(join(top, next));
+    };
+
+    // ── WATCHER PUSH REFRESH (M24.6) ─────────────────────────────────────────
+    // widgets/lib/watcher.ts (@parcel/watcher; fs.watch fallback in the compiled
+    // binary) — measured working under bun in this process (import + events).
+    // Events refresh the visible tree expansion-preservingly; while the Files
+    // tab is backgrounded they only mark it stale (refreshed on tab return).
+    // The watcher ignores .git, so index-only changes (external staging) ride
+    // the 3s status poll armed in onMount instead.
+    let stopFilesWatch: (() => Promise<void>) | null = null;
+    let filesWatchDir = "";
+    let filesStale = false;
+    const onFilesWatchEvent = () => {
+      if (mode() === "editor") {
+        refreshTree();
+      } else {
+        filesStale = true;
+      }
+    };
+    const ensureFilesWatch = (root: string) => {
+      if (filesWatchDir === root) return;
+      filesWatchDir = root;
+      const prev = stopFilesWatch;
+      stopFilesWatch = null;
+      void prev?.().catch(() => {});
+      void watchDirectory(root, onFilesWatchEvent, { ignore: [...ALWAYS_IGNORE] })
+        .then((stop) => {
+          if (filesWatchDir !== root) {
+            void stop().catch(() => {});
+            return;
+          }
+          stopFilesWatch = stop;
+        })
+        .catch(() => {
+          // watcher unavailable — the Files-tab status poll still runs, and
+          // `r` / toggles / mutations refresh on demand.
+        });
+    };
+    onCleanup(() => void stopFilesWatch?.().catch(() => {}));
+    /** A tab switch back onto a stale Files surface catches up in one shot. */
+    const catchUpFilesIfStale = () => {
+      if (!filesStale) return;
+      filesStale = false;
+      refreshTree();
+    };
+    // Status letters must also follow index-only changes (external staging),
+    // which the directory watcher never sees — a light poll while the Files
+    // tab is active, mirroring the diff panel's 3s discipline.
+    const filesStatusPoll = setInterval(() => {
+      if (mode() === "editor" && fileNodes().length > 0) refreshFileStatus();
+    }, 3000);
+    onCleanup(() => clearInterval(filesStatusPoll));
 
     /** The project dir the fleet payload records for `session` (null if unknown). */
     const dirForSession = (name: string): string | null => {
@@ -2113,7 +2358,10 @@ render(
         else setTab("diff");
         return;
       }
-      if (t === "files" && fileNodes().length === 0) loadFileList(workspaceDir());
+      if (t === "files") {
+        if (fileNodes().length === 0) loadFileList(workspaceDir());
+        else catchUpFilesIfStale();
+      }
       setTab(t);
     };
 
@@ -2129,6 +2377,50 @@ render(
     // a press outside dismisses. Keyboard behavior is unchanged.
     const [paletteOpen, setPaletteOpen] = createSignal(false);
     const [paletteQuery, setPaletteQuery] = createSignal("");
+    // "Go to file:" source (M24.6): the workspace's ignore-respecting file list,
+    // repo-relative, capped, refreshed on each palette open (async — the rows
+    // appear as soon as the list lands). `git ls-files -co --exclude-standard`
+    // where the workspace is a repo; a capped, filtered async walk elsewhere.
+    const REPO_FILES_CAP = 2000;
+    const REPO_WALK_DEPTH = 8;
+    const [repoFiles, setRepoFiles] = createSignal<string[]>([]);
+    const walkRepoFiles = async (root: string): Promise<string[]> => {
+      const out: string[] = [];
+      let queue: { dir: string; depth: number }[] = [{ dir: root, depth: 0 }];
+      while (queue.length > 0 && out.length < REPO_FILES_CAP) {
+        const next: typeof queue = [];
+        for (const { dir, depth } of queue) {
+          const ents = await listDir(dir).catch(() => []);
+          for (const e of ents) {
+            if (out.length >= REPO_FILES_CAP) break;
+            const abs = join(dir, e.name);
+            if (e.isDir) {
+              if (depth + 1 < REPO_WALK_DEPTH) next.push({ dir: abs, depth: depth + 1 });
+            } else {
+              const rel = relPath(root, abs);
+              if (rel) out.push(rel);
+            }
+          }
+        }
+        queue = next;
+      }
+      return out;
+    };
+    const loadRepoFiles = () => {
+      const root = workspaceDir();
+      runGitFiles(["ls-files", "-co", "--exclude-standard"], (out) => {
+        if (root !== workspaceDir()) return;
+        if (out) {
+          setRepoFiles(out.split("\n").filter(Boolean).slice(0, REPO_FILES_CAP));
+          return;
+        }
+        void walkRepoFiles(root)
+          .then((files) => {
+            if (root === workspaceDir()) setRepoFiles(files);
+          })
+          .catch(() => setRepoFiles([]));
+      });
+    };
     const [paletteSel, setPaletteSel] = createSignal(0);
     // The wheel-scrolled window top of the result list (0 unless scrolled — the
     // keyboard never moves it, so keyboard-only sessions render exactly as
@@ -2147,6 +2439,8 @@ render(
           // Pins "New agent: <name> (again)" FIRST when this context has spawn
           // memory (M24.1) — F5 → Enter repeats the last spawn.
           againName: currentAgainName(),
+          // "Go to file:" rows (M24.6) — appended after everything.
+          repoFiles: repoFiles(),
         },
       ),
     );
@@ -2168,6 +2462,7 @@ render(
       setPaletteTop(0);
       setPaletteBuffers(null); // always open on the action list, never mid-picker
       setHoverIf(null); // the overlay owns the pointer; drop any underlying tint
+      loadRepoFiles(); // refresh the "Go to file:" source (async, M24.6)
       setPaletteOpen(true);
     };
     const runPaletteAction = (a: PaletteAction) => {
@@ -2215,6 +2510,10 @@ render(
           break;
         case "open-file":
           openEditor(a.path);
+          break;
+        case "go-file":
+          // A fuzzy-matched repo file (M24.6) — path is workspace-relative.
+          openEditor(join(workspaceDir(), a.path));
           break;
         case "save":
           saveEditor();
@@ -2663,6 +2962,8 @@ render(
         recentFolders: recentFolders(),
         lastSpawns: lastSpawns(),
         customCommands: customCommands(),
+        filesShowHidden: showHiddenFiles(),
+        filesShowIgnored: showIgnoredFiles(),
       };
       if (saveTimer) clearTimeout(saveTimer);
       saveTimer = setTimeout(() => void saveAppState(snapshot), 400);
@@ -3289,9 +3590,9 @@ render(
         const overList = x < sidebarW() + filesListW();
         const contentY = gy - HEADER_ROWS;
         if (!overList || contentY < 0) return null;
-        const top = clampTop(fileTop(), fileNodes().length, editorRows());
+        const top = clampTop(fileTop(), visibleFiles().length, editorRows());
         const idx = top + contentY;
-        const node = fileNodes()[idx];
+        const node = visibleFiles()[idx]?.node;
         if (!node) return null;
         return {
           region: "file",
@@ -3477,7 +3778,7 @@ render(
           void writeFile(p, "", { flag: "wx" })
             .then(() => {
               setStatusNote(`created ${val}`);
-              loadFileList(workspaceDir());
+              refreshTree(); // expansion-preserving (M24.6)
             })
             .catch((e) => setStatusNote(`create failed: ${(e as Error).message}`));
         } else if (id === "rename" && val && m.filePath) {
@@ -3485,14 +3786,14 @@ render(
           void rename(m.filePath, p)
             .then(() => {
               setStatusNote(`renamed → ${val}`);
-              loadFileList(workspaceDir());
+              refreshTree();
             })
             .catch((e) => setStatusNote(`rename failed: ${(e as Error).message}`));
         } else if (id === "delete" && m.filePath) {
           void rm(m.filePath, { recursive: true, force: false })
             .then(() => {
               setStatusNote(`deleted ${basename(m.filePath!)}`);
-              loadFileList(workspaceDir());
+              refreshTree();
             })
             .catch((e) => setStatusNote(`delete failed: ${(e as Error).message}`));
         }
@@ -3783,10 +4084,59 @@ render(
           return;
         }
         // File LIST focus: j/k navigate, enter opens a file (→ editor focus) or
-        // toggles a directory. Otherwise the EDITOR has focus and types; esc hands
-        // focus back to the list.
+        // toggles a directory; `/` opens the live name filter, [ / ] hop the
+        // changed files, H / I toggle hidden / gitignored visibility (M24.6).
+        // Otherwise the EDITOR has focus and types; esc hands focus back to the
+        // list.
         if (filesFocus() === "list") {
-          if (evt.name === "j" || evt.name === "down") moveFileSel(1);
+          const q = filesQuery();
+          if (q !== null) {
+            // Filter input active: printable chars narrow live; arrows move in
+            // the FILTERED rows; enter activates the row (exiting the filter);
+            // escape restores the full list and the pre-filter selection.
+            if (evt.name === "escape") {
+              setFilesQuery(null);
+              const back = filesPreFilterPath ? indexOfPath(fileNodes(), filesPreFilterPath) : -1;
+              const idx = back !== -1 ? back : 0;
+              setFileSel(idx);
+              setFileTop((t) => scrollToCursor(idx, t, editorRows(), visibleFiles().length));
+            } else if (evt.name === "return") {
+              const row = visibleFiles()[fileSel()];
+              setFilesQuery(null);
+              if (row) {
+                const idx = indexOfPath(fileNodes(), row.node.path);
+                if (idx !== -1) {
+                  setFileSel(idx);
+                  setFileTop((t) => scrollToCursor(idx, t, editorRows(), visibleFiles().length));
+                  activateFile(idx);
+                }
+              }
+            } else if (evt.name === "backspace") {
+              setFilesQuery(q.slice(0, -1));
+              setFileSel(0);
+              setFileTop(0);
+            } else if (evt.name === "down") {
+              moveFileSel(1);
+            } else if (evt.name === "up") {
+              moveFileSel(-1);
+            } else if (evt.name.length === 1 && !evt.ctrl && !evt.meta) {
+              setFilesQuery(q + (evt.shift ? evt.name.toUpperCase() : evt.name));
+              setFileSel(0);
+              setFileTop(0);
+            }
+            return;
+          }
+          if (evt.name === "/") {
+            filesPreFilterPath = visibleFiles()[fileSel()]?.node.path ?? null;
+            setFilesQuery("");
+            setFileSel(0);
+            setFileTop(0);
+          } else if (evt.name === "]") hopChanged(1);
+          else if (evt.name === "[") hopChanged(-1);
+          else if (evt.shift && evt.name === "h") toggleHiddenFiles();
+          else if (evt.shift && evt.name === "i") toggleIgnoredFiles();
+          else if (evt.name === "r") refreshTree();
+          else if (evt.name === "j" || evt.name === "down") moveFileSel(1);
           else if (evt.name === "k" || evt.name === "up") moveFileSel(-1);
           else if (evt.name === "return") activateFile(fileSel());
           return;
@@ -4237,9 +4587,11 @@ render(
           setHoverIf(null);
           return;
         }
-        const top = clampTop(fileTop(), fileNodes().length, editorRows());
+        const top = clampTop(fileTop(), visibleFiles().length, editorRows());
         const idx = top + contentY;
-        setHoverIf(idx >= 0 && idx < fileNodes().length ? { region: "files", index: idx } : null);
+        setHoverIf(
+          idx >= 0 && idx < visibleFiles().length ? { region: "files", index: idx } : null,
+        );
         return;
       }
       if (m === "diff") {
@@ -4687,7 +5039,7 @@ render(
           const dir = e.scroll?.direction;
           if (dir !== "up" && dir !== "down") return;
           const step = dir === "up" ? -SCROLL_STEP : SCROLL_STEP;
-          if (overList) setFileTop((t) => clampTop(t + step, fileNodes().length, editorRows()));
+          if (overList) setFileTop((t) => clampTop(t + step, visibleFiles().length, editorRows()));
           else setEditorTop((t) => clampTop(t + step, editorLines().length, editorRows()));
           return;
         }
@@ -4702,9 +5054,9 @@ render(
         const contentY = gy - HEADER_ROWS;
         if (contentY < 0 || contentY >= editorRows()) return;
         if (overList) {
-          const top = clampTop(fileTop(), fileNodes().length, editorRows());
+          const top = clampTop(fileTop(), visibleFiles().length, editorRows());
           const idx = top + contentY;
-          if (idx >= 0 && idx < fileNodes().length) {
+          if (idx >= 0 && idx < visibleFiles().length) {
             clearSelection();
             setFilesFocus("list");
             activateFile(idx);
@@ -5496,6 +5848,9 @@ render(
                 <text fg={MUTED}>{`${editorCursor().row + 1}:${editorCursor().col + 1}`}</text>
                 <text fg={MUTED}>{`${editorLines().length}L`}</text>
                 <text fg={MUTED}>{editorMsg()}</text>
+                <Show when={filesQuery() !== null}>
+                  <text fg={ACCENT}>{`/${filesQuery()}▏`}</text>
+                </Show>
                 {buttonRow(headerButtons)}
               </box>
               <Show
@@ -5513,13 +5868,16 @@ render(
                     {(row) => {
                       const n = row.node;
                       const selected = () => row.index === fileSel() && filesFocus() === "list";
+                      // Reactive: the status map refreshes on the watcher/poll.
+                      const letter = () => fileStatusFor(n);
                       const prefix =
                         "  ".repeat(n.depth) + (n.isDir ? (n.expanded ? "▾ " : "▸ ") : "  ");
-                      const label = (prefix + n.name).slice(0, filesListW() - 1);
+                      const label = (prefix + n.name).slice(0, filesListW() - 4);
                       return (
                         <box
                           paddingLeft={1}
                           height={1}
+                          flexDirection="row"
                           backgroundColor={
                             selected()
                               ? TAB_ACTIVE_BG
@@ -5528,9 +5886,25 @@ render(
                                 : GUTTER_BG
                           }
                         >
-                          <text fg={n.isDir ? DIR_FG : selected() ? DEFAULT_FG : MUTED}>
+                          <text
+                            flexGrow={1}
+                            fg={
+                              n.ignored
+                                ? DIFF_META_FG // gitignored: dimmed when shown
+                                : n.isDir
+                                  ? DIR_FG
+                                  : selected()
+                                    ? DEFAULT_FG
+                                    : MUTED
+                            }
+                          >
                             {label}
                           </text>
+                          <Show when={letter()}>
+                            <text fg={STATUS_LETTER_FG[letter()!] ?? DEFAULT_FG}>
+                              {` ${letter()!}`}
+                            </text>
+                          </Show>
                         </box>
                       );
                     }}
@@ -5581,7 +5955,11 @@ render(
               </box>
               <box paddingLeft={1}>
                 <text fg={MUTED}>
-                  {`j/k file · enter open · ^s save · esc list · ^g home · ${QUIT_HINT}`}
+                  {`j/k · enter open · [/] change · / filter · H dot:${
+                    showHiddenFiles() ? "on" : "off"
+                  } · I ign:${
+                    showIgnoredFiles() ? "on" : "off"
+                  } · ^s save · esc list · ^g home · ${QUIT_HINT}`}
                 </text>
               </box>
             </Show>

--- a/packages/daemon/src/tui/mirror/diff-model.test.ts
+++ b/packages/daemon/src/tui/mirror/diff-model.test.ts
@@ -5,7 +5,28 @@ import {
   classifyDiff,
   untrackedDiffText,
   clampSel,
+  parseStatusGroups,
+  filterEntries,
+  buildDiffRows,
+  rowIndexOfFile,
+  parseNumstat,
+  untrackedLineCount,
+  applyCounts,
+  totalCounts,
+  parseHunkHeader,
+  hunkLineIndices,
+  nextHunkTop,
+  hunkEditTarget,
+  type DiffEntry,
 } from "./diff-model.ts";
+
+const entry = (group: DiffEntry["group"], path: string, status = "M"): DiffEntry => ({
+  group,
+  status,
+  path,
+  additions: null,
+  deletions: null,
+});
 
 describe("parseStatusPorcelain", () => {
   it("parses index/worktree/untracked states into display letters", () => {
@@ -82,5 +103,198 @@ describe("clampSel", () => {
     expect(clampSel(5, 3)).toBe(2);
     expect(clampSel(-1, 3)).toBe(0);
     expect(clampSel(1, 0)).toBe(0);
+  });
+});
+
+describe("parseStatusGroups", () => {
+  it("splits XY lines into staged/unstaged/untracked components", () => {
+    const out = [" M work.ts", "M  index.ts", "?? new.ts", "A  added.ts", " D gone.ts"].join("\n");
+    expect(parseStatusGroups(out)).toEqual([
+      entry("unstaged", "work.ts", "M"),
+      entry("staged", "index.ts", "M"),
+      entry("untracked", "new.ts", "?"),
+      entry("staged", "added.ts", "A"),
+      entry("unstaged", "gone.ts", "D"),
+    ]);
+  });
+  it("yields BOTH a staged and an unstaged entry for MM (staged-then-edited)", () => {
+    expect(parseStatusGroups("MM both.ts")).toEqual([
+      entry("staged", "both.ts", "M"),
+      entry("unstaged", "both.ts", "M"),
+    ]);
+  });
+  it("takes the new path for renames and skips ignored/short lines", () => {
+    expect(parseStatusGroups("R  old.ts -> new.ts\n!! dist\nx\n")).toEqual([
+      entry("staged", "new.ts", "R"),
+    ]);
+  });
+});
+
+describe("filterEntries", () => {
+  const entries = [
+    entry("staged", "src/App.tsx"),
+    entry("unstaged", "docs/readme.md"),
+    entry("untracked", "src/new.ts", "?"),
+  ];
+  it("narrows to case-insensitive path substrings", () => {
+    expect(filterEntries(entries, "SRC").map((e) => e.path)).toEqual(["src/App.tsx", "src/new.ts"]);
+  });
+  it("returns the input unchanged for an empty/blank query", () => {
+    expect(filterEntries(entries, "")).toBe(entries);
+    expect(filterEntries(entries, "  ")).toBe(entries);
+  });
+});
+
+describe("buildDiffRows", () => {
+  it("orders non-empty sections Staged→Unstaged→Untracked with counted headers", () => {
+    const { rows, files } = buildDiffRows([
+      entry("untracked", "n.ts", "?"),
+      entry("staged", "s.ts", "A"),
+      entry("unstaged", "u.ts"),
+      entry("staged", "s2.ts"),
+    ]);
+    expect(rows.map((r) => (r.kind === "header" ? r.label : r.entry.path))).toEqual([
+      "Staged (2)",
+      "s.ts",
+      "s2.ts",
+      "Unstaged (1)",
+      "u.ts",
+      "Untracked (1)",
+      "n.ts",
+    ]);
+    expect(files.map((f) => f.path)).toEqual(["s.ts", "s2.ts", "u.ts", "n.ts"]);
+    // File rows carry their index into the flat selectable order.
+    expect(
+      rows.filter((r) => r.kind === "file").map((r) => (r.kind === "file" ? r.fileIndex : -1)),
+    ).toEqual([0, 1, 2, 3]);
+  });
+  it("emits no header for an empty group and handles an empty list", () => {
+    const { rows, files } = buildDiffRows([entry("unstaged", "u.ts")]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ kind: "header", group: "unstaged", label: "Unstaged (1)" });
+    expect(files).toHaveLength(1);
+    expect(buildDiffRows([])).toEqual({ rows: [], files: [] });
+  });
+});
+
+describe("rowIndexOfFile", () => {
+  it("maps a file index to its row (headers offset it), -1 when absent", () => {
+    const { rows } = buildDiffRows([entry("staged", "a.ts"), entry("unstaged", "b.ts")]);
+    expect(rowIndexOfFile(rows, 0)).toBe(1);
+    expect(rowIndexOfFile(rows, 1)).toBe(3);
+    expect(rowIndexOfFile(rows, 9)).toBe(-1);
+  });
+});
+
+describe("parseNumstat", () => {
+  it("parses added/deleted per path and skips binary rows", () => {
+    const out = ["3\t1\tsrc/a.ts", "-\t-\timg.png", "0\t5\tgone.ts", ""].join("\n");
+    const m = parseNumstat(out);
+    expect(m.get("src/a.ts")).toEqual({ additions: 3, deletions: 1 });
+    expect(m.get("gone.ts")).toEqual({ additions: 0, deletions: 5 });
+    expect(m.has("img.png")).toBe(false);
+  });
+  it("resolves rename cells to the new path (brace and bare forms)", () => {
+    const m = parseNumstat("1\t2\tsrc/{old.ts => new.ts}\n3\t4\ta.ts => b.ts");
+    expect(m.get("src/new.ts")).toEqual({ additions: 1, deletions: 2 });
+    expect(m.get("b.ts")).toEqual({ additions: 3, deletions: 4 });
+  });
+});
+
+describe("untrackedLineCount", () => {
+  it("counts content lines, ignoring the single trailing newline", () => {
+    expect(untrackedLineCount("a\nb\n")).toBe(2);
+    expect(untrackedLineCount("a\nb")).toBe(2);
+    expect(untrackedLineCount("")).toBe(0);
+  });
+});
+
+describe("applyCounts / totalCounts", () => {
+  it("merges the right map per group and leaves misses null", () => {
+    const entries = [
+      entry("staged", "s.ts"),
+      entry("unstaged", "s.ts"),
+      entry("untracked", "n.ts", "?"),
+      entry("unstaged", "bin.png"),
+    ];
+    const merged = applyCounts(
+      entries,
+      new Map([["s.ts", { additions: 2, deletions: 1 }]]),
+      new Map([["s.ts", { additions: 4, deletions: 3 }]]),
+      new Map([["n.ts", 7]]),
+    );
+    expect(merged[0]).toMatchObject({ additions: 2, deletions: 1 });
+    expect(merged[1]).toMatchObject({ additions: 4, deletions: 3 });
+    expect(merged[2]).toMatchObject({ additions: 7, deletions: 0 });
+    expect(merged[3]).toMatchObject({ additions: null, deletions: null });
+    expect(totalCounts(merged)).toEqual({ additions: 13, deletions: 4 });
+  });
+});
+
+describe("parseHunkHeader", () => {
+  it("parses full and count-omitted forms", () => {
+    expect(parseHunkHeader("@@ -5,3 +7,4 @@ fn ctx()")).toEqual({
+      oldStart: 5,
+      oldCount: 3,
+      newStart: 7,
+      newCount: 4,
+    });
+    expect(parseHunkHeader("@@ -1 +1 @@")).toEqual({
+      oldStart: 1,
+      oldCount: 1,
+      newStart: 1,
+      newCount: 1,
+    });
+    expect(parseHunkHeader("+not a hunk")).toBeNull();
+  });
+});
+
+// A two-hunk classified diff used by the hunk-math tables below.
+const TWO_HUNKS = classifyDiff(
+  [
+    "diff --git a/f b/f",
+    "index 111..222 100644",
+    "--- a/f",
+    "+++ b/f",
+    "@@ -1,3 +1,4 @@", // line 4
+    " ctx1",
+    "+added at new line 2",
+    " ctx2",
+    " ctx3",
+    "@@ -10,2 +11,1 @@", // line 9
+    " ctx",
+    "-removed (was new line 12's spot)",
+    "",
+  ].join("\n"),
+);
+
+describe("hunkLineIndices / nextHunkTop", () => {
+  it("finds hunk lines and steps ]/[ between them", () => {
+    expect(hunkLineIndices(TWO_HUNKS)).toEqual([4, 9]);
+    expect(nextHunkTop(TWO_HUNKS, 0, 1)).toBe(4);
+    expect(nextHunkTop(TWO_HUNKS, 4, 1)).toBe(9);
+    expect(nextHunkTop(TWO_HUNKS, 9, 1)).toBeNull();
+    expect(nextHunkTop(TWO_HUNKS, 9, -1)).toBe(4);
+    expect(nextHunkTop(TWO_HUNKS, 4, -1)).toBeNull();
+    expect(nextHunkTop([], 0, 1)).toBeNull();
+  });
+});
+
+describe("hunkEditTarget", () => {
+  it("targets the first changed line of the hunk at/above the view top", () => {
+    // View above/at the first hunk: header +1,4, first add after one context
+    // line → new-file line 2 → 0-based 1.
+    expect(hunkEditTarget(TWO_HUNKS, 0)).toBe(1);
+    expect(hunkEditTarget(TWO_HUNKS, 4)).toBe(1);
+    // Scrolled into the second hunk: header +11,1, del after one context line
+    // → new-file position 12 → 0-based 11.
+    expect(hunkEditTarget(TWO_HUNKS, 9)).toBe(11);
+    expect(hunkEditTarget(TWO_HUNKS, 11)).toBe(11);
+  });
+  it("falls back to the hunk start without ± lines and null without hunks", () => {
+    const ctxOnly = classifyDiff("@@ -3,2 +5,2 @@\n ctx\n ctx\n");
+    expect(hunkEditTarget(ctxOnly, 0)).toBe(4);
+    expect(hunkEditTarget(classifyDiff("Binary files differ\n"), 0)).toBeNull();
+    expect(hunkEditTarget([], 0)).toBeNull();
   });
 });

--- a/packages/daemon/src/tui/mirror/diff-model.ts
+++ b/packages/daemon/src/tui/mirror/diff-model.ts
@@ -1,14 +1,22 @@
 /**
- * Pure, io-free helpers for the built-in git diff panel (M18.3).
+ * Pure, io-free helpers for the built-in git diff panel (M18.3; grouped +
+ * stage-aware M24.5).
  *
  * Like {@link ./editor-buffer.ts}, this imports NOTHING from @opentui/core: the
  * app runs the git subprocesses (async execFile) and reads untracked files, but
  * the PARSING and coordinate math live here so they unit-test as tables under
  * the Node/vitest runner while app.tsx keeps the OpenTUI wiring.
  *
- * Three concerns: (1) parse `git status --porcelain` into a flat, display-ready
- * file list; (2) classify each `git diff` line so the renderer can color it; and
- * (3) turn an untracked file's contents into an all-additions pseudo-diff (git
+ * Concerns: (1) parse `git status --porcelain` into display-ready entries —
+ * flat ({@link parseStatusPorcelain}, legacy) or split into Staged / Unstaged /
+ * Untracked components ({@link parseStatusGroups}: an `MM` file yields BOTH a
+ * staged and an unstaged row, each diffing its own side of the index); (2) lay
+ * the grouped entries out as list ROWS (section headers + files) whose math is
+ * shared by the render and the mouse router ({@link buildDiffRows}); (3) merge
+ * `git diff --numstat` ± counts into the entries; (4) classify each `git diff`
+ * line so the renderer can color it; (5) hunk coordinate math — `]`/`[` jump
+ * targets and the `^e` open-editor-at-line target parsed from `@@ -a,b +c,d`;
+ * (6) turn an untracked file's contents into an all-additions pseudo-diff (git
  * diff prints nothing for untracked paths).
  */
 
@@ -109,4 +117,271 @@ export function untrackedDiffText(content: string): string {
 export function clampSel(sel: number, count: number): number {
   if (count <= 0) return 0;
   return Math.max(0, Math.min(sel, count - 1));
+}
+
+// ── Grouped list (M24.5) ─────────────────────────────────────────────────────
+
+/** Which section of the grouped list an entry belongs to. */
+export type DiffGroup = "staged" | "unstaged" | "untracked";
+
+/** One stage-aware changed-file entry: a porcelain XY line is SPLIT into its
+ *  index and worktree components, so an `MM` file yields two entries — the
+ *  staged one diffs `--cached`, the unstaged one diffs the worktree. */
+export interface DiffEntry {
+  group: DiffGroup;
+  /** Display letter for THIS component: the X (index) letter for staged rows,
+   *  the Y (worktree) letter for unstaged rows, `?` for untracked. */
+  status: string;
+  /** Repo-relative path (the NEW path for renames). */
+  path: string;
+  /** ± line counts from `git diff --numstat` (untracked: the file's line
+   *  count). `null` until loaded, and for binary/unreadable files. */
+  additions: number | null;
+  deletions: number | null;
+}
+
+/**
+ * PURE — parse porcelain v1 output into grouped, stage-aware entries. Each
+ * `XY PATH` line contributes: a STAGED entry when X is a real index state, an
+ * UNSTAGED entry when Y is a real worktree state, or one UNTRACKED entry for
+ * `??`. Ignored (`!!`) and malformed lines are skipped. Counts start `null`
+ * ({@link applyCounts} fills them).
+ */
+export function parseStatusGroups(out: string): DiffEntry[] {
+  const entries: DiffEntry[] = [];
+  for (const line of out.split("\n")) {
+    if (line.length < 4) continue;
+    const index = line[0]!;
+    const work = line[1]!;
+    let rest = line.slice(3);
+    const arrow = rest.indexOf(" -> ");
+    if (arrow !== -1) rest = rest.slice(arrow + 4);
+    if (index === "!" && work === "!") continue;
+    if (index === "?" && work === "?") {
+      entries.push({
+        group: "untracked",
+        status: "?",
+        path: rest,
+        additions: null,
+        deletions: null,
+      });
+      continue;
+    }
+    if (index !== " " && index !== "?")
+      entries.push({
+        group: "staged",
+        status: index,
+        path: rest,
+        additions: null,
+        deletions: null,
+      });
+    if (work !== " " && work !== "?")
+      entries.push({
+        group: "unstaged",
+        status: work,
+        path: rest,
+        additions: null,
+        deletions: null,
+      });
+  }
+  return entries;
+}
+
+/** PURE — narrow entries to paths containing `query` (case-insensitive
+ *  substring). An empty/blank query returns the input unchanged. */
+export function filterEntries(entries: DiffEntry[], query: string): DiffEntry[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return entries;
+  return entries.filter((e) => e.path.toLowerCase().includes(q));
+}
+
+/** One row of the grouped file list: a non-selectable section header or a file
+ *  entry carrying its index into the flat selectable-file order. */
+export type DiffRow =
+  | { kind: "header"; group: DiffGroup; label: string }
+  | { kind: "file"; entry: DiffEntry; fileIndex: number };
+
+const GROUP_ORDER: { group: DiffGroup; label: string }[] = [
+  { group: "staged", label: "Staged" },
+  { group: "unstaged", label: "Unstaged" },
+  { group: "untracked", label: "Untracked" },
+];
+
+/**
+ * PURE — lay grouped entries out as list rows: per-group `Label (n)` headers
+ * (only for non-empty groups, in Staged → Unstaged → Untracked order) followed
+ * by that group's files. `files` is the flat selectable order — `fileIndex` on
+ * each file row indexes it, so the selection model stays a plain integer while
+ * the render/hit math walk ROWS. Shared render↔router, one source of truth.
+ */
+export function buildDiffRows(entries: DiffEntry[]): { rows: DiffRow[]; files: DiffEntry[] } {
+  const rows: DiffRow[] = [];
+  const files: DiffEntry[] = [];
+  for (const { group, label } of GROUP_ORDER) {
+    const members = entries.filter((e) => e.group === group);
+    if (members.length === 0) continue;
+    rows.push({ kind: "header", group, label: `${label} (${members.length})` });
+    for (const entry of members) {
+      rows.push({ kind: "file", entry, fileIndex: files.length });
+      files.push(entry);
+    }
+  }
+  return { rows, files };
+}
+
+/** PURE — the row index of selectable file `fileIndex` (for keeping the
+ *  selection in view when the list scrolls over ROWS). -1 when absent. */
+export function rowIndexOfFile(rows: DiffRow[], fileIndex: number): number {
+  return rows.findIndex((r) => r.kind === "file" && r.fileIndex === fileIndex);
+}
+
+// ── numstat (M24.5) ──────────────────────────────────────────────────────────
+
+/** ± line counts for one file. */
+export interface Numstat {
+  additions: number;
+  deletions: number;
+}
+
+/** Resolve a numstat path cell to the NEW path: renames print either
+ *  `pre{old => new}post` (common-prefix brace form) or a bare `old => new`. */
+function numstatPath(raw: string): string {
+  const brace = raw.match(/^(.*)\{(.*) => (.*)\}(.*)$/);
+  if (brace) return `${brace[1]}${brace[3]}${brace[4]}`;
+  const arrow = raw.indexOf(" => ");
+  if (arrow !== -1) return raw.slice(arrow + 4);
+  return raw;
+}
+
+/**
+ * PURE — parse `git diff --numstat` output (`added<TAB>deleted<TAB>path`) into
+ * a path → counts map. Binary files print `-	-	path` and are SKIPPED (their
+ * entries keep `null` counts); rename cells resolve to the new path.
+ */
+export function parseNumstat(out: string): Map<string, Numstat> {
+  const counts = new Map<string, Numstat>();
+  for (const line of out.split("\n")) {
+    if (!line) continue;
+    const parts = line.split("\t");
+    if (parts.length < 3) continue;
+    const additions = parseInt(parts[0]!, 10);
+    const deletions = parseInt(parts[1]!, 10);
+    if (Number.isNaN(additions) || Number.isNaN(deletions)) continue; // binary: "-"
+    counts.set(numstatPath(parts.slice(2).join("\t")), { additions, deletions });
+  }
+  return counts;
+}
+
+/** PURE — the line count an untracked file shows as its `+` count: content
+ *  lines, with the single trailing newline's empty not counted (mirrors
+ *  {@link untrackedDiffText}); empty content counts 0. */
+export function untrackedLineCount(content: string): number {
+  if (content === "") return 0;
+  const lines = content.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines.length;
+}
+
+/**
+ * PURE — merge per-group counts into entries (staged entries read the
+ * `--cached` numstat, unstaged the worktree numstat, untracked the line-count
+ * map). Entries without a match keep `null` counts (binary/unreadable).
+ */
+export function applyCounts(
+  entries: DiffEntry[],
+  staged: Map<string, Numstat>,
+  unstaged: Map<string, Numstat>,
+  untrackedLines: Map<string, number>,
+): DiffEntry[] {
+  return entries.map((e) => {
+    if (e.group === "untracked") {
+      const lines = untrackedLines.get(e.path);
+      return lines === undefined ? e : { ...e, additions: lines, deletions: 0 };
+    }
+    const n = (e.group === "staged" ? staged : unstaged).get(e.path);
+    return n === undefined ? e : { ...e, additions: n.additions, deletions: n.deletions };
+  });
+}
+
+/** PURE — sum the loaded ± counts across entries (nulls contribute 0), for the
+ *  header totals. */
+export function totalCounts(entries: DiffEntry[]): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const e of entries) {
+    additions += e.additions ?? 0;
+    deletions += e.deletions ?? 0;
+  }
+  return { additions, deletions };
+}
+
+// ── Hunk math (M24.5) ────────────────────────────────────────────────────────
+
+/** A parsed `@@ -a,b +c,d @@` header (counts default 1 when omitted). */
+export interface HunkHeader {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+}
+
+/** PURE — parse a hunk header line; null for anything else. */
+export function parseHunkHeader(text: string): HunkHeader | null {
+  const m = text.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+  if (!m) return null;
+  return {
+    oldStart: parseInt(m[1]!, 10),
+    oldCount: m[2] !== undefined ? parseInt(m[2], 10) : 1,
+    newStart: parseInt(m[3]!, 10),
+    newCount: m[4] !== undefined ? parseInt(m[4], 10) : 1,
+  };
+}
+
+/** PURE — the indices of all hunk-header lines in a classified diff. */
+export function hunkLineIndices(lines: DiffLine[]): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < lines.length; i++) if (lines[i]!.kind === "hunk") out.push(i);
+  return out;
+}
+
+/** PURE — the `]`/`[` jump target: the first hunk-line index strictly after
+ *  (`dir` 1) or before (`dir` -1) the current view top. null = no further hunk
+ *  in that direction (the view stays put). */
+export function nextHunkTop(lines: DiffLine[], top: number, dir: 1 | -1): number | null {
+  const hunks = hunkLineIndices(lines);
+  if (dir === 1) {
+    for (const i of hunks) if (i > top) return i;
+    return null;
+  }
+  for (let j = hunks.length - 1; j >= 0; j--) if (hunks[j]! < top) return hunks[j]!;
+  return null;
+}
+
+/**
+ * PURE — the `^e` open-editor target: the 0-based NEW-file line of the first
+ * changed (add/del) line of the SELECTED hunk — the hunk whose header is at or
+ * nearest above the current view top (the first hunk when the view is above
+ * them all). Walks from `+c` counting context/add lines; a del line targets
+ * the new-file position where the removal happened. Falls back to `c` itself
+ * for a hunk with no explicit ± lines, and null when the diff has no hunks
+ * (binary/meta-only/pseudo-diff — the caller opens at 0).
+ */
+export function hunkEditTarget(lines: DiffLine[], top: number): number | null {
+  const hunks = hunkLineIndices(lines);
+  if (hunks.length === 0) return null;
+  let h = hunks[0]!;
+  for (const i of hunks) {
+    if (i <= top) h = i;
+    else break;
+  }
+  const hdr = parseHunkHeader(lines[h]!.text);
+  if (!hdr) return null;
+  let newLine = hdr.newStart; // 1-based
+  for (let i = h + 1; i < lines.length; i++) {
+    const kind = lines[i]!.kind;
+    if (kind === "hunk" || kind === "meta") break;
+    if (kind === "add" || kind === "del") return Math.max(0, newLine - 1);
+    newLine++; // context
+  }
+  return Math.max(0, hdr.newStart - 1);
 }

--- a/packages/daemon/src/tui/mirror/file-tree.test.ts
+++ b/packages/daemon/src/tui/mirror/file-tree.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
+  ancestorDirs,
   buildNodes,
+  changedFileWalk,
+  filterEntries,
+  filterView,
+  indexOfPath,
   insertChildrenAt,
+  nextChangedPath,
+  rebuildTree,
+  relPath,
   removeSubtreeAt,
   sortEntries,
+  statusMapFromEntries,
+  treePathCompare,
   type FileNode,
+  type RawEntry,
 } from "./file-tree.ts";
 
 describe("sortEntries", () => {
@@ -23,8 +34,41 @@ describe("buildNodes", () => {
   it("joins names onto the dir and tags depth, tolerating a trailing slash", () => {
     const nodes = buildNodes("/root/", [{ name: "a.ts", isDir: false }], 0);
     expect(nodes).toEqual([
-      { name: "a.ts", path: "/root/a.ts", isDir: false, depth: 0, expanded: false },
+      { name: "a.ts", path: "/root/a.ts", isDir: false, depth: 0, expanded: false, ignored: false },
     ]);
+  });
+
+  it("carries the ignored flag through to the node", () => {
+    const nodes = buildNodes("/r", [{ name: "gen.ts", isDir: false, ignored: true }], 1);
+    expect(nodes[0]!.ignored).toBe(true);
+    expect(nodes[0]!.depth).toBe(1);
+  });
+});
+
+describe("filterEntries", () => {
+  const entries: RawEntry[] = [
+    { name: "node_modules", isDir: true },
+    { name: ".git", isDir: true },
+    { name: ".env", isDir: false },
+    { name: "gen", isDir: true, ignored: true },
+    { name: "out.log", isDir: false, ignored: true },
+    { name: "src", isDir: true },
+    { name: "main.ts", isDir: false },
+  ];
+
+  it("defaults hide ALWAYS_IGNORE, dotfiles, and gitignored entries", () => {
+    const out = filterEntries(entries, { showHidden: false, showIgnored: false });
+    expect(out.map((e) => e.name)).toEqual(["src", "main.ts"]);
+  });
+
+  it("H shows dotfiles but never ALWAYS_IGNORE names", () => {
+    const out = filterEntries(entries, { showHidden: true, showIgnored: false });
+    expect(out.map((e) => e.name)).toEqual([".env", "src", "main.ts"]);
+  });
+
+  it("I shows gitignored entries", () => {
+    const out = filterEntries(entries, { showHidden: false, showIgnored: true });
+    expect(out.map((e) => e.name)).toEqual(["gen", "out.log", "src", "main.ts"]);
   });
 });
 
@@ -66,5 +110,167 @@ describe("insertChildrenAt / removeSubtreeAt", () => {
     const collapsed = removeSubtreeAt(out, 0);
     expect(collapsed.map((n) => n.name)).toEqual(["dir", "z.ts"]);
     expect(collapsed[0]!.expanded).toBe(false);
+  });
+});
+
+describe("relPath / ancestorDirs", () => {
+  it("strips the root prefix, tolerating a trailing slash", () => {
+    expect(relPath("/w", "/w/a/b.ts")).toBe("a/b.ts");
+    expect(relPath("/w/", "/w/a/b.ts")).toBe("a/b.ts");
+    expect(relPath("/w", "/w")).toBe("");
+    expect(relPath("/w", "/wider/x")).toBe(""); // not under root
+  });
+
+  it("lists ancestor dirs outermost first", () => {
+    expect(ancestorDirs("a/b/c.ts")).toEqual(["a", "a/b"]);
+    expect(ancestorDirs("top.ts")).toEqual([]);
+  });
+});
+
+describe("statusMapFromEntries", () => {
+  it("maps files and propagates the first-seen status to ancestor dirs", () => {
+    const map = statusMapFromEntries([
+      { path: "src/deep/a.ts", status: "M" },
+      { path: "src/b.ts", status: "A" },
+      { path: "top.ts", status: "?" },
+    ]);
+    expect(map.get("src/deep/a.ts")).toBe("M");
+    expect(map.get("src/deep")).toBe("M");
+    expect(map.get("src")).toBe("M"); // first child wins, not overwritten by A
+    expect(map.get("src/b.ts")).toBe("A");
+    expect(map.get("top.ts")).toBe("?");
+    expect(map.has("")).toBe(false);
+  });
+});
+
+describe("treePathCompare", () => {
+  it("orders like the rendered tree: dirs before files, case-insensitive", () => {
+    const paths = ["z.ts", "a/x.ts", "B.ts", "a/deep/y.ts", "a/a.ts"];
+    paths.sort(treePathCompare);
+    expect(paths).toEqual(["a/deep/y.ts", "a/a.ts", "a/x.ts", "B.ts", "z.ts"]);
+  });
+
+  it("a dir component beats a file segment even when named later", () => {
+    expect(treePathCompare("zebra/x.ts", "apple.ts")).toBeLessThan(0);
+  });
+});
+
+describe("changedFileWalk", () => {
+  it("dedupes, drops ALWAYS_IGNORE segments and deletions, sorts in tree order", () => {
+    const walk = changedFileWalk(
+      [
+        { path: "src/b.ts" },
+        { path: "a.ts" },
+        { path: "src/b.ts" },
+        { path: "node_modules/x/y.js" },
+        { path: "vendor/lib.go" },
+        // a deleted file has no tree row — hopping onto it would wedge `]`
+        { path: "gone.ts", status: "D" },
+      ],
+      { showHidden: true },
+    );
+    expect(walk).toEqual(["src/b.ts", "a.ts"]);
+  });
+
+  it("drops dot segments while hidden files are off, keeps them when on", () => {
+    const entries = [{ path: ".config/app.json" }, { path: "src/.env" }, { path: "src/ok.ts" }];
+    expect(changedFileWalk(entries, { showHidden: false })).toEqual(["src/ok.ts"]);
+    expect(changedFileWalk(entries, { showHidden: true })).toEqual([
+      ".config/app.json",
+      "src/.env",
+      "src/ok.ts",
+    ]);
+  });
+});
+
+describe("nextChangedPath", () => {
+  const walk = ["a/deep/y.ts", "a/x.ts", "m.ts", "z.ts"];
+
+  it("steps forward and backward with wraparound", () => {
+    expect(nextChangedPath(walk, "a/x.ts", 1)).toBe("m.ts");
+    expect(nextChangedPath(walk, "z.ts", 1)).toBe("a/deep/y.ts"); // wrap
+    expect(nextChangedPath(walk, "m.ts", -1)).toBe("a/x.ts");
+    expect(nextChangedPath(walk, "a/deep/y.ts", -1)).toBe("z.ts"); // wrap
+  });
+
+  it("lands on the nearest entry when current is not in the walk", () => {
+    expect(nextChangedPath(walk, "b.ts", 1)).toBe("m.ts");
+    expect(nextChangedPath(walk, "b.ts", -1)).toBe("a/x.ts");
+  });
+
+  it("handles a null current and an empty walk", () => {
+    expect(nextChangedPath(walk, null, 1)).toBe("a/deep/y.ts");
+    expect(nextChangedPath(walk, null, -1)).toBe("z.ts");
+    expect(nextChangedPath([], "x", 1)).toBeNull();
+  });
+});
+
+describe("filterView", () => {
+  const list = buildNodes(
+    "/r",
+    [
+      { name: "src", isDir: true },
+      { name: "main.ts", isDir: false },
+      { name: "Makefile", isDir: false },
+    ],
+    0,
+  );
+
+  it("null or empty query returns every row with its own index", () => {
+    expect(filterView(list, null).map((r) => r.index)).toEqual([0, 1, 2]);
+    expect(filterView(list, "").length).toBe(3);
+  });
+
+  it("narrows by case-insensitive name containment, keeping underlying indices", () => {
+    const rows = filterView(list, "MA");
+    expect(rows.map((r) => r.node.name)).toEqual(["main.ts", "Makefile"]);
+    expect(rows.map((r) => r.index)).toEqual([1, 2]);
+  });
+});
+
+describe("indexOfPath", () => {
+  it("finds a row by absolute path", () => {
+    const list = buildNodes("/r", [{ name: "a.ts", isDir: false }], 0);
+    expect(indexOfPath(list, "/r/a.ts")).toBe(0);
+    expect(indexOfPath(list, "/r/missing")).toBe(-1);
+  });
+});
+
+describe("rebuildTree", () => {
+  it("rebuilds from fresh listings, preserving expansion", () => {
+    const listing = new Map<string, RawEntry[]>([
+      [
+        "/r",
+        [
+          { name: "dir", isDir: true },
+          { name: "z.ts", isDir: false },
+        ],
+      ],
+      [
+        "/r/dir",
+        [
+          { name: "sub", isDir: true },
+          { name: "new.ts", isDir: false },
+        ],
+      ],
+      ["/r/dir/sub", [{ name: "deep.ts", isDir: false }]],
+    ]);
+    const out = rebuildTree("/r", listing, new Set(["/r/dir", "/r/dir/sub"]));
+    expect(out.map((n) => `${n.depth}:${n.name}`)).toEqual([
+      "0:dir",
+      "1:sub",
+      "2:deep.ts",
+      "1:new.ts",
+      "0:z.ts",
+    ]);
+    expect(out[0]!.expanded).toBe(true);
+    expect(out[1]!.expanded).toBe(true);
+  });
+
+  it("collapses a dir whose fresh listing was not provided and drops vanished dirs", () => {
+    const listing = new Map<string, RawEntry[]>([["/r", [{ name: "dir", isDir: true }]]]);
+    const out = rebuildTree("/r", listing, new Set(["/r/dir", "/r/gone"]));
+    expect(out.map((n) => n.name)).toEqual(["dir"]);
+    expect(out[0]!.expanded).toBe(false);
   });
 });

--- a/packages/daemon/src/tui/mirror/file-tree.ts
+++ b/packages/daemon/src/tui/mirror/file-tree.ts
@@ -1,8 +1,10 @@
 /**
- * Pure model for the Files tab's one-level-expandable file list (M18.4). Like
- * {@link ./diff-model.ts}, the io (async `fs.readdir`) stays in app.tsx; the
- * ORDERING and the flat-tree splice/prune math live here so they unit-test as
- * tables.
+ * Pure model for the Files tab's expandable file list (M18.4, uplifted M24.6).
+ * Like {@link ./diff-model.ts}, the io (async `fs.readdir`, git subprocesses,
+ * the `ignore` matcher fed from .gitignore) stays in app.tsx; the ORDERING, the
+ * flat-tree splice/prune math, the ignore/hidden FILTERING, the git-status
+ * DECORATION merge, the changed-file WALK for `[`/`]`, the `/` FILTER view and
+ * the expansion-preserving REBUILD all live here so they unit-test as tables.
  *
  * The list is a FLAT array of {@link FileNode}s carrying a `depth`; a directory
  * "expands" by splicing its freshly-read children in right after it and
@@ -11,21 +13,69 @@
  * a file manager does.
  */
 
+/** Names that are NEVER listed, whatever the toggles say (the explorer
+ *  widget's battle-tested list — build artifacts and VCS internals that would
+ *  only bury the code). */
+export const ALWAYS_IGNORE: ReadonlySet<string> = new Set([
+  "node_modules",
+  ".git",
+  ".svn",
+  ".hg",
+  "dist",
+  "build",
+  "out",
+  ".next",
+  ".turbo",
+  ".cache",
+  "__pycache__",
+  "coverage",
+  ".nyc_output",
+  "target",
+  "vendor",
+  "bower_components",
+]);
+
 /** One row in the flat file list. `path` is absolute; `depth` is the indent
- *  level (0 = the context dir's immediate children). */
+ *  level (0 = the context dir's immediate children). `ignored` marks a
+ *  gitignored entry — visible only when the I toggle shows them, dimmed. */
 export interface FileNode {
   name: string;
   path: string;
   isDir: boolean;
   depth: number;
   expanded: boolean;
+  ignored: boolean;
 }
 
 /** A raw `fs.readdir(..., { withFileTypes: true })` entry, reduced to what we
- *  need (kept minimal so callers can map Dirent → this trivially). */
+ *  need (kept minimal so callers can map Dirent → this trivially). `ignored`
+ *  is stamped by the caller's gitignore matcher (io stays outside). */
 export interface RawEntry {
   name: string;
   isDir: boolean;
+  ignored?: boolean;
+}
+
+/** The two Files-surface visibility toggles (both default OFF = filtered). */
+export interface ListFilter {
+  /** Show dotfiles (H). */
+  showHidden: boolean;
+  /** Show gitignored entries (I) — they render dimmed. */
+  showIgnored: boolean;
+}
+
+/**
+ * PURE — drop the entries the current toggles hide: {@link ALWAYS_IGNORE}
+ * names always, dotfiles unless `showHidden`, gitignored entries (as stamped
+ * by the caller) unless `showIgnored`.
+ */
+export function filterEntries(entries: readonly RawEntry[], filter: ListFilter): RawEntry[] {
+  return entries.filter((e) => {
+    if (ALWAYS_IGNORE.has(e.name)) return false;
+    if (!filter.showHidden && e.name.startsWith(".")) return false;
+    if (!filter.showIgnored && e.ignored) return false;
+    return true;
+  });
 }
 
 /**
@@ -57,6 +107,7 @@ export function buildNodes(dir: string, entries: RawEntry[], depth: number): Fil
     isDir: e.isDir,
     depth,
     expanded: false,
+    ignored: e.ignored ?? false,
   }));
 }
 
@@ -94,4 +145,178 @@ export function removeSubtreeAt(list: FileNode[], index: number): FileNode[] {
   next.splice(index + 1, end - (index + 1));
   next[index] = { ...parent, expanded: false };
   return next;
+}
+
+// ── M24.6 — decoration, changed walk, filter view, rebuild ──────────────────
+
+/** PURE — `abs` relative to `root` ("" when equal or not under root). Both are
+ *  plain string paths; a trailing slash on root is tolerated. */
+export function relPath(root: string, abs: string): string {
+  const base = root.endsWith("/") ? root.slice(0, -1) : root;
+  if (abs === base) return "";
+  return abs.startsWith(base + "/") ? abs.slice(base.length + 1) : "";
+}
+
+/** PURE — every ancestor DIRECTORY of a repo-relative path, outermost first:
+ *  `a/b/c.ts` → `["a", "a/b"]`. A top-level path has none. */
+export function ancestorDirs(rel: string): string[] {
+  const out: string[] = [];
+  let idx = rel.indexOf("/");
+  while (idx !== -1) {
+    out.push(rel.slice(0, idx));
+    idx = rel.indexOf("/", idx + 1);
+  }
+  return out;
+}
+
+/**
+ * PURE — the per-path git status map from parsed porcelain entries
+ * (repo-relative `path` + one-letter `status`), with the explorer widget's
+ * parent-dir propagation: every ancestor directory inherits the FIRST child
+ * status seen, so a collapsed dir still shows that something changed inside.
+ */
+export function statusMapFromEntries(
+  entries: readonly { path: string; status: string }[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const file of entries) {
+    map.set(file.path, file.status);
+    let parent = file.path;
+    while (parent.includes("/")) {
+      parent = parent.slice(0, parent.lastIndexOf("/"));
+      if (!map.has(parent)) map.set(parent, file.status);
+    }
+  }
+  return map;
+}
+
+/** PURE — compare two repo-relative paths in TREE DISPLAY order: walk the
+ *  segments; where they diverge, a directory component (more segments follow)
+ *  sorts before a terminal file segment — matching {@link sortEntries}'
+ *  dirs-first, case-insensitive ordering. */
+export function treePathCompare(a: string, b: string): number {
+  const as = a.split("/");
+  const bs = b.split("/");
+  const n = Math.min(as.length, bs.length);
+  for (let i = 0; i < n; i++) {
+    const aDir = i < as.length - 1;
+    const bDir = i < bs.length - 1;
+    const av = as[i]!;
+    const bv = bs[i]!;
+    if (av === bv && aDir && bDir) continue;
+    // At the divergence point a directory component sorts before a file
+    // segment, regardless of name (dirs-first display order).
+    if (aDir !== bDir) return aDir ? -1 : 1;
+    const al = av.toLowerCase();
+    const bl = bv.toLowerCase();
+    if (al !== bl) return al < bl ? -1 : 1;
+    if (av !== bv) return av < bv ? -1 : 1;
+  }
+  return as.length - bs.length;
+}
+
+/**
+ * PURE — the ordered changed-FILE walk for `[`/`]`: the porcelain entries'
+ * paths, deduped, minus anything the surface can never show (a DELETED file
+ * has no row at all, an {@link ALWAYS_IGNORE} segment or a dot segment while
+ * hidden files are off is filtered out — hopping to an unrevealable row would
+ * strand the selection and wedge the chain), sorted in tree display order.
+ */
+export function changedFileWalk(
+  entries: readonly { path: string; status?: string }[],
+  opts: { showHidden: boolean },
+): string[] {
+  const seen = new Set<string>();
+  for (const e of entries) {
+    if (!e.path) continue;
+    if (e.status === "D") continue;
+    const segs = e.path.split("/");
+    if (segs.some((s) => ALWAYS_IGNORE.has(s))) continue;
+    if (!opts.showHidden && segs.some((s) => s.startsWith("."))) continue;
+    seen.add(e.path);
+  }
+  return [...seen].sort(treePathCompare);
+}
+
+/**
+ * PURE — the next/previous changed path from `current` (repo-relative, or null
+ * when the selection is nowhere useful), wrapping around. `current` need not
+ * be IN the walk — the step lands on the nearest entry in walk order, so a hop
+ * from an unchanged file between two changed ones does the right thing.
+ */
+export function nextChangedPath(
+  walk: readonly string[],
+  current: string | null,
+  dir: 1 | -1,
+): string | null {
+  if (walk.length === 0) return null;
+  if (current === null) return dir === 1 ? walk[0]! : walk[walk.length - 1]!;
+  if (dir === 1) {
+    for (const p of walk) if (treePathCompare(p, current) > 0) return p;
+    return walk[0]!;
+  }
+  for (let i = walk.length - 1; i >= 0; i--) {
+    if (treePathCompare(walk[i]!, current) < 0) return walk[i]!;
+  }
+  return walk[walk.length - 1]!;
+}
+
+/** One visible row of the `/`-filtered tree: the node plus its index into the
+ *  UNDERLYING flat list (so activation/expansion math still applies there). */
+export interface FilteredRow {
+  node: FileNode;
+  index: number;
+}
+
+/**
+ * PURE — the `/` filter view over the flat list: rows whose NAME contains the
+ * query case-insensitively, each carrying its underlying index. A null or
+ * empty query is "filter off" — every row, in order. The list itself is never
+ * touched, so expanded state trivially survives the filter.
+ */
+export function filterView(list: readonly FileNode[], query: string | null): FilteredRow[] {
+  if (!query) return list.map((node, index) => ({ node, index }));
+  const q = query.toLowerCase();
+  const out: FilteredRow[] = [];
+  for (let index = 0; index < list.length; index++) {
+    const node = list[index]!;
+    if (node.name.toLowerCase().includes(q)) out.push({ node, index });
+  }
+  return out;
+}
+
+/** PURE — the index of `path` in the flat list, or -1. */
+export function indexOfPath(list: readonly FileNode[], path: string): number {
+  for (let i = 0; i < list.length; i++) if (list[i]!.path === path) return i;
+  return -1;
+}
+
+/**
+ * PURE — rebuild the whole flat tree from fresh directory listings while
+ * PRESERVING expansion: `listing` maps a directory's absolute path → its
+ * fresh (already filtered/annotated) entries, `expanded` is the set of dir
+ * paths that were expanded before the refresh. A dir stays expanded only when
+ * it survived the refresh AND its fresh listing was provided; a vanished or
+ * newly-hidden dir simply drops out. Keys must be the exact `FileNode.path`
+ * strings (and the root exactly as passed).
+ */
+export function rebuildTree(
+  rootDir: string,
+  listing: ReadonlyMap<string, readonly RawEntry[]>,
+  expanded: ReadonlySet<string>,
+): FileNode[] {
+  const walk = (dir: string, depth: number): FileNode[] => {
+    const ents = listing.get(dir);
+    if (!ents) return [];
+    const out: FileNode[] = [];
+    for (const node of buildNodes(dir, [...ents], depth)) {
+      if (node.isDir && expanded.has(node.path) && listing.has(node.path)) {
+        out.push({ ...node, expanded: true }, ...walk(node.path, depth + 1));
+      } else {
+        out.push(node);
+      }
+    }
+    return out;
+  };
+  return walk(rootDir, 0);
 }

--- a/packages/daemon/src/tui/mirror/palette.test.ts
+++ b/packages/daemon/src/tui/mirror/palette.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { staticPaletteActions, filterPaletteActions, parseBufferList } from "./palette.ts";
+import {
+  staticPaletteActions,
+  filterPaletteActions,
+  parseBufferList,
+  paletteActionKey,
+  paletteRows,
+  paletteRowText,
+  firstPaletteAction,
+  stepPaletteRow,
+  PALETTE_RECENT_LIMIT,
+  type PaletteAction,
+  type PaletteRow,
+} from "./palette.ts";
 
 describe("staticPaletteActions", () => {
   it("offers the four tab switches, one attach per session, then save/refresh/paste/settings/quit", () => {
@@ -241,6 +253,227 @@ describe("palette overlay geometry (M21.9)", () => {
     expect(clampPaletteTop(99, 25, 10)).toBe(15);
     expect(clampPaletteTop(-3, 25, 10)).toBe(0);
     expect(clampPaletteTop(4, 6, 10)).toBe(0); // shorter than a page never scrolls
+  });
+});
+
+describe("paletteActionKey (M24.4)", () => {
+  it("keys on kind + restart-stable payload, never the label or pane id", () => {
+    expect(paletteActionKey({ kind: "tab", tab: "files", label: "Switch tab: Files" })).toBe(
+      "tab:files",
+    );
+    expect(paletteActionKey({ kind: "attach", session: "web", label: "x" })).toBe("attach:web");
+    // jump keys by SESSION: pane ids renumber across restarts, labels relabel.
+    expect(
+      paletteActionKey({
+        kind: "jump-agent",
+        paneId: "%9",
+        session: "web",
+        windowIndex: 2,
+        label: "y",
+      }),
+    ).toBe("jump-agent:web");
+    expect(
+      paletteActionKey({
+        kind: "restart-agent",
+        paneId: "%9",
+        agentKind: "claude",
+        session: "web",
+        label: "z",
+      }),
+    ).toBe("restart-agent:web:claude");
+    expect(paletteActionKey({ kind: "settings", id: "settings-theme", label: "w" })).toBe(
+      "settings:settings-theme",
+    );
+    expect(paletteActionKey({ kind: "select-layout", layout: "tiled", label: "v" })).toBe(
+      "select-layout:tiled",
+    );
+    expect(paletteActionKey({ kind: "open-file", path: "src/a.ts", label: "u" })).toBe(
+      "open-file:src/a.ts",
+    );
+    expect(paletteActionKey({ kind: "save", label: "Save file" })).toBe("save");
+    // rename-window's typed name is query state, not identity.
+    expect(paletteActionKey({ kind: "rename-window", name: "build", label: "t" })).toBe(
+      "rename-window",
+    );
+  });
+
+  it("identical actions with different labels share a key (relabels keep history)", () => {
+    const a: PaletteAction = { kind: "attach", session: "web", label: "Attach session: web" };
+    const b: PaletteAction = { kind: "attach", session: "web", label: "Open workspace: web" };
+    expect(paletteActionKey(a)).toBe(paletteActionKey(b));
+  });
+});
+
+describe("filterPaletteActions usage tie-break (M24.4)", () => {
+  it("breaks score ties by frequency then recency; score still wins first", () => {
+    // "attach s" matches every attach row identically — usage decides.
+    const usage = {
+      "attach:beta": { count: 2, lastUsed: 100 },
+      "attach:alpha": { count: 1, lastUsed: 999 },
+    };
+    const ranked = filterPaletteActions("attach s", ["alpha", "beta", "gamma"], { usage })
+      .filter((a) => a.kind === "attach")
+      .map((a) => (a.kind === "attach" ? a.session : ""));
+    expect(ranked).toEqual(["beta", "alpha", "gamma"]);
+    // …but usage never outranks a better fuzzy score: an exact session query
+    // puts that session first however often another was used.
+    const exact = filterPaletteActions("attach session: gamma", ["alpha", "beta", "gamma"], {
+      usage: { "attach:beta": { count: 50, lastUsed: 999 } },
+    }).filter((a) => a.kind === "attach");
+    expect(exact[0]).toMatchObject({ session: "gamma" });
+  });
+});
+
+describe("paletteRows (M24.4 — grouped empty query)", () => {
+  const agent = (over: Partial<{ paneId: string; session: string; state: string }>) => ({
+    paneId: over.paneId ?? "%1",
+    windowIndex: 0,
+    session: over.session ?? "web",
+    kind: "claude",
+    state: (over.state ?? "working") as "working" | "blocked",
+    since: null,
+  });
+  const labels = (rows: PaletteRow[]) =>
+    rows.map((r) => (r.type === "header" ? `#${r.label}` : r.action.label));
+
+  it("is exactly the ungrouped statics when there is nothing to group", () => {
+    const rows = paletteRows("", ["alpha"]);
+    expect(rows.every((r) => r.type === "action")).toBe(true);
+    expect(rows.map((r) => (r.type === "action" ? r.action.label : ""))).toEqual(
+      staticPaletteActions(["alpha"]).map((a) => a.label),
+    );
+  });
+
+  it("shows recent-then-suggested-then-commands; a twice-used action outranks a once-used", () => {
+    const usage = {
+      "tab:diff": { count: 1, lastUsed: 999 }, // once, most recently
+      save: { count: 2, lastUsed: 100 }, // twice, earlier — frequency wins
+    };
+    const rows = paletteRows("", ["alpha"], { usage, surface: "files" });
+    const ls = labels(rows);
+    expect(ls[0]).toBe("#recent");
+    expect(ls[1]).toBe("Save file");
+    expect(ls[2]).toBe("Switch tab: Diff");
+    const sug = ls.indexOf("#suggested");
+    expect(sug).toBeGreaterThan(2);
+    // Files surface suggests save + open-folder; save is already RECENT, so
+    // only open-folder remains (no duplicate rows).
+    expect(ls.slice(sug + 1, ls.indexOf("#commands"))).toEqual(["Open folder…"]);
+    expect(ls.filter((l) => l === "Save file")).toHaveLength(1);
+    // …and the rest keeps today's natural order under "#commands".
+    expect(ls.indexOf("#commands")).toBeGreaterThan(sug);
+    expect(ls.slice(ls.indexOf("#commands") + 1)).toContain("Quit");
+  });
+
+  it("caps the recent group and ignores usage keys with no current action", () => {
+    const usage: Record<string, { count: number; lastUsed: number }> = {
+      "attach:gone-session": { count: 9, lastUsed: 999 }, // no longer offerable
+    };
+    for (let i = 0; i < 8; i++) usage[`settings:x${i}`] = { count: 1, lastUsed: i };
+    usage["save"] = { count: 1, lastUsed: 50 };
+    usage["quit"] = { count: 1, lastUsed: 51 };
+    const rows = paletteRows("", [], { usage });
+    const recent = [];
+    for (const r of rows.slice(1)) {
+      if (r.type === "header") break;
+      recent.push(r.action.label);
+    }
+    // only real, currently-offered actions land, capped at the limit
+    expect(recent.length).toBeLessThanOrEqual(PALETTE_RECENT_LIMIT);
+    expect(recent).toContain("Save file");
+    expect(recent).toContain("Quit");
+  });
+
+  it("tops the suggested group with BLOCKED agents' jumps, attention order kept", () => {
+    const agents = [
+      agent({ paneId: "%3", session: "help-me", state: "blocked" }),
+      agent({ paneId: "%4", session: "busy", state: "working" }),
+    ];
+    const rows = paletteRows("", ["help-me", "busy"], {
+      agents,
+      surface: "terminal",
+      terminal: true,
+    });
+    const ls = labels(rows);
+    const sug = ls.indexOf("#suggested");
+    expect(sug).toBeGreaterThanOrEqual(0);
+    expect(ls[sug + 1]).toBe("Agent: claude · help-me (blocked)");
+    // the WORKING agent's jump is not suggested — it stays under commands
+    expect(ls.slice(sug, ls.indexOf("#commands"))).not.toContain("Agent: claude · busy (working)");
+  });
+
+  it("suggests the Terminal surface's again-spawn + window/pane verbs", () => {
+    const rows = paletteRows("", ["a"], {
+      terminal: true,
+      surface: "terminal",
+      againName: "claude",
+    });
+    const ls = labels(rows);
+    const sug = ls.indexOf("#suggested");
+    const cmd = ls.indexOf("#commands");
+    const suggested = ls.slice(sug + 1, cmd);
+    expect(suggested[0]).toBe("New agent: claude (again)");
+    expect(suggested).toEqual(
+      expect.arrayContaining(["New window", "Zoom pane", "Swap pane with next"]),
+    );
+  });
+
+  it("a typed query yields a FLAT ranked list — no headers", () => {
+    const rows = paletteRows("set", ["a"], { usage: { save: { count: 3, lastUsed: 9 } } });
+    expect(rows.some((r) => r.type === "header")).toBe(false);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it("attaches the keycap to rows whose action key has one", () => {
+    const rows = paletteRows("", ["a"], { keycaps: { save: "^s", "tab:home": "F1" } });
+    const save = rows.find((r) => r.type === "action" && r.action.kind === "save");
+    const home = rows.find(
+      (r) => r.type === "action" && r.action.kind === "tab" && r.action.tab === "home",
+    );
+    const quit = rows.find((r) => r.type === "action" && r.action.kind === "quit");
+    expect(save?.type === "action" && save.shortcut).toBe("^s");
+    expect(home?.type === "action" && home.shortcut).toBe("F1");
+    expect(quit?.type === "action" && quit.shortcut).toBe(null);
+  });
+});
+
+describe("palette selection helpers (M24.4)", () => {
+  const rows: PaletteRow[] = [
+    { type: "header", label: "recent" },
+    { type: "action", action: { kind: "save", label: "Save file" }, shortcut: null },
+    { type: "header", label: "commands" },
+    { type: "action", action: { kind: "quit", label: "Quit" }, shortcut: null },
+  ];
+  it("firstPaletteAction lands past a leading header; -1 when no actions", () => {
+    expect(firstPaletteAction(rows)).toBe(1);
+    expect(firstPaletteAction([{ type: "header", label: "x" }])).toBe(-1);
+    expect(firstPaletteAction([])).toBe(-1);
+  });
+  it("stepPaletteRow skips headers both ways and pins at the ends", () => {
+    expect(stepPaletteRow(rows, 1, 1)).toBe(3); // down over the header
+    expect(stepPaletteRow(rows, 3, -1)).toBe(1); // up over the header
+    expect(stepPaletteRow(rows, 3, 1)).toBe(3); // bottom stays
+    expect(stepPaletteRow(rows, 1, -1)).toBe(1); // top stays (header above)
+  });
+});
+
+describe("paletteRowText (M24.4 — right-aligned keycaps)", () => {
+  it("right-aligns the keycap and pads between", () => {
+    expect(paletteRowText("Save file", "^s", 20)).toBe("Save file         ^s");
+  });
+  it("truncates the label with an ellipsis so the keycap always fits", () => {
+    const out = paletteRowText("A very long palette action label", "F1", 20);
+    expect(out).toHaveLength(20);
+    expect(out.endsWith("F1")).toBe(true);
+    expect(out).toContain("…");
+  });
+  it("without a keycap it only truncates", () => {
+    expect(paletteRowText("Quit", null, 20)).toBe("Quit");
+    expect(paletteRowText("A very long palette action label", null, 10)).toBe("A very lo…");
+  });
+  it("degrades safely at tiny widths", () => {
+    expect(paletteRowText("Save file", "^s", 3)).toBe("Sa…");
+    expect(paletteRowText("Save file", "^s", 0)).toBe("");
   });
 });
 

--- a/packages/daemon/src/tui/mirror/palette.test.ts
+++ b/packages/daemon/src/tui/mirror/palette.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { staticPaletteActions, filterPaletteActions, parseBufferList } from "./palette.ts";
+import {
+  staticPaletteActions,
+  filterPaletteActions,
+  parseBufferList,
+  goToFileActions,
+  GO_FILE_CAP,
+} from "./palette.ts";
 
 describe("staticPaletteActions", () => {
   it("offers the four tab switches, one attach per session, then save/refresh/paste/settings/quit", () => {
@@ -264,5 +270,29 @@ describe("select-text action (M22.9)", () => {
   it("fuzzy-matches by typing 'select'", () => {
     const filtered = filterPaletteActions("select", [], { terminal: true, appMousePane: true });
     expect(filtered.some((a) => a.kind === "select-text")).toBe(true);
+  });
+});
+
+describe("goToFileActions / repoFiles (M24.6)", () => {
+  const files = ["src/tui/mirror/file-tree.ts", "src/lib/app-config.ts", "README.md"];
+
+  it("offers fuzzy-matched Go to file rows, capped, and none on an empty query", () => {
+    const rows = goToFileActions("filetree", files);
+    expect(rows.map((a) => a.label)).toEqual(["Go to file: src/tui/mirror/file-tree.ts"]);
+    expect(rows[0]).toMatchObject({ kind: "go-file", path: "src/tui/mirror/file-tree.ts" });
+    expect(goToFileActions("", files)).toEqual([]);
+    expect(goToFileActions("x", [])).toEqual([]);
+    const many = Array.from({ length: 30 }, (_, i) => `src/f${i}.ts`);
+    expect(goToFileActions("src", many, GO_FILE_CAP).length).toBe(GO_FILE_CAP);
+  });
+
+  it("appends go-file rows AFTER the existing results (ranking untouched)", () => {
+    const out = filterPaletteActions("readme", [], { repoFiles: files });
+    const kinds = out.map((a) => a.kind);
+    // the dynamic open-file row still precedes the appended go-file rows
+    expect(kinds.indexOf("open-file")).toBeLessThan(kinds.indexOf("go-file"));
+    expect(out[out.length - 1]).toMatchObject({ kind: "go-file", path: "README.md" });
+    // without repoFiles the list is exactly as before — no go-file rows
+    expect(filterPaletteActions("readme", []).some((a) => a.kind === "go-file")).toBe(false);
   });
 });

--- a/packages/daemon/src/tui/mirror/palette.ts
+++ b/packages/daemon/src/tui/mirror/palette.ts
@@ -38,6 +38,7 @@ export type PaletteAction =
   | { kind: "save"; label: string }
   | { kind: "refresh-diff"; label: string }
   | { kind: "paste-buffer"; label: string }
+  | { kind: "search-scrollback"; label: string }
   | { kind: "new-window"; label: string }
   | { kind: "rename-window"; name: string; label: string }
   | { kind: "kill-window"; label: string }
@@ -177,6 +178,10 @@ export function staticPaletteActions(
     actions.push({ kind: "settings", id: c.id, label: c.label });
   }
   if (ctx.terminal) {
+    // `/` only opens search while scrolled into history (at the live prompt it
+    // belongs to the pane — agents' slash commands); this is the always-there
+    // entry.
+    actions.push({ kind: "search-scrollback", label: "Search scrollback" });
     actions.push({ kind: "new-window", label: "New window" });
     actions.push({ kind: "kill-window", label: "Kill window" });
     actions.push({ kind: "zoom-pane", label: "Zoom pane" });

--- a/packages/daemon/src/tui/mirror/palette.ts
+++ b/packages/daemon/src/tui/mirror/palette.ts
@@ -12,7 +12,7 @@
  * to the top when the query looks like a path.
  */
 import { fuzzyFilter } from "../team/fuzzy.ts";
-import type { Tab } from "./app-state.ts";
+import type { PaletteUsageEntry, Tab } from "./app-state.ts";
 import type { AgentRowInput } from "./agent-rows.ts";
 import { SETTINGS_PALETTE_COMMANDS, type SettingsCommandId } from "./settings-model.ts";
 
@@ -84,6 +84,19 @@ export interface PaletteContext {
    *  argv, …) — when set, a direct "New agent: <name> (again)" action is PINNED
    *  FIRST, so a repeat spawn is F5 → Enter (M24.1's ≤2-Enters bar). */
   againName?: string | null;
+  /** Palette usage history (M24.4) keyed by {@link paletteActionKey}: drives
+   *  the empty-query "recent" group and the frequency/recency tie-break on a
+   *  typed query. Persisted in app-state. */
+  usage?: Readonly<Record<string, PaletteUsageEntry>>;
+  /** The active surface tab (M24.4) — steers the empty-query "suggested"
+   *  group (Terminal → window/pane verbs + the again spawn; Files → save +
+   *  open-folder). `terminal` above stays THE gate for the window/pane verbs
+   *  so existing callers/tests are untouched. */
+  surface?: Tab;
+  /** Action key → keycap ({@link ../mirror/settings-model.ts}'s
+   *  PALETTE_KEYCAPS) — rows whose action has one right-align it (M24.4).
+   *  app.tsx drops `quit` in HOSTED mode, where ^q detaches instead. */
+  keycaps?: Readonly<Record<string, string>>;
 }
 
 const TAB_LABELS: { tab: Tab; label: string }[] = [
@@ -291,8 +304,52 @@ function looksLikePath(q: string): boolean {
 }
 
 /**
+ * PURE — the STABLE identity of an action for usage history (M24.4): the kind
+ * plus the payload fields that survive restarts (session/layout/settings id/
+ * path — NOT the label, so relabeling never orphans history, and NOT pane ids,
+ * which tmux renumbers). Kinds without a stable payload are keyed by kind
+ * alone (rename-window's typed name is query-dependent, not identity).
+ */
+export function paletteActionKey(a: PaletteAction): string {
+  switch (a.kind) {
+    case "tab":
+      return `tab:${a.tab}`;
+    case "attach":
+      return `attach:${a.session}`;
+    case "jump-agent":
+      return `jump-agent:${a.session}`;
+    case "restart-agent":
+      return `restart-agent:${a.session}:${a.agentKind}`;
+    case "stop-agent":
+      return `stop-agent:${a.session}:${a.agentKind}`;
+    case "select-layout":
+      return `select-layout:${a.layout}`;
+    case "settings":
+      return `settings:${a.id}`;
+    case "open-file":
+      return `open-file:${a.path}`;
+    default:
+      return a.kind;
+  }
+}
+
+/** PURE — the usage comparator (frequency first, then recency): negative when
+ *  `a` should rank before `b`. Unused actions rank last, mutually tied. */
+function compareUsage(
+  a: PaletteAction,
+  b: PaletteAction,
+  usage: Readonly<Record<string, PaletteUsageEntry>> | undefined,
+): number {
+  const ua = usage?.[paletteActionKey(a)];
+  const ub = usage?.[paletteActionKey(b)];
+  return (ub?.count ?? 0) - (ua?.count ?? 0) || (ub?.lastUsed ?? 0) - (ua?.lastUsed ?? 0);
+}
+
+/**
  * PURE — the palette result list for `query`: the static actions fuzzy-filtered
- * and score-sorted, plus (when the query is non-empty) a dynamic
+ * and score-sorted (exact/prefix matches outrank mid-word via the scorer's
+ * label-start weighting; score TIES break by usage — frequency then recency —
+ * M24.4), plus (when the query is non-empty) a dynamic
  * "Open file: <query>" action. That open-file entry is pinned FIRST when the
  * query looks like a path, otherwise appended LAST so it never buries a real
  * match. An empty query returns every static action in natural order.
@@ -305,7 +362,11 @@ export function filterPaletteActions(
   const statics = staticPaletteActions(sessions, ctx);
   const q = query.trim();
   const matched =
-    q.length === 0 ? statics : fuzzyFilter(query, statics, (a) => a.label).map((m) => m.item);
+    q.length === 0
+      ? statics
+      : fuzzyFilter(query, statics, (a) => a.label)
+          .sort((x, y) => y.score - x.score || compareUsage(x.item, y.item, ctx.usage))
+          .map((m) => m.item);
   if (q.length === 0) return matched;
   const dynamic: PaletteAction[] = [{ kind: "open-file", path: q, label: `Open file: ${q}` }];
   // On the Terminal surface a non-empty query also offers a rename-to-<query>
@@ -315,4 +376,148 @@ export function filterPaletteActions(
     dynamic.push({ kind: "rename-window", name: q, label: `Rename window: ${q}` });
   }
   return looksLikePath(q) ? [...dynamic, ...matched] : [...matched, ...dynamic];
+}
+
+// ── Grouped rows (M24.4 — the palette's list model) ─────────────────────────
+// The overlay renders ROWS, not bare actions: on an EMPTY query the list opens
+// with a "recent" group (top used actions), a contextual "suggested" group,
+// then everything else under "commands"; a typed query is one flat ranked list
+// (no headers). Headers are real rows — they occupy a screen line, scroll with
+// the list, and are NOT selectable/clickable — so the selection helpers below
+// are what the keyboard/router use to move between action rows.
+
+/** One rendered palette line: a group header, or an action with its optional
+ *  right-aligned keycap (from ctx.keycaps). */
+export type PaletteRow =
+  | { type: "header"; label: string }
+  | { type: "action"; action: PaletteAction; shortcut: string | null };
+
+/** How many actions the empty-query "recent" group shows at most. */
+export const PALETTE_RECENT_LIMIT = 5;
+
+/** The Terminal surface's suggested window/pane verbs, in offer order. */
+const TERMINAL_SUGGESTED_KINDS: ReadonlyArray<PaletteAction["kind"]> = [
+  "new-window",
+  "kill-window",
+  "zoom-pane",
+  "swap-pane",
+  "break-pane",
+  "rotate-window",
+];
+
+/**
+ * PURE — the palette rows for `query` (M24.4). A non-empty query is the flat
+ * {@link filterPaletteActions} ranking. An empty query groups:
+ *   1. "recent" — up to {@link PALETTE_RECENT_LIMIT} previously-run actions
+ *      still offerable now (usage keys matched against the current statics),
+ *      most-frequently-used first, recency breaking ties;
+ *   2. "suggested" — BLOCKED agents' jump actions first (ctx.agents arrives
+ *      attention-sorted, so their relative order is the sidebar's), then the
+ *      surface's verbs: Terminal → the again-spawn + window/pane verbs, Files
+ *      → save + open-folder;
+ *   3. "commands" — every remaining action in today's natural order.
+ * With nothing to group (no usage, no suggestions) the list is exactly the
+ * ungrouped statics — no headers, same as before this card.
+ */
+export function paletteRows(
+  query: string,
+  sessions: string[],
+  ctx: PaletteContext = {},
+): PaletteRow[] {
+  const row = (action: PaletteAction): PaletteRow => ({
+    type: "action",
+    action,
+    shortcut: ctx.keycaps?.[paletteActionKey(action)] ?? null,
+  });
+  if (query.trim().length > 0) return filterPaletteActions(query, sessions, ctx).map(row);
+
+  const statics = staticPaletteActions(sessions, ctx);
+  // First static per key — recents resolve through this so a persisted key
+  // finds the action's CURRENT incarnation (relabels don't orphan history).
+  const byKey = new Map<string, PaletteAction>();
+  for (const a of statics) {
+    const k = paletteActionKey(a);
+    if (!byKey.has(k)) byKey.set(k, a);
+  }
+  const taken = new Set<PaletteAction>();
+
+  const recent: PaletteAction[] = [];
+  const usedKeys = Object.entries(ctx.usage ?? {})
+    .sort(([, a], [, b]) => b.count - a.count || b.lastUsed - a.lastUsed)
+    .map(([k]) => k);
+  for (const k of usedKeys) {
+    if (recent.length >= PALETTE_RECENT_LIMIT) break;
+    const a = byKey.get(k);
+    if (a && !taken.has(a)) {
+      recent.push(a);
+      taken.add(a);
+    }
+  }
+
+  const suggested: PaletteAction[] = [];
+  const suggest = (pred: (a: PaletteAction) => boolean): void => {
+    for (const a of statics) {
+      if (!taken.has(a) && pred(a)) {
+        suggested.push(a);
+        taken.add(a);
+      }
+    }
+  };
+  // Blocked agents outrank every other suggestion — they are why the user is
+  // opening the palette (the sidebar's attention-first law, applied here).
+  const blockedPanes = new Set(
+    (ctx.agents ?? []).filter((x) => x.state === "blocked").map((x) => x.paneId),
+  );
+  suggest((a) => a.kind === "jump-agent" && blockedPanes.has(a.paneId));
+  if (ctx.surface === "terminal") {
+    suggest((a) => a.kind === "new-agent-again");
+    suggest((a) => TERMINAL_SUGGESTED_KINDS.includes(a.kind));
+  } else if (ctx.surface === "files") {
+    suggest((a) => a.kind === "save" || a.kind === "open-folder");
+  }
+
+  if (recent.length === 0 && suggested.length === 0) return statics.map(row);
+  const rows: PaletteRow[] = [];
+  if (recent.length > 0) {
+    rows.push({ type: "header", label: "recent" });
+    for (const a of recent) rows.push(row(a));
+  }
+  if (suggested.length > 0) {
+    rows.push({ type: "header", label: "suggested" });
+    for (const a of suggested) rows.push(row(a));
+  }
+  rows.push({ type: "header", label: "commands" });
+  for (const a of statics) if (!taken.has(a)) rows.push(row(a));
+  return rows;
+}
+
+/** PURE — the first selectable (action) row index, or -1 when none. Where the
+ *  selection starts on open/query edits (headers are never selected). */
+export function firstPaletteAction(rows: readonly PaletteRow[]): number {
+  return rows.findIndex((r) => r.type === "action");
+}
+
+/** PURE — the next action row from `cur` in `dir` (±1), skipping headers;
+ *  stays put at the list's ends. The keyboard's up/down. */
+export function stepPaletteRow(rows: readonly PaletteRow[], cur: number, dir: 1 | -1): number {
+  for (let i = cur + dir; i >= 0 && i < rows.length; i += dir) {
+    if (rows[i]!.type === "action") return i;
+  }
+  return cur;
+}
+
+/**
+ * PURE — one action row's text after the selection prefix: the label, then —
+ * when the row has a keycap — right-aligned padding + the keycap inside
+ * `width` cells. The label truncates with an ellipsis so the keycap ALWAYS
+ * fits (min one space between); without a keycap the label just truncates.
+ */
+export function paletteRowText(label: string, shortcut: string | null, width: number): string {
+  if (width <= 0) return "";
+  if (!shortcut || shortcut.length + 2 > width) {
+    return label.length <= width ? label : label.slice(0, Math.max(0, width - 1)) + "…";
+  }
+  const labelMax = width - shortcut.length - 1;
+  const shown = label.length <= labelMax ? label : label.slice(0, Math.max(0, labelMax - 1)) + "…";
+  return shown + " ".repeat(width - shown.length - shortcut.length) + shortcut;
 }

--- a/packages/daemon/src/tui/mirror/palette.ts
+++ b/packages/daemon/src/tui/mirror/palette.ts
@@ -35,6 +35,10 @@ export type PaletteAction =
   | { kind: "restart-agent"; paneId: string; agentKind: string; session: string; label: string }
   | { kind: "stop-agent"; paneId: string; agentKind: string; session: string; label: string }
   | { kind: "open-file"; path: string; label: string }
+  // "Go to file:" (M24.6) — one row per fuzzy-matched REPO file (workspace-
+  // relative, ignore-respecting, fed by the app via ctx.repoFiles), unlike
+  // open-file whose path is whatever the user typed.
+  | { kind: "go-file"; path: string; label: string }
   | { kind: "save"; label: string }
   | { kind: "refresh-diff"; label: string }
   | { kind: "paste-buffer"; label: string }
@@ -84,6 +88,10 @@ export interface PaletteContext {
    *  argv, …) — when set, a direct "New agent: <name> (again)" action is PINNED
    *  FIRST, so a repeat spawn is F5 → Enter (M24.1's ≤2-Enters bar). */
   againName?: string | null;
+  /** The workspace's file list (M24.6) — repo-relative paths, gitignore-
+   *  respecting, capped by the caller. A non-empty query offers fuzzy-matched
+   *  "Go to file: <path>" rows via {@link goToFileActions}. */
+  repoFiles?: readonly string[];
 }
 
 const TAB_LABELS: { tab: Tab; label: string }[] = [
@@ -290,6 +298,29 @@ function looksLikePath(q: string): boolean {
   return /[/.~]/.test(q);
 }
 
+/** Cap on "Go to file:" rows so a big repo never floods the palette. */
+export const GO_FILE_CAP = 8;
+
+/**
+ * PURE (M24.6) — the dynamic "Go to file:" rows for `query`: the repo's
+ * (ignore-respecting) file list fuzzy-filtered against the query, one open
+ * action per match, capped at `cap`. An empty query offers none — the static
+ * list stays uncluttered. Strictly ADDITIVE to the palette: this only CALLS
+ * the shared fuzzy filter, and its rows are appended after the existing
+ * results (see {@link filterPaletteActions}).
+ */
+export function goToFileActions(
+  query: string,
+  repoFiles: readonly string[],
+  cap: number = GO_FILE_CAP,
+): PaletteAction[] {
+  const q = query.trim();
+  if (q.length === 0 || repoFiles.length === 0) return [];
+  return fuzzyFilter(q, [...repoFiles], (p) => p)
+    .slice(0, cap)
+    .map((m) => ({ kind: "go-file" as const, path: m.item, label: `Go to file: ${m.item}` }));
+}
+
 /**
  * PURE — the palette result list for `query`: the static actions fuzzy-filtered
  * and score-sorted, plus (when the query is non-empty) a dynamic
@@ -314,5 +345,10 @@ export function filterPaletteActions(
   if (ctx.terminal) {
     dynamic.push({ kind: "rename-window", name: q, label: `Rename window: ${q}` });
   }
-  return looksLikePath(q) ? [...dynamic, ...matched] : [...matched, ...dynamic];
+  // "Go to file:" rows (M24.6) are APPENDED after everything so this addition
+  // cannot disturb the existing result ranking.
+  const goFiles = goToFileActions(q, ctx.repoFiles ?? []);
+  return looksLikePath(q)
+    ? [...dynamic, ...matched, ...goFiles]
+    : [...matched, ...dynamic, ...goFiles];
 }

--- a/packages/daemon/src/tui/mirror/settings-model.test.ts
+++ b/packages/daemon/src/tui/mirror/settings-model.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../chrome/notify.ts";
 import { prefixKeyBinds } from "../chrome/statusline.ts";
 import {
+  PALETTE_KEYCAPS,
   SETTINGS_PALETTE_COMMANDS,
   THEME_PRESETS,
   keybindingItems,
@@ -173,6 +174,33 @@ describe("keybinding viewer", () => {
     expect(keybindingItems(rebound).find((r) => r.label === "Home cockpit")?.detail).toBe("M-c");
     // the app's fixed keys are listed after the chrome rows
     expect(rows.some((r) => r.id === "app:Command palette")).toBe(true);
+  });
+  it("appends the kitty ⌘K fast path to the palette row only when enabled (M24.4)", () => {
+    const off = keybindingItems(CHROME_DEFAULT_KEYS);
+    expect(off.find((r) => r.id === "app:Command palette")?.detail).toBe("F5 · ^p");
+    const on = keybindingItems(CHROME_DEFAULT_KEYS, true);
+    expect(on.find((r) => r.id === "app:Command palette")?.detail).toBe("F5 · ^p · ⌘K");
+    // no other row changes
+    expect(on.filter((r) => r.detail?.includes("⌘K"))).toHaveLength(1);
+  });
+});
+
+describe("PALETTE_KEYCAPS (M24.4 — the palette rows' shortcut source)", () => {
+  it("maps exactly the actions the viewer enumerates with palette keys", () => {
+    expect(PALETTE_KEYCAPS).toEqual({
+      "tab:home": "F1",
+      "tab:terminal": "F2",
+      "tab:files": "F3",
+      "tab:diff": "F4",
+      save: "^s",
+      quit: "^q",
+    });
+  });
+  it("agrees with the viewer rows (single source — no drift)", () => {
+    const rows = keybindingItems(CHROME_DEFAULT_KEYS);
+    for (const keycap of Object.values(PALETTE_KEYCAPS)) {
+      expect(rows.some((r) => r.detail === keycap)).toBe(true);
+    }
   });
 });
 

--- a/packages/daemon/src/tui/mirror/settings-model.ts
+++ b/packages/daemon/src/tui/mirror/settings-model.ts
@@ -258,10 +258,35 @@ export function prefixTwinFor(altKey: string): string | null {
   return letter;
 }
 
+/** THE app-key enumeration — the ONE place the unified app's fixed keys are
+ *  listed (M24.4). The keybind viewer's app rows AND the palette's right-aligned
+ *  row shortcuts both read this; `paletteAction` is the stable palette action
+ *  key ({@link ./palette.ts}'s paletteActionKey) a keycap attaches to. */
+const APP_KEY_ROWS: ReadonlyArray<{ label: string; keycap: string; paletteAction?: string }> = [
+  { label: "Command palette", keycap: "F5 · ^p" },
+  { label: "Home tab", keycap: "F1", paletteAction: "tab:home" },
+  { label: "Terminal tab", keycap: "F2", paletteAction: "tab:terminal" },
+  { label: "Files tab", keycap: "F3", paletteAction: "tab:files" },
+  { label: "Diff tab", keycap: "F4", paletteAction: "tab:diff" },
+  { label: "Save file", keycap: "^s", paletteAction: "save" },
+  { label: "Back to Home", keycap: "^g" },
+  { label: "Toggle editor", keycap: "^e" },
+  { label: "Quit / detach", keycap: "^q", paletteAction: "quit" },
+];
+
+/** PURE — palette action key → keycap, derived from {@link APP_KEY_ROWS}. The
+ *  palette right-aligns these on rows that have one; app.tsx drops `quit` in
+ *  HOSTED mode, where ^q detaches instead. */
+export const PALETTE_KEYCAPS: Readonly<Record<string, string>> = Object.fromEntries(
+  APP_KEY_ROWS.filter((r) => r.paletteAction).map((r) => [r.paletteAction!, r.keycap]),
+);
+
 /** PURE — the read-only shortcut rows: the chrome actions from the LIVE config
  *  (prefix-first, the Alt fast path second — the prefix form is the one that
- *  survives every keyboard protocol) and then the app's fixed keys. */
-export function keybindingItems(keys: AppKeys): DialogSelectItem[] {
+ *  survives every keyboard protocol) and then the app's fixed keys
+ *  ({@link APP_KEY_ROWS}). `superK` appends the kitty-protocol ⌘K fast path to
+ *  the palette row — shown only when the renderer actually enables it. */
+export function keybindingItems(keys: AppKeys, superK = false): DialogSelectItem[] {
   const chrome: Array<{ label: string; altKey: string }> = [
     { label: "Home cockpit", altKey: keys.home },
     { label: "Session switcher", altKey: keys.popup },
@@ -280,14 +305,10 @@ export function keybindingItems(keys: AppKeys): DialogSelectItem[] {
       detail: twin ? `prefix ${twin} · ${altKey}` : altKey,
     };
   });
-  const app: Array<[string, string]> = [
-    ["Command palette", "F5 · ^p"],
-    ["Home / Terminal / Files / Diff tabs", "F1–F4"],
-    ["Back to Home", "^g"],
-    ["Toggle editor", "^e"],
-    ["Detach from the app", "^q"],
-  ];
-  for (const [label, detail] of app) rows.push({ id: `app:${label}`, label, detail });
+  for (const { label, keycap } of APP_KEY_ROWS) {
+    const detail = superK && label === "Command palette" ? `${keycap} · ⌘K` : keycap;
+    rows.push({ id: `app:${label}`, label, detail });
+  }
   return rows;
 }
 

--- a/packages/daemon/src/tui/team/fuzzy.test.ts
+++ b/packages/daemon/src/tui/team/fuzzy.test.ts
@@ -43,6 +43,27 @@ describe("fuzzyMatch", () => {
     const midWord = fuzzyMatch("web", "wavyrwebsite")!;
     expect(postSep.score).toBeGreaterThan(midWord.score);
   });
+
+  it("ranks a label-start (prefix) match above a mid-word run (M24.4)", () => {
+    const prefix = fuzzyMatch("abcd", "abcdxyz")!;
+    const midWord = fuzzyMatch("abcd", "xxabcdxx")!;
+    expect(prefix.score).toBeGreaterThan(midWord.score);
+    expect(prefix.positions).toEqual([0, 1, 2, 3]);
+  });
+
+  it("ranks a prefix match above a scattered match rich in word-start bonuses (M24.4)", () => {
+    // Measured regression this tier fixes: three word-start hits (30) used to
+    // outscore the exact prefix (29), so "save" ranked the wrong label first.
+    const prefix = fuzzyMatch("save", "save file")!;
+    const scattered = fuzzyMatch("save", "swap pane view east")!;
+    expect(prefix.score).toBeGreaterThan(scattered.score);
+  });
+
+  it("the prefix tier is case-insensitive and leaves non-prefix anchoring alone", () => {
+    expect(fuzzyMatch("SAVE", "Save file")!.score).toBe(fuzzyMatch("save", "Save file")!.score);
+    // "web" still anchors on the word after the separator, not the leading w.
+    expect(fuzzyMatch("web", "wavyr-website")!.positions).toEqual([6, 7, 8]);
+  });
 });
 
 describe("fuzzyFilter", () => {

--- a/packages/daemon/src/tui/team/fuzzy.ts
+++ b/packages/daemon/src/tui/team/fuzzy.ts
@@ -24,6 +24,15 @@ const START_BONUS = 10; // matched char is the first char of the target
 const SEPARATOR_BONUS = 8; // matched char follows a separator (word start)
 const CONTIGUOUS_BONUS = 5; // matched char is adjacent to the previous match
 const BASE = 1; // every matched char is worth at least this
+// Whole-alignment extra when the query is a contiguous PREFIX of the target
+// (M24.4): typing a label's start must rank that label above mid-word runs
+// AND above scattered matches that rack up several word-start bonuses —
+// measured: "save" scored 29 on "Save file" but 30 on "swap pane view east"
+// (three word-start hits). Sized to dominate realistic competitors (a
+// non-prefix alignment outscores a prefix only past ~8 all-word-start chars);
+// word-boundary preference WITHIN non-prefix matches is untouched ("web"
+// still anchors on the "web" of `wavyr-website`, not the leading "w").
+const PREFIX_EXTRA = 24;
 
 /**
  * Case-insensitive subsequence match of `query` against `target`.
@@ -105,6 +114,17 @@ export function fuzzyMatch(
     }
   }
   if (start === -1) return null;
+
+  // The exact/prefix tier (M24.4): when the query IS the target's start, that
+  // alignment (positions 0..m-1) + PREFIX_EXTRA competes with the DP's best —
+  // and effectively always wins, so prefix matches rank first however many
+  // word-start bonuses a scattered alignment collected.
+  if (t.startsWith(q)) {
+    const prefixScore = m * BASE + START_BONUS + (m - 1) * CONTIGUOUS_BONUS + PREFIX_EXTRA;
+    if (prefixScore >= bestScore) {
+      return { score: prefixScore, positions: Array.from({ length: m }, (_, i) => i) };
+    }
+  }
 
   const positions: number[] = [];
   let j = start;


### PR DESCRIPTION
The viewer-parity wave: command palette with ⌘K/kitty protocol + learning ranking + row keycaps; diff surface with stage/unstage verbs, grouping, ± counts, hunk nav, ^e-to-line; files surface with gitignore filtering, git decorations, change-hop, go-to-file. Plus: / no longer hijacked at the live prompt (agents own it — searches only while scrolled), and the editor-space bug fixed. Semantic merge reconciliation documented in the merge commit. 1287 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)