### PR TITLE
feat: notifications that reach you + resume & detection breadth (M25.1/3/4)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2427,7 +2427,7 @@ function excludeSidebarPanes(panes) {
   return panes.filter((pane) => !pane.sidebar);
 }
 function isListableSession(name) {
-  return !name.startsWith("_");
+  return !name.startsWith("_") && !name.startsWith("zz-");
 }
 function tmux(args) {
   try {
@@ -2481,7 +2481,8 @@ function listTeamSessions(tracker, opts = {}) {
         sessionName: name,
         paneId: pane.id,
         agent: manifest && manifest.id !== "shell" ? manifest.id : null,
-        status: status2
+        status: status2,
+        windowIndex: pane.windowIndex
       });
       const entry = buildAgentEntry({ sessionName: name, pane, manifest, state: status2, since });
       if (entry) agents.push(entry);
@@ -4047,6 +4048,22 @@ var init_kitty_keys = __esm({
   }
 });
 
+// packages/daemon/src/tui/chrome/front-door.ts
+function updaterProbeArgv() {
+  return ["has-session", "-t", `=${UPDATER_SESSION}`];
+}
+function updaterSpawnArgv() {
+  return ["new-session", "-d", "-s", UPDATER_SESSION, "exec tmux-ide chrome-updater"];
+}
+var ADOPTED_OPTION, UPDATER_SESSION;
+var init_front_door = __esm({
+  "packages/daemon/src/tui/chrome/front-door.ts"() {
+    "use strict";
+    ADOPTED_OPTION = "@tmux_ide_adopted";
+    UPDATER_SESSION = "_tmux-ide-chrome";
+  }
+});
+
 // packages/daemon/src/schemas/registry.ts
 import { z as z10 } from "zod";
 var RegisteredProjectSchemaZ, RegisterProjectRequestSchemaZ, InitProjectRequestSchemaZ, ProjectTemplateSchemaZ;
@@ -4425,6 +4442,18 @@ var init_chip = __esm({
   }
 });
 
+// packages/daemon/src/lib/state-home.ts
+import { homedir as homedir10 } from "node:os";
+import { join as join10 } from "node:path";
+function stateHome() {
+  return process.env.TMUX_IDE_HOME ?? join10(homedir10(), ".tmux-ide");
+}
+var init_state_home = __esm({
+  "packages/daemon/src/lib/state-home.ts"() {
+    "use strict";
+  }
+});
+
 // packages/daemon/src/tui/chrome/events.ts
 var events_exports = {};
 __export(events_exports, {
@@ -4436,8 +4465,7 @@ __export(events_exports, {
   shouldRotate: () => shouldRotate
 });
 import { appendFileSync, existsSync as existsSync13, mkdirSync as mkdirSync8, renameSync as renameSync4, statSync } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { join as join10 } from "node:path";
+import { join as join11 } from "node:path";
 function diffFleet(prev, next) {
   const state = /* @__PURE__ */ new Map();
   const events = [];
@@ -4464,13 +4492,13 @@ function formatEventLine(ev, paint = (_s, t) => t) {
   return `${isoTime(ev.ts)} ${ev.session} ${from} \u2192 ${paint(ev.to, ev.to)}`;
 }
 function eventsPath() {
-  return join10(homedir10(), ".tmux-ide", "events.jsonl");
+  return join11(stateHome(), "events.jsonl");
 }
 function appendEvents(events, now = () => (/* @__PURE__ */ new Date()).toISOString()) {
   if (events.length === 0) return;
   const path2 = eventsPath();
   try {
-    mkdirSync8(join10(homedir10(), ".tmux-ide"), { recursive: true });
+    mkdirSync8(stateHome(), { recursive: true });
     if (existsSync13(path2) && shouldRotate(statSync(path2).size)) {
       renameSync4(path2, `${path2}.1`);
     }
@@ -4485,11 +4513,90 @@ var EVENTS_MAX_BYTES;
 var init_events = __esm({
   "packages/daemon/src/tui/chrome/events.ts"() {
     "use strict";
+    init_state_home();
     EVENTS_MAX_BYTES = 1024 * 1024;
   }
 });
 
+// packages/daemon/src/tui/mirror/hosted.ts
+function wantsHostedApp(input) {
+  if (input.hostedEnv) return false;
+  return input.flagDetachable || input.flagHosted || input.configDetachable;
+}
+function shellQuote(word) {
+  return `'${word.replaceAll("'", `'\\''`)}'`;
+}
+function hostedEnvVars(base) {
+  const env = {
+    [HOSTED_ENV]: "1",
+    TMUX_IDE_CWD: base.cwd,
+    TMUX_IDE_CLI: base.cli
+  };
+  if (base.path) env.PATH = base.path;
+  if (base.home) env.TMUX_IDE_HOME = base.home;
+  if (base.config) env.TMUX_IDE_CONFIG = base.config;
+  if (base.tuiBin) env.TMUX_IDE_TUI_BIN = base.tuiBin;
+  return env;
+}
+function hostedCommandLine(bin, argv, env) {
+  const assigns = Object.entries(env).map(([k, v]) => `${k}=${shellQuote(v)}`);
+  return ["exec", "env", ...assigns, shellQuote(bin), ...argv.map(shellQuote)].join(" ");
+}
+function hostExistsArgv() {
+  return ["has-session", "-t", `=${APP_HOST_SESSION}`];
+}
+function hostCreateArgv(opts) {
+  return ["new-session", "-d", "-s", APP_HOST_SESSION, "-c", opts.cwd, opts.commandLine];
+}
+function hostSetupArgvs() {
+  return [
+    ["set-option", "-t", APP_HOST_SESSION, "status", "off"],
+    ["set-option", "-w", "-t", `${APP_HOST_SESSION}:`, "window-size", "latest"]
+  ];
+}
+function hostAttachArgv(insideTmux) {
+  return insideTmux ? ["switch-client", "-t", `=${APP_HOST_SESSION}`] : ["attach-session", "-t", `=${APP_HOST_SESSION}`];
+}
+var APP_HOST_SESSION, HOSTED_ENV;
+var init_hosted = __esm({
+  "packages/daemon/src/tui/mirror/hosted.ts"() {
+    "use strict";
+    APP_HOST_SESSION = "_tmux-ide-app";
+    HOSTED_ENV = "TMUX_IDE_HOSTED";
+  }
+});
+
 // packages/daemon/src/tui/chrome/notify.ts
+var notify_exports = {};
+__export(notify_exports, {
+  APP_FOCUS_OPTION: () => APP_FOCUS_OPTION,
+  APP_FOCUS_STALE_MS: () => APP_FOCUS_STALE_MS,
+  APP_JUMP_OPTION: () => APP_JUMP_OPTION,
+  DEFAULT_NOTIFICATION_PREFS: () => DEFAULT_NOTIFICATION_PREFS,
+  NOTIFY_DEBOUNCE_MS: () => NOTIFY_DEBOUNCE_MS,
+  NOTIFY_MAX_LEN: () => NOTIFY_MAX_LEN,
+  applyKillSwitch: () => applyKillSwitch,
+  buildAppFocusValue: () => buildAppFocusValue,
+  decideNotifications: () => decideNotifications,
+  enabledStates: () => enabledStates,
+  hasTerminalNotifier: () => hasTerminalNotifier,
+  inQuietHours: () => inQuietHours,
+  listAttachedClients: () => listAttachedClients,
+  notifierExecuteCommand: () => notifierExecuteCommand,
+  notifyConfigPath: () => notifyConfigPath,
+  notifyDebounceKey: () => notifyDebounceKey,
+  notifyMessage: () => notifyMessage,
+  parseAppFocus: () => parseAppFocus,
+  parseClients: () => parseClients,
+  parseHHMM: () => parseHHMM,
+  parseNotificationPrefs: () => parseNotificationPrefs,
+  readAppFocus: () => readAppFocus,
+  readNotificationPrefs: () => readNotificationPrefs,
+  sendSystemNotification: () => sendSystemNotification,
+  sendToasts: () => sendToasts,
+  suppressToastFor: () => suppressToastFor,
+  terminalNotifierArgs: () => terminalNotifierArgs
+});
 import { execFileSync as execFileSync6 } from "node:child_process";
 import { existsSync as existsSync14, readFileSync as readFileSync8 } from "node:fs";
 function statusPhrase(to) {
@@ -4507,19 +4614,31 @@ function enabledStates(prefs) {
   if (prefs.onDone) states.add("done");
   return states;
 }
-function decideNotifications(events, clients, lastNotified, nowMs, states = NOTIFY_STATES) {
+function notifyDebounceKey(ev) {
+  return `${ev.paneId ?? ev.session}:${ev.to}`;
+}
+function suppressToastFor(client, ev) {
+  if (client.session === APP_HOST_SESSION) return true;
+  if (client.session !== ev.session) return false;
+  if (ev.windowIndex === void 0 || ev.windowIndex === null) return true;
+  if (client.windowIndex === void 0 || client.windowIndex === null) return true;
+  return client.windowIndex === ev.windowIndex;
+}
+function decideNotifications(events, clients, lastNotified, nowMs, states = NOTIFY_STATES, appFocus = null) {
   const nextLastNotified = new Map(lastNotified);
   const toasts = [];
   const system = [];
   for (const ev of events) {
+    if (ev.from === null) continue;
     if (!states.has(ev.to)) continue;
-    const key = `${ev.session}:${ev.to}`;
+    const key = notifyDebounceKey(ev);
     const last = nextLastNotified.get(key);
     if (last !== void 0 && nowMs - last < NOTIFY_DEBOUNCE_MS) continue;
+    if (appFocus?.attached && ev.paneId && appFocus.panes.includes(ev.paneId)) continue;
     nextLastNotified.set(key, nowMs);
     const message = notifyMessage(ev);
     for (const c of clients) {
-      if (c.session === ev.session) continue;
+      if (suppressToastFor(c, ev)) continue;
       toasts.push({ client: c.client, message });
     }
     system.push({ message, session: ev.session });
@@ -4529,17 +4648,47 @@ function decideNotifications(events, clients, lastNotified, nowMs, states = NOTI
 function parseClients(lines) {
   const out = [];
   for (const line of lines) {
-    const [client = "", session = ""] = line.split("	");
-    if (client && session) out.push({ client, session });
+    const [client = "", session = "", win = ""] = line.split("	");
+    if (!client || !session) continue;
+    const n = Number.parseInt(win, 10);
+    out.push({ client, session, windowIndex: Number.isInteger(n) ? n : null });
   }
   return out;
 }
 function listAttachedClients() {
   try {
-    const raw = runTmux(["list-clients", "-F", "#{client_name}	#{session_name}"]).toString().trim();
+    const raw = runTmux(["list-clients", "-F", "#{client_name}	#{session_name}	#{window_index}"]).toString().trim();
     return raw ? parseClients(raw.split("\n")) : [];
   } catch {
     return [];
+  }
+}
+function buildAppFocusValue(focus) {
+  return JSON.stringify(focus);
+}
+function parseAppFocus(raw, nowMs) {
+  if (!raw) return null;
+  try {
+    const o = JSON.parse(raw);
+    if (!o || typeof o !== "object") return null;
+    const ts = typeof o.ts === "number" ? o.ts : null;
+    if (ts === null || nowMs - ts > APP_FOCUS_STALE_MS) return null;
+    return {
+      ts,
+      attached: o.attached === true,
+      session: typeof o.session === "string" ? o.session : "",
+      panes: Array.isArray(o.panes) ? o.panes.filter((p) => typeof p === "string") : []
+    };
+  } catch {
+    return null;
+  }
+}
+function readAppFocus(nowMs = Date.now()) {
+  try {
+    const raw = runTmux(["show-option", "-s", "-v", APP_FOCUS_OPTION]).toString().trim();
+    return parseAppFocus(raw, nowMs);
+  } catch {
+    return null;
   }
 }
 function sendToasts(toasts) {
@@ -4561,6 +4710,11 @@ function hasTerminalNotifier() {
 function shellSingleQuote(value) {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
+function notifierExecuteCommand(session) {
+  const target = shellSingleQuote(session);
+  const host = shellSingleQuote(`=${APP_HOST_SESSION}`);
+  return `if tmux has-session -t ${host} 2>/dev/null; then tmux set-option -t ${shellSingleQuote(APP_HOST_SESSION)} ${APP_JUMP_OPTION} ${target}; tmux switch-client -t ${host}; else tmux switch-client -t ${target}; fi`;
+}
 function terminalNotifierArgs(n) {
   return [
     "-title",
@@ -4568,7 +4722,7 @@ function terminalNotifierArgs(n) {
     "-message",
     n.message,
     "-execute",
-    `tmux switch-client -t ${shellSingleQuote(n.session)}`
+    notifierExecuteCommand(n.session)
   ];
 }
 function sendSystemNotification(n) {
@@ -4631,6 +4785,9 @@ function parseNotificationPrefs(rawConfig) {
 function applyKillSwitch(prefs, envValue) {
   return envValue === "0" ? { ...prefs, enabled: false, toast: false, macos: false } : prefs;
 }
+function notifyConfigPath() {
+  return appConfigPath();
+}
 function readRawConfig() {
   const path2 = appConfigPath();
   if (!existsSync14(path2)) return void 0;
@@ -4643,15 +4800,19 @@ function readRawConfig() {
 function readNotificationPrefs() {
   return applyKillSwitch(parseNotificationPrefs(readRawConfig()), process.env.TMUX_IDE_NOTIFY);
 }
-var NOTIFY_STATES, NOTIFY_DEBOUNCE_MS, NOTIFY_MAX_LEN, DEFAULT_NOTIFICATION_PREFS;
+var NOTIFY_STATES, NOTIFY_DEBOUNCE_MS, NOTIFY_MAX_LEN, APP_FOCUS_OPTION, APP_FOCUS_STALE_MS, APP_JUMP_OPTION, DEFAULT_NOTIFICATION_PREFS;
 var init_notify = __esm({
   "packages/daemon/src/tui/chrome/notify.ts"() {
     "use strict";
     init_src();
     init_app_config();
+    init_hosted();
     NOTIFY_STATES = /* @__PURE__ */ new Set(["blocked", "done"]);
     NOTIFY_DEBOUNCE_MS = 3e4;
     NOTIFY_MAX_LEN = 120;
+    APP_FOCUS_OPTION = "@tmux_ide_app_focus";
+    APP_FOCUS_STALE_MS = 15e3;
+    APP_JUMP_OPTION = "@tmux_ide_app_jump";
     DEFAULT_NOTIFICATION_PREFS = {
       enabled: true,
       toast: true,
@@ -4663,10 +4824,63 @@ var init_notify = __esm({
   }
 });
 
+// packages/daemon/src/tui/chrome/notify-state.ts
+import { existsSync as existsSync15, mkdirSync as mkdirSync9, readFileSync as readFileSync9, writeFileSync as writeFileSync9 } from "node:fs";
+import { join as join12 } from "node:path";
+function notifyStatePath() {
+  return join12(stateHome(), "notify-state.json");
+}
+function serializeLastNotified(map, nowMs) {
+  const lastNotified = {};
+  for (const [key, ts] of map) {
+    if (nowMs - ts < NOTIFY_DEBOUNCE_MS) lastNotified[key] = ts;
+  }
+  return JSON.stringify({ lastNotified });
+}
+function parseLastNotified(json2, nowMs) {
+  const out = /* @__PURE__ */ new Map();
+  try {
+    const parsed = JSON.parse(json2);
+    const raw = parsed?.lastNotified;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return out;
+    for (const [key, ts] of Object.entries(raw)) {
+      if (typeof ts !== "number") continue;
+      if (nowMs - ts >= NOTIFY_DEBOUNCE_MS) continue;
+      if (ts - nowMs > NOTIFY_DEBOUNCE_MS) continue;
+      out.set(key, ts);
+    }
+  } catch {
+  }
+  return out;
+}
+function loadLastNotified(nowMs = Date.now()) {
+  const path2 = notifyStatePath();
+  if (!existsSync15(path2)) return /* @__PURE__ */ new Map();
+  try {
+    return parseLastNotified(readFileSync9(path2, "utf-8"), nowMs);
+  } catch {
+    return /* @__PURE__ */ new Map();
+  }
+}
+function saveLastNotified(map, nowMs = Date.now()) {
+  try {
+    mkdirSync9(stateHome(), { recursive: true });
+    writeFileSync9(notifyStatePath(), serializeLastNotified(map, nowMs));
+  } catch {
+  }
+}
+var init_notify_state = __esm({
+  "packages/daemon/src/tui/chrome/notify-state.ts"() {
+    "use strict";
+    init_state_home();
+    init_notify();
+  }
+});
+
 // packages/daemon/src/tui/chrome/snapshot.ts
-import { existsSync as existsSync15, mkdirSync as mkdirSync9, readFileSync as readFileSync9, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
+import { existsSync as existsSync16, mkdirSync as mkdirSync10, readFileSync as readFileSync10, renameSync as renameSync5, writeFileSync as writeFileSync10 } from "node:fs";
 import { homedir as homedir11 } from "node:os";
-import { dirname as dirname11, join as join11 } from "node:path";
+import { dirname as dirname11, join as join13 } from "node:path";
 import { z as z12 } from "zod";
 function isBareShell(cmd) {
   return /^-?(zsh|bash|sh|fish|dash|ksh|tcsh|csh|nu)$/.test(cmd.trim());
@@ -4781,15 +4995,15 @@ function collectFleetSnapshot(io = defaultIo) {
   return buildSnapshot(rawPanes, rawSessions, io.processTable());
 }
 function snapshotPath() {
-  return join11(homedir11(), ".tmux-ide", "snapshot.json");
+  return join13(homedir11(), ".tmux-ide", "snapshot.json");
 }
 function writeSnapshot(snapshot) {
   const path2 = snapshotPath();
   try {
-    mkdirSync9(dirname11(path2), { recursive: true });
+    mkdirSync10(dirname11(path2), { recursive: true });
     const tmp = `${path2}.tmp`;
-    writeFileSync9(tmp, JSON.stringify(snapshot, null, 2) + "\n");
-    if (existsSync15(path2)) {
+    writeFileSync10(tmp, JSON.stringify(snapshot, null, 2) + "\n");
+    if (existsSync16(path2)) {
       try {
         renameSync5(path2, `${path2}.1`);
       } catch {
@@ -4802,8 +5016,8 @@ function writeSnapshot(snapshot) {
 function readSnapshot() {
   const path2 = snapshotPath();
   try {
-    if (!existsSync15(path2)) return null;
-    const raw = readFileSync9(path2, "utf-8");
+    if (!existsSync16(path2)) return null;
+    const raw = readFileSync10(path2, "utf-8");
     if (raw.trim().length === 0) return null;
     const result = FleetSnapshotSchemaZ.safeParse(JSON.parse(raw));
     return result.success ? result.data : null;
@@ -4899,19 +5113,22 @@ __export(updater_exports, {
   TICK_MS: () => TICK_MS,
   UPDATER_PID_OPTION: () => UPDATER_PID_OPTION,
   UPDATER_SESSION: () => UPDATER_SESSION,
+  UPDATER_UNREACHABLE_EXIT_TICKS: () => UPDATER_UNREACHABLE_EXIT_TICKS,
   adoptedSessionsFrom: () => adoptedSessionsFrom,
-  enrichEvents: () => enrichEvents,
+  createUnreachableCounter: () => createUnreachableCounter,
+  diffPaneTransitions: () => diffPaneTransitions,
   fleetStatuses: () => fleetStatuses,
   listAdoptedSessions: () => listAdoptedSessions,
   paneLocation: () => paneLocation,
-  pickRepresentativePane: () => pickRepresentativePane,
   runUpdaterLoop: () => runUpdaterLoop,
   runUpdaterTick: () => runUpdaterTick,
   seedSessionStatus: () => seedSessionStatus,
   startUpdaterIfNeeded: () => startUpdaterIfNeeded,
   stopUpdater: () => stopUpdater,
   updateSegment: () => updateSegment,
-  updaterRunning: () => updaterRunning
+  updaterProbeArgv: () => updaterProbeArgv,
+  updaterRunning: () => updaterRunning,
+  updaterSpawnArgv: () => updaterSpawnArgv
 });
 function adoptedSessionsFrom(lines) {
   const out = [];
@@ -4959,10 +5176,11 @@ function runUpdaterTick(deps2) {
     const { events, state } = diffFleet(deps2.prevState, fleetStatuses(projects));
     deps2.prevState.clear();
     for (const [name, status2] of state) deps2.prevState.set(name, status2);
-    if (events.length > 0) {
-      deps2.appendEvents(events);
-      dispatchNotifications(deps2, enrichEvents(events, panes, deps2.locatePane));
-    }
+    if (events.length > 0) deps2.appendEvents(events);
+  }
+  if (deps2.prevPaneState) {
+    const events = diffPaneTransitions(deps2.prevPaneState, panes, deps2.locatePane);
+    if (events.length > 0) dispatchNotifications(deps2, events);
   }
 }
 function writeChips(deps2, adopted, panes, theme) {
@@ -4977,21 +5195,27 @@ function writeChips(deps2, adopted, panes, theme) {
     writeChip(pane.paneId, chip);
   }
 }
-function pickRepresentativePane(session, to, panes) {
-  const matching = panes.filter((p) => p.sessionName === session && p.status === to);
-  if (matching.length === 0) return null;
-  return matching.find((p) => p.agent !== null) ?? matching[0];
-}
-function enrichEvents(events, panes, locate) {
-  return events.map((ev) => {
-    const notifiable = ev.to === "blocked" || ev.to === "done";
-    const rep = notifiable ? pickRepresentativePane(ev.session, ev.to, panes) : null;
-    return {
-      ...ev,
-      agent: rep?.agent ?? null,
-      location: rep && locate ? locate(rep.paneId) : ev.session
-    };
-  });
+function diffPaneTransitions(prev, panes, locate) {
+  const events = [];
+  const next = /* @__PURE__ */ new Map();
+  for (const pane of panes) {
+    const before = prev.has(pane.paneId) ? prev.get(pane.paneId) : null;
+    next.set(pane.paneId, pane.status);
+    if (before === pane.status) continue;
+    const notifiable = before !== null && (pane.status === "blocked" || pane.status === "done");
+    events.push({
+      session: pane.sessionName,
+      from: before,
+      to: pane.status,
+      paneId: pane.paneId,
+      windowIndex: pane.windowIndex,
+      agent: pane.agent,
+      location: notifiable && locate ? locate(pane.paneId) : pane.sessionName
+    });
+  }
+  prev.clear();
+  for (const [paneId, status2] of next) prev.set(paneId, status2);
+  return events;
 }
 function dispatchNotifications(deps2, events) {
   const { listClients, lastNotified, now, prefs, sendToasts: toast, sendSystem } = deps2;
@@ -5004,10 +5228,12 @@ function dispatchNotifications(deps2, events) {
     listClients(),
     lastNotified,
     nowMs,
-    enabledStates(prefs)
+    enabledStates(prefs),
+    deps2.appFocus?.() ?? null
   );
   lastNotified.clear();
   for (const [key, ts] of decision.nextLastNotified) lastNotified.set(key, ts);
+  if (decision.system.length > 0) deps2.persistNotified?.(lastNotified);
   if (prefs.toast && toast) toast(decision.toasts);
   if (prefs.macos && sendSystem && !inQuietHours(new Date(nowMs), prefs.quietHours)) {
     for (const n of decision.system) sendSystem(n);
@@ -5052,7 +5278,7 @@ function updaterRunning() {
 function startUpdaterIfNeeded() {
   try {
     if (updaterRunning()) return;
-    runTmux(["new-session", "-d", "-s", UPDATER_SESSION, "exec tmux-ide chrome-updater"]);
+    runTmux(updaterSpawnArgv());
   } catch {
   }
 }
@@ -5086,12 +5312,28 @@ function releaseUpdater() {
   } catch {
   }
 }
+function createUnreachableCounter(threshold = UPDATER_UNREACHABLE_EXIT_TICKS) {
+  let consecutive = 0;
+  return (reachable) => {
+    consecutive = reachable ? 0 : consecutive + 1;
+    return consecutive >= threshold;
+  };
+}
+function isServerReachable() {
+  try {
+    runTmux(["list-sessions", "-F", "#{session_name}"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
 function runUpdaterLoop() {
   if (!claimUpdater()) return;
   const config2 = getAppConfig();
   const tracker = createStatusTracker();
   const prevState = /* @__PURE__ */ new Map();
-  const lastNotified = /* @__PURE__ */ new Map();
+  const prevPaneState = /* @__PURE__ */ new Map();
+  const lastNotified = loadLastNotified();
   const chipCache = /* @__PURE__ */ new Map();
   const snapshotter = createSnapshotter({
     collect: () => collectFleetSnapshot(),
@@ -5099,6 +5341,7 @@ function runUpdaterLoop() {
     write: writeSnapshot,
     every: config2.updater.snapshotEvery
   });
+  const shouldGiveUp = createUnreachableCounter();
   const tick = () => {
     try {
       runUpdaterTick({
@@ -5110,6 +5353,7 @@ function runUpdaterLoop() {
         chipCache,
         prevState,
         appendEvents,
+        prevPaneState,
         listClients: listAttachedClients,
         lastNotified,
         now: () => Date.now(),
@@ -5117,6 +5361,8 @@ function runUpdaterLoop() {
         sendToasts,
         sendSystem: sendSystemNotification,
         locatePane: paneLocation,
+        appFocus: () => readAppFocus(),
+        persistNotified: (map) => saveLastNotified(map),
         maybeCheckForUpdate: () => maybeCheckForUpdate({ enabled: config2.updates.check }),
         markUpdateNotified
       });
@@ -5126,8 +5372,13 @@ function runUpdaterLoop() {
       snapshotter.onTick();
     } catch {
     }
+    if (shouldGiveUp(isServerReachable())) {
+      console.error(
+        `tmux-ide chrome-updater: tmux server unreachable for ${UPDATER_UNREACHABLE_EXIT_TICKS} consecutive ticks \u2014 exiting`
+      );
+      shutdown();
+    }
   };
-  tick();
   const timer = setInterval(tick, config2.updater.tickMs);
   const shutdown = () => {
     clearInterval(timer);
@@ -5136,12 +5387,14 @@ function runUpdaterLoop() {
   };
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
+  tick();
 }
-var STATUS_OPTION, CHIP_OPTION, ADOPTED_OPTION, UPDATER_SESSION, UPDATER_PID_OPTION, TICK_MS;
+var STATUS_OPTION, CHIP_OPTION, UPDATER_PID_OPTION, TICK_MS, UPDATER_UNREACHABLE_EXIT_TICKS;
 var init_updater = __esm({
   "packages/daemon/src/tui/chrome/updater.ts"() {
     "use strict";
     init_src();
+    init_front_door();
     init_app_config();
     init_update_check();
     init_classify();
@@ -5149,14 +5402,15 @@ var init_updater = __esm({
     init_chip();
     init_events();
     init_notify();
+    init_notify_state();
     init_snapshot2();
     init_statusline();
+    init_front_door();
     STATUS_OPTION = "@tmux_ide_status";
     CHIP_OPTION = "@tmux_ide_chip";
-    ADOPTED_OPTION = "@tmux_ide_adopted";
-    UPDATER_SESSION = "_tmux-ide-chrome";
     UPDATER_PID_OPTION = "@tmux_ide_updater_pid";
     TICK_MS = 2e3;
+    UPDATER_UNREACHABLE_EXIT_TICKS = 5;
   }
 });
 
@@ -5436,12 +5690,12 @@ __export(canonical_daemon_exports, {
   warnOnDaemonVersionSkew: () => warnOnDaemonVersionSkew,
   writeCanonicalDaemonInfo: () => writeCanonicalDaemonInfo
 });
-import { existsSync as existsSync16, mkdirSync as mkdirSync10, readFileSync as readFileSync10, renameSync as renameSync6, rmSync, writeFileSync as writeFileSync10 } from "node:fs";
+import { existsSync as existsSync17, mkdirSync as mkdirSync11, readFileSync as readFileSync11, renameSync as renameSync6, rmSync, writeFileSync as writeFileSync11 } from "node:fs";
 import { homedir as homedir12 } from "node:os";
-import { dirname as dirname12, join as join12 } from "node:path";
+import { dirname as dirname12, join as join14 } from "node:path";
 function getCanonicalDaemonInfoPath() {
-  const dir = process.env[DAEMON_INFO_DIR_ENV] ?? process.env[REGISTRY_DIR_ENV2] ?? join12(homedir12(), ".tmux-ide");
-  return join12(dir, DAEMON_INFO_FILE);
+  const dir = process.env[DAEMON_INFO_DIR_ENV] ?? process.env[REGISTRY_DIR_ENV2] ?? join14(homedir12(), ".tmux-ide");
+  return join14(dir, DAEMON_INFO_FILE);
 }
 function parseCanonicalDaemonInfo(raw) {
   if (!raw || typeof raw !== "object") return null;
@@ -5464,7 +5718,7 @@ function parseCanonicalDaemonInfo(raw) {
 }
 function writeCanonicalDaemonInfo(info) {
   const path2 = getCanonicalDaemonInfoPath();
-  mkdirSync10(dirname12(path2), { recursive: true });
+  mkdirSync11(dirname12(path2), { recursive: true });
   const tmpPath = `${path2}.${process.pid}.${Date.now()}.tmp`;
   const persisted = {
     pid: info.pid,
@@ -5474,14 +5728,14 @@ function writeCanonicalDaemonInfo(info) {
     bindHostname: info.bindHostname,
     authToken: info.authToken
   };
-  writeFileSync10(tmpPath, JSON.stringify(persisted, null, 2) + "\n", "utf-8");
+  writeFileSync11(tmpPath, JSON.stringify(persisted, null, 2) + "\n", "utf-8");
   renameSync6(tmpPath, path2);
 }
 function readCanonicalDaemonInfo() {
   const path2 = getCanonicalDaemonInfoPath();
-  if (!existsSync16(path2)) return null;
+  if (!existsSync17(path2)) return null;
   try {
-    return parseCanonicalDaemonInfo(JSON.parse(readFileSync10(path2, "utf-8")));
+    return parseCanonicalDaemonInfo(JSON.parse(readFileSync11(path2, "utf-8")));
   } catch {
     return null;
   }
@@ -5771,13 +6025,13 @@ var init_launch = __esm({
 
 // packages/daemon/src/detect.ts
 import { resolve as resolve10, basename as basename4 } from "node:path";
-import { readFileSync as readFileSync11, existsSync as existsSync17 } from "node:fs";
+import { readFileSync as readFileSync12, existsSync as existsSync18 } from "node:fs";
 function fileExists(dir, name) {
-  return existsSync17(resolve10(dir, name));
+  return existsSync18(resolve10(dir, name));
 }
 function readJson(dir, name) {
   try {
-    return JSON.parse(readFileSync11(resolve10(dir, name), "utf-8"));
+    return JSON.parse(readFileSync12(resolve10(dir, name), "utf-8"));
   } catch {
     return null;
   }
@@ -5839,7 +6093,7 @@ function detectStack(dir) {
     detected.language = detected.language ?? "python";
     detected.reasons.push('Detected Python from "pyproject.toml" or "requirements.txt".');
     try {
-      const pyproject = readFileSync11(resolve10(dir, "pyproject.toml"), "utf-8");
+      const pyproject = readFileSync12(resolve10(dir, "pyproject.toml"), "utf-8");
       if (pyproject.includes("fastapi"))
         pushFramework(detected, "fastapi", 'Found "fastapi" in pyproject.toml.');
       else if (pyproject.includes("django"))
@@ -5986,28 +6240,28 @@ __export(skill_sync_exports, {
   syncSkill: () => syncSkill,
   versionMarker: () => versionMarker
 });
-import { existsSync as existsSync19, mkdirSync as mkdirSync12, readFileSync as readFileSync13, writeFileSync as writeFileSync12 } from "node:fs";
+import { existsSync as existsSync20, mkdirSync as mkdirSync13, readFileSync as readFileSync14, writeFileSync as writeFileSync13 } from "node:fs";
 import { homedir as homedir13 } from "node:os";
-import { dirname as dirname14, join as join14 } from "node:path";
+import { dirname as dirname14, join as join16 } from "node:path";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
 function claudeDir() {
-  return process.env.TMUX_IDE_CLAUDE_DIR ?? join14(homedir13(), ".claude");
+  return process.env.TMUX_IDE_CLAUDE_DIR ?? join16(homedir13(), ".claude");
 }
 function skillTargetDir() {
-  return join14(claudeDir(), "skills", "tmux-ide");
+  return join16(claudeDir(), "skills", "tmux-ide");
 }
 function skillTargetFile() {
-  return join14(skillTargetDir(), "SKILL.md");
+  return join16(skillTargetDir(), "SKILL.md");
 }
 function defaultSkillSource() {
   const here = dirname14(fileURLToPath6(import.meta.url));
   const candidates = [
-    join14(here, "../skill/SKILL.md"),
+    join16(here, "../skill/SKILL.md"),
     // bundled bin/cli.js → repo root
-    join14(here, "../../../../skill/SKILL.md")
+    join16(here, "../../../../skill/SKILL.md")
     // dev src/lib → repo root
   ];
-  return candidates.find((c) => existsSync19(c)) ?? candidates[0];
+  return candidates.find((c) => existsSync20(c)) ?? candidates[0];
 }
 function versionMarker(version) {
   return `<!-- tmux-ide-skill-version: ${version} -->`;
@@ -6021,10 +6275,10 @@ function rewriteVersionMarker(content, version) {
   return content.replace(VERSION_MARKER_RE, versionMarker(version));
 }
 function installedSkillVersion(dir = skillTargetDir()) {
-  const file = join14(dir, "SKILL.md");
-  if (!existsSync19(file)) return null;
+  const file = join16(dir, "SKILL.md");
+  if (!existsSync20(file)) return null;
   try {
-    return parseSkillVersion(readFileSync13(file, "utf-8"));
+    return parseSkillVersion(readFileSync14(file, "utf-8"));
   } catch {
     return null;
   }
@@ -6033,15 +6287,15 @@ function syncSkill({
   source = defaultSkillSource(),
   version = getCurrentVersion()
 } = {}) {
-  const rendered = rewriteVersionMarker(readFileSync13(source, "utf-8"), version);
+  const rendered = rewriteVersionMarker(readFileSync14(source, "utf-8"), version);
   const dir = skillTargetDir();
-  const target = join14(dir, "SKILL.md");
-  const existing = existsSync19(target) ? readFileSync13(target, "utf-8") : null;
+  const target = join16(dir, "SKILL.md");
+  const existing = existsSync20(target) ? readFileSync14(target, "utf-8") : null;
   if (existing === rendered) {
     return { action: "unchanged", path: target, to: version };
   }
-  mkdirSync12(dir, { recursive: true });
-  writeFileSync12(target, rendered, "utf-8");
+  mkdirSync13(dir, { recursive: true });
+  writeFileSync13(target, rendered, "utf-8");
   if (existing === null) return { action: "installed", path: target, to: version };
   return { action: "updated", path: target, from: parseSkillVersion(existing), to: version };
 }
@@ -6242,8 +6496,8 @@ var init_PtyAdapter = __esm({
 });
 
 // packages/daemon/src/terminal/NodePtyAdapter.ts
-import { chmodSync as chmodSync3, existsSync as existsSync22, statSync as statSync2 } from "node:fs";
-import { dirname as dirname16, join as join15 } from "node:path";
+import { chmodSync as chmodSync3, existsSync as existsSync23, statSync as statSync2 } from "node:fs";
+import { dirname as dirname16, join as join17 } from "node:path";
 import { createRequire } from "node:module";
 import * as pty from "node-pty";
 function candidateSpawnHelperPaths() {
@@ -6256,9 +6510,9 @@ function candidateSpawnHelperPaths() {
   }
   const pkgDir = dirname16(pkgJsonPath);
   return [
-    join15(pkgDir, "build", "Release", "spawn-helper"),
-    join15(pkgDir, "build", "Debug", "spawn-helper"),
-    join15(pkgDir, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper")
+    join17(pkgDir, "build", "Release", "spawn-helper"),
+    join17(pkgDir, "build", "Debug", "spawn-helper"),
+    join17(pkgDir, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper")
   ];
 }
 function ensureNodePtySpawnHelperExecutable(options = {}) {
@@ -6266,7 +6520,7 @@ function ensureNodePtySpawnHelperExecutable(options = {}) {
   if (!options.force && !options.explicitPath && helperEnsured) return;
   const candidates = options.explicitPath ? [options.explicitPath] : candidateSpawnHelperPaths();
   for (const candidate of candidates) {
-    if (!existsSync22(candidate)) continue;
+    if (!existsSync23(candidate)) continue;
     try {
       chmodSync3(candidate, 493);
     } catch {
@@ -7255,9 +7509,9 @@ var init_pane_comms = __esm({
 
 // packages/daemon/src/lib/workspace-registry.ts
 import { EventEmitter as EventEmitter3 } from "node:events";
-import { existsSync as existsSync23, mkdirSync as mkdirSync13, readFileSync as readFileSync14, renameSync as renameSync8, writeFileSync as writeFileSync13 } from "node:fs";
+import { existsSync as existsSync24, mkdirSync as mkdirSync14, readFileSync as readFileSync15, renameSync as renameSync8, writeFileSync as writeFileSync14 } from "node:fs";
 import { homedir as homedir14 } from "node:os";
-import { dirname as dirname17, join as join16 } from "node:path";
+import { dirname as dirname17, join as join18 } from "node:path";
 import { z as z13 } from "zod";
 function getDefaultWorkspaceRegistry() {
   if (!_default) _default = new WorkspaceRegistry();
@@ -7306,7 +7560,7 @@ var init_workspace_registry = __esm({
       workspaces = [];
       loaded = false;
       constructor(options = {}) {
-        this.dir = options.dir ?? process.env[REGISTRY_DIR_ENV3] ?? join16(homedir14(), ".tmux-ide");
+        this.dir = options.dir ?? process.env[REGISTRY_DIR_ENV3] ?? join18(homedir14(), ".tmux-ide");
         this.listSessions = options.listSessions ?? defaultListSessions;
         this.emitter.setMaxListeners(0);
       }
@@ -7373,14 +7627,14 @@ var init_workspace_registry = __esm({
       }
       // ----------------- io -----------------
       filePath() {
-        return join16(this.dir, "workspaces.json");
+        return join18(this.dir, "workspaces.json");
       }
       readDisk() {
         const path2 = this.filePath();
-        if (!existsSync23(path2)) return [];
+        if (!existsSync24(path2)) return [];
         let parsed;
         try {
-          parsed = JSON.parse(readFileSync14(path2, "utf-8"));
+          parsed = JSON.parse(readFileSync15(path2, "utf-8"));
         } catch {
           return [];
         }
@@ -7390,10 +7644,10 @@ var init_workspace_registry = __esm({
       }
       writeDisk() {
         const path2 = this.filePath();
-        mkdirSync13(dirname17(path2), { recursive: true });
+        mkdirSync14(dirname17(path2), { recursive: true });
         const file = { version: 1, workspaces: this.workspaces };
         const tmp = `${path2}.tmp`;
-        writeFileSync13(tmp, JSON.stringify(file, null, 2) + "\n");
+        writeFileSync14(tmp, JSON.stringify(file, null, 2) + "\n");
         renameSync8(tmp, path2);
       }
       /** @internal Test-only: assert the registry is loaded. */
@@ -7675,14 +7929,14 @@ var init_auth_token = __esm({
 });
 
 // packages/daemon/src/lib/app-settings.ts
-import { existsSync as existsSync24, mkdirSync as mkdirSync14, readFileSync as readFileSync15, renameSync as renameSync9, writeFileSync as writeFileSync14 } from "node:fs";
-import { dirname as dirname18, join as join17 } from "node:path";
+import { existsSync as existsSync25, mkdirSync as mkdirSync15, readFileSync as readFileSync16, renameSync as renameSync9, writeFileSync as writeFileSync15 } from "node:fs";
+import { dirname as dirname18, join as join19 } from "node:path";
 import { homedir as homedir15 } from "node:os";
 function settingsDir() {
-  return process.env.TMUX_IDE_SETTINGS_DIR ?? join17(homedir15(), ".tmux-ide");
+  return process.env.TMUX_IDE_SETTINGS_DIR ?? join19(homedir15(), ".tmux-ide");
 }
 function appSettingsPath() {
-  return join17(settingsDir(), "app-settings.json");
+  return join19(settingsDir(), "app-settings.json");
 }
 function normalizeSettings(value) {
   if (!value || typeof value !== "object") return structuredClone(DEFAULT_SETTINGS);
@@ -7695,18 +7949,18 @@ function normalizeSettings(value) {
 }
 function readAppSettings() {
   const path2 = appSettingsPath();
-  if (!existsSync24(path2)) return structuredClone(DEFAULT_SETTINGS);
+  if (!existsSync25(path2)) return structuredClone(DEFAULT_SETTINGS);
   try {
-    return normalizeSettings(JSON.parse(readFileSync15(path2, "utf-8")));
+    return normalizeSettings(JSON.parse(readFileSync16(path2, "utf-8")));
   } catch {
     return structuredClone(DEFAULT_SETTINGS);
   }
 }
 function writeAppSettings(next) {
   const path2 = appSettingsPath();
-  mkdirSync14(dirname18(path2), { recursive: true });
+  mkdirSync15(dirname18(path2), { recursive: true });
   const tmp = `${path2}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync14(tmp, `${JSON.stringify(normalizeSettings(next), null, 2)}
+  writeFileSync15(tmp, `${JSON.stringify(normalizeSettings(next), null, 2)}
 `, "utf-8");
   renameSync9(tmp, path2);
 }
@@ -7896,16 +8150,16 @@ var init_active_projects = __esm({
 
 // packages/daemon/src/send.ts
 import { randomUUID } from "node:crypto";
-import { resolve as resolve17, join as join18 } from "node:path";
-import { existsSync as existsSync25, mkdirSync as mkdirSync15, writeFileSync as writeFileSync15 } from "node:fs";
+import { resolve as resolve17, join as join20 } from "node:path";
+import { existsSync as existsSync26, mkdirSync as mkdirSync16, writeFileSync as writeFileSync16 } from "node:fs";
 function writeDispatchFile(dir, paneId, message) {
   if (message.length <= LONG_MESSAGE_THRESHOLD) return null;
-  const dispatchDir = join18(dir, ".tasks", "dispatch");
-  if (!existsSync25(dispatchDir)) mkdirSync15(dispatchDir, { recursive: true });
+  const dispatchDir = join20(dir, ".tasks", "dispatch");
+  if (!existsSync26(dispatchDir)) mkdirSync16(dispatchDir, { recursive: true });
   const paneSlug = paneId.replace("%", "");
   const filename = `send-${paneSlug}-${Date.now()}-${randomUUID().slice(0, 8)}.md`;
-  const filePath = join18(dispatchDir, filename);
-  writeFileSync15(filePath, message);
+  const filePath = join20(dispatchDir, filename);
+  writeFileSync16(filePath, message);
   return { filePath, triggerCmd: `Read and execute: .tasks/dispatch/${filename}` };
 }
 function resolvePane(panes, target) {
@@ -8155,19 +8409,19 @@ var init_schemas = __esm({
 });
 
 // packages/daemon/src/lib/terminals-store.ts
-import { existsSync as existsSync26, mkdirSync as mkdirSync16, readFileSync as readFileSync16, renameSync as renameSync10, writeFileSync as writeFileSync16 } from "node:fs";
-import { dirname as dirname19, join as join19 } from "node:path";
+import { existsSync as existsSync27, mkdirSync as mkdirSync17, readFileSync as readFileSync17, renameSync as renameSync10, writeFileSync as writeFileSync17 } from "node:fs";
+import { dirname as dirname19, join as join21 } from "node:path";
 function path(dir) {
-  return join19(dir, TERMINALS_FILE);
+  return join21(dir, TERMINALS_FILE);
 }
 function ensureDir(dir) {
-  mkdirSync16(dirname19(path(dir)), { recursive: true });
+  mkdirSync17(dirname19(path(dir)), { recursive: true });
 }
 function loadTerminals(dir) {
   const file = path(dir);
-  if (!existsSync26(file)) return [];
+  if (!existsSync27(file)) return [];
   try {
-    const body = readFileSync16(file, "utf-8");
+    const body = readFileSync17(file, "utf-8");
     const parsed = JSON.parse(body);
     if (!parsed.terminals || !Array.isArray(parsed.terminals)) return [];
     return parsed.terminals.filter((t) => isTerminal(t)).map((t) => ({ ...t }));
@@ -8184,7 +8438,7 @@ function writeAtomic(dir, terminals) {
   ensureDir(dir);
   const file = path(dir);
   const tmp = `${file}.tmp`;
-  writeFileSync16(tmp, JSON.stringify({ terminals }, null, 2) + "\n");
+  writeFileSync17(tmp, JSON.stringify({ terminals }, null, 2) + "\n");
   renameSync10(tmp, file);
 }
 function upsertTerminal(dir, input) {
@@ -8246,8 +8500,8 @@ __export(auth_service_exports, {
   AuthService: () => AuthService
 });
 import * as crypto2 from "node:crypto";
-import { readFileSync as readFileSync17, existsSync as existsSync27 } from "node:fs";
-import { join as join20 } from "node:path";
+import { readFileSync as readFileSync18, existsSync as existsSync28 } from "node:fs";
+import { join as join22 } from "node:path";
 import { homedir as homedir16 } from "node:os";
 function base64url(buf) {
   const b = typeof buf === "string" ? Buffer.from(buf) : buf;
@@ -8391,9 +8645,9 @@ var init_auth_service = __esm({
       checkSSHKeyAuthorization(userId, publicKey) {
         try {
           const home = userId === process.env.USER ? homedir16() : `/home/${userId}`;
-          const authKeysPath = join20(home, ".ssh", "authorized_keys");
-          if (!existsSync27(authKeysPath)) return false;
-          const authorizedKeys = readFileSync17(authKeysPath, "utf-8");
+          const authKeysPath = join22(home, ".ssh", "authorized_keys");
+          if (!existsSync28(authKeysPath)) return false;
+          const authorizedKeys = readFileSync18(authKeysPath, "utf-8");
           const parts = publicKey.trim().split(" ");
           const keyData = parts.length > 1 ? parts[1] : parts[0];
           return authorizedKeys.includes(keyData);
@@ -8791,11 +9045,11 @@ var init_project_context = __esm({
 });
 
 // packages/daemon/src/command-center/actions/handlers/config-actions.ts
-import { existsSync as existsSync28 } from "node:fs";
-import { join as join21 } from "node:path";
+import { existsSync as existsSync29 } from "node:fs";
+import { join as join23 } from "node:path";
 function mutateConfigAction(input, deps2, fn) {
   const context = resolveProjectContext(input, deps2);
-  if (!existsSync28(join21(context.dir, "ide.yml"))) {
+  if (!existsSync29(join23(context.dir, "ide.yml"))) {
     throw new ActionError({
       code: "ide_yml_missing",
       message: "ide.yml was not found",
@@ -9219,7 +9473,7 @@ var init_inspect = __esm({
 // packages/daemon/src/lib/filesystem-browser.ts
 import { realpathSync, readdirSync as readdirSync3, statSync as statSync4 } from "node:fs";
 import { homedir as homedir17 } from "node:os";
-import { isAbsolute as isAbsolute3, join as join22, resolve as resolve19, sep } from "node:path";
+import { isAbsolute as isAbsolute3, join as join24, resolve as resolve19, sep } from "node:path";
 function isUnderRoot(canonical, root) {
   if (canonical === root) return true;
   const prefix = root.endsWith(sep) ? root : root + sep;
@@ -9248,7 +9502,7 @@ var init_filesystem_browser = __esm({
 });
 
 // packages/daemon/src/lib/project-inspect.ts
-import { existsSync as existsSync29 } from "node:fs";
+import { existsSync as existsSync30 } from "node:fs";
 import { isAbsolute as isAbsolute4, resolve as resolve20 } from "node:path";
 function narrowPackageManager(raw) {
   if (!raw) return null;
@@ -9259,7 +9513,7 @@ function inferTestCommand(packageManager) {
   return packageManager === "npm" ? "npm test" : `${packageManager} test`;
 }
 async function inspectProject(dir, io = {}) {
-  const exists = io.exists ?? existsSync29;
+  const exists = io.exists ?? existsSync30;
   const absoluteDir = isAbsolute4(dir) ? dir : resolve20(dir);
   if (!exists(absoluteDir)) {
     throw new InspectDirNotFoundError(absoluteDir);
@@ -9300,8 +9554,8 @@ var init_project_inspect = __esm({
 
 // packages/daemon/src/lib/project-onboard.ts
 import yaml2 from "js-yaml";
-import { existsSync as existsSync30 } from "node:fs";
-import { join as join23 } from "node:path";
+import { existsSync as existsSync31 } from "node:fs";
+import { join as join25 } from "node:path";
 function composeIdeYmlConfig(input) {
   if (!Number.isInteger(input.agents) || input.agents < 1 || input.agents > 3) {
     throw new OnboardInvalidInputError(
@@ -9359,8 +9613,8 @@ function composeIdeYmlConfig(input) {
   }
   return config2;
 }
-function assertNoExistingIdeYml(dir, exists = existsSync30) {
-  const path2 = join23(dir, "ide.yml");
+function assertNoExistingIdeYml(dir, exists = existsSync31) {
+  const path2 = join25(dir, "ide.yml");
   if (exists(path2)) {
     throw new OnboardConflictError(path2);
   }
@@ -9395,8 +9649,8 @@ __export(server_exports, {
 });
 import { execFile as execFile2 } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync as existsSync31, readFileSync as readFileSync18, readdirSync as readdirSync4 } from "node:fs";
-import { join as join24, dirname as dirname20, basename as basename8 } from "node:path";
+import { existsSync as existsSync32, readFileSync as readFileSync19, readdirSync as readdirSync4 } from "node:fs";
+import { join as join26, dirname as dirname20, basename as basename8 } from "node:path";
 import { fileURLToPath as fileURLToPath8 } from "node:url";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
@@ -9408,10 +9662,10 @@ import { isAbsolute as isAbsolute5, resolve as pathResolve } from "node:path";
 import { randomUUID as randomUUID3 } from "node:crypto";
 import { WebSocketServer } from "ws";
 function resolvePackageVersion() {
-  const candidates = [join24(__dirname5, "../../package.json"), join24(__dirname5, "../package.json")];
+  const candidates = [join26(__dirname5, "../../package.json"), join26(__dirname5, "../package.json")];
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(readFileSync18(candidate, "utf-8"));
+      const parsed = JSON.parse(readFileSync19(candidate, "utf-8"));
       if (typeof parsed.version === "string") return parsed.version;
     } catch {
     }
@@ -10145,7 +10399,7 @@ function createApp(options = {}) {
     if (!parsed.success) {
       return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
     }
-    if (!existsSync31(parsed.data.dir)) {
+    if (!existsSync32(parsed.data.dir)) {
       return c.json({ error: `Directory "${parsed.data.dir}" does not exist` }, 400);
     }
     const jobId = randomUUID3();
@@ -10252,8 +10506,8 @@ function createApp(options = {}) {
 function listAvailableTemplates() {
   const __filename = fileURLToPath8(import.meta.url);
   const __dir = dirname20(__filename);
-  const templatesDir = join24(__dir, "..", "..", "..", "..", "templates");
-  if (!existsSync31(templatesDir)) return [];
+  const templatesDir = join26(__dir, "..", "..", "..", "..", "templates");
+  if (!existsSync32(templatesDir)) return [];
   const labels = {
     default: { label: "Default", description: "Single Claude pane + dev/shell row" },
     nextjs: {
@@ -12370,14 +12624,14 @@ __export(server_exports2, {
   defaultControlSocketPath: () => defaultControlSocketPath,
   startControlServer: () => startControlServer
 });
-import { chmodSync as chmodSync4, existsSync as existsSync32, mkdirSync as mkdirSync17, statSync as statSync5, unlinkSync } from "node:fs";
+import { chmodSync as chmodSync4, existsSync as existsSync33, mkdirSync as mkdirSync18, statSync as statSync5, unlinkSync } from "node:fs";
 import { createServer as createServer2, connect } from "node:net";
-import { dirname as dirname21, join as join25 } from "node:path";
+import { dirname as dirname21, join as join27 } from "node:path";
 function defaultControlSocketPath() {
-  return join25(tuiStateHome(), "control.sock");
+  return join27(tuiStateHome(), "control.sock");
 }
 async function claimSocketPath(path2) {
-  if (!existsSync32(path2)) return;
+  if (!existsSync33(path2)) return;
   if (!statSync5(path2).isSocket()) {
     throw new IdeError(
       `${path2} exists and is not a socket \u2014 refusing to remove it. Pass a different --socket path.`,
@@ -12407,7 +12661,7 @@ async function startControlServer(opts = {}) {
   const log = opts.log ?? (() => {
   });
   const tickMs = opts.tickMs ?? TICK_MS;
-  mkdirSync17(dirname21(socketPath), { recursive: true });
+  mkdirSync18(dirname21(socketPath), { recursive: true });
   await claimSocketPath(socketPath);
   const tracker = createStatusTracker();
   const handlers = createVerbHandlers({ tracker });
@@ -12641,7 +12895,7 @@ __export(worktree_exports, {
   worktreeSessionName: () => worktreeSessionName
 });
 import { execFileSync as execFileSync13 } from "node:child_process";
-import { basename as basename9, dirname as dirname22, isAbsolute as isAbsolute6, join as join26, resolve as resolve22 } from "node:path";
+import { basename as basename9, dirname as dirname22, isAbsolute as isAbsolute6, join as join28, resolve as resolve22 } from "node:path";
 function sanitizeForTmux(part) {
   return part.replace(/[.:/\s]+/g, "-");
 }
@@ -12650,11 +12904,11 @@ function worktreeSessionName(project, branch) {
 }
 function defaultWorktreeBaseDir(repoDir) {
   const abs = resolve22(repoDir);
-  return join26(dirname22(abs), `${basename9(abs)}-worktrees`);
+  return join28(dirname22(abs), `${basename9(abs)}-worktrees`);
 }
 function worktreePath(repoDir, branch, configuredDir) {
   const base = configuredDir && configuredDir.length > 0 ? isAbsolute6(configuredDir) ? configuredDir : resolve22(repoDir, configuredDir) : defaultWorktreeBaseDir(repoDir);
-  return join26(base, branch);
+  return join28(base, branch);
 }
 function parseWorktreeList(porcelain) {
   const entries = [];
@@ -12798,8 +13052,8 @@ __export(update_exports, {
   runUpdate: () => runUpdate
 });
 import { execSync as execSync4 } from "node:child_process";
-import { existsSync as existsSync33 } from "node:fs";
-import { dirname as dirname23, join as join27 } from "node:path";
+import { existsSync as existsSync34 } from "node:fs";
+import { dirname as dirname23, join as join29 } from "node:path";
 function detectPackageManager(cliPath) {
   const p = cliPath.toLowerCase();
   if (/(^|\/)\.?bun(\/|$)/.test(p)) return "bun";
@@ -12845,7 +13099,7 @@ function renderPlan(plan, { current, latest, dryRun }) {
 function findGitCheckoutRoot(startDir) {
   let dir = startDir;
   for (; ; ) {
-    if (existsSync33(join27(dir, ".git"))) return dir;
+    if (existsSync34(join29(dir, ".git"))) return dir;
     const parent = dirname23(dir);
     if (parent === dir) return null;
     dir = parent;
@@ -12978,9 +13232,9 @@ var init_server3 = __esm({
 // bin/cli.ts
 init_launch();
 import { parseArgs } from "node:util";
-import { resolve as resolve23, dirname as dirname24, join as join28 } from "node:path";
+import { resolve as resolve23, dirname as dirname24, join as join30 } from "node:path";
 import { execFileSync as execFileSync14 } from "node:child_process";
-import { existsSync as existsSync34 } from "node:fs";
+import { existsSync as existsSync35 } from "node:fs";
 import { fileURLToPath as fileURLToPath9 } from "node:url";
 
 // packages/daemon/src/tui/team/entry.ts
@@ -12998,48 +13252,48 @@ init_compiled();
 init_detect();
 init_output();
 import {
-  existsSync as existsSync18,
-  readFileSync as readFileSync12,
-  writeFileSync as writeFileSync11,
+  existsSync as existsSync19,
+  readFileSync as readFileSync13,
+  writeFileSync as writeFileSync12,
   renameSync as renameSync7,
-  mkdirSync as mkdirSync11,
+  mkdirSync as mkdirSync12,
   readdirSync as readdirSync2,
   copyFileSync as copyFileSync2
 } from "node:fs";
-import { resolve as resolve11, join as join13, basename as basename5, dirname as dirname13 } from "node:path";
+import { resolve as resolve11, join as join15, basename as basename5, dirname as dirname13 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 var __dirname4 = dirname13(fileURLToPath5(import.meta.url));
 function copyTemplateSkills(targetDir) {
   const created = [];
   const templateSkillsDir = resolve11(__dirname4, "..", "..", "..", "templates", "skills");
-  if (!existsSync18(templateSkillsDir)) return created;
-  mkdirSync11(targetDir, { recursive: true });
+  if (!existsSync19(templateSkillsDir)) return created;
+  mkdirSync12(targetDir, { recursive: true });
   for (const file of readdirSync2(templateSkillsDir)) {
     if (!file.endsWith(".md")) continue;
-    const destination = join13(targetDir, file);
-    copyFileSync2(join13(templateSkillsDir, file), destination);
+    const destination = join15(targetDir, file);
+    copyFileSync2(join15(templateSkillsDir, file), destination);
     created.push(destination);
   }
   return created;
 }
 function scaffoldLibraryStubs(dir) {
   const created = [];
-  const libraryDir = join13(dir, ".tmux-ide", "library");
-  if (!existsSync18(libraryDir)) {
-    mkdirSync11(libraryDir, { recursive: true });
+  const libraryDir = join15(dir, ".tmux-ide", "library");
+  if (!existsSync19(libraryDir)) {
+    mkdirSync12(libraryDir, { recursive: true });
     created.push(libraryDir);
   }
-  const archPath = join13(libraryDir, "architecture.md");
-  if (!existsSync18(archPath)) {
-    writeFileSync11(
+  const archPath = join15(libraryDir, "architecture.md");
+  if (!existsSync19(archPath)) {
+    writeFileSync12(
       archPath,
       "# Architecture\n\n<!-- Describe your project's architecture here. This context is injected into agent dispatch prompts. -->\n"
     );
     created.push(archPath);
   }
-  const learningsPath = join13(libraryDir, "learnings.md");
-  if (!existsSync18(learningsPath)) {
-    writeFileSync11(
+  const learningsPath = join15(libraryDir, "learnings.md");
+  if (!existsSync19(learningsPath)) {
+    writeFileSync12(
       learningsPath,
       "# Learnings\n\n<!-- Task summaries are automatically appended here by the orchestrator. -->\n"
     );
@@ -13049,13 +13303,13 @@ function scaffoldLibraryStubs(dir) {
 }
 function scaffoldValidationContract(dir) {
   const created = [];
-  const tasksDir = join13(dir, ".tasks");
-  if (!existsSync18(tasksDir)) {
-    mkdirSync11(tasksDir, { recursive: true });
+  const tasksDir = join15(dir, ".tasks");
+  if (!existsSync19(tasksDir)) {
+    mkdirSync12(tasksDir, { recursive: true });
   }
-  const contractPath = join13(tasksDir, "validation-contract.md");
-  if (!existsSync18(contractPath)) {
-    writeFileSync11(
+  const contractPath = join15(tasksDir, "validation-contract.md");
+  if (!existsSync19(contractPath)) {
+    writeFileSync12(
       contractPath,
       "# Validation Contract\n\n<!-- Define assertions that the validator agent will verify. Example: -->\n<!-- - VAL-001: All tests pass -->\n<!-- - VAL-002: No TypeScript errors -->\n<!-- - VAL-003: Lint passes with zero warnings -->\n"
     );
@@ -13066,11 +13320,11 @@ function scaffoldValidationContract(dir) {
 function scaffoldAgentsMd(dir, name) {
   const created = [];
   const agentsTemplatePath = resolve11(__dirname4, "..", "..", "..", "templates", "AGENTS.md");
-  if (existsSync18(agentsTemplatePath)) {
-    const agentsPath = join13(dir, "AGENTS.md");
-    if (!existsSync18(agentsPath)) {
-      const content = readFileSync12(agentsTemplatePath, "utf-8").replace(/{{name}}/g, name);
-      writeFileSync11(agentsPath, content);
+  if (existsSync19(agentsTemplatePath)) {
+    const agentsPath = join15(dir, "AGENTS.md");
+    if (!existsSync19(agentsPath)) {
+      const content = readFileSync13(agentsTemplatePath, "utf-8").replace(/{{name}}/g, name);
+      writeFileSync12(agentsPath, content);
       created.push(agentsPath);
     }
   }
@@ -13088,7 +13342,7 @@ function scaffoldTeamWorkspace(dir, name) {
 }
 function scaffoldMissionsWorkspace(dir, name) {
   const created = [];
-  const skillsDir = join13(dir, ".tmux-ide", "skills");
+  const skillsDir = join15(dir, ".tmux-ide", "skills");
   created.push(...copyTemplateSkills(skillsDir));
   created.push(...scaffoldTeamWorkspace(dir, name));
   return created;
@@ -13099,30 +13353,30 @@ async function init({
 } = {}) {
   const dir = process.cwd();
   const configPath = resolve11(dir, "ide.yml");
-  if (existsSync18(configPath)) {
+  if (existsSync19(configPath)) {
     outputError("ide.yml already exists in this directory", "EXISTS");
   }
   if (template) {
     const templatePath = resolve11(__dirname4, "..", "..", "..", "templates", `${template}.yml`);
-    if (!existsSync18(templatePath)) {
+    if (!existsSync19(templatePath)) {
       outputError(`Template "${template}" not found`, "NOT_FOUND");
     }
-    let content = readFileSync12(templatePath, "utf-8");
+    let content = readFileSync13(templatePath, "utf-8");
     const name2 = basename5(dir);
     content = content.replace(/^name: .+/m, `name: ${name2}`);
     const tmpPath = configPath + ".tmp";
-    writeFileSync11(tmpPath, content);
+    writeFileSync12(tmpPath, content);
     renameSync7(tmpPath, configPath);
     let created;
     if (template === "missions") {
       created = scaffoldMissionsWorkspace(dir, name2);
     } else if (isTeamTemplate(template)) {
       created = [
-        ...copyTemplateSkills(join13(dir, ".tmux-ide", "skills")),
+        ...copyTemplateSkills(join15(dir, ".tmux-ide", "skills")),
         ...scaffoldTeamWorkspace(dir, name2)
       ];
     } else {
-      created = copyTemplateSkills(join13(dir, ".tmux-ide", "skills"));
+      created = copyTemplateSkills(join15(dir, ".tmux-ide", "skills"));
     }
     if (json2) {
       console.log(JSON.stringify({ created: true, template, name: name2, paths: created }));
@@ -13142,7 +13396,7 @@ async function init({
     const config2 = suggestConfig(dir, detected);
     const yaml3 = (await import("js-yaml")).default;
     const tmpPath2 = configPath + ".tmp";
-    writeFileSync11(tmpPath2, yaml3.dump(config2, { lineWidth: -1, noRefs: true, quotingType: '"' }));
+    writeFileSync12(tmpPath2, yaml3.dump(config2, { lineWidth: -1, noRefs: true, quotingType: '"' }));
     renameSync7(tmpPath2, configPath);
     const desc = detected.frameworks.join(" + ");
     if (json2) {
@@ -13154,10 +13408,10 @@ async function init({
     }
   } else {
     const templatePath = resolve11(__dirname4, "..", "..", "..", "templates", "default.yml");
-    let content = readFileSync12(templatePath, "utf-8");
+    let content = readFileSync13(templatePath, "utf-8");
     content = content.replace(/^name: .+/m, `name: ${name}`);
     const tmpPath3 = configPath + ".tmp";
-    writeFileSync11(tmpPath3, content);
+    writeFileSync12(tmpPath3, content);
     renameSync7(tmpPath3, configPath);
     if (json2) {
       console.log(JSON.stringify({ created: true, template: "default", name }));
@@ -13168,8 +13422,8 @@ async function init({
       console.log("Edit it to configure your workspace, then run: tmux-ide");
     }
   }
-  const skillsDir = join13(dir, ".tmux-ide", "skills");
-  if (!existsSync18(skillsDir)) {
+  const skillsDir = join15(dir, ".tmux-ide", "skills");
+  if (!existsSync19(skillsDir)) {
     const created = copyTemplateSkills(skillsDir);
     if (created.length > 0 && !json2) {
       console.log("Copied built-in skill templates to .tmux-ide/skills/");
@@ -13257,8 +13511,9 @@ init_skill_sync();
 init_agent_discovery();
 init_compiled();
 init_claude();
+init_notify();
 import { execSync as execSync3 } from "node:child_process";
-import { accessSync, constants, existsSync as existsSync20 } from "node:fs";
+import { accessSync, constants, existsSync as existsSync21 } from "node:fs";
 import { resolve as resolve14, dirname as dirname15 } from "node:path";
 import { fileURLToPath as fileURLToPath7 } from "node:url";
 function agentIntegrationRows(agents) {
@@ -13294,6 +13549,23 @@ function hooksTargetRow(facts) {
     label,
     pass: false,
     detail: `cannot write ${facts.settingsPath} \u2014 fix its permissions (chown/chmod), or point TMUX_IDE_CLAUDE_SETTINGS at a writable path`,
+    optional: true
+  };
+}
+function notifierRow(present) {
+  const label = "notification click-to-jump (terminal-notifier)";
+  if (present) {
+    return {
+      label,
+      pass: true,
+      detail: "found \u2014 clicking a banner jumps to the session that needs you",
+      optional: true
+    };
+  }
+  return {
+    label,
+    pass: false,
+    detail: "macOS notifications are on, but terminal-notifier isn't installed \u2014 banners will still show, just without click-to-jump. Install it: `brew install terminal-notifier`",
     optional: true
   };
 }
@@ -13352,7 +13624,7 @@ async function doctor({
   checks.push(
     check("ide.yml exists", () => {
       const path2 = resolve14(".", "ide.yml");
-      if (!existsSync20(path2)) throw new Error("not found in current directory");
+      if (!existsSync21(path2)) throw new Error("not found in current directory");
       return "found";
     })
   );
@@ -13364,7 +13636,7 @@ async function doctor({
         const checkoutEntry = [
           resolve14(here, "../packages/daemon/src/tui/team/index.tsx"),
           resolve14(here, "tui/team/index.tsx")
-        ].find(existsSync20);
+        ].find(existsSync21);
         const binary = findCompiledTui();
         if (checkoutEntry && isBunAvailable()) return "dev checkout (bun)";
         if (binary) return `compiled binary (${binary})`;
@@ -13404,9 +13676,9 @@ async function doctor({
   checks.push(
     (() => {
       const settingsPath = claudeSettingsPath();
-      const fileExists2 = existsSync20(settingsPath);
+      const fileExists2 = existsSync21(settingsPath);
       let probe = fileExists2 ? settingsPath : dirname15(settingsPath);
-      while (!existsSync20(probe)) {
+      while (!existsSync21(probe)) {
         const parent = dirname15(probe);
         if (parent === probe) break;
         probe = parent;
@@ -13451,6 +13723,9 @@ async function doctor({
       { optional: true }
     )
   );
+  if (process.platform === "darwin" && readNotificationPrefs().macos) {
+    checks.push(notifierRow(hasTerminalNotifier()));
+  }
   checks.push(...agentIntegrationRows(discoverAgents()));
   const allPass = checks.every((c) => c.pass || c.optional);
   if (json2) {
@@ -13470,11 +13745,11 @@ init_yaml_io();
 init_src();
 init_canonical_daemon();
 import { resolve as resolve15 } from "node:path";
-import { existsSync as existsSync21 } from "node:fs";
+import { existsSync as existsSync22 } from "node:fs";
 async function status(targetDir, { json: json2 } = {}) {
   const dir = resolve15(targetDir ?? ".");
   const { name: session } = getSessionName(dir);
-  const configExists = existsSync21(resolve15(dir, "ide.yml"));
+  const configExists = existsSync22(resolve15(dir, "ide.yml"));
   const state = getSessionState(session);
   const running = state.running;
   let panes = [];
@@ -13934,50 +14209,7 @@ function reportPlan(plan, snapshot, { json: json2, dryRun, restored, launched, r
 init_send();
 init_errors2();
 init_output();
-
-// packages/daemon/src/tui/mirror/hosted.ts
-var APP_HOST_SESSION = "_tmux-ide-app";
-var HOSTED_ENV = "TMUX_IDE_HOSTED";
-function wantsHostedApp(input) {
-  if (input.hostedEnv) return false;
-  return input.flagDetachable || input.flagHosted || input.configDetachable;
-}
-function shellQuote(word) {
-  return `'${word.replaceAll("'", `'\\''`)}'`;
-}
-function hostedEnvVars(base) {
-  const env = {
-    [HOSTED_ENV]: "1",
-    TMUX_IDE_CWD: base.cwd,
-    TMUX_IDE_CLI: base.cli
-  };
-  if (base.path) env.PATH = base.path;
-  if (base.home) env.TMUX_IDE_HOME = base.home;
-  if (base.config) env.TMUX_IDE_CONFIG = base.config;
-  if (base.tuiBin) env.TMUX_IDE_TUI_BIN = base.tuiBin;
-  return env;
-}
-function hostedCommandLine(bin, argv, env) {
-  const assigns = Object.entries(env).map(([k, v]) => `${k}=${shellQuote(v)}`);
-  return ["exec", "env", ...assigns, shellQuote(bin), ...argv.map(shellQuote)].join(" ");
-}
-function hostExistsArgv() {
-  return ["has-session", "-t", `=${APP_HOST_SESSION}`];
-}
-function hostCreateArgv(opts) {
-  return ["new-session", "-d", "-s", APP_HOST_SESSION, "-c", opts.cwd, opts.commandLine];
-}
-function hostSetupArgvs() {
-  return [
-    ["set-option", "-t", APP_HOST_SESSION, "status", "off"],
-    ["set-option", "-w", "-t", `${APP_HOST_SESSION}:`, "window-size", "latest"]
-  ];
-}
-function hostAttachArgv(insideTmux) {
-  return insideTmux ? ["switch-client", "-t", `=${APP_HOST_SESSION}`] : ["attach-session", "-t", `=${APP_HOST_SESSION}`];
-}
-
-// bin/cli.ts
+init_hosted();
 var __dirname6 = dirname24(fileURLToPath9(import.meta.url));
 var selfPath = fileURLToPath9(import.meta.url);
 var nodeCliPath = selfPath.endsWith(".js") ? selfPath : resolve23(__dirname6, "cli.js");
@@ -14194,7 +14426,7 @@ function execBunWidget(surface, scriptPath, args, commandLabel, extraEnv = {}) {
     surface,
     scriptPath,
     args,
-    checkoutExists: existsSync34(scriptPath),
+    checkoutExists: existsSync35(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui()
   });
@@ -14226,7 +14458,7 @@ function launchHostedApp(scriptPath, appArgs) {
     surface: "app",
     scriptPath,
     args: appArgs,
-    checkoutExists: existsSync34(scriptPath),
+    checkoutExists: existsSync35(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui()
   });
@@ -14325,7 +14557,7 @@ try {
         }
       }
       const targetDir = resolve23(startTargetDir || ".");
-      const hasIdeYml = existsSync34(join28(targetDir, "ide.yml"));
+      const hasIdeYml = existsSync35(join30(targetDir, "ide.yml"));
       const entry = resolveEntry({
         hasIdeYml,
         teamFlag: values.team === true,
@@ -14437,8 +14669,8 @@ try {
       const messageStart = values.to ? 1 : 2;
       let message = positionals.slice(messageStart).join(" ");
       if (!message && !process.stdin.isTTY) {
-        const { readFileSync: readFileSync19 } = await import("node:fs");
-        message = readFileSync19(0, "utf-8").trim();
+        const { readFileSync: readFileSync20 } = await import("node:fs");
+        message = readFileSync20(0, "utf-8").trim();
       }
       await send(null, { json, to: target, message, noEnter: values["no-enter"] });
       break;
@@ -14570,7 +14802,7 @@ try {
       break;
     }
     case "events": {
-      const { readFileSync: readFileSync19, existsSync: existsSync35, statSync: statSync6, openSync, readSync, closeSync } = await import("node:fs");
+      const { readFileSync: readFileSync20, existsSync: existsSync36, statSync: statSync6, openSync, readSync, closeSync } = await import("node:fs");
       const { eventsPath: eventsPath2, formatEventLine: formatEventLine2 } = await Promise.resolve().then(() => (init_events(), events_exports));
       const path2 = eventsPath2();
       const paintStatus = (status2, text) => {
@@ -14595,8 +14827,8 @@ try {
           socketPath: typeof socketFlag === "string" ? socketFlag : void 0
         }).catch(() => null);
         if (client) {
-          if (existsSync35(path2)) {
-            const backlog = readFileSync19(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
+          if (existsSync36(path2)) {
+            const backlog = readFileSync20(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
             for (const line of backlog.slice(-50)) printLine(line);
           }
           await client.subscribe((frame) => {
@@ -14610,11 +14842,11 @@ try {
           break;
         }
       }
-      if (!existsSync35(path2)) {
+      if (!existsSync36(path2)) {
         console.log("no events yet \u2014 is a session adopted? (the chrome updater writes events)");
         break;
       }
-      const allLines = readFileSync19(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
+      const allLines = readFileSync20(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
       for (const line of allLines.slice(-50)) printLine(line);
       if (!values.follow) break;
       let offset = statSync6(path2).size;
@@ -14736,6 +14968,51 @@ try {
         console.log(
           "installed \u2014 NEW Claude Code sessions now report working/blocked/done authoritatively into the tmux-ide chrome."
         );
+        const { getAppConfig: getAppConfig2, updateAppConfig: updateAppConfig2 } = await Promise.resolve().then(() => (init_app_config(), app_config_exports));
+        const { hasTerminalNotifier: hasTerminalNotifier2 } = await Promise.resolve().then(() => (init_notify(), notify_exports));
+        const forcedKey = process.env.TMUX_IDE_NOTIFY_KEY;
+        const canAsk = forcedKey !== void 0 || process.stdin.isTTY === true;
+        if (process.platform === "darwin" && !getAppConfig2().notifications.macos && canAsk) {
+          const act = (key) => {
+            if (key === "y" || key === "Y") {
+              updateAppConfig2({ notifications: { macos: true } });
+              console.log(
+                "macOS notifications on \u2014 you'll get a banner when an agent blocks or finishes."
+              );
+              if (!hasTerminalNotifier2()) {
+                console.log(
+                  "tip: `brew install terminal-notifier` makes those banners clickable (a click jumps to the session)."
+                );
+              }
+            } else {
+              console.log(
+                "skipped \u2014 turn banners on anytime: notifications.macos in ~/.tmux-ide/config.json."
+              );
+            }
+          };
+          process.stdout.write("\nAlso get a macOS notification when an agent needs you? [y/N] ");
+          if (forcedKey !== void 0) {
+            console.log(forcedKey);
+            act(forcedKey);
+          } else {
+            const key = await new Promise((resolve24) => {
+              try {
+                process.stdin.setRawMode?.(true);
+                process.stdin.resume();
+                process.stdin.once("data", (data) => resolve24(data.toString()));
+              } catch {
+                resolve24("");
+              }
+            });
+            try {
+              process.stdin.setRawMode?.(false);
+              process.stdin.pause();
+            } catch {
+            }
+            console.log(/^[ -~]$/.test(key) ? key : "");
+            act(key);
+          }
+        }
       } else if (sub === "uninstall") {
         const { wasInstalled } = mod.uninstallClaudeIntegration();
         console.log(wasInstalled ? "uninstalled \u2014 hook entries removed" : "was not installed");
@@ -15021,7 +15298,7 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
       const mainPath = worktrees[0]?.path ?? repoDir;
       const projectName = getSessionName2(mainPath).name;
       async function openWorktreeSession(wtPath, name) {
-        if (existsSync34(join28(wtPath, "ide.yml"))) {
+        if (existsSync35(join30(wtPath, "ide.yml"))) {
           await launch(wtPath, { attach: false, sessionName: name });
         } else {
           if (!hasSession2(name)) createDetachedSession2(name, wtPath);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2276,6 +2276,9 @@ function parsePsOutput(raw) {
   return entries;
 }
 function subtreeCommands(entries, rootPid, maxDepth = 6) {
+  return subtreeEntries(entries, rootPid, maxDepth).map((entry) => entry.command);
+}
+function subtreeEntries(entries, rootPid, maxDepth = 6) {
   const childrenByParent = /* @__PURE__ */ new Map();
   const byPid = /* @__PURE__ */ new Map();
   for (const entry of entries) {
@@ -2286,7 +2289,7 @@ function subtreeCommands(entries, rootPid, maxDepth = 6) {
   }
   const root = byPid.get(rootPid);
   if (!root) return [];
-  const commands = [];
+  const out = [];
   const visited = /* @__PURE__ */ new Set();
   const walk = (pid, depth) => {
     if (depth > maxDepth || visited.has(pid)) return;
@@ -2295,10 +2298,10 @@ function subtreeCommands(entries, rootPid, maxDepth = 6) {
       walk(child.pid, depth + 1);
     }
     const self = byPid.get(pid);
-    if (self) commands.push(self.command);
+    if (self) out.push(self);
   };
   walk(rootPid, 0);
-  return commands;
+  return out;
 }
 function describeSubtree(entries, rootPid, limit = 8) {
   const seen = [];
@@ -2481,7 +2484,10 @@ function listTeamSessions(tracker, opts = {}) {
         sessionName: name,
         paneId: pane.id,
         agent: manifest && manifest.id !== "shell" ? manifest.id : null,
-        status: status2
+        status: status2,
+        pid: pane.pid,
+        dir: pane.dir,
+        sessionId: pane.sessionId.length > 0 ? pane.sessionId : null
       });
       const entry = buildAgentEntry({ sessionName: name, pane, manifest, state: status2, since });
       if (entry) agents.push(entry);
@@ -2509,7 +2515,7 @@ function collectPanes() {
     // title stays the trailing catch-all — window names/paths don't contain tabs
     // in practice. pane_current_path rides this SAME list-panes call (no extra
     // tmux round-trip) so per-pane agent entries can carry a working dir.
-    `#{session_name}	#{pane_id}	#{pane_pid}	#{pane_current_command}	#{@agent_state}	#{@agent_hint}	#{${SIDEBAR_PANE_OPTION}}	#{window_index}	#{window_name}	#{window_active}	#{pane_current_path}	#{pane_title}`
+    `#{session_name}	#{pane_id}	#{pane_pid}	#{pane_current_command}	#{@agent_state}	#{@agent_hint}	#{@agent_session_id}	#{${SIDEBAR_PANE_OPTION}}	#{window_index}	#{window_name}	#{window_active}	#{pane_current_path}	#{pane_title}`
   ]);
   const bySession = /* @__PURE__ */ new Map();
   for (const line of raw.split("\n").filter(Boolean)) {
@@ -2520,6 +2526,7 @@ function collectPanes() {
       cmd = "",
       authority = "",
       hint = "",
+      sessionId = "",
       sidebar = "",
       windowIndex = "0",
       windowName = "",
@@ -2535,6 +2542,7 @@ function collectPanes() {
       cmd,
       authority,
       hint,
+      sessionId,
       sidebar: sidebar === "1",
       windowIndex: Number(windowIndex) || 0,
       windowName,
@@ -4047,6 +4055,255 @@ var init_kitty_keys = __esm({
   }
 });
 
+// packages/daemon/src/tui/detect/session-id.ts
+import { execFileSync as execFileSync6 } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readdirSync as readdirSync2, readFileSync as readFileSync7, readlinkSync, statSync } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { join as join9 } from "node:path";
+function codexIdFromOpenFiles(paths) {
+  for (const path2 of paths) {
+    const match = CODEX_ROLLOUT_RE.exec(path2);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+function cursorIdFromOpenFiles(paths) {
+  for (const path2 of paths) {
+    const match = CURSOR_STORE_RE.exec(path2);
+    if (match?.[1] && SAFE_SESSION_ID.test(match[1])) return match[1];
+  }
+  return null;
+}
+function parseEtimeSeconds(raw) {
+  const trimmed = raw.trim();
+  const match = /^(?:(\d+)-)?(?:(\d+):)?(\d{1,2}):(\d{2})$/.exec(trimmed);
+  if (!match) return null;
+  const days = Number(match[1] ?? 0);
+  const hours = Number(match[2] ?? 0);
+  const minutes = Number(match[3]);
+  const seconds = Number(match[4]);
+  if (minutes >= 60 || seconds >= 60 || match[2] !== void 0 && hours >= 24) return null;
+  return ((days * 24 + hours) * 60 + minutes) * 60 + seconds;
+}
+function agentPidsInSubtree(table, panePid, bins) {
+  const wanted = new Set(bins);
+  const pids = [];
+  for (const entry of subtreeEntries(table, panePid)) {
+    if (commandTokens(entry.command).some((token) => wanted.has(token))) pids.push(entry.pid);
+  }
+  return pids;
+}
+function parseCodexRolloutName(name) {
+  const match = /^rollout-(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})-([0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})\.jsonl$/.exec(
+    name
+  );
+  if (!match) return null;
+  const [, y, mo, d, h, mi, s, id] = match;
+  const tsMs = new Date(
+    Number(y),
+    Number(mo) - 1,
+    Number(d),
+    Number(h),
+    Number(mi),
+    Number(s)
+  ).getTime();
+  return Number.isFinite(tsMs) && id ? { tsMs, id } : null;
+}
+function codexIdFromStateDir(root, paneCwd, startMs, io, nowMs = Date.now()) {
+  const cutoff = startMs - START_SLACK_MS;
+  const candidates = [];
+  for (let offset = 0; offset <= MAX_SCAN_DAYS; offset++) {
+    const day = new Date(nowMs - offset * 864e5);
+    if (day.getTime() < cutoff - 864e5) break;
+    const dir = join9(
+      root,
+      String(day.getFullYear()),
+      String(day.getMonth() + 1).padStart(2, "0"),
+      String(day.getDate()).padStart(2, "0")
+    );
+    for (const name of io.listDir(dir)) {
+      const parsed = parseCodexRolloutName(name);
+      if (parsed && parsed.tsMs >= cutoff && parsed.tsMs <= nowMs + START_SLACK_MS) {
+        candidates.push({ tsMs: parsed.tsMs, path: join9(dir, name), id: parsed.id });
+      }
+    }
+  }
+  candidates.sort((a, b) => b.tsMs - a.tsMs);
+  for (const candidate of candidates) {
+    const line = io.readFirstLine(candidate.path);
+    if (!line) continue;
+    let meta;
+    try {
+      meta = JSON.parse(line).payload;
+    } catch {
+      continue;
+    }
+    if (!meta || meta.cwd !== paneCwd) continue;
+    if (meta.thread_source === "subagent") continue;
+    if (typeof meta.source === "object" && meta.source !== null && "subagent" in meta.source) {
+      continue;
+    }
+    return candidate.id;
+  }
+  return null;
+}
+function cursorIdFromStateDir(chatsRoot, paneCwd, startMs, io) {
+  const hashed = join9(chatsRoot, createHash("md5").update(paneCwd).digest("hex"));
+  const cutoff = startMs - START_SLACK_MS;
+  let best = null;
+  for (const name of io.listDir(hashed)) {
+    if (!SAFE_SESSION_ID.test(name)) continue;
+    const mtime = io.mtimeMs(join9(hashed, name));
+    if (mtime === null || mtime < cutoff) continue;
+    if (!best || mtime > best.mtime) best = { name, mtime };
+  }
+  return best?.name ?? null;
+}
+function probeKind(pane, kind, io) {
+  const table = io.processTable();
+  const pids = agentPidsInSubtree(table, pane.pid, KIND_BINS[kind]);
+  if (pids.length === 0) return null;
+  const fromOpen = kind === "codex" ? codexIdFromOpenFiles : cursorIdFromOpenFiles;
+  for (const pid of pids) {
+    const id = fromOpen(io.openFiles(pid));
+    if (id) return id;
+  }
+  const startMs = io.processStartMs(pids[0]);
+  if (startMs === null) return null;
+  return kind === "codex" ? codexIdFromStateDir(io.codexSessionsRoot(), pane.dir, startMs, io.stateDir, io.now()) : cursorIdFromStateDir(io.cursorChatsRoot(), pane.dir, startMs, io.stateDir);
+}
+function createSessionIdCapturer(deps2) {
+  const every = deps2.everyTicks ?? CAPTURE_EVERY_TICKS;
+  const probe = deps2.probe ?? ((pane) => defaultProbe(pane));
+  const stampedByUs = /* @__PURE__ */ new Set();
+  let ticks = 0;
+  return {
+    onTick(panes) {
+      ticks++;
+      if (every <= 0 || ticks % every !== 0) return;
+      for (const pane of panes) {
+        if (!pane.agent || pane.sessionId || stampedByUs.has(pane.paneId)) continue;
+        const kindProbe = CAPTURE_PROBES[pane.agent];
+        if (!kindProbe) continue;
+        let id;
+        try {
+          id = probe(pane);
+        } catch {
+          continue;
+        }
+        if (!id || !SAFE_SESSION_ID.test(id)) continue;
+        try {
+          deps2.stamp(pane.paneId, id);
+          stampedByUs.add(pane.paneId);
+        } catch {
+        }
+      }
+    }
+  };
+}
+function readOpenFiles(pid) {
+  try {
+    const fdDir = `/proc/${pid}/fd`;
+    const names = readdirSync2(fdDir);
+    const paths = [];
+    for (const name of names) {
+      try {
+        const target = readlinkSync(join9(fdDir, name));
+        if (target.startsWith("/")) paths.push(target);
+      } catch {
+      }
+    }
+    return paths;
+  } catch {
+  }
+  try {
+    const raw = execFileSync6("lsof", ["-p", String(pid), "-Fn"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 3e3
+    });
+    return raw.split("\n").filter((line) => line.startsWith("n/")).map((line) => line.slice(1));
+  } catch {
+    return [];
+  }
+}
+function processStartMs(pid, nowMs = Date.now()) {
+  try {
+    const raw = execFileSync6("ps", ["-o", "etime=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2e3
+    });
+    const seconds = parseEtimeSeconds(raw);
+    return seconds === null ? null : nowMs - seconds * 1e3;
+  } catch {
+    return null;
+  }
+}
+function liveProbeIo() {
+  return {
+    processTable: readProcessTable,
+    openFiles: readOpenFiles,
+    processStartMs: (pid) => processStartMs(pid),
+    stateDir: liveStateDirIo,
+    codexSessionsRoot: () => process.env.TMUX_IDE_CODEX_SESSIONS ?? join9(homedir9(), ".codex", "sessions"),
+    cursorChatsRoot: () => process.env.TMUX_IDE_CURSOR_CHATS ?? join9(homedir9(), ".cursor", "chats"),
+    now: () => Date.now()
+  };
+}
+function defaultProbe(pane) {
+  const kindProbe = pane.agent ? CAPTURE_PROBES[pane.agent] : void 0;
+  return kindProbe ? kindProbe(pane, liveProbeIo()) : null;
+}
+var SAFE_SESSION_ID, CODEX_ROLLOUT_RE, CURSOR_STORE_RE, START_SLACK_MS, MAX_SCAN_DAYS, KIND_BINS, CAPTURE_PROBES, PROBED_KINDS, CAPTURE_EVERY_TICKS, liveStateDirIo;
+var init_session_id = __esm({
+  "packages/daemon/src/tui/detect/session-id.ts"() {
+    "use strict";
+    init_process_tree();
+    SAFE_SESSION_ID = /^[A-Za-z0-9_-]+$/;
+    CODEX_ROLLOUT_RE = /\/rollout-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-([0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})\.jsonl$/;
+    CURSOR_STORE_RE = /\/\.cursor\/chats\/[0-9a-f]{32}\/([A-Za-z0-9-]+)\/store\.db$/;
+    START_SLACK_MS = 12e4;
+    MAX_SCAN_DAYS = 7;
+    KIND_BINS = {
+      codex: ["codex", "codex.exe"],
+      cursor: ["cursor-agent", "cursor"]
+    };
+    CAPTURE_PROBES = {
+      codex: (pane, io) => probeKind(pane, "codex", io),
+      cursor: (pane, io) => probeKind(pane, "cursor", io)
+    };
+    PROBED_KINDS = Object.keys(CAPTURE_PROBES);
+    CAPTURE_EVERY_TICKS = 5;
+    liveStateDirIo = {
+      listDir: (path2) => {
+        try {
+          return readdirSync2(path2);
+        } catch {
+          return [];
+        }
+      },
+      mtimeMs: (path2) => {
+        try {
+          return statSync(path2).mtimeMs;
+        } catch {
+          return null;
+        }
+      },
+      readFirstLine: (path2) => {
+        try {
+          const fd = readFileSync7(path2, { encoding: "utf8", flag: "r" });
+          const newline = fd.indexOf("\n");
+          return newline === -1 ? fd : fd.slice(0, newline);
+        } catch {
+          return null;
+        }
+      }
+    };
+  }
+});
+
 // packages/daemon/src/schemas/registry.ts
 import { z as z10 } from "zod";
 var RegisteredProjectSchemaZ, RegisterProjectRequestSchemaZ, InitProjectRequestSchemaZ, ProjectTemplateSchemaZ;
@@ -4137,9 +4394,9 @@ var init_project_probe = __esm({
 
 // packages/daemon/src/lib/project-registry.ts
 import { EventEmitter } from "node:events";
-import { existsSync as existsSync12, mkdirSync as mkdirSync7, readFileSync as readFileSync7, renameSync as renameSync3, writeFileSync as writeFileSync8 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { dirname as dirname10, isAbsolute as isAbsolute2, join as join9, resolve as resolve8 } from "node:path";
+import { existsSync as existsSync12, mkdirSync as mkdirSync7, readFileSync as readFileSync8, renameSync as renameSync3, writeFileSync as writeFileSync8 } from "node:fs";
+import { homedir as homedir10 } from "node:os";
+import { dirname as dirname10, isAbsolute as isAbsolute2, join as join10, resolve as resolve8 } from "node:path";
 import { z as z11 } from "zod";
 function applyAction(state, action) {
   switch (action.type) {
@@ -4171,15 +4428,15 @@ function buildRegisteredProject(probe, name, registeredAt) {
 function registryDir() {
   const override = process.env[REGISTRY_DIR_ENV];
   if (override && override.length > 0) return override;
-  return join9(homedir9(), ".tmux-ide");
+  return join10(homedir10(), ".tmux-ide");
 }
 function registryPath() {
-  return join9(registryDir(), "projects.json");
+  return join10(registryDir(), "projects.json");
 }
 function readDisk() {
   const path2 = registryPath();
   if (!existsSync12(path2)) return [];
-  const raw = readFileSync7(path2, "utf-8");
+  const raw = readFileSync8(path2, "utf-8");
   if (raw.trim().length === 0) return [];
   let parsed;
   try {
@@ -4435,9 +4692,9 @@ __export(events_exports, {
   formatEventLine: () => formatEventLine,
   shouldRotate: () => shouldRotate
 });
-import { appendFileSync, existsSync as existsSync13, mkdirSync as mkdirSync8, renameSync as renameSync4, statSync } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { join as join10 } from "node:path";
+import { appendFileSync, existsSync as existsSync13, mkdirSync as mkdirSync8, renameSync as renameSync4, statSync as statSync2 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { join as join11 } from "node:path";
 function diffFleet(prev, next) {
   const state = /* @__PURE__ */ new Map();
   const events = [];
@@ -4464,14 +4721,14 @@ function formatEventLine(ev, paint = (_s, t) => t) {
   return `${isoTime(ev.ts)} ${ev.session} ${from} \u2192 ${paint(ev.to, ev.to)}`;
 }
 function eventsPath() {
-  return join10(homedir10(), ".tmux-ide", "events.jsonl");
+  return join11(homedir11(), ".tmux-ide", "events.jsonl");
 }
 function appendEvents(events, now = () => (/* @__PURE__ */ new Date()).toISOString()) {
   if (events.length === 0) return;
   const path2 = eventsPath();
   try {
-    mkdirSync8(join10(homedir10(), ".tmux-ide"), { recursive: true });
-    if (existsSync13(path2) && shouldRotate(statSync(path2).size)) {
+    mkdirSync8(join11(homedir11(), ".tmux-ide"), { recursive: true });
+    if (existsSync13(path2) && shouldRotate(statSync2(path2).size)) {
       renameSync4(path2, `${path2}.1`);
     }
     const ts = now();
@@ -4490,8 +4747,8 @@ var init_events = __esm({
 });
 
 // packages/daemon/src/tui/chrome/notify.ts
-import { execFileSync as execFileSync6 } from "node:child_process";
-import { existsSync as existsSync14, readFileSync as readFileSync8 } from "node:fs";
+import { execFileSync as execFileSync7 } from "node:child_process";
+import { existsSync as existsSync14, readFileSync as readFileSync9 } from "node:fs";
 function statusPhrase(to) {
   return to === "blocked" ? "needs input" : "finished";
 }
@@ -4552,7 +4809,7 @@ function sendToasts(toasts) {
 }
 function hasTerminalNotifier() {
   try {
-    execFileSync6("which", ["terminal-notifier"], { stdio: "ignore" });
+    execFileSync7("which", ["terminal-notifier"], { stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -4575,11 +4832,11 @@ function sendSystemNotification(n) {
   if (process.platform !== "darwin") return;
   try {
     if (hasTerminalNotifier()) {
-      execFileSync6("terminal-notifier", terminalNotifierArgs(n), { stdio: "ignore" });
+      execFileSync7("terminal-notifier", terminalNotifierArgs(n), { stdio: "ignore" });
       return;
     }
     const escaped = n.message.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-    execFileSync6("osascript", ["-e", `display notification "${escaped}" with title "tmux-ide"`], {
+    execFileSync7("osascript", ["-e", `display notification "${escaped}" with title "tmux-ide"`], {
       stdio: "ignore"
     });
   } catch {
@@ -4635,7 +4892,7 @@ function readRawConfig() {
   const path2 = appConfigPath();
   if (!existsSync14(path2)) return void 0;
   try {
-    return JSON.parse(readFileSync8(path2, "utf-8"));
+    return JSON.parse(readFileSync9(path2, "utf-8"));
   } catch {
     return void 0;
   }
@@ -4664,9 +4921,9 @@ var init_notify = __esm({
 });
 
 // packages/daemon/src/tui/chrome/snapshot.ts
-import { existsSync as existsSync15, mkdirSync as mkdirSync9, readFileSync as readFileSync9, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
-import { homedir as homedir11 } from "node:os";
-import { dirname as dirname11, join as join11 } from "node:path";
+import { existsSync as existsSync15, mkdirSync as mkdirSync9, readFileSync as readFileSync10, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
+import { homedir as homedir12 } from "node:os";
+import { dirname as dirname11, join as join12 } from "node:path";
 import { z as z12 } from "zod";
 function isBareShell(cmd) {
   return /^-?(zsh|bash|sh|fish|dash|ksh|tcsh|csh|nu)$/.test(cmd.trim());
@@ -4781,7 +5038,7 @@ function collectFleetSnapshot(io = defaultIo) {
   return buildSnapshot(rawPanes, rawSessions, io.processTable());
 }
 function snapshotPath() {
-  return join11(homedir11(), ".tmux-ide", "snapshot.json");
+  return join12(homedir12(), ".tmux-ide", "snapshot.json");
 }
 function writeSnapshot(snapshot) {
   const path2 = snapshotPath();
@@ -4803,7 +5060,7 @@ function readSnapshot() {
   const path2 = snapshotPath();
   try {
     if (!existsSync15(path2)) return null;
-    const raw = readFileSync9(path2, "utf-8");
+    const raw = readFileSync10(path2, "utf-8");
     if (raw.trim().length === 0) return null;
     const result = FleetSnapshotSchemaZ.safeParse(JSON.parse(raw));
     return result.success ? result.data : null;
@@ -4954,6 +5211,7 @@ function runUpdaterTick(deps2) {
     deps2.writeStatus(session, buildStatusline(projects, session, 12, theme, extra));
   }
   writeChips(deps2, adopted, panes, theme);
+  deps2.captureSessionIds?.(panes);
   if (update?.updateAvailable && update.latest) dispatchUpdateToast(deps2, update.latest);
   if (deps2.prevState && deps2.appendEvents) {
     const { events, state } = diffFleet(deps2.prevState, fleetStatuses(projects));
@@ -5093,6 +5351,11 @@ function runUpdaterLoop() {
   const prevState = /* @__PURE__ */ new Map();
   const lastNotified = /* @__PURE__ */ new Map();
   const chipCache = /* @__PURE__ */ new Map();
+  const capturer = createSessionIdCapturer({
+    // Throwing is fine here — the capturer treats a failed stamp as "retry on
+    // the next capture window".
+    stamp: (paneId, id) => runTmux(["set-option", "-p", "-t", paneId, "@agent_session_id", id])
+  });
   const snapshotter = createSnapshotter({
     collect: () => collectFleetSnapshot(),
     read: readSnapshot,
@@ -5118,7 +5381,8 @@ function runUpdaterLoop() {
         sendSystem: sendSystemNotification,
         locatePane: paneLocation,
         maybeCheckForUpdate: () => maybeCheckForUpdate({ enabled: config2.updates.check }),
-        markUpdateNotified
+        markUpdateNotified,
+        captureSessionIds: (panes) => capturer.onTick(panes)
       });
     } catch {
     }
@@ -5145,6 +5409,7 @@ var init_updater = __esm({
     init_app_config();
     init_update_check();
     init_classify();
+    init_session_id();
     init_projects();
     init_chip();
     init_events();
@@ -5436,12 +5701,12 @@ __export(canonical_daemon_exports, {
   warnOnDaemonVersionSkew: () => warnOnDaemonVersionSkew,
   writeCanonicalDaemonInfo: () => writeCanonicalDaemonInfo
 });
-import { existsSync as existsSync16, mkdirSync as mkdirSync10, readFileSync as readFileSync10, renameSync as renameSync6, rmSync, writeFileSync as writeFileSync10 } from "node:fs";
-import { homedir as homedir12 } from "node:os";
-import { dirname as dirname12, join as join12 } from "node:path";
+import { existsSync as existsSync16, mkdirSync as mkdirSync10, readFileSync as readFileSync11, renameSync as renameSync6, rmSync, writeFileSync as writeFileSync10 } from "node:fs";
+import { homedir as homedir13 } from "node:os";
+import { dirname as dirname12, join as join13 } from "node:path";
 function getCanonicalDaemonInfoPath() {
-  const dir = process.env[DAEMON_INFO_DIR_ENV] ?? process.env[REGISTRY_DIR_ENV2] ?? join12(homedir12(), ".tmux-ide");
-  return join12(dir, DAEMON_INFO_FILE);
+  const dir = process.env[DAEMON_INFO_DIR_ENV] ?? process.env[REGISTRY_DIR_ENV2] ?? join13(homedir13(), ".tmux-ide");
+  return join13(dir, DAEMON_INFO_FILE);
 }
 function parseCanonicalDaemonInfo(raw) {
   if (!raw || typeof raw !== "object") return null;
@@ -5481,7 +5746,7 @@ function readCanonicalDaemonInfo() {
   const path2 = getCanonicalDaemonInfoPath();
   if (!existsSync16(path2)) return null;
   try {
-    return parseCanonicalDaemonInfo(JSON.parse(readFileSync10(path2, "utf-8")));
+    return parseCanonicalDaemonInfo(JSON.parse(readFileSync11(path2, "utf-8")));
   } catch {
     return null;
   }
@@ -5541,7 +5806,7 @@ __export(launch_exports, {
 });
 import { resolve as resolve9 } from "node:path";
 import { execSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash as createHash2 } from "node:crypto";
 function stripWidgetPanes(rows) {
   return rows.map((row) => ({
     ...row,
@@ -5552,7 +5817,7 @@ function sleepMs(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 function configHash(config2) {
-  return createHash("sha256").update(JSON.stringify(config2)).digest("hex").slice(0, 12);
+  return createHash2("sha256").update(JSON.stringify(config2)).digest("hex").slice(0, 12);
 }
 function waitForPaneCommand(targetPane, expectedCommands, {
   attempts = 20,
@@ -5771,13 +6036,13 @@ var init_launch = __esm({
 
 // packages/daemon/src/detect.ts
 import { resolve as resolve10, basename as basename4 } from "node:path";
-import { readFileSync as readFileSync11, existsSync as existsSync17 } from "node:fs";
+import { readFileSync as readFileSync12, existsSync as existsSync17 } from "node:fs";
 function fileExists(dir, name) {
   return existsSync17(resolve10(dir, name));
 }
 function readJson(dir, name) {
   try {
-    return JSON.parse(readFileSync11(resolve10(dir, name), "utf-8"));
+    return JSON.parse(readFileSync12(resolve10(dir, name), "utf-8"));
   } catch {
     return null;
   }
@@ -5839,7 +6104,7 @@ function detectStack(dir) {
     detected.language = detected.language ?? "python";
     detected.reasons.push('Detected Python from "pyproject.toml" or "requirements.txt".');
     try {
-      const pyproject = readFileSync11(resolve10(dir, "pyproject.toml"), "utf-8");
+      const pyproject = readFileSync12(resolve10(dir, "pyproject.toml"), "utf-8");
       if (pyproject.includes("fastapi"))
         pushFramework(detected, "fastapi", 'Found "fastapi" in pyproject.toml.');
       else if (pyproject.includes("django"))
@@ -5986,25 +6251,25 @@ __export(skill_sync_exports, {
   syncSkill: () => syncSkill,
   versionMarker: () => versionMarker
 });
-import { existsSync as existsSync19, mkdirSync as mkdirSync12, readFileSync as readFileSync13, writeFileSync as writeFileSync12 } from "node:fs";
-import { homedir as homedir13 } from "node:os";
-import { dirname as dirname14, join as join14 } from "node:path";
+import { existsSync as existsSync19, mkdirSync as mkdirSync12, readFileSync as readFileSync14, writeFileSync as writeFileSync12 } from "node:fs";
+import { homedir as homedir14 } from "node:os";
+import { dirname as dirname14, join as join15 } from "node:path";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
 function claudeDir() {
-  return process.env.TMUX_IDE_CLAUDE_DIR ?? join14(homedir13(), ".claude");
+  return process.env.TMUX_IDE_CLAUDE_DIR ?? join15(homedir14(), ".claude");
 }
 function skillTargetDir() {
-  return join14(claudeDir(), "skills", "tmux-ide");
+  return join15(claudeDir(), "skills", "tmux-ide");
 }
 function skillTargetFile() {
-  return join14(skillTargetDir(), "SKILL.md");
+  return join15(skillTargetDir(), "SKILL.md");
 }
 function defaultSkillSource() {
   const here = dirname14(fileURLToPath6(import.meta.url));
   const candidates = [
-    join14(here, "../skill/SKILL.md"),
+    join15(here, "../skill/SKILL.md"),
     // bundled bin/cli.js → repo root
-    join14(here, "../../../../skill/SKILL.md")
+    join15(here, "../../../../skill/SKILL.md")
     // dev src/lib → repo root
   ];
   return candidates.find((c) => existsSync19(c)) ?? candidates[0];
@@ -6021,10 +6286,10 @@ function rewriteVersionMarker(content, version) {
   return content.replace(VERSION_MARKER_RE, versionMarker(version));
 }
 function installedSkillVersion(dir = skillTargetDir()) {
-  const file = join14(dir, "SKILL.md");
+  const file = join15(dir, "SKILL.md");
   if (!existsSync19(file)) return null;
   try {
-    return parseSkillVersion(readFileSync13(file, "utf-8"));
+    return parseSkillVersion(readFileSync14(file, "utf-8"));
   } catch {
     return null;
   }
@@ -6033,10 +6298,10 @@ function syncSkill({
   source = defaultSkillSource(),
   version = getCurrentVersion()
 } = {}) {
-  const rendered = rewriteVersionMarker(readFileSync13(source, "utf-8"), version);
+  const rendered = rewriteVersionMarker(readFileSync14(source, "utf-8"), version);
   const dir = skillTargetDir();
-  const target = join14(dir, "SKILL.md");
-  const existing = existsSync19(target) ? readFileSync13(target, "utf-8") : null;
+  const target = join15(dir, "SKILL.md");
+  const existing = existsSync19(target) ? readFileSync14(target, "utf-8") : null;
   if (existing === rendered) {
     return { action: "unchanged", path: target, to: version };
   }
@@ -6054,6 +6319,93 @@ var init_skill_sync = __esm({
   }
 });
 
+// packages/daemon/src/tui/integrations/opencode.ts
+var opencode_exports = {};
+__export(opencode_exports, {
+  PLUGIN_FILENAME: () => PLUGIN_FILENAME,
+  PLUGIN_MARKER: () => PLUGIN_MARKER,
+  PLUGIN_SOURCE: () => PLUGIN_SOURCE,
+  installOpencodeIntegration: () => installOpencodeIntegration,
+  isOurPlugin: () => isOurPlugin,
+  opencodeIntegrationStatus: () => opencodeIntegrationStatus,
+  opencodePluginPath: () => opencodePluginPath,
+  uninstallOpencodeIntegration: () => uninstallOpencodeIntegration
+});
+import { existsSync as existsSync20, mkdirSync as mkdirSync13, readFileSync as readFileSync15, rmSync as rmSync2, writeFileSync as writeFileSync13 } from "node:fs";
+import { homedir as homedir15 } from "node:os";
+import { dirname as dirname15, join as join16 } from "node:path";
+function opencodePluginPath() {
+  const override = process.env.TMUX_IDE_OPENCODE_DIR;
+  if (override) return join16(override, PLUGIN_FILENAME);
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const configRoot = xdg && xdg.length > 0 ? xdg : join16(homedir15(), ".config");
+  return join16(configRoot, "opencode", "plugin", PLUGIN_FILENAME);
+}
+function isOurPlugin(content) {
+  return content.includes(PLUGIN_MARKER);
+}
+function installOpencodeIntegration() {
+  const pluginPath = opencodePluginPath();
+  mkdirSync13(dirname15(pluginPath), { recursive: true });
+  writeFileSync13(pluginPath, PLUGIN_SOURCE, "utf8");
+  return { pluginPath };
+}
+function uninstallOpencodeIntegration() {
+  const pluginPath = opencodePluginPath();
+  const wasInstalled = opencodeIntegrationStatus().installed;
+  if (wasInstalled) rmSync2(pluginPath, { force: true });
+  return { pluginPath, wasInstalled };
+}
+function opencodeIntegrationStatus() {
+  const pluginPath = opencodePluginPath();
+  try {
+    if (!existsSync20(pluginPath)) return { installed: false };
+    return { installed: isOurPlugin(readFileSync15(pluginPath, "utf8")) };
+  } catch {
+    return { installed: false };
+  }
+}
+var PLUGIN_MARKER, PLUGIN_FILENAME, PLUGIN_SOURCE;
+var init_opencode = __esm({
+  "packages/daemon/src/tui/integrations/opencode.ts"() {
+    "use strict";
+    PLUGIN_MARKER = "installed by: tmux-ide integration install opencode";
+    PLUGIN_FILENAME = "tmux-ide.js";
+    PLUGIN_SOURCE = `/**
+ * tmux-ide opencode plugin (${PLUGIN_MARKER})
+ *
+ * Stamps this pane's @agent_session_id tmux option with the opencode session
+ * id so \`tmux-ide restore --resume-agents\` can revive the conversation via
+ * \`opencode --session <id>\` after a tmux server death.
+ *
+ * Remove with: tmux-ide integration uninstall opencode
+ */
+export const TmuxIde = async () => {
+  const pane = process.env.TMUX_PANE;
+  if (!pane) return {}; // not inside tmux \u2014 inert
+  const { execFile } = await import("node:child_process");
+  let last = "";
+  const stamp = (id) => {
+    if (typeof id !== "string" || !/^[A-Za-z0-9_-]+$/.test(id) || id === last) return;
+    last = id;
+    execFile("tmux", ["set-option", "-p", "-t", pane, "@agent_session_id", id], () => {});
+  };
+  return {
+    event: async ({ event }) => {
+      // session.updated fires on create + every update; info.id is the
+      // resumable session id. Child sessions (subagents) carry parentID and
+      // must never overwrite the pane's own conversation key.
+      if (event && event.type === "session.updated") {
+        const info = event.properties && event.properties.info;
+        if (info && !info.parentID) stamp(info.id);
+      }
+    },
+  };
+};
+`;
+  }
+});
+
 // packages/daemon/src/lib/agent-discovery.ts
 var agent_discovery_exports = {};
 __export(agent_discovery_exports, {
@@ -6061,13 +6413,22 @@ __export(agent_discovery_exports, {
   discoverAgents: () => discoverAgents,
   presentAgents: () => presentAgents
 });
-import { execFileSync as execFileSync7 } from "node:child_process";
+import { execFileSync as execFileSync8 } from "node:child_process";
 function discoverAgents(which = defaultWhich, isInstalled2 = defaultIntegrationProbe) {
   return KNOWN_AGENTS.map((agent) => {
     const path2 = which(agent.bin);
     const present = path2 !== null;
     const installed = present && agent.integration ? isInstalled2(agent.id) : false;
-    return { id: agent.id, bin: agent.bin, integration: agent.integration, path: path2, installed };
+    const captureActive = agent.capture === "probe" ? present : agent.capture !== null ? installed : false;
+    return {
+      id: agent.id,
+      bin: agent.bin,
+      integration: agent.integration,
+      path: path2,
+      installed,
+      capture: agent.capture,
+      captureActive
+    };
   });
 }
 function presentAgents(agents) {
@@ -6078,16 +6439,19 @@ var init_agent_discovery = __esm({
   "packages/daemon/src/lib/agent-discovery.ts"() {
     "use strict";
     init_claude();
+    init_opencode();
     KNOWN_AGENTS = [
-      { id: "claude", bin: "claude", integration: true },
-      { id: "codex", bin: "codex", integration: false },
-      { id: "opencode", bin: "opencode", integration: false },
-      { id: "gemini", bin: "gemini", integration: false },
-      { id: "aider", bin: "aider", integration: false }
+      { id: "claude", bin: "claude", integration: true, capture: "hooks" },
+      { id: "codex", bin: "codex", integration: false, capture: "probe" },
+      { id: "opencode", bin: "opencode", integration: true, capture: "plugin" },
+      { id: "gemini", bin: "gemini", integration: false, capture: null },
+      { id: "aider", bin: "aider", integration: false, capture: null },
+      { id: "cursor", bin: "cursor-agent", integration: false, capture: "probe" },
+      { id: "copilot", bin: "copilot", integration: false, capture: null }
     ];
     defaultWhich = (bin) => {
       try {
-        const out = execFileSync7("which", [bin], {
+        const out = execFileSync8("which", [bin], {
           encoding: "utf-8",
           stdio: ["ignore", "pipe", "ignore"],
           timeout: 2e3
@@ -6099,9 +6463,10 @@ var init_agent_discovery = __esm({
       }
     };
     defaultIntegrationProbe = (agentId) => {
-      if (agentId !== "claude") return false;
       try {
-        return claudeIntegrationStatus().installed;
+        if (agentId === "claude") return claudeIntegrationStatus().installed;
+        if (agentId === "opencode") return opencodeIntegrationStatus().installed;
+        return false;
       } catch {
         return false;
       }
@@ -6137,10 +6502,10 @@ var init_contract = __esm({
 });
 
 // packages/daemon/src/lib/session-monitor.ts
-import { execFileSync as execFileSync8 } from "node:child_process";
+import { execFileSync as execFileSync9 } from "node:child_process";
 function getListeningPids() {
   try {
-    const raw = execFileSync8("lsof", ["-nP", "-iTCP", "-sTCP:LISTEN", "-FpPn"], {
+    const raw = execFileSync9("lsof", ["-nP", "-iTCP", "-sTCP:LISTEN", "-FpPn"], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 2e3
@@ -6165,7 +6530,7 @@ function getListeningPids() {
 }
 function getProcessTree() {
   try {
-    const raw = execFileSync8("ps", ["-axo", "pid=,ppid="], {
+    const raw = execFileSync9("ps", ["-axo", "pid=,ppid="], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 2e3
@@ -6242,8 +6607,8 @@ var init_PtyAdapter = __esm({
 });
 
 // packages/daemon/src/terminal/NodePtyAdapter.ts
-import { chmodSync as chmodSync3, existsSync as existsSync22, statSync as statSync2 } from "node:fs";
-import { dirname as dirname16, join as join15 } from "node:path";
+import { chmodSync as chmodSync3, existsSync as existsSync23, statSync as statSync3 } from "node:fs";
+import { dirname as dirname17, join as join17 } from "node:path";
 import { createRequire } from "node:module";
 import * as pty from "node-pty";
 function candidateSpawnHelperPaths() {
@@ -6254,11 +6619,11 @@ function candidateSpawnHelperPaths() {
   } catch {
     return [];
   }
-  const pkgDir = dirname16(pkgJsonPath);
+  const pkgDir = dirname17(pkgJsonPath);
   return [
-    join15(pkgDir, "build", "Release", "spawn-helper"),
-    join15(pkgDir, "build", "Debug", "spawn-helper"),
-    join15(pkgDir, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper")
+    join17(pkgDir, "build", "Release", "spawn-helper"),
+    join17(pkgDir, "build", "Debug", "spawn-helper"),
+    join17(pkgDir, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper")
   ];
 }
 function ensureNodePtySpawnHelperExecutable(options = {}) {
@@ -6266,7 +6631,7 @@ function ensureNodePtySpawnHelperExecutable(options = {}) {
   if (!options.force && !options.explicitPath && helperEnsured) return;
   const candidates = options.explicitPath ? [options.explicitPath] : candidateSpawnHelperPaths();
   for (const candidate of candidates) {
-    if (!existsSync22(candidate)) continue;
+    if (!existsSync23(candidate)) continue;
     try {
       chmodSync3(candidate, 493);
     } catch {
@@ -6372,7 +6737,7 @@ var init_NodePtyAdapter = __esm({
       skipHelperEnsure;
       constructor(options = {}) {
         this.spawnPty = options.spawnPty ?? pty.spawn;
-        this.statCwd = options.statCwd ?? statSync2;
+        this.statCwd = options.statCwd ?? statSync3;
         this.skipHelperEnsure = options.skipHelperEnsure ?? false;
       }
       async spawn(input) {
@@ -7157,7 +7522,7 @@ var init_ws_route = __esm({
 });
 
 // packages/daemon/src/widgets/lib/pane-comms.ts
-import { execFileSync as execFileSync9 } from "node:child_process";
+import { execFileSync as execFileSync10 } from "node:child_process";
 function tmux2(...args) {
   try {
     return _executor2("tmux", args, {
@@ -7248,25 +7613,25 @@ var _executor2, SHELL_COMMANDS;
 var init_pane_comms = __esm({
   "packages/daemon/src/widgets/lib/pane-comms.ts"() {
     "use strict";
-    _executor2 = (cmd, args, options) => execFileSync9(cmd, args, { encoding: "utf-8", ...options }).toString();
+    _executor2 = (cmd, args, options) => execFileSync10(cmd, args, { encoding: "utf-8", ...options }).toString();
     SHELL_COMMANDS = /* @__PURE__ */ new Set(["zsh", "bash", "sh", "fish"]);
   }
 });
 
 // packages/daemon/src/lib/workspace-registry.ts
 import { EventEmitter as EventEmitter3 } from "node:events";
-import { existsSync as existsSync23, mkdirSync as mkdirSync13, readFileSync as readFileSync14, renameSync as renameSync8, writeFileSync as writeFileSync13 } from "node:fs";
-import { homedir as homedir14 } from "node:os";
-import { dirname as dirname17, join as join16 } from "node:path";
+import { existsSync as existsSync24, mkdirSync as mkdirSync14, readFileSync as readFileSync16, renameSync as renameSync8, writeFileSync as writeFileSync14 } from "node:fs";
+import { homedir as homedir16 } from "node:os";
+import { dirname as dirname18, join as join18 } from "node:path";
 import { z as z13 } from "zod";
 function getDefaultWorkspaceRegistry() {
   if (!_default) _default = new WorkspaceRegistry();
   return _default;
 }
 function defaultListSessions() {
-  const { execFileSync: execFileSync15 } = __require("node:child_process");
+  const { execFileSync: execFileSync16 } = __require("node:child_process");
   try {
-    const raw = execFileSync15("tmux", ["list-sessions", "-F", "#{session_name}"], {
+    const raw = execFileSync16("tmux", ["list-sessions", "-F", "#{session_name}"], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"]
     });
@@ -7306,7 +7671,7 @@ var init_workspace_registry = __esm({
       workspaces = [];
       loaded = false;
       constructor(options = {}) {
-        this.dir = options.dir ?? process.env[REGISTRY_DIR_ENV3] ?? join16(homedir14(), ".tmux-ide");
+        this.dir = options.dir ?? process.env[REGISTRY_DIR_ENV3] ?? join18(homedir16(), ".tmux-ide");
         this.listSessions = options.listSessions ?? defaultListSessions;
         this.emitter.setMaxListeners(0);
       }
@@ -7373,14 +7738,14 @@ var init_workspace_registry = __esm({
       }
       // ----------------- io -----------------
       filePath() {
-        return join16(this.dir, "workspaces.json");
+        return join18(this.dir, "workspaces.json");
       }
       readDisk() {
         const path2 = this.filePath();
-        if (!existsSync23(path2)) return [];
+        if (!existsSync24(path2)) return [];
         let parsed;
         try {
-          parsed = JSON.parse(readFileSync14(path2, "utf-8"));
+          parsed = JSON.parse(readFileSync16(path2, "utf-8"));
         } catch {
           return [];
         }
@@ -7390,10 +7755,10 @@ var init_workspace_registry = __esm({
       }
       writeDisk() {
         const path2 = this.filePath();
-        mkdirSync13(dirname17(path2), { recursive: true });
+        mkdirSync14(dirname18(path2), { recursive: true });
         const file = { version: 1, workspaces: this.workspaces };
         const tmp = `${path2}.tmp`;
-        writeFileSync13(tmp, JSON.stringify(file, null, 2) + "\n");
+        writeFileSync14(tmp, JSON.stringify(file, null, 2) + "\n");
         renameSync8(tmp, path2);
       }
       /** @internal Test-only: assert the registry is loaded. */
@@ -7406,7 +7771,7 @@ var init_workspace_registry = __esm({
 });
 
 // packages/daemon/src/command-center/discovery.ts
-import { execFileSync as execFileSync10 } from "node:child_process";
+import { execFileSync as execFileSync11 } from "node:child_process";
 function tmuxSilent(args) {
   try {
     return _tmuxRunner(args);
@@ -7456,7 +7821,7 @@ var init_discovery = __esm({
     "use strict";
     init_pane_comms();
     init_workspace_registry();
-    _tmuxRunner = (args) => execFileSync10("tmux", args, {
+    _tmuxRunner = (args) => execFileSync11("tmux", args, {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"]
     }).trim();
@@ -7675,14 +8040,14 @@ var init_auth_token = __esm({
 });
 
 // packages/daemon/src/lib/app-settings.ts
-import { existsSync as existsSync24, mkdirSync as mkdirSync14, readFileSync as readFileSync15, renameSync as renameSync9, writeFileSync as writeFileSync14 } from "node:fs";
-import { dirname as dirname18, join as join17 } from "node:path";
-import { homedir as homedir15 } from "node:os";
+import { existsSync as existsSync25, mkdirSync as mkdirSync15, readFileSync as readFileSync17, renameSync as renameSync9, writeFileSync as writeFileSync15 } from "node:fs";
+import { dirname as dirname19, join as join19 } from "node:path";
+import { homedir as homedir17 } from "node:os";
 function settingsDir() {
-  return process.env.TMUX_IDE_SETTINGS_DIR ?? join17(homedir15(), ".tmux-ide");
+  return process.env.TMUX_IDE_SETTINGS_DIR ?? join19(homedir17(), ".tmux-ide");
 }
 function appSettingsPath() {
-  return join17(settingsDir(), "app-settings.json");
+  return join19(settingsDir(), "app-settings.json");
 }
 function normalizeSettings(value) {
   if (!value || typeof value !== "object") return structuredClone(DEFAULT_SETTINGS);
@@ -7695,18 +8060,18 @@ function normalizeSettings(value) {
 }
 function readAppSettings() {
   const path2 = appSettingsPath();
-  if (!existsSync24(path2)) return structuredClone(DEFAULT_SETTINGS);
+  if (!existsSync25(path2)) return structuredClone(DEFAULT_SETTINGS);
   try {
-    return normalizeSettings(JSON.parse(readFileSync15(path2, "utf-8")));
+    return normalizeSettings(JSON.parse(readFileSync17(path2, "utf-8")));
   } catch {
     return structuredClone(DEFAULT_SETTINGS);
   }
 }
 function writeAppSettings(next) {
   const path2 = appSettingsPath();
-  mkdirSync14(dirname18(path2), { recursive: true });
+  mkdirSync15(dirname19(path2), { recursive: true });
   const tmp = `${path2}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync14(tmp, `${JSON.stringify(normalizeSettings(next), null, 2)}
+  writeFileSync15(tmp, `${JSON.stringify(normalizeSettings(next), null, 2)}
 `, "utf-8");
   renameSync9(tmp, path2);
 }
@@ -7896,16 +8261,16 @@ var init_active_projects = __esm({
 
 // packages/daemon/src/send.ts
 import { randomUUID } from "node:crypto";
-import { resolve as resolve17, join as join18 } from "node:path";
-import { existsSync as existsSync25, mkdirSync as mkdirSync15, writeFileSync as writeFileSync15 } from "node:fs";
+import { resolve as resolve17, join as join20 } from "node:path";
+import { existsSync as existsSync26, mkdirSync as mkdirSync16, writeFileSync as writeFileSync16 } from "node:fs";
 function writeDispatchFile(dir, paneId, message) {
   if (message.length <= LONG_MESSAGE_THRESHOLD) return null;
-  const dispatchDir = join18(dir, ".tasks", "dispatch");
-  if (!existsSync25(dispatchDir)) mkdirSync15(dispatchDir, { recursive: true });
+  const dispatchDir = join20(dir, ".tasks", "dispatch");
+  if (!existsSync26(dispatchDir)) mkdirSync16(dispatchDir, { recursive: true });
   const paneSlug = paneId.replace("%", "");
   const filename = `send-${paneSlug}-${Date.now()}-${randomUUID().slice(0, 8)}.md`;
-  const filePath = join18(dispatchDir, filename);
-  writeFileSync15(filePath, message);
+  const filePath = join20(dispatchDir, filename);
+  writeFileSync16(filePath, message);
   return { filePath, triggerCmd: `Read and execute: .tasks/dispatch/${filename}` };
 }
 function resolvePane(panes, target) {
@@ -8155,19 +8520,19 @@ var init_schemas = __esm({
 });
 
 // packages/daemon/src/lib/terminals-store.ts
-import { existsSync as existsSync26, mkdirSync as mkdirSync16, readFileSync as readFileSync16, renameSync as renameSync10, writeFileSync as writeFileSync16 } from "node:fs";
-import { dirname as dirname19, join as join19 } from "node:path";
+import { existsSync as existsSync27, mkdirSync as mkdirSync17, readFileSync as readFileSync18, renameSync as renameSync10, writeFileSync as writeFileSync17 } from "node:fs";
+import { dirname as dirname20, join as join21 } from "node:path";
 function path(dir) {
-  return join19(dir, TERMINALS_FILE);
+  return join21(dir, TERMINALS_FILE);
 }
 function ensureDir(dir) {
-  mkdirSync16(dirname19(path(dir)), { recursive: true });
+  mkdirSync17(dirname20(path(dir)), { recursive: true });
 }
 function loadTerminals(dir) {
   const file = path(dir);
-  if (!existsSync26(file)) return [];
+  if (!existsSync27(file)) return [];
   try {
-    const body = readFileSync16(file, "utf-8");
+    const body = readFileSync18(file, "utf-8");
     const parsed = JSON.parse(body);
     if (!parsed.terminals || !Array.isArray(parsed.terminals)) return [];
     return parsed.terminals.filter((t) => isTerminal(t)).map((t) => ({ ...t }));
@@ -8184,7 +8549,7 @@ function writeAtomic(dir, terminals) {
   ensureDir(dir);
   const file = path(dir);
   const tmp = `${file}.tmp`;
-  writeFileSync16(tmp, JSON.stringify({ terminals }, null, 2) + "\n");
+  writeFileSync17(tmp, JSON.stringify({ terminals }, null, 2) + "\n");
   renameSync10(tmp, file);
 }
 function upsertTerminal(dir, input) {
@@ -8246,9 +8611,9 @@ __export(auth_service_exports, {
   AuthService: () => AuthService
 });
 import * as crypto2 from "node:crypto";
-import { readFileSync as readFileSync17, existsSync as existsSync27 } from "node:fs";
-import { join as join20 } from "node:path";
-import { homedir as homedir16 } from "node:os";
+import { readFileSync as readFileSync19, existsSync as existsSync28 } from "node:fs";
+import { join as join22 } from "node:path";
+import { homedir as homedir18 } from "node:os";
 function base64url(buf) {
   const b = typeof buf === "string" ? Buffer.from(buf) : buf;
   return b.toString("base64url");
@@ -8390,10 +8755,10 @@ var init_auth_service = __esm({
       }
       checkSSHKeyAuthorization(userId, publicKey) {
         try {
-          const home = userId === process.env.USER ? homedir16() : `/home/${userId}`;
-          const authKeysPath = join20(home, ".ssh", "authorized_keys");
-          if (!existsSync27(authKeysPath)) return false;
-          const authorizedKeys = readFileSync17(authKeysPath, "utf-8");
+          const home = userId === process.env.USER ? homedir18() : `/home/${userId}`;
+          const authKeysPath = join22(home, ".ssh", "authorized_keys");
+          if (!existsSync28(authKeysPath)) return false;
+          const authorizedKeys = readFileSync19(authKeysPath, "utf-8");
           const parts = publicKey.trim().split(" ");
           const keyData = parts.length > 1 ? parts[1] : parts[0];
           return authorizedKeys.includes(keyData);
@@ -8791,11 +9156,11 @@ var init_project_context = __esm({
 });
 
 // packages/daemon/src/command-center/actions/handlers/config-actions.ts
-import { existsSync as existsSync28 } from "node:fs";
-import { join as join21 } from "node:path";
+import { existsSync as existsSync29 } from "node:fs";
+import { join as join23 } from "node:path";
 function mutateConfigAction(input, deps2, fn) {
   const context = resolveProjectContext(input, deps2);
-  if (!existsSync28(join21(context.dir, "ide.yml"))) {
+  if (!existsSync29(join23(context.dir, "ide.yml"))) {
     throw new ActionError({
       code: "ide_yml_missing",
       message: "ide.yml was not found",
@@ -9217,9 +9582,9 @@ var init_inspect = __esm({
 });
 
 // packages/daemon/src/lib/filesystem-browser.ts
-import { realpathSync, readdirSync as readdirSync3, statSync as statSync4 } from "node:fs";
-import { homedir as homedir17 } from "node:os";
-import { isAbsolute as isAbsolute3, join as join22, resolve as resolve19, sep } from "node:path";
+import { realpathSync, readdirSync as readdirSync4, statSync as statSync5 } from "node:fs";
+import { homedir as homedir19 } from "node:os";
+import { isAbsolute as isAbsolute3, join as join24, resolve as resolve19, sep } from "node:path";
 function isUnderRoot(canonical, root) {
   if (canonical === root) return true;
   const prefix = root.endsWith(sep) ? root : root + sep;
@@ -9248,7 +9613,7 @@ var init_filesystem_browser = __esm({
 });
 
 // packages/daemon/src/lib/project-inspect.ts
-import { existsSync as existsSync29 } from "node:fs";
+import { existsSync as existsSync30 } from "node:fs";
 import { isAbsolute as isAbsolute4, resolve as resolve20 } from "node:path";
 function narrowPackageManager(raw) {
   if (!raw) return null;
@@ -9259,7 +9624,7 @@ function inferTestCommand(packageManager) {
   return packageManager === "npm" ? "npm test" : `${packageManager} test`;
 }
 async function inspectProject(dir, io = {}) {
-  const exists = io.exists ?? existsSync29;
+  const exists = io.exists ?? existsSync30;
   const absoluteDir = isAbsolute4(dir) ? dir : resolve20(dir);
   if (!exists(absoluteDir)) {
     throw new InspectDirNotFoundError(absoluteDir);
@@ -9300,8 +9665,8 @@ var init_project_inspect = __esm({
 
 // packages/daemon/src/lib/project-onboard.ts
 import yaml2 from "js-yaml";
-import { existsSync as existsSync30 } from "node:fs";
-import { join as join23 } from "node:path";
+import { existsSync as existsSync31 } from "node:fs";
+import { join as join25 } from "node:path";
 function composeIdeYmlConfig(input) {
   if (!Number.isInteger(input.agents) || input.agents < 1 || input.agents > 3) {
     throw new OnboardInvalidInputError(
@@ -9359,8 +9724,8 @@ function composeIdeYmlConfig(input) {
   }
   return config2;
 }
-function assertNoExistingIdeYml(dir, exists = existsSync30) {
-  const path2 = join23(dir, "ide.yml");
+function assertNoExistingIdeYml(dir, exists = existsSync31) {
+  const path2 = join25(dir, "ide.yml");
   if (exists(path2)) {
     throw new OnboardConflictError(path2);
   }
@@ -9395,23 +9760,23 @@ __export(server_exports, {
 });
 import { execFile as execFile2 } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync as existsSync31, readFileSync as readFileSync18, readdirSync as readdirSync4 } from "node:fs";
-import { join as join24, dirname as dirname20, basename as basename8 } from "node:path";
+import { existsSync as existsSync32, readFileSync as readFileSync20, readdirSync as readdirSync5 } from "node:fs";
+import { join as join26, dirname as dirname21, basename as basename8 } from "node:path";
 import { fileURLToPath as fileURLToPath8 } from "node:url";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { cors } from "hono/cors";
 import { zValidator } from "@hono/zod-validator";
 import { realpathSync as realpathSync2 } from "node:fs";
-import { homedir as homedir18 } from "node:os";
+import { homedir as homedir20 } from "node:os";
 import { isAbsolute as isAbsolute5, resolve as pathResolve } from "node:path";
 import { randomUUID as randomUUID3 } from "node:crypto";
 import { WebSocketServer } from "ws";
 function resolvePackageVersion() {
-  const candidates = [join24(__dirname5, "../../package.json"), join24(__dirname5, "../package.json")];
+  const candidates = [join26(__dirname5, "../../package.json"), join26(__dirname5, "../package.json")];
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(readFileSync18(candidate, "utf-8"));
+      const parsed = JSON.parse(readFileSync20(candidate, "utf-8"));
       if (typeof parsed.version === "string") return parsed.version;
     } catch {
     }
@@ -9475,7 +9840,7 @@ function sandboxResolveDir(rawDir) {
   if (trimmed.includes("\0")) {
     return { error: "invalid-path", message: "Path contains a null byte", status: 400 };
   }
-  const home = process.env.TMUX_IDE_HOME_OVERRIDE && process.env.TMUX_IDE_HOME_OVERRIDE.trim().length > 0 ? process.env.TMUX_IDE_HOME_OVERRIDE : homedir18();
+  const home = process.env.TMUX_IDE_HOME_OVERRIDE && process.env.TMUX_IDE_HOME_OVERRIDE.trim().length > 0 ? process.env.TMUX_IDE_HOME_OVERRIDE : homedir20();
   let candidate = trimmed;
   if (candidate === "~") {
     candidate = home;
@@ -10145,7 +10510,7 @@ function createApp(options = {}) {
     if (!parsed.success) {
       return c.json({ error: "Invalid request", details: parsed.error.issues }, 400);
     }
-    if (!existsSync31(parsed.data.dir)) {
+    if (!existsSync32(parsed.data.dir)) {
       return c.json({ error: `Directory "${parsed.data.dir}" does not exist` }, 400);
     }
     const jobId = randomUUID3();
@@ -10251,9 +10616,9 @@ function createApp(options = {}) {
 }
 function listAvailableTemplates() {
   const __filename = fileURLToPath8(import.meta.url);
-  const __dir = dirname20(__filename);
-  const templatesDir = join24(__dir, "..", "..", "..", "..", "templates");
-  if (!existsSync31(templatesDir)) return [];
+  const __dir = dirname21(__filename);
+  const templatesDir = join26(__dir, "..", "..", "..", "..", "templates");
+  if (!existsSync32(templatesDir)) return [];
   const labels = {
     default: { label: "Default", description: "Single Claude pane + dev/shell row" },
     nextjs: {
@@ -10284,7 +10649,7 @@ function listAvailableTemplates() {
       description: "Mission-driven layout with planner, validator, and researcher"
     }
   };
-  const entries = readdirSync4(templatesDir).filter((f) => f.endsWith(".yml"));
+  const entries = readdirSync5(templatesDir).filter((f) => f.endsWith(".yml"));
   return entries.map((file) => {
     const id = file.replace(/\.yml$/, "");
     const meta = labels[id];
@@ -10342,7 +10707,7 @@ var init_server = __esm({
     init_filesystem_browser();
     init_project_inspect();
     init_project_onboard();
-    __dirname5 = dirname20(fileURLToPath8(import.meta.url));
+    __dirname5 = dirname21(fileURLToPath8(import.meta.url));
     pkgVersion = resolvePackageVersion();
     projectStreamConnections = 0;
     sseMetrics = {
@@ -10365,13 +10730,13 @@ var init_types = __esm({
 });
 
 // packages/daemon/src/lib/daemon-embed.ts
-import { execFileSync as execFileSync11 } from "node:child_process";
+import { execFileSync as execFileSync12 } from "node:child_process";
 import { randomBytes as randomBytes3 } from "node:crypto";
 import { createServer } from "node:http";
 import { createRequire as createRequire2 } from "node:module";
 import { WebSocket, WebSocketServer as WebSocketServer2 } from "ws";
 function tmux3(...args) {
-  return execFileSync11("tmux", args, {
+  return execFileSync12("tmux", args, {
     encoding: "utf-8",
     // Pipe stdio explicitly. Inheriting (the default) inherits the parent's
     // file descriptors; when the daemon is launched detached (nohup, disown,
@@ -11828,10 +12193,10 @@ __export(agent_explain_exports, {
   buildReport: () => buildReport,
   renderReport: () => renderReport
 });
-import { execFileSync as execFileSync12 } from "node:child_process";
+import { execFileSync as execFileSync13 } from "node:child_process";
 function tmux4(args) {
   try {
-    return execFileSync12("tmux", args, {
+    return execFileSync13("tmux", args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
     }).trim();
@@ -12370,15 +12735,15 @@ __export(server_exports2, {
   defaultControlSocketPath: () => defaultControlSocketPath,
   startControlServer: () => startControlServer
 });
-import { chmodSync as chmodSync4, existsSync as existsSync32, mkdirSync as mkdirSync17, statSync as statSync5, unlinkSync } from "node:fs";
+import { chmodSync as chmodSync4, existsSync as existsSync33, mkdirSync as mkdirSync18, statSync as statSync6, unlinkSync } from "node:fs";
 import { createServer as createServer2, connect } from "node:net";
-import { dirname as dirname21, join as join25 } from "node:path";
+import { dirname as dirname22, join as join27 } from "node:path";
 function defaultControlSocketPath() {
-  return join25(tuiStateHome(), "control.sock");
+  return join27(tuiStateHome(), "control.sock");
 }
 async function claimSocketPath(path2) {
-  if (!existsSync32(path2)) return;
-  if (!statSync5(path2).isSocket()) {
+  if (!existsSync33(path2)) return;
+  if (!statSync6(path2).isSocket()) {
     throw new IdeError(
       `${path2} exists and is not a socket \u2014 refusing to remove it. Pass a different --socket path.`,
       { code: "USAGE", exitCode: 1 }
@@ -12407,7 +12772,7 @@ async function startControlServer(opts = {}) {
   const log = opts.log ?? (() => {
   });
   const tickMs = opts.tickMs ?? TICK_MS;
-  mkdirSync17(dirname21(socketPath), { recursive: true });
+  mkdirSync18(dirname22(socketPath), { recursive: true });
   await claimSocketPath(socketPath);
   const tracker = createStatusTracker();
   const handlers = createVerbHandlers({ tracker });
@@ -12640,8 +13005,8 @@ __export(worktree_exports, {
   worktreePath: () => worktreePath,
   worktreeSessionName: () => worktreeSessionName
 });
-import { execFileSync as execFileSync13 } from "node:child_process";
-import { basename as basename9, dirname as dirname22, isAbsolute as isAbsolute6, join as join26, resolve as resolve22 } from "node:path";
+import { execFileSync as execFileSync14 } from "node:child_process";
+import { basename as basename9, dirname as dirname23, isAbsolute as isAbsolute6, join as join28, resolve as resolve22 } from "node:path";
 function sanitizeForTmux(part) {
   return part.replace(/[.:/\s]+/g, "-");
 }
@@ -12650,11 +13015,11 @@ function worktreeSessionName(project, branch) {
 }
 function defaultWorktreeBaseDir(repoDir) {
   const abs = resolve22(repoDir);
-  return join26(dirname22(abs), `${basename9(abs)}-worktrees`);
+  return join28(dirname23(abs), `${basename9(abs)}-worktrees`);
 }
 function worktreePath(repoDir, branch, configuredDir) {
   const base = configuredDir && configuredDir.length > 0 ? isAbsolute6(configuredDir) ? configuredDir : resolve22(repoDir, configuredDir) : defaultWorktreeBaseDir(repoDir);
-  return join26(base, branch);
+  return join28(base, branch);
 }
 function parseWorktreeList(porcelain) {
   const entries = [];
@@ -12779,7 +13144,7 @@ var init_worktree = __esm({
         this.name = "WorktreeError";
       }
     };
-    gitRunner = (repoDir, args) => execFileSync13("git", args, {
+    gitRunner = (repoDir, args) => execFileSync14("git", args, {
       cwd: repoDir,
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"]
@@ -12798,8 +13163,8 @@ __export(update_exports, {
   runUpdate: () => runUpdate
 });
 import { execSync as execSync4 } from "node:child_process";
-import { existsSync as existsSync33 } from "node:fs";
-import { dirname as dirname23, join as join27 } from "node:path";
+import { existsSync as existsSync34 } from "node:fs";
+import { dirname as dirname24, join as join29 } from "node:path";
 function detectPackageManager(cliPath) {
   const p = cliPath.toLowerCase();
   if (/(^|\/)\.?bun(\/|$)/.test(p)) return "bun";
@@ -12845,8 +13210,8 @@ function renderPlan(plan, { current, latest, dryRun }) {
 function findGitCheckoutRoot(startDir) {
   let dir = startDir;
   for (; ; ) {
-    if (existsSync33(join27(dir, ".git"))) return dir;
-    const parent = dirname23(dir);
+    if (existsSync34(join29(dir, ".git"))) return dir;
+    const parent = dirname24(dir);
     if (parent === dir) return null;
     dir = parent;
   }
@@ -12978,9 +13343,9 @@ var init_server3 = __esm({
 // bin/cli.ts
 init_launch();
 import { parseArgs } from "node:util";
-import { resolve as resolve23, dirname as dirname24, join as join28 } from "node:path";
-import { execFileSync as execFileSync14 } from "node:child_process";
-import { existsSync as existsSync34 } from "node:fs";
+import { resolve as resolve23, dirname as dirname25, join as join30 } from "node:path";
+import { execFileSync as execFileSync15 } from "node:child_process";
+import { existsSync as existsSync35 } from "node:fs";
 import { fileURLToPath as fileURLToPath9 } from "node:url";
 
 // packages/daemon/src/tui/team/entry.ts
@@ -12999,14 +13364,14 @@ init_detect();
 init_output();
 import {
   existsSync as existsSync18,
-  readFileSync as readFileSync12,
+  readFileSync as readFileSync13,
   writeFileSync as writeFileSync11,
   renameSync as renameSync7,
   mkdirSync as mkdirSync11,
-  readdirSync as readdirSync2,
+  readdirSync as readdirSync3,
   copyFileSync as copyFileSync2
 } from "node:fs";
-import { resolve as resolve11, join as join13, basename as basename5, dirname as dirname13 } from "node:path";
+import { resolve as resolve11, join as join14, basename as basename5, dirname as dirname13 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 var __dirname4 = dirname13(fileURLToPath5(import.meta.url));
 function copyTemplateSkills(targetDir) {
@@ -13014,22 +13379,22 @@ function copyTemplateSkills(targetDir) {
   const templateSkillsDir = resolve11(__dirname4, "..", "..", "..", "templates", "skills");
   if (!existsSync18(templateSkillsDir)) return created;
   mkdirSync11(targetDir, { recursive: true });
-  for (const file of readdirSync2(templateSkillsDir)) {
+  for (const file of readdirSync3(templateSkillsDir)) {
     if (!file.endsWith(".md")) continue;
-    const destination = join13(targetDir, file);
-    copyFileSync2(join13(templateSkillsDir, file), destination);
+    const destination = join14(targetDir, file);
+    copyFileSync2(join14(templateSkillsDir, file), destination);
     created.push(destination);
   }
   return created;
 }
 function scaffoldLibraryStubs(dir) {
   const created = [];
-  const libraryDir = join13(dir, ".tmux-ide", "library");
+  const libraryDir = join14(dir, ".tmux-ide", "library");
   if (!existsSync18(libraryDir)) {
     mkdirSync11(libraryDir, { recursive: true });
     created.push(libraryDir);
   }
-  const archPath = join13(libraryDir, "architecture.md");
+  const archPath = join14(libraryDir, "architecture.md");
   if (!existsSync18(archPath)) {
     writeFileSync11(
       archPath,
@@ -13037,7 +13402,7 @@ function scaffoldLibraryStubs(dir) {
     );
     created.push(archPath);
   }
-  const learningsPath = join13(libraryDir, "learnings.md");
+  const learningsPath = join14(libraryDir, "learnings.md");
   if (!existsSync18(learningsPath)) {
     writeFileSync11(
       learningsPath,
@@ -13049,11 +13414,11 @@ function scaffoldLibraryStubs(dir) {
 }
 function scaffoldValidationContract(dir) {
   const created = [];
-  const tasksDir = join13(dir, ".tasks");
+  const tasksDir = join14(dir, ".tasks");
   if (!existsSync18(tasksDir)) {
     mkdirSync11(tasksDir, { recursive: true });
   }
-  const contractPath = join13(tasksDir, "validation-contract.md");
+  const contractPath = join14(tasksDir, "validation-contract.md");
   if (!existsSync18(contractPath)) {
     writeFileSync11(
       contractPath,
@@ -13067,9 +13432,9 @@ function scaffoldAgentsMd(dir, name) {
   const created = [];
   const agentsTemplatePath = resolve11(__dirname4, "..", "..", "..", "templates", "AGENTS.md");
   if (existsSync18(agentsTemplatePath)) {
-    const agentsPath = join13(dir, "AGENTS.md");
+    const agentsPath = join14(dir, "AGENTS.md");
     if (!existsSync18(agentsPath)) {
-      const content = readFileSync12(agentsTemplatePath, "utf-8").replace(/{{name}}/g, name);
+      const content = readFileSync13(agentsTemplatePath, "utf-8").replace(/{{name}}/g, name);
       writeFileSync11(agentsPath, content);
       created.push(agentsPath);
     }
@@ -13088,7 +13453,7 @@ function scaffoldTeamWorkspace(dir, name) {
 }
 function scaffoldMissionsWorkspace(dir, name) {
   const created = [];
-  const skillsDir = join13(dir, ".tmux-ide", "skills");
+  const skillsDir = join14(dir, ".tmux-ide", "skills");
   created.push(...copyTemplateSkills(skillsDir));
   created.push(...scaffoldTeamWorkspace(dir, name));
   return created;
@@ -13107,7 +13472,7 @@ async function init({
     if (!existsSync18(templatePath)) {
       outputError(`Template "${template}" not found`, "NOT_FOUND");
     }
-    let content = readFileSync12(templatePath, "utf-8");
+    let content = readFileSync13(templatePath, "utf-8");
     const name2 = basename5(dir);
     content = content.replace(/^name: .+/m, `name: ${name2}`);
     const tmpPath = configPath + ".tmp";
@@ -13118,11 +13483,11 @@ async function init({
       created = scaffoldMissionsWorkspace(dir, name2);
     } else if (isTeamTemplate(template)) {
       created = [
-        ...copyTemplateSkills(join13(dir, ".tmux-ide", "skills")),
+        ...copyTemplateSkills(join14(dir, ".tmux-ide", "skills")),
         ...scaffoldTeamWorkspace(dir, name2)
       ];
     } else {
-      created = copyTemplateSkills(join13(dir, ".tmux-ide", "skills"));
+      created = copyTemplateSkills(join14(dir, ".tmux-ide", "skills"));
     }
     if (json2) {
       console.log(JSON.stringify({ created: true, template, name: name2, paths: created }));
@@ -13154,7 +13519,7 @@ async function init({
     }
   } else {
     const templatePath = resolve11(__dirname4, "..", "..", "..", "templates", "default.yml");
-    let content = readFileSync12(templatePath, "utf-8");
+    let content = readFileSync13(templatePath, "utf-8");
     content = content.replace(/^name: .+/m, `name: ${name}`);
     const tmpPath3 = configPath + ".tmp";
     writeFileSync11(tmpPath3, content);
@@ -13168,7 +13533,7 @@ async function init({
       console.log("Edit it to configure your workspace, then run: tmux-ide");
     }
   }
-  const skillsDir = join13(dir, ".tmux-ide", "skills");
+  const skillsDir = join14(dir, ".tmux-ide", "skills");
   if (!existsSync18(skillsDir)) {
     const created = copyTemplateSkills(skillsDir);
     if (created.length > 0 && !json2) {
@@ -13258,17 +13623,18 @@ init_agent_discovery();
 init_compiled();
 init_claude();
 import { execSync as execSync3 } from "node:child_process";
-import { accessSync, constants, existsSync as existsSync20 } from "node:fs";
-import { resolve as resolve14, dirname as dirname15 } from "node:path";
+import { accessSync, constants, existsSync as existsSync21 } from "node:fs";
+import { resolve as resolve14, dirname as dirname16 } from "node:path";
 import { fileURLToPath as fileURLToPath7 } from "node:url";
 function agentIntegrationRows(agents) {
   return presentAgents(agents).map((agent) => {
     const label = `agent: ${agent.id}`;
     if (agent.integration) {
+      const benefit = agent.capture === "hooks" ? "for ground-truth status" : "to record session ids for restore --resume-agents";
       return agent.installed ? { label, pass: true, detail: "integration installed \u2713", optional: true } : {
         label,
         pass: false,
-        detail: `found on PATH \u2014 run \`tmux-ide integration install ${agent.id}\` for ground-truth status`,
+        detail: `found on PATH \u2014 run \`tmux-ide integration install ${agent.id}\` ${benefit}`,
         optional: true
       };
     }
@@ -13352,7 +13718,7 @@ async function doctor({
   checks.push(
     check("ide.yml exists", () => {
       const path2 = resolve14(".", "ide.yml");
-      if (!existsSync20(path2)) throw new Error("not found in current directory");
+      if (!existsSync21(path2)) throw new Error("not found in current directory");
       return "found";
     })
   );
@@ -13360,11 +13726,11 @@ async function doctor({
     check(
       "TUI surfaces (cockpit / widgets)",
       () => {
-        const here = dirname15(fileURLToPath7(import.meta.url));
+        const here = dirname16(fileURLToPath7(import.meta.url));
         const checkoutEntry = [
           resolve14(here, "../packages/daemon/src/tui/team/index.tsx"),
           resolve14(here, "tui/team/index.tsx")
-        ].find(existsSync20);
+        ].find(existsSync21);
         const binary = findCompiledTui();
         if (checkoutEntry && isBunAvailable()) return "dev checkout (bun)";
         if (binary) return `compiled binary (${binary})`;
@@ -13404,10 +13770,10 @@ async function doctor({
   checks.push(
     (() => {
       const settingsPath = claudeSettingsPath();
-      const fileExists2 = existsSync20(settingsPath);
-      let probe = fileExists2 ? settingsPath : dirname15(settingsPath);
-      while (!existsSync20(probe)) {
-        const parent = dirname15(probe);
+      const fileExists2 = existsSync21(settingsPath);
+      let probe = fileExists2 ? settingsPath : dirname16(settingsPath);
+      while (!existsSync21(probe)) {
+        const parent = dirname16(probe);
         if (parent === probe) break;
         probe = parent;
       }
@@ -13470,11 +13836,11 @@ init_yaml_io();
 init_src();
 init_canonical_daemon();
 import { resolve as resolve15 } from "node:path";
-import { existsSync as existsSync21 } from "node:fs";
+import { existsSync as existsSync22 } from "node:fs";
 async function status(targetDir, { json: json2 } = {}) {
   const dir = resolve15(targetDir ?? ".");
   const { name: session } = getSessionName(dir);
-  const configExists = existsSync21(resolve15(dir, "ide.yml"));
+  const configExists = existsSync22(resolve15(dir, "ide.yml"));
   const state = getSessionState(session);
   const running = state.running;
   let panes = [];
@@ -13664,7 +14030,7 @@ function buildRestorePlan(snapshot, liveSessionNames, ideProjects = /* @__PURE__
   }
   return { actions, paneCount };
 }
-var SAFE_SESSION_ID = /^[A-Za-z0-9_-]+$/;
+var SAFE_SESSION_ID2 = /^[A-Za-z0-9_-]+$/;
 var AGENT_RESUME_COMMANDS = {
   claude: (id) => `claude --resume ${id}`,
   codex: (id) => `codex resume ${id}`,
@@ -13677,7 +14043,7 @@ function paneResumeCommand(pane, opts) {
   const resume = pane.agent ? AGENT_RESUME_COMMANDS[pane.agent] : void 0;
   if (!resume) return null;
   const id = pane.agentSessionId;
-  if (!id || !SAFE_SESSION_ID.test(id)) return null;
+  if (!id || !SAFE_SESSION_ID2.test(id)) return null;
   return resume(id);
 }
 function countResumableAgents(session, resumeAgents) {
@@ -13978,7 +14344,7 @@ function hostAttachArgv(insideTmux) {
 }
 
 // bin/cli.ts
-var __dirname6 = dirname24(fileURLToPath9(import.meta.url));
+var __dirname6 = dirname25(fileURLToPath9(import.meta.url));
 var selfPath = fileURLToPath9(import.meta.url);
 var nodeCliPath = selfPath.endsWith(".js") ? selfPath : resolve23(__dirname6, "cli.js");
 var { positionals, values } = parseArgs({
@@ -14194,7 +14560,7 @@ function execBunWidget(surface, scriptPath, args, commandLabel, extraEnv = {}) {
     surface,
     scriptPath,
     args,
-    checkoutExists: existsSync34(scriptPath),
+    checkoutExists: existsSync35(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui()
   });
@@ -14212,21 +14578,21 @@ Install bun (https://bun.sh) \u2014 the TUI surfaces run on it. Sources ship wit
     ...extraEnv
   };
   if (launch2.mode === "bun") {
-    execFileSync14(launch2.bin, launch2.argv, {
+    execFileSync15(launch2.bin, launch2.argv, {
       stdio: "inherit",
       cwd: resolve23(__dirname6, ".."),
       env
     });
     return;
   }
-  execFileSync14(launch2.bin, launch2.argv, { stdio: "inherit", env });
+  execFileSync15(launch2.bin, launch2.argv, { stdio: "inherit", env });
 }
 function launchHostedApp(scriptPath, appArgs) {
   const launch2 = resolveTuiLaunch({
     surface: "app",
     scriptPath,
     args: appArgs,
-    checkoutExists: existsSync34(scriptPath),
+    checkoutExists: existsSync35(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui()
   });
@@ -14239,7 +14605,7 @@ Install bun (https://bun.sh) \u2014 the TUI surfaces run on it. Sources ship wit
   }
   let exists = true;
   try {
-    execFileSync14("tmux", hostExistsArgv(), { stdio: "ignore" });
+    execFileSync15("tmux", hostExistsArgv(), { stdio: "ignore" });
   } catch {
     exists = false;
   }
@@ -14257,10 +14623,10 @@ Install bun (https://bun.sh) \u2014 the TUI surfaces run on it. Sources ship wit
         tuiBin: process.env.TMUX_IDE_TUI_BIN
       })
     );
-    execFileSync14("tmux", hostCreateArgv({ cwd, commandLine }), { stdio: "ignore" });
-    for (const args of hostSetupArgvs()) execFileSync14("tmux", args, { stdio: "ignore" });
+    execFileSync15("tmux", hostCreateArgv({ cwd, commandLine }), { stdio: "ignore" });
+    for (const args of hostSetupArgvs()) execFileSync15("tmux", args, { stdio: "ignore" });
   }
-  execFileSync14("tmux", hostAttachArgv(Boolean(process.env.TMUX)), { stdio: "inherit" });
+  execFileSync15("tmux", hostAttachArgv(Boolean(process.env.TMUX)), { stdio: "inherit" });
 }
 async function printFleetJson() {
   const { createStatusTracker: createStatusTracker2 } = await Promise.resolve().then(() => (init_classify(), classify_exports));
@@ -14325,7 +14691,7 @@ try {
         }
       }
       const targetDir = resolve23(startTargetDir || ".");
-      const hasIdeYml = existsSync34(join28(targetDir, "ide.yml"));
+      const hasIdeYml = existsSync35(join30(targetDir, "ide.yml"));
       const entry = resolveEntry({
         hasIdeYml,
         teamFlag: values.team === true,
@@ -14437,8 +14803,8 @@ try {
       const messageStart = values.to ? 1 : 2;
       let message = positionals.slice(messageStart).join(" ");
       if (!message && !process.stdin.isTTY) {
-        const { readFileSync: readFileSync19 } = await import("node:fs");
-        message = readFileSync19(0, "utf-8").trim();
+        const { readFileSync: readFileSync21 } = await import("node:fs");
+        message = readFileSync21(0, "utf-8").trim();
       }
       await send(null, { json, to: target, message, noEnter: values["no-enter"] });
       break;
@@ -14570,7 +14936,7 @@ try {
       break;
     }
     case "events": {
-      const { readFileSync: readFileSync19, existsSync: existsSync35, statSync: statSync6, openSync, readSync, closeSync } = await import("node:fs");
+      const { readFileSync: readFileSync21, existsSync: existsSync36, statSync: statSync7, openSync, readSync, closeSync } = await import("node:fs");
       const { eventsPath: eventsPath2, formatEventLine: formatEventLine2 } = await Promise.resolve().then(() => (init_events(), events_exports));
       const path2 = eventsPath2();
       const paintStatus = (status2, text) => {
@@ -14595,8 +14961,8 @@ try {
           socketPath: typeof socketFlag === "string" ? socketFlag : void 0
         }).catch(() => null);
         if (client) {
-          if (existsSync35(path2)) {
-            const backlog = readFileSync19(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
+          if (existsSync36(path2)) {
+            const backlog = readFileSync21(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
             for (const line of backlog.slice(-50)) printLine(line);
           }
           await client.subscribe((frame) => {
@@ -14610,19 +14976,19 @@ try {
           break;
         }
       }
-      if (!existsSync35(path2)) {
+      if (!existsSync36(path2)) {
         console.log("no events yet \u2014 is a session adopted? (the chrome updater writes events)");
         break;
       }
-      const allLines = readFileSync19(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
+      const allLines = readFileSync21(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
       for (const line of allLines.slice(-50)) printLine(line);
       if (!values.follow) break;
-      let offset = statSync6(path2).size;
+      let offset = statSync7(path2).size;
       let leftover = "";
       const timer = setInterval(() => {
         let size;
         try {
-          size = statSync6(path2).size;
+          size = statSync7(path2).size;
         } catch {
           return;
         }
@@ -14667,7 +15033,7 @@ try {
     case "adopt": {
       const { adoptSession: adoptSession2, adoptableSessionNames: adoptableSessionNames2 } = await Promise.resolve().then(() => (init_statusline(), statusline_exports));
       if (values.all) {
-        const raw = execFileSync14("tmux", ["list-sessions", "-F", "#{session_name}"], {
+        const raw = execFileSync15("tmux", ["list-sessions", "-F", "#{session_name}"], {
           encoding: "utf8",
           stdio: ["ignore", "pipe", "ignore"]
         }).trim();
@@ -14718,12 +15084,27 @@ try {
     case "integration": {
       const sub = positionals[1];
       const agent = positionals[2];
-      const needsClaude = sub === "install" || sub === "uninstall";
-      if (!sub || needsClaude && agent !== "claude") {
+      const needsAgent = sub === "install" || sub === "uninstall";
+      const installable = agent === "claude" || agent === "opencode";
+      if (!sub || needsAgent && !installable) {
         console.error(
-          "Usage: tmux-ide integration <install|uninstall|status|offer> [claude]\n  install    hook Claude Code lifecycle events into tmux pane state\n  uninstall  remove exactly the tmux-ide hook entries\n  status     list discovered agents + integration state\n  offer      one-time first-adopt install prompt (used by the popup)"
+          "Usage: tmux-ide integration <install|uninstall|status|offer> [claude|opencode]\n  install    claude: hook lifecycle events into tmux pane state\n             opencode: plugin that records the session id for restore --resume-agents\n  uninstall  remove exactly the tmux-ide entries for that agent\n  status     list discovered agents + integration/capture state\n  offer      one-time first-adopt install prompt (used by the popup)"
         );
         process.exit(1);
+      }
+      if (needsAgent && agent === "opencode") {
+        const oc = await Promise.resolve().then(() => (init_opencode(), opencode_exports));
+        if (sub === "install") {
+          const { pluginPath } = oc.installOpencodeIntegration();
+          console.log(`plugin: ${pluginPath}`);
+          console.log(
+            "installed \u2014 NEW opencode sessions record their session id into the pane\n(@agent_session_id), so `tmux-ide restore --resume-agents` can revive them."
+          );
+        } else {
+          const { wasInstalled } = oc.uninstallOpencodeIntegration();
+          console.log(wasInstalled ? "uninstalled \u2014 plugin removed" : "was not installed");
+        }
+        break;
       }
       const mod = await Promise.resolve().then(() => (init_claude(), claude_exports));
       if (sub === "install") {
@@ -14794,7 +15175,14 @@ install failed: ${e.message}`);
           else if (a.integration)
             state = a.installed ? "integration installed \u2713" : "on PATH \u2014 integration not installed";
           else state = "detected (no integration)";
-          console.log(`  ${a.id.padEnd(10)} ${state}`);
+          let capture = "";
+          if (a.path !== null) {
+            if (a.capture === "probe") capture = " \xB7 session-id capture: automatic";
+            else if (a.capture !== null)
+              capture = a.captureActive ? ` \xB7 session-id capture: ${a.capture} \u2713` : ` \xB7 session-id capture: ${a.capture} (install to enable)`;
+            else capture = " \xB7 session-id capture: none";
+          }
+          console.log(`  ${a.id.padEnd(10)} ${state}${capture}`);
         }
       }
       break;
@@ -14869,7 +15257,7 @@ install failed: ${e.message}`);
         const rawClient = typeof values.client === "string" ? values.client : "";
         let client = rawClient && !rawClient.includes("#{") ? rawClient : "";
         if (!client) {
-          const raw = execFileSync14(
+          const raw = execFileSync15(
             "tmux",
             ["list-clients", "-F", "#{client_activity} #{client_name}"],
             tmuxCap
@@ -14901,7 +15289,7 @@ install failed: ${e.message}`);
           ...position,
           ...buildMenu2(sessions, getAppConfig2().theme, getUpdateStatus2())
         ];
-        execFileSync14("tmux", args, { stdio: "ignore", timeout: 2e3 });
+        execFileSync15("tmux", args, { stdio: "ignore", timeout: 2e3 });
       } catch {
       }
       break;
@@ -14919,7 +15307,7 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
       const scriptPath = resolve23(__dirname6, "../packages/daemon/src/widgets", widget, "index.tsx");
       let popupSession = "";
       try {
-        popupSession = execFileSync14("tmux", ["display-message", "-p", "#{session_name}"], {
+        popupSession = execFileSync15("tmux", ["display-message", "-p", "#{session_name}"], {
           encoding: "utf8",
           stdio: ["ignore", "pipe", "ignore"],
           timeout: 2e3
@@ -14943,7 +15331,7 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
         let session = typeof values.session === "string" ? values.session.trim() : "";
         if (!session || session.includes("#{")) {
           try {
-            session = execFileSync14("tmux", ["display-message", "-p", "#{session_name}"], {
+            session = execFileSync15("tmux", ["display-message", "-p", "#{session_name}"], {
               encoding: "utf8",
               stdio: ["ignore", "pipe", "ignore"],
               timeout: 2e3
@@ -15021,7 +15409,7 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
       const mainPath = worktrees[0]?.path ?? repoDir;
       const projectName = getSessionName2(mainPath).name;
       async function openWorktreeSession(wtPath, name) {
-        if (existsSync34(join28(wtPath, "ide.yml"))) {
+        if (existsSync35(join30(wtPath, "ide.yml"))) {
           await launch(wtPath, { attach: false, sessionName: name });
         } else {
           if (!hasSession2(name)) createDetachedSession2(name, wtPath);
@@ -15224,7 +15612,7 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
         const scriptPath = resolve23(__dirname6, "../packages/daemon/src/server/standalone.ts");
         const serverArgs = ["--experimental-strip-types", scriptPath];
         if (values.port) serverArgs.push("--port", values.port);
-        execFileSync14("node", serverArgs, { stdio: "inherit" });
+        execFileSync15("node", serverArgs, { stdio: "inherit" });
       } else {
         const { start: start2 } = await Promise.resolve().then(() => (init_server3(), server_exports3));
         await start2(values.port ? parseInt(values.port, 10) : void 0);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1711,6 +1711,13 @@ function explain(snapshot, manifest) {
   const winner = checked.find((c) => c.matched);
   return { state: winner ? winner.state : null, checked };
 }
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+function containsSegment(haystack, needle) {
+  if (!haystack.includes(needle)) return false;
+  return new RegExp(`(^|[^a-z0-9])${escapeRegex(needle)}([^a-z0-9]|$)`).test(haystack);
+}
 function pickManifest(command2, manifests) {
   const cmd = command2.trim().toLowerCase();
   if (cmd.length === 0) return void 0;
@@ -1719,7 +1726,7 @@ function pickManifest(command2, manifests) {
   return manifests.find(
     (m) => m.commands.some((c) => {
       const name = c.toLowerCase();
-      return cmd.includes(name) || name.includes(cmd);
+      return containsSegment(cmd, name) || containsSegment(name, cmd);
     })
   );
 }
@@ -1732,7 +1739,7 @@ var init_manifest = __esm({
 });
 
 // packages/daemon/src/tui/detect/manifests.ts
-var BRAILLE_SPINNER, CLAUDE, CODEX, OPENCODE, GEMINI, AIDER, COPILOT, CURSOR, GOOSE, AMP, SHELL, BUNDLED_MANIFESTS;
+var BRAILLE_SPINNER, CLAUDE, CODEX, OPENCODE, GEMINI, AIDER, COPILOT, CURSOR, GOOSE, AMP, DEVIN, KIMI, PI, GROK, KIRO, CLINE, DROID, KILO, SHELL, BUNDLED_MANIFESTS;
 var init_manifests = __esm({
   "packages/daemon/src/tui/detect/manifests.ts"() {
     "use strict";
@@ -2013,6 +2020,220 @@ var init_manifests = __esm({
         }
       }
     };
+    DEVIN = {
+      id: "devin",
+      commands: ["devin"],
+      confidence: "conservative",
+      states: {
+        // conservative — Devin CLI (Cognition; closed-source native Rust binary,
+        // needs an account). Blocked markers are VERBATIM from docs.devin.ai
+        // (cli/changelog + essential-commands via llms-full.txt): the plan-mode
+        // approval menu and the always-allow option. Devin has NO verified working
+        // text (its spinner is unlabeled; docs say interrupt is Ctrl+C, not esc),
+        // so working keeps only the shared spinner probe.
+        blocked: {
+          any: [
+            // seen (docs): "Yes, implement plan and accept edits" / "…and bypass
+            // permissions" — the shared prefix covers both.
+            { region: "bottom", contains: "Yes, implement plan and" },
+            { region: "bottom", contains: "No, plan needs changes" },
+            { region: "bottom", contains: "Yes, always allow" }
+          ]
+        },
+        working: {
+          any: [
+            { region: "bottom", regex: BRAILLE_SPINNER },
+            { region: "title", regex: BRAILLE_SPINNER }
+          ]
+        }
+      }
+    };
+    KIMI = {
+      id: "kimi",
+      commands: ["kimi"],
+      confidence: "conservative",
+      states: {
+        // conservative — kimi CLI (MoonshotAI/kimi-cli, Python/prompt_toolkit).
+        // Blocked markers are VERBATIM from its source (_approval_panel.py): the
+        // approval panel's "<tool> is requesting approval to …" header and its
+        // option labels. Its working spinner is a text-less moon animation (not
+        // braille), so working may under-detect until tuned — the braille probe is
+        // kept only as the shared fallback. ("Thinking"/"Thought for" deliberately
+        // NOT matched: they persist in the transcript after the turn.)
+        blocked: {
+          any: [
+            { region: "bottom", contains: " is requesting approval to " },
+            { region: "bottom", contains: "Approve for this session" },
+            { region: "bottom", contains: "Reject, tell the model" }
+          ]
+        },
+        working: {
+          any: [
+            { region: "bottom", regex: BRAILLE_SPINNER },
+            { region: "title", regex: BRAILLE_SPINNER }
+          ]
+        }
+      }
+    };
+    PI = {
+      id: "pi",
+      commands: ["pi"],
+      confidence: "conservative",
+      states: {
+        // conservative — pi (@mariozechner/pi-coding-agent, node). Working marker
+        // is VERBATIM from its source (interactive-mode.ts): the status line is
+        // `Working... (esc to interrupt)`, with `(esc to cancel)` retry/compacting
+        // variants. Its core has NO distinctive approval wording (generic Yes/No
+        // via extensions), so blocked is deliberately ABSENT — authority
+        // self-reporting or the classifier's fallback carry it.
+        working: {
+          any: [
+            { region: "bottom", contains: "Working... (esc to interrupt)" },
+            { region: "bottom", contains: "(esc to cancel)" },
+            { region: "bottom", regex: BRAILLE_SPINNER },
+            { region: "title", regex: BRAILLE_SPINNER }
+          ]
+        }
+      }
+    };
+    GROK = {
+      id: "grok",
+      commands: ["grok"],
+      confidence: "conservative",
+      states: {
+        // conservative — the community grok CLI (@vibe-kit/grok-cli /
+        // superagent-ai/grok-cli, node/OpenTUI). Working markers are VERBATIM from
+        // its source (app.tsx / headless output.ts): the mid-turn placeholder
+        // carries "(esc to interrupt)" and headless prints "⏳ Processing...".
+        // Its ConfirmationDialog wording could not be verified, so blocked keeps
+        // only a high-precision generic. NOTE: xAI's separate official
+        // `grok-build` binary substring-matches this manifest but has no verified
+        // strings — it will simply read idle until evidence exists.
+        blocked: {
+          any: [{ region: "bottom", contains: "(y/n)", caseInsensitive: true }]
+        },
+        working: {
+          any: [
+            { region: "bottom", contains: "esc to interrupt", caseInsensitive: true },
+            { region: "bottom", contains: "\u23F3 Processing" },
+            { region: "bottom", regex: BRAILLE_SPINNER },
+            { region: "title", regex: BRAILLE_SPINNER }
+          ]
+        }
+      }
+    };
+    KIRO = {
+      id: "kiro",
+      commands: ["kiro-cli", "kiro"],
+      confidence: "conservative",
+      states: {
+        // conservative — Kiro CLI (AWS; the rebranded Amazon Q Developer CLI, a
+        // native Rust binary). Markers are VERBATIM from the open-source
+        // predecessor (aws/amazon-q-developer-cli chat-cli/src/cli/chat/mod.rs):
+        // the tool-approval question and the Spinners::Dots "Thinking..." status.
+        // The closed Kiro build may drift — same lineage, pending live capture.
+        // NOTE: the predecessor's 1-char `q` binary is deliberately NOT a command
+        // token (a single letter substring-matches far too much).
+        blocked: {
+          any: [
+            { region: "bottom", contains: "Allow this action?" },
+            { region: "bottom", contains: "to trust (always allow) this tool" }
+          ]
+        },
+        working: {
+          any: [
+            { region: "bottom", contains: "Thinking..." },
+            { region: "bottom", regex: BRAILLE_SPINNER },
+            { region: "title", regex: BRAILLE_SPINNER }
+          ]
+        }
+      }
+    };
+    CLINE = {
+      id: "cline",
+      commands: ["cline"],
+      confidence: "conservative",
+      states: {
+        // conservative — cline CLI (cline.bot; CLI 2.0 ships prebuilt platform
+        // binaries, OpenTUI). Markers are VERBATIM from its source: the approval
+        // dialog's "Cline needs permission" title + "Approve tool call?" header
+        // (tui/components/dialogs/tool-approval.tsx) and the streaming
+        // "Thinking... (esc to cancel)" status (chat-message-list.tsx).
+        blocked: {
+          any: [
+            { region: "bottom", contains: "Cline needs permission" },
+            { region: "bottom", contains: "Approve tool call?" },
+            { region: "bottom", contains: "[y] Approve" }
+          ]
+        },
+        working: {
+          any: [
+            { region: "bottom", contains: "esc to cancel", caseInsensitive: true },
+            { region: "bottom", regex: BRAILLE_SPINNER },
+            { region: "title", regex: BRAILLE_SPINNER }
+          ]
+        }
+      }
+    };
+    DROID = {
+      id: "droid",
+      commands: ["droid"],
+      confidence: "conservative",
+      states: {
+        // conservative — droid (Factory CLI) was launched live (v0.114.1) but sits
+        // on an auth-gated login menu without a Factory account, so only the login
+        // splash could be captured (it reads IDLE and is deliberately not matched:
+        // "Please login with your Factory account to continue." / "> Login").
+        // Verified live: droid runs as its OWN process (`pane_current_command` =
+        // "droid"), so command matching needs no process-tree help.
+        // Blocked markers are docs-derived (docs.factory.ai auto-run levels,
+        // corroborated third-party walkthrough) — the Spec-mode proceed menu names
+        // its autonomy levels verbatim. Pending live-capture confirmation.
+        blocked: {
+          any: [
+            { region: "bottom", contains: "Proceed, manual approval" },
+            { region: "bottom", contains: "Proceed, allow safe commands" },
+            { region: "bottom", contains: "Proceed, allow all commands" }
+          ]
+        },
+        working: {
+          any: [
+            { region: "bottom", contains: "esc to interrupt", caseInsensitive: true },
+            { region: "bottom", regex: BRAILLE_SPINNER },
+            { region: "title", regex: BRAILLE_SPINNER }
+          ]
+        }
+      }
+    };
+    KILO = {
+      id: "kilo",
+      commands: ["kilo", ".kilo", "kilocode"],
+      confidence: "conservative",
+      states: {
+        // conservative, but the blocked markers are VERBATIM from the shipped
+        // @kilocode/cli binary (v7.4.5, strings-extracted — no account to drive a
+        // live capture): the permission dialog renders a "△ Permission required"
+        // header over an "Allow once" / "Allow always" / "Reject" option list.
+        // NOTE: the CLI's npm launcher (`bin/kilo`, node) execs the platform
+        // binary installed as `bin/.kilo`, hence the ".kilo" command token.
+        blocked: {
+          any: [
+            { region: "bottom", contains: "Permission required" },
+            { region: "bottom", contains: "Allow once" },
+            { region: "bottom", contains: "Allow always" }
+          ]
+        },
+        // No working-state string was found in the binary (its status UI renders
+        // from dynamic parts) — only the shared spinner probe, so kilo may read
+        // idle while working until a live capture tunes it.
+        working: {
+          any: [
+            { region: "bottom", regex: BRAILLE_SPINNER },
+            { region: "title", regex: BRAILLE_SPINNER }
+          ]
+        }
+      }
+    };
     SHELL = {
       id: "shell",
       commands: ["bash", "zsh", "sh", "fish", "nu"],
@@ -2039,6 +2260,14 @@ var init_manifests = __esm({
       CURSOR,
       GOOSE,
       AMP,
+      DEVIN,
+      KIMI,
+      PI,
+      GROK,
+      KIRO,
+      CLINE,
+      DROID,
+      KILO,
       SHELL
     ];
   }
@@ -2047,11 +2276,13 @@ var init_manifests = __esm({
 // packages/daemon/src/tui/detect/classify.ts
 var classify_exports = {};
 __export(classify_exports, {
+  AGENT_TEXT_MAX: () => AGENT_TEXT_MAX,
   classifyInstant: () => classifyInstant,
   classifyPaneCommand: () => classifyPaneCommand,
   createStatusTracker: () => createStatusTracker,
   parseAuthority: () => parseAuthority,
-  parseAuthorityEpoch: () => parseAuthorityEpoch
+  parseAuthorityEpoch: () => parseAuthorityEpoch,
+  sanitizeAgentText: () => sanitizeAgentText
 });
 function parseAuthority(raw, nowSec) {
   if (!raw) return null;
@@ -2064,6 +2295,13 @@ function parseAuthority(raw, nowSec) {
     return null;
   }
   return state;
+}
+function sanitizeAgentText(raw) {
+  if (!raw) return void 0;
+  const cleaned = raw.replace(/\x1b\[[0-9;?]*[ -/]*[\x40-\x7e]/g, "").replace(/[\x00-\x1f\x7f]/g, " ").replace(/\s+/g, " ").trim();
+  if (cleaned.length === 0) return void 0;
+  if (cleaned.length <= AGENT_TEXT_MAX) return cleaned;
+  return cleaned.slice(0, AGENT_TEXT_MAX - 1) + "\u2026";
 }
 function parseAuthorityEpoch(raw) {
   if (!raw) return null;
@@ -2136,7 +2374,7 @@ function createStatusTracker() {
     }
   };
 }
-var AUTHORITY_STALE_SECONDS, AUTHORITY_STATES;
+var AUTHORITY_STALE_SECONDS, AUTHORITY_STATES, AGENT_TEXT_MAX;
 var init_classify = __esm({
   "packages/daemon/src/tui/detect/classify.ts"() {
     "use strict";
@@ -2144,6 +2382,7 @@ var init_classify = __esm({
     init_manifests();
     AUTHORITY_STALE_SECONDS = 600;
     AUTHORITY_STATES = /* @__PURE__ */ new Set(["working", "blocked", "done", "idle"]);
+    AGENT_TEXT_MAX = 32;
   }
 });
 
@@ -2152,7 +2391,11 @@ import { readdirSync, readFileSync as readFileSync2 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 function overrideDir() {
-  return join(homedir(), ".tmux-ide", "agent-detection");
+  const home = process.env.TMUX_IDE_HOME ?? join(homedir(), ".tmux-ide");
+  return join(home, "agent-detection");
+}
+function packFile(dir = overrideDir()) {
+  return join(dir, "pack", "manifest-pack.json");
 }
 function validateManifestShape(value) {
   if (typeof value !== "object" || value === null) return false;
@@ -2242,8 +2485,35 @@ function warnOnce(path2, reason) {
   process.stderr.write(`tmux-ide: skipping agent-detection override ${path2}: ${reason}
 `);
 }
+function readPackManifests(dir = overrideDir()) {
+  const path2 = packFile(dir);
+  let raw;
+  try {
+    raw = readFileSync2(path2, "utf8");
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    const manifests = parsed?.manifests;
+    if (!Array.isArray(manifests)) {
+      warnOnce(path2, "not a manifest pack (missing manifests[])");
+      return [];
+    }
+    const valid = [];
+    for (const entry of manifests) {
+      if (validateManifestShape(entry)) valid.push(normalizeStates(entry));
+      else warnOnce(path2, "pack entry is not a valid AgentManifest \u2014 entry skipped");
+    }
+    return valid;
+  } catch (err) {
+    warnOnce(path2, err instanceof Error ? err.message : String(err));
+    return [];
+  }
+}
 function loadManifests() {
-  return mergeManifests(BUNDLED_MANIFESTS, readOverrideManifests());
+  const withPack = mergeManifests(BUNDLED_MANIFESTS, readPackManifests());
+  return mergeManifests(withPack, readOverrideManifests());
 }
 function getManifests() {
   if (!cache) cache = loadManifests();
@@ -2399,6 +2669,7 @@ var init_snapshot = __esm({
 var sessions_exports = {};
 __export(sessions_exports, {
   SIDEBAR_PANE_OPTION: () => SIDEBAR_PANE_OPTION,
+  agentMetadataFor: () => agentMetadataFor,
   buildAgentEntry: () => buildAgentEntry,
   excludeSidebarPanes: () => excludeSidebarPanes,
   isListableSession: () => isListableSession,
@@ -2420,7 +2691,18 @@ function buildAgentEntry(input) {
     since: input.since,
     title: pane.title,
     command: pane.cmd,
-    dir: pane.dir
+    dir: pane.dir,
+    ...input.statusText !== void 0 ? { statusText: input.statusText } : {},
+    ...input.displayName !== void 0 ? { displayName: input.displayName } : {}
+  };
+}
+function agentMetadataFor(pane, authorityFresh) {
+  if (!authorityFresh) return {};
+  const statusText = sanitizeAgentText(pane.statusTextRaw);
+  const displayName = sanitizeAgentText(pane.displayNameRaw);
+  return {
+    ...statusText !== void 0 ? { statusText } : {},
+    ...displayName !== void 0 ? { displayName } : {}
   };
 }
 function excludeSidebarPanes(panes) {
@@ -2483,7 +2765,14 @@ function listTeamSessions(tracker, opts = {}) {
         agent: manifest && manifest.id !== "shell" ? manifest.id : null,
         status: status2
       });
-      const entry = buildAgentEntry({ sessionName: name, pane, manifest, state: status2, since });
+      const entry = buildAgentEntry({
+        sessionName: name,
+        pane,
+        manifest,
+        state: status2,
+        since,
+        ...agentMetadataFor(pane, authority !== null)
+      });
       if (entry) agents.push(entry);
       return status2;
     });
@@ -2509,7 +2798,10 @@ function collectPanes() {
     // title stays the trailing catch-all — window names/paths don't contain tabs
     // in practice. pane_current_path rides this SAME list-panes call (no extra
     // tmux round-trip) so per-pane agent entries can carry a working dir.
-    `#{session_name}	#{pane_id}	#{pane_pid}	#{pane_current_command}	#{@agent_state}	#{@agent_hint}	#{${SIDEBAR_PANE_OPTION}}	#{window_index}	#{window_name}	#{window_active}	#{pane_current_path}	#{pane_title}`
+    // @agent_status_text/@agent_display_name ride the same caveat: the contract
+    // (skill/SKILL.md) says plain text; a stamped tab would shift this one
+    // pane's fields (sanitizeAgentText strips control chars AFTER the split).
+    `#{session_name}	#{pane_id}	#{pane_pid}	#{pane_current_command}	#{@agent_state}	#{@agent_hint}	#{@agent_status_text}	#{@agent_display_name}	#{${SIDEBAR_PANE_OPTION}}	#{window_index}	#{window_name}	#{window_active}	#{pane_current_path}	#{pane_title}`
   ]);
   const bySession = /* @__PURE__ */ new Map();
   for (const line of raw.split("\n").filter(Boolean)) {
@@ -2520,6 +2812,8 @@ function collectPanes() {
       cmd = "",
       authority = "",
       hint = "",
+      statusTextRaw = "",
+      displayNameRaw = "",
       sidebar = "",
       windowIndex = "0",
       windowName = "",
@@ -2535,6 +2829,8 @@ function collectPanes() {
       cmd,
       authority,
       hint,
+      statusTextRaw,
+      displayNameRaw,
       sidebar: sidebar === "1",
       windowIndex: Number(windowIndex) || 0,
       windowName,
@@ -2589,6 +2885,358 @@ var init_sessions2 = __esm({
   }
 });
 
+// packages/daemon/src/lib/app-config.ts
+var app_config_exports = {};
+__export(app_config_exports, {
+  DEFAULT_APP_CONFIG: () => DEFAULT_APP_CONFIG,
+  DEFAULT_KEYS: () => DEFAULT_KEYS,
+  DEFAULT_THEME: () => DEFAULT_THEME,
+  _resetForTests: () => _resetForTests,
+  appConfigPath: () => appConfigPath,
+  getAppConfig: () => getAppConfig,
+  loadAppConfig: () => loadAppConfig,
+  loadRawAppConfig: () => loadRawAppConfig,
+  mergeConfigPatch: () => mergeConfigPatch,
+  parseAppConfig: () => parseAppConfig,
+  updateAppConfig: () => updateAppConfig
+});
+import { existsSync, mkdirSync, readFileSync as readFileSync3, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
+import { homedir as homedir2 } from "node:os";
+import { dirname, join as join2 } from "node:path";
+function asObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+function pickString(value, fallback) {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+function pickBool(value, fallback) {
+  return typeof value === "boolean" ? value : fallback;
+}
+function pickPosInt(value, fallback) {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+function pickChoice(value, allowed, fallback) {
+  return typeof value === "string" && allowed.includes(value) ? value : fallback;
+}
+function parseAppConfig(input) {
+  const D = DEFAULT_APP_CONFIG;
+  const root = asObject(input);
+  const keys = asObject(root.keys);
+  const panels = asObject(keys.panels);
+  const theme = asObject(root.theme);
+  const status2 = asObject(theme.status);
+  const glyphs = asObject(theme.glyphs);
+  const updater = asObject(root.updater);
+  const notifications = asObject(root.notifications);
+  const restore2 = asObject(root.restore);
+  const updates = asObject(root.updates);
+  const welcome = asObject(root.welcome);
+  const integrations = asObject(root.integrations);
+  const worktrees = asObject(root.worktrees);
+  const app = asObject(root.app);
+  return {
+    keys: {
+      popup: pickString(keys.popup, D.keys.popup),
+      home: pickString(keys.home, D.keys.home),
+      cheatsheet: pickString(keys.cheatsheet, D.keys.cheatsheet),
+      menu: pickString(keys.menu, D.keys.menu),
+      sidebar: pickString(keys.sidebar, D.keys.sidebar),
+      panels: {
+        explorer: pickString(panels.explorer, D.keys.panels.explorer),
+        changes: pickString(panels.changes, D.keys.panels.changes),
+        config: pickString(panels.config, D.keys.panels.config)
+      }
+    },
+    theme: {
+      accent: pickString(theme.accent, D.theme.accent),
+      muted: pickString(theme.muted, D.theme.muted),
+      fg: pickString(theme.fg, D.theme.fg),
+      status: {
+        blocked: pickString(status2.blocked, D.theme.status.blocked),
+        working: pickString(status2.working, D.theme.status.working),
+        done: pickString(status2.done, D.theme.status.done),
+        idle: pickString(status2.idle, D.theme.status.idle),
+        unknown: pickString(status2.unknown, D.theme.status.unknown)
+      },
+      glyphs: {
+        active: pickString(glyphs.active, D.theme.glyphs.active),
+        inactive: pickString(glyphs.inactive, D.theme.glyphs.inactive)
+      }
+    },
+    updater: {
+      tickMs: pickPosInt(updater.tickMs, D.updater.tickMs),
+      snapshotEvery: pickPosInt(updater.snapshotEvery, D.updater.snapshotEvery)
+    },
+    notifications: {
+      toast: pickBool(notifications.toast, D.notifications.toast),
+      macos: pickBool(notifications.macos, D.notifications.macos)
+    },
+    restore: { resumeAgents: pickBool(restore2.resumeAgents, D.restore.resumeAgents) },
+    updates: {
+      check: pickBool(updates.check, D.updates.check),
+      manifests: pickBool(updates.manifests, D.updates.manifests)
+    },
+    welcome: { show: pickBool(welcome.show, D.welcome.show) },
+    integrations: { offer: pickBool(integrations.offer, D.integrations.offer) },
+    worktrees: { dir: pickString(worktrees.dir, D.worktrees.dir) },
+    app: {
+      frontDoor: pickBool(app.frontDoor, D.app.frontDoor),
+      detachable: pickBool(app.detachable, D.app.detachable),
+      dragSelect: pickChoice(app.dragSelect, ["agents", "always", "never"], D.app.dragSelect),
+      newAgentCwd: pickChoice(app.newAgentCwd, ["pane", "session"], D.app.newAgentCwd),
+      kittyKeys: pickBool(app.kittyKeys, D.app.kittyKeys)
+    }
+  };
+}
+function appConfigPath() {
+  return process.env.TMUX_IDE_CONFIG ?? join2(homedir2(), ".tmux-ide", "config.json");
+}
+function loadAppConfig() {
+  const path2 = appConfigPath();
+  if (!existsSync(path2)) return parseAppConfig(void 0);
+  try {
+    return parseAppConfig(JSON.parse(readFileSync3(path2, "utf-8")));
+  } catch {
+    return parseAppConfig(void 0);
+  }
+}
+function getAppConfig() {
+  if (!cached) cached = loadAppConfig();
+  return cached;
+}
+function _resetForTests() {
+  cached = null;
+}
+function loadRawAppConfig() {
+  const path2 = appConfigPath();
+  if (!existsSync(path2)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync3(path2, "utf-8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+function isPlainObject(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+function mergeConfigPatch(raw, patch) {
+  const out = { ...raw };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === void 0) {
+      delete out[key];
+    } else if (isPlainObject(value) && isPlainObject(out[key])) {
+      out[key] = mergeConfigPatch(out[key], value);
+    } else if (isPlainObject(value)) {
+      out[key] = mergeConfigPatch({}, value);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+function updateAppConfig(patch) {
+  const path2 = appConfigPath();
+  const merged = mergeConfigPatch(loadRawAppConfig(), patch);
+  mkdirSync(dirname(path2), { recursive: true });
+  const tmp = `${path2}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync2(tmp, `${JSON.stringify(merged, null, 2)}
+`, "utf-8");
+  renameSync(tmp, path2);
+  cached = null;
+  return parseAppConfig(merged);
+}
+var DEFAULT_APP_CONFIG, DEFAULT_THEME, DEFAULT_KEYS, cached;
+var init_app_config = __esm({
+  "packages/daemon/src/lib/app-config.ts"() {
+    "use strict";
+    DEFAULT_APP_CONFIG = {
+      keys: {
+        popup: "M-p",
+        home: "M-h",
+        cheatsheet: "M-k",
+        menu: "M-m",
+        sidebar: "M-b",
+        panels: { explorer: "M-e", changes: "M-g", config: "M-," }
+      },
+      theme: {
+        accent: "colour75",
+        muted: "colour240",
+        fg: "colour250",
+        status: {
+          blocked: "colour203",
+          working: "colour221",
+          done: "colour111",
+          idle: "colour114",
+          unknown: "colour244"
+        },
+        glyphs: { active: "\u25CF", inactive: "\u25CB" }
+      },
+      updater: { tickMs: 2e3, snapshotEvery: 15 },
+      notifications: { toast: true, macos: false },
+      restore: { resumeAgents: false },
+      updates: { check: true, manifests: false },
+      welcome: { show: true },
+      integrations: { offer: true },
+      worktrees: { dir: "" },
+      app: {
+        frontDoor: false,
+        detachable: false,
+        dragSelect: "agents",
+        newAgentCwd: "pane",
+        kittyKeys: true
+      }
+    };
+    DEFAULT_THEME = DEFAULT_APP_CONFIG.theme;
+    DEFAULT_KEYS = DEFAULT_APP_CONFIG.keys;
+    cached = null;
+  }
+});
+
+// packages/daemon/src/lib/manifest-pack.ts
+var manifest_pack_exports = {};
+__export(manifest_pack_exports, {
+  MANIFEST_PACK_ASSET: () => MANIFEST_PACK_ASSET,
+  MANIFEST_PACK_SCHEMA: () => MANIFEST_PACK_SCHEMA,
+  MANIFEST_PACK_URL_ENV: () => MANIFEST_PACK_URL_ENV,
+  fetchManifestPack: () => fetchManifestPack,
+  installManifestPack: () => installManifestPack,
+  isAllowedPackUrl: () => isAllowedPackUrl,
+  manifestPackUrl: () => manifestPackUrl,
+  maybeRefreshManifestPack: () => maybeRefreshManifestPack,
+  packDir: () => packDir,
+  packPath: () => packPath,
+  updateManifestPack: () => updateManifestPack,
+  validateManifestPack: () => validateManifestPack
+});
+import { mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { dirname as dirname2, join as join3 } from "node:path";
+import { fileURLToPath } from "node:url";
+function manifestPackUrl(version = getCurrentVersion()) {
+  const v = version.startsWith("v") ? version.slice(1) : version;
+  return `https://github.com/${RELEASE_REPO}/releases/download/v${v}/${MANIFEST_PACK_ASSET}`;
+}
+function isAllowedPackUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol === "https:" || parsed.protocol === "file:") return true;
+  if (parsed.protocol === "http:") {
+    return ["127.0.0.1", "localhost", "[::1]", "::1"].includes(parsed.hostname);
+  }
+  return false;
+}
+function validateManifestPack(value) {
+  if (typeof value !== "object" || value === null) return { ok: false, reason: "not an object" };
+  const v = value;
+  if (v.schema !== MANIFEST_PACK_SCHEMA) {
+    return {
+      ok: false,
+      reason: `unsupported schema ${JSON.stringify(v.schema)} (want ${MANIFEST_PACK_SCHEMA})`
+    };
+  }
+  if (typeof v.pack !== "string" || v.pack.trim().length === 0) {
+    return { ok: false, reason: "missing pack version string" };
+  }
+  if (!Array.isArray(v.manifests) || v.manifests.length === 0) {
+    return { ok: false, reason: "manifests must be a non-empty array" };
+  }
+  for (let i = 0; i < v.manifests.length; i++) {
+    if (!validateManifestShape(v.manifests[i])) {
+      return {
+        ok: false,
+        reason: `manifests[${i}] is not a valid AgentManifest (need id, commands[], states)`
+      };
+    }
+  }
+  return {
+    ok: true,
+    pack: { schema: MANIFEST_PACK_SCHEMA, pack: v.pack, manifests: v.manifests }
+  };
+}
+function packDir() {
+  return join3(overrideDir(), "pack");
+}
+function packPath() {
+  return join3(packDir(), "manifest-pack.json");
+}
+async function fetchManifestPack(url, timeoutMs = 5e3) {
+  if (!isAllowedPackUrl(url)) {
+    throw new Error(
+      `refusing manifest-pack URL ${url} \u2014 https only (file:// and loopback http are allowed for local testing)`
+    );
+  }
+  let body;
+  if (url.startsWith("file:")) {
+    body = readFileSync4(fileURLToPath(url), "utf8");
+  } else {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) {
+        throw new Error(
+          `manifest-pack download failed (${url} \u2192 HTTP ${res.status} ${res.statusText})`
+        );
+      }
+      body = await res.text();
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(`manifest pack at ${url} is not valid JSON`);
+  }
+  const verdict = validateManifestPack(parsed);
+  if (!verdict.ok) {
+    throw new Error(`manifest pack at ${url} rejected: ${verdict.reason}`);
+  }
+  return verdict.pack;
+}
+function installManifestPack(pack, dest = packPath()) {
+  mkdirSync2(dirname2(dest), { recursive: true });
+  const tmp = `${dest}.${process.pid}.tmp`;
+  writeFileSync3(tmp, JSON.stringify(pack, null, 2));
+  renameSync2(tmp, dest);
+  return dest;
+}
+async function updateManifestPack(opts = {}) {
+  const log = opts.log ?? (() => {
+  });
+  const url = opts.url ?? process.env[MANIFEST_PACK_URL_ENV] ?? manifestPackUrl();
+  log(`fetching manifest pack from ${url}`);
+  const pack = await fetchManifestPack(url);
+  const path2 = installManifestPack(pack);
+  log(`installed pack ${pack.pack} (${pack.manifests.length} manifests) \u2192 ${path2}`);
+  return { path: path2, packVersion: pack.pack, count: pack.manifests.length };
+}
+async function maybeRefreshManifestPack() {
+  try {
+    if (!getAppConfig().updates.manifests) return;
+    await updateManifestPack();
+  } catch {
+  }
+}
+var MANIFEST_PACK_SCHEMA, MANIFEST_PACK_ASSET, MANIFEST_PACK_URL_ENV;
+var init_manifest_pack = __esm({
+  "packages/daemon/src/lib/manifest-pack.ts"() {
+    "use strict";
+    init_manifest_loader();
+    init_app_config();
+    init_update_check();
+    init_tui_binary();
+    MANIFEST_PACK_SCHEMA = 1;
+    MANIFEST_PACK_ASSET = "agent-manifests.json";
+    MANIFEST_PACK_URL_ENV = "TMUX_IDE_MANIFEST_PACK_URL";
+  }
+});
+
 // packages/daemon/src/lib/update-check.ts
 var update_check_exports = {};
 __export(update_check_exports, {
@@ -2609,10 +3257,10 @@ __export(update_check_exports, {
   updateCachePath: () => updateCachePath,
   writeUpdateCache: () => writeUpdateCache
 });
-import { existsSync, mkdirSync, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir2 } from "node:os";
-import { dirname, join as join2 } from "node:path";
-import { fileURLToPath } from "node:url";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync5, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { dirname as dirname3, join as join4 } from "node:path";
+import { fileURLToPath as fileURLToPath2 } from "node:url";
 function parseSemver(version) {
   const core = version.trim().replace(/^v/i, "").split("+")[0] ?? "";
   const dash = core.indexOf("-");
@@ -2660,14 +3308,14 @@ function deriveStatus(latest, currentVersion) {
   };
 }
 function updateCachePath() {
-  const home = process.env.TMUX_IDE_HOME ?? join2(homedir2(), ".tmux-ide");
-  return join2(home, "update-check.json");
+  const home = process.env.TMUX_IDE_HOME ?? join4(homedir3(), ".tmux-ide");
+  return join4(home, "update-check.json");
 }
 function readUpdateCache() {
   const path2 = updateCachePath();
-  if (!existsSync(path2)) return null;
+  if (!existsSync2(path2)) return null;
   try {
-    const parsed = JSON.parse(readFileSync3(path2, "utf-8"));
+    const parsed = JSON.parse(readFileSync5(path2, "utf-8"));
     if (!parsed || typeof parsed !== "object") return null;
     const obj = parsed;
     const lastCheckedAt = typeof obj.lastCheckedAt === "number" ? obj.lastCheckedAt : null;
@@ -2681,8 +3329,8 @@ function readUpdateCache() {
 function writeUpdateCache(cache3) {
   const path2 = updateCachePath();
   try {
-    mkdirSync(dirname(path2), { recursive: true });
-    writeFileSync2(path2, JSON.stringify(cache3));
+    mkdirSync3(dirname3(path2), { recursive: true });
+    writeFileSync4(path2, JSON.stringify(cache3));
   } catch {
   }
 }
@@ -2700,16 +3348,16 @@ async function fetchLatestVersion(timeoutMs = 3e3) {
   }
 }
 function getCurrentVersion() {
-  const here = dirname(fileURLToPath(import.meta.url));
+  const here = dirname3(fileURLToPath2(import.meta.url));
   const candidates = [
-    join2(here, "../package.json"),
+    join4(here, "../package.json"),
     // bundled bin/cli.js → repo root
-    join2(here, "../../../../package.json")
+    join4(here, "../../../../package.json")
     // dev src/lib → repo root
   ];
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(readFileSync3(candidate, "utf-8"));
+      const parsed = JSON.parse(readFileSync5(candidate, "utf-8"));
       if (typeof parsed.version === "string" && parsed.version.length > 0) return parsed.version;
     } catch {
     }
@@ -2725,6 +3373,8 @@ function getUpdateStatus({
 async function runUpdateCheck({ now = Date.now() } = {}) {
   const cache3 = readUpdateCache();
   if (!shouldCheck(cache3?.lastCheckedAt ?? null, now)) return;
+  void Promise.resolve().then(() => (init_manifest_pack(), manifest_pack_exports)).then((m) => m.maybeRefreshManifestPack()).catch(() => {
+  });
   const fetched = await fetchLatestVersion();
   writeUpdateCache({
     lastCheckedAt: now,
@@ -2774,9 +3424,9 @@ __export(tui_binary_exports, {
   tuiPlatformTag: () => tuiPlatformTag,
   tuiStateHome: () => tuiStateHome
 });
-import { chmodSync, existsSync as existsSync2, mkdirSync as mkdirSync2, renameSync, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { dirname as dirname2, join as join3 } from "node:path";
+import { chmodSync, existsSync as existsSync3, mkdirSync as mkdirSync4, renameSync as renameSync3, writeFileSync as writeFileSync5 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { dirname as dirname4, join as join5 } from "node:path";
 import { gunzipSync } from "node:zlib";
 function tuiPlatformTag(platform = process.platform, arch = process.arch) {
   return SUPPORTED[`${platform}-${arch}`] ?? null;
@@ -2794,16 +3444,16 @@ function releaseAssetUrl(version, tag) {
   return `https://github.com/${RELEASE_REPO}/releases/download/v${normalizeVersion(version)}/${releaseAssetName(tag)}`;
 }
 function downloadedTuiPath(home, tag, version) {
-  return join3(home, "bin", `tmux-ide-tui-${tag}-${normalizeVersion(version)}`);
+  return join5(home, "bin", `tmux-ide-tui-${tag}-${normalizeVersion(version)}`);
 }
 function tuiStateHome() {
-  return process.env.TMUX_IDE_HOME ?? join3(homedir3(), ".tmux-ide");
+  return process.env.TMUX_IDE_HOME ?? join5(homedir4(), ".tmux-ide");
 }
 function findDownloadedTui(version = getCurrentVersion()) {
   const tag = tuiPlatformTag();
   if (!tag) return null;
   const path2 = downloadedTuiPath(tuiStateHome(), tag, version);
-  return existsSync2(path2) ? path2 : null;
+  return existsSync3(path2) ? path2 : null;
 }
 async function downloadTuiBinary(opts = {}) {
   const log = opts.log ?? (() => {
@@ -2817,7 +3467,7 @@ async function downloadTuiBinary(opts = {}) {
   }
   const url = releaseAssetUrl(version, tag);
   const dest = downloadedTuiPath(tuiStateHome(), tag, version);
-  mkdirSync2(dirname2(dest), { recursive: true });
+  mkdirSync4(dirname4(dest), { recursive: true });
   log(`downloading ${url}`);
   const res = await fetch(url);
   if (!res.ok) {
@@ -2833,9 +3483,9 @@ async function downloadTuiBinary(opts = {}) {
     );
   }
   const tmp = `${dest}.${process.pid}.tmp`;
-  writeFileSync3(tmp, bin, { mode: 493 });
+  writeFileSync5(tmp, bin, { mode: 493 });
   chmodSync(tmp, 493);
-  renameSync(tmp, dest);
+  renameSync3(tmp, dest);
   const mb = (bin.byteLength / 1024 / 1024).toFixed(1);
   log(`installed ${dest} (${mb} MB)`);
   return { path: dest, bytes: bin.byteLength };
@@ -2857,9 +3507,9 @@ var init_tui_binary = __esm({
 });
 
 // packages/daemon/src/tui/compiled.ts
-import { existsSync as existsSync3 } from "node:fs";
-import { dirname as dirname3, resolve as resolve4 } from "node:path";
-import { fileURLToPath as fileURLToPath2 } from "node:url";
+import { existsSync as existsSync4 } from "node:fs";
+import { dirname as dirname5, resolve as resolve4 } from "node:path";
+import { fileURLToPath as fileURLToPath3 } from "node:url";
 import { execFileSync as execFileSync4 } from "node:child_process";
 function resolveTuiLaunch(input) {
   if (input.checkoutExists && input.bunAvailable) {
@@ -2884,14 +3534,14 @@ function resolveTuiLaunch(input) {
 }
 function findCompiledTui() {
   const override = process.env.TMUX_IDE_TUI_BIN;
-  if (override) return existsSync3(override) ? override : null;
+  if (override) return existsSync4(override) ? override : null;
   const anchors = [];
-  if (process.argv[1]) anchors.push(dirname3(process.argv[1]));
+  if (process.argv[1]) anchors.push(dirname5(process.argv[1]));
   anchors.push(__dirname);
   for (const anchor of anchors) {
     for (const rel of BINARY_RELS) {
       const candidate = resolve4(anchor, rel);
-      if (existsSync3(candidate)) return candidate;
+      if (existsSync4(candidate)) return candidate;
     }
   }
   return findDownloadedTui();
@@ -2909,7 +3559,7 @@ var init_compiled = __esm({
   "packages/daemon/src/tui/compiled.ts"() {
     "use strict";
     init_tui_binary();
-    __dirname = dirname3(fileURLToPath2(import.meta.url));
+    __dirname = dirname5(fileURLToPath3(import.meta.url));
     BINARY_RELS = [
       "../packages/daemon/dist/tui/tmux-ide-tui",
       "../../dist/tui/tmux-ide-tui",
@@ -2937,15 +3587,15 @@ __export(sidebar_exports, {
   sidebarWidgetCommand: () => sidebarWidgetCommand,
   sidebarWidgetScript: () => sidebarWidgetScript
 });
-import { existsSync as existsSync4 } from "node:fs";
-import { dirname as dirname4, resolve as resolve5 } from "node:path";
-import { fileURLToPath as fileURLToPath3 } from "node:url";
+import { existsSync as existsSync5 } from "node:fs";
+import { dirname as dirname6, resolve as resolve5 } from "node:path";
+import { fileURLToPath as fileURLToPath4 } from "node:url";
 function sidebarWidgetScript() {
   const candidates = [
     resolve5(__dirname2, "../../widgets/sidebar/index.tsx"),
     resolve5(__dirname2, "../packages/daemon/src/widgets/sidebar/index.tsx")
   ];
-  return candidates.find((p) => existsSync4(p)) ?? candidates[0];
+  return candidates.find((p) => existsSync5(p)) ?? candidates[0];
 }
 function sidebarWidgetCommand(scriptPath, session, dir, theme) {
   const args = [`--session=${session}`, `--dir=${dir}`];
@@ -2954,7 +3604,7 @@ function sidebarWidgetCommand(scriptPath, session, dir, theme) {
     surface: "sidebar",
     scriptPath,
     args,
-    checkoutExists: existsSync4(scriptPath),
+    checkoutExists: existsSync5(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui()
   });
@@ -3033,7 +3683,7 @@ var init_sidebar = __esm({
     init_shell();
     init_sessions2();
     init_compiled();
-    __dirname2 = dirname4(fileURLToPath3(import.meta.url));
+    __dirname2 = dirname6(fileURLToPath4(import.meta.url));
     SIDEBAR_KEY = "M-b";
     DEFAULT_SIDEBAR_WIDTH = 30;
   }
@@ -3046,12 +3696,12 @@ __export(resolve_exports, {
   resolveWidgetCommand: () => resolveWidgetCommand,
   resolveWidgetSpawn: () => resolveWidgetSpawn
 });
-import { resolve as resolve6, dirname as dirname5 } from "node:path";
-import { existsSync as existsSync5 } from "node:fs";
-import { fileURLToPath as fileURLToPath4 } from "node:url";
+import { resolve as resolve6, dirname as dirname7 } from "node:path";
+import { existsSync as existsSync6 } from "node:fs";
+import { fileURLToPath as fileURLToPath5 } from "node:url";
 function widgetEntryPath(entry) {
   const sibling = resolve6(__dirname3, entry);
-  if (existsSync5(sibling)) return sibling;
+  if (existsSync6(sibling)) return sibling;
   return resolve6(__dirname3, "../packages/daemon/src/widgets", entry);
 }
 function widgetArgs(opts) {
@@ -3068,7 +3718,7 @@ function resolveWidgetCommand(type, opts) {
     surface: type,
     scriptPath,
     args: widgetArgs(opts),
-    checkoutExists: existsSync5(scriptPath),
+    checkoutExists: existsSync6(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui()
   });
@@ -3089,7 +3739,7 @@ function resolveWidgetSpawn(type, opts) {
     surface: type,
     scriptPath,
     args: widgetArgs(opts),
-    checkoutExists: existsSync5(scriptPath),
+    checkoutExists: existsSync6(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui()
   });
@@ -3105,7 +3755,7 @@ var init_resolve = __esm({
     "use strict";
     init_shell();
     init_compiled();
-    __dirname3 = dirname5(fileURLToPath4(import.meta.url));
+    __dirname3 = dirname7(fileURLToPath5(import.meta.url));
     WIDGET_ENTRY_POINTS = {
       explorer: "explorer/index.tsx",
       changes: "changes/index.tsx",
@@ -3114,220 +3764,15 @@ var init_resolve = __esm({
       config: "config/index.tsx",
       sidebar: "sidebar/index.tsx"
     };
-    REPO_ROOT = existsSync5(resolve6(__dirname3, "explorer/index.tsx")) ? resolve6(__dirname3, "../../../..") : resolve6(__dirname3, "..");
+    REPO_ROOT = existsSync6(resolve6(__dirname3, "explorer/index.tsx")) ? resolve6(__dirname3, "../../../..") : resolve6(__dirname3, "..");
     WIDGET_TYPES = Object.keys(WIDGET_ENTRY_POINTS);
   }
 });
 
-// packages/daemon/src/lib/app-config.ts
-var app_config_exports = {};
-__export(app_config_exports, {
-  DEFAULT_APP_CONFIG: () => DEFAULT_APP_CONFIG,
-  DEFAULT_KEYS: () => DEFAULT_KEYS,
-  DEFAULT_THEME: () => DEFAULT_THEME,
-  _resetForTests: () => _resetForTests,
-  appConfigPath: () => appConfigPath,
-  getAppConfig: () => getAppConfig,
-  loadAppConfig: () => loadAppConfig,
-  loadRawAppConfig: () => loadRawAppConfig,
-  mergeConfigPatch: () => mergeConfigPatch,
-  parseAppConfig: () => parseAppConfig,
-  updateAppConfig: () => updateAppConfig
-});
-import { existsSync as existsSync6, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname as dirname6, join as join4 } from "node:path";
-function asObject(value) {
-  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
-}
-function pickString(value, fallback) {
-  return typeof value === "string" && value.length > 0 ? value : fallback;
-}
-function pickBool(value, fallback) {
-  return typeof value === "boolean" ? value : fallback;
-}
-function pickPosInt(value, fallback) {
-  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
-}
-function pickChoice(value, allowed, fallback) {
-  return typeof value === "string" && allowed.includes(value) ? value : fallback;
-}
-function parseAppConfig(input) {
-  const D = DEFAULT_APP_CONFIG;
-  const root = asObject(input);
-  const keys = asObject(root.keys);
-  const panels = asObject(keys.panels);
-  const theme = asObject(root.theme);
-  const status2 = asObject(theme.status);
-  const glyphs = asObject(theme.glyphs);
-  const updater = asObject(root.updater);
-  const notifications = asObject(root.notifications);
-  const restore2 = asObject(root.restore);
-  const updates = asObject(root.updates);
-  const welcome = asObject(root.welcome);
-  const integrations = asObject(root.integrations);
-  const worktrees = asObject(root.worktrees);
-  const app = asObject(root.app);
-  return {
-    keys: {
-      popup: pickString(keys.popup, D.keys.popup),
-      home: pickString(keys.home, D.keys.home),
-      cheatsheet: pickString(keys.cheatsheet, D.keys.cheatsheet),
-      menu: pickString(keys.menu, D.keys.menu),
-      sidebar: pickString(keys.sidebar, D.keys.sidebar),
-      panels: {
-        explorer: pickString(panels.explorer, D.keys.panels.explorer),
-        changes: pickString(panels.changes, D.keys.panels.changes),
-        config: pickString(panels.config, D.keys.panels.config)
-      }
-    },
-    theme: {
-      accent: pickString(theme.accent, D.theme.accent),
-      muted: pickString(theme.muted, D.theme.muted),
-      fg: pickString(theme.fg, D.theme.fg),
-      status: {
-        blocked: pickString(status2.blocked, D.theme.status.blocked),
-        working: pickString(status2.working, D.theme.status.working),
-        done: pickString(status2.done, D.theme.status.done),
-        idle: pickString(status2.idle, D.theme.status.idle),
-        unknown: pickString(status2.unknown, D.theme.status.unknown)
-      },
-      glyphs: {
-        active: pickString(glyphs.active, D.theme.glyphs.active),
-        inactive: pickString(glyphs.inactive, D.theme.glyphs.inactive)
-      }
-    },
-    updater: {
-      tickMs: pickPosInt(updater.tickMs, D.updater.tickMs),
-      snapshotEvery: pickPosInt(updater.snapshotEvery, D.updater.snapshotEvery)
-    },
-    notifications: {
-      toast: pickBool(notifications.toast, D.notifications.toast),
-      macos: pickBool(notifications.macos, D.notifications.macos)
-    },
-    restore: { resumeAgents: pickBool(restore2.resumeAgents, D.restore.resumeAgents) },
-    updates: { check: pickBool(updates.check, D.updates.check) },
-    welcome: { show: pickBool(welcome.show, D.welcome.show) },
-    integrations: { offer: pickBool(integrations.offer, D.integrations.offer) },
-    worktrees: { dir: pickString(worktrees.dir, D.worktrees.dir) },
-    app: {
-      frontDoor: pickBool(app.frontDoor, D.app.frontDoor),
-      detachable: pickBool(app.detachable, D.app.detachable),
-      dragSelect: pickChoice(app.dragSelect, ["agents", "always", "never"], D.app.dragSelect),
-      newAgentCwd: pickChoice(app.newAgentCwd, ["pane", "session"], D.app.newAgentCwd),
-      kittyKeys: pickBool(app.kittyKeys, D.app.kittyKeys)
-    }
-  };
-}
-function appConfigPath() {
-  return process.env.TMUX_IDE_CONFIG ?? join4(homedir4(), ".tmux-ide", "config.json");
-}
-function loadAppConfig() {
-  const path2 = appConfigPath();
-  if (!existsSync6(path2)) return parseAppConfig(void 0);
-  try {
-    return parseAppConfig(JSON.parse(readFileSync4(path2, "utf-8")));
-  } catch {
-    return parseAppConfig(void 0);
-  }
-}
-function getAppConfig() {
-  if (!cached) cached = loadAppConfig();
-  return cached;
-}
-function _resetForTests() {
-  cached = null;
-}
-function loadRawAppConfig() {
-  const path2 = appConfigPath();
-  if (!existsSync6(path2)) return {};
-  try {
-    const parsed = JSON.parse(readFileSync4(path2, "utf-8"));
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
-  } catch {
-    return {};
-  }
-}
-function isPlainObject(value) {
-  return !!value && typeof value === "object" && !Array.isArray(value);
-}
-function mergeConfigPatch(raw, patch) {
-  const out = { ...raw };
-  for (const [key, value] of Object.entries(patch)) {
-    if (value === void 0) {
-      delete out[key];
-    } else if (isPlainObject(value) && isPlainObject(out[key])) {
-      out[key] = mergeConfigPatch(out[key], value);
-    } else if (isPlainObject(value)) {
-      out[key] = mergeConfigPatch({}, value);
-    } else {
-      out[key] = value;
-    }
-  }
-  return out;
-}
-function updateAppConfig(patch) {
-  const path2 = appConfigPath();
-  const merged = mergeConfigPatch(loadRawAppConfig(), patch);
-  mkdirSync3(dirname6(path2), { recursive: true });
-  const tmp = `${path2}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync4(tmp, `${JSON.stringify(merged, null, 2)}
-`, "utf-8");
-  renameSync2(tmp, path2);
-  cached = null;
-  return parseAppConfig(merged);
-}
-var DEFAULT_APP_CONFIG, DEFAULT_THEME, DEFAULT_KEYS, cached;
-var init_app_config = __esm({
-  "packages/daemon/src/lib/app-config.ts"() {
-    "use strict";
-    DEFAULT_APP_CONFIG = {
-      keys: {
-        popup: "M-p",
-        home: "M-h",
-        cheatsheet: "M-k",
-        menu: "M-m",
-        sidebar: "M-b",
-        panels: { explorer: "M-e", changes: "M-g", config: "M-," }
-      },
-      theme: {
-        accent: "colour75",
-        muted: "colour240",
-        fg: "colour250",
-        status: {
-          blocked: "colour203",
-          working: "colour221",
-          done: "colour111",
-          idle: "colour114",
-          unknown: "colour244"
-        },
-        glyphs: { active: "\u25CF", inactive: "\u25CB" }
-      },
-      updater: { tickMs: 2e3, snapshotEvery: 15 },
-      notifications: { toast: true, macos: false },
-      restore: { resumeAgents: false },
-      updates: { check: true },
-      welcome: { show: true },
-      integrations: { offer: true },
-      worktrees: { dir: "" },
-      app: {
-        frontDoor: false,
-        detachable: false,
-        dragSelect: "agents",
-        newAgentCwd: "pane",
-        kittyKeys: true
-      }
-    };
-    DEFAULT_THEME = DEFAULT_APP_CONFIG.theme;
-    DEFAULT_KEYS = DEFAULT_APP_CONFIG.keys;
-    cached = null;
-  }
-});
-
 // packages/daemon/src/tui/team/keymap.ts
-import { existsSync as existsSync7, readFileSync as readFileSync5 } from "node:fs";
+import { existsSync as existsSync7, readFileSync as readFileSync6 } from "node:fs";
 import { homedir as homedir5 } from "node:os";
-import { join as join5 } from "node:path";
+import { join as join6 } from "node:path";
 var ACTION_ORDER, DEFAULT_KEYMAP;
 var init_keymap = __esm({
   "packages/daemon/src/tui/team/keymap.ts"() {
@@ -3756,15 +4201,15 @@ __export(welcome_exports, {
   welcomeMarkerPath: () => welcomeMarkerPath
 });
 import { spawn as spawn2 } from "node:child_process";
-import { existsSync as existsSync8, mkdirSync as mkdirSync4, writeFileSync as writeFileSync5 } from "node:fs";
+import { existsSync as existsSync8, mkdirSync as mkdirSync5, writeFileSync as writeFileSync6 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { dirname as dirname7, join as join6 } from "node:path";
+import { dirname as dirname8, join as join7 } from "node:path";
 function renderKey2(tmuxKey) {
   return tmuxKey.replace(/M-/g, "\u2325").replace(/C-/g, "^").replace(/S-/g, "\u21E7");
 }
 function welcomeMarkerPath() {
-  const home = process.env.TMUX_IDE_HOME ?? join6(homedir6(), ".tmux-ide");
-  return join6(home, "welcomed");
+  const home = process.env.TMUX_IDE_HOME ?? join7(homedir6(), ".tmux-ide");
+  return join7(home, "welcomed");
 }
 function shouldShowWelcome() {
   return !existsSync8(welcomeMarkerPath()) && getAppConfig().welcome.show;
@@ -3772,8 +4217,8 @@ function shouldShowWelcome() {
 function markWelcomed() {
   const path2 = welcomeMarkerPath();
   try {
-    mkdirSync4(dirname7(path2), { recursive: true });
-    writeFileSync5(path2, (/* @__PURE__ */ new Date()).toISOString());
+    mkdirSync5(dirname8(path2), { recursive: true });
+    writeFileSync6(path2, (/* @__PURE__ */ new Date()).toISOString());
   } catch {
   }
 }
@@ -3836,17 +4281,17 @@ import {
   chmodSync as chmodSync2,
   copyFileSync,
   existsSync as existsSync9,
-  mkdirSync as mkdirSync5,
-  readFileSync as readFileSync6,
-  writeFileSync as writeFileSync6
+  mkdirSync as mkdirSync6,
+  readFileSync as readFileSync7,
+  writeFileSync as writeFileSync7
 } from "node:fs";
 import { homedir as homedir7 } from "node:os";
-import { dirname as dirname8, join as join7 } from "node:path";
+import { dirname as dirname9, join as join8 } from "node:path";
 function hookScriptPath() {
-  return join7(homedir7(), HOOK_SCRIPT_RELPATH);
+  return join8(homedir7(), HOOK_SCRIPT_RELPATH);
 }
 function claudeSettingsPath() {
-  return process.env.TMUX_IDE_CLAUDE_SETTINGS ?? join7(homedir7(), ".claude", "settings.json");
+  return process.env.TMUX_IDE_CLAUDE_SETTINGS ?? join8(homedir7(), ".claude", "settings.json");
 }
 function isOurs(group) {
   return group.hooks?.some((h) => h.command?.includes(HOOK_SCRIPT_RELPATH)) ?? false;
@@ -3881,22 +4326,22 @@ function isInstalled(settings) {
 function readSettings(path2) {
   if (!existsSync9(path2)) return {};
   try {
-    return JSON.parse(readFileSync6(path2, "utf8"));
+    return JSON.parse(readFileSync7(path2, "utf8"));
   } catch {
     throw new Error(`${path2} is not valid JSON \u2014 fix or move it, then retry`);
   }
 }
 function installClaudeIntegration() {
   const script = hookScriptPath();
-  mkdirSync5(dirname8(script), { recursive: true });
-  writeFileSync6(script, HOOK_SCRIPT, "utf8");
+  mkdirSync6(dirname9(script), { recursive: true });
+  writeFileSync7(script, HOOK_SCRIPT, "utf8");
   chmodSync2(script, 493);
   const settingsPath = claudeSettingsPath();
-  mkdirSync5(dirname8(settingsPath), { recursive: true });
+  mkdirSync6(dirname9(settingsPath), { recursive: true });
   const settings = readSettings(settingsPath);
   const backup = `${settingsPath}.tmux-ide.bak`;
   if (existsSync9(settingsPath) && !existsSync9(backup)) copyFileSync(settingsPath, backup);
-  writeFileSync6(settingsPath, `${JSON.stringify(mergeHooks(settings, script), null, 2)}
+  writeFileSync7(settingsPath, `${JSON.stringify(mergeHooks(settings, script), null, 2)}
 `, "utf8");
   return { scriptPath: script, settingsPath };
 }
@@ -3905,7 +4350,7 @@ function uninstallClaudeIntegration() {
   const settings = readSettings(settingsPath);
   const wasInstalled = isInstalled(settings);
   if (wasInstalled) {
-    writeFileSync6(settingsPath, `${JSON.stringify(removeHooks(settings), null, 2)}
+    writeFileSync7(settingsPath, `${JSON.stringify(removeHooks(settings), null, 2)}
 `, "utf8");
   }
   return { settingsPath, wasInstalled };
@@ -3952,12 +4397,12 @@ __export(offer_exports, {
   shouldOfferIntegration: () => shouldOfferIntegration
 });
 import { execFileSync as execFileSync5, spawn as spawn3 } from "node:child_process";
-import { existsSync as existsSync10, mkdirSync as mkdirSync6, writeFileSync as writeFileSync7 } from "node:fs";
+import { existsSync as existsSync10, mkdirSync as mkdirSync7, writeFileSync as writeFileSync8 } from "node:fs";
 import { homedir as homedir8 } from "node:os";
-import { dirname as dirname9, join as join8 } from "node:path";
+import { dirname as dirname10, join as join9 } from "node:path";
 function integrationOfferMarkerPath() {
-  const home = process.env.TMUX_IDE_HOME ?? join8(homedir8(), ".tmux-ide");
-  return join8(home, "integration-offered");
+  const home = process.env.TMUX_IDE_HOME ?? join9(homedir8(), ".tmux-ide");
+  return join9(home, "integration-offered");
 }
 function shouldOfferIntegration(input) {
   return input.claudeOnPath && !input.integrationInstalled && !input.markerPresent && input.offerEnabled;
@@ -3965,8 +4410,8 @@ function shouldOfferIntegration(input) {
 function markIntegrationOffered() {
   const path2 = integrationOfferMarkerPath();
   try {
-    mkdirSync6(dirname9(path2), { recursive: true });
-    writeFileSync7(path2, (/* @__PURE__ */ new Date()).toISOString());
+    mkdirSync7(dirname10(path2), { recursive: true });
+    writeFileSync8(path2, (/* @__PURE__ */ new Date()).toISOString());
   } catch {
   }
 }
@@ -4137,9 +4582,9 @@ var init_project_probe = __esm({
 
 // packages/daemon/src/lib/project-registry.ts
 import { EventEmitter } from "node:events";
-import { existsSync as existsSync12, mkdirSync as mkdirSync7, readFileSync as readFileSync7, renameSync as renameSync3, writeFileSync as writeFileSync8 } from "node:fs";
+import { existsSync as existsSync12, mkdirSync as mkdirSync8, readFileSync as readFileSync8, renameSync as renameSync4, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir9 } from "node:os";
-import { dirname as dirname10, isAbsolute as isAbsolute2, join as join9, resolve as resolve8 } from "node:path";
+import { dirname as dirname11, isAbsolute as isAbsolute2, join as join10, resolve as resolve8 } from "node:path";
 import { z as z11 } from "zod";
 function applyAction(state, action) {
   switch (action.type) {
@@ -4171,15 +4616,15 @@ function buildRegisteredProject(probe, name, registeredAt) {
 function registryDir() {
   const override = process.env[REGISTRY_DIR_ENV];
   if (override && override.length > 0) return override;
-  return join9(homedir9(), ".tmux-ide");
+  return join10(homedir9(), ".tmux-ide");
 }
 function registryPath() {
-  return join9(registryDir(), "projects.json");
+  return join10(registryDir(), "projects.json");
 }
 function readDisk() {
   const path2 = registryPath();
   if (!existsSync12(path2)) return [];
-  const raw = readFileSync7(path2, "utf-8");
+  const raw = readFileSync8(path2, "utf-8");
   if (raw.trim().length === 0) return [];
   let parsed;
   try {
@@ -4201,12 +4646,12 @@ function readDisk() {
 }
 function writeDisk(projects) {
   const path2 = registryPath();
-  const dir = dirname10(path2);
-  mkdirSync7(dir, { recursive: true });
+  const dir = dirname11(path2);
+  mkdirSync8(dir, { recursive: true });
   const file = { version: 1, projects };
   const tmpPath = `${path2}.tmp`;
-  writeFileSync8(tmpPath, JSON.stringify(file, null, 2) + "\n");
-  renameSync3(tmpPath, path2);
+  writeFileSync9(tmpPath, JSON.stringify(file, null, 2) + "\n");
+  renameSync4(tmpPath, path2);
 }
 function ensureCache() {
   if (cache2 !== null) return cache2;
@@ -4435,9 +4880,9 @@ __export(events_exports, {
   formatEventLine: () => formatEventLine,
   shouldRotate: () => shouldRotate
 });
-import { appendFileSync, existsSync as existsSync13, mkdirSync as mkdirSync8, renameSync as renameSync4, statSync } from "node:fs";
+import { appendFileSync, existsSync as existsSync13, mkdirSync as mkdirSync9, renameSync as renameSync5, statSync } from "node:fs";
 import { homedir as homedir10 } from "node:os";
-import { join as join10 } from "node:path";
+import { join as join11 } from "node:path";
 function diffFleet(prev, next) {
   const state = /* @__PURE__ */ new Map();
   const events = [];
@@ -4464,15 +4909,15 @@ function formatEventLine(ev, paint = (_s, t) => t) {
   return `${isoTime(ev.ts)} ${ev.session} ${from} \u2192 ${paint(ev.to, ev.to)}`;
 }
 function eventsPath() {
-  return join10(homedir10(), ".tmux-ide", "events.jsonl");
+  return join11(homedir10(), ".tmux-ide", "events.jsonl");
 }
 function appendEvents(events, now = () => (/* @__PURE__ */ new Date()).toISOString()) {
   if (events.length === 0) return;
   const path2 = eventsPath();
   try {
-    mkdirSync8(join10(homedir10(), ".tmux-ide"), { recursive: true });
+    mkdirSync9(join11(homedir10(), ".tmux-ide"), { recursive: true });
     if (existsSync13(path2) && shouldRotate(statSync(path2).size)) {
-      renameSync4(path2, `${path2}.1`);
+      renameSync5(path2, `${path2}.1`);
     }
     const ts = now();
     const lines = events.map((e) => `${JSON.stringify({ ts, ...e })}
@@ -4491,7 +4936,7 @@ var init_events = __esm({
 
 // packages/daemon/src/tui/chrome/notify.ts
 import { execFileSync as execFileSync6 } from "node:child_process";
-import { existsSync as existsSync14, readFileSync as readFileSync8 } from "node:fs";
+import { existsSync as existsSync14, readFileSync as readFileSync9 } from "node:fs";
 function statusPhrase(to) {
   return to === "blocked" ? "needs input" : "finished";
 }
@@ -4635,7 +5080,7 @@ function readRawConfig() {
   const path2 = appConfigPath();
   if (!existsSync14(path2)) return void 0;
   try {
-    return JSON.parse(readFileSync8(path2, "utf-8"));
+    return JSON.parse(readFileSync9(path2, "utf-8"));
   } catch {
     return void 0;
   }
@@ -4664,9 +5109,9 @@ var init_notify = __esm({
 });
 
 // packages/daemon/src/tui/chrome/snapshot.ts
-import { existsSync as existsSync15, mkdirSync as mkdirSync9, readFileSync as readFileSync9, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
+import { existsSync as existsSync15, mkdirSync as mkdirSync10, readFileSync as readFileSync10, renameSync as renameSync6, writeFileSync as writeFileSync10 } from "node:fs";
 import { homedir as homedir11 } from "node:os";
-import { dirname as dirname11, join as join11 } from "node:path";
+import { dirname as dirname12, join as join12 } from "node:path";
 import { z as z12 } from "zod";
 function isBareShell(cmd) {
   return /^-?(zsh|bash|sh|fish|dash|ksh|tcsh|csh|nu)$/.test(cmd.trim());
@@ -4781,21 +5226,21 @@ function collectFleetSnapshot(io = defaultIo) {
   return buildSnapshot(rawPanes, rawSessions, io.processTable());
 }
 function snapshotPath() {
-  return join11(homedir11(), ".tmux-ide", "snapshot.json");
+  return join12(homedir11(), ".tmux-ide", "snapshot.json");
 }
 function writeSnapshot(snapshot) {
   const path2 = snapshotPath();
   try {
-    mkdirSync9(dirname11(path2), { recursive: true });
+    mkdirSync10(dirname12(path2), { recursive: true });
     const tmp = `${path2}.tmp`;
-    writeFileSync9(tmp, JSON.stringify(snapshot, null, 2) + "\n");
+    writeFileSync10(tmp, JSON.stringify(snapshot, null, 2) + "\n");
     if (existsSync15(path2)) {
       try {
-        renameSync5(path2, `${path2}.1`);
+        renameSync6(path2, `${path2}.1`);
       } catch {
       }
     }
-    renameSync5(tmp, path2);
+    renameSync6(tmp, path2);
   } catch {
   }
 }
@@ -4803,7 +5248,7 @@ function readSnapshot() {
   const path2 = snapshotPath();
   try {
     if (!existsSync15(path2)) return null;
-    const raw = readFileSync9(path2, "utf-8");
+    const raw = readFileSync10(path2, "utf-8");
     if (raw.trim().length === 0) return null;
     const result = FleetSnapshotSchemaZ.safeParse(JSON.parse(raw));
     return result.success ? result.data : null;
@@ -5436,12 +5881,12 @@ __export(canonical_daemon_exports, {
   warnOnDaemonVersionSkew: () => warnOnDaemonVersionSkew,
   writeCanonicalDaemonInfo: () => writeCanonicalDaemonInfo
 });
-import { existsSync as existsSync16, mkdirSync as mkdirSync10, readFileSync as readFileSync10, renameSync as renameSync6, rmSync, writeFileSync as writeFileSync10 } from "node:fs";
+import { existsSync as existsSync16, mkdirSync as mkdirSync11, readFileSync as readFileSync11, renameSync as renameSync7, rmSync, writeFileSync as writeFileSync11 } from "node:fs";
 import { homedir as homedir12 } from "node:os";
-import { dirname as dirname12, join as join12 } from "node:path";
+import { dirname as dirname13, join as join13 } from "node:path";
 function getCanonicalDaemonInfoPath() {
-  const dir = process.env[DAEMON_INFO_DIR_ENV] ?? process.env[REGISTRY_DIR_ENV2] ?? join12(homedir12(), ".tmux-ide");
-  return join12(dir, DAEMON_INFO_FILE);
+  const dir = process.env[DAEMON_INFO_DIR_ENV] ?? process.env[REGISTRY_DIR_ENV2] ?? join13(homedir12(), ".tmux-ide");
+  return join13(dir, DAEMON_INFO_FILE);
 }
 function parseCanonicalDaemonInfo(raw) {
   if (!raw || typeof raw !== "object") return null;
@@ -5464,7 +5909,7 @@ function parseCanonicalDaemonInfo(raw) {
 }
 function writeCanonicalDaemonInfo(info) {
   const path2 = getCanonicalDaemonInfoPath();
-  mkdirSync10(dirname12(path2), { recursive: true });
+  mkdirSync11(dirname13(path2), { recursive: true });
   const tmpPath = `${path2}.${process.pid}.${Date.now()}.tmp`;
   const persisted = {
     pid: info.pid,
@@ -5474,14 +5919,14 @@ function writeCanonicalDaemonInfo(info) {
     bindHostname: info.bindHostname,
     authToken: info.authToken
   };
-  writeFileSync10(tmpPath, JSON.stringify(persisted, null, 2) + "\n", "utf-8");
-  renameSync6(tmpPath, path2);
+  writeFileSync11(tmpPath, JSON.stringify(persisted, null, 2) + "\n", "utf-8");
+  renameSync7(tmpPath, path2);
 }
 function readCanonicalDaemonInfo() {
   const path2 = getCanonicalDaemonInfoPath();
   if (!existsSync16(path2)) return null;
   try {
-    return parseCanonicalDaemonInfo(JSON.parse(readFileSync10(path2, "utf-8")));
+    return parseCanonicalDaemonInfo(JSON.parse(readFileSync11(path2, "utf-8")));
   } catch {
     return null;
   }
@@ -5771,13 +6216,13 @@ var init_launch = __esm({
 
 // packages/daemon/src/detect.ts
 import { resolve as resolve10, basename as basename4 } from "node:path";
-import { readFileSync as readFileSync11, existsSync as existsSync17 } from "node:fs";
+import { readFileSync as readFileSync12, existsSync as existsSync17 } from "node:fs";
 function fileExists(dir, name) {
   return existsSync17(resolve10(dir, name));
 }
 function readJson(dir, name) {
   try {
-    return JSON.parse(readFileSync11(resolve10(dir, name), "utf-8"));
+    return JSON.parse(readFileSync12(resolve10(dir, name), "utf-8"));
   } catch {
     return null;
   }
@@ -5839,7 +6284,7 @@ function detectStack(dir) {
     detected.language = detected.language ?? "python";
     detected.reasons.push('Detected Python from "pyproject.toml" or "requirements.txt".');
     try {
-      const pyproject = readFileSync11(resolve10(dir, "pyproject.toml"), "utf-8");
+      const pyproject = readFileSync12(resolve10(dir, "pyproject.toml"), "utf-8");
       if (pyproject.includes("fastapi"))
         pushFramework(detected, "fastapi", 'Found "fastapi" in pyproject.toml.');
       else if (pyproject.includes("django"))
@@ -5986,25 +6431,25 @@ __export(skill_sync_exports, {
   syncSkill: () => syncSkill,
   versionMarker: () => versionMarker
 });
-import { existsSync as existsSync19, mkdirSync as mkdirSync12, readFileSync as readFileSync13, writeFileSync as writeFileSync12 } from "node:fs";
+import { existsSync as existsSync19, mkdirSync as mkdirSync13, readFileSync as readFileSync14, writeFileSync as writeFileSync13 } from "node:fs";
 import { homedir as homedir13 } from "node:os";
-import { dirname as dirname14, join as join14 } from "node:path";
-import { fileURLToPath as fileURLToPath6 } from "node:url";
+import { dirname as dirname15, join as join15 } from "node:path";
+import { fileURLToPath as fileURLToPath7 } from "node:url";
 function claudeDir() {
-  return process.env.TMUX_IDE_CLAUDE_DIR ?? join14(homedir13(), ".claude");
+  return process.env.TMUX_IDE_CLAUDE_DIR ?? join15(homedir13(), ".claude");
 }
 function skillTargetDir() {
-  return join14(claudeDir(), "skills", "tmux-ide");
+  return join15(claudeDir(), "skills", "tmux-ide");
 }
 function skillTargetFile() {
-  return join14(skillTargetDir(), "SKILL.md");
+  return join15(skillTargetDir(), "SKILL.md");
 }
 function defaultSkillSource() {
-  const here = dirname14(fileURLToPath6(import.meta.url));
+  const here = dirname15(fileURLToPath7(import.meta.url));
   const candidates = [
-    join14(here, "../skill/SKILL.md"),
+    join15(here, "../skill/SKILL.md"),
     // bundled bin/cli.js → repo root
-    join14(here, "../../../../skill/SKILL.md")
+    join15(here, "../../../../skill/SKILL.md")
     // dev src/lib → repo root
   ];
   return candidates.find((c) => existsSync19(c)) ?? candidates[0];
@@ -6021,10 +6466,10 @@ function rewriteVersionMarker(content, version) {
   return content.replace(VERSION_MARKER_RE, versionMarker(version));
 }
 function installedSkillVersion(dir = skillTargetDir()) {
-  const file = join14(dir, "SKILL.md");
+  const file = join15(dir, "SKILL.md");
   if (!existsSync19(file)) return null;
   try {
-    return parseSkillVersion(readFileSync13(file, "utf-8"));
+    return parseSkillVersion(readFileSync14(file, "utf-8"));
   } catch {
     return null;
   }
@@ -6033,15 +6478,15 @@ function syncSkill({
   source = defaultSkillSource(),
   version = getCurrentVersion()
 } = {}) {
-  const rendered = rewriteVersionMarker(readFileSync13(source, "utf-8"), version);
+  const rendered = rewriteVersionMarker(readFileSync14(source, "utf-8"), version);
   const dir = skillTargetDir();
-  const target = join14(dir, "SKILL.md");
-  const existing = existsSync19(target) ? readFileSync13(target, "utf-8") : null;
+  const target = join15(dir, "SKILL.md");
+  const existing = existsSync19(target) ? readFileSync14(target, "utf-8") : null;
   if (existing === rendered) {
     return { action: "unchanged", path: target, to: version };
   }
-  mkdirSync12(dir, { recursive: true });
-  writeFileSync12(target, rendered, "utf-8");
+  mkdirSync13(dir, { recursive: true });
+  writeFileSync13(target, rendered, "utf-8");
   if (existing === null) return { action: "installed", path: target, to: version };
   return { action: "updated", path: target, from: parseSkillVersion(existing), to: version };
 }
@@ -6243,7 +6688,7 @@ var init_PtyAdapter = __esm({
 
 // packages/daemon/src/terminal/NodePtyAdapter.ts
 import { chmodSync as chmodSync3, existsSync as existsSync22, statSync as statSync2 } from "node:fs";
-import { dirname as dirname16, join as join15 } from "node:path";
+import { dirname as dirname17, join as join16 } from "node:path";
 import { createRequire } from "node:module";
 import * as pty from "node-pty";
 function candidateSpawnHelperPaths() {
@@ -6254,11 +6699,11 @@ function candidateSpawnHelperPaths() {
   } catch {
     return [];
   }
-  const pkgDir = dirname16(pkgJsonPath);
+  const pkgDir = dirname17(pkgJsonPath);
   return [
-    join15(pkgDir, "build", "Release", "spawn-helper"),
-    join15(pkgDir, "build", "Debug", "spawn-helper"),
-    join15(pkgDir, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper")
+    join16(pkgDir, "build", "Release", "spawn-helper"),
+    join16(pkgDir, "build", "Debug", "spawn-helper"),
+    join16(pkgDir, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper")
   ];
 }
 function ensureNodePtySpawnHelperExecutable(options = {}) {
@@ -7255,9 +7700,9 @@ var init_pane_comms = __esm({
 
 // packages/daemon/src/lib/workspace-registry.ts
 import { EventEmitter as EventEmitter3 } from "node:events";
-import { existsSync as existsSync23, mkdirSync as mkdirSync13, readFileSync as readFileSync14, renameSync as renameSync8, writeFileSync as writeFileSync13 } from "node:fs";
+import { existsSync as existsSync23, mkdirSync as mkdirSync14, readFileSync as readFileSync15, renameSync as renameSync9, writeFileSync as writeFileSync14 } from "node:fs";
 import { homedir as homedir14 } from "node:os";
-import { dirname as dirname17, join as join16 } from "node:path";
+import { dirname as dirname18, join as join17 } from "node:path";
 import { z as z13 } from "zod";
 function getDefaultWorkspaceRegistry() {
   if (!_default) _default = new WorkspaceRegistry();
@@ -7306,7 +7751,7 @@ var init_workspace_registry = __esm({
       workspaces = [];
       loaded = false;
       constructor(options = {}) {
-        this.dir = options.dir ?? process.env[REGISTRY_DIR_ENV3] ?? join16(homedir14(), ".tmux-ide");
+        this.dir = options.dir ?? process.env[REGISTRY_DIR_ENV3] ?? join17(homedir14(), ".tmux-ide");
         this.listSessions = options.listSessions ?? defaultListSessions;
         this.emitter.setMaxListeners(0);
       }
@@ -7373,14 +7818,14 @@ var init_workspace_registry = __esm({
       }
       // ----------------- io -----------------
       filePath() {
-        return join16(this.dir, "workspaces.json");
+        return join17(this.dir, "workspaces.json");
       }
       readDisk() {
         const path2 = this.filePath();
         if (!existsSync23(path2)) return [];
         let parsed;
         try {
-          parsed = JSON.parse(readFileSync14(path2, "utf-8"));
+          parsed = JSON.parse(readFileSync15(path2, "utf-8"));
         } catch {
           return [];
         }
@@ -7390,11 +7835,11 @@ var init_workspace_registry = __esm({
       }
       writeDisk() {
         const path2 = this.filePath();
-        mkdirSync13(dirname17(path2), { recursive: true });
+        mkdirSync14(dirname18(path2), { recursive: true });
         const file = { version: 1, workspaces: this.workspaces };
         const tmp = `${path2}.tmp`;
-        writeFileSync13(tmp, JSON.stringify(file, null, 2) + "\n");
-        renameSync8(tmp, path2);
+        writeFileSync14(tmp, JSON.stringify(file, null, 2) + "\n");
+        renameSync9(tmp, path2);
       }
       /** @internal Test-only: assert the registry is loaded. */
       _isLoaded() {
@@ -7675,14 +8120,14 @@ var init_auth_token = __esm({
 });
 
 // packages/daemon/src/lib/app-settings.ts
-import { existsSync as existsSync24, mkdirSync as mkdirSync14, readFileSync as readFileSync15, renameSync as renameSync9, writeFileSync as writeFileSync14 } from "node:fs";
-import { dirname as dirname18, join as join17 } from "node:path";
+import { existsSync as existsSync24, mkdirSync as mkdirSync15, readFileSync as readFileSync16, renameSync as renameSync10, writeFileSync as writeFileSync15 } from "node:fs";
+import { dirname as dirname19, join as join18 } from "node:path";
 import { homedir as homedir15 } from "node:os";
 function settingsDir() {
-  return process.env.TMUX_IDE_SETTINGS_DIR ?? join17(homedir15(), ".tmux-ide");
+  return process.env.TMUX_IDE_SETTINGS_DIR ?? join18(homedir15(), ".tmux-ide");
 }
 function appSettingsPath() {
-  return join17(settingsDir(), "app-settings.json");
+  return join18(settingsDir(), "app-settings.json");
 }
 function normalizeSettings(value) {
   if (!value || typeof value !== "object") return structuredClone(DEFAULT_SETTINGS);
@@ -7697,18 +8142,18 @@ function readAppSettings() {
   const path2 = appSettingsPath();
   if (!existsSync24(path2)) return structuredClone(DEFAULT_SETTINGS);
   try {
-    return normalizeSettings(JSON.parse(readFileSync15(path2, "utf-8")));
+    return normalizeSettings(JSON.parse(readFileSync16(path2, "utf-8")));
   } catch {
     return structuredClone(DEFAULT_SETTINGS);
   }
 }
 function writeAppSettings(next) {
   const path2 = appSettingsPath();
-  mkdirSync14(dirname18(path2), { recursive: true });
+  mkdirSync15(dirname19(path2), { recursive: true });
   const tmp = `${path2}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync14(tmp, `${JSON.stringify(normalizeSettings(next), null, 2)}
+  writeFileSync15(tmp, `${JSON.stringify(normalizeSettings(next), null, 2)}
 `, "utf-8");
-  renameSync9(tmp, path2);
+  renameSync10(tmp, path2);
 }
 var DEFAULT_SETTINGS;
 var init_app_settings = __esm({
@@ -7896,16 +8341,16 @@ var init_active_projects = __esm({
 
 // packages/daemon/src/send.ts
 import { randomUUID } from "node:crypto";
-import { resolve as resolve17, join as join18 } from "node:path";
-import { existsSync as existsSync25, mkdirSync as mkdirSync15, writeFileSync as writeFileSync15 } from "node:fs";
+import { resolve as resolve17, join as join19 } from "node:path";
+import { existsSync as existsSync25, mkdirSync as mkdirSync16, writeFileSync as writeFileSync16 } from "node:fs";
 function writeDispatchFile(dir, paneId, message) {
   if (message.length <= LONG_MESSAGE_THRESHOLD) return null;
-  const dispatchDir = join18(dir, ".tasks", "dispatch");
-  if (!existsSync25(dispatchDir)) mkdirSync15(dispatchDir, { recursive: true });
+  const dispatchDir = join19(dir, ".tasks", "dispatch");
+  if (!existsSync25(dispatchDir)) mkdirSync16(dispatchDir, { recursive: true });
   const paneSlug = paneId.replace("%", "");
   const filename = `send-${paneSlug}-${Date.now()}-${randomUUID().slice(0, 8)}.md`;
-  const filePath = join18(dispatchDir, filename);
-  writeFileSync15(filePath, message);
+  const filePath = join19(dispatchDir, filename);
+  writeFileSync16(filePath, message);
   return { filePath, triggerCmd: `Read and execute: .tasks/dispatch/${filename}` };
 }
 function resolvePane(panes, target) {
@@ -8155,19 +8600,19 @@ var init_schemas = __esm({
 });
 
 // packages/daemon/src/lib/terminals-store.ts
-import { existsSync as existsSync26, mkdirSync as mkdirSync16, readFileSync as readFileSync16, renameSync as renameSync10, writeFileSync as writeFileSync16 } from "node:fs";
-import { dirname as dirname19, join as join19 } from "node:path";
+import { existsSync as existsSync26, mkdirSync as mkdirSync17, readFileSync as readFileSync17, renameSync as renameSync11, writeFileSync as writeFileSync17 } from "node:fs";
+import { dirname as dirname20, join as join20 } from "node:path";
 function path(dir) {
-  return join19(dir, TERMINALS_FILE);
+  return join20(dir, TERMINALS_FILE);
 }
 function ensureDir(dir) {
-  mkdirSync16(dirname19(path(dir)), { recursive: true });
+  mkdirSync17(dirname20(path(dir)), { recursive: true });
 }
 function loadTerminals(dir) {
   const file = path(dir);
   if (!existsSync26(file)) return [];
   try {
-    const body = readFileSync16(file, "utf-8");
+    const body = readFileSync17(file, "utf-8");
     const parsed = JSON.parse(body);
     if (!parsed.terminals || !Array.isArray(parsed.terminals)) return [];
     return parsed.terminals.filter((t) => isTerminal(t)).map((t) => ({ ...t }));
@@ -8184,8 +8629,8 @@ function writeAtomic(dir, terminals) {
   ensureDir(dir);
   const file = path(dir);
   const tmp = `${file}.tmp`;
-  writeFileSync16(tmp, JSON.stringify({ terminals }, null, 2) + "\n");
-  renameSync10(tmp, file);
+  writeFileSync17(tmp, JSON.stringify({ terminals }, null, 2) + "\n");
+  renameSync11(tmp, file);
 }
 function upsertTerminal(dir, input) {
   if (!SAFE_ID.test(input.id)) {
@@ -8246,8 +8691,8 @@ __export(auth_service_exports, {
   AuthService: () => AuthService
 });
 import * as crypto2 from "node:crypto";
-import { readFileSync as readFileSync17, existsSync as existsSync27 } from "node:fs";
-import { join as join20 } from "node:path";
+import { readFileSync as readFileSync18, existsSync as existsSync27 } from "node:fs";
+import { join as join21 } from "node:path";
 import { homedir as homedir16 } from "node:os";
 function base64url(buf) {
   const b = typeof buf === "string" ? Buffer.from(buf) : buf;
@@ -8391,9 +8836,9 @@ var init_auth_service = __esm({
       checkSSHKeyAuthorization(userId, publicKey) {
         try {
           const home = userId === process.env.USER ? homedir16() : `/home/${userId}`;
-          const authKeysPath = join20(home, ".ssh", "authorized_keys");
+          const authKeysPath = join21(home, ".ssh", "authorized_keys");
           if (!existsSync27(authKeysPath)) return false;
-          const authorizedKeys = readFileSync17(authKeysPath, "utf-8");
+          const authorizedKeys = readFileSync18(authKeysPath, "utf-8");
           const parts = publicKey.trim().split(" ");
           const keyData = parts.length > 1 ? parts[1] : parts[0];
           return authorizedKeys.includes(keyData);
@@ -8792,10 +9237,10 @@ var init_project_context = __esm({
 
 // packages/daemon/src/command-center/actions/handlers/config-actions.ts
 import { existsSync as existsSync28 } from "node:fs";
-import { join as join21 } from "node:path";
+import { join as join22 } from "node:path";
 function mutateConfigAction(input, deps2, fn) {
   const context = resolveProjectContext(input, deps2);
-  if (!existsSync28(join21(context.dir, "ide.yml"))) {
+  if (!existsSync28(join22(context.dir, "ide.yml"))) {
     throw new ActionError({
       code: "ide_yml_missing",
       message: "ide.yml was not found",
@@ -9219,7 +9664,7 @@ var init_inspect = __esm({
 // packages/daemon/src/lib/filesystem-browser.ts
 import { realpathSync, readdirSync as readdirSync3, statSync as statSync4 } from "node:fs";
 import { homedir as homedir17 } from "node:os";
-import { isAbsolute as isAbsolute3, join as join22, resolve as resolve19, sep } from "node:path";
+import { isAbsolute as isAbsolute3, join as join23, resolve as resolve19, sep } from "node:path";
 function isUnderRoot(canonical, root) {
   if (canonical === root) return true;
   const prefix = root.endsWith(sep) ? root : root + sep;
@@ -9301,7 +9746,7 @@ var init_project_inspect = __esm({
 // packages/daemon/src/lib/project-onboard.ts
 import yaml2 from "js-yaml";
 import { existsSync as existsSync30 } from "node:fs";
-import { join as join23 } from "node:path";
+import { join as join24 } from "node:path";
 function composeIdeYmlConfig(input) {
   if (!Number.isInteger(input.agents) || input.agents < 1 || input.agents > 3) {
     throw new OnboardInvalidInputError(
@@ -9360,7 +9805,7 @@ function composeIdeYmlConfig(input) {
   return config2;
 }
 function assertNoExistingIdeYml(dir, exists = existsSync30) {
-  const path2 = join23(dir, "ide.yml");
+  const path2 = join24(dir, "ide.yml");
   if (exists(path2)) {
     throw new OnboardConflictError(path2);
   }
@@ -9395,9 +9840,9 @@ __export(server_exports, {
 });
 import { execFile as execFile2 } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync as existsSync31, readFileSync as readFileSync18, readdirSync as readdirSync4 } from "node:fs";
-import { join as join24, dirname as dirname20, basename as basename8 } from "node:path";
-import { fileURLToPath as fileURLToPath8 } from "node:url";
+import { existsSync as existsSync31, readFileSync as readFileSync19, readdirSync as readdirSync4 } from "node:fs";
+import { join as join25, dirname as dirname21, basename as basename8 } from "node:path";
+import { fileURLToPath as fileURLToPath9 } from "node:url";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { cors } from "hono/cors";
@@ -9408,10 +9853,10 @@ import { isAbsolute as isAbsolute5, resolve as pathResolve } from "node:path";
 import { randomUUID as randomUUID3 } from "node:crypto";
 import { WebSocketServer } from "ws";
 function resolvePackageVersion() {
-  const candidates = [join24(__dirname5, "../../package.json"), join24(__dirname5, "../package.json")];
+  const candidates = [join25(__dirname5, "../../package.json"), join25(__dirname5, "../package.json")];
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(readFileSync18(candidate, "utf-8"));
+      const parsed = JSON.parse(readFileSync19(candidate, "utf-8"));
       if (typeof parsed.version === "string") return parsed.version;
     } catch {
     }
@@ -10250,9 +10695,9 @@ function createApp(options = {}) {
   return app;
 }
 function listAvailableTemplates() {
-  const __filename = fileURLToPath8(import.meta.url);
-  const __dir = dirname20(__filename);
-  const templatesDir = join24(__dir, "..", "..", "..", "..", "templates");
+  const __filename = fileURLToPath9(import.meta.url);
+  const __dir = dirname21(__filename);
+  const templatesDir = join25(__dir, "..", "..", "..", "..", "templates");
   if (!existsSync31(templatesDir)) return [];
   const labels = {
     default: { label: "Default", description: "Single Claude pane + dev/shell row" },
@@ -10342,7 +10787,7 @@ var init_server = __esm({
     init_filesystem_browser();
     init_project_inspect();
     init_project_onboard();
-    __dirname5 = dirname20(fileURLToPath8(import.meta.url));
+    __dirname5 = dirname21(fileURLToPath9(import.meta.url));
     pkgVersion = resolvePackageVersion();
     projectStreamConnections = 0;
     sseMetrics = {
@@ -12185,7 +12630,21 @@ var init_agent_lifecycle = __esm({
       copilot: "copilot",
       cursor: "cursor-agent",
       goose: "goose",
-      amp: "amp"
+      amp: "amp",
+      // M25.4 breadth — real installable CLIs only (spawn-picker honesty), each
+      // verified against an installer/package: devin (curl cli.devin.ai), kimi
+      // (curl code.kimi.com), pi (npm @mariozechner/pi-coding-agent), grok (npm
+      // @vibe-kit/grok-cli), kiro (curl cli.kiro.dev → kiro-cli), cline (npm
+      // cline), droid (verified live — Factory CLI, own process), kilo (npm
+      // @kilocode/cli; the manifest matches its ".kilo" platform binary too).
+      devin: "devin",
+      kimi: "kimi",
+      pi: "pi",
+      grok: "grok",
+      kiro: "kiro-cli",
+      cline: "cline",
+      droid: "droid",
+      kilo: "kilo"
     };
     PRINT_PANE_ID = ["-P", "-F", "#{pane_id}"];
     EXTRA_SHELLS = ["dash", "ksh", "tcsh", "csh"];
@@ -12370,11 +12829,11 @@ __export(server_exports2, {
   defaultControlSocketPath: () => defaultControlSocketPath,
   startControlServer: () => startControlServer
 });
-import { chmodSync as chmodSync4, existsSync as existsSync32, mkdirSync as mkdirSync17, statSync as statSync5, unlinkSync } from "node:fs";
+import { chmodSync as chmodSync4, existsSync as existsSync32, mkdirSync as mkdirSync18, statSync as statSync5, unlinkSync } from "node:fs";
 import { createServer as createServer2, connect } from "node:net";
-import { dirname as dirname21, join as join25 } from "node:path";
+import { dirname as dirname22, join as join26 } from "node:path";
 function defaultControlSocketPath() {
-  return join25(tuiStateHome(), "control.sock");
+  return join26(tuiStateHome(), "control.sock");
 }
 async function claimSocketPath(path2) {
   if (!existsSync32(path2)) return;
@@ -12407,7 +12866,7 @@ async function startControlServer(opts = {}) {
   const log = opts.log ?? (() => {
   });
   const tickMs = opts.tickMs ?? TICK_MS;
-  mkdirSync17(dirname21(socketPath), { recursive: true });
+  mkdirSync18(dirname22(socketPath), { recursive: true });
   await claimSocketPath(socketPath);
   const tracker = createStatusTracker();
   const handlers = createVerbHandlers({ tracker });
@@ -12641,7 +13100,7 @@ __export(worktree_exports, {
   worktreeSessionName: () => worktreeSessionName
 });
 import { execFileSync as execFileSync13 } from "node:child_process";
-import { basename as basename9, dirname as dirname22, isAbsolute as isAbsolute6, join as join26, resolve as resolve22 } from "node:path";
+import { basename as basename9, dirname as dirname23, isAbsolute as isAbsolute6, join as join27, resolve as resolve22 } from "node:path";
 function sanitizeForTmux(part) {
   return part.replace(/[.:/\s]+/g, "-");
 }
@@ -12650,11 +13109,11 @@ function worktreeSessionName(project, branch) {
 }
 function defaultWorktreeBaseDir(repoDir) {
   const abs = resolve22(repoDir);
-  return join26(dirname22(abs), `${basename9(abs)}-worktrees`);
+  return join27(dirname23(abs), `${basename9(abs)}-worktrees`);
 }
 function worktreePath(repoDir, branch, configuredDir) {
   const base = configuredDir && configuredDir.length > 0 ? isAbsolute6(configuredDir) ? configuredDir : resolve22(repoDir, configuredDir) : defaultWorktreeBaseDir(repoDir);
-  return join26(base, branch);
+  return join27(base, branch);
 }
 function parseWorktreeList(porcelain) {
   const entries = [];
@@ -12799,7 +13258,7 @@ __export(update_exports, {
 });
 import { execSync as execSync4 } from "node:child_process";
 import { existsSync as existsSync33 } from "node:fs";
-import { dirname as dirname23, join as join27 } from "node:path";
+import { dirname as dirname24, join as join28 } from "node:path";
 function detectPackageManager(cliPath) {
   const p = cliPath.toLowerCase();
   if (/(^|\/)\.?bun(\/|$)/.test(p)) return "bun";
@@ -12845,8 +13304,8 @@ function renderPlan(plan, { current, latest, dryRun }) {
 function findGitCheckoutRoot(startDir) {
   let dir = startDir;
   for (; ; ) {
-    if (existsSync33(join27(dir, ".git"))) return dir;
-    const parent = dirname23(dir);
+    if (existsSync33(join28(dir, ".git"))) return dir;
+    const parent = dirname24(dir);
     if (parent === dir) return null;
     dir = parent;
   }
@@ -12978,10 +13437,10 @@ var init_server3 = __esm({
 // bin/cli.ts
 init_launch();
 import { parseArgs } from "node:util";
-import { resolve as resolve23, dirname as dirname24, join as join28 } from "node:path";
+import { resolve as resolve23, dirname as dirname25, join as join29 } from "node:path";
 import { execFileSync as execFileSync14 } from "node:child_process";
 import { existsSync as existsSync34 } from "node:fs";
-import { fileURLToPath as fileURLToPath9 } from "node:url";
+import { fileURLToPath as fileURLToPath10 } from "node:url";
 
 // packages/daemon/src/tui/team/entry.ts
 function resolveEntry(opts) {
@@ -12999,47 +13458,47 @@ init_detect();
 init_output();
 import {
   existsSync as existsSync18,
-  readFileSync as readFileSync12,
-  writeFileSync as writeFileSync11,
-  renameSync as renameSync7,
-  mkdirSync as mkdirSync11,
+  readFileSync as readFileSync13,
+  writeFileSync as writeFileSync12,
+  renameSync as renameSync8,
+  mkdirSync as mkdirSync12,
   readdirSync as readdirSync2,
   copyFileSync as copyFileSync2
 } from "node:fs";
-import { resolve as resolve11, join as join13, basename as basename5, dirname as dirname13 } from "node:path";
-import { fileURLToPath as fileURLToPath5 } from "node:url";
-var __dirname4 = dirname13(fileURLToPath5(import.meta.url));
+import { resolve as resolve11, join as join14, basename as basename5, dirname as dirname14 } from "node:path";
+import { fileURLToPath as fileURLToPath6 } from "node:url";
+var __dirname4 = dirname14(fileURLToPath6(import.meta.url));
 function copyTemplateSkills(targetDir) {
   const created = [];
   const templateSkillsDir = resolve11(__dirname4, "..", "..", "..", "templates", "skills");
   if (!existsSync18(templateSkillsDir)) return created;
-  mkdirSync11(targetDir, { recursive: true });
+  mkdirSync12(targetDir, { recursive: true });
   for (const file of readdirSync2(templateSkillsDir)) {
     if (!file.endsWith(".md")) continue;
-    const destination = join13(targetDir, file);
-    copyFileSync2(join13(templateSkillsDir, file), destination);
+    const destination = join14(targetDir, file);
+    copyFileSync2(join14(templateSkillsDir, file), destination);
     created.push(destination);
   }
   return created;
 }
 function scaffoldLibraryStubs(dir) {
   const created = [];
-  const libraryDir = join13(dir, ".tmux-ide", "library");
+  const libraryDir = join14(dir, ".tmux-ide", "library");
   if (!existsSync18(libraryDir)) {
-    mkdirSync11(libraryDir, { recursive: true });
+    mkdirSync12(libraryDir, { recursive: true });
     created.push(libraryDir);
   }
-  const archPath = join13(libraryDir, "architecture.md");
+  const archPath = join14(libraryDir, "architecture.md");
   if (!existsSync18(archPath)) {
-    writeFileSync11(
+    writeFileSync12(
       archPath,
       "# Architecture\n\n<!-- Describe your project's architecture here. This context is injected into agent dispatch prompts. -->\n"
     );
     created.push(archPath);
   }
-  const learningsPath = join13(libraryDir, "learnings.md");
+  const learningsPath = join14(libraryDir, "learnings.md");
   if (!existsSync18(learningsPath)) {
-    writeFileSync11(
+    writeFileSync12(
       learningsPath,
       "# Learnings\n\n<!-- Task summaries are automatically appended here by the orchestrator. -->\n"
     );
@@ -13049,13 +13508,13 @@ function scaffoldLibraryStubs(dir) {
 }
 function scaffoldValidationContract(dir) {
   const created = [];
-  const tasksDir = join13(dir, ".tasks");
+  const tasksDir = join14(dir, ".tasks");
   if (!existsSync18(tasksDir)) {
-    mkdirSync11(tasksDir, { recursive: true });
+    mkdirSync12(tasksDir, { recursive: true });
   }
-  const contractPath = join13(tasksDir, "validation-contract.md");
+  const contractPath = join14(tasksDir, "validation-contract.md");
   if (!existsSync18(contractPath)) {
-    writeFileSync11(
+    writeFileSync12(
       contractPath,
       "# Validation Contract\n\n<!-- Define assertions that the validator agent will verify. Example: -->\n<!-- - VAL-001: All tests pass -->\n<!-- - VAL-002: No TypeScript errors -->\n<!-- - VAL-003: Lint passes with zero warnings -->\n"
     );
@@ -13067,10 +13526,10 @@ function scaffoldAgentsMd(dir, name) {
   const created = [];
   const agentsTemplatePath = resolve11(__dirname4, "..", "..", "..", "templates", "AGENTS.md");
   if (existsSync18(agentsTemplatePath)) {
-    const agentsPath = join13(dir, "AGENTS.md");
+    const agentsPath = join14(dir, "AGENTS.md");
     if (!existsSync18(agentsPath)) {
-      const content = readFileSync12(agentsTemplatePath, "utf-8").replace(/{{name}}/g, name);
-      writeFileSync11(agentsPath, content);
+      const content = readFileSync13(agentsTemplatePath, "utf-8").replace(/{{name}}/g, name);
+      writeFileSync12(agentsPath, content);
       created.push(agentsPath);
     }
   }
@@ -13088,7 +13547,7 @@ function scaffoldTeamWorkspace(dir, name) {
 }
 function scaffoldMissionsWorkspace(dir, name) {
   const created = [];
-  const skillsDir = join13(dir, ".tmux-ide", "skills");
+  const skillsDir = join14(dir, ".tmux-ide", "skills");
   created.push(...copyTemplateSkills(skillsDir));
   created.push(...scaffoldTeamWorkspace(dir, name));
   return created;
@@ -13107,22 +13566,22 @@ async function init({
     if (!existsSync18(templatePath)) {
       outputError(`Template "${template}" not found`, "NOT_FOUND");
     }
-    let content = readFileSync12(templatePath, "utf-8");
+    let content = readFileSync13(templatePath, "utf-8");
     const name2 = basename5(dir);
     content = content.replace(/^name: .+/m, `name: ${name2}`);
     const tmpPath = configPath + ".tmp";
-    writeFileSync11(tmpPath, content);
-    renameSync7(tmpPath, configPath);
+    writeFileSync12(tmpPath, content);
+    renameSync8(tmpPath, configPath);
     let created;
     if (template === "missions") {
       created = scaffoldMissionsWorkspace(dir, name2);
     } else if (isTeamTemplate(template)) {
       created = [
-        ...copyTemplateSkills(join13(dir, ".tmux-ide", "skills")),
+        ...copyTemplateSkills(join14(dir, ".tmux-ide", "skills")),
         ...scaffoldTeamWorkspace(dir, name2)
       ];
     } else {
-      created = copyTemplateSkills(join13(dir, ".tmux-ide", "skills"));
+      created = copyTemplateSkills(join14(dir, ".tmux-ide", "skills"));
     }
     if (json2) {
       console.log(JSON.stringify({ created: true, template, name: name2, paths: created }));
@@ -13142,8 +13601,8 @@ async function init({
     const config2 = suggestConfig(dir, detected);
     const yaml3 = (await import("js-yaml")).default;
     const tmpPath2 = configPath + ".tmp";
-    writeFileSync11(tmpPath2, yaml3.dump(config2, { lineWidth: -1, noRefs: true, quotingType: '"' }));
-    renameSync7(tmpPath2, configPath);
+    writeFileSync12(tmpPath2, yaml3.dump(config2, { lineWidth: -1, noRefs: true, quotingType: '"' }));
+    renameSync8(tmpPath2, configPath);
     const desc = detected.frameworks.join(" + ");
     if (json2) {
       console.log(JSON.stringify({ created: true, detected: detected.frameworks, name }));
@@ -13154,11 +13613,11 @@ async function init({
     }
   } else {
     const templatePath = resolve11(__dirname4, "..", "..", "..", "templates", "default.yml");
-    let content = readFileSync12(templatePath, "utf-8");
+    let content = readFileSync13(templatePath, "utf-8");
     content = content.replace(/^name: .+/m, `name: ${name}`);
     const tmpPath3 = configPath + ".tmp";
-    writeFileSync11(tmpPath3, content);
-    renameSync7(tmpPath3, configPath);
+    writeFileSync12(tmpPath3, content);
+    renameSync8(tmpPath3, configPath);
     if (json2) {
       console.log(JSON.stringify({ created: true, template: "default", name }));
     } else {
@@ -13168,7 +13627,7 @@ async function init({
       console.log("Edit it to configure your workspace, then run: tmux-ide");
     }
   }
-  const skillsDir = join13(dir, ".tmux-ide", "skills");
+  const skillsDir = join14(dir, ".tmux-ide", "skills");
   if (!existsSync18(skillsDir)) {
     const created = copyTemplateSkills(skillsDir);
     if (created.length > 0 && !json2) {
@@ -13259,8 +13718,8 @@ init_compiled();
 init_claude();
 import { execSync as execSync3 } from "node:child_process";
 import { accessSync, constants, existsSync as existsSync20 } from "node:fs";
-import { resolve as resolve14, dirname as dirname15 } from "node:path";
-import { fileURLToPath as fileURLToPath7 } from "node:url";
+import { resolve as resolve14, dirname as dirname16 } from "node:path";
+import { fileURLToPath as fileURLToPath8 } from "node:url";
 function agentIntegrationRows(agents) {
   return presentAgents(agents).map((agent) => {
     const label = `agent: ${agent.id}`;
@@ -13360,7 +13819,7 @@ async function doctor({
     check(
       "TUI surfaces (cockpit / widgets)",
       () => {
-        const here = dirname15(fileURLToPath7(import.meta.url));
+        const here = dirname16(fileURLToPath8(import.meta.url));
         const checkoutEntry = [
           resolve14(here, "../packages/daemon/src/tui/team/index.tsx"),
           resolve14(here, "tui/team/index.tsx")
@@ -13405,9 +13864,9 @@ async function doctor({
     (() => {
       const settingsPath = claudeSettingsPath();
       const fileExists2 = existsSync20(settingsPath);
-      let probe = fileExists2 ? settingsPath : dirname15(settingsPath);
+      let probe = fileExists2 ? settingsPath : dirname16(settingsPath);
       while (!existsSync20(probe)) {
-        const parent = dirname15(probe);
+        const parent = dirname16(probe);
         if (parent === probe) break;
         probe = parent;
       }
@@ -13978,8 +14437,8 @@ function hostAttachArgv(insideTmux) {
 }
 
 // bin/cli.ts
-var __dirname6 = dirname24(fileURLToPath9(import.meta.url));
-var selfPath = fileURLToPath9(import.meta.url);
+var __dirname6 = dirname25(fileURLToPath10(import.meta.url));
+var selfPath = fileURLToPath10(import.meta.url);
 var nodeCliPath = selfPath.endsWith(".js") ? selfPath : resolve23(__dirname6, "cli.js");
 var { positionals, values } = parseArgs({
   allowPositionals: true,
@@ -14152,6 +14611,7 @@ ${bold3("Usage:")}
   ${cyan2("tmux-ide inspect")} [--json]   ${dim3("Show effective config and runtime state")}
   ${cyan2("tmux-ide doctor")}             ${dim3("Check system requirements")}
   ${cyan2("tmux-ide update")} [--dry-run] ${dim3("Update tmux-ide (detects dev checkout vs npm/pnpm/bun global)")}
+  ${cyan2("tmux-ide update --manifests")} ${dim3("Fetch the latest agent-detection manifest pack (your overrides still win)")}
   ${cyan2("tmux-ide skill-sync")}         ${dim3("Refresh the bundled Claude Code skill in ~/.claude/skills/tmux-ide")}
   ${cyan2("tmux-ide validate")} [--json]  ${dim3("Validate ide.yml")}
   ${cyan2("tmux-ide detect")} [--json]    ${dim3("Detect project stack")}
@@ -14325,7 +14785,7 @@ try {
         }
       }
       const targetDir = resolve23(startTargetDir || ".");
-      const hasIdeYml = existsSync34(join28(targetDir, "ide.yml"));
+      const hasIdeYml = existsSync34(join29(targetDir, "ide.yml"));
       const entry = resolveEntry({
         hasIdeYml,
         teamFlag: values.team === true,
@@ -14437,8 +14897,8 @@ try {
       const messageStart = values.to ? 1 : 2;
       let message = positionals.slice(messageStart).join(" ");
       if (!message && !process.stdin.isTTY) {
-        const { readFileSync: readFileSync19 } = await import("node:fs");
-        message = readFileSync19(0, "utf-8").trim();
+        const { readFileSync: readFileSync20 } = await import("node:fs");
+        message = readFileSync20(0, "utf-8").trim();
       }
       await send(null, { json, to: target, message, noEnter: values["no-enter"] });
       break;
@@ -14570,7 +15030,7 @@ try {
       break;
     }
     case "events": {
-      const { readFileSync: readFileSync19, existsSync: existsSync35, statSync: statSync6, openSync, readSync, closeSync } = await import("node:fs");
+      const { readFileSync: readFileSync20, existsSync: existsSync35, statSync: statSync6, openSync, readSync, closeSync } = await import("node:fs");
       const { eventsPath: eventsPath2, formatEventLine: formatEventLine2 } = await Promise.resolve().then(() => (init_events(), events_exports));
       const path2 = eventsPath2();
       const paintStatus = (status2, text) => {
@@ -14596,7 +15056,7 @@ try {
         }).catch(() => null);
         if (client) {
           if (existsSync35(path2)) {
-            const backlog = readFileSync19(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
+            const backlog = readFileSync20(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
             for (const line of backlog.slice(-50)) printLine(line);
           }
           await client.subscribe((frame) => {
@@ -14614,7 +15074,7 @@ try {
         console.log("no events yet \u2014 is a session adopted? (the chrome updater writes events)");
         break;
       }
-      const allLines = readFileSync19(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
+      const allLines = readFileSync20(path2, "utf8").split("\n").filter((l) => l.trim().length > 0);
       for (const line of allLines.slice(-50)) printLine(line);
       if (!values.follow) break;
       let offset = statSync6(path2).size;
@@ -15021,7 +15481,7 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
       const mainPath = worktrees[0]?.path ?? repoDir;
       const projectName = getSessionName2(mainPath).name;
       async function openWorktreeSession(wtPath, name) {
-        if (existsSync34(join28(wtPath, "ide.yml"))) {
+        if (existsSync34(join29(wtPath, "ide.yml"))) {
           await launch(wtPath, { attach: false, sessionName: name });
         } else {
           if (!hasSession2(name)) createDetachedSession2(name, wtPath);
@@ -15158,6 +15618,28 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
       break;
     }
     case "update": {
+      if (values["manifests"] === true) {
+        const { updateManifestPack: updateManifestPack2 } = await Promise.resolve().then(() => (init_manifest_pack(), manifest_pack_exports));
+        try {
+          const r = await updateManifestPack2({ log: (m) => console.error(m) });
+          if (json) {
+            console.log(JSON.stringify({ ok: true, ...r }, null, 2));
+          } else {
+            console.log(
+              `manifest pack ${r.packVersion} installed (${r.count} manifests): ${r.path}`
+            );
+            console.log(
+              "your own agent-detection/*.json overrides still win \u2014 the pack merges beneath them"
+            );
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (json) console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+          else console.error(`manifest pack NOT installed: ${message}`);
+          process.exitCode = 1;
+        }
+        break;
+      }
       if (values["tui-binary"] === true) {
         const { downloadTuiBinary: downloadTuiBinary2 } = await Promise.resolve().then(() => (init_tui_binary(), tui_binary_exports));
         const { path: path2 } = await downloadTuiBinary2({ log: (m) => console.error(m) });

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -976,17 +976,35 @@ try {
     case "integration": {
       const sub = positionals[1];
       const agent = positionals[2];
-      // `status` and `offer` need no agent arg; install/uninstall are claude-only.
-      const needsClaude = sub === "install" || sub === "uninstall";
-      if (!sub || (needsClaude && agent !== "claude")) {
+      // `status` and `offer` need no agent arg; install/uninstall take a kind
+      // we ship an integration for (claude hooks, opencode plugin).
+      const needsAgent = sub === "install" || sub === "uninstall";
+      const installable = agent === "claude" || agent === "opencode";
+      if (!sub || (needsAgent && !installable)) {
         console.error(
-          "Usage: tmux-ide integration <install|uninstall|status|offer> [claude]\n" +
-            "  install    hook Claude Code lifecycle events into tmux pane state\n" +
-            "  uninstall  remove exactly the tmux-ide hook entries\n" +
-            "  status     list discovered agents + integration state\n" +
+          "Usage: tmux-ide integration <install|uninstall|status|offer> [claude|opencode]\n" +
+            "  install    claude: hook lifecycle events into tmux pane state\n" +
+            "             opencode: plugin that records the session id for restore --resume-agents\n" +
+            "  uninstall  remove exactly the tmux-ide entries for that agent\n" +
+            "  status     list discovered agents + integration/capture state\n" +
             "  offer      one-time first-adopt install prompt (used by the popup)",
         );
         process.exit(1);
+      }
+      if (needsAgent && agent === "opencode") {
+        const oc = await import("../packages/daemon/src/tui/integrations/opencode.ts");
+        if (sub === "install") {
+          const { pluginPath } = oc.installOpencodeIntegration();
+          console.log(`plugin: ${pluginPath}`);
+          console.log(
+            "installed — NEW opencode sessions record their session id into the pane\n" +
+              "(@agent_session_id), so `tmux-ide restore --resume-agents` can revive them.",
+          );
+        } else {
+          const { wasInstalled } = oc.uninstallOpencodeIntegration();
+          console.log(wasInstalled ? "uninstalled — plugin removed" : "was not installed");
+        }
+        break;
       }
       const mod = await import("../packages/daemon/src/tui/integrations/claude.ts");
       if (sub === "install") {
@@ -1068,7 +1086,18 @@ try {
           else if (a.integration)
             state = a.installed ? "integration installed ✓" : "on PATH — integration not installed";
           else state = "detected (no integration)";
-          console.log(`  ${a.id.padEnd(10)} ${state}`);
+          // The resume-key story: how @agent_session_id (what `restore
+          // --resume-agents` revives from) gets captured for this kind.
+          let capture = "";
+          if (a.path !== null) {
+            if (a.capture === "probe") capture = " · session-id capture: automatic";
+            else if (a.capture !== null)
+              capture = a.captureActive
+                ? ` · session-id capture: ${a.capture} ✓`
+                : ` · session-id capture: ${a.capture} (install to enable)`;
+            else capture = " · session-id capture: none";
+          }
+          console.log(`  ${a.id.padEnd(10)} ${state}${capture}`);
         }
       }
       break;

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1003,6 +1003,57 @@ try {
           "installed — NEW Claude Code sessions now report working/blocked/done " +
             "authoritatively into the tmux-ide chrome.",
         );
+        // M25.1: this is the moment the user is wiring notifications, so offer
+        // the macOS banner channel here — one plain y/N key, same shape as the
+        // first-adopt offer. Skipped when already on, off-macOS, or when there
+        // is no TTY to ask (TMUX_IDE_NOTIFY_KEY forces an answer for tests).
+        const { getAppConfig, updateAppConfig } =
+          await import("../packages/daemon/src/lib/app-config.ts");
+        const { hasTerminalNotifier } = await import("../packages/daemon/src/tui/chrome/notify.ts");
+        const forcedKey = process.env.TMUX_IDE_NOTIFY_KEY;
+        const canAsk = forcedKey !== undefined || process.stdin.isTTY === true;
+        if (process.platform === "darwin" && !getAppConfig().notifications.macos && canAsk) {
+          const act = (key: string): void => {
+            if (key === "y" || key === "Y") {
+              updateAppConfig({ notifications: { macos: true } });
+              console.log(
+                "macOS notifications on — you'll get a banner when an agent blocks or finishes.",
+              );
+              if (!hasTerminalNotifier()) {
+                console.log(
+                  "tip: `brew install terminal-notifier` makes those banners clickable (a click jumps to the session).",
+                );
+              }
+            } else {
+              console.log(
+                "skipped — turn banners on anytime: notifications.macos in ~/.tmux-ide/config.json.",
+              );
+            }
+          };
+          process.stdout.write("\nAlso get a macOS notification when an agent needs you? [y/N] ");
+          if (forcedKey !== undefined) {
+            console.log(forcedKey);
+            act(forcedKey);
+          } else {
+            const key = await new Promise<string>((resolve) => {
+              try {
+                process.stdin.setRawMode?.(true);
+                process.stdin.resume();
+                process.stdin.once("data", (data) => resolve(data.toString()));
+              } catch {
+                resolve(""); // no readable stdin — treat as "no"
+              }
+            });
+            try {
+              process.stdin.setRawMode?.(false);
+              process.stdin.pause();
+            } catch {
+              // best-effort terminal restore
+            }
+            console.log(/^[ -~]$/.test(key) ? key : "");
+            act(key);
+          }
+        }
       } else if (sub === "uninstall") {
         const { wasInstalled } = mod.uninstallClaudeIntegration();
         console.log(wasInstalled ? "uninstalled — hook entries removed" : "was not installed");

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -230,6 +230,7 @@ ${bold("Usage:")}
   ${cyan("tmux-ide inspect")} [--json]   ${dim("Show effective config and runtime state")}
   ${cyan("tmux-ide doctor")}             ${dim("Check system requirements")}
   ${cyan("tmux-ide update")} [--dry-run] ${dim("Update tmux-ide (detects dev checkout vs npm/pnpm/bun global)")}
+  ${cyan("tmux-ide update --manifests")} ${dim("Fetch the latest agent-detection manifest pack (your overrides still win)")}
   ${cyan("tmux-ide skill-sync")}         ${dim("Refresh the bundled Claude Code skill in ~/.claude/skills/tmux-ide")}
   ${cyan("tmux-ide validate")} [--json]  ${dim("Validate ide.yml")}
   ${cyan("tmux-ide detect")} [--json]    ${dim("Detect project stack")}
@@ -1545,6 +1546,32 @@ try {
     }
 
     case "update": {
+      // `--manifests`: fetch the agent-detection manifest pack (versioned JSON,
+      // a GitHub release asset) into ~/.tmux-ide/agent-detection/pack/ — the
+      // loader hot-merges it under bundled<pack<user precedence. Schema-invalid
+      // packs are rejected loudly. See lib/manifest-pack.ts for the format.
+      if (values["manifests"] === true) {
+        const { updateManifestPack } = await import("../packages/daemon/src/lib/manifest-pack.ts");
+        try {
+          const r = await updateManifestPack({ log: (m) => console.error(m) });
+          if (json) {
+            console.log(JSON.stringify({ ok: true, ...r }, null, 2));
+          } else {
+            console.log(
+              `manifest pack ${r.packVersion} installed (${r.count} manifests): ${r.path}`,
+            );
+            console.log(
+              "your own agent-detection/*.json overrides still win — the pack merges beneath them",
+            );
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (json) console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+          else console.error(`manifest pack NOT installed: ${message}`);
+          process.exitCode = 1;
+        }
+        break;
+      }
       // `--tui-binary`: download the per-platform TUI binary (the fallback that
       // lets an npm install with no bun run the full cockpit). Explicit opt-in —
       // never auto-fetched on install (it's ~70MB). See lib/tui-binary.ts.

--- a/docs/content/docs/restore-resume.mdx
+++ b/docs/content/docs/restore-resume.mdx
@@ -1,6 +1,6 @@
 ---
 title: Restore & Resume
-description: Rebuild your whole fleet after a tmux server death — sessions, windows, layouts, cwds, titles, and Claude conversations
+description: Rebuild your whole fleet after a tmux server death — sessions, windows, layouts, cwds, titles, and agent conversations
 ---
 
 # Restore & resume
@@ -44,13 +44,12 @@ tmux-ide restore --dry-run
 tmux-ide restore --dry-run --json
 ```
 
-## Resume Claude conversations
+## Resume agent conversations
 
 The strongest form of recovery brings the **conversations** back, not just the
-panes. When the Claude Code integration is installed, each agent pane carries a
-recorded `@agent_session_id`. With `--resume-agents`, a rebuilt Claude pane that
-has one relaunches as `claude --resume <id>` — reviving the actual conversation
-instead of opening a fresh shell.
+panes. An agent pane that carries a recorded `@agent_session_id` relaunches,
+under `--resume-agents`, with its kind's native resume invocation — reviving
+the actual conversation instead of opening a fresh shell.
 
 ```bash
 tmux-ide restore --resume-agents
@@ -65,6 +64,38 @@ You can make this the default in `~/.tmux-ide/config.json`:
   }
 }
 ```
+
+### Support per agent
+
+Two things have to be true for a pane to resume: tmux-ide must know the kind's
+**resume invocation**, and the pane's **session id** must have been captured
+while the agent ran. Honest status of both:
+
+| Agent                     | Resume invocation            | Session-id capture                                                           |
+| ------------------------- | ---------------------------- | ---------------------------------------------------------------------------- |
+| Claude Code               | `claude --resume <id>`       | automatic once `tmux-ide integration install claude` is set up (hooks)       |
+| Codex CLI                 | `codex resume <id>`          | **automatic** — the updater reads the session's own rollout file             |
+| Cursor CLI                | `cursor-agent --resume <id>` | **automatic** — the updater reads the CLI's chat store                       |
+| opencode                  | `opencode --session <id>`    | automatic once `tmux-ide integration install opencode` is set up (plugin)    |
+| Copilot CLI               | `copilot --resume=<id>`      | not automatic (no stable capture surface yet) — self-report works, see below |
+| gemini, aider, goose, amp | —                            | no verified native resume invocation                                         |
+
+Check what's active on your machine:
+
+```bash
+tmux-ide integration status
+```
+
+Any agent not listed can still join: the agent contract is open. An agent that
+writes its own id resumes like the rest (given a known invocation for its kind):
+
+```bash
+tmux set-option -p @agent_session_id <its-session-id>
+```
+
+Capture never overwrites: an id stamped by an integration (or by the agent
+itself) is left alone. Codex/Cursor capture runs inside the chrome updater, so
+it is active whenever any session is adopted.
 
 ## Snapshot cadence
 

--- a/packages/daemon/src/doctor.test.ts
+++ b/packages/daemon/src/doctor.test.ts
@@ -12,6 +12,8 @@ const agent = (over: Partial<DiscoveredAgent>): DiscoveredAgent => ({
   integration: false,
   path: "/usr/bin/x",
   installed: false,
+  capture: null,
+  captureActive: false,
   ...over,
 });
 

--- a/packages/daemon/src/doctor.test.ts
+++ b/packages/daemon/src/doctor.test.ts
@@ -94,3 +94,22 @@ describe("hooksTargetRow", () => {
     }
   });
 });
+
+describe("notifierRow", () => {
+  it("passes when terminal-notifier is present", async () => {
+    const { notifierRow } = await import("./doctor.ts");
+    const row = notifierRow(true);
+    expect(row.pass).toBe(true);
+    expect(row.optional).toBe(true);
+    expect(row.detail).toContain("jumps to the session");
+  });
+
+  it("hints plainly (brew install) when banners are on but the helper is absent", async () => {
+    const { notifierRow } = await import("./doctor.ts");
+    const row = notifierRow(false);
+    expect(row.pass).toBe(false);
+    expect(row.optional).toBe(true); // informational — never fails doctor
+    expect(row.detail).toContain("brew install terminal-notifier");
+    expect(row.detail).toContain("without click-to-jump");
+  });
+});

--- a/packages/daemon/src/doctor.ts
+++ b/packages/daemon/src/doctor.ts
@@ -28,12 +28,19 @@ export function agentIntegrationRows(agents: DiscoveredAgent[]): CheckResult[] {
   return presentAgents(agents).map((agent) => {
     const label = `agent: ${agent.id}`;
     if (agent.integration) {
+      // What installing actually buys, honestly per mechanism: claude's hooks
+      // give ground-truth status (and record resume ids); opencode's plugin
+      // records resume ids only.
+      const benefit =
+        agent.capture === "hooks"
+          ? "for ground-truth status"
+          : "to record session ids for restore --resume-agents";
       return agent.installed
         ? { label, pass: true, detail: "integration installed ✓", optional: true }
         : {
             label,
             pass: false,
-            detail: `found on PATH — run \`tmux-ide integration install ${agent.id}\` for ground-truth status`,
+            detail: `found on PATH — run \`tmux-ide integration install ${agent.id}\` ${benefit}`,
             optional: true,
           };
     }

--- a/packages/daemon/src/doctor.ts
+++ b/packages/daemon/src/doctor.ts
@@ -7,6 +7,7 @@ import { installedSkillVersion } from "./lib/skill-sync.ts";
 import { discoverAgents, presentAgents, type DiscoveredAgent } from "./lib/agent-discovery.ts";
 import { findCompiledTui, isBunAvailable } from "./tui/compiled.ts";
 import { claudeSettingsPath } from "./tui/integrations/claude.ts";
+import { hasTerminalNotifier, readNotificationPrefs } from "./tui/chrome/notify.ts";
 
 interface CheckResult {
   label: string;
@@ -70,6 +71,31 @@ export function hooksTargetRow(facts: {
     label,
     pass: false,
     detail: `cannot write ${facts.settingsPath} — fix its permissions (chown/chmod), or point TMUX_IDE_CLAUDE_SETTINGS at a writable path`,
+    optional: true,
+  };
+}
+
+/**
+ * PURE — the "banner clicks can jump" row, shown only when macOS notifications
+ * are actually ON (`notifications.macos`): without `terminal-notifier`,
+ * banners fall back to osascript, which shows fine but a click does nothing.
+ * Optional — informational, never fails doctor.
+ */
+export function notifierRow(present: boolean): CheckResult {
+  const label = "notification click-to-jump (terminal-notifier)";
+  if (present) {
+    return {
+      label,
+      pass: true,
+      detail: "found — clicking a banner jumps to the session that needs you",
+      optional: true,
+    };
+  }
+  return {
+    label,
+    pass: false,
+    detail:
+      "macOS notifications are on, but terminal-notifier isn't installed — banners will still show, just without click-to-jump. Install it: `brew install terminal-notifier`",
     optional: true,
   };
 }
@@ -268,6 +294,12 @@ export async function doctor({
       { optional: true },
     ),
   );
+
+  // Banner click-to-jump: only when the macOS channel is actually on (a user
+  // who never enabled banners shouldn't be told to install its helper).
+  if (process.platform === "darwin" && readNotificationPrefs().macos) {
+    checks.push(notifierRow(hasTerminalNotifier()));
+  }
 
   // Agent integrations: one row per agent discovered on PATH (absent → no row).
   checks.push(...agentIntegrationRows(discoverAgents()));

--- a/packages/daemon/src/lib/__tests__/agent-discovery.test.ts
+++ b/packages/daemon/src/lib/__tests__/agent-discovery.test.ts
@@ -12,23 +12,42 @@ import {
 } from "../agent-discovery.ts";
 
 describe("KNOWN_AGENTS", () => {
-  it("lists claude as the only integrated agent, with stable ids/bins", () => {
+  it("ships installers for exactly claude (hooks) and opencode (plugin)", () => {
     const claude = KNOWN_AGENTS.find((a) => a.id === "claude");
-    expect(claude).toEqual({ id: "claude", bin: "claude", integration: true });
-    // exactly one integration installer today
-    expect(KNOWN_AGENTS.filter((a) => a.integration).map((a) => a.id)).toEqual(["claude"]);
-    // the rest are detection-only
+    expect(claude).toEqual({ id: "claude", bin: "claude", integration: true, capture: "hooks" });
+    expect(KNOWN_AGENTS.filter((a) => a.integration).map((a) => a.id)).toEqual([
+      "claude",
+      "opencode",
+    ]);
     expect(KNOWN_AGENTS.map((a) => a.id)).toEqual([
       "claude",
       "codex",
       "opencode",
       "gemini",
       "aider",
+      "cursor",
+      "copilot",
     ]);
   });
 
-  it("uses the id as the probed binary for every agent", () => {
-    for (const a of KNOWN_AGENTS) expect(a.bin).toBe(a.id);
+  it("uses the id as the probed binary except cursor (binary: cursor-agent)", () => {
+    for (const a of KNOWN_AGENTS) {
+      if (a.id === "cursor") expect(a.bin).toBe("cursor-agent");
+      else expect(a.bin).toBe(a.id);
+    }
+  });
+
+  it("records the session-id capture story per kind (matching the shipped probes)", () => {
+    const byId = Object.fromEntries(KNOWN_AGENTS.map((a) => [a.id, a.capture]));
+    expect(byId).toEqual({
+      claude: "hooks",
+      codex: "probe",
+      opencode: "plugin",
+      gemini: null,
+      aider: null,
+      cursor: "probe",
+      copilot: null,
+    });
   });
 });
 
@@ -63,8 +82,38 @@ describe("discoverAgents", () => {
     const installed = discoverAgents(which, (id) => id === "claude");
     const byId = Object.fromEntries(installed.map((a) => [a.id, a]));
     expect(byId.claude!.installed).toBe(true);
-    // present but non-integrated → never "installed"
+    // opencode integrates too — present but its probe says not installed
     expect(byId.opencode!.installed).toBe(false);
+    // present but non-integrated → never "installed"
+    const codex = discoverAgents(foundAt({ codex: "/opt/codex" }), () => true);
+    expect(codex.find((a) => a.id === "codex")!.installed).toBe(false);
+  });
+
+  it("marks probe-captured kinds active whenever the binary is present", () => {
+    const which = foundAt({ codex: "/opt/codex", "cursor-agent": "/usr/bin/cursor-agent" });
+    const agents = discoverAgents(which, () => false);
+    const byId = Object.fromEntries(agents.map((a) => [a.id, a]));
+    expect(byId.codex!.captureActive).toBe(true);
+    expect(byId.cursor!.captureActive).toBe(true);
+    // absent binary → no capture
+    expect(byId.claude!.captureActive).toBe(false);
+  });
+
+  it("marks hook/plugin-captured kinds active only once their integration is installed", () => {
+    const which = foundAt({ claude: "/usr/bin/claude", opencode: "/usr/bin/opencode" });
+    const none = discoverAgents(which, () => false);
+    expect(none.find((a) => a.id === "claude")!.captureActive).toBe(false);
+    expect(none.find((a) => a.id === "opencode")!.captureActive).toBe(false);
+    const all = discoverAgents(which, () => true);
+    expect(all.find((a) => a.id === "claude")!.captureActive).toBe(true);
+    expect(all.find((a) => a.id === "opencode")!.captureActive).toBe(true);
+  });
+
+  it("never marks capture-less kinds active", () => {
+    const which = foundAt({ copilot: "/usr/bin/copilot", gemini: "/usr/bin/gemini" });
+    const agents = discoverAgents(which, () => true);
+    expect(agents.find((a) => a.id === "copilot")!.captureActive).toBe(false);
+    expect(agents.find((a) => a.id === "gemini")!.captureActive).toBe(false);
   });
 
   it("leaves installed false when claude is present but the integration is not installed", () => {

--- a/packages/daemon/src/lib/__tests__/manifest-pack.test.ts
+++ b/packages/daemon/src/lib/__tests__/manifest-pack.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for the remote manifest pack (M25.4): the pure validator + URL
+ * policy, and the io flow driven entirely through `file://` fixtures and a
+ * `TMUX_IDE_HOME`/`TMUX_IDE_CONFIG` scratch (never the network, never real
+ * user state).
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  fetchManifestPack,
+  installManifestPack,
+  isAllowedPackUrl,
+  manifestPackUrl,
+  maybeRefreshManifestPack,
+  packPath,
+  updateManifestPack,
+  validateManifestPack,
+  MANIFEST_PACK_URL_ENV,
+} from "../manifest-pack.ts";
+import {
+  readPackManifests,
+  _resetForTests as resetLoader,
+} from "../../tui/detect/manifest-loader.ts";
+import { _resetForTests as resetConfig } from "../app-config.ts";
+
+const VALID_PACK = {
+  schema: 1,
+  pack: "2026.07.12",
+  manifests: [
+    {
+      id: "droid",
+      commands: ["droid"],
+      confidence: "conservative",
+      states: { working: { any: [{ contains: "esc to interrupt" }] } },
+    },
+  ],
+};
+
+describe("validateManifestPack (pure)", () => {
+  it("accepts a well-formed pack", () => {
+    const v = validateManifestPack(VALID_PACK);
+    expect(v.ok).toBe(true);
+    if (v.ok) expect(v.pack.manifests[0]?.id).toBe("droid");
+  });
+
+  it("rejects a wrong schema version, loudly naming it", () => {
+    const v = validateManifestPack({ ...VALID_PACK, schema: 2 });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toContain("schema");
+  });
+
+  it("rejects a missing pack version, an empty manifest list, and a bad entry", () => {
+    expect(validateManifestPack({ ...VALID_PACK, pack: "" }).ok).toBe(false);
+    expect(validateManifestPack({ ...VALID_PACK, manifests: [] }).ok).toBe(false);
+    const bad = validateManifestPack({ ...VALID_PACK, manifests: [{ id: "nope" }] });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.reason).toContain("manifests[0]");
+  });
+
+  it("rejects non-objects", () => {
+    expect(validateManifestPack(null).ok).toBe(false);
+    expect(validateManifestPack("[]").ok).toBe(false);
+  });
+});
+
+describe("isAllowedPackUrl (pure)", () => {
+  it("allows https anywhere, file, and loopback http only", () => {
+    expect(isAllowedPackUrl("https://github.com/x/y/releases/download/v1/a.json")).toBe(true);
+    expect(isAllowedPackUrl("file:///tmp/pack.json")).toBe(true);
+    expect(isAllowedPackUrl("http://127.0.0.1:8080/pack.json")).toBe(true);
+    expect(isAllowedPackUrl("http://localhost:8080/pack.json")).toBe(true);
+  });
+
+  it("rejects remote http, other schemes, and garbage", () => {
+    expect(isAllowedPackUrl("http://example.com/pack.json")).toBe(false);
+    expect(isAllowedPackUrl("ftp://example.com/pack.json")).toBe(false);
+    expect(isAllowedPackUrl("not a url")).toBe(false);
+  });
+});
+
+describe("manifestPackUrl (pure)", () => {
+  it("constructs the release-asset URL like the TUI binary does", () => {
+    expect(manifestPackUrl("2.7.0")).toBe(
+      "https://github.com/wavyrai/tmux-ide/releases/download/v2.7.0/agent-manifests.json",
+    );
+    // A leading v is normalized, not doubled.
+    expect(manifestPackUrl("v2.7.0")).toContain("/v2.7.0/");
+  });
+});
+
+describe("fetch + install + loader pickup (file:// fixtures, scratch home)", () => {
+  let home: string;
+  let fixtures: string;
+  const prevHome = process.env.TMUX_IDE_HOME;
+  const prevUrl = process.env[MANIFEST_PACK_URL_ENV];
+  const prevConfig = process.env.TMUX_IDE_CONFIG;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "tmux-ide-pack-home-"));
+    fixtures = mkdtempSync(join(tmpdir(), "tmux-ide-pack-fixtures-"));
+    process.env.TMUX_IDE_HOME = home;
+    resetLoader();
+    resetConfig();
+  });
+  afterEach(() => {
+    for (const [key, val] of [
+      ["TMUX_IDE_HOME", prevHome],
+      [MANIFEST_PACK_URL_ENV, prevUrl],
+      ["TMUX_IDE_CONFIG", prevConfig],
+    ] as const) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+    rmSync(home, { recursive: true, force: true });
+    rmSync(fixtures, { recursive: true, force: true });
+    resetLoader();
+    resetConfig();
+  });
+
+  const writeFixture = (name: string, content: unknown): string => {
+    const path = join(fixtures, name);
+    writeFileSync(path, typeof content === "string" ? content : JSON.stringify(content));
+    return pathToFileURL(path).href;
+  };
+
+  it("fetches a valid pack from file:// and installs it where the loader reads", async () => {
+    const url = writeFixture("pack.json", VALID_PACK);
+    const pack = await fetchManifestPack(url);
+    const dest = installManifestPack(pack);
+    expect(dest).toBe(packPath());
+    expect(dest.startsWith(home)).toBe(true);
+    // The loader picks it up (same TMUX_IDE_HOME).
+    expect(readPackManifests().map((m) => m.id)).toEqual(["droid"]);
+  });
+
+  it("updateManifestPack honors the env URL override and reports what it did", async () => {
+    process.env[MANIFEST_PACK_URL_ENV] = writeFixture("pack.json", VALID_PACK);
+    const r = await updateManifestPack();
+    expect(r.count).toBe(1);
+    expect(r.packVersion).toBe("2026.07.12");
+    expect(JSON.parse(readFileSync(r.path, "utf8")).manifests[0].id).toBe("droid");
+  });
+
+  it("rejects a schema-invalid pack loudly and installs nothing", async () => {
+    const url = writeFixture("bad.json", { ...VALID_PACK, schema: 99 });
+    await expect(fetchManifestPack(url)).rejects.toThrow(/rejected: unsupported schema/);
+    expect(readPackManifests()).toEqual([]);
+  });
+
+  it("rejects malformed JSON and disallowed URLs", async () => {
+    const url = writeFixture("garbage.json", "{ nope");
+    await expect(fetchManifestPack(url)).rejects.toThrow(/not valid JSON/);
+    await expect(fetchManifestPack("http://example.com/pack.json")).rejects.toThrow(/https only/);
+  });
+
+  it("maybeRefreshManifestPack is OFF by default (updates.manifests: false)", async () => {
+    process.env[MANIFEST_PACK_URL_ENV] = writeFixture("pack.json", VALID_PACK);
+    // Default config — the gate is closed, so nothing installs.
+    process.env.TMUX_IDE_CONFIG = join(fixtures, "missing-config.json");
+    resetConfig();
+    await maybeRefreshManifestPack();
+    expect(readPackManifests()).toEqual([]);
+  });
+
+  it("maybeRefreshManifestPack installs when updates.manifests is opted in — and never throws on failure", async () => {
+    process.env[MANIFEST_PACK_URL_ENV] = writeFixture("pack.json", VALID_PACK);
+    const configPath = join(fixtures, "config.json");
+    writeFileSync(configPath, JSON.stringify({ updates: { check: true, manifests: true } }));
+    process.env.TMUX_IDE_CONFIG = configPath;
+    resetConfig();
+    await maybeRefreshManifestPack();
+    expect(readPackManifests().map((m) => m.id)).toEqual(["droid"]);
+
+    // A later broken source degrades silently, keeping the installed pack.
+    process.env[MANIFEST_PACK_URL_ENV] = writeFixture("bad.json", "{ nope");
+    await expect(maybeRefreshManifestPack()).resolves.toBeUndefined();
+    expect(readPackManifests().map((m) => m.id)).toEqual(["droid"]);
+  });
+
+  it("user override files still beat an installed pack (precedence, end to end)", async () => {
+    const url = writeFixture("pack.json", {
+      schema: 1,
+      pack: "t",
+      manifests: [
+        {
+          id: "claude",
+          commands: ["claude"],
+          states: { working: { any: [{ contains: "PACK-WINS" }] } },
+        },
+      ],
+    });
+    installManifestPack(await fetchManifestPack(url));
+    const detect = join(home, "agent-detection");
+    mkdirSync(detect, { recursive: true });
+    writeFileSync(
+      join(detect, "claude.json"),
+      JSON.stringify({
+        id: "claude",
+        commands: ["claude"],
+        states: { working: { any: [{ contains: "USER-WINS" }] } },
+      }),
+    );
+    resetLoader();
+    const { loadManifests } = await import("../../tui/detect/manifest-loader.ts");
+    const claude = loadManifests().find((m) => m.id === "claude")!;
+    expect(claude.states.working?.any?.[0]?.contains).toBe("USER-WINS");
+  });
+});

--- a/packages/daemon/src/lib/agent-discovery.ts
+++ b/packages/daemon/src/lib/agent-discovery.ts
@@ -17,6 +17,21 @@
  */
 import { execFileSync } from "node:child_process";
 import { claudeIntegrationStatus } from "../tui/integrations/claude.ts";
+import { opencodeIntegrationStatus } from "../tui/integrations/opencode.ts";
+
+/**
+ * How a kind's `@agent_session_id` (the `restore --resume-agents` key) gets
+ * captured:
+ *  - `"hooks"`  — the agent's own lifecycle hooks stamp it (claude; needs
+ *    `integration install`).
+ *  - `"plugin"` — an in-process plugin stamps it (opencode; needs
+ *    `integration install`).
+ *  - `"probe"`  — the chrome updater discovers it from the agent's own on-disk
+ *    session state (codex, cursor; automatic, nothing to install).
+ *  - `null`     — no defensible capture surface (see
+ *    {@link ../tui/detect/session-id.ts} for the per-kind evidence).
+ */
+export type CaptureMechanism = "hooks" | "plugin" | "probe" | null;
 
 /** A coding agent tmux-ide knows how to detect. */
 export interface KnownAgent {
@@ -26,19 +41,24 @@ export interface KnownAgent {
   bin: string;
   /** True → tmux-ide ships a lifecycle-integration installer for this agent. */
   integration: boolean;
+  /** How this kind's session id is captured for `restore --resume-agents`. */
+  capture: CaptureMechanism;
 }
 
 /**
  * The agents tmux-ide recognizes. `integration: true` means we HAVE an installer
- * (a real lifecycle hook → ground-truth pane state); the rest are detected via
- * screen-manifest scraping only, with no lifecycle hook yet.
+ * (claude's lifecycle hooks, opencode's plugin); the rest are detected via
+ * screen-manifest scraping only. `capture` records each kind's session-id
+ * story ({@link CaptureMechanism}).
  */
 export const KNOWN_AGENTS: readonly KnownAgent[] = [
-  { id: "claude", bin: "claude", integration: true },
-  { id: "codex", bin: "codex", integration: false },
-  { id: "opencode", bin: "opencode", integration: false },
-  { id: "gemini", bin: "gemini", integration: false },
-  { id: "aider", bin: "aider", integration: false },
+  { id: "claude", bin: "claude", integration: true, capture: "hooks" },
+  { id: "codex", bin: "codex", integration: false, capture: "probe" },
+  { id: "opencode", bin: "opencode", integration: true, capture: "plugin" },
+  { id: "gemini", bin: "gemini", integration: false, capture: null },
+  { id: "aider", bin: "aider", integration: false, capture: null },
+  { id: "cursor", bin: "cursor-agent", integration: false, capture: "probe" },
+  { id: "copilot", bin: "copilot", integration: false, capture: null },
 ];
 
 /** One probed agent: its registry facts plus what the PATH/integration probe found. */
@@ -55,6 +75,15 @@ export interface DiscoveredAgent {
    * integrate (there's nothing to install) and for any agent absent from PATH.
    */
   installed: boolean;
+  /** How this kind's session id is captured (copied from the registry). */
+  capture: CaptureMechanism;
+  /**
+   * Whether session-id capture is LIVE for this kind on this machine:
+   * `"probe"` capture is automatic whenever the binary is present; hook/plugin
+   * capture requires the integration to be installed; `null` capture is never
+   * active.
+   */
+  captureActive: boolean;
 }
 
 /** Resolve a binary to its absolute path, or null. Must never throw. */
@@ -84,14 +113,15 @@ const defaultWhich: WhichRunner = (bin) => {
 };
 
 /**
- * Default integration probe: only `claude` has an installer, so only it can be
- * "installed". Reads the real Claude settings; any failure degrades to false so
- * discovery never throws.
+ * Default integration probe: claude's hooks and opencode's plugin are the two
+ * shipped installers. Reads the real settings/plugin file; any failure degrades
+ * to false so discovery never throws.
  */
 const defaultIntegrationProbe: IntegrationProbe = (agentId) => {
-  if (agentId !== "claude") return false;
   try {
-    return claudeIntegrationStatus().installed;
+    if (agentId === "claude") return claudeIntegrationStatus().installed;
+    if (agentId === "opencode") return opencodeIntegrationStatus().installed;
+    return false;
   } catch {
     return false;
   }
@@ -111,7 +141,17 @@ export function discoverAgents(
     const path = which(agent.bin);
     const present = path !== null;
     const installed = present && agent.integration ? isInstalled(agent.id) : false;
-    return { id: agent.id, bin: agent.bin, integration: agent.integration, path, installed };
+    const captureActive =
+      agent.capture === "probe" ? present : agent.capture !== null ? installed : false;
+    return {
+      id: agent.id,
+      bin: agent.bin,
+      integration: agent.integration,
+      path,
+      installed,
+      capture: agent.capture,
+      captureActive,
+    };
   });
 }
 

--- a/packages/daemon/src/lib/app-config.test.ts
+++ b/packages/daemon/src/lib/app-config.test.ts
@@ -158,7 +158,14 @@ describe("parseAppConfig — mistyped fields fall back to default", () => {
       toast: false,
       macos: true,
     });
-    expect(parseAppConfig({ updates: { check: false } }).updates).toEqual({ check: false });
+    expect(parseAppConfig({ updates: { check: false } }).updates).toEqual({
+      check: false,
+      manifests: false,
+    });
+    expect(parseAppConfig({ updates: { manifests: true } }).updates).toEqual({
+      check: true,
+      manifests: true,
+    });
   });
 
   it("worktrees.dir — a non-empty string overrides, anything else stays the empty default", () => {

--- a/packages/daemon/src/lib/app-config.ts
+++ b/packages/daemon/src/lib/app-config.ts
@@ -110,6 +110,14 @@ export interface AppRestore {
 /** Update-check toggles (consumed later by the update-flow card). */
 export interface AppUpdates {
   check: boolean;
+  /**
+   * Whether the daily update check ALSO refreshes the remote agent-detection
+   * manifest pack into `~/.tmux-ide/agent-detection/pack/` (M25.4). Default
+   * FALSE — auto-installing detection rules is opt-in; `tmux-ide update
+   * --manifests` always works explicitly. Requires `check: true` (the refresh
+   * rides the same daily throttle — no timer of its own).
+   */
+  manifests: boolean;
 }
 
 /** First-run welcome toggles. */
@@ -238,7 +246,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   updater: { tickMs: 2000, snapshotEvery: 15 },
   notifications: { toast: true, macos: false },
   restore: { resumeAgents: false },
-  updates: { check: true },
+  updates: { check: true, manifests: false },
   welcome: { show: true },
   integrations: { offer: true },
   worktrees: { dir: "" },
@@ -350,7 +358,10 @@ export function parseAppConfig(input: unknown): AppConfig {
       macos: pickBool(notifications.macos, D.notifications.macos),
     },
     restore: { resumeAgents: pickBool(restore.resumeAgents, D.restore.resumeAgents) },
-    updates: { check: pickBool(updates.check, D.updates.check) },
+    updates: {
+      check: pickBool(updates.check, D.updates.check),
+      manifests: pickBool(updates.manifests, D.updates.manifests),
+    },
     welcome: { show: pickBool(welcome.show, D.welcome.show) },
     integrations: { offer: pickBool(integrations.offer, D.integrations.offer) },
     worktrees: { dir: pickString(worktrees.dir, D.worktrees.dir) },

--- a/packages/daemon/src/lib/manifest-pack.ts
+++ b/packages/daemon/src/lib/manifest-pack.ts
@@ -1,0 +1,255 @@
+/**
+ * Remote agent-detection manifest packs — `tmux-ide update --manifests` (M25.4).
+ *
+ * Detection breadth shouldn't wait for an npm release: agent TUIs change their
+ * chrome between our versions, and a re-tuned manifest is pure data. This
+ * module fetches a versioned MANIFEST PACK from a static URL and installs it
+ * where the manifest loader already hot-merges from.
+ *
+ * ## The pack format (publish contract)
+ *
+ * A single JSON document:
+ *
+ * ```json
+ * {
+ *   "schema": 1,                       // this format's version — reject others
+ *   "pack": "2026.07.12",              // pack version (informational, any string)
+ *   "manifests": [                     // one AgentManifest per entry, exactly the
+ *     {                                //   override-file shape manifest-loader.ts
+ *       "id": "claude",                //   documents (id, commands[], states,
+ *       "commands": ["claude"],        //   optional confidence)
+ *       "confidence": "tuned",
+ *       "states": { "working": { "any": [{ "contains": "esc to interrupt" }] } }
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * Publishing: attach the document as the `agent-manifests.json` asset on a
+ * GitHub release — {@link manifestPackUrl} constructs the same
+ * `releases/download/v<version>/<asset>` URL the TUI-binary download uses, so
+ * a pack rides every release and a NEWER pack can be re-attached to the
+ * CURRENT release tag at any time (the fetch always re-downloads; the pane
+ * option cache never pins it).
+ *
+ * ## Precedence (verified by tests)
+ *
+ * The pack installs into `<agent-detection>/pack/manifest-pack.json` — a
+ * SUBDIRECTORY of the user-override dir, so `readOverrideManifests` (which
+ * lists only `*.json` FILES in the top level) never sees it. The loader merges
+ * `bundled → pack → user`: a pack manifest replaces a bundled id or appends a
+ * new one, and a user's own `<agent-detection>/*.json` file ALWAYS beats both.
+ *
+ * ## Safety
+ *
+ * - Https only for remote URLs. `file://` and loopback `http://` are accepted
+ *   ONLY so tests/dev can exercise the flow without the network — anything
+ *   else is rejected before a byte is fetched.
+ * - The pack is schema-validated ({@link validateManifestPack}) BEFORE being
+ *   written; an invalid pack fails loudly and leaves the previous one intact.
+ * - The gated periodic refresh ({@link maybeRefreshManifestPack}) rides the
+ *   existing daily update check (see {@link ./update-check.ts}) — no timers or
+ *   daemons of its own — and is double-gated on `updates.check` (the caller)
+ *   and `updates.manifests` (read here, default false).
+ */
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AgentManifest } from "../tui/detect/manifest.ts";
+import { overrideDir, validateManifestShape } from "../tui/detect/manifest-loader.ts";
+import { getAppConfig } from "./app-config.ts";
+import { getCurrentVersion } from "./update-check.ts";
+import { RELEASE_REPO } from "./tui-binary.ts";
+
+/** The pack-format version this build understands. */
+export const MANIFEST_PACK_SCHEMA = 1;
+
+/** The release asset name a pack is published under. */
+export const MANIFEST_PACK_ASSET = "agent-manifests.json";
+
+/** Env override for the pack URL (tests/dev; may be `file://` or loopback http). */
+export const MANIFEST_PACK_URL_ENV = "TMUX_IDE_MANIFEST_PACK_URL";
+
+/** A fetched/validated manifest pack. */
+export interface ManifestPack {
+  schema: number;
+  /** Pack version — informational (surfaced in logs), any non-empty string. */
+  pack: string;
+  manifests: AgentManifest[];
+}
+
+// ---------------------------------------------------------------------------
+// Pure
+// ---------------------------------------------------------------------------
+
+/**
+ * PURE — the default pack URL for a version:
+ * `https://github.com/<repo>/releases/download/v<version>/agent-manifests.json`
+ * (the same asset-URL construction as the TUI binary download).
+ */
+export function manifestPackUrl(version: string = getCurrentVersion()): string {
+  const v = version.startsWith("v") ? version.slice(1) : version;
+  return `https://github.com/${RELEASE_REPO}/releases/download/v${v}/${MANIFEST_PACK_ASSET}`;
+}
+
+/**
+ * PURE — is `url` an acceptable pack source? `https:` always; `file:` and
+ * LOOPBACK `http:` (127.0.0.1 / localhost / [::1]) only so tests and local
+ * fixtures can drive the flow. Any other scheme/host is rejected.
+ */
+export function isAllowedPackUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol === "https:" || parsed.protocol === "file:") return true;
+  if (parsed.protocol === "http:") {
+    return ["127.0.0.1", "localhost", "[::1]", "::1"].includes(parsed.hostname);
+  }
+  return false;
+}
+
+/**
+ * PURE — validate an untrusted pack document. Returns the typed pack or a
+ * human-readable reason. Every manifest entry must pass the SAME structural
+ * validation user override files do ({@link validateManifestShape}) — one bad
+ * entry rejects the whole pack (a partial install would be harder to reason
+ * about than a loud failure). Never throws.
+ */
+export function validateManifestPack(
+  value: unknown,
+): { ok: true; pack: ManifestPack } | { ok: false; reason: string } {
+  if (typeof value !== "object" || value === null) return { ok: false, reason: "not an object" };
+  const v = value as Record<string, unknown>;
+  if (v.schema !== MANIFEST_PACK_SCHEMA) {
+    return {
+      ok: false,
+      reason: `unsupported schema ${JSON.stringify(v.schema)} (want ${MANIFEST_PACK_SCHEMA})`,
+    };
+  }
+  if (typeof v.pack !== "string" || v.pack.trim().length === 0) {
+    return { ok: false, reason: "missing pack version string" };
+  }
+  if (!Array.isArray(v.manifests) || v.manifests.length === 0) {
+    return { ok: false, reason: "manifests must be a non-empty array" };
+  }
+  for (let i = 0; i < v.manifests.length; i++) {
+    if (!validateManifestShape(v.manifests[i])) {
+      return {
+        ok: false,
+        reason: `manifests[${i}] is not a valid AgentManifest (need id, commands[], states)`,
+      };
+    }
+  }
+  return {
+    ok: true,
+    pack: { schema: MANIFEST_PACK_SCHEMA, pack: v.pack, manifests: v.manifests as AgentManifest[] },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// io
+// ---------------------------------------------------------------------------
+
+/** The installed pack's directory: `<agent-detection>/pack/`. */
+export function packDir(): string {
+  return join(overrideDir(), "pack");
+}
+
+/** The installed pack's path: `<agent-detection>/pack/manifest-pack.json`. */
+export function packPath(): string {
+  return join(packDir(), "manifest-pack.json");
+}
+
+/**
+ * io — fetch and validate a pack. `file://` URLs are read from disk (Node's
+ * fetch does not speak file:); everything else goes through fetch with a
+ * timeout. THROWS with an actionable message on a disallowed URL, a failed
+ * fetch, malformed JSON, or a schema-invalid pack — the caller decides whether
+ * that is loud (CLI) or swallowed (the background refresh).
+ */
+export async function fetchManifestPack(url: string, timeoutMs = 5000): Promise<ManifestPack> {
+  if (!isAllowedPackUrl(url)) {
+    throw new Error(
+      `refusing manifest-pack URL ${url} — https only (file:// and loopback http are allowed for local testing)`,
+    );
+  }
+  let body: string;
+  if (url.startsWith("file:")) {
+    body = readFileSync(fileURLToPath(url), "utf8");
+  } else {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) {
+        throw new Error(
+          `manifest-pack download failed (${url} → HTTP ${res.status} ${res.statusText})`,
+        );
+      }
+      body = await res.text();
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(`manifest pack at ${url} is not valid JSON`);
+  }
+  const verdict = validateManifestPack(parsed);
+  if (!verdict.ok) {
+    throw new Error(`manifest pack at ${url} rejected: ${verdict.reason}`);
+  }
+  return verdict.pack;
+}
+
+/**
+ * io — write a validated pack into place atomically (temp-in-same-dir →
+ * rename, so a crash never leaves a half-written pack the loader would then
+ * warn about every run). Returns the installed path.
+ */
+export function installManifestPack(pack: ManifestPack, dest: string = packPath()): string {
+  mkdirSync(dirname(dest), { recursive: true });
+  const tmp = `${dest}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(pack, null, 2));
+  renameSync(tmp, dest);
+  return dest;
+}
+
+/**
+ * io — the `tmux-ide update --manifests` flow: resolve the URL (env override →
+ * the release-asset default), fetch, validate, install. Throws loudly on any
+ * failure (the CLI surfaces it); returns what was installed for reporting.
+ */
+export async function updateManifestPack(
+  opts: { url?: string; log?: (msg: string) => void } = {},
+): Promise<{ path: string; packVersion: string; count: number }> {
+  const log = opts.log ?? (() => {});
+  const url = opts.url ?? process.env[MANIFEST_PACK_URL_ENV] ?? manifestPackUrl();
+  log(`fetching manifest pack from ${url}`);
+  const pack = await fetchManifestPack(url);
+  const path = installManifestPack(pack);
+  log(`installed pack ${pack.pack} (${pack.manifests.length} manifests) → ${path}`);
+  return { path, packVersion: pack.pack, count: pack.manifests.length };
+}
+
+/**
+ * io — the GATED background refresh the daily update check invokes (see
+ * `runUpdateCheck` in {@link ./update-check.ts}). Opt-in via
+ * `updates.manifests: true` (default false); NEVER throws — a failed refresh
+ * just keeps the previous pack, exactly like a failed version check keeps the
+ * previous `latest`.
+ */
+export async function maybeRefreshManifestPack(): Promise<void> {
+  try {
+    if (!getAppConfig().updates.manifests) return;
+    await updateManifestPack();
+  } catch {
+    // Offline, a missing release asset, or an invalid pack — all degrade to
+    // "keep what we have"; the explicit CLI path reports errors loudly instead.
+  }
+}

--- a/packages/daemon/src/lib/state-home.ts
+++ b/packages/daemon/src/lib/state-home.ts
@@ -1,0 +1,13 @@
+/**
+ * THE tmux-ide state home — `TMUX_IDE_HOME` when set (tests / per-run
+ * overrides), else `~/.tmux-ide`. The same resolution the welcome marker,
+ * update cache, and app state each grew locally; new state files should
+ * resolve through here so none of them can drift from the override again.
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Absolute path to the state home directory (not created here). */
+export function stateHome(): string {
+  return process.env.TMUX_IDE_HOME ?? join(homedir(), ".tmux-ide");
+}

--- a/packages/daemon/src/lib/update-check.ts
+++ b/packages/daemon/src/lib/update-check.ts
@@ -252,6 +252,11 @@ export function getUpdateStatus({
 export async function runUpdateCheck({ now = Date.now() }: { now?: number } = {}): Promise<void> {
   const cache = readUpdateCache();
   if (!shouldCheck(cache?.lastCheckedAt ?? null, now)) return;
+  // The agent-detection manifest-pack refresh RIDES this same daily throttle
+  // (M25.4) — no timer of its own, gated again inside on `updates.manifests`
+  // (default false) and never throwing. Dynamic import: manifest-pack imports
+  // this module for getCurrentVersion, so a static import would be a cycle.
+  void import("./manifest-pack.ts").then((m) => m.maybeRefreshManifestPack()).catch(() => {});
   const fetched = await fetchLatestVersion();
   writeUpdateCache({
     lastCheckedAt: now,

--- a/packages/daemon/src/restore.ts
+++ b/packages/daemon/src/restore.ts
@@ -114,9 +114,15 @@ const SAFE_SESSION_ID = /^[A-Za-z0-9_-]+$/;
  * Unverified (no entry): gemini, aider, goose, amp — no confirmed native
  * per-session resume invocation at the time of writing.
  *
- * Only claude's hooks record `@agent_session_id` automatically today; the
- * other entries fire for panes whose agent self-reported the id per the agent
- * contract (`tmux set-option -p @agent_session_id <id>`).
+ * How `@agent_session_id` gets recorded per kind (M25.3):
+ *  - claude — the hooks integration (`integration install claude`).
+ *  - opencode — the plugin integration (`integration install opencode`).
+ *  - codex, cursor — automatic: the chrome updater probes the agent's own
+ *    on-disk session state ({@link ./tui/detect/session-id.ts}).
+ *  - copilot — no automatic capture (skipped with evidence — see the
+ *    session-id module header); fires only for panes whose agent self-reported
+ *    the id per the agent contract
+ *    (`tmux set-option -p @agent_session_id <id>`), which any kind may do.
  */
 export const AGENT_RESUME_COMMANDS: Record<string, (id: string) => string> = {
   claude: (id) => `claude --resume ${id}`,

--- a/packages/daemon/src/tui/chrome/events.test.ts
+++ b/packages/daemon/src/tui/chrome/events.test.ts
@@ -101,3 +101,19 @@ describe("shouldRotate", () => {
     expect(shouldRotate(EVENTS_MAX_BYTES + 1)).toBe(true);
   });
 });
+
+describe("eventsPath", () => {
+  it("honors TMUX_IDE_HOME (the state-home override), falling back to ~/.tmux-ide", async () => {
+    const { eventsPath } = await import("./events.ts");
+    const prev = process.env.TMUX_IDE_HOME;
+    try {
+      process.env.TMUX_IDE_HOME = "/tmp/zz-events-home";
+      expect(eventsPath()).toBe("/tmp/zz-events-home/events.jsonl");
+      delete process.env.TMUX_IDE_HOME;
+      expect(eventsPath().endsWith("/.tmux-ide/events.jsonl")).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.TMUX_IDE_HOME;
+      else process.env.TMUX_IDE_HOME = prev;
+    }
+  });
+});

--- a/packages/daemon/src/tui/chrome/events.ts
+++ b/packages/daemon/src/tui/chrome/events.ts
@@ -13,8 +13,8 @@
  * file, and appends.
  */
 import { appendFileSync, existsSync, mkdirSync, renameSync, statSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { stateHome } from "../../lib/state-home.ts";
 import type { AgentStatus } from "../detect/classify.ts";
 
 /** A single session-level status transition. `from` is null the first time a session is seen. */
@@ -86,9 +86,9 @@ export function formatEventLine(
   return `${isoTime(ev.ts)} ${ev.session} ${from} → ${paint(ev.to, ev.to)}`;
 }
 
-/** Absolute path to the fleet event log. */
+/** Absolute path to the fleet event log (under the `TMUX_IDE_HOME`-aware home). */
 export function eventsPath(): string {
-  return join(homedir(), ".tmux-ide", "events.jsonl");
+  return join(stateHome(), "events.jsonl");
 }
 
 /**
@@ -106,7 +106,7 @@ export function appendEvents(
   if (events.length === 0) return;
   const path = eventsPath();
   try {
-    mkdirSync(join(homedir(), ".tmux-ide"), { recursive: true });
+    mkdirSync(stateHome(), { recursive: true });
     if (existsSync(path) && shouldRotate(statSync(path).size)) {
       renameSync(path, `${path}.1`);
     }

--- a/packages/daemon/src/tui/chrome/front-door.ts
+++ b/packages/daemon/src/tui/chrome/front-door.ts
@@ -1,0 +1,39 @@
+/**
+ * The chrome front door (M25.1) — the tiny, LEAF constants + argv builders the
+ * unified app needs to get a session watched without importing the chrome/data
+ * graph (app.tsx deliberately never imports the sync fleet-scan modules that
+ * {@link ./updater.ts} pulls in; see the FleetSession note there).
+ *
+ * "Watched" means: stamped with {@link ADOPTED_OPTION} so the background
+ * updater enumerates it (VERIFIED inert for a session that never ran `adopt` —
+ * none of adopt's status-row/border options are set, so the updater's status/
+ * chip var writes land on options nothing reads), and the updater itself
+ * ensured up. The sync twin of that flow lives in `updater.ts`
+ * (`startUpdaterIfNeeded`); the app uses these argvs with async execFile (the
+ * render-loop law).
+ */
+
+/** Per-session marker option set on adopt so the updater can enumerate adopted
+ *  sessions. (Owned here; re-exported by `updater.ts` for its callers.) */
+export const ADOPTED_OPTION = "@tmux_ide_adopted";
+
+/** The hidden internal session that hosts the updater loop. */
+export const UPDATER_SESSION = "_tmux-ide-chrome";
+
+/** PURE — stamp `session` watched (see the header: inert re: chrome painting). */
+export function adoptMarkArgv(session: string): string[] {
+  return ["set-option", "-t", session, ADOPTED_OPTION, "1"];
+}
+
+/** PURE — the existence probe for the updater session (`=` exact-match, so a
+ *  user session that merely starts with the name can't shadow it). Exit 0 =
+ *  running. */
+export function updaterProbeArgv(): string[] {
+  return ["has-session", "-t", `=${UPDATER_SESSION}`];
+}
+
+/** PURE — the argv that spawns the updater loop, detached. `exec` replaces the
+ *  shell so the pane IS the loop; killing the session stops it. */
+export function updaterSpawnArgv(): string[] {
+  return ["new-session", "-d", "-s", UPDATER_SESSION, "exec tmux-ide chrome-updater"];
+}

--- a/packages/daemon/src/tui/chrome/notify-state.test.ts
+++ b/packages/daemon/src/tui/chrome/notify-state.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the persisted notification-debounce map — the pure
+ * serialize/parse pair (round-trip, pruning, garbage tolerance) plus the io
+ * wrappers against a TMUX_IDE_HOME-scoped temp dir.
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NOTIFY_DEBOUNCE_MS } from "./notify.ts";
+import {
+  loadLastNotified,
+  notifyStatePath,
+  parseLastNotified,
+  saveLastNotified,
+  serializeLastNotified,
+} from "./notify-state.ts";
+
+describe("serializeLastNotified / parseLastNotified", () => {
+  it("round-trips fresh entries", () => {
+    const map = new Map([
+      ["%1:blocked", 1000],
+      ["%2:done", 2000],
+    ]);
+    expect(parseLastNotified(serializeLastNotified(map, 3000), 3000)).toEqual(map);
+  });
+
+  it("prunes entries outside the debounce window on BOTH ends of the trip", () => {
+    const now = 100_000;
+    const map = new Map([
+      ["%1:blocked", now - NOTIFY_DEBOUNCE_MS], // exactly expired
+      ["%2:blocked", now - NOTIFY_DEBOUNCE_MS + 1], // still alive
+    ]);
+    expect([...parseLastNotified(serializeLastNotified(map, now), now).keys()]).toEqual([
+      "%2:blocked",
+    ]);
+    // An already-serialized stale entry is also dropped at parse time.
+    const stale = JSON.stringify({ lastNotified: { "%1:blocked": 0 } });
+    expect(parseLastNotified(stale, now).size).toBe(0);
+  });
+
+  it("drops absurd future timestamps (clock skew) and non-numeric values", () => {
+    const now = 1000;
+    const body = JSON.stringify({
+      lastNotified: { future: now + NOTIFY_DEBOUNCE_MS + 1, bad: "x", ok: now },
+    });
+    expect([...parseLastNotified(body, now).keys()]).toEqual(["ok"]);
+  });
+
+  it("never throws on garbage", () => {
+    expect(parseLastNotified("not json", 0).size).toBe(0);
+    expect(parseLastNotified("[]", 0).size).toBe(0);
+    expect(parseLastNotified(JSON.stringify({ lastNotified: [1] }), 0).size).toBe(0);
+  });
+});
+
+describe("load/save (io, TMUX_IDE_HOME-scoped)", () => {
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "tmux-ide-notify-state-"));
+    prevHome = process.env.TMUX_IDE_HOME;
+    process.env.TMUX_IDE_HOME = home;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.TMUX_IDE_HOME;
+    else process.env.TMUX_IDE_HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("resolves the path under TMUX_IDE_HOME and round-trips a map", () => {
+    expect(notifyStatePath()).toBe(join(home, "notify-state.json"));
+    const map = new Map([["%1:blocked", 5000]]);
+    saveLastNotified(map, 6000);
+    expect(loadLastNotified(6000)).toEqual(map);
+    // The file is real JSON on disk.
+    expect(JSON.parse(readFileSync(notifyStatePath(), "utf-8"))).toEqual({
+      lastNotified: { "%1:blocked": 5000 },
+    });
+  });
+
+  it("returns an empty map for a missing or unreadable file", () => {
+    expect(loadLastNotified().size).toBe(0);
+    writeFileSync(notifyStatePath(), "garbage");
+    expect(loadLastNotified().size).toBe(0);
+  });
+});

--- a/packages/daemon/src/tui/chrome/notify-state.ts
+++ b/packages/daemon/src/tui/chrome/notify-state.ts
@@ -1,0 +1,76 @@
+/**
+ * Persistence for the notification debounce map (M25.1) — `lastNotified`
+ * survives updater restarts, so a respawned updater can't re-ping inside the
+ * debounce window (the old in-memory map made every restart an amnesty).
+ *
+ * Same split and same home discipline as {@link ../../lib/update-check.ts}:
+ * {@link serializeLastNotified} + {@link parseLastNotified} are PURE (and prune
+ * entries older than the debounce window — a stamp that can no longer suppress
+ * anything is dead weight); {@link loadLastNotified} / {@link saveLastNotified}
+ * are the thin, never-throwing io wrappers over
+ * `<TMUX_IDE_HOME>/notify-state.json`.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { stateHome } from "../../lib/state-home.ts";
+import { NOTIFY_DEBOUNCE_MS } from "./notify.ts";
+
+/** Absolute path to the persisted debounce map. */
+export function notifyStatePath(): string {
+  return join(stateHome(), "notify-state.json");
+}
+
+/** PURE — the JSON body for a debounce map, dropping entries whose timestamp
+ *  is already outside the debounce window (they can't suppress anything). */
+export function serializeLastNotified(map: ReadonlyMap<string, number>, nowMs: number): string {
+  const lastNotified: Record<string, number> = {};
+  for (const [key, ts] of map) {
+    if (nowMs - ts < NOTIFY_DEBOUNCE_MS) lastNotified[key] = ts;
+  }
+  return JSON.stringify({ lastNotified });
+}
+
+/** PURE — parse a persisted body back into the map, pruning stale entries.
+ *  Malformed input (or a FUTURE timestamp beyond the window — clock skew)
+ *  yields an empty/partial map, never a throw. */
+export function parseLastNotified(json: string, nowMs: number): Map<string, number> {
+  const out = new Map<string, number>();
+  try {
+    const parsed = JSON.parse(json) as { lastNotified?: unknown };
+    const raw = parsed?.lastNotified;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return out;
+    for (const [key, ts] of Object.entries(raw as Record<string, unknown>)) {
+      if (typeof ts !== "number") continue;
+      if (nowMs - ts >= NOTIFY_DEBOUNCE_MS) continue; // expired
+      if (ts - nowMs > NOTIFY_DEBOUNCE_MS) continue; // absurd future stamp
+      out.set(key, ts);
+    }
+  } catch {
+    // unreadable state just means a fresh debounce map
+  }
+  return out;
+}
+
+/** io — load the persisted map (empty when missing/unreadable). Never throws. */
+export function loadLastNotified(nowMs: number = Date.now()): Map<string, number> {
+  const path = notifyStatePath();
+  if (!existsSync(path)) return new Map();
+  try {
+    return parseLastNotified(readFileSync(path, "utf-8"), nowMs);
+  } catch {
+    return new Map();
+  }
+}
+
+/** io — persist the map (creating the home if needed). Best-effort. */
+export function saveLastNotified(
+  map: ReadonlyMap<string, number>,
+  nowMs: number = Date.now(),
+): void {
+  try {
+    mkdirSync(stateHome(), { recursive: true });
+    writeFileSync(notifyStatePath(), serializeLastNotified(map, nowMs));
+  } catch {
+    // an unwritable map just means a restart re-arms the debounce — never fatal
+  }
+}

--- a/packages/daemon/src/tui/chrome/notify.test.ts
+++ b/packages/daemon/src/tui/chrome/notify.test.ts
@@ -6,18 +6,25 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  APP_FOCUS_STALE_MS,
   applyKillSwitch,
+  buildAppFocusValue,
   decideNotifications,
   DEFAULT_NOTIFICATION_PREFS,
   enabledStates,
   inQuietHours,
+  notifierExecuteCommand,
+  notifyDebounceKey,
   notifyMessage,
   NOTIFY_DEBOUNCE_MS,
   NOTIFY_MAX_LEN,
+  parseAppFocus,
   parseHHMM,
   parseNotificationPrefs,
   parseClients,
+  suppressToastFor,
   terminalNotifierArgs,
+  type AppFocus,
   type AttachedClient,
   type NotificationPrefs,
   type NotifyEvent,
@@ -189,15 +196,155 @@ describe("decideNotifications", () => {
     decideNotifications([ev("web", "blocked")], clients, lastNotified, 0);
     expect(lastNotified.size).toBe(0);
   });
+
+  it("never notifies a first-sight event (from: null) — the restart/first-tick grace", () => {
+    const clients: AttachedClient[] = [{ client: "c1", session: "other" }];
+    const d = decideNotifications(
+      [ev("web", "blocked", { from: null, paneId: "%1" })],
+      clients,
+      new Map(),
+      0,
+    );
+    expect(d.toasts).toEqual([]);
+    expect(d.system).toEqual([]);
+    expect(d.nextLastNotified.size).toBe(0);
+  });
+
+  it("debounces per PANE, so two agents blocking in the same session both ping", () => {
+    const clients: AttachedClient[] = [{ client: "c1", session: "other" }];
+    const first = decideNotifications(
+      [ev("web", "blocked", { paneId: "%1", agent: "claude" })],
+      clients,
+      new Map(),
+      0,
+    );
+    expect(first.toasts).toHaveLength(1);
+    // 10s later, a SECOND pane in the same session blocks — inside the window.
+    const second = decideNotifications(
+      [ev("web", "blocked", { paneId: "%2", agent: "codex" })],
+      clients,
+      first.nextLastNotified,
+      10_000,
+    );
+    expect(second.toasts).toHaveLength(1);
+    expect(second.nextLastNotified.get("%1:blocked")).toBe(0);
+    expect(second.nextLastNotified.get("%2:blocked")).toBe(10_000);
+    // The SAME pane flapping again inside the window stays quiet.
+    const flap = decideNotifications(
+      [ev("web", "blocked", { paneId: "%1" })],
+      clients,
+      second.nextLastNotified,
+      20_000,
+    );
+    expect(flap.toasts).toEqual([]);
+  });
+
+  it("suppresses toast AND banner when the app is attached and the pane is on its screen", () => {
+    const clients: AttachedClient[] = [{ client: "c1", session: "other" }];
+    const focus: AppFocus = { ts: 0, attached: true, session: "web", panes: ["%1"] };
+    const visible = decideNotifications(
+      [ev("web", "blocked", { paneId: "%1" })],
+      clients,
+      new Map(),
+      0,
+      undefined,
+      focus,
+    );
+    expect(visible.toasts).toEqual([]);
+    expect(visible.system).toEqual([]);
+    // Nothing fired → nothing stamped: the transition isn't debounced away for later.
+    expect(visible.nextLastNotified.size).toBe(0);
+    // A pane NOT on the app's screen still pings.
+    const hidden = decideNotifications(
+      [ev("web", "blocked", { paneId: "%2" })],
+      clients,
+      new Map(),
+      0,
+      undefined,
+      focus,
+    );
+    expect(hidden.system).toHaveLength(1);
+    // A DETACHED app suppresses nothing.
+    const detached = decideNotifications(
+      [ev("web", "blocked", { paneId: "%1" })],
+      clients,
+      new Map(),
+      0,
+      undefined,
+      { ...focus, attached: false },
+    );
+    expect(detached.system).toHaveLength(1);
+  });
+});
+
+describe("notifyDebounceKey", () => {
+  it("keys on the pane when known, else the session", () => {
+    expect(notifyDebounceKey({ session: "web", to: "blocked", paneId: "%3" })).toBe("%3:blocked");
+    expect(notifyDebounceKey({ session: "web", to: "blocked" })).toBe("web:blocked");
+    expect(notifyDebounceKey({ session: "web", to: "done", paneId: null })).toBe("web:done");
+  });
+});
+
+describe("suppressToastFor", () => {
+  const event = ev("web", "blocked", { paneId: "%1", windowIndex: 2 });
+
+  it("is window-granular: same session other window still toasts", () => {
+    expect(suppressToastFor({ client: "c", session: "web", windowIndex: 2 }, event)).toBe(true);
+    expect(suppressToastFor({ client: "c", session: "web", windowIndex: 1 }, event)).toBe(false);
+    expect(suppressToastFor({ client: "c", session: "api", windowIndex: 2 }, event)).toBe(false);
+  });
+
+  it("degrades to session granularity when either window is unknown", () => {
+    expect(suppressToastFor({ client: "c", session: "web", windowIndex: null }, event)).toBe(true);
+    expect(suppressToastFor({ client: "c", session: "web" }, ev("web", "blocked"))).toBe(true);
+  });
+
+  it("always suppresses clients viewing the hosted app (in-app surfacing owns that screen)", () => {
+    expect(suppressToastFor({ client: "c", session: "_tmux-ide-app", windowIndex: 0 }, event)).toBe(
+      true,
+    );
+  });
+});
+
+describe("app focus record", () => {
+  const focus: AppFocus = { ts: 10_000, attached: true, session: "web", panes: ["%1", "%2"] };
+
+  it("round-trips through build + parse while fresh", () => {
+    expect(parseAppFocus(buildAppFocusValue(focus), 10_000 + 3000)).toEqual(focus);
+  });
+
+  it("treats a stale record as absent (an app that died without cleanup)", () => {
+    expect(parseAppFocus(buildAppFocusValue(focus), 10_000 + APP_FOCUS_STALE_MS + 1)).toBeNull();
+  });
+
+  it("never throws on garbage and filters non-string pane ids", () => {
+    expect(parseAppFocus("not json", 0)).toBeNull();
+    expect(parseAppFocus("", 0)).toBeNull();
+    expect(parseAppFocus(null, 0)).toBeNull();
+    expect(parseAppFocus(JSON.stringify({ ts: 5, panes: ["%1", 7, null] }), 5)).toEqual({
+      ts: 5,
+      attached: false,
+      session: "",
+      panes: ["%1"],
+    });
+    expect(parseAppFocus(JSON.stringify({ attached: true }), 0)).toBeNull(); // no ts
+  });
 });
 
 describe("parseClients", () => {
-  it("parses client\\tsession lines and drops malformed ones", () => {
+  it("parses client\\tsession\\twindow lines and drops malformed ones", () => {
     expect(
-      parseClients(["/dev/ttys000\tweb", "/dev/ttys001\tapi", "", "lonely", "\tdangling"]),
+      parseClients(["/dev/ttys000\tweb\t2", "/dev/ttys001\tapi\t0", "", "lonely", "\tdangling\t1"]),
     ).toEqual([
-      { client: "/dev/ttys000", session: "web" },
-      { client: "/dev/ttys001", session: "api" },
+      { client: "/dev/ttys000", session: "web", windowIndex: 2 },
+      { client: "/dev/ttys001", session: "api", windowIndex: 0 },
+    ]);
+  });
+
+  it("parses a missing/garbage window field as null (session-granular fallback)", () => {
+    expect(parseClients(["/dev/ttys000\tweb", "/dev/ttys001\tapi\tx"])).toEqual([
+      { client: "/dev/ttys000", session: "web", windowIndex: null },
+      { client: "/dev/ttys001", session: "api", windowIndex: null },
     ]);
   });
 });
@@ -311,8 +458,25 @@ describe("applyKillSwitch", () => {
   });
 });
 
+describe("notifierExecuteCommand", () => {
+  it("routes through the hosted cockpit when it exists, else switches straight to the session", () => {
+    expect(notifierExecuteCommand("web")).toBe(
+      "if tmux has-session -t '=_tmux-ide-app' 2>/dev/null; then " +
+        "tmux set-option -t '_tmux-ide-app' @tmux_ide_app_jump 'web'; " +
+        "tmux switch-client -t '=_tmux-ide-app'; " +
+        "else tmux switch-client -t 'web'; fi",
+    );
+  });
+
+  it("single-quote-escapes the session name in both branches", () => {
+    const cmd = notifierExecuteCommand("wei'rd");
+    expect(cmd).toContain("@tmux_ide_app_jump 'wei'\\''rd'");
+    expect(cmd).toContain("else tmux switch-client -t 'wei'\\''rd'; fi");
+  });
+});
+
 describe("terminalNotifierArgs", () => {
-  it("builds a click-through banner that switches to the session", () => {
+  it("builds a click-through banner whose -execute is the jump command", () => {
     expect(
       terminalNotifierArgs({ message: "claude blocked · web:1.2 — needs input", session: "web" }),
     ).toEqual([
@@ -321,18 +485,7 @@ describe("terminalNotifierArgs", () => {
       "-message",
       "claude blocked · web:1.2 — needs input",
       "-execute",
-      "tmux switch-client -t 'web'",
-    ]);
-  });
-
-  it("single-quote-escapes a session name for the -execute shell command", () => {
-    expect(terminalNotifierArgs({ message: "m", session: "wei'rd" })).toEqual([
-      "-title",
-      "tmux-ide",
-      "-message",
-      "m",
-      "-execute",
-      "tmux switch-client -t 'wei'\\''rd'",
+      notifierExecuteCommand("web"),
     ]);
   });
 });

--- a/packages/daemon/src/tui/chrome/notify.ts
+++ b/packages/daemon/src/tui/chrome/notify.ts
@@ -20,14 +20,17 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { runTmux } from "@tmux-ide/tmux-bridge";
 import { appConfigPath, parseAppConfig } from "../../lib/app-config.ts";
+import { APP_HOST_SESSION } from "../mirror/hosted.ts";
 import type { AgentStatus } from "../detect/classify.ts";
 
 /**
- * A fleet transition this tick — the shape {@link ./events.ts diffFleet} emits,
- * ENRICHED by the updater with the pane's resolved `agent` id and human
- * `location` (`session:window.pane`) so the ping can name who needs the user.
- * Both are optional: a caller that can't resolve them falls back to a generic
- * `agent` label and the bare session name (see {@link notifyMessage}).
+ * A fleet transition this tick — since M25.1 a PANE-level transition (the
+ * updater diffs per-pane states, not the session rollup, so a second agent
+ * blocking in an already-blocked session still pings), ENRICHED with the
+ * pane's resolved `agent` id and human `location` (`session:window.pane`) so
+ * the ping can name who needs the user. The enrichments are optional: a caller
+ * that can't resolve them falls back to a generic `agent` label and the bare
+ * session name (see {@link notifyMessage}).
  */
 export interface NotifyEvent {
   session: string;
@@ -37,12 +40,22 @@ export interface NotifyEvent {
   agent?: string | null;
   /** Human location `session:window.pane` (e.g. `myproj:1.2`); falls back to `session`. */
   location?: string;
+  /** The pane behind the transition — the debounce key and the visibility
+   *  test both want the pane, not the session. Absent for a caller that only
+   *  has session granularity (falls back to session-keyed behavior). */
+  paneId?: string | null;
+  /** The pane's `window_index` — window-granular toast suppression needs it.
+   *  Absent/null degrades that check to session granularity. */
+  windowIndex?: number | null;
 }
 
-/** An attached tmux client and the session it's currently viewing. */
+/** An attached tmux client, the session it's viewing, and that session's
+ *  CURRENT window (null when the caller couldn't resolve it — suppression then
+ *  degrades to session granularity for that client). */
 export interface AttachedClient {
   client: string;
   session: string;
+  windowIndex?: number | null;
 }
 
 /** A toast destined for one client's status line. */
@@ -109,16 +122,44 @@ export function enabledStates(prefs: NotificationPrefs): ReadonlySet<AgentStatus
   return states;
 }
 
+/** PURE — the debounce-map key for an event: the PANE when known (so a second
+ *  agent blocking in the same session still pings — per-pane debounce), else
+ *  the session (session-granular callers keep the old behavior). */
+export function notifyDebounceKey(ev: Pick<NotifyEvent, "session" | "to" | "paneId">): string {
+  return `${ev.paneId ?? ev.session}:${ev.to}`;
+}
+
+/** PURE — should this client's toast be suppressed for this event? A client
+ *  gets no toast when it is already LOOKING at the transition: same session
+ *  AND same window (window-granular since M25.1 — an agent in window 2 while
+ *  the client views window 1 IS toast-worthy). Unknown window info on either
+ *  side degrades to the old session-granular suppression. Clients viewing the
+ *  hosted app are always suppressed: the app has its own in-app surfacing, and
+ *  a raw tmux message over the app's renderer is noise. */
+export function suppressToastFor(client: AttachedClient, ev: NotifyEvent): boolean {
+  if (client.session === APP_HOST_SESSION) return true;
+  if (client.session !== ev.session) return false;
+  if (ev.windowIndex === undefined || ev.windowIndex === null) return true;
+  if (client.windowIndex === undefined || client.windowIndex === null) return true;
+  return client.windowIndex === ev.windowIndex;
+}
+
 /**
  * PURE — decide who to ping from this tick's transitions.
  *
  * Rules:
+ *   - a FIRST-SIGHT event (`from: null`) never notifies — the updater's first
+ *     tick (or a restart, or a session appearing) sees every pane as new, and
+ *     re-pinging an agent that has been blocked for an hour is noise;
  *   - only states in `states` qualify (default {@link NOTIFY_STATES}; the caller
  *     narrows it via {@link enabledStates} to honor `onBlocked`/`onDone`);
- *   - DEBOUNCE: skip a session+state that fired within {@link NOTIFY_DEBOUNCE_MS}
- *     — this is the flap guard (see {@link NOTIFY_DEBOUNCE_MS});
- *   - SUPPRESS the toast for any client already viewing that session (they can
- *     see the bar flip themselves) — other clients still get toasted;
+ *   - DEBOUNCE: skip a pane+state (see {@link notifyDebounceKey}) that fired
+ *     within {@link NOTIFY_DEBOUNCE_MS} — the flap guard;
+ *   - APP FOCUS: when the unified app is attached and the event's pane is on
+ *     its screen ({@link AppFocus}), the user is LOOKING at it — no toast, no
+ *     banner (and no debounce stamp: nothing fired);
+ *   - SUPPRESS the toast for any client already viewing that pane's window
+ *     ({@link suppressToastFor}) — other clients still get toasted;
  *   - a `system` entry is produced per qualifying, non-debounced event regardless
  *     of clients (so the macOS path fires even with nothing attached — the
  *     caller gates it on prefs / quiet hours).
@@ -132,19 +173,22 @@ export function decideNotifications(
   lastNotified: Map<string, number>,
   nowMs: number,
   states: ReadonlySet<AgentStatus> = NOTIFY_STATES,
+  appFocus: AppFocus | null = null,
 ): NotifyDecision {
   const nextLastNotified = new Map(lastNotified);
   const toasts: ToastTarget[] = [];
   const system: SystemNotification[] = [];
   for (const ev of events) {
+    if (ev.from === null) continue; // first sight — not a transition worth pinging
     if (!states.has(ev.to)) continue;
-    const key = `${ev.session}:${ev.to}`;
+    const key = notifyDebounceKey(ev);
     const last = nextLastNotified.get(key);
     if (last !== undefined && nowMs - last < NOTIFY_DEBOUNCE_MS) continue;
+    if (appFocus?.attached && ev.paneId && appFocus.panes.includes(ev.paneId)) continue;
     nextLastNotified.set(key, nowMs);
     const message = notifyMessage(ev);
     for (const c of clients) {
-      if (c.session === ev.session) continue; // they're already looking at it
+      if (suppressToastFor(c, ev)) continue;
       toasts.push({ client: c.client, message });
     }
     system.push({ message, session: ev.session });
@@ -152,25 +196,102 @@ export function decideNotifications(
   return { toasts, system, nextLastNotified };
 }
 
-/** PURE — parse `list-clients -F '#{client_name}\t#{session_name}'` output. */
+/** PURE — parse `list-clients -F '#{client_name}\t#{session_name}\t#{window_index}'`
+ *  output (the third field is the client's session's CURRENT window; missing/
+ *  non-numeric parses as null so old two-field callers degrade gracefully). */
 export function parseClients(lines: string[]): AttachedClient[] {
   const out: AttachedClient[] = [];
   for (const line of lines) {
-    const [client = "", session = ""] = line.split("\t");
-    if (client && session) out.push({ client, session });
+    const [client = "", session = "", win = ""] = line.split("\t");
+    if (!client || !session) continue;
+    const n = Number.parseInt(win, 10);
+    out.push({ client, session, windowIndex: Number.isInteger(n) ? n : null });
   }
   return out;
 }
 
-/** io — enumerate attached clients from the live tmux server. Never throws. */
+/** io — enumerate attached clients (+ their current window) from the live tmux
+ *  server. Never throws. */
 export function listAttachedClients(): AttachedClient[] {
   try {
-    const raw = runTmux(["list-clients", "-F", "#{client_name}\t#{session_name}"])
+    const raw = runTmux(["list-clients", "-F", "#{client_name}\t#{session_name}\t#{window_index}"])
       .toString()
       .trim();
     return raw ? parseClients(raw.split("\n")) : [];
   } catch {
     return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The app focus handshake (M25.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * What the unified app publishes about its own screen, so the updater can
+ * suppress pings for panes the user is literally looking at. Lives as a tmux
+ * SERVER option ({@link APP_FOCUS_OPTION}) rather than a file: the record is
+ * scoped to exactly the server whose panes are being watched (no cross-server
+ * or cross-`TMUX_IDE_HOME` leakage), it is readable in the same cheap tmux
+ * calls the updater already makes, and it DIES WITH THE SERVER — a crashed
+ * server can't leave a stale record behind. A crashed APP can, which is what
+ * the `ts` staleness guard covers ({@link APP_FOCUS_STALE_MS}).
+ */
+export interface AppFocus {
+  /** Epoch ms the app last refreshed the record (each fleet poll, ~3s). */
+  ts: number;
+  /** Whether a client is attached to the app (hosted: probed; plain: true). */
+  attached: boolean;
+  /** The session the app's Terminal tab mirrors ("" on Home with no context). */
+  session: string;
+  /** Pane ids VISIBLE on the app's screen right now — the mirrored window's
+   *  panes while the Terminal tab is active, [] on Files/Diff/Home. */
+  panes: string[];
+}
+
+/** The tmux server option carrying the app's JSON {@link AppFocus} record. */
+export const APP_FOCUS_OPTION = "@tmux_ide_app_focus";
+/** Ignore a focus record older than this — covers an app that died without
+ *  cleanup (the app refreshes every ~3s fleet poll). */
+export const APP_FOCUS_STALE_MS = 15_000;
+
+/** PURE — serialize an {@link AppFocus} for the option value. */
+export function buildAppFocusValue(focus: AppFocus): string {
+  return JSON.stringify(focus);
+}
+
+/** PURE — parse a raw option value into a live {@link AppFocus}, or null for
+ *  anything missing, malformed, or STALE (`ts` older than
+ *  {@link APP_FOCUS_STALE_MS} relative to `nowMs`). Never throws. */
+export function parseAppFocus(raw: string | null | undefined, nowMs: number): AppFocus | null {
+  if (!raw) return null;
+  try {
+    const o = JSON.parse(raw) as Record<string, unknown>;
+    if (!o || typeof o !== "object") return null;
+    const ts = typeof o.ts === "number" ? o.ts : null;
+    if (ts === null || nowMs - ts > APP_FOCUS_STALE_MS) return null;
+    return {
+      ts,
+      attached: o.attached === true,
+      session: typeof o.session === "string" ? o.session : "",
+      panes: Array.isArray(o.panes)
+        ? o.panes.filter((p): p is string => typeof p === "string")
+        : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** io — read the app's focus record off the live tmux server (null when unset,
+ *  malformed, or stale). Never throws. */
+export function readAppFocus(nowMs: number = Date.now()): AppFocus | null {
+  try {
+    const raw = runTmux(["show-option", "-s", "-v", APP_FOCUS_OPTION]).toString().trim();
+    return parseAppFocus(raw, nowMs);
+  } catch {
+    // option never set (unset server user-options error out) — no app around
+    return null;
   }
 }
 
@@ -203,12 +324,41 @@ function shellSingleQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+/** The session option a banner click stamps on the hosted app: "open THIS
+ *  session when you next look". The app consumes it on its fleet poll. */
+export const APP_JUMP_OPTION = "@tmux_ide_app_jump";
+
+/**
+ * PURE — the shell command a banner click runs (M25.1 click-to-jump v2).
+ * When the hosted app exists, the click routes THROUGH the cockpit: stamp
+ * {@link APP_JUMP_OPTION} on the host session (the running app consumes it and
+ * opens that workspace — so even a DETACHED cockpit shows the right session on
+ * the next attach), then switch the user's most-recent client to the cockpit.
+ * Without a hosted app, fall back to switching the client straight to the
+ * session. (`switch-client` without `-c` targets the last-active client — the
+ * best we can do without knowing which terminal the click came from; with no
+ * client attached at all it fails silently, and the jump stamp still lands.)
+ *
+ * NOTE the target spellings: has-session/switch-client take the `=` exact-match
+ * prefix, but set-option REJECTS it ("no such session", measured on 3.7b — see
+ * {@link ../mirror/hosted.ts hostSetupArgvs}), so the stamp uses the plain name.
+ */
+export function notifierExecuteCommand(session: string): string {
+  const target = shellSingleQuote(session);
+  const host = shellSingleQuote(`=${APP_HOST_SESSION}`);
+  return (
+    `if tmux has-session -t ${host} 2>/dev/null; then ` +
+    `tmux set-option -t ${shellSingleQuote(APP_HOST_SESSION)} ${APP_JUMP_OPTION} ${target}; ` +
+    `tmux switch-client -t ${host}; ` +
+    `else tmux switch-client -t ${target}; fi`
+  );
+}
+
 /**
  * PURE — the `terminal-notifier` argv for a click-through banner: clicking it
- * runs `tmux switch-client -t <session>`, jumping the user's most-recent client
- * straight to the session that needs them. (`switch-client` without `-c` targets
- * the last-active client — the best we can do without knowing which terminal the
- * click came from.)
+ * runs {@link notifierExecuteCommand}, which jumps the user's most-recent
+ * client to the hosted cockpit (selecting the session that needs them) when
+ * one exists, else straight to the session.
  */
 export function terminalNotifierArgs(n: SystemNotification): string[] {
   return [
@@ -217,7 +367,7 @@ export function terminalNotifierArgs(n: SystemNotification): string[] {
     "-message",
     n.message,
     "-execute",
-    `tmux switch-client -t ${shellSingleQuote(n.session)}`,
+    notifierExecuteCommand(n.session),
   ];
 }
 

--- a/packages/daemon/src/tui/chrome/updater.test.ts
+++ b/packages/daemon/src/tui/chrome/updater.test.ts
@@ -35,6 +35,16 @@ const FULL_PREFS: NotificationPrefs = {
   quietHours: null,
 };
 
+/**
+ * PaneDetail factory — the chip/notify tests only care about identity + agent +
+ * status; the capture fields (pid/dir/sessionId) get inert defaults.
+ */
+function pd(
+  over: Pick<PaneDetail, "sessionName" | "paneId" | "agent" | "status"> & Partial<PaneDetail>,
+): PaneDetail {
+  return { pid: 0, dir: "/", sessionId: null, ...over };
+}
+
 function project(name: string, overrides: Partial<TeamProject> = {}): TeamProject {
   return {
     name,
@@ -151,7 +161,7 @@ describe("runUpdaterTick", () => {
       listAdopted: () => ["web"],
       // Emit a blocked claude pane so enrichment can name it.
       computeProjects: (onPane) => {
-        onPane({ sessionName: "web", paneId: "%3", agent: "claude", status: "blocked" });
+        onPane(pd({ sessionName: "web", paneId: "%3", agent: "claude", status: "blocked" }));
         return [
           project("web", {
             status: "blocked",
@@ -305,10 +315,10 @@ describe("runUpdaterTick", () => {
 
 describe("pickRepresentativePane", () => {
   const panes: PaneDetail[] = [
-    { sessionName: "web", paneId: "%1", agent: null, status: "blocked" },
-    { sessionName: "web", paneId: "%2", agent: "claude", status: "blocked" },
-    { sessionName: "web", paneId: "%3", agent: "codex", status: "working" },
-    { sessionName: "api", paneId: "%4", agent: "claude", status: "blocked" },
+    pd({ sessionName: "web", paneId: "%1", agent: null, status: "blocked" }),
+    pd({ sessionName: "web", paneId: "%2", agent: "claude", status: "blocked" }),
+    pd({ sessionName: "web", paneId: "%3", agent: "codex", status: "working" }),
+    pd({ sessionName: "api", paneId: "%4", agent: "claude", status: "blocked" }),
   ];
 
   it("prefers a matching pane that resolved to a real agent", () => {
@@ -317,7 +327,7 @@ describe("pickRepresentativePane", () => {
 
   it("falls back to the first matching pane when none has an agent", () => {
     const shells: PaneDetail[] = [
-      { sessionName: "web", paneId: "%9", agent: null, status: "blocked" },
+      pd({ sessionName: "web", paneId: "%9", agent: null, status: "blocked" }),
     ];
     expect(pickRepresentativePane("web", "blocked", shells)?.paneId).toBe("%9");
   });
@@ -330,7 +340,7 @@ describe("pickRepresentativePane", () => {
 
 describe("enrichEvents", () => {
   const panes: PaneDetail[] = [
-    { sessionName: "web", paneId: "%2", agent: "claude", status: "blocked" },
+    pd({ sessionName: "web", paneId: "%2", agent: "claude", status: "blocked" }),
   ];
 
   it("attaches the resolved agent + located pane for a blocked/done event", () => {
@@ -383,8 +393,8 @@ describe("runUpdaterTick — pane chips", () => {
     runUpdaterTick({
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "working" },
-        { sessionName: "web", paneId: "%2", agent: null, status: "idle" },
+        pd({ sessionName: "web", paneId: "%1", agent: "claude", status: "working" }),
+        pd({ sessionName: "web", paneId: "%2", agent: null, status: "idle" }),
       ]),
       writeStatus: () => {},
       writeChip: (paneId, value) => writes.push([paneId, value]),
@@ -401,8 +411,8 @@ describe("runUpdaterTick — pane chips", () => {
     runUpdaterTick({
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "working" },
-        { sessionName: "other", paneId: "%9", agent: "codex", status: "blocked" },
+        pd({ sessionName: "web", paneId: "%1", agent: "claude", status: "working" }),
+        pd({ sessionName: "other", paneId: "%9", agent: "codex", status: "blocked" }),
       ]),
       writeStatus: () => {},
       writeChip,
@@ -418,7 +428,7 @@ describe("runUpdaterTick — pane chips", () => {
     const deps = {
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "working" as AgentStatus },
+        pd({ sessionName: "web", paneId: "%1", agent: "claude", status: "working" as AgentStatus }),
       ]),
       writeStatus: () => {},
       writeChip,
@@ -436,7 +446,7 @@ describe("runUpdaterTick — pane chips", () => {
     runUpdaterTick({
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "working" },
+        pd({ sessionName: "web", paneId: "%1", agent: "claude", status: "working" }),
       ]),
       writeStatus: () => {},
       writeChip,
@@ -445,7 +455,7 @@ describe("runUpdaterTick — pane chips", () => {
     runUpdaterTick({
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "blocked" },
+        pd({ sessionName: "web", paneId: "%1", agent: "claude", status: "blocked" }),
       ]),
       writeStatus: () => {},
       writeChip,
@@ -461,7 +471,7 @@ describe("runUpdaterTick — pane chips", () => {
     runUpdaterTick({
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "working" },
+        pd({ sessionName: "web", paneId: "%1", agent: "claude", status: "working" }),
       ]),
       writeStatus: (s) => writes.push(s),
     });
@@ -558,5 +568,35 @@ describe("runUpdaterTick — update surface", () => {
       prefs: { toast: false, macos: false },
     });
     expect(toasted).toHaveLength(0);
+  });
+});
+
+describe("runUpdaterTick — session-id capture", () => {
+  it("forwards this tick's pane details to captureSessionIds", () => {
+    const seen: PaneDetail[][] = [];
+    const panes = [
+      pd({ sessionName: "web", paneId: "%1", agent: "codex", status: "working" }),
+      pd({ sessionName: "web", paneId: "%2", agent: null, status: "idle" }),
+    ];
+    runUpdaterTick({
+      listAdopted: () => ["web"],
+      computeProjects: (onPane) => {
+        for (const pane of panes) onPane(pane);
+        return [project("web")];
+      },
+      writeStatus: () => {},
+      captureSessionIds: (p) => seen.push(p),
+    });
+    expect(seen).toEqual([panes]);
+  });
+
+  it("is optional — a tick without the capture dep still runs", () => {
+    expect(() =>
+      runUpdaterTick({
+        listAdopted: () => ["web"],
+        computeProjects: () => [project("web")],
+        writeStatus: () => {},
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/daemon/src/tui/chrome/updater.test.ts
+++ b/packages/daemon/src/tui/chrome/updater.test.ts
@@ -5,9 +5,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   adoptedSessionsFrom,
-  enrichEvents,
-  pickRepresentativePane,
+  createUnreachableCounter,
+  diffPaneTransitions,
   runUpdaterTick,
+  updaterProbeArgv,
+  updaterSpawnArgv,
+  UPDATER_SESSION,
+  UPDATER_UNREACHABLE_EXIT_TICKS,
   updateSegment,
 } from "./updater.ts";
 import { buildStatusline } from "./statusline.ts";
@@ -143,15 +147,22 @@ describe("runUpdaterTick", () => {
     expect(prevState.get("api")).toBe("working");
   });
 
-  it("dispatches a toast when a session transitions to blocked, naming the agent + location", () => {
+  it("dispatches a toast when a PANE transitions to blocked, naming the agent + location", () => {
     const toasted: ToastTarget[][] = [];
     const clients: AttachedClient[] = [{ client: "/dev/ttys000", session: "other" }];
     const lastNotified = new Map<string, number>();
+    const persistNotified = vi.fn();
     runUpdaterTick({
       listAdopted: () => ["web"],
-      // Emit a blocked claude pane so enrichment can name it.
+      // Emit a blocked claude pane — pane transitions drive the notification.
       computeProjects: (onPane) => {
-        onPane({ sessionName: "web", paneId: "%3", agent: "claude", status: "blocked" });
+        onPane({
+          sessionName: "web",
+          paneId: "%3",
+          agent: "claude",
+          status: "blocked",
+          windowIndex: 1,
+        });
         return [
           project("web", {
             status: "blocked",
@@ -171,6 +182,7 @@ describe("runUpdaterTick", () => {
       writeStatus: () => {},
       prevState: new Map<string, AgentStatus>([["web", "working"]]),
       appendEvents: () => {},
+      prevPaneState: new Map<string, AgentStatus>([["%3", "working"]]),
       listClients: () => clients,
       lastNotified,
       now: () => 1000,
@@ -178,37 +190,65 @@ describe("runUpdaterTick", () => {
       sendToasts: (t) => toasted.push(t),
       sendSystem: () => {},
       locatePane: (paneId) => (paneId === "%3" ? "web:1.2" : paneId),
+      persistNotified,
     });
 
     expect(toasted).toEqual([
       [{ client: "/dev/ttys000", message: "claude blocked · web:1.2 — needs input" }],
     ]);
-    // The debounce map was updated in place for the next tick.
-    expect(lastNotified.get("web:blocked")).toBe(1000);
+    // The debounce map was updated in place (per-pane key) AND persisted.
+    expect(lastNotified.get("%3:blocked")).toBe(1000);
+    expect(persistNotified).toHaveBeenCalledWith(lastNotified);
+  });
+
+  it("does not re-ping a pane the updater sees for the FIRST time (restart grace)", () => {
+    const sendToasts = vi.fn();
+    const sendSystem = vi.fn();
+    const persistNotified = vi.fn();
+    runUpdaterTick({
+      listAdopted: () => ["web"],
+      computeProjects: (onPane) => {
+        // Already blocked when the (re)started updater first looks.
+        onPane({
+          sessionName: "web",
+          paneId: "%3",
+          agent: "claude",
+          status: "blocked",
+          windowIndex: 0,
+        });
+        return [project("web")];
+      },
+      writeStatus: () => {},
+      prevPaneState: new Map(), // fresh start — no pane ever seen
+      listClients: () => [{ client: "c1", session: "other" }],
+      lastNotified: new Map(),
+      now: () => 1000,
+      prefs: FULL_PREFS,
+      sendToasts,
+      sendSystem,
+      persistNotified,
+    });
+    expect(sendToasts).toHaveBeenCalledWith([]);
+    expect(sendSystem).not.toHaveBeenCalled();
+    expect(persistNotified).not.toHaveBeenCalled();
   });
 
   it("dispatches no toast for a working transition (only blocked/done notify)", () => {
     const sendToasts = vi.fn();
     runUpdaterTick({
       listAdopted: () => ["web"],
-      computeProjects: () => [
-        project("web", {
+      computeProjects: (onPane) => {
+        onPane({
+          sessionName: "web",
+          paneId: "%3",
+          agent: "claude",
           status: "working",
-          sessions: [
-            {
-              name: "web",
-              attached: false,
-              windows: 1,
-              panes: 1,
-              status: "working",
-              windowList: [],
-            },
-          ],
-        }),
-      ],
+          windowIndex: 0,
+        });
+        return [project("web")];
+      },
       writeStatus: () => {},
-      prevState: new Map<string, AgentStatus>([["web", "idle"]]),
-      appendEvents: () => {},
+      prevPaneState: new Map<string, AgentStatus>([["%3", "idle"]]),
       listClients: () => [{ client: "c1", session: "other" }],
       lastNotified: new Map(),
       now: () => 1000,
@@ -232,8 +272,8 @@ describe("runUpdaterTick", () => {
     expect(appendEvents).not.toHaveBeenCalled();
   });
 
-  // Drive a single blocked transition through the notification path with the
-  // given prefs / clock, returning what each channel received.
+  // Drive a single blocked PANE transition through the notification path with
+  // the given prefs / clock, returning what each channel received.
   function runBlockedTick(opts: {
     prefs: NotificationPrefs;
     now?: number;
@@ -243,24 +283,18 @@ describe("runUpdaterTick", () => {
     const system: SystemNotification[] = [];
     runUpdaterTick({
       listAdopted: () => ["web"],
-      computeProjects: () => [
-        project("web", {
+      computeProjects: (onPane) => {
+        onPane({
+          sessionName: "web",
+          paneId: "%1",
+          agent: null,
           status: "blocked",
-          sessions: [
-            {
-              name: "web",
-              attached: false,
-              windows: 1,
-              panes: 1,
-              status: "blocked",
-              windowList: [],
-            },
-          ],
-        }),
-      ],
+          windowIndex: 0,
+        });
+        return [project("web")];
+      },
       writeStatus: () => {},
-      prevState: new Map<string, AgentStatus>([["web", "working"]]),
-      appendEvents: () => {},
+      prevPaneState: new Map<string, AgentStatus>([["%1", "working"]]),
       listClients: () => [{ client: "c1", session: "other" }],
       lastNotified: opts.lastNotified ?? new Map(),
       now: () => opts.now ?? 1000,
@@ -303,68 +337,105 @@ describe("runUpdaterTick", () => {
   });
 });
 
-describe("pickRepresentativePane", () => {
-  const panes: PaneDetail[] = [
-    { sessionName: "web", paneId: "%1", agent: null, status: "blocked" },
-    { sessionName: "web", paneId: "%2", agent: "claude", status: "blocked" },
-    { sessionName: "web", paneId: "%3", agent: "codex", status: "working" },
-    { sessionName: "api", paneId: "%4", agent: "claude", status: "blocked" },
-  ];
+describe("diffPaneTransitions", () => {
+  const pane = (
+    paneId: string,
+    status: AgentStatus,
+    agent: string | null = "claude",
+  ): PaneDetail => ({ sessionName: "web", paneId, agent, status, windowIndex: 1 });
 
-  it("prefers a matching pane that resolved to a real agent", () => {
-    expect(pickRepresentativePane("web", "blocked", panes)?.paneId).toBe("%2");
+  it("emits a located, enriched event for a pane's blocked/done transition", () => {
+    const prev = new Map<string, AgentStatus>([["%2", "working"]]);
+    const events = diffPaneTransitions(prev, [pane("%2", "blocked")], (id) =>
+      id === "%2" ? "web:1.2" : id,
+    );
+    expect(events).toEqual([
+      {
+        session: "web",
+        from: "working",
+        to: "blocked",
+        paneId: "%2",
+        windowIndex: 1,
+        agent: "claude",
+        location: "web:1.2",
+      },
+    ]);
+    // prev was mutated in place to the fresh pane state.
+    expect(prev.get("%2")).toBe("blocked");
   });
 
-  it("falls back to the first matching pane when none has an agent", () => {
-    const shells: PaneDetail[] = [
-      { sessionName: "web", paneId: "%9", agent: null, status: "blocked" },
-    ];
-    expect(pickRepresentativePane("web", "blocked", shells)?.paneId).toBe("%9");
+  it("emits first-sight events with from: null and does NOT locate them", () => {
+    const locate = vi.fn((id: string) => id);
+    const events = diffPaneTransitions(new Map(), [pane("%2", "blocked")], locate);
+    expect(events).toEqual([
+      {
+        session: "web",
+        from: null,
+        to: "blocked",
+        paneId: "%2",
+        windowIndex: 1,
+        agent: "claude",
+        location: "web",
+      },
+    ]);
+    expect(locate).not.toHaveBeenCalled();
   });
 
-  it("returns null when no pane matches the session + state", () => {
-    expect(pickRepresentativePane("web", "done", panes)).toBeNull();
-    expect(pickRepresentativePane("nope", "blocked", panes)).toBeNull();
+  it("does not locate a non-notifiable transition either (no tmux call for a non-ping)", () => {
+    const locate = vi.fn((id: string) => id);
+    const prev = new Map<string, AgentStatus>([["%2", "blocked"]]);
+    const events = diffPaneTransitions(prev, [pane("%2", "working")], locate);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.location).toBe("web");
+    expect(locate).not.toHaveBeenCalled();
+  });
+
+  it("emits one event PER PANE — a second agent blocking in the same session is seen", () => {
+    const prev = new Map<string, AgentStatus>([
+      ["%1", "blocked"],
+      ["%2", "working"],
+    ]);
+    const events = diffPaneTransitions(prev, [pane("%1", "blocked"), pane("%2", "blocked")]);
+    expect(events.map((e) => e.paneId)).toEqual(["%2"]);
+  });
+
+  it("drops vanished panes from the state and emits nothing for them", () => {
+    const prev = new Map<string, AgentStatus>([["%9", "working"]]);
+    const events = diffPaneTransitions(prev, []);
+    expect(events).toEqual([]);
+    expect(prev.size).toBe(0);
   });
 });
 
-describe("enrichEvents", () => {
-  const panes: PaneDetail[] = [
-    { sessionName: "web", paneId: "%2", agent: "claude", status: "blocked" },
-  ];
-
-  it("attaches the resolved agent + located pane for a blocked/done event", () => {
-    const enriched = enrichEvents(
-      [{ session: "web", from: "working", to: "blocked" }],
-      panes,
-      (id) => (id === "%2" ? "web:1.2" : id),
-    );
-    expect(enriched).toEqual([
-      { session: "web", from: "working", to: "blocked", agent: "claude", location: "web:1.2" },
-    ]);
+describe("createUnreachableCounter", () => {
+  it("trips only after N consecutive misses and resets on any success", () => {
+    const shouldExit = createUnreachableCounter(3);
+    expect(shouldExit(false)).toBe(false);
+    expect(shouldExit(false)).toBe(false);
+    expect(shouldExit(true)).toBe(false); // reset
+    expect(shouldExit(false)).toBe(false);
+    expect(shouldExit(false)).toBe(false);
+    expect(shouldExit(false)).toBe(true); // 3 in a row
   });
 
-  it("leaves a non-notifiable event unlocated (location = session, agent null)", () => {
-    const locate = vi.fn();
-    const enriched = enrichEvents(
-      [{ session: "web", from: "blocked", to: "working" }],
-      panes,
-      locate,
-    );
-    expect(enriched).toEqual([
-      { session: "web", from: "blocked", to: "working", agent: null, location: "web" },
-    ]);
-    expect(locate).not.toHaveBeenCalled(); // no live tmux call for a non-ping
+  it("defaults to the exported threshold", () => {
+    const shouldExit = createUnreachableCounter();
+    for (let i = 0; i < UPDATER_UNREACHABLE_EXIT_TICKS - 1; i++) {
+      expect(shouldExit(false)).toBe(false);
+    }
+    expect(shouldExit(false)).toBe(true);
   });
+});
 
-  it("falls back to the session name when no representative pane is found", () => {
-    const enriched = enrichEvents(
-      [{ session: "ghost", from: "working", to: "done" }],
-      panes,
-      (id) => id,
-    );
-    expect(enriched).toEqual([
-      { session: "ghost", from: "working", to: "done", agent: null, location: "ghost" },
+describe("updater argv builders (the app's async front door)", () => {
+  it("probes with an exact-match has-session and spawns the loop detached", () => {
+    expect(updaterProbeArgv()).toEqual(["has-session", "-t", `=${UPDATER_SESSION}`]);
+    expect(updaterSpawnArgv()).toEqual([
+      "new-session",
+      "-d",
+      "-s",
+      UPDATER_SESSION,
+      "exec tmux-ide chrome-updater",
     ]);
   });
 });
@@ -383,8 +454,8 @@ describe("runUpdaterTick — pane chips", () => {
     runUpdaterTick({
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "working" },
-        { sessionName: "web", paneId: "%2", agent: null, status: "idle" },
+        { sessionName: "web", paneId: "%1", agent: "claude", status: "working", windowIndex: 0 },
+        { sessionName: "web", paneId: "%2", agent: null, status: "idle", windowIndex: 0 },
       ]),
       writeStatus: () => {},
       writeChip: (paneId, value) => writes.push([paneId, value]),
@@ -401,8 +472,8 @@ describe("runUpdaterTick — pane chips", () => {
     runUpdaterTick({
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "working" },
-        { sessionName: "other", paneId: "%9", agent: "codex", status: "blocked" },
+        { sessionName: "web", paneId: "%1", agent: "claude", status: "working", windowIndex: 0 },
+        { sessionName: "other", paneId: "%9", agent: "codex", status: "blocked", windowIndex: 0 },
       ]),
       writeStatus: () => {},
       writeChip,
@@ -418,7 +489,13 @@ describe("runUpdaterTick — pane chips", () => {
     const deps = {
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "working" as AgentStatus },
+        {
+          sessionName: "web",
+          paneId: "%1",
+          agent: "claude",
+          status: "working" as AgentStatus,
+          windowIndex: 0,
+        },
       ]),
       writeStatus: () => {},
       writeChip,
@@ -436,7 +513,7 @@ describe("runUpdaterTick — pane chips", () => {
     runUpdaterTick({
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "working" },
+        { sessionName: "web", paneId: "%1", agent: "claude", status: "working", windowIndex: 0 },
       ]),
       writeStatus: () => {},
       writeChip,
@@ -445,7 +522,7 @@ describe("runUpdaterTick — pane chips", () => {
     runUpdaterTick({
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "blocked" },
+        { sessionName: "web", paneId: "%1", agent: "claude", status: "blocked", windowIndex: 0 },
       ]),
       writeStatus: () => {},
       writeChip,
@@ -461,7 +538,7 @@ describe("runUpdaterTick — pane chips", () => {
     runUpdaterTick({
       listAdopted: () => ["web"],
       computeProjects: withPanes([
-        { sessionName: "web", paneId: "%1", agent: "claude", status: "working" },
+        { sessionName: "web", paneId: "%1", agent: "claude", status: "working", windowIndex: 0 },
       ]),
       writeStatus: (s) => writes.push(s),
     });

--- a/packages/daemon/src/tui/chrome/updater.ts
+++ b/packages/daemon/src/tui/chrome/updater.ts
@@ -21,6 +21,7 @@
  * without a live tmux; `adoptedSessionsFrom` is a pure parser.
  */
 import { hasSession, isProcessAlive, runTmux } from "@tmux-ide/tmux-bridge";
+import { ADOPTED_OPTION, UPDATER_SESSION, updaterSpawnArgv } from "./front-door.ts";
 import { DEFAULT_THEME, getAppConfig, type AppTheme } from "../../lib/app-config.ts";
 import {
   maybeCheckForUpdate,
@@ -37,15 +38,18 @@ import {
   enabledStates,
   inQuietHours,
   listAttachedClients,
+  readAppFocus,
   readNotificationPrefs,
   sendSystemNotification,
   sendToasts,
+  type AppFocus,
   type AttachedClient,
   type NotificationPrefs,
   type NotifyEvent,
   type SystemNotification,
   type ToastTarget,
 } from "./notify.ts";
+import { loadLastNotified, saveLastNotified } from "./notify-state.ts";
 import {
   collectFleetSnapshot,
   createSnapshotter,
@@ -58,10 +62,15 @@ import { buildStatusline } from "./statusline.ts";
 export const STATUS_OPTION = "@tmux_ide_status";
 /** Per-PANE user option holding the pre-rendered agent chip (read by pane-border-format). */
 export const CHIP_OPTION = "@tmux_ide_chip";
-/** Per-session marker option set on adopt so the updater can enumerate adopted sessions. */
-export const ADOPTED_OPTION = "@tmux_ide_adopted";
-/** The hidden internal session that hosts the updater loop. */
-export const UPDATER_SESSION = "_tmux-ide-chrome";
+// The adopted marker, the updater session name, and their argv builders live
+// in the LEAF module front-door.ts (the unified app imports them without
+// pulling this module's fleet-scan graph); re-exported here for the chrome.
+export {
+  ADOPTED_OPTION,
+  UPDATER_SESSION,
+  updaterProbeArgv,
+  updaterSpawnArgv,
+} from "./front-door.ts";
 /** Server option holding the running updater's pid (a lightweight single-owner guard). */
 export const UPDATER_PID_OPTION = "@tmux_ide_updater_pid";
 /** Default tick cadence — overridable via `updater.tickMs` in the app config. */
@@ -140,18 +149,29 @@ export interface UpdaterTickDeps {
   prevState?: Map<string, AgentStatus>;
   appendEvents?: (events: AgentEventInit[]) => void;
   /**
-   * Notification dispatch (optional). When wired alongside `prevState`, the tick
-   * turns THIS tick's transitions into user pings — toasts on attached clients
-   * and/or a macOS notification — via {@link decideNotifications}, gated on
-   * `prefs`. `lastNotified` is the persistent debounce map, mutated in place.
-   * All deps-injected so the routing is unit-tested without a live tmux.
+   * Notification dispatch (optional). When wired alongside `prevPaneState`
+   * (M25.1 — notifications are PANE-granular so a second agent blocking in an
+   * already-blocked session still pings), the tick turns THIS tick's pane
+   * transitions into user pings — toasts on attached clients and/or a macOS
+   * notification — via {@link decideNotifications}, gated on `prefs`.
+   * `lastNotified` is the persistent debounce map, mutated in place (and
+   * persisted via `persistNotified` when a ping fired, so a restart can't
+   * re-ping inside the window). All deps-injected so the routing is
+   * unit-tested without a live tmux.
    */
+  prevPaneState?: Map<string, AgentStatus>;
   listClients?: () => AttachedClient[];
   lastNotified?: Map<string, number>;
   now?: () => number;
   prefs?: NotificationPrefs;
   sendToasts?: (toasts: ToastTarget[]) => void;
   sendSystem?: (n: SystemNotification) => void;
+  /** The unified app's focus record (see {@link AppFocus}) — pings for panes
+   *  on the app's screen are suppressed. Wired to {@link readAppFocus}. */
+  appFocus?: () => AppFocus | null;
+  /** Persist the debounce map after a tick that fired a ping. Wired to
+   *  {@link saveLastNotified}. */
+  persistNotified?: (map: ReadonlyMap<string, number>) => void;
   /**
    * Resolve a pane id to its human `session:window.pane` location for the ping
    * text (optional). Wired to the live tmux {@link paneLocation}; tests inject a
@@ -221,10 +241,14 @@ export function runUpdaterTick(deps: UpdaterTickDeps): void {
     const { events, state } = diffFleet(deps.prevState, fleetStatuses(projects));
     deps.prevState.clear();
     for (const [name, status] of state) deps.prevState.set(name, status);
-    if (events.length > 0) {
-      deps.appendEvents(events);
-      dispatchNotifications(deps, enrichEvents(events, panes, deps.locatePane));
-    }
+    if (events.length > 0) deps.appendEvents(events);
+  }
+  // Notifications ride PANE transitions (M25.1), not the session rollup — a
+  // second agent blocking in an already-blocked session is invisible at the
+  // session level but is exactly who the user needs to hear about.
+  if (deps.prevPaneState) {
+    const events = diffPaneTransitions(deps.prevPaneState, panes, deps.locatePane);
+    if (events.length > 0) dispatchNotifications(deps, events);
   }
 }
 
@@ -254,43 +278,42 @@ function writeChips(
 }
 
 /**
- * PURE — pick the pane to name in a session-level ping. A session rolls up many
- * panes; the ping should point at ONE. We take a pane whose status matches the
- * transition (`to`), preferring one that resolved to a real agent (so the ping
- * reads `claude blocked …`, not a bare shell). Null when no pane matches — the
- * updater then falls back to the session name / a generic label.
+ * PURE (given `locate`) — diff the previous per-pane states against this
+ * tick's panes into ready-to-ping {@link NotifyEvent}s: each carries its
+ * `paneId` (the debounce/visibility key), `windowIndex` (window-granular toast
+ * suppression), the pane's resolved `agent`, and — only for a notifiable
+ * blocked/done transition that isn't first-sight — the human `location`
+ * (`locate` is a live tmux call, so it only fires for a potential ping).
+ * `prev` is mutated in place to the fresh state, like the session-level
+ * `prevState`; a pane that vanished simply drops out. First sight of a pane
+ * emits `from: null`, which {@link decideNotifications} ignores — that's the
+ * restart/first-tick grace.
  */
-export function pickRepresentativePane(
-  session: string,
-  to: AgentStatus,
-  panes: PaneDetail[],
-): PaneDetail | null {
-  const matching = panes.filter((p) => p.sessionName === session && p.status === to);
-  if (matching.length === 0) return null;
-  return matching.find((p) => p.agent !== null) ?? matching[0]!;
-}
-
-/**
- * PURE — enrich session-level transitions with the pane's `agent` id and human
- * `location` so {@link notifyMessage} can name who needs the user. Only the
- * notifiable states (blocked/done) get resolved — everything else keeps the bare
- * session as its location and is filtered out downstream anyway, so `locate`
- * (a live tmux call) only fires for a real ping.
- */
-export function enrichEvents(
-  events: AgentEventInit[],
+export function diffPaneTransitions(
+  prev: Map<string, AgentStatus>,
   panes: PaneDetail[],
   locate?: (paneId: string) => string,
 ): NotifyEvent[] {
-  return events.map((ev) => {
-    const notifiable = ev.to === "blocked" || ev.to === "done";
-    const rep = notifiable ? pickRepresentativePane(ev.session, ev.to, panes) : null;
-    return {
-      ...ev,
-      agent: rep?.agent ?? null,
-      location: rep && locate ? locate(rep.paneId) : ev.session,
-    };
-  });
+  const events: NotifyEvent[] = [];
+  const next = new Map<string, AgentStatus>();
+  for (const pane of panes) {
+    const before = prev.has(pane.paneId) ? prev.get(pane.paneId)! : null;
+    next.set(pane.paneId, pane.status);
+    if (before === pane.status) continue;
+    const notifiable = before !== null && (pane.status === "blocked" || pane.status === "done");
+    events.push({
+      session: pane.sessionName,
+      from: before,
+      to: pane.status,
+      paneId: pane.paneId,
+      windowIndex: pane.windowIndex,
+      agent: pane.agent,
+      location: notifiable && locate ? locate(pane.paneId) : pane.sessionName,
+    });
+  }
+  prev.clear();
+  for (const [paneId, status] of next) prev.set(paneId, status);
+  return events;
 }
 
 /**
@@ -313,9 +336,13 @@ function dispatchNotifications(deps: UpdaterTickDeps, events: NotifyEvent[]): vo
     lastNotified,
     nowMs,
     enabledStates(prefs),
+    deps.appFocus?.() ?? null,
   );
   lastNotified.clear();
   for (const [key, ts] of decision.nextLastNotified) lastNotified.set(key, ts);
+  // A system entry exists for every event that actually fired (stamped the
+  // debounce map), so this is exactly "the map changed — persist it".
+  if (decision.system.length > 0) deps.persistNotified?.(lastNotified);
   if (prefs.toast && toast) toast(decision.toasts);
   if (prefs.macos && sendSystem && !inQuietHours(new Date(nowMs), prefs.quietHours)) {
     for (const n of decision.system) sendSystem(n);
@@ -384,15 +411,14 @@ export function updaterRunning(): boolean {
 
 /**
  * Ensure the background updater is running: if the `_tmux-ide-chrome` session
- * isn't up, start it detached running `tmux-ide chrome-updater`. `exec` replaces
- * the shell so the pane IS the loop; killing the session stops it. `_`-internal
+ * isn't up, start it detached running `tmux-ide chrome-updater`. `_`-internal
  * so it's hidden from the bar/switcher. Best-effort — a chrome failure must
  * never break adopt/launch.
  */
 export function startUpdaterIfNeeded(): void {
   try {
     if (updaterRunning()) return;
-    runTmux(["new-session", "-d", "-s", UPDATER_SESSION, "exec tmux-ide chrome-updater"]);
+    runTmux(updaterSpawnArgv());
   } catch {
     // best-effort — the bar still works via the last-written var
   }
@@ -444,11 +470,43 @@ function releaseUpdater(): void {
   }
 }
 
+/** Exit the loop after this many CONSECUTIVE ticks with the tmux server gone —
+ *  a dead server means nothing to watch and nobody to ping, and an immortal
+ *  interval would zombie (two were found live before M25.1). */
+export const UPDATER_UNREACHABLE_EXIT_TICKS = 5;
+
+/** PURE — a consecutive-failure counter: feed it each tick's reachability;
+ *  it answers "give up now?" after `threshold` misses in a row (any success
+ *  resets the run). */
+export function createUnreachableCounter(
+  threshold: number = UPDATER_UNREACHABLE_EXIT_TICKS,
+): (reachable: boolean) => boolean {
+  let consecutive = 0;
+  return (reachable: boolean): boolean => {
+    consecutive = reachable ? 0 : consecutive + 1;
+    return consecutive >= threshold;
+  };
+}
+
+/** io — can we still talk to the tmux server? (A server with zero sessions
+ *  exits, so `list-sessions` failing means the server itself is gone.) */
+function isServerReachable(): boolean {
+  try {
+    runTmux(["list-sessions", "-F", "#{session_name}"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Run the updater loop forever (the body of `tmux-ide chrome-updater`). Claims
  * single-ownership, then rewrites every adopted session's bar immediately and
  * every {@link TICK_MS} thereafter behind ONE persistent tracker (so `done`
- * transitions surface). Blocks — the interval keeps the event loop alive.
+ * transitions surface). Blocks — the interval keeps the event loop alive —
+ * until the tmux server has been unreachable for
+ * {@link UPDATER_UNREACHABLE_EXIT_TICKS} consecutive ticks, at which point the
+ * loop logs once and exits instead of running headless forever.
  */
 export function runUpdaterLoop(): void {
   if (!claimUpdater()) return;
@@ -459,8 +517,11 @@ export function runUpdaterLoop(): void {
   const tracker = createStatusTracker();
   // Persistent across ticks so `diffFleet` can spot working→done etc.
   const prevState = new Map<string, AgentStatus>();
-  // Persistent so the notification debounce survives across ticks.
-  const lastNotified = new Map<string, number>();
+  // Per-PANE states for the notification path (M25.1 — pane-granular pings).
+  const prevPaneState = new Map<string, AgentStatus>();
+  // The notification debounce map — restored from disk so a restart can't
+  // re-ping inside the window, persisted back on every ping.
+  const lastNotified = loadLastNotified();
   // Persistent per-pane chip cache so we only rewrite a chip when it changed.
   const chipCache = new Map<string, string>();
   // The fleet snapshotter — pulsed each tick, self-throttled, writes only on a
@@ -471,6 +532,7 @@ export function runUpdaterLoop(): void {
     write: writeSnapshot,
     every: config.updater.snapshotEvery,
   });
+  const shouldGiveUp = createUnreachableCounter();
   const tick = () => {
     try {
       runUpdaterTick({
@@ -482,6 +544,7 @@ export function runUpdaterLoop(): void {
         chipCache,
         prevState,
         appendEvents,
+        prevPaneState,
         listClients: listAttachedClients,
         lastNotified,
         now: () => Date.now(),
@@ -489,6 +552,8 @@ export function runUpdaterLoop(): void {
         sendToasts,
         sendSystem: sendSystemNotification,
         locatePane: paneLocation,
+        appFocus: () => readAppFocus(),
+        persistNotified: (map) => saveLastNotified(map),
         maybeCheckForUpdate: () => maybeCheckForUpdate({ enabled: config.updates.check }),
         markUpdateNotified,
       });
@@ -500,8 +565,14 @@ export function runUpdaterLoop(): void {
     } catch {
       // a failed snapshot just means staler disaster-recovery state
     }
+    // Self-exit when the server we exist to watch is gone (logged ONCE).
+    if (shouldGiveUp(isServerReachable())) {
+      console.error(
+        `tmux-ide chrome-updater: tmux server unreachable for ${UPDATER_UNREACHABLE_EXIT_TICKS} consecutive ticks — exiting`,
+      );
+      shutdown();
+    }
   };
-  tick();
   const timer = setInterval(tick, config.updater.tickMs);
   const shutdown = () => {
     clearInterval(timer);
@@ -510,4 +581,5 @@ export function runUpdaterLoop(): void {
   };
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
+  tick();
 }

--- a/packages/daemon/src/tui/chrome/updater.ts
+++ b/packages/daemon/src/tui/chrome/updater.ts
@@ -28,6 +28,7 @@ import {
   type UpdateStatus,
 } from "../../lib/update-check.ts";
 import { createStatusTracker, type AgentStatus } from "../detect/classify.ts";
+import { createSessionIdCapturer } from "../detect/session-id.ts";
 import { listTeamProjects, type TeamProject } from "../team/projects.ts";
 import type { PaneDetail } from "../team/sessions.ts";
 import { paneChip } from "./chip.ts";
@@ -168,6 +169,14 @@ export interface UpdaterTickDeps {
    */
   maybeCheckForUpdate?: () => UpdateStatus;
   markUpdateNotified?: (version: string) => boolean;
+  /**
+   * Session-id capture (optional). When wired, receives this tick's per-pane
+   * detail so the capturer ({@link ../detect/session-id.ts}) can stamp
+   * `@agent_session_id` on codex/cursor panes that lack one — the key
+   * `restore --resume-agents` resumes from. Self-throttled and stamp-once, so
+   * a fleet with no unstamped capturable panes costs nothing.
+   */
+  captureSessionIds?: (panes: PaneDetail[]) => void;
 }
 
 /**
@@ -216,6 +225,7 @@ export function runUpdaterTick(deps: UpdaterTickDeps): void {
     deps.writeStatus(session, buildStatusline(projects, session, 12, theme, extra));
   }
   writeChips(deps, adopted, panes, theme);
+  deps.captureSessionIds?.(panes);
   if (update?.updateAvailable && update.latest) dispatchUpdateToast(deps, update.latest);
   if (deps.prevState && deps.appendEvents) {
     const { events, state } = diffFleet(deps.prevState, fleetStatuses(projects));
@@ -463,6 +473,14 @@ export function runUpdaterLoop(): void {
   const lastNotified = new Map<string, number>();
   // Persistent per-pane chip cache so we only rewrite a chip when it changed.
   const chipCache = new Map<string, string>();
+  // Session-id capture for kinds without a hook integration (codex/cursor):
+  // stamps @agent_session_id so restore --resume-agents has its key. Throttled
+  // internally; probes only unstamped panes of capturable kinds.
+  const capturer = createSessionIdCapturer({
+    // Throwing is fine here — the capturer treats a failed stamp as "retry on
+    // the next capture window".
+    stamp: (paneId, id) => runTmux(["set-option", "-p", "-t", paneId, "@agent_session_id", id]),
+  });
   // The fleet snapshotter — pulsed each tick, self-throttled, writes only on a
   // structural change so the fleet can be rebuilt after a tmux-server death.
   const snapshotter = createSnapshotter({
@@ -491,6 +509,7 @@ export function runUpdaterLoop(): void {
         locatePane: paneLocation,
         maybeCheckForUpdate: () => maybeCheckForUpdate({ enabled: config.updates.check }),
         markUpdateNotified,
+        captureSessionIds: (panes) => capturer.onTick(panes),
       });
     } catch {
       // never let one bad tick kill the loop

--- a/packages/daemon/src/tui/detect/classify.test.ts
+++ b/packages/daemon/src/tui/detect/classify.test.ts
@@ -6,7 +6,13 @@
  * sequence.
  */
 import { describe, expect, it } from "vitest";
-import { classifyInstant, createStatusTracker, parseAuthorityEpoch } from "./classify.ts";
+import {
+  AGENT_TEXT_MAX,
+  classifyInstant,
+  createStatusTracker,
+  parseAuthorityEpoch,
+  sanitizeAgentText,
+} from "./classify.ts";
 import type { AgentManifest } from "./manifest.ts";
 import type { PaneSnapshot } from "./snapshot.ts";
 
@@ -130,5 +136,42 @@ describe("StatusTracker", () => {
     t.update("b", "idle");
     expect(t.update("a", "idle")).toBe("done");
     expect(t.update("b", "idle")).toBe("idle");
+  });
+});
+
+describe("sanitizeAgentText (display metadata, M25.4)", () => {
+  const ESC = String.fromCharCode(27);
+
+  it("passes plain short text through", () => {
+    expect(sanitizeAgentText("refactoring auth")).toBe("refactoring auth");
+  });
+
+  it("returns undefined for absent/empty/whitespace-only values", () => {
+    expect(sanitizeAgentText(undefined)).toBeUndefined();
+    expect(sanitizeAgentText("")).toBeUndefined();
+    expect(sanitizeAgentText("   ")).toBeUndefined();
+  });
+
+  it("strips ANSI CSI sequences entirely (no leftover brackets)", () => {
+    expect(sanitizeAgentText(`${ESC}[1;31mred${ESC}[0m text`)).toBe("red text");
+  });
+
+  it("replaces control chars (tabs, newlines) with spaces and collapses runs", () => {
+    expect(sanitizeAgentText("a\tb\n\ncd")).toBe("a b cd");
+  });
+
+  it("clamps to AGENT_TEXT_MAX with a trailing ellipsis", () => {
+    const out = sanitizeAgentText("x".repeat(80))!;
+    expect(out.length).toBe(AGENT_TEXT_MAX);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("a value that is exactly the max survives untouched", () => {
+    const exact = "y".repeat(AGENT_TEXT_MAX);
+    expect(sanitizeAgentText(exact)).toBe(exact);
+  });
+
+  it("a value that is ONLY control chars sanitizes to undefined", () => {
+    expect(sanitizeAgentText(`${ESC}[2J\t\n`)).toBeUndefined();
   });
 });

--- a/packages/daemon/src/tui/detect/classify.ts
+++ b/packages/daemon/src/tui/detect/classify.ts
@@ -49,6 +49,40 @@ export function parseAuthority(raw: string | undefined, nowSec: number): AgentSt
   return state as AgentStatus;
 }
 
+/** Display-metadata budget — `@agent_status_text` / `@agent_display_name`
+ *  values are clamped to this many characters (ellipsis included). */
+export const AGENT_TEXT_MAX = 32;
+
+/**
+ * Sanitize a self-reported display-metadata pane option
+ * (`@agent_status_text` / `@agent_display_name`) — PURE, never throws.
+ *
+ * ANSI escape sequences are stripped, remaining control characters become
+ * spaces, runs of whitespace collapse to one space, and the result is clamped
+ * to {@link AGENT_TEXT_MAX} characters (with a trailing ellipsis when cut).
+ * Returns undefined for an absent or effectively-empty value, so callers can
+ * spread the field additively (`...(text ? { statusText: text } : {})`).
+ *
+ * Freshness is NOT judged here: the metadata options carry no epoch of their
+ * own — they ride the pane's `@agent_state` stamp, and the caller surfaces
+ * them only while {@link parseAuthority} reports that stamp fresh.
+ */
+export function sanitizeAgentText(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const cleaned = raw
+    // CSI escape sequences (colors, cursor moves) — drop entirely.
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\[[0-9;?]*[ -/]*[\x40-\x7e]/g, "")
+    // Any remaining C0 control chars (incl. bare ESC, tabs, newlines) + DEL.
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (cleaned.length === 0) return undefined;
+  if (cleaned.length <= AGENT_TEXT_MAX) return cleaned;
+  return cleaned.slice(0, AGENT_TEXT_MAX - 1) + "…";
+}
+
 /**
  * Extract the epoch STAMP from an `@agent_state` value (`"<state>:<epoch>"`) —
  * the "since" timestamp of the reported state. PURE — returns the epoch, or

--- a/packages/daemon/src/tui/detect/manifest-corpus.test.ts
+++ b/packages/daemon/src/tui/detect/manifest-corpus.test.ts
@@ -287,6 +287,214 @@ describe("manifest corpus — cursor-agent (conservative)", () => {
   });
 });
 
+// ── M25.4 breadth — kilo (synthesized from binary-verbatim strings) ─────────
+
+// SYNTHESIZED (kilo, blocked) — assembled from strings extracted VERBATIM from
+// the shipped @kilocode/cli binary (v7.4.5): the permission dialog's
+// "△ Permission required" header and its "Allow once" / "Allow always" /
+// "Reject" options. The layout around them is our reconstruction (no account
+// was available to drive a live capture); replace with a real capture when one
+// exists.
+const KILO_BLOCKED = `
+ △ Permission required
+   Bash: rm -rf ./dist
+ ❯ Allow once
+   Allow always
+   Reject
+`;
+
+// SYNTHESIZED (kilo, idle) — a bare prompt with the documented slash-command
+// hint chrome; must NOT read blocked/working.
+const KILO_IDLE = `
+ Welcome to Kilo Code
+ >
+ /connect /models /new /status /exit
+`;
+
+describe("manifest corpus — kilo (binary-verbatim strings, v7.4.5)", () => {
+  const kilo = byId("kilo");
+
+  it("permission dialog (Permission required / Allow once) → blocked", () => {
+    const snap = parseSnapshot(KILO_BLOCKED);
+    expect(evaluateManifest(snap, kilo).state).toBe("blocked");
+    expect(classifyInstant(snap, kilo)).toBe("blocked");
+  });
+
+  it("idle prompt chrome → idle", () => {
+    const snap = parseSnapshot(KILO_IDLE);
+    expect(evaluateManifest(snap, kilo).state).toBe(null);
+    expect(classifyInstant(snap, kilo)).toBe("idle");
+  });
+});
+
+// ── M25.4 breadth — droid (REAL login capture + docs-derived blocked) ───────
+
+// REAL (droid, auth-gated login) — Factory CLI v0.114.1 captured live (no
+// account, so this is the only reachable screen). MUST read idle: the login
+// menu is not working/blocked evidence. (Also verified live: droid runs as its
+// OWN process — `pane_current_command` = "droid".)
+const DROID_LOGIN = `
+                     v0.114.1 (ctrl+j for changelog)
+          TIP: Use /settings to customize your experience
+         shift+tab to cycle modes · ctrl+N to cycle models
+              ctrl+L for autonomy · tab for reasoning
+               Skills (4) ✓  MCPs (0) ✗  AGENTS.md ✗
+╭──────────────────────────────────────────────╮
+│ Welcome to Factory CLI                        │
+╰──────────────────────────────────────────────╯
+Please login with your Factory account to continue.
+> Login
+  Exit
+`;
+
+// SYNTHESIZED (droid, blocked) — the Spec-mode proceed menu, assembled from
+// the docs-verbatim autonomy-level option labels (docs.factory.ai auto-run).
+// Pending live-capture confirmation; replace when an authenticated pane exists.
+const DROID_BLOCKED = `
+ Ready to proceed with this plan?
+ ❯ Proceed, manual approval (Low)
+   Proceed, allow safe commands (Medium)
+   Proceed, allow all commands (High)
+`;
+
+describe("manifest corpus — droid (login captured live, blocked docs-derived)", () => {
+  const droid = byId("droid");
+
+  it("auth-gated login menu → idle, not working/blocked", () => {
+    const snap = parseSnapshot(DROID_LOGIN);
+    expect(evaluateManifest(snap, droid).state).toBe(null);
+    expect(classifyInstant(snap, droid)).toBe("idle");
+  });
+
+  it("Spec-mode proceed menu (Proceed, manual approval …) → blocked", () => {
+    const snap = parseSnapshot(DROID_BLOCKED);
+    expect(evaluateManifest(snap, droid).state).toBe("blocked");
+    expect(classifyInstant(snap, droid)).toBe("blocked");
+  });
+});
+
+// ── M25.4 breadth — devin / kimi / pi / grok / kiro / cline ─────────────────
+// All SYNTHESIZED from documented output (each fixture's markers are verbatim
+// from the agent's own source or docs — see the manifest comments for the
+// provenance trail); layout around the markers is our reconstruction.
+
+// devin (docs.devin.ai changelog): the plan-mode approval menu.
+const DEVIN_BLOCKED = `
+ Plan is ready.
+ ❯ Yes, implement plan and accept edits
+   Yes, implement plan and bypass permissions
+   No, plan needs changes
+`;
+
+// kimi (MoonshotAI/kimi-cli _approval_panel.py): the tool-approval panel.
+const KIMI_BLOCKED = `
+ Bash is requesting approval to run \`rm -rf dist\`
+ ❯ Approve once
+   Approve for this session
+   Reject
+   Reject, tell the model what to do instead
+`;
+
+// pi (interactive-mode.ts): the literal working status line.
+const PI_WORKING = `
+> fix the failing test
+Working... (esc to interrupt)
+`;
+
+// grok (superagent-ai/grok-cli app.tsx + headless output.ts).
+const GROK_WORKING = `
+⏳ Processing...
+Queue a follow-up... (esc to interrupt)
+`;
+
+// kiro (aws/amazon-q-developer-cli chat-cli mod.rs): tool approval + spinner.
+const KIRO_BLOCKED = `
+Using tool: execute_bash
+Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:
+`;
+const KIRO_WORKING = `
+Thinking...
+`;
+
+// cline (apps/cli tui components): approval dialog + streaming status.
+const CLINE_BLOCKED = `
+ Cline needs permission
+ Approve tool call?
+ write_to_file: src/index.ts
+ [y] Approve   [n] deny
+`;
+const CLINE_WORKING = `
+Thinking... (esc to cancel)
+`;
+
+describe("manifest corpus — M25.4 breadth (synthesized from documented output)", () => {
+  const cases: Array<[string, string, "blocked" | "working"]> = [
+    ["devin", DEVIN_BLOCKED, "blocked"],
+    ["kimi", KIMI_BLOCKED, "blocked"],
+    ["pi", PI_WORKING, "working"],
+    ["grok", GROK_WORKING, "working"],
+    ["kiro", KIRO_BLOCKED, "blocked"],
+    ["kiro", KIRO_WORKING, "working"],
+    ["cline", CLINE_BLOCKED, "blocked"],
+    ["cline", CLINE_WORKING, "working"],
+  ];
+  for (const [id, screen, expected] of cases) {
+    it(`${id}: documented ${expected} screen → ${expected}`, () => {
+      const snap = parseSnapshot(screen);
+      expect(evaluateManifest(snap, byId(id)).state).toBe(expected);
+      expect(classifyInstant(snap, byId(id))).toBe(expected);
+    });
+  }
+
+  it("pi ships NO blocked rule — its core has no distinctive approval wording", () => {
+    expect(byId("pi").states.blocked).toBeUndefined();
+  });
+});
+
+// ── M25.4 cross-check — new manifests must stay silent on the OTHER agents'
+//    screens (and every manifest on the new agents' idle screens) ───────────
+
+/** Every idle/quiet screen in this corpus — no manifest may fire on ANY of
+ *  them (a state on someone else's idle screen is a cross-agent misfire). */
+const IDLE_SCREENS: Array<[string, string]> = [
+  ["claude idle", CLAUDE_IDLE],
+  ["claude finished", CLAUDE_IDLE_FINISHED],
+  ["claude survey", CLAUDE_SURVEY],
+  ["codex idle", CODEX_IDLE],
+  ["codex idle (live)", CODEX_IDLE_LIVE],
+  ["aider idle", AIDER_IDLE],
+  ["cursor pre-auth", CURSOR_PREAUTH],
+  ["droid login", DROID_LOGIN],
+  ["kilo idle", KILO_IDLE],
+];
+
+/** The M25.4 additions under cross-check. */
+const NEW_IDS = ["devin", "kimi", "pi", "grok", "kiro", "cline", "droid", "kilo"];
+
+describe("cross-check — M25.4 manifests never fire on any idle screen", () => {
+  for (const id of NEW_IDS) {
+    const manifest = byId(id);
+    for (const [label, screen] of IDLE_SCREENS) {
+      it(`${id} on "${label}" → no state`, () => {
+        expect(evaluateManifest(parseSnapshot(screen), manifest).state).toBe(null);
+      });
+    }
+  }
+
+  // And the reverse: NO manifest (old or new) fires on the new agents' idle
+  // screens (the new chrome must not read as someone else's evidence).
+  for (const manifest of BUNDLED_MANIFESTS) {
+    for (const [label, screen] of [
+      ["droid login", DROID_LOGIN],
+      ["kilo idle", KILO_IDLE],
+    ] as const) {
+      it(`${manifest.id} on ${label} → no state`, () => {
+        expect(evaluateManifest(parseSnapshot(screen), manifest).state).toBe(null);
+      });
+    }
+  }
+});
+
 // ── False-positive guard (table-driven, EVERY manifest) ────────────────────
 
 // A realistic idle shell prompt (oh-my-zsh powerline style) + a plain one.
@@ -317,7 +525,20 @@ describe("manifest confidence metadata", () => {
   }
 
   it("newly added agents are present and conservative", () => {
-    for (const id of ["cursor", "goose", "amp"]) {
+    for (const id of [
+      "cursor",
+      "goose",
+      "amp",
+      // M25.4 breadth:
+      "devin",
+      "kimi",
+      "pi",
+      "grok",
+      "kiro",
+      "cline",
+      "droid",
+      "kilo",
+    ]) {
       const m = BUNDLED_MANIFESTS.find((x) => x.id === id);
       expect(m, `manifest ${id} missing`).toBeDefined();
       expect(m?.confidence).toBe("conservative");

--- a/packages/daemon/src/tui/detect/manifest-loader.test.ts
+++ b/packages/daemon/src/tui/detect/manifest-loader.test.ts
@@ -2,12 +2,19 @@
  * Unit tests for manifest override loading: the pure merge + validator, and
  * the io wrapper reading a real temp override directory.
  */
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { AgentManifest } from "./manifest.ts";
-import { mergeManifests, readOverrideManifests, validateManifestShape } from "./manifest-loader.ts";
+import {
+  loadManifests,
+  mergeManifests,
+  readOverrideManifests,
+  readPackManifests,
+  validateManifestShape,
+  _resetForTests,
+} from "./manifest-loader.ts";
 
 const bundled: AgentManifest[] = [
   { id: "claude", commands: ["claude"], states: { working: { any: [{ contains: "x" }] } } },
@@ -142,5 +149,89 @@ describe("readOverrideManifests (io)", () => {
     );
     const [m] = readOverrideManifests(dir);
     expect(Object.keys(m!.states)).toEqual(["working"]);
+  });
+});
+
+// ── The fetched manifest pack (M25.4) ───────────────────────────────────────
+
+const packEntry = (id: string, marker: string) => ({
+  id,
+  commands: [id],
+  states: { working: { any: [{ contains: marker }] } },
+});
+
+describe("readPackManifests (io)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "tmux-ide-pack-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writePack = (content: unknown) => {
+    mkdirSync(join(dir, "pack"), { recursive: true });
+    writeFileSync(
+      join(dir, "pack", "manifest-pack.json"),
+      typeof content === "string" ? content : JSON.stringify(content),
+    );
+  };
+
+  it("returns [] when no pack is installed", () => {
+    expect(readPackManifests(dir)).toEqual([]);
+  });
+
+  it("reads valid pack entries and skips invalid ones", () => {
+    writePack({
+      schema: 1,
+      pack: "test",
+      manifests: [packEntry("droid", "WORK"), { id: "broken" }],
+    });
+    expect(readPackManifests(dir).map((m) => m.id)).toEqual(["droid"]);
+  });
+
+  it("a corrupt pack file yields [] (warn, never throw)", () => {
+    writePack("{ not json");
+    expect(readPackManifests(dir)).toEqual([]);
+  });
+});
+
+describe("pack precedence — bundled < pack < user (TMUX_IDE_HOME scratch)", () => {
+  let home: string;
+  const prev = process.env.TMUX_IDE_HOME;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "tmux-ide-home-"));
+    process.env.TMUX_IDE_HOME = home;
+    _resetForTests();
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.TMUX_IDE_HOME;
+    else process.env.TMUX_IDE_HOME = prev;
+    rmSync(home, { recursive: true, force: true });
+    _resetForTests();
+  });
+
+  it("a pack manifest replaces a bundled id and appends new ids; a user file beats the pack", () => {
+    const detect = join(home, "agent-detection");
+    mkdirSync(join(detect, "pack"), { recursive: true });
+    // Pack: re-tunes claude AND ships a brand-new kind.
+    writeFileSync(
+      join(detect, "pack", "manifest-pack.json"),
+      JSON.stringify({
+        schema: 1,
+        pack: "test",
+        manifests: [packEntry("claude", "PACK-CLAUDE"), packEntry("newkid", "PACK-NEW")],
+      }),
+    );
+    // User override: the user's own claude tuning must WIN over the pack's.
+    writeFileSync(join(detect, "claude.json"), JSON.stringify(packEntry("claude", "USER-CLAUDE")));
+
+    const merged = loadManifests();
+    const claude = merged.find((m) => m.id === "claude")!;
+    expect(claude.states.working?.any?.[0]?.contains).toBe("USER-CLAUDE");
+    // The pack's new kind is present…
+    expect(merged.some((m) => m.id === "newkid")).toBe(true);
+    // …and bundled position/order is preserved (claude still first).
+    expect(merged[0]?.id).toBe("claude");
   });
 });

--- a/packages/daemon/src/tui/detect/manifest-loader.ts
+++ b/packages/daemon/src/tui/detect/manifest-loader.ts
@@ -30,9 +30,20 @@ import { join } from "node:path";
 import type { AgentManifest, Rule, StateRules } from "./manifest.ts";
 import { BUNDLED_MANIFESTS } from "./manifests.ts";
 
-/** Directory scanned for user override manifests. */
+/** Directory scanned for user override manifests. Honors `TMUX_IDE_HOME` (the
+ *  state-home override every other `~/.tmux-ide` consumer respects) so tests
+ *  never read a real user's overrides. */
 export function overrideDir(): string {
-  return join(homedir(), ".tmux-ide", "agent-detection");
+  const home = process.env.TMUX_IDE_HOME ?? join(homedir(), ".tmux-ide");
+  return join(home, "agent-detection");
+}
+
+/** The fetched manifest-pack file (`tmux-ide update --manifests` installs it;
+ *  see `lib/manifest-pack.ts` for the format + publish contract). Lives in a
+ *  SUBDIRECTORY so {@link readOverrideManifests}'s top-level `*.json` scan
+ *  never sees it — that is what keeps user files ABOVE the pack. */
+export function packFile(dir = overrideDir()): string {
+  return join(dir, "pack", "manifest-pack.json");
 }
 
 /**
@@ -167,11 +178,49 @@ function warnOnce(path: string, reason: string): void {
 }
 
 /**
- * Load the full manifest set: bundled + user overrides, merged. Does io on
- * every call — prefer {@link getManifests} for hot paths.
+ * Read the installed manifest PACK (fetched by `tmux-ide update --manifests`),
+ * or `[]` when none is installed. Thin io — a malformed pack file is skipped
+ * with a one-time stderr warning, never a throw (the pack was schema-validated
+ * at install time; this guards a hand-edited/corrupted file). Each entry gets
+ * the same structural validation + normalization as a user override file.
+ */
+export function readPackManifests(dir = overrideDir()): AgentManifest[] {
+  const path = packFile(dir);
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    // No pack installed (the common case).
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const manifests = (parsed as { manifests?: unknown })?.manifests;
+    if (!Array.isArray(manifests)) {
+      warnOnce(path, "not a manifest pack (missing manifests[])");
+      return [];
+    }
+    const valid: AgentManifest[] = [];
+    for (const entry of manifests) {
+      if (validateManifestShape(entry)) valid.push(normalizeStates(entry));
+      else warnOnce(path, "pack entry is not a valid AgentManifest — entry skipped");
+    }
+    return valid;
+  } catch (err) {
+    warnOnce(path, err instanceof Error ? err.message : String(err));
+    return [];
+  }
+}
+
+/**
+ * Load the full manifest set: bundled + pack + user overrides, merged in that
+ * PRECEDENCE order — a fetched pack refines the bundled set, and a user's own
+ * `agent-detection/*.json` file always beats both (it is merged LAST). Does io
+ * on every call — prefer {@link getManifests} for hot paths.
  */
 export function loadManifests(): AgentManifest[] {
-  return mergeManifests(BUNDLED_MANIFESTS, readOverrideManifests());
+  const withPack = mergeManifests(BUNDLED_MANIFESTS, readPackManifests());
+  return mergeManifests(withPack, readOverrideManifests());
 }
 
 /** Process-lifetime cache for the merged manifest set. */

--- a/packages/daemon/src/tui/detect/manifest.test.ts
+++ b/packages/daemon/src/tui/detect/manifest.test.ts
@@ -135,6 +135,24 @@ describe("pickManifest", () => {
     expect(pickManifest("emacs", BUNDLED_MANIFESTS)).toBeUndefined();
     expect(pickManifest("", BUNDLED_MANIFESTS)).toBeUndefined();
   });
+
+  it("matches whole segments in either direction (M25.4)", () => {
+    // command contains a manifest token as a segment…
+    expect(pickManifest("grok-build", BUNDLED_MANIFESTS)?.id).toBe("grok");
+    expect(pickManifest(".kilo", BUNDLED_MANIFESTS)?.id).toBe("kilo");
+    expect(pickManifest("codex.exe", BUNDLED_MANIFESTS)?.id).toBe("codex");
+    // …or a manifest token contains the command as a segment.
+    expect(pickManifest("kiro", BUNDLED_MANIFESTS)?.id).toBe("kiro");
+    expect(pickManifest("cursor", BUNDLED_MANIFESTS)?.id).toBe("cursor");
+  });
+
+  it("does NOT raw-substring match — short tokens can't hijack unrelated commands (M25.4)", () => {
+    expect(pickManifest("pip", BUNDLED_MANIFESTS)).toBeUndefined(); // not `pi`
+    expect(pickManifest("pipx", BUNDLED_MANIFESTS)).toBeUndefined();
+    expect(pickManifest("api-server", BUNDLED_MANIFESTS)).toBeUndefined();
+    expect(pickManifest("vi", BUNDLED_MANIFESTS)).toBeUndefined(); // not `devin`
+    expect(pickManifest("dev", BUNDLED_MANIFESTS)).toBeUndefined();
+  });
 });
 
 describe("claude manifest against realistic snapshots", () => {

--- a/packages/daemon/src/tui/detect/manifest.ts
+++ b/packages/daemon/src/tui/detect/manifest.ts
@@ -175,10 +175,31 @@ export function explain(
   return { state: winner ? winner.state : null, checked };
 }
 
+/** Escape a string for literal use inside a RegExp source. */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Does `haystack` contain `needle` as a WHOLE alphanumeric segment (delimited
+ * by start/end or any non-alphanumeric)? `grok-build` contains the segment
+ * `grok`; `pip` does NOT contain the segment `pi`. This is what keeps short
+ * manifest command tokens (pi, devin, kimi — M25.4) from substring-matching
+ * unrelated commands (`pip`, `vi`, `api-server`).
+ */
+function containsSegment(haystack: string, needle: string): boolean {
+  if (!haystack.includes(needle)) return false;
+  return new RegExp(`(^|[^a-z0-9])${escapeRegex(needle)}([^a-z0-9]|$)`).test(haystack);
+}
+
 /**
  * Pick the manifest whose `commands` best match a pane's current command.
- * Prefers an exact (case-insensitive) match, then a substring match in either
- * direction. Returns undefined when nothing applies.
+ * Prefers an exact (case-insensitive) match, then a SEGMENT match in either
+ * direction — the command contains a manifest token as a whole segment
+ * (`grok-build` → `grok`, `.kilo` → `kilo`) or vice versa (`cursor` →
+ * `cursor-agent`). Raw substring matching was retired in M25.4: it made every
+ * short token a false-positive machine (`pi` ⊂ `pip`, `vi` ⊂ `devin`).
+ * Returns undefined when nothing applies.
  */
 export function pickManifest(
   command: string,
@@ -193,7 +214,7 @@ export function pickManifest(
   return manifests.find((m) =>
     m.commands.some((c) => {
       const name = c.toLowerCase();
-      return cmd.includes(name) || name.includes(cmd);
+      return containsSegment(cmd, name) || containsSegment(name, cmd);
     }),
   );
 }

--- a/packages/daemon/src/tui/detect/manifests.ts
+++ b/packages/daemon/src/tui/detect/manifests.ts
@@ -16,12 +16,16 @@
  *     in its installed source (`io.py` confirm_ask, `waiting.py` spinner).
  *     Each matcher cites the invariant it was built from ("seen: …").
  *   - `conservative` — best-effort from public docs/common knowledge
- *     (`opencode`, `gemini`, `copilot`, `cursor`, `goose`, `amp`). Every
- *     matcher is HIGH-PRECISION (esc-to-interrupt / spinner / explicit y-n /
- *     "Do you want") so it can never false-positive on a plain prompt, but it
- *     may miss real states until a live capture upgrades it. `opencode` was
- *     attempted live but its local auth DB errored and the TUI rendered blank,
- *     so it stays conservative.
+ *     (`opencode`, `gemini`, `copilot`, `cursor`, `goose`, `amp`, and the
+ *     M25.4 breadth set: `devin`, `kimi`, `pi`, `grok`, `kiro`, `cline`,
+ *     `droid`, `kilo`). Every matcher is HIGH-PRECISION (esc-to-interrupt /
+ *     spinner / explicit y-n / "Do you want") so it can never false-positive
+ *     on a plain prompt, but it may miss real states until a live capture
+ *     upgrades it. `opencode` was attempted live but its local auth DB errored
+ *     and the TUI rendered blank, so it stays conservative. Several M25.4
+ *     manifests carry source/binary-VERBATIM markers (see each manifest's
+ *     provenance comment) but stay conservative until a live capture confirms
+ *     the surrounding chrome.
  *
  * Users can override any of these with a JSON file in
  * `~/.tmux-ide/agent-detection/` (see `manifest-loader.ts`).
@@ -317,6 +321,228 @@ const AMP: AgentManifest = {
   },
 };
 
+const DEVIN: AgentManifest = {
+  id: "devin",
+  commands: ["devin"],
+  confidence: "conservative",
+  states: {
+    // conservative — Devin CLI (Cognition; closed-source native Rust binary,
+    // needs an account). Blocked markers are VERBATIM from docs.devin.ai
+    // (cli/changelog + essential-commands via llms-full.txt): the plan-mode
+    // approval menu and the always-allow option. Devin has NO verified working
+    // text (its spinner is unlabeled; docs say interrupt is Ctrl+C, not esc),
+    // so working keeps only the shared spinner probe.
+    blocked: {
+      any: [
+        // seen (docs): "Yes, implement plan and accept edits" / "…and bypass
+        // permissions" — the shared prefix covers both.
+        { region: "bottom", contains: "Yes, implement plan and" },
+        { region: "bottom", contains: "No, plan needs changes" },
+        { region: "bottom", contains: "Yes, always allow" },
+      ],
+    },
+    working: {
+      any: [
+        { region: "bottom", regex: BRAILLE_SPINNER },
+        { region: "title", regex: BRAILLE_SPINNER },
+      ],
+    },
+  },
+};
+
+const KIMI: AgentManifest = {
+  id: "kimi",
+  commands: ["kimi"],
+  confidence: "conservative",
+  states: {
+    // conservative — kimi CLI (MoonshotAI/kimi-cli, Python/prompt_toolkit).
+    // Blocked markers are VERBATIM from its source (_approval_panel.py): the
+    // approval panel's "<tool> is requesting approval to …" header and its
+    // option labels. Its working spinner is a text-less moon animation (not
+    // braille), so working may under-detect until tuned — the braille probe is
+    // kept only as the shared fallback. ("Thinking"/"Thought for" deliberately
+    // NOT matched: they persist in the transcript after the turn.)
+    blocked: {
+      any: [
+        { region: "bottom", contains: " is requesting approval to " },
+        { region: "bottom", contains: "Approve for this session" },
+        { region: "bottom", contains: "Reject, tell the model" },
+      ],
+    },
+    working: {
+      any: [
+        { region: "bottom", regex: BRAILLE_SPINNER },
+        { region: "title", regex: BRAILLE_SPINNER },
+      ],
+    },
+  },
+};
+
+const PI: AgentManifest = {
+  id: "pi",
+  commands: ["pi"],
+  confidence: "conservative",
+  states: {
+    // conservative — pi (@mariozechner/pi-coding-agent, node). Working marker
+    // is VERBATIM from its source (interactive-mode.ts): the status line is
+    // `Working... (esc to interrupt)`, with `(esc to cancel)` retry/compacting
+    // variants. Its core has NO distinctive approval wording (generic Yes/No
+    // via extensions), so blocked is deliberately ABSENT — authority
+    // self-reporting or the classifier's fallback carry it.
+    working: {
+      any: [
+        { region: "bottom", contains: "Working... (esc to interrupt)" },
+        { region: "bottom", contains: "(esc to cancel)" },
+        { region: "bottom", regex: BRAILLE_SPINNER },
+        { region: "title", regex: BRAILLE_SPINNER },
+      ],
+    },
+  },
+};
+
+const GROK: AgentManifest = {
+  id: "grok",
+  commands: ["grok"],
+  confidence: "conservative",
+  states: {
+    // conservative — the community grok CLI (@vibe-kit/grok-cli /
+    // superagent-ai/grok-cli, node/OpenTUI). Working markers are VERBATIM from
+    // its source (app.tsx / headless output.ts): the mid-turn placeholder
+    // carries "(esc to interrupt)" and headless prints "⏳ Processing...".
+    // Its ConfirmationDialog wording could not be verified, so blocked keeps
+    // only a high-precision generic. NOTE: xAI's separate official
+    // `grok-build` binary substring-matches this manifest but has no verified
+    // strings — it will simply read idle until evidence exists.
+    blocked: {
+      any: [{ region: "bottom", contains: "(y/n)", caseInsensitive: true }],
+    },
+    working: {
+      any: [
+        { region: "bottom", contains: "esc to interrupt", caseInsensitive: true },
+        { region: "bottom", contains: "⏳ Processing" },
+        { region: "bottom", regex: BRAILLE_SPINNER },
+        { region: "title", regex: BRAILLE_SPINNER },
+      ],
+    },
+  },
+};
+
+const KIRO: AgentManifest = {
+  id: "kiro",
+  commands: ["kiro-cli", "kiro"],
+  confidence: "conservative",
+  states: {
+    // conservative — Kiro CLI (AWS; the rebranded Amazon Q Developer CLI, a
+    // native Rust binary). Markers are VERBATIM from the open-source
+    // predecessor (aws/amazon-q-developer-cli chat-cli/src/cli/chat/mod.rs):
+    // the tool-approval question and the Spinners::Dots "Thinking..." status.
+    // The closed Kiro build may drift — same lineage, pending live capture.
+    // NOTE: the predecessor's 1-char `q` binary is deliberately NOT a command
+    // token (a single letter substring-matches far too much).
+    blocked: {
+      any: [
+        { region: "bottom", contains: "Allow this action?" },
+        { region: "bottom", contains: "to trust (always allow) this tool" },
+      ],
+    },
+    working: {
+      any: [
+        { region: "bottom", contains: "Thinking..." },
+        { region: "bottom", regex: BRAILLE_SPINNER },
+        { region: "title", regex: BRAILLE_SPINNER },
+      ],
+    },
+  },
+};
+
+const CLINE: AgentManifest = {
+  id: "cline",
+  commands: ["cline"],
+  confidence: "conservative",
+  states: {
+    // conservative — cline CLI (cline.bot; CLI 2.0 ships prebuilt platform
+    // binaries, OpenTUI). Markers are VERBATIM from its source: the approval
+    // dialog's "Cline needs permission" title + "Approve tool call?" header
+    // (tui/components/dialogs/tool-approval.tsx) and the streaming
+    // "Thinking... (esc to cancel)" status (chat-message-list.tsx).
+    blocked: {
+      any: [
+        { region: "bottom", contains: "Cline needs permission" },
+        { region: "bottom", contains: "Approve tool call?" },
+        { region: "bottom", contains: "[y] Approve" },
+      ],
+    },
+    working: {
+      any: [
+        { region: "bottom", contains: "esc to cancel", caseInsensitive: true },
+        { region: "bottom", regex: BRAILLE_SPINNER },
+        { region: "title", regex: BRAILLE_SPINNER },
+      ],
+    },
+  },
+};
+
+const DROID: AgentManifest = {
+  id: "droid",
+  commands: ["droid"],
+  confidence: "conservative",
+  states: {
+    // conservative — droid (Factory CLI) was launched live (v0.114.1) but sits
+    // on an auth-gated login menu without a Factory account, so only the login
+    // splash could be captured (it reads IDLE and is deliberately not matched:
+    // "Please login with your Factory account to continue." / "> Login").
+    // Verified live: droid runs as its OWN process (`pane_current_command` =
+    // "droid"), so command matching needs no process-tree help.
+    // Blocked markers are docs-derived (docs.factory.ai auto-run levels,
+    // corroborated third-party walkthrough) — the Spec-mode proceed menu names
+    // its autonomy levels verbatim. Pending live-capture confirmation.
+    blocked: {
+      any: [
+        { region: "bottom", contains: "Proceed, manual approval" },
+        { region: "bottom", contains: "Proceed, allow safe commands" },
+        { region: "bottom", contains: "Proceed, allow all commands" },
+      ],
+    },
+    working: {
+      any: [
+        { region: "bottom", contains: "esc to interrupt", caseInsensitive: true },
+        { region: "bottom", regex: BRAILLE_SPINNER },
+        { region: "title", regex: BRAILLE_SPINNER },
+      ],
+    },
+  },
+};
+
+const KILO: AgentManifest = {
+  id: "kilo",
+  commands: ["kilo", ".kilo", "kilocode"],
+  confidence: "conservative",
+  states: {
+    // conservative, but the blocked markers are VERBATIM from the shipped
+    // @kilocode/cli binary (v7.4.5, strings-extracted — no account to drive a
+    // live capture): the permission dialog renders a "△ Permission required"
+    // header over an "Allow once" / "Allow always" / "Reject" option list.
+    // NOTE: the CLI's npm launcher (`bin/kilo`, node) execs the platform
+    // binary installed as `bin/.kilo`, hence the ".kilo" command token.
+    blocked: {
+      any: [
+        { region: "bottom", contains: "Permission required" },
+        { region: "bottom", contains: "Allow once" },
+        { region: "bottom", contains: "Allow always" },
+      ],
+    },
+    // No working-state string was found in the binary (its status UI renders
+    // from dynamic parts) — only the shared spinner probe, so kilo may read
+    // idle while working until a live capture tunes it.
+    working: {
+      any: [
+        { region: "bottom", regex: BRAILLE_SPINNER },
+        { region: "title", regex: BRAILLE_SPINNER },
+      ],
+    },
+  },
+};
+
 const SHELL: AgentManifest = {
   id: "shell",
   commands: ["bash", "zsh", "sh", "fish", "nu"],
@@ -350,5 +576,13 @@ export const BUNDLED_MANIFESTS: AgentManifest[] = [
   CURSOR,
   GOOSE,
   AMP,
+  DEVIN,
+  KIMI,
+  PI,
+  GROK,
+  KIRO,
+  CLINE,
+  DROID,
+  KILO,
   SHELL,
 ];

--- a/packages/daemon/src/tui/detect/process-tree.ts
+++ b/packages/daemon/src/tui/detect/process-tree.ts
@@ -53,6 +53,16 @@ export function parsePsOutput(raw: string): ProcEntry[] {
  * depth are guarded.
  */
 export function subtreeCommands(entries: ProcEntry[], rootPid: number, maxDepth = 6): string[] {
+  return subtreeEntries(entries, rootPid, maxDepth).map((entry) => entry.command);
+}
+
+/**
+ * The full {@link ProcEntry} rows of the subtree rooted at `rootPid`, in the
+ * same deepest-first order as {@link subtreeCommands}. Callers that need PIDs
+ * (e.g. the session-id capture probing a pane's agent process by open files)
+ * use this; the command-only view above stays the common path.
+ */
+export function subtreeEntries(entries: ProcEntry[], rootPid: number, maxDepth = 6): ProcEntry[] {
   const childrenByParent = new Map<number, ProcEntry[]>();
   const byPid = new Map<number, ProcEntry>();
   for (const entry of entries) {
@@ -65,7 +75,7 @@ export function subtreeCommands(entries: ProcEntry[], rootPid: number, maxDepth 
   const root = byPid.get(rootPid);
   if (!root) return [];
 
-  const commands: string[] = [];
+  const out: ProcEntry[] = [];
   const visited = new Set<number>();
 
   const walk = (pid: number, depth: number): void => {
@@ -76,11 +86,11 @@ export function subtreeCommands(entries: ProcEntry[], rootPid: number, maxDepth 
       walk(child.pid, depth + 1);
     }
     const self = byPid.get(pid);
-    if (self) commands.push(self.command);
+    if (self) out.push(self);
   };
 
   walk(rootPid, 0);
-  return commands;
+  return out;
 }
 
 /**

--- a/packages/daemon/src/tui/detect/session-id.test.ts
+++ b/packages/daemon/src/tui/detect/session-id.test.ts
@@ -1,0 +1,392 @@
+import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import type { ProcEntry } from "./process-tree.ts";
+import {
+  agentPidsInSubtree,
+  codexIdFromOpenFiles,
+  codexIdFromStateDir,
+  createSessionIdCapturer,
+  cursorIdFromOpenFiles,
+  cursorIdFromStateDir,
+  parseCodexRolloutName,
+  parseEtimeSeconds,
+  CAPTURE_PROBES,
+  PROBED_KINDS,
+  type CapturePane,
+  type ProbeIo,
+  type StateDirIo,
+} from "./session-id.ts";
+
+// The REAL rollout path observed live (codex-cli 0.144.1, lsof fd 34w).
+const REAL_ROLLOUT =
+  "/Users/thijs/.codex/sessions/2026/07/12/rollout-2026-07-12T12-16-13-019f55d3-d466-79a2-b9df-bcad709922ff.jsonl";
+const REAL_ROLLOUT_ID = "019f55d3-d466-79a2-b9df-bcad709922ff";
+
+describe("codexIdFromOpenFiles", () => {
+  it("extracts the uuid from a real rollout path", () => {
+    expect(codexIdFromOpenFiles(["/dev/null", REAL_ROLLOUT])).toBe(REAL_ROLLOUT_ID);
+  });
+
+  it("ignores non-rollout paths and malformed names", () => {
+    expect(
+      codexIdFromOpenFiles([
+        "/Users/x/.codex/history.jsonl",
+        "/Users/x/.codex/sessions/2026/07/12/rollout-not-a-date-xyz.jsonl",
+        "/Users/x/notes/rollout-2026-07-12T12-16-13-shortid.jsonl",
+      ]),
+    ).toBeNull();
+    expect(codexIdFromOpenFiles([])).toBeNull();
+  });
+});
+
+describe("cursorIdFromOpenFiles", () => {
+  it("extracts the chatId from a store.db path under a hashed cwd dir", () => {
+    const paths = [
+      "/dev/ttys001",
+      "/Users/x/.cursor/chats/1459cb3fe30531b805749c215a475e1a/0e87b7e0-83ad-4fd3-af94-f7daa83c021a/store.db",
+    ];
+    expect(cursorIdFromOpenFiles(paths)).toBe("0e87b7e0-83ad-4fd3-af94-f7daa83c021a");
+  });
+
+  it("rejects paths whose hash dir is not 32 hex chars", () => {
+    expect(cursorIdFromOpenFiles(["/Users/x/.cursor/chats/nothex/abc-def/store.db"])).toBeNull();
+  });
+
+  it("rejects unsafe chat ids", () => {
+    expect(
+      cursorIdFromOpenFiles([
+        "/Users/x/.cursor/chats/1459cb3fe30531b805749c215a475e1a/$(evil)/store.db",
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("parseEtimeSeconds", () => {
+  it("parses mm:ss", () => {
+    expect(parseEtimeSeconds("01:23")).toBe(83);
+    expect(parseEtimeSeconds("  00:05\n")).toBe(5);
+  });
+
+  it("parses hh:mm:ss and dd-hh:mm:ss", () => {
+    expect(parseEtimeSeconds("1:02:03")).toBe(3723);
+    expect(parseEtimeSeconds("2-03:04:05")).toBe(2 * 86400 + 3 * 3600 + 4 * 60 + 5);
+  });
+
+  it("rejects garbage and out-of-range fields", () => {
+    expect(parseEtimeSeconds("")).toBeNull();
+    expect(parseEtimeSeconds("abc")).toBeNull();
+    expect(parseEtimeSeconds("99")).toBeNull();
+    expect(parseEtimeSeconds("61:99")).toBeNull();
+  });
+});
+
+describe("agentPidsInSubtree", () => {
+  // Modeled on the REAL live tree: shell → node shim (token "codex") → vendor binary.
+  const table: ProcEntry[] = [
+    { pid: 100, ppid: 1, command: "-zsh" },
+    { pid: 200, ppid: 100, command: "node /Users/thijs/.bun/bin/codex" },
+    { pid: 300, ppid: 200, command: "/Users/x/vendor/aarch64-apple-darwin/bin/codex" },
+    { pid: 400, ppid: 100, command: "vim /Users/x/.codex/notes.md" },
+  ];
+
+  it("finds every subtree process carrying the kind's binary token", () => {
+    expect(agentPidsInSubtree(table, 100, ["codex"]).sort()).toEqual([200, 300]);
+  });
+
+  it("does not false-positive on incidental paths in arguments", () => {
+    // pid 400's argv contains `.codex` only inside a file path — commandTokens
+    // yields ["vim", "notes.md"], so it must not match.
+    expect(agentPidsInSubtree(table, 100, ["codex"])).not.toContain(400);
+  });
+
+  it("returns [] when the pane root is unknown or nothing matches", () => {
+    expect(agentPidsInSubtree(table, 999, ["codex"])).toEqual([]);
+    expect(agentPidsInSubtree(table, 100, ["cursor-agent"])).toEqual([]);
+  });
+});
+
+describe("parseCodexRolloutName", () => {
+  it("parses the timestamp (local time) and uuid", () => {
+    const parsed = parseCodexRolloutName(
+      "rollout-2026-07-12T12-16-13-019f55d3-d466-79a2-b9df-bcad709922ff.jsonl",
+    );
+    expect(parsed?.id).toBe(REAL_ROLLOUT_ID);
+    expect(parsed?.tsMs).toBe(new Date(2026, 6, 12, 12, 16, 13).getTime());
+  });
+
+  it("rejects anything else", () => {
+    expect(parseCodexRolloutName("rollout-2026-07-12T12-16-13-shortid.jsonl")).toBeNull();
+    expect(parseCodexRolloutName("history.jsonl")).toBeNull();
+  });
+});
+
+/** Build a fixture StateDirIo from path→entries / path→mtime / path→first-line maps. */
+function fixtureIo(fixture: {
+  dirs?: Record<string, string[]>;
+  mtimes?: Record<string, number>;
+  firstLines?: Record<string, string>;
+}): StateDirIo {
+  return {
+    listDir: (path) => fixture.dirs?.[path] ?? [],
+    mtimeMs: (path) => fixture.mtimes?.[path] ?? null,
+    readFirstLine: (path) => fixture.firstLines?.[path] ?? null,
+  };
+}
+
+/** A codex session_meta first line, shaped like the real one (cli 0.144.1). */
+function codexMeta(cwd: string, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    timestamp: "2026-07-12T10:17:13.701Z",
+    type: "session_meta",
+    payload: { cwd, originator: "codex-tui", cli_version: "0.144.1", source: "cli", ...extra },
+  });
+}
+
+describe("codexIdFromStateDir", () => {
+  const root = "/fake/.codex/sessions";
+  const now = new Date(2026, 6, 12, 13, 0, 0).getTime();
+  const day = join(root, "2026", "07", "12");
+  const nameA = "rollout-2026-07-12T12-16-13-019f55d3-d466-79a2-b9df-bcad709922ff.jsonl";
+  const nameB = "rollout-2026-07-12T12-40-00-029f55d3-d466-79a2-b9df-bcad70992200.jsonl";
+  const start = new Date(2026, 6, 12, 12, 15, 0).getTime();
+
+  it("picks the newest rollout whose meta cwd matches the pane", () => {
+    const io = fixtureIo({
+      dirs: { [day]: [nameA, nameB] },
+      firstLines: {
+        [join(day, nameA)]: codexMeta("/work/project"),
+        [join(day, nameB)]: codexMeta("/somewhere/else"),
+      },
+    });
+    expect(codexIdFromStateDir(root, "/work/project", start, io, now)).toBe(REAL_ROLLOUT_ID);
+  });
+
+  it("skips subagent threads even when their cwd matches", () => {
+    const io = fixtureIo({
+      dirs: { [day]: [nameB] },
+      firstLines: {
+        [join(day, nameB)]: codexMeta("/work/project", {
+          source: { subagent: { depth: 1 } },
+          thread_source: "subagent",
+        }),
+      },
+    });
+    expect(codexIdFromStateDir(root, "/work/project", start, io, now)).toBeNull();
+  });
+
+  it("ignores rollouts older than the agent process", () => {
+    // Session started 12:16 but the pane's codex only started 12:30 → not ours.
+    const lateStart = new Date(2026, 6, 12, 12, 30, 0).getTime();
+    const io = fixtureIo({
+      dirs: { [day]: [nameA] },
+      firstLines: { [join(day, nameA)]: codexMeta("/work/project") },
+    });
+    expect(codexIdFromStateDir(root, "/work/project", lateStart, io, now)).toBeNull();
+  });
+
+  it("tolerates malformed first lines", () => {
+    const io = fixtureIo({
+      dirs: { [day]: [nameA] },
+      firstLines: { [join(day, nameA)]: "not json{" },
+    });
+    expect(codexIdFromStateDir(root, "/work/project", start, io, now)).toBeNull();
+  });
+
+  it("scans back across day directories", () => {
+    const yesterday = join(root, "2026", "07", "11");
+    const nameY = "rollout-2026-07-11T23-50-00-039f55d3-d466-79a2-b9df-bcad70992211.jsonl";
+    const io = fixtureIo({
+      dirs: { [yesterday]: [nameY] },
+      firstLines: { [join(yesterday, nameY)]: codexMeta("/work/project") },
+    });
+    const eveningStart = new Date(2026, 6, 11, 23, 45, 0).getTime();
+    expect(codexIdFromStateDir(root, "/work/project", eveningStart, io, now)).toBe(
+      "039f55d3-d466-79a2-b9df-bcad70992211",
+    );
+  });
+});
+
+describe("cursorIdFromStateDir", () => {
+  const chatsRoot = "/fake/.cursor/chats";
+  const cwd = "/work/project";
+  const hashed = join(chatsRoot, createHash("md5").update(cwd).digest("hex"));
+  const start = 1_000_000_000;
+
+  it("picks the newest chat dir modified after the process start", () => {
+    const io = fixtureIo({
+      dirs: { [hashed]: ["old-chat", "new-chat"] },
+      mtimes: {
+        [join(hashed, "old-chat")]: start + 10_000,
+        [join(hashed, "new-chat")]: start + 60_000,
+      },
+    });
+    expect(cursorIdFromStateDir(chatsRoot, cwd, start, io)).toBe("new-chat");
+  });
+
+  it("ignores chats older than the process (stale conversations in the same cwd)", () => {
+    const io = fixtureIo({
+      dirs: { [hashed]: ["stale"] },
+      mtimes: { [join(hashed, "stale")]: start - 3_600_000 },
+    });
+    expect(cursorIdFromStateDir(chatsRoot, cwd, start, io)).toBeNull();
+  });
+
+  it("skips unsafe dir names and missing hash dirs", () => {
+    const io = fixtureIo({
+      dirs: { [hashed]: ["$(evil)"] },
+      mtimes: { [join(hashed, "$(evil)")]: start + 10_000 },
+    });
+    expect(cursorIdFromStateDir(chatsRoot, cwd, start, io)).toBeNull();
+    expect(cursorIdFromStateDir(chatsRoot, "/other/cwd", start, io)).toBeNull();
+  });
+});
+
+describe("CAPTURE_PROBES (kind dispatch over injected io)", () => {
+  const pane: CapturePane = {
+    paneId: "%7",
+    agent: "codex",
+    pid: 100,
+    dir: "/work/project",
+    sessionId: null,
+  };
+  const table: ProcEntry[] = [
+    { pid: 100, ppid: 1, command: "-zsh" },
+    { pid: 200, ppid: 100, command: "node /Users/thijs/.bun/bin/codex" },
+  ];
+
+  function io(overrides: Partial<ProbeIo>): ProbeIo {
+    return {
+      processTable: () => table,
+      openFiles: () => [],
+      processStartMs: () => null,
+      stateDir: fixtureIo({}),
+      codexSessionsRoot: () => "/fake/.codex/sessions",
+      cursorChatsRoot: () => "/fake/.cursor/chats",
+      now: () => Date.now(),
+      ...overrides,
+    };
+  }
+
+  it("prefers the open-files probe (exact)", () => {
+    const result = CAPTURE_PROBES.codex!(pane, io({ openFiles: () => [REAL_ROLLOUT] }));
+    expect(result).toBe(REAL_ROLLOUT_ID);
+  });
+
+  it("falls back to the state dir when no session file is open", () => {
+    const now = new Date(2026, 6, 12, 13, 0, 0).getTime();
+    const day = join("/fake/.codex/sessions", "2026", "07", "12");
+    const name = "rollout-2026-07-12T12-16-13-019f55d3-d466-79a2-b9df-bcad709922ff.jsonl";
+    const result = CAPTURE_PROBES.codex!(
+      pane,
+      io({
+        processStartMs: () => new Date(2026, 6, 12, 12, 15, 0).getTime(),
+        stateDir: fixtureIo({
+          dirs: { [day]: [name] },
+          firstLines: { [join(day, name)]: codexMeta("/work/project") },
+        }),
+        now: () => now,
+      }),
+    );
+    expect(result).toBe(REAL_ROLLOUT_ID);
+  });
+
+  it("returns null when the pane's subtree has no agent process", () => {
+    const shellOnly: ProcEntry[] = [{ pid: 100, ppid: 1, command: "-zsh" }];
+    expect(CAPTURE_PROBES.codex!(pane, io({ processTable: () => shellOnly }))).toBeNull();
+  });
+
+  it("ships probes for exactly codex and cursor", () => {
+    expect([...PROBED_KINDS].sort()).toEqual(["codex", "cursor"]);
+  });
+});
+
+describe("createSessionIdCapturer", () => {
+  const codexPane = (over: Partial<CapturePane> = {}): CapturePane => ({
+    paneId: "%1",
+    agent: "codex",
+    pid: 10,
+    dir: "/w",
+    sessionId: null,
+    ...over,
+  });
+
+  it("probes only every N ticks and stamps a discovered id once", () => {
+    const stamps: Array<[string, string]> = [];
+    let probes = 0;
+    const capturer = createSessionIdCapturer({
+      probe: () => {
+        probes++;
+        return "abc-123";
+      },
+      stamp: (paneId, id) => stamps.push([paneId, id]),
+      everyTicks: 3,
+    });
+    capturer.onTick([codexPane()]);
+    capturer.onTick([codexPane()]);
+    expect(probes).toBe(0); // throttled
+    capturer.onTick([codexPane()]);
+    expect(probes).toBe(1);
+    expect(stamps).toEqual([["%1", "abc-123"]]);
+    // Already stamped by us — later windows skip it entirely.
+    for (let i = 0; i < 6; i++) capturer.onTick([codexPane()]);
+    expect(probes).toBe(1);
+  });
+
+  it("skips panes that are non-agents, already stamped, or of unprobed kinds", () => {
+    let probes = 0;
+    const capturer = createSessionIdCapturer({
+      probe: () => {
+        probes++;
+        return "abc";
+      },
+      stamp: () => {},
+      everyTicks: 1,
+    });
+    capturer.onTick([
+      codexPane({ agent: null }),
+      codexPane({ paneId: "%2", sessionId: "already-there" }),
+      codexPane({ paneId: "%3", agent: "claude" }), // hook-captured, not probed
+      codexPane({ paneId: "%4", agent: "gemini" }), // no resume story
+    ]);
+    expect(probes).toBe(0);
+  });
+
+  it("retries after a failed stamp and never lets a throwing probe hurt the tick", () => {
+    const stamps: string[] = [];
+    let attempts = 0;
+    const capturer = createSessionIdCapturer({
+      probe: () => "abc",
+      stamp: (paneId) => {
+        attempts++;
+        if (attempts === 1) throw new Error("pane gone");
+        stamps.push(paneId);
+      },
+      everyTicks: 1,
+    });
+    capturer.onTick([codexPane()]);
+    capturer.onTick([codexPane()]);
+    expect(attempts).toBe(2);
+    expect(stamps).toEqual(["%1"]); // second window succeeded, then remembered
+
+    const throwing = createSessionIdCapturer({
+      probe: () => {
+        throw new Error("lsof exploded");
+      },
+      stamp: () => {},
+      everyTicks: 1,
+    });
+    expect(() => throwing.onTick([codexPane()])).not.toThrow();
+  });
+
+  it("rejects unsafe ids from a probe", () => {
+    const stamps: string[] = [];
+    const capturer = createSessionIdCapturer({
+      probe: () => "$(rm -rf /)",
+      stamp: (paneId) => stamps.push(paneId),
+      everyTicks: 1,
+    });
+    capturer.onTick([codexPane()]);
+    expect(stamps).toEqual([]);
+  });
+});

--- a/packages/daemon/src/tui/detect/session-id.ts
+++ b/packages/daemon/src/tui/detect/session-id.ts
@@ -1,0 +1,503 @@
+/**
+ * Agent session-id capture — stamping `@agent_session_id` for agents whose
+ * CLIs don't announce their session id the way Claude Code's hooks do.
+ *
+ * WHY: `tmux-ide restore --resume-agents` revives a pane's conversation via its
+ * kind's verified resume invocation ({@link ../../restore.ts AGENT_RESUME_COMMANDS}),
+ * keyed on the pane-local `@agent_session_id` option. Claude's integration
+ * records it from lifecycle hooks; opencode's integration records it from a
+ * plugin. codex and cursor-agent expose NO hook surface, but both keep their
+ * session's identity ON DISK in a deterministic place — the exact layout their
+ * own `resume` pickers read. This module probes that, per pane, and stamps the
+ * option so restore needs no changes.
+ *
+ * Per-kind mechanism (verdicts investigated 2026-07, versions noted):
+ *
+ *  - `codex` (codex-cli 0.144.1, VERIFIED LIVE): every session appends to
+ *    `~/.codex/sessions/YYYY/MM/DD/rollout-<local-ts>-<uuid>.jsonl`; the uuid in
+ *    the filename IS the id `codex resume <id>` accepts (verified end-to-end:
+ *    quit + `codex resume <uuid>` revived the conversation). Two probes:
+ *      1. OPEN FILES (exact): the codex process holds its rollout file open for
+ *         write for the whole session — including across a resume, which
+ *         re-opens the SAME file (verified via lsof, fd `34w`). Pane pid →
+ *         process subtree → codex pid(s) → open files → rollout filename.
+ *      2. STATE DIR (fallback, when lsof/procfs is unavailable): newest rollout
+ *         whose filename timestamp is at/after the agent process start and whose
+ *         first-line `session_meta` records `cwd` == the pane's cwd. Subagent
+ *         threads (`payload.source.subagent` / `thread_source: "subagent"`) are
+ *         skipped — they live in the same dir with the same cwd.
+ *    The rollout file only exists after the FIRST turn (verified: a fresh TUI
+ *    writes nothing until a message is sent), so capture keeps retrying until
+ *    the session materializes.
+ *
+ *  - `cursor` (cursor-agent 2026.04.30): chats live at
+ *    `~/.cursor/chats/<md5-hex-of-cwd>/<chatId>/store.db` — the md5(cwd) dir
+ *    naming is VERIFIED against a real state dir, and this layout is what
+ *    `cursor-agent --resume [chatId]` / `cursor-agent ls` themselves read. Same
+ *    two probes: open `store.db` handles first (sqlite stays open), else the
+ *    newest chat dir under md5(pane cwd) modified at/after the agent process
+ *    start. A live working session could not be driven on this machine (the CLI
+ *    sat on its pre-auth login screen — same limitation the detection manifest
+ *    notes), so the cursor probes are exercised against fixtures shaped from
+ *    the real on-disk layout.
+ *
+ *  - `claude` / `opencode`: captured by their integrations (hooks / plugin) —
+ *    deliberately NOT probed here; an integration-stamped id always wins
+ *    because capture only ever fills EMPTY stamps.
+ *
+ *  - `copilot`: SKIPPED (documented, revisit with a real install). Two known
+ *    surfaces, neither shippable blind: (1) Copilot CLI has Claude-style
+ *    lifecycle hooks (docs.github.com/en/copilot/reference/hooks-configuration)
+ *    whose payloads carry the session id + cwd — the RIGHT future path, an
+ *    `integration install copilot` — but the payload key casing is known to
+ *    flip (sessionId vs session_id) and the hooks-config schema couldn't be
+ *    verified against a real install (the CLI isn't installed here); a wrong
+ *    hook config risks breaking the user's copilot startup. (2) Disk probing
+ *    `~/.copilot/session-state/<uuid>/workspace.yaml` (id/cwd/created_at) is
+ *    viable in principle but the field shape is confirmed only by secondary
+ *    sources, `--resume` currently spawns phantom EMPTY session dirs
+ *    (github/copilot-cli#3908) that break newest-dir heuristics, and the
+ *    legacy `history-session-state/` rename shows the layout still moves.
+ *
+ *  - `gemini` / `aider` / `goose` / `amp`: SKIPPED — no verified native resume
+ *    invocation in {@link ../../restore.ts AGENT_RESUME_COMMANDS}, so a
+ *    captured id would have nothing to feed.
+ *
+ * Shape: pure probe logic + a stateful, throttled capturer the chrome updater
+ * pulses each tick; all io (ps/lsof/procfs/fs) is injectable so every decision
+ * path is unit-tested against fixtures.
+ */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, readlinkSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readProcessTable, subtreeEntries, commandTokens, type ProcEntry } from "./process-tree.ts";
+
+// ---------------------------------------------------------------------------
+// Pure — id extraction from open-file paths
+// ---------------------------------------------------------------------------
+
+/** Same trust gate restore applies: uuid-ish only, nothing shell-active. */
+const SAFE_SESSION_ID = /^[A-Za-z0-9_-]+$/;
+
+/** `…/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` → the uuid (codex's resume key). */
+const CODEX_ROLLOUT_RE =
+  /\/rollout-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-([0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})\.jsonl$/;
+
+/** `…/.cursor/chats/<md5(cwd)>/<chatId>/store.db` → the chatId (cursor's resume key). */
+const CURSOR_STORE_RE = /\/\.cursor\/chats\/[0-9a-f]{32}\/([A-Za-z0-9-]+)\/store\.db$/;
+
+/** PURE — codex session id from a process's open-file paths, or null. */
+export function codexIdFromOpenFiles(paths: string[]): string | null {
+  for (const path of paths) {
+    const match = CODEX_ROLLOUT_RE.exec(path);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+
+/** PURE — cursor chat id from a process's open-file paths, or null. */
+export function cursorIdFromOpenFiles(paths: string[]): string | null {
+  for (const path of paths) {
+    const match = CURSOR_STORE_RE.exec(path);
+    if (match?.[1] && SAFE_SESSION_ID.test(match[1])) return match[1];
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Pure — process helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * PURE — parse `ps -o etime=` output (`[[dd-]hh:]mm:ss`) into seconds, or null
+ * for anything malformed. The etime format is the portable way to recover a
+ * process's start time (start ≈ now − etime) without locale-dependent `lstart`
+ * parsing.
+ */
+export function parseEtimeSeconds(raw: string): number | null {
+  const trimmed = raw.trim();
+  const match = /^(?:(\d+)-)?(?:(\d+):)?(\d{1,2}):(\d{2})$/.exec(trimmed);
+  if (!match) return null;
+  const days = Number(match[1] ?? 0);
+  const hours = Number(match[2] ?? 0);
+  const minutes = Number(match[3]);
+  const seconds = Number(match[4]);
+  if (minutes >= 60 || seconds >= 60 || (match[2] !== undefined && hours >= 24)) return null;
+  return ((days * 24 + hours) * 60 + minutes) * 60 + seconds;
+}
+
+/**
+ * PURE — the pids under `panePid` whose command tokens include one of the
+ * kind's binary names (e.g. codex's `node` shim AND its vendor binary both
+ * carry the `codex` token). These are the candidates worth an open-files look.
+ */
+export function agentPidsInSubtree(table: ProcEntry[], panePid: number, bins: string[]): number[] {
+  const wanted = new Set(bins);
+  const pids: number[] = [];
+  for (const entry of subtreeEntries(table, panePid)) {
+    if (commandTokens(entry.command).some((token) => wanted.has(token))) pids.push(entry.pid);
+  }
+  return pids;
+}
+
+// ---------------------------------------------------------------------------
+// Pure — state-dir fallback probes (injectable fs)
+// ---------------------------------------------------------------------------
+
+/** The minimal fs surface the state-dir probes need — injectable for fixtures. */
+export interface StateDirIo {
+  /** Directory entry NAMES (not paths); [] when missing/unreadable. */
+  listDir: (path: string) => string[];
+  /** mtime in ms, or null when missing. */
+  mtimeMs: (path: string) => number | null;
+  /** First line of a file (utf8), or null. */
+  readFirstLine: (path: string) => string | null;
+}
+
+/** Slack applied before the process start when comparing session timestamps —
+ *  covers clock/etime rounding, not ambiguity (a session can't predate its CLI). */
+const START_SLACK_MS = 120_000;
+
+/** How many day-directories back the codex fallback scans (start-date → today,
+ *  capped) — a resumable pane's session started while its process was alive. */
+const MAX_SCAN_DAYS = 7;
+
+/** `rollout-2026-07-12T12-16-13-<uuid>.jsonl` → { tsMs (LOCAL time), id } | null. */
+export function parseCodexRolloutName(name: string): { tsMs: number; id: string } | null {
+  const match =
+    /^rollout-(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})-([0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})\.jsonl$/.exec(
+      name,
+    );
+  if (!match) return null;
+  const [, y, mo, d, h, mi, s, id] = match;
+  // The filename timestamp is LOCAL time (verified: a 14:50Z session wrote
+  // rollout-…T16-50-38 under CEST) — construct via local Date components.
+  const tsMs = new Date(
+    Number(y),
+    Number(mo) - 1,
+    Number(d),
+    Number(h),
+    Number(mi),
+    Number(s),
+  ).getTime();
+  return Number.isFinite(tsMs) && id ? { tsMs, id } : null;
+}
+
+/** A parsed codex `session_meta` first line — only the fields the probe reads. */
+interface CodexSessionMeta {
+  cwd?: string;
+  source?: unknown;
+  thread_source?: string;
+}
+
+/** PURE-ish (io-injected) — codex fallback: newest non-subagent rollout under
+ *  `root` started at/after `startMs` whose recorded cwd matches the pane's. */
+export function codexIdFromStateDir(
+  root: string,
+  paneCwd: string,
+  startMs: number,
+  io: StateDirIo,
+  nowMs: number = Date.now(),
+): string | null {
+  const cutoff = startMs - START_SLACK_MS;
+  // Enumerate day dirs from the start date to today (session files are laid out
+  // by LOCAL date, matching the filename timestamps).
+  const candidates: Array<{ tsMs: number; path: string; id: string }> = [];
+  for (let offset = 0; offset <= MAX_SCAN_DAYS; offset++) {
+    const day = new Date(nowMs - offset * 86_400_000);
+    if (day.getTime() < cutoff - 86_400_000) break;
+    const dir = join(
+      root,
+      String(day.getFullYear()),
+      String(day.getMonth() + 1).padStart(2, "0"),
+      String(day.getDate()).padStart(2, "0"),
+    );
+    for (const name of io.listDir(dir)) {
+      const parsed = parseCodexRolloutName(name);
+      if (parsed && parsed.tsMs >= cutoff && parsed.tsMs <= nowMs + START_SLACK_MS) {
+        candidates.push({ tsMs: parsed.tsMs, path: join(dir, name), id: parsed.id });
+      }
+    }
+  }
+  candidates.sort((a, b) => b.tsMs - a.tsMs);
+  for (const candidate of candidates) {
+    const line = io.readFirstLine(candidate.path);
+    if (!line) continue;
+    let meta: CodexSessionMeta | undefined;
+    try {
+      meta = (JSON.parse(line) as { payload?: CodexSessionMeta }).payload;
+    } catch {
+      continue;
+    }
+    if (!meta || meta.cwd !== paneCwd) continue;
+    // Skip subagent threads — same dir, same cwd, but not the pane's own
+    // conversation (their meta carries subagent provenance).
+    if (meta.thread_source === "subagent") continue;
+    if (typeof meta.source === "object" && meta.source !== null && "subagent" in meta.source) {
+      continue;
+    }
+    return candidate.id;
+  }
+  return null;
+}
+
+/** PURE-ish (io-injected) — cursor fallback: newest chat dir under
+ *  `chats/<md5(pane cwd)>` modified at/after the agent process start. */
+export function cursorIdFromStateDir(
+  chatsRoot: string,
+  paneCwd: string,
+  startMs: number,
+  io: StateDirIo,
+): string | null {
+  const hashed = join(chatsRoot, createHash("md5").update(paneCwd).digest("hex"));
+  const cutoff = startMs - START_SLACK_MS;
+  let best: { name: string; mtime: number } | null = null;
+  for (const name of io.listDir(hashed)) {
+    if (!SAFE_SESSION_ID.test(name)) continue;
+    const mtime = io.mtimeMs(join(hashed, name));
+    if (mtime === null || mtime < cutoff) continue;
+    if (!best || mtime > best.mtime) best = { name, mtime };
+  }
+  return best?.name ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// The per-kind probe registry
+// ---------------------------------------------------------------------------
+
+/** One capture-eligible pane, as the updater tick sees it. */
+export interface CapturePane {
+  paneId: string;
+  /** Resolved agent kind (manifest id), or null for a non-agent pane. */
+  agent: string | null;
+  /** `pane_pid` — root of the pane's process tree. */
+  pid: number;
+  /** `pane_current_path`. */
+  dir: string;
+  /** Existing `@agent_session_id`, or null — capture only fills EMPTY stamps. */
+  sessionId: string | null;
+}
+
+/** The io a live probe needs — injectable so probes are tested without ps/lsof. */
+export interface ProbeIo {
+  processTable: () => ProcEntry[];
+  /** Absolute paths of a pid's open files ([] on any failure). */
+  openFiles: (pid: number) => string[];
+  /** Epoch ms a pid started at, or null. */
+  processStartMs: (pid: number) => number | null;
+  stateDir: StateDirIo;
+  /** State roots, overridable for tests. */
+  codexSessionsRoot: () => string;
+  cursorChatsRoot: () => string;
+  now: () => number;
+}
+
+/** The binary tokens per kind worth an open-files look (see {@link agentPidsInSubtree}). */
+const KIND_BINS: Record<string, string[]> = {
+  codex: ["codex", "codex.exe"],
+  cursor: ["cursor-agent", "cursor"],
+};
+
+function probeKind(pane: CapturePane, kind: "codex" | "cursor", io: ProbeIo): string | null {
+  const table = io.processTable();
+  const pids = agentPidsInSubtree(table, pane.pid, KIND_BINS[kind]!);
+  if (pids.length === 0) return null;
+  // 1. Exact: an open session file names the id directly.
+  const fromOpen = kind === "codex" ? codexIdFromOpenFiles : cursorIdFromOpenFiles;
+  for (const pid of pids) {
+    const id = fromOpen(io.openFiles(pid));
+    if (id) return id;
+  }
+  // 2. Fallback: deterministic state-dir probe anchored on the agent's start time.
+  const startMs = io.processStartMs(pids[0]!);
+  if (startMs === null) return null;
+  return kind === "codex"
+    ? codexIdFromStateDir(io.codexSessionsRoot(), pane.dir, startMs, io.stateDir, io.now())
+    : cursorIdFromStateDir(io.cursorChatsRoot(), pane.dir, startMs, io.stateDir);
+}
+
+/**
+ * The kinds this module captures for, with their probes. claude/opencode are
+ * integration-captured (hooks/plugin); the rest of the resume table has no
+ * defensible disk surface (see the header verdicts).
+ */
+export const CAPTURE_PROBES: Record<string, (pane: CapturePane, io: ProbeIo) => string | null> = {
+  codex: (pane, io) => probeKind(pane, "codex", io),
+  cursor: (pane, io) => probeKind(pane, "cursor", io),
+};
+
+/** The kinds with a shipped probe (surfaced by `integration status`). */
+export const PROBED_KINDS: readonly string[] = Object.keys(CAPTURE_PROBES);
+
+// ---------------------------------------------------------------------------
+// The capturer — throttled, stamp-once, pulsed by the updater tick
+// ---------------------------------------------------------------------------
+
+/** Probe cadence in updater ticks (~2s each) — sessions materialize lazily
+ *  (codex writes its rollout only on the first turn), so capture RETRIES until
+ *  a pane is stamped, but never more than once per window. */
+export const CAPTURE_EVERY_TICKS = 5;
+
+export interface SessionIdCapturerDeps {
+  /** Probe one pane → id | null. Defaults to {@link CAPTURE_PROBES} over live io. */
+  probe?: (pane: CapturePane) => string | null;
+  /** Stamp `@agent_session_id` on a pane. */
+  stamp: (paneId: string, id: string) => void;
+  everyTicks?: number;
+}
+
+export interface SessionIdCapturer {
+  /** Pulse with this tick's panes; probes at most every `everyTicks` pulses. */
+  onTick: (panes: CapturePane[]) => void;
+}
+
+/**
+ * Create the stateful capturer. Cheap by construction: panes are considered
+ * only when their resolved kind has a probe AND they carry no stamp yet (an
+ * integration-written or restore-re-stamped id short-circuits everything), and
+ * even then only every {@link CAPTURE_EVERY_TICKS} ticks. A stamped pane costs
+ * nothing on every later tick. Stamped ids are remembered so a pane is never
+ * re-stamped by us within one updater lifetime (the option itself is the
+ * durable record; the memory just bridges the ticks until the next scan
+ * reflects it).
+ */
+export function createSessionIdCapturer(deps: SessionIdCapturerDeps): SessionIdCapturer {
+  const every = deps.everyTicks ?? CAPTURE_EVERY_TICKS;
+  const probe = deps.probe ?? ((pane: CapturePane) => defaultProbe(pane));
+  const stampedByUs = new Set<string>();
+  let ticks = 0;
+  return {
+    onTick(panes: CapturePane[]): void {
+      ticks++;
+      if (every <= 0 || ticks % every !== 0) return;
+      for (const pane of panes) {
+        if (!pane.agent || pane.sessionId || stampedByUs.has(pane.paneId)) continue;
+        const kindProbe = CAPTURE_PROBES[pane.agent];
+        if (!kindProbe) continue;
+        let id: string | null;
+        try {
+          id = probe(pane);
+        } catch {
+          continue; // a failed probe must never hurt the tick
+        }
+        if (!id || !SAFE_SESSION_ID.test(id)) continue;
+        try {
+          deps.stamp(pane.paneId, id);
+          // Marked only AFTER a successful stamp — a failed set-option retries
+          // on the next capture window instead of silently never stamping.
+          stampedByUs.add(pane.paneId);
+        } catch {
+          // stamp failed (pane gone / tmux hiccup) — retry next window
+        }
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// io — the live defaults
+// ---------------------------------------------------------------------------
+
+/** Live fs io for the state-dir probes. Never throws. */
+export const liveStateDirIo: StateDirIo = {
+  listDir: (path) => {
+    try {
+      return readdirSync(path);
+    } catch {
+      return [];
+    }
+  },
+  mtimeMs: (path) => {
+    try {
+      return statSync(path).mtimeMs;
+    } catch {
+      return null;
+    }
+  },
+  readFirstLine: (path) => {
+    try {
+      // Session-meta lines are small; a bounded read keeps this cheap even on
+      // a large rollout file.
+      const fd = readFileSync(path, { encoding: "utf8", flag: "r" });
+      const newline = fd.indexOf("\n");
+      return newline === -1 ? fd : fd.slice(0, newline);
+    } catch {
+      return null;
+    }
+  },
+};
+
+/**
+ * io — a pid's open regular files: `/proc/<pid>/fd` on Linux (no subprocess),
+ * `lsof -p <pid>` elsewhere. [] on any failure — the state-dir fallback covers.
+ */
+export function readOpenFiles(pid: number): string[] {
+  // Linux: readlink the fd table directly.
+  try {
+    const fdDir = `/proc/${pid}/fd`;
+    const names = readdirSync(fdDir);
+    const paths: string[] = [];
+    for (const name of names) {
+      try {
+        const target = readlinkSync(join(fdDir, name));
+        if (target.startsWith("/")) paths.push(target);
+      } catch {
+        // fd raced away — skip
+      }
+    }
+    return paths;
+  } catch {
+    // not Linux (or unreadable) — fall through to lsof
+  }
+  try {
+    const raw = execFileSync("lsof", ["-p", String(pid), "-Fn"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 3000,
+    });
+    // -Fn output: one field per line; `n<path>` lines carry the name.
+    return raw
+      .split("\n")
+      .filter((line) => line.startsWith("n/"))
+      .map((line) => line.slice(1));
+  } catch {
+    return [];
+  }
+}
+
+/** io — a pid's start time via `ps -o etime=` (start ≈ now − elapsed). */
+export function processStartMs(pid: number, nowMs: number = Date.now()): number | null {
+  try {
+    const raw = execFileSync("ps", ["-o", "etime=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2000,
+    });
+    const seconds = parseEtimeSeconds(raw);
+    return seconds === null ? null : nowMs - seconds * 1000;
+  } catch {
+    return null;
+  }
+}
+
+/** The live {@link ProbeIo}. State roots honor test overrides. */
+export function liveProbeIo(): ProbeIo {
+  return {
+    processTable: readProcessTable,
+    openFiles: readOpenFiles,
+    processStartMs: (pid) => processStartMs(pid),
+    stateDir: liveStateDirIo,
+    codexSessionsRoot: () =>
+      process.env.TMUX_IDE_CODEX_SESSIONS ?? join(homedir(), ".codex", "sessions"),
+    cursorChatsRoot: () => process.env.TMUX_IDE_CURSOR_CHATS ?? join(homedir(), ".cursor", "chats"),
+    now: () => Date.now(),
+  };
+}
+
+/** The default live probe: kind-dispatched over {@link liveProbeIo}. */
+export function defaultProbe(pane: CapturePane): string | null {
+  const kindProbe = pane.agent ? CAPTURE_PROBES[pane.agent] : undefined;
+  return kindProbe ? kindProbe(pane, liveProbeIo()) : null;
+}

--- a/packages/daemon/src/tui/integrations/opencode.test.ts
+++ b/packages/daemon/src/tui/integrations/opencode.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  installOpencodeIntegration,
+  isOurPlugin,
+  opencodeIntegrationStatus,
+  opencodePluginPath,
+  uninstallOpencodeIntegration,
+  PLUGIN_FILENAME,
+  PLUGIN_MARKER,
+  PLUGIN_SOURCE,
+} from "./opencode.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "tmux-ide-opencode-"));
+  process.env.TMUX_IDE_OPENCODE_DIR = dir;
+});
+
+afterEach(() => {
+  delete process.env.TMUX_IDE_OPENCODE_DIR;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("opencodePluginPath", () => {
+  it("honors the test override", () => {
+    expect(opencodePluginPath()).toBe(join(dir, PLUGIN_FILENAME));
+  });
+
+  it("falls back to XDG config, then ~/.config", () => {
+    delete process.env.TMUX_IDE_OPENCODE_DIR;
+    const priorXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = "/xdg-root";
+    try {
+      expect(opencodePluginPath()).toBe(join("/xdg-root", "opencode", "plugin", PLUGIN_FILENAME));
+      delete process.env.XDG_CONFIG_HOME;
+      expect(opencodePluginPath()).toContain(join(".config", "opencode", "plugin"));
+    } finally {
+      if (priorXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = priorXdg;
+    }
+  });
+});
+
+describe("PLUGIN_SOURCE", () => {
+  it("carries the removal marker and the safe-id gate", () => {
+    expect(isOurPlugin(PLUGIN_SOURCE)).toBe(true);
+    // The same charset restore trusts — nothing shell-active can be stamped.
+    expect(PLUGIN_SOURCE).toContain("/^[A-Za-z0-9_-]+$/");
+    // Child sessions must never overwrite the pane's own conversation key.
+    expect(PLUGIN_SOURCE).toContain("parentID");
+    // Stays inert outside tmux.
+    expect(PLUGIN_SOURCE).toContain("TMUX_PANE");
+  });
+
+  it("is valid ESM (parses as a module)", async () => {
+    const file = join(dir, "parse-check.mjs");
+    writeFileSync(file, PLUGIN_SOURCE, "utf8");
+    const mod = await import(file);
+    expect(typeof mod.TmuxIde).toBe("function");
+    // Outside tmux the plugin returns an inert hook set.
+    const priorPane = process.env.TMUX_PANE;
+    delete process.env.TMUX_PANE;
+    try {
+      expect(await mod.TmuxIde()).toEqual({});
+    } finally {
+      if (priorPane !== undefined) process.env.TMUX_PANE = priorPane;
+    }
+  });
+});
+
+describe("install / uninstall / status", () => {
+  it("installs the plugin file and reports installed", () => {
+    expect(opencodeIntegrationStatus().installed).toBe(false);
+    const { pluginPath } = installOpencodeIntegration();
+    expect(pluginPath).toBe(join(dir, PLUGIN_FILENAME));
+    expect(readFileSync(pluginPath, "utf8")).toContain(PLUGIN_MARKER);
+    expect(opencodeIntegrationStatus().installed).toBe(true);
+  });
+
+  it("is idempotent", () => {
+    installOpencodeIntegration();
+    installOpencodeIntegration();
+    expect(opencodeIntegrationStatus().installed).toBe(true);
+  });
+
+  it("uninstall removes exactly our file", () => {
+    installOpencodeIntegration();
+    const { wasInstalled, pluginPath } = uninstallOpencodeIntegration();
+    expect(wasInstalled).toBe(true);
+    expect(existsSync(pluginPath)).toBe(false);
+    expect(uninstallOpencodeIntegration().wasInstalled).toBe(false);
+  });
+
+  it("never deletes a user's own tmux-ide.js (no marker)", () => {
+    const pluginPath = opencodePluginPath();
+    writeFileSync(pluginPath, "export const Mine = async () => ({});\n", "utf8");
+    expect(opencodeIntegrationStatus().installed).toBe(false);
+    const { wasInstalled } = uninstallOpencodeIntegration();
+    expect(wasInstalled).toBe(false);
+    expect(existsSync(pluginPath)).toBe(true);
+  });
+});

--- a/packages/daemon/src/tui/integrations/opencode.ts
+++ b/packages/daemon/src/tui/integrations/opencode.ts
@@ -1,0 +1,121 @@
+/**
+ * opencode integration — session-id capture via a first-class opencode plugin.
+ *
+ * opencode (v1.17.x) auto-loads ESM plugins from the GLOBAL plugin dir
+ * (`~/.config/opencode/plugin/*.js` — XDG-aware) at startup; a plugin runs
+ * IN-PROCESS (Bun), so `process.env.TMUX_PANE` is exactly the pane opencode
+ * lives in, and its `event` hook sees the session lifecycle. That's the same
+ * authority-shaped surface Claude Code's hooks give us, so this integration
+ * mirrors {@link ./claude.ts}: `tmux-ide integration install opencode` writes
+ * one marker-tagged plugin file; uninstall removes exactly that file.
+ *
+ * The plugin stamps ONLY `@agent_session_id` (the key
+ * `tmux-ide restore --resume-agents` feeds to `opencode --session <id>`):
+ *  - `session.updated` fires on create + every update; the id lives at
+ *    `event.properties.info.id` (format `ses_<base62>`).
+ *  - Child/subagent sessions carry `info.parentID` — those are NOT the pane's
+ *    resumable conversation, so they never stamp.
+ *  - `@agent_state` is deliberately NOT stamped: `session.updated` is not a
+ *    truthful working/blocked signal, and a wrong authority stamp would
+ *    suppress correct screen-scraping for the staleness window.
+ *
+ * Install takes effect for NEW opencode sessions (plugins load at startup).
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+/** Marker every installed plugin contains — the ownership/removal key. */
+export const PLUGIN_MARKER = "installed by: tmux-ide integration install opencode";
+
+/** The plugin filename inside opencode's global plugin dir. */
+export const PLUGIN_FILENAME = "tmux-ide.js";
+
+/**
+ * Absolute path to the plugin file: `TMUX_IDE_OPENCODE_DIR` when set (tests /
+ * per-run overrides — points at the PLUGIN DIR), else XDG config, else
+ * `~/.config/opencode/plugin/`. The override keeps tests away from real state,
+ * matching `TMUX_IDE_CLAUDE_SETTINGS`.
+ */
+export function opencodePluginPath(): string {
+  const override = process.env.TMUX_IDE_OPENCODE_DIR;
+  if (override) return join(override, PLUGIN_FILENAME);
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const configRoot = xdg && xdg.length > 0 ? xdg : join(homedir(), ".config");
+  return join(configRoot, "opencode", "plugin", PLUGIN_FILENAME);
+}
+
+/**
+ * The plugin source. Plain ESM JS, zero dependencies beyond node builtins
+ * (opencode runs plugins under Bun, which provides them). Defensive by
+ * construction: no TMUX pane → inert; malformed events → ignored; the id is
+ * gated on the same uuid-ish charset restore trusts before it ever reaches
+ * `set-option`.
+ */
+export const PLUGIN_SOURCE = `/**
+ * tmux-ide opencode plugin (${PLUGIN_MARKER})
+ *
+ * Stamps this pane's @agent_session_id tmux option with the opencode session
+ * id so \`tmux-ide restore --resume-agents\` can revive the conversation via
+ * \`opencode --session <id>\` after a tmux server death.
+ *
+ * Remove with: tmux-ide integration uninstall opencode
+ */
+export const TmuxIde = async () => {
+  const pane = process.env.TMUX_PANE;
+  if (!pane) return {}; // not inside tmux — inert
+  const { execFile } = await import("node:child_process");
+  let last = "";
+  const stamp = (id) => {
+    if (typeof id !== "string" || !/^[A-Za-z0-9_-]+$/.test(id) || id === last) return;
+    last = id;
+    execFile("tmux", ["set-option", "-p", "-t", pane, "@agent_session_id", id], () => {});
+  };
+  return {
+    event: async ({ event }) => {
+      // session.updated fires on create + every update; info.id is the
+      // resumable session id. Child sessions (subagents) carry parentID and
+      // must never overwrite the pane's own conversation key.
+      if (event && event.type === "session.updated") {
+        const info = event.properties && event.properties.info;
+        if (info && !info.parentID) stamp(info.id);
+      }
+    },
+  };
+};
+`;
+
+/** PURE — is this plugin file content ours? (contains the install marker) */
+export function isOurPlugin(content: string): boolean {
+  return content.includes(PLUGIN_MARKER);
+}
+
+/** Install: write the marker-tagged plugin file. Idempotent. */
+export function installOpencodeIntegration(): { pluginPath: string } {
+  const pluginPath = opencodePluginPath();
+  mkdirSync(dirname(pluginPath), { recursive: true });
+  writeFileSync(pluginPath, PLUGIN_SOURCE, "utf8");
+  return { pluginPath };
+}
+
+/**
+ * Uninstall: remove the plugin file — but only when it's OURS (marker present),
+ * so a user's hand-written `tmux-ide.js` is never deleted.
+ */
+export function uninstallOpencodeIntegration(): { pluginPath: string; wasInstalled: boolean } {
+  const pluginPath = opencodePluginPath();
+  const wasInstalled = opencodeIntegrationStatus().installed;
+  if (wasInstalled) rmSync(pluginPath, { force: true });
+  return { pluginPath, wasInstalled };
+}
+
+/** Whether OUR plugin is installed (file exists AND carries the marker). */
+export function opencodeIntegrationStatus(): { installed: boolean } {
+  const pluginPath = opencodePluginPath();
+  try {
+    if (!existsSync(pluginPath)) return { installed: false };
+    return { installed: isOurPlugin(readFileSync(pluginPath, "utf8")) };
+  } catch {
+    return { installed: false };
+  }
+}

--- a/packages/daemon/src/tui/mirror/agent-chip.test.ts
+++ b/packages/daemon/src/tui/mirror/agent-chip.test.ts
@@ -88,3 +88,41 @@ describe("chipLabel", () => {
     expect(chipLabel(entry({ kind: "copilot-workspace" }), "●", now, 10)).toBe("●");
   });
 });
+
+describe("chipLabel — display metadata (M25.4)", () => {
+  const now = 1_000_000_000_000;
+
+  it("appends the self-reported status text", () => {
+    const e = entry({ statusText: "refactoring auth" });
+    expect(chipLabel(e, "●", now, 44)).toBe("● claude · refactoring auth");
+  });
+
+  it("displayName replaces the kind in the label", () => {
+    const e = entry({ displayName: "reviewer", statusText: "checking PR" });
+    expect(chipLabel(e, "●", now, 44)).toBe("● reviewer · checking PR");
+    expect(chipLabel(entry({ displayName: "reviewer" }), "●", now, 44)).toBe("● reviewer");
+  });
+
+  it("blocked keeps its spelled state FIRST, status text riding after", () => {
+    const e = entry({ state: "blocked", since: now / 1000 - 240, statusText: "needs approval" });
+    expect(chipLabel(e, "●", now, 60)).toBe("● claude · blocked 4m · needs approval");
+  });
+
+  it("an overflowing status text is truncated with an ellipsis, not dropped mid-step", () => {
+    const e = entry({ statusText: "refactoring auth" });
+    // "● claude · " is 11 cells; budget 20 leaves 9 for the text → 8 + "…".
+    expect(chipLabel(e, "●", now, 20)).toBe("● claude · refactor…");
+  });
+
+  it("with no room for readable text the suffix drops to the base label, then the glyph", () => {
+    const e = entry({ statusText: "refactoring auth" });
+    expect(chipLabel(e, "●", now, 13)).toBe("● claude");
+    expect(chipLabel(e, "●", now, 3)).toBe("●");
+  });
+
+  it("blocked degradation still walks blocked-age → blocked → base when the text can't fit", () => {
+    const e = entry({ state: "blocked", since: now / 1000 - 240, statusText: "needs approval" });
+    expect(chipLabel(e, "●", now, 21)).toBe("● claude · blocked 4m");
+    expect(chipLabel(e, "●", now, 18)).toBe("● claude · blocked");
+  });
+});

--- a/packages/daemon/src/tui/mirror/agent-chip.ts
+++ b/packages/daemon/src/tui/mirror/agent-chip.ts
@@ -30,6 +30,13 @@ export interface ChipAgent {
   /** Authority epoch (SECONDS) when the authority layer supplied the state;
    *  null for scraped panes. Feeds the "blocked 4m" age suffix. */
   since: number | null;
+  /** Self-reported one-liner (`@agent_status_text`, already sanitized ≤32 chars
+   *  by the report; absent when the pane never stamped one or its authority
+   *  stamp went stale). Renders as the "· refactoring auth" suffix. */
+  statusText?: string;
+  /** Self-reported display name (`@agent_display_name`) — replaces `kind` in
+   *  the label when present. Same staleness gate as {@link statusText}. */
+  displayName?: string;
 }
 
 /**
@@ -64,19 +71,28 @@ export function stateAge(since: number | null, nowMs: number): string | null {
   return `${Math.floor(s / 86400)}d`;
 }
 
+/** The least status-text worth showing: 3 chars + the ellipsis. Below this the
+ *  suffix is dropped instead of rendering an unreadable "· r…". */
+const MIN_STATUS_TEXT = 4;
+
 /**
  * Build a chip label that fits `budget` cells (the printable text, WITHOUT the
  * one-cell padding the renderer adds each side). Degrades in steps rather than
  * mid-word ellipsis so a narrow pane still reads:
  *
- *   `● claude · blocked 4m`   blocked, authority age known
- *   `● claude · blocked`      blocked, scraped (no stamp)
- *   `● claude`                any other state (color carries the state)
- *   `●`                       narrow pane
- *   null                      no room at all (or a hidden-worthy budget < 1)
+ *   `● claude · refactoring auth`  self-reported status text (M25.4)
+ *   `● claude · blocked 4m`        blocked, authority age known
+ *   `● claude · blocked`           blocked, scraped (no stamp)
+ *   `● claude`                     any other state (color carries the state)
+ *   `●`                            narrow pane
+ *   null                           no room at all (or a hidden-worthy budget < 1)
  *
- * Only `blocked` spells its state out — it is the attention state; everything
- * else leans on the glyph color, matching the dock chips' quiet default.
+ * `displayName` replaces the kind when the agent stamped one. A status-text
+ * candidate that overflows is first re-fit by truncating the TEXT with an
+ * ellipsis (never the glyph/name prefix), then dropped entirely — so the
+ * degradation order stays step-wise and readable. Blocked still spells its
+ * state out (it is the attention state) and outranks the status text; the text
+ * rides after it when the budget allows.
  */
 export function chipLabel(
   entry: ChipAgent,
@@ -84,14 +100,27 @@ export function chipLabel(
   nowMs: number,
   budget: number,
 ): string | null {
-  const base = `${glyph} ${entry.kind}`;
+  const base = `${glyph} ${entry.displayName ?? entry.kind}`;
+  const text = entry.statusText;
   const candidates: string[] = [];
   if (entry.state === "blocked") {
     const age = stateAge(entry.since, nowMs);
-    if (age) candidates.push(`${base} · blocked ${age}`);
-    candidates.push(`${base} · blocked`);
+    const blocked = age ? `${base} · blocked ${age}` : `${base} · blocked`;
+    if (text) candidates.push(`${blocked} · ${text}`);
+    candidates.push(blocked);
+    if (age) candidates.push(`${base} · blocked`);
+  } else if (text) {
+    candidates.push(`${base} · ${text}`);
   }
   candidates.push(base, glyph);
-  for (const c of candidates) if (c.length <= budget) return c;
+  for (const c of candidates) {
+    if (c.length <= budget) return c;
+    // A status-text candidate re-fits by truncating its text before giving up.
+    if (text && c.endsWith(` · ${text}`)) {
+      const head = c.slice(0, c.length - text.length);
+      const room = budget - head.length;
+      if (room >= MIN_STATUS_TEXT) return head + text.slice(0, room - 1) + "…";
+    }
+  }
   return null;
 }

--- a/packages/daemon/src/tui/mirror/agent-lifecycle.test.ts
+++ b/packages/daemon/src/tui/mirror/agent-lifecycle.test.ts
@@ -320,6 +320,11 @@ describe("teamItems", () => {
   it("offers restart/stop as the footer ctrl-actions", () => {
     expect(TEAM_ACTIONS.map((a) => a.key)).toEqual(["r", "s"]);
   });
+
+  it("a stamped display name replaces the kind in the row label (M25.4)", () => {
+    const named: AgentRowInput[] = [{ ...agents[0]!, displayName: "reviewer" }];
+    expect(teamItems(named, 1000)[1]!.label).toBe("reviewer · web");
+  });
 });
 
 describe("isShellCommand", () => {

--- a/packages/daemon/src/tui/mirror/agent-lifecycle.ts
+++ b/packages/daemon/src/tui/mirror/agent-lifecycle.ts
@@ -23,7 +23,7 @@
  */
 import type { AgentManifest } from "../detect/manifest.ts";
 import type { DialogRowAction, DialogSelectItem } from "./dialog-model.ts";
-import { agentAgeLabel, type AgentRowInput } from "./agent-rows.ts";
+import { agentAgeLabel, agentDisplayKind, type AgentRowInput } from "./agent-rows.ts";
 
 /** The "Custom command…" picker row — resolves to a DialogPrompt, not a kind. */
 export const CUSTOM_KIND_ID = "custom-command";
@@ -51,6 +51,20 @@ export const AGENT_LAUNCH_COMMANDS: Record<string, string> = {
   cursor: "cursor-agent",
   goose: "goose",
   amp: "amp",
+  // M25.4 breadth — real installable CLIs only (spawn-picker honesty), each
+  // verified against an installer/package: devin (curl cli.devin.ai), kimi
+  // (curl code.kimi.com), pi (npm @mariozechner/pi-coding-agent), grok (npm
+  // @vibe-kit/grok-cli), kiro (curl cli.kiro.dev → kiro-cli), cline (npm
+  // cline), droid (verified live — Factory CLI, own process), kilo (npm
+  // @kilocode/cli; the manifest matches its ".kilo" platform binary too).
+  devin: "devin",
+  kimi: "kimi",
+  pi: "pi",
+  grok: "grok",
+  kiro: "kiro-cli",
+  cline: "cline",
+  droid: "droid",
+  kilo: "kilo",
 };
 
 /**
@@ -326,7 +340,9 @@ export function teamItems(agents: readonly AgentRowInput[], nowSec: number): Dia
   agents.forEach((a, i) => {
     items.push({
       id: teamAgentId(i),
-      label: `${a.kind} · ${a.session}`,
+      // Display-name precedence (M25.4): the Team dialog names an agent the
+      // same way the sidebar rows do.
+      label: `${agentDisplayKind(a)} · ${a.session}`,
       detail: agentAgeLabel(a.state, a.since, nowSec) ?? a.state,
     });
   });

--- a/packages/daemon/src/tui/mirror/agent-rows.test.ts
+++ b/packages/daemon/src/tui/mirror/agent-rows.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   sortAgentRows,
+  agentDisplayKind,
   agentRowLabel,
   agentsHeaderLabel,
   agentAgeLabel,
@@ -57,6 +58,13 @@ describe("sortAgentRows", () => {
 
   it("handles an empty list", () => {
     expect(sortAgentRows([])).toEqual([]);
+  });
+});
+
+describe("agentDisplayKind", () => {
+  it("prefers a stamped display name over the detected kind", () => {
+    expect(agentDisplayKind(mk({ displayName: "reviewer" }))).toBe("reviewer");
+    expect(agentDisplayKind(mk({}))).toBe("claude");
   });
 });
 

--- a/packages/daemon/src/tui/mirror/agent-rows.ts
+++ b/packages/daemon/src/tui/mirror/agent-rows.ts
@@ -30,6 +30,19 @@ export interface AgentRowInput {
   state: AgentStatus;
   /** Authority state's epoch-seconds stamp, or null for a scraped pane. */
   since: number | null;
+  /** Self-reported one-liner (`@agent_status_text`, sanitized by the report;
+   *  dropped with a stale authority stamp). Rides to the pane chips (M25.4). */
+  statusText?: string;
+  /** Self-reported display name (`@agent_display_name`) — row-label precedence
+   *  over the detected `kind` ({@link agentDisplayKind}). */
+  displayName?: string;
+}
+
+/** PURE — what an agent row is CALLED: the self-reported display name when one
+ *  is stamped (and fresh — the report already applied staleness), else the
+ *  detected kind. The one precedence rule every label surface shares. */
+export function agentDisplayKind(a: Pick<AgentRowInput, "kind" | "displayName">): string {
+  return a.displayName ?? a.kind;
 }
 
 /** Attention-first rank: blocked, working, done, idle (from `ROLLUP_ORDER`), then

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -340,7 +340,21 @@ import {
   type SettingsCommandId,
 } from "./settings-model.ts";
 import { loadAppConfig, loadRawAppConfig, updateAppConfig } from "../../lib/app-config.ts";
-import { parseNotificationPrefs } from "../chrome/notify.ts";
+import {
+  APP_FOCUS_OPTION,
+  APP_JUMP_OPTION,
+  buildAppFocusValue,
+  parseNotificationPrefs,
+} from "../chrome/notify.ts";
+import { adoptMarkArgv, updaterProbeArgv, updaterSpawnArgv } from "../chrome/front-door.ts";
+import { APP_HOST_SESSION } from "./hosted.ts";
+import {
+  ATTENTION_FLASH_MS,
+  attentionNoteLine,
+  diffAttention,
+  noteworthyTransitions,
+  type AttentionAgent,
+} from "./attention.ts";
 import {
   buildHomeItems,
   centerPad,
@@ -1129,6 +1143,95 @@ render(
           .filter((a, i, arr) => arr.findIndex((b) => b.paneId === a.paneId) === i),
       ),
     );
+
+    // ── IN-APP ATTENTION (M25.1) ─────────────────────────────────────────────
+    // The 3s fleet poll diffs the previous per-pane agent states against the
+    // fresh payload (pure math in attention.ts); blocked/done flips for agents
+    // NOT on the current screen (other workspace / other window / a non-
+    // Terminal tab) surface as a status-strip note plus a brief flash on their
+    // sidebar rows. First sight is graced — an app boot announces nothing.
+    let attnPrev = new Map<string, AgentStatus>();
+    const [attnFlash, setAttnFlash] = createSignal<ReadonlySet<string>>(new Set());
+    let attnFlashTimer: ReturnType<typeof setTimeout> | null = null;
+    const noteAttention = (projects: FleetProject[]) => {
+      const agents: AttentionAgent[] = projects.flatMap((p) =>
+        p.sessions.flatMap((s) =>
+          (s.agents ?? []).map((a) => ({
+            paneId: a.paneId,
+            session: a.session,
+            kind: a.kind,
+            state: a.state,
+          })),
+        ),
+      );
+      const { transitions, next } = diffAttention(attnPrev, agents);
+      attnPrev = next;
+      const worthy = noteworthyTransitions(transitions, {
+        tab: tab(),
+        visiblePaneIds: tab() === "terminal" ? panes().map((p) => p.id) : [],
+      });
+      const line = attentionNoteLine(worthy);
+      if (!line) return;
+      setStatusNote(line);
+      setAttnFlash(new Set(worthy.map((w) => w.paneId)));
+      if (attnFlashTimer) clearTimeout(attnFlashTimer);
+      attnFlashTimer = setTimeout(() => setAttnFlash(new Set()), ATTENTION_FLASH_MS);
+    };
+
+    // ── FOCUS HANDSHAKE (M25.1) ──────────────────────────────────────────────
+    // The app publishes what it is showing — attached?, the mirrored session,
+    // the on-screen pane ids — as a tmux SERVER option the chrome updater's
+    // notify path reads (see notify.ts AppFocus for the option-vs-file
+    // rationale). Refreshed on every fleet poll and on tab switches; the
+    // record's `ts` plus the reader's staleness guard cover an app that died
+    // without cleanup. Hosted attachment is probed (the cockpit keeps running
+    // detached); a plain app IS the user's terminal, so it's attached while
+    // it runs.
+    const writeFocusRecord = (attached: boolean) => {
+      const value = buildAppFocusValue({
+        ts: Date.now(),
+        attached,
+        session: curTarget(),
+        panes: tab() === "terminal" ? panes().map((p) => p.id) : [],
+      });
+      execFile("tmux", ["set-option", "-s", APP_FOCUS_OPTION, value], () => {});
+    };
+    const refreshFocusRecord = () => {
+      if (!HOSTED) {
+        writeFocusRecord(true);
+        return;
+      }
+      execFile("tmux", ["list-clients", "-t", `=${APP_HOST_SESSION}`, "-F", "x"], (err, stdout) =>
+        writeFocusRecord(!err && stdout.trim().length > 0),
+      );
+    };
+    onCleanup(() => {
+      if (attnFlashTimer) clearTimeout(attnFlashTimer);
+      // Best-effort; the staleness guard is the real cleanup for a hard death.
+      execFile("tmux", ["set-option", "-s", "-u", APP_FOCUS_OPTION], () => {});
+    });
+
+    // ── CLICK-TO-JUMP CONSUME (M25.1, hosted only) ───────────────────────────
+    // A macOS banner click stamps @tmux_ide_app_jump on the host session (see
+    // notify.ts notifierExecuteCommand) and switches the user's client to the
+    // cockpit. The fleet poll consumes the stamp: unset it FIRST (never loop),
+    // then open that session's workspace — which also serves the detached
+    // case, where the switch-client had nobody to move but the next attach
+    // should land on the session that needed input.
+    const consumeJumpRequest = () => {
+      if (!HOSTED) return;
+      execFile(
+        "tmux",
+        ["show-option", "-t", APP_HOST_SESSION, "-qv", APP_JUMP_OPTION],
+        (err, stdout) => {
+          const target = err ? "" : stdout.trim();
+          if (!target) return;
+          execFile("tmux", ["set-option", "-t", APP_HOST_SESSION, "-u", APP_JUMP_OPTION], () => {
+            openWorkspace(target, dirForSession(target));
+          });
+        },
+      );
+    };
     const homeItems = createMemo<HomeItem[]>(() => buildHomeItems(projectsData(), recentFolders()));
     // First-run (M22.5): a truly empty fleet gets a centered welcome. It reserves
     // WELCOME_ROWS at the top of the content area, so the home row math shifts by
@@ -1727,17 +1830,20 @@ render(
       clearSelection();
       if (name === curTarget() && mirror) {
         setTab("terminal");
+        refreshFocusRecord();
         return;
       }
       setCurTarget(name);
       setTab("terminal");
       attach(name);
+      refreshFocusRecord();
     };
     /** ^g / F1 — show the HOME tab. The mirror is KEPT ALIVE (it keeps streaming
      *  in the background so a back-switch is instant); the session is untouched. */
     const goHome = () => {
       clearSelection();
       setTab("home");
+      refreshFocusRecord();
     };
 
     // ── FILES TAB (M18.4, uplifted M24.6) ────────────────────────────────────
@@ -2079,6 +2185,21 @@ render(
       });
     };
 
+    /** FRONT DOOR (M25.1): a session the app itself creates is WATCHED — the
+     *  adopted marker is stamped (inert re: chrome painting; none of adopt's
+     *  status-row/border options are set — see ../chrome/front-door.ts) and
+     *  the background updater is ensured up, probed the way adopt probes. So
+     *  pure app users get blocked/done notifications without ever running
+     *  `adopt`, with zero visible dock changes. Async execFile only (the
+     *  render-loop law); everything best-effort. */
+    const watchCreatedSession = (name: string) => {
+      execFile("tmux", adoptMarkArgv(name), () => {
+        execFile("tmux", updaterProbeArgv(), (probeErr) => {
+          if (probeErr) execFile("tmux", updaterSpawnArgv(), () => {});
+        });
+      });
+    };
+
     /** Create a detached session named `name` in `dir` and open it as the
      *  workspace (M21.9 — the home "launch project" / "new session" verbs).
      *  ASYNC execFile only (the render-loop law); an already-existing session
@@ -2093,6 +2214,7 @@ render(
         }
         if (!err) {
           execFile("tmux", ["set-environment", "-t", name, "TMUX_IDE", "1"], () => {});
+          watchCreatedSession(name);
           setStatusNote(`launched ${name}`);
         }
         fleetRefresh?.();
@@ -2296,6 +2418,7 @@ render(
           setStatusNote(err ? `couldn't start ${command}` : `started ${command} in ${name}`);
           if (!err) {
             execFile("tmux", ["set-environment", "-t", name, "TMUX_IDE", "1"], () => {});
+            watchCreatedSession(name);
             decorate(stdout);
           }
           setTimeout(() => fleetRefresh?.(), 300);
@@ -2306,7 +2429,13 @@ render(
       const args = spawnAgentArgs(placement as SpawnPlacement, target, dir, command);
       execFile("tmux", args, (err, stdout) => {
         setStatusNote(err ? `couldn't start ${command}` : `started ${command} in ${ctx.session}`);
-        if (!err) decorate(stdout);
+        if (!err) {
+          decorate(stdout);
+          // The agent's session must be watched for its blocked/done pings to
+          // exist — front-door sessions were stamped at create, but a spawn
+          // can target a pre-existing, never-adopted session too.
+          watchCreatedSession(target.session);
+        }
         setTimeout(() => fleetRefresh?.(), 300);
       });
     };
@@ -2647,6 +2776,7 @@ render(
       if (t === "diff") {
         if (diffEntries().length === 0) enterDiff(workspaceDir());
         else setTab("diff");
+        refreshFocusRecord(); // visibility changed — tell the notify path now
         return;
       }
       if (t === "files") {
@@ -2654,6 +2784,7 @@ render(
         else catchUpFilesIfStale();
       }
       setTab(t);
+      refreshFocusRecord(); // visibility changed — tell the notify path now
     };
 
     // ── COMMAND PALETTE (M18.4, mouse-complete M21.9) ───────────────────────
@@ -3355,6 +3486,10 @@ render(
       let fleetInFlight = false;
       const refreshFleet = () => {
         pruneDragOverrides();
+        // The M25.1 handshakes piggyback on the poll cadence: publish what the
+        // app is showing, and consume any banner-click jump request.
+        refreshFocusRecord();
+        consumeJumpRequest();
         if (fleetInFlight) return;
         fleetInFlight = true;
         execFile("node", [cliPath, "team", "--json"], { timeout: 10_000 }, (err, stdout) => {
@@ -3363,6 +3498,7 @@ render(
           try {
             const data = JSON.parse(stdout) as { projects?: FleetProject[] };
             setProjectsData(data.projects ?? []);
+            noteAttention(data.projects ?? []);
             // Reconcile a RESTORED context session to its project dir once the
             // fleet lands (persistence carries the name, not the dir). One-shot:
             // only while contextDir is still unresolved.
@@ -5825,11 +5961,16 @@ render(
                     // Blocked is the attention state: bold, matching the
                     // statusline's grammar (`blocked` reads bold there too).
                     const attn = () => (a.state === "blocked" ? 1 : 0);
+                    // M25.1: a just-flipped hidden agent flashes its row for a
+                    // beat (the status-strip note's "look here" twin).
+                    const flashed = () => attnFlash().has(a.paneId);
                     return (
                       <box
                         flexDirection="row"
                         gap={1}
-                        backgroundColor={hovered() ? HOVER_BG : SIDEBAR_BG}
+                        backgroundColor={
+                          flashed() ? CHIP_ATTN_BG : hovered() ? HOVER_BG : SIDEBAR_BG
+                        }
                       >
                         <text fg={STATUS_COLOR[a.state]} attributes={attn()}>
                           {STATUS_GLYPH[a.state]}

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -357,6 +357,7 @@ import {
   agentRowLabel,
   agentsHeaderLabel,
   agentAgeLabel,
+  agentDisplayKind,
   sidebarHit,
   AGENTS_ADD_CHIP,
   AGENTS_EMPTY_LINE,
@@ -5624,7 +5625,10 @@ render(
         if (!e || !p) return null;
         // Budget: pane width minus the left inset (1) + padding (2), capped so a
         // wide pane's chip stays a chip (and clears the top-right scroll badge).
-        return chipLabel(e, STATUS_GLYPH[e.state], Date.now(), Math.min(p.width - 3, 28));
+        // A self-reported status text earns a wider cap (M25.4) — "● claude ·
+        // refactoring auth" needs the room; chipLabel still truncates to fit.
+        const cap = e.statusText ? 44 : 28;
+        return chipLabel(e, STATUS_GLYPH[e.state], Date.now(), Math.min(p.width - 3, cap));
       };
       return (
         <Show when={label()}>
@@ -5838,7 +5842,7 @@ render(
                           fg={a.state === "blocked" ? STATUS_COLOR.blocked : MUTED}
                           attributes={attn()}
                         >
-                          {agentRowLabel(a.kind, a.session, labelBudget())}
+                          {agentRowLabel(agentDisplayKind(a), a.session, labelBudget())}
                         </text>
                         <Show when={ageShown()}>
                           <box flexGrow={1} />

--- a/packages/daemon/src/tui/mirror/attention.test.ts
+++ b/packages/daemon/src/tui/mirror/attention.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the in-app attention model — the per-pane diff, the
+ * visibility test, and the note formatting.
+ */
+import { describe, expect, it } from "vitest";
+import type { AgentStatus } from "../detect/classify.ts";
+import {
+  attentionNote,
+  attentionNoteLine,
+  diffAttention,
+  isPaneVisible,
+  noteworthyTransitions,
+  type AttentionAgent,
+  type AttentionTransition,
+} from "./attention.ts";
+
+const agent = (paneId: string, state: AgentStatus, session = "api"): AttentionAgent => ({
+  paneId,
+  session,
+  kind: "claude",
+  state,
+});
+
+const t = (over: Partial<AttentionTransition> = {}): AttentionTransition => ({
+  paneId: "%1",
+  session: "api",
+  kind: "claude",
+  from: "working",
+  to: "blocked",
+  ...over,
+});
+
+describe("diffAttention", () => {
+  it("emits transitions for changed panes and first-sight (from null) for new ones", () => {
+    const prev = new Map<string, AgentStatus>([["%1", "working"]]);
+    const { transitions, next } = diffAttention(prev, [
+      agent("%1", "blocked"),
+      agent("%2", "working"),
+    ]);
+    expect(transitions).toEqual([
+      { paneId: "%1", session: "api", kind: "claude", from: "working", to: "blocked" },
+      { paneId: "%2", session: "api", kind: "claude", from: null, to: "working" },
+    ]);
+    expect(next.get("%1")).toBe("blocked");
+    // The input map is untouched (app.tsx swaps in `next` itself).
+    expect(prev.get("%1")).toBe("working");
+  });
+
+  it("emits nothing for unchanged panes and drops vanished ones from the state", () => {
+    const prev = new Map<string, AgentStatus>([
+      ["%1", "working"],
+      ["%9", "blocked"],
+    ]);
+    const { transitions, next } = diffAttention(prev, [agent("%1", "working")]);
+    expect(transitions).toEqual([]);
+    expect(next.has("%9")).toBe(false);
+  });
+
+  it("dedupes a pane surfacing under two projects", () => {
+    const { transitions } = diffAttention(new Map([["%1", "working"]]), [
+      agent("%1", "blocked"),
+      agent("%1", "blocked"),
+    ]);
+    expect(transitions).toHaveLength(1);
+  });
+});
+
+describe("isPaneVisible / noteworthyTransitions", () => {
+  it("only Terminal-tab panes of the mirrored window are visible", () => {
+    expect(isPaneVisible("%1", { tab: "terminal", visiblePaneIds: ["%1", "%2"] })).toBe(true);
+    expect(isPaneVisible("%3", { tab: "terminal", visiblePaneIds: ["%1", "%2"] })).toBe(false);
+    expect(isPaneVisible("%1", { tab: "files", visiblePaneIds: ["%1"] })).toBe(false);
+    expect(isPaneVisible("%1", { tab: "home", visiblePaneIds: [] })).toBe(false);
+  });
+
+  it("notes blocked/done for hidden panes only; first-sight and working never note", () => {
+    const view = { tab: "terminal", visiblePaneIds: ["%1"] };
+    const worthy = noteworthyTransitions(
+      [
+        t({ paneId: "%1" }), // visible — suppressed
+        t({ paneId: "%2" }), // hidden blocked — notes
+        t({ paneId: "%3", to: "done" }), // hidden done — notes
+        t({ paneId: "%4", from: null }), // first sight — graced
+        t({ paneId: "%5", to: "working" }), // not a notify state
+      ],
+      view,
+    );
+    expect(worthy.map((w) => w.paneId)).toEqual(["%2", "%3"]);
+  });
+
+  it("a non-Terminal tab makes every transition noteworthy (nothing is visible)", () => {
+    const worthy = noteworthyTransitions([t({ paneId: "%1" })], {
+      tab: "diff",
+      visiblePaneIds: ["%1"],
+    });
+    expect(worthy).toHaveLength(1);
+  });
+});
+
+describe("attentionNote / attentionNoteLine", () => {
+  it("formats the card's example shape, with ✓ for done", () => {
+    expect(attentionNote(t({ session: "zz-api" }))).toBe(
+      "● claude blocked · zz-api — click agents",
+    );
+    expect(attentionNote(t({ to: "done" }))).toBe("✓ claude done · api — click agents");
+  });
+
+  it("collapses a multi-agent poll into one line with a (+N) tail", () => {
+    expect(attentionNoteLine([])).toBeNull();
+    expect(attentionNoteLine([t()])).toBe("● claude blocked · api — click agents");
+    expect(attentionNoteLine([t(), t({ paneId: "%2" }), t({ paneId: "%3" })])).toBe(
+      "● claude blocked · api — click agents (+2)",
+    );
+  });
+});

--- a/packages/daemon/src/tui/mirror/attention.ts
+++ b/packages/daemon/src/tui/mirror/attention.ts
@@ -1,0 +1,110 @@
+/**
+ * In-app attention surfacing (M25.1) — the PURE half of "an agent you can't
+ * see needs you". The app's 3s fleet poll diffs the previous per-pane agent
+ * states against the fresh payload; blocked/done transitions for agents NOT on
+ * the current screen (another workspace, another window, or a non-Terminal
+ * tab) become a status-strip note plus a brief sidebar flash. The diff, the
+ * visibility test, and the note text live here so they unit-test without
+ * OpenTUI; app.tsx supplies the signals and timers.
+ *
+ * First sight is graced exactly like the chrome updater's notification path
+ * (`from: null` never notes) — an app boot must not re-announce every agent
+ * that was already blocked.
+ */
+import type { AgentStatus } from "../detect/classify.ts";
+
+/** The per-agent slice of the fleet payload the diff needs. */
+export interface AttentionAgent {
+  paneId: string;
+  session: string;
+  kind: string;
+  state: AgentStatus;
+}
+
+/** One agent's state change between two fleet polls. */
+export interface AttentionTransition {
+  paneId: string;
+  session: string;
+  kind: string;
+  from: AgentStatus | null;
+  to: AgentStatus;
+}
+
+/** What the app is currently showing — the visibility side of the test. */
+export interface AttentionView {
+  /** The active surface tab (only `terminal` shows panes at all). */
+  tab: string;
+  /** Pane ids on screen right now (the mirrored window's panes). */
+  visiblePaneIds: readonly string[];
+}
+
+/** The two states worth interrupting the user over (mirrors the chrome
+ *  updater's NOTIFY_STATES). */
+const NOTE_STATES: ReadonlySet<AgentStatus> = new Set<AgentStatus>(["blocked", "done"]);
+
+/**
+ * PURE — diff the previous per-pane states against this poll's agents.
+ * Returns the transitions plus the fresh state map to thread into the next
+ * poll (the input map is NOT mutated). A pane that vanished emits nothing and
+ * drops out of the state.
+ */
+export function diffAttention(
+  prev: ReadonlyMap<string, AgentStatus>,
+  agents: readonly AttentionAgent[],
+): { transitions: AttentionTransition[]; next: Map<string, AgentStatus> } {
+  const next = new Map<string, AgentStatus>();
+  const transitions: AttentionTransition[] = [];
+  for (const a of agents) {
+    if (next.has(a.paneId)) continue; // deduped: a session can surface under two projects
+    const before = prev.has(a.paneId) ? prev.get(a.paneId)! : null;
+    next.set(a.paneId, a.state);
+    if (before === a.state) continue;
+    transitions.push({
+      paneId: a.paneId,
+      session: a.session,
+      kind: a.kind,
+      from: before,
+      to: a.state,
+    });
+  }
+  return { transitions, next };
+}
+
+/** PURE — is this pane on the app's screen right now? Only the Terminal tab
+ *  shows panes; there, exactly the mirrored window's panes are visible. */
+export function isPaneVisible(paneId: string, view: AttentionView): boolean {
+  return view.tab === "terminal" && view.visiblePaneIds.includes(paneId);
+}
+
+/**
+ * PURE — the transitions worth a note: blocked/done, not first-sight, and not
+ * currently visible (the user can see a visible pane flip themselves).
+ */
+export function noteworthyTransitions(
+  transitions: readonly AttentionTransition[],
+  view: AttentionView,
+): AttentionTransition[] {
+  return transitions.filter(
+    (t) => t.from !== null && NOTE_STATES.has(t.to) && !isPaneVisible(t.paneId, view),
+  );
+}
+
+/** PURE — the status-strip note for one transition, e.g.
+ *  `● claude blocked · zz-api — click agents`. Done reads `✓ … — click agents`. */
+export function attentionNote(t: AttentionTransition): string {
+  const glyph = t.to === "blocked" ? "●" : "✓";
+  return `${glyph} ${t.kind} ${t.to} · ${t.session} — click agents`;
+}
+
+/** PURE — the note line for a whole poll's noteworthy set: the first (most
+ *  recent diff order) transition's note, with a `(+N)` tail when several agents
+ *  flipped in the same poll. Null for an empty set. */
+export function attentionNoteLine(worthy: readonly AttentionTransition[]): string | null {
+  const first = worthy[0];
+  if (!first) return null;
+  const extra = worthy.length > 1 ? ` (+${worthy.length - 1})` : "";
+  return `${attentionNote(first)}${extra}`;
+}
+
+/** How long the sidebar attention flash lasts. */
+export const ATTENTION_FLASH_MS = 2500;

--- a/packages/daemon/src/tui/team/sessions.test.ts
+++ b/packages/daemon/src/tui/team/sessions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  agentMetadataFor,
   buildAgentEntry,
   excludeSidebarPanes,
   isListableSession,
@@ -166,6 +167,55 @@ describe("buildAgentEntry", () => {
       since: null,
     });
     expect(entry?.since).toBeNull();
+  });
+
+  it("threads display metadata additively — absent fields stay ABSENT, not undefined-valued", () => {
+    const withMeta = buildAgentEntry({
+      sessionName: "web",
+      pane,
+      manifest: claude,
+      state: "working",
+      since: 1700000000,
+      statusText: "refactoring auth",
+      displayName: "reviewer",
+    })!;
+    expect(withMeta.statusText).toBe("refactoring auth");
+    expect(withMeta.displayName).toBe("reviewer");
+
+    const without = buildAgentEntry({
+      sessionName: "web",
+      pane,
+      manifest: claude,
+      state: "working",
+      since: null,
+    })!;
+    expect("statusText" in without).toBe(false);
+    expect("displayName" in without).toBe(false);
+  });
+});
+
+describe("agentMetadataFor (staleness gate, M25.4)", () => {
+  const pane = { statusTextRaw: "refactoring auth", displayNameRaw: "reviewer" };
+
+  it("surfaces sanitized metadata while the authority stamp is fresh", () => {
+    expect(agentMetadataFor(pane, true)).toEqual({
+      statusText: "refactoring auth",
+      displayName: "reviewer",
+    });
+  });
+
+  it("drops ALL metadata when the authority stamp is stale/absent — same rules as @agent_state", () => {
+    expect(agentMetadataFor(pane, false)).toEqual({});
+  });
+
+  it("sanitizes: control chars stripped, overlong text ellipsized, empty → omitted", () => {
+    const meta = agentMetadataFor(
+      { statusTextRaw: "a\tb " + "x".repeat(60), displayNameRaw: "  " },
+      true,
+    );
+    expect(meta.displayName).toBeUndefined();
+    expect(meta.statusText?.length).toBe(32);
+    expect(meta.statusText?.startsWith("a b x")).toBe(true);
   });
 });
 

--- a/packages/daemon/src/tui/team/sessions.test.ts
+++ b/packages/daemon/src/tui/team/sessions.test.ts
@@ -176,8 +176,15 @@ describe("isListableSession", () => {
     expect(isListableSession("_")).toBe(false);
   });
 
-  it("keeps every non-internal session", () => {
+  it("hides `zz-`-prefixed scratch sessions (dev scratch is internal, per the contract)", () => {
+    expect(isListableSession("zz-probe")).toBe(false);
+    expect(isListableSession("zz-")).toBe(false);
+  });
+
+  it("keeps every non-internal session (zz must be a PREFIX, not a substring)", () => {
     expect(isListableSession("my-project")).toBe(true);
     expect(isListableSession("tmux-ide")).toBe(true);
+    expect(isListableSession("fizz-buzz")).toBe(true);
+    expect(isListableSession("zzz")).toBe(true);
   });
 });

--- a/packages/daemon/src/tui/team/sessions.ts
+++ b/packages/daemon/src/tui/team/sessions.ts
@@ -138,6 +138,9 @@ export interface PaneDetail {
   paneId: string;
   agent: string | null;
   status: AgentStatus;
+  /** `window_index` of the pane's window — the notification path suppresses
+   *  toasts window-granularly, so the transition must know its window. */
+  windowIndex: number;
 }
 
 interface PaneRecord {
@@ -182,12 +185,13 @@ export function excludeSidebarPanes<T extends { sidebar: boolean }>(panes: T[]):
 const SEVERITY: AgentStatus[] = ["blocked", "working", "done", "idle", "unknown"];
 
 /**
- * Whether a session should appear in the switcher. Any `_`-prefixed session is
- * internal plumbing (the `_tmux-ide-chrome` updater, scratch sessions, …) and
- * is filtered out so the cockpit never lists — or navigates into — infrastructure.
+ * Whether a session should appear in the switcher. `_`-prefixed sessions are
+ * internal plumbing (the `_tmux-ide-chrome` updater, the `_tmux-ide-app` host)
+ * and `zz-`-prefixed sessions are development scratch sessions — both are
+ * filtered out so the cockpit never lists — or navigates into — infrastructure.
  */
 export function isListableSession(name: string): boolean {
-  return !name.startsWith("_");
+  return !name.startsWith("_") && !name.startsWith("zz-");
 }
 
 function tmux(args: string[]): string {
@@ -300,6 +304,7 @@ export function listTeamSessions(
           paneId: pane.id,
           agent: manifest && manifest.id !== "shell" ? manifest.id : null,
           status,
+          windowIndex: pane.windowIndex,
         });
         // Surface per-pane agent detail (same resolved manifest/status — nothing
         // re-derived). Non-agent panes yield null and are skipped.

--- a/packages/daemon/src/tui/team/sessions.ts
+++ b/packages/daemon/src/tui/team/sessions.ts
@@ -15,6 +15,7 @@ import {
   classifyInstant,
   parseAuthority,
   parseAuthorityEpoch,
+  sanitizeAgentText,
   type AgentStatus,
   type StatusTracker,
 } from "../detect/classify.ts";
@@ -78,6 +79,19 @@ export interface PaneAgentEntry {
   command: string;
   /** `pane_current_path` — the pane's working directory. */
   dir: string;
+  /**
+   * Self-reported one-liner (`@agent_status_text`, sanitized + clamped to 32
+   * chars) — what the agent says it is doing ("refactoring auth"). ADDITIVE and
+   * present only while the pane's `@agent_state` stamp is FRESH (the metadata
+   * follows the same authority-staleness rules; stale/absent authority drops it).
+   */
+  statusText?: string;
+  /**
+   * Self-reported display name (`@agent_display_name`, sanitized) — label
+   * precedence over `kind` in the sidebar/chips. Same freshness gate as
+   * {@link statusText}. ADDITIVE.
+   */
+  displayName?: string;
 }
 
 /**
@@ -93,6 +107,9 @@ export function buildAgentEntry(input: {
   manifest: AgentManifest | undefined;
   state: AgentStatus;
   since: number | null;
+  /** Already-sanitized display metadata (undefined when absent/stale). */
+  statusText?: string;
+  displayName?: string;
 }): PaneAgentEntry | null {
   const { manifest, pane } = input;
   if (!manifest || manifest.id === "shell") return null;
@@ -107,6 +124,29 @@ export function buildAgentEntry(input: {
     title: pane.title,
     command: pane.cmd,
     dir: pane.dir,
+    ...(input.statusText !== undefined ? { statusText: input.statusText } : {}),
+    ...(input.displayName !== undefined ? { displayName: input.displayName } : {}),
+  };
+}
+
+/**
+ * PURE — the display metadata a pane's agent entry surfaces: the sanitized
+ * `@agent_status_text` / `@agent_display_name` options, gated on the SAME
+ * authority-freshness verdict as the state itself. `authorityFresh` is
+ * `parseAuthority(...) !== null` — when the pane's `@agent_state` stamp is
+ * absent or stale (a dead hook mid-turn), the metadata is dropped with it
+ * rather than lying alongside a scraped state.
+ */
+export function agentMetadataFor(
+  pane: Pick<PaneRecord, "statusTextRaw" | "displayNameRaw">,
+  authorityFresh: boolean,
+): { statusText?: string; displayName?: string } {
+  if (!authorityFresh) return {};
+  const statusText = sanitizeAgentText(pane.statusTextRaw);
+  const displayName = sanitizeAgentText(pane.displayNameRaw);
+  return {
+    ...(statusText !== undefined ? { statusText } : {}),
+    ...(displayName !== undefined ? { displayName } : {}),
   };
 }
 
@@ -155,6 +195,10 @@ interface PaneRecord {
   authority: string;
   /** Raw `@agent_hint` pane option — forces a manifest when set. */
   hint: string;
+  /** Raw `@agent_status_text` pane option — sanitized by {@link agentMetadataFor}. */
+  statusTextRaw: string;
+  /** Raw `@agent_display_name` pane option — sanitized by {@link agentMetadataFor}. */
+  displayNameRaw: string;
   /** `window_index` — the window (tab) this pane lives in. */
   windowIndex: number;
   /** `window_name`. */
@@ -302,8 +346,17 @@ export function listTeamSessions(
           status,
         });
         // Surface per-pane agent detail (same resolved manifest/status — nothing
-        // re-derived). Non-agent panes yield null and are skipped.
-        const entry = buildAgentEntry({ sessionName: name, pane, manifest, state: status, since });
+        // re-derived). Non-agent panes yield null and are skipped. Display
+        // metadata (@agent_status_text/@agent_display_name) is gated on the SAME
+        // freshness verdict as the authority state — stale/absent stamp drops it.
+        const entry = buildAgentEntry({
+          sessionName: name,
+          pane,
+          manifest,
+          state: status,
+          since,
+          ...agentMetadataFor(pane, authority !== null),
+        });
         if (entry) agents.push(entry);
         return status;
       });
@@ -332,7 +385,10 @@ function collectPanes(): Map<string, PaneRecord[]> {
     // title stays the trailing catch-all — window names/paths don't contain tabs
     // in practice. pane_current_path rides this SAME list-panes call (no extra
     // tmux round-trip) so per-pane agent entries can carry a working dir.
-    `#{session_name}\t#{pane_id}\t#{pane_pid}\t#{pane_current_command}\t#{@agent_state}\t#{@agent_hint}\t#{${SIDEBAR_PANE_OPTION}}\t#{window_index}\t#{window_name}\t#{window_active}\t#{pane_current_path}\t#{pane_title}`,
+    // @agent_status_text/@agent_display_name ride the same caveat: the contract
+    // (skill/SKILL.md) says plain text; a stamped tab would shift this one
+    // pane's fields (sanitizeAgentText strips control chars AFTER the split).
+    `#{session_name}\t#{pane_id}\t#{pane_pid}\t#{pane_current_command}\t#{@agent_state}\t#{@agent_hint}\t#{@agent_status_text}\t#{@agent_display_name}\t#{${SIDEBAR_PANE_OPTION}}\t#{window_index}\t#{window_name}\t#{window_active}\t#{pane_current_path}\t#{pane_title}`,
   ]);
   const bySession = new Map<string, PaneRecord[]>();
   for (const line of raw.split("\n").filter(Boolean)) {
@@ -343,6 +399,8 @@ function collectPanes(): Map<string, PaneRecord[]> {
       cmd = "",
       authority = "",
       hint = "",
+      statusTextRaw = "",
+      displayNameRaw = "",
       sidebar = "",
       windowIndex = "0",
       windowName = "",
@@ -358,6 +416,8 @@ function collectPanes(): Map<string, PaneRecord[]> {
       cmd,
       authority,
       hint,
+      statusTextRaw,
+      displayNameRaw,
       sidebar: sidebar === "1",
       windowIndex: Number(windowIndex) || 0,
       windowName,

--- a/packages/daemon/src/tui/team/sessions.ts
+++ b/packages/daemon/src/tui/team/sessions.ts
@@ -138,6 +138,12 @@ export interface PaneDetail {
   paneId: string;
   agent: string | null;
   status: AgentStatus;
+  /** `pane_pid` — root of the pane's process tree (session-id capture probes from it). */
+  pid: number;
+  /** `pane_current_path` — the pane's working directory. */
+  dir: string;
+  /** Existing `@agent_session_id` stamp, or null (capture only fills empty ones). */
+  sessionId: string | null;
 }
 
 interface PaneRecord {
@@ -155,6 +161,8 @@ interface PaneRecord {
   authority: string;
   /** Raw `@agent_hint` pane option — forces a manifest when set. */
   hint: string;
+  /** Raw `@agent_session_id` pane option — the agent's own session id, if recorded. */
+  sessionId: string;
   /** `window_index` — the window (tab) this pane lives in. */
   windowIndex: number;
   /** `window_name`. */
@@ -300,6 +308,9 @@ export function listTeamSessions(
           paneId: pane.id,
           agent: manifest && manifest.id !== "shell" ? manifest.id : null,
           status,
+          pid: pane.pid,
+          dir: pane.dir,
+          sessionId: pane.sessionId.length > 0 ? pane.sessionId : null,
         });
         // Surface per-pane agent detail (same resolved manifest/status — nothing
         // re-derived). Non-agent panes yield null and are skipped.
@@ -332,7 +343,7 @@ function collectPanes(): Map<string, PaneRecord[]> {
     // title stays the trailing catch-all — window names/paths don't contain tabs
     // in practice. pane_current_path rides this SAME list-panes call (no extra
     // tmux round-trip) so per-pane agent entries can carry a working dir.
-    `#{session_name}\t#{pane_id}\t#{pane_pid}\t#{pane_current_command}\t#{@agent_state}\t#{@agent_hint}\t#{${SIDEBAR_PANE_OPTION}}\t#{window_index}\t#{window_name}\t#{window_active}\t#{pane_current_path}\t#{pane_title}`,
+    `#{session_name}\t#{pane_id}\t#{pane_pid}\t#{pane_current_command}\t#{@agent_state}\t#{@agent_hint}\t#{@agent_session_id}\t#{${SIDEBAR_PANE_OPTION}}\t#{window_index}\t#{window_name}\t#{window_active}\t#{pane_current_path}\t#{pane_title}`,
   ]);
   const bySession = new Map<string, PaneRecord[]>();
   for (const line of raw.split("\n").filter(Boolean)) {
@@ -343,6 +354,7 @@ function collectPanes(): Map<string, PaneRecord[]> {
       cmd = "",
       authority = "",
       hint = "",
+      sessionId = "",
       sidebar = "",
       windowIndex = "0",
       windowName = "",
@@ -358,6 +370,7 @@ function collectPanes(): Map<string, PaneRecord[]> {
       cmd,
       authority,
       hint,
+      sessionId,
       sidebar: sidebar === "1",
       windowIndex: Number(windowIndex) || 0,
       windowName,

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -34,7 +34,7 @@ minutes is treated as stale (the detector falls back to Layer 2), so long-runnin
 agents should re-stamp periodically. Two optional companions:
 
 ```bash
-tmux set-option -p @agent_session_id "<id>"   # your Claude session id — powers restore --resume-agents
+tmux set-option -p @agent_session_id "<id>"   # your own session id — powers restore --resume-agents
 tmux set-option -p @agent_hint claude          # force which agent manifest Layer 2 uses for this pane
 ```
 
@@ -44,6 +44,13 @@ every lifecycle event (UserPromptSubmit/PreToolUse → working, Notification →
 blocked, Stop → done, SessionEnd → idle) and records `@agent_session_id`. It
 takes effect for **new** Claude Code sessions; the merge is reversible
 (`integration uninstall claude`).
+
+**Session-id capture for other kinds** (what `restore --resume-agents` resumes
+from): codex and cursor-agent panes are stamped **automatically** — the chrome
+updater reads each CLI's own on-disk session state; opencode gets a plugin via
+`tmux-ide integration install opencode`. `tmux-ide integration status` shows
+what's active. Kinds without a verified resume story (gemini, aider, copilot, …)
+can self-report the id as above.
 
 **How detection layers work:** Layer 1 is the authority above — a fresh
 `@agent_state` option is ground truth. When none is present, Layer 2 resolves the
@@ -91,7 +98,7 @@ tmux-ide adopt --all                       # adopt every live session
 tmux-ide unadopt <session>                 # remove the dock — sessions keep running as plain tmux
 
 tmux-ide restore --dry-run --json          # preview rebuilding the fleet from the last snapshot
-tmux-ide restore --resume-agents           # rebuild after a tmux crash; revive Claude convos via claude --resume
+tmux-ide restore --resume-agents           # rebuild after a tmux crash; revive agent convos (claude/codex/cursor/opencode)
 
 tmux-ide worktree create <branch> --from <ref>   # git worktree on a new branch + a session in it
 tmux-ide worktree open <branch>            # open/switch to an existing worktree's session

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -38,6 +38,22 @@ tmux set-option -p @agent_session_id "<id>"   # your Claude session id — power
 tmux set-option -p @agent_hint claude          # force which agent manifest Layer 2 uses for this pane
 ```
 
+**Display metadata** — say WHAT you're doing and WHO you are, right in the
+fleet UI. Two more optional pane-local options:
+
+```bash
+tmux set-option -p @agent_status_text "refactoring auth"  # one-liner, ≤32 chars — shows in the pane chip ("● claude · refactoring auth")
+tmux set-option -p @agent_display_name "reviewer"          # your name — replaces the detected kind in sidebar rows & chips
+```
+
+Plain text only (control characters are stripped, tabs break the line for your
+pane — don't stamp them; anything past 32 chars is ellipsized). Both surface in
+`tmux-ide team --json` (per-pane `statusText` / `displayName`), the unified
+app's pane chips, and the sidebar agent rows. They follow the SAME staleness
+rules as `@agent_state`: they only show while your state stamp is fresh, so
+re-stamp `@agent_state` alongside — update the text whenever your focus
+changes, and it disappears with a stale/cleared state instead of lying.
+
 **Claude Code users get this for free** — `tmux-ide integration install claude`
 writes a POSIX hook into `~/.claude/settings.json` that stamps `@agent_state` on
 every lifecycle event (UserPromptSubmit/PreToolUse → working, Notification →


### PR DESCRIPTION
Three cards: front-door notification coverage with pane-granular, focus-aware decisions and click-to-jump v2; automatic resume-id capture for codex/opencode/cursor; 8 new evidence-backed agent manifests + self-reported status text + remote manifest packs. Cross-merge reconciliation in the merge commits. 1547 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)