### PR TITLE
feat: notification channels + hosted cockpit size-follow (M25.2, M25.5)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2924,6 +2924,9 @@ function pickBool(value, fallback) {
 function pickPosInt(value, fallback) {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
 }
+function pickNonNegInt(value, fallback) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : fallback;
+}
 function pickChoice(value, allowed, fallback) {
   return typeof value === "string" && allowed.includes(value) ? value : fallback;
 }
@@ -2978,7 +2981,10 @@ function parseAppConfig(input) {
     },
     notifications: {
       toast: pickBool(notifications.toast, D.notifications.toast),
-      macos: pickBool(notifications.macos, D.notifications.macos)
+      macos: pickBool(notifications.macos, D.notifications.macos),
+      terminal: pickBool(notifications.terminal, D.notifications.terminal),
+      delaySeconds: pickNonNegInt(notifications.delaySeconds, D.notifications.delaySeconds),
+      sound: pickChoice(notifications.sound, ["blocked", "all", "none"], D.notifications.sound)
     },
     restore: { resumeAgents: pickBool(restore2.resumeAgents, D.restore.resumeAgents) },
     updates: {
@@ -3082,7 +3088,7 @@ var init_app_config = __esm({
         glyphs: { active: "\u25CF", inactive: "\u25CB" }
       },
       updater: { tickMs: 2e3, snapshotEvery: 15 },
-      notifications: { toast: true, macos: false },
+      notifications: { toast: true, macos: false, terminal: true, delaySeconds: 2, sound: "blocked" },
       restore: { resumeAgents: false },
       updates: { check: true, manifests: false },
       welcome: { show: true },
@@ -5268,18 +5274,32 @@ var init_hosted = __esm({
   }
 });
 
+// packages/daemon/src/tui/mirror/selection.ts
+function tmuxPassthrough(seq) {
+  const doubled = seq.split("\x1B").join("\x1B\x1B");
+  return `\x1BPtmux;${doubled}\x1B\\`;
+}
+var init_selection = __esm({
+  "packages/daemon/src/tui/mirror/selection.ts"() {
+    "use strict";
+  }
+});
+
 // packages/daemon/src/tui/chrome/notify.ts
 var notify_exports = {};
 __export(notify_exports, {
   APP_FOCUS_OPTION: () => APP_FOCUS_OPTION,
   APP_FOCUS_STALE_MS: () => APP_FOCUS_STALE_MS,
   APP_JUMP_OPTION: () => APP_JUMP_OPTION,
+  DARWIN_SOUND_FILE: () => DARWIN_SOUND_FILE,
   DEFAULT_NOTIFICATION_PREFS: () => DEFAULT_NOTIFICATION_PREFS,
+  LINUX_SOUND_FILE: () => LINUX_SOUND_FILE,
   NOTIFY_DEBOUNCE_MS: () => NOTIFY_DEBOUNCE_MS,
   NOTIFY_MAX_LEN: () => NOTIFY_MAX_LEN,
   applyKillSwitch: () => applyKillSwitch,
   buildAppFocusValue: () => buildAppFocusValue,
   decideNotifications: () => decideNotifications,
+  decideTtyWrites: () => decideTtyWrites,
   enabledStates: () => enabledStates,
   hasTerminalNotifier: () => hasTerminalNotifier,
   inQuietHours: () => inQuietHours,
@@ -5288,19 +5308,35 @@ __export(notify_exports, {
   notifyConfigPath: () => notifyConfigPath,
   notifyDebounceKey: () => notifyDebounceKey,
   notifyMessage: () => notifyMessage,
+  notifySendArgs: () => notifySendArgs,
+  osc99Notification: () => osc99Notification,
+  osc9Notification: () => osc9Notification,
   parseAppFocus: () => parseAppFocus,
   parseClients: () => parseClients,
   parseHHMM: () => parseHHMM,
   parseNotificationPrefs: () => parseNotificationPrefs,
+  playPingSound: () => playPingSound,
   readAppFocus: () => readAppFocus,
   readNotificationPrefs: () => readNotificationPrefs,
   sendSystemNotification: () => sendSystemNotification,
   sendToasts: () => sendToasts,
+  soundArgv: () => soundArgv,
+  soundEligible: () => soundEligible,
   suppressToastFor: () => suppressToastFor,
-  terminalNotifierArgs: () => terminalNotifierArgs
+  terminalNotifierArgs: () => terminalNotifierArgs,
+  terminalNotifyEscape: () => terminalNotifyEscape,
+  writeClientTty: () => writeClientTty,
+  writeTtys: () => writeTtys
 });
-import { execFileSync as execFileSync7 } from "node:child_process";
-import { existsSync as existsSync14, readFileSync as readFileSync10 } from "node:fs";
+import { execFileSync as execFileSync7, spawn as spawn4 } from "node:child_process";
+import {
+  closeSync,
+  constants as fsConstants,
+  existsSync as existsSync14,
+  openSync,
+  readFileSync as readFileSync10,
+  writeSync
+} from "node:fs";
 function statusPhrase(to) {
   return to === "blocked" ? "needs input" : "finished";
 }
@@ -5343,23 +5379,39 @@ function decideNotifications(events, clients, lastNotified, nowMs, states = NOTI
       if (suppressToastFor(c, ev)) continue;
       toasts.push({ client: c.client, message });
     }
-    system.push({ message, session: ev.session });
+    system.push({
+      message,
+      session: ev.session,
+      state: ev.to,
+      paneId: ev.paneId ?? null,
+      windowIndex: ev.windowIndex ?? null
+    });
   }
   return { toasts, system, nextLastNotified };
 }
 function parseClients(lines) {
   const out = [];
   for (const line of lines) {
-    const [client = "", session = "", win = ""] = line.split("	");
+    const [client = "", session = "", win = "", tty = "", termname = ""] = line.split("	");
     if (!client || !session) continue;
     const n = Number.parseInt(win, 10);
-    out.push({ client, session, windowIndex: Number.isInteger(n) ? n : null });
+    out.push({
+      client,
+      session,
+      windowIndex: Number.isInteger(n) ? n : null,
+      tty: tty || null,
+      termname: termname || null
+    });
   }
   return out;
 }
 function listAttachedClients() {
   try {
-    const raw = runTmux(["list-clients", "-F", "#{client_name}	#{session_name}	#{window_index}"]).toString().trim();
+    const raw = runTmux([
+      "list-clients",
+      "-F",
+      "#{client_name}	#{session_name}	#{window_index}	#{client_tty}	#{client_termname}"
+    ]).toString().trim();
     return raw ? parseClients(raw.split("\n")) : [];
   } catch {
     return [];
@@ -5401,9 +5453,87 @@ function sendToasts(toasts) {
     }
   }
 }
-function hasTerminalNotifier() {
+function osc9Notification(text) {
+  return `\x1B]9;${text}\x07`;
+}
+function osc99Notification(text, urgent) {
+  return `\x1B]99;${urgent ? "u=2" : ""};${text}\x1B\\`;
+}
+function terminalNotifyEscape(termname, text, urgent) {
+  const t = termname ?? "";
+  if (t.includes("kitty")) return osc99Notification(text, urgent);
+  if (t.startsWith("tmux") || t.startsWith("screen")) {
+    return tmuxPassthrough(osc9Notification(text));
+  }
+  return osc9Notification(text);
+}
+function soundEligible(state, sound) {
+  if (sound === "none") return false;
+  if (sound === "all") return state === "blocked" || state === "done";
+  return state === "blocked";
+}
+function belEligible(state, sound) {
+  return state === "blocked" && sound !== "none";
+}
+function decideTtyWrites(n, clients, prefs) {
+  const asEvent = {
+    session: n.session,
+    from: null,
+    to: n.state,
+    paneId: n.paneId,
+    windowIndex: n.windowIndex
+  };
+  const bel = belEligible(n.state, prefs.sound) ? "\x07" : "";
+  const out = [];
+  for (const c of clients) {
+    if (!c.tty) continue;
+    if (suppressToastFor(c, asEvent)) continue;
+    const escape = prefs.terminal ? terminalNotifyEscape(c.termname, n.message, n.state === "blocked") : "";
+    const data = escape + bel;
+    if (data) out.push({ tty: c.tty, data });
+  }
+  return out;
+}
+function writeClientTty(write) {
+  let fd = null;
   try {
-    execFileSync7("which", ["terminal-notifier"], { stdio: "ignore" });
+    fd = openSync(write.tty, fsConstants.O_WRONLY | fsConstants.O_NOCTTY | fsConstants.O_NONBLOCK);
+    writeSync(fd, write.data);
+  } catch {
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+      }
+    }
+  }
+}
+function writeTtys(writes) {
+  for (const w of writes) writeClientTty(w);
+}
+function soundArgv(platform) {
+  if (platform === "darwin") return ["afplay", DARWIN_SOUND_FILE];
+  if (platform === "linux") return ["paplay", LINUX_SOUND_FILE];
+  return null;
+}
+function playPingSound(platform = process.platform) {
+  const argv = soundArgv(platform);
+  if (!argv || !existsSync14(argv[1])) return;
+  try {
+    const child = spawn4(argv[0], argv.slice(1), { stdio: "ignore", detached: true });
+    child.on("error", () => {
+    });
+    child.unref();
+  } catch {
+  }
+}
+function hasTerminalNotifier() {
+  return hasBinary("terminal-notifier");
+}
+function hasBinary(name) {
+  try {
+    execFileSync7("which", [name], { stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -5427,17 +5557,32 @@ function terminalNotifierArgs(n) {
     notifierExecuteCommand(n.session)
   ];
 }
-function sendSystemNotification(n) {
-  if (process.platform !== "darwin") return;
+function notifySendArgs(n) {
+  const args = ["--app-name=tmux-ide"];
+  if (n.state === "blocked") args.push("--urgency=critical");
+  args.push("tmux-ide", n.message);
+  return args;
+}
+function sendSystemNotification(n, io = {}) {
+  const platform = io.platform ?? process.platform;
+  const exec = io.exec ?? ((cmd, args) => execFileSync7(cmd, args, { stdio: "ignore" }));
+  const has = io.hasBinary ?? hasBinary;
   try {
-    if (hasTerminalNotifier()) {
-      execFileSync7("terminal-notifier", terminalNotifierArgs(n), { stdio: "ignore" });
+    if (platform === "darwin") {
+      if (has("terminal-notifier")) {
+        exec("terminal-notifier", terminalNotifierArgs(n));
+        return;
+      }
+      const escaped = n.message.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      exec("osascript", ["-e", `display notification "${escaped}" with title "tmux-ide"`]);
       return;
     }
-    const escaped = n.message.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-    execFileSync7("osascript", ["-e", `display notification "${escaped}" with title "tmux-ide"`], {
-      stdio: "ignore"
-    });
+    if (platform === "linux") {
+      const env = io.env ?? process.env;
+      if (!env.DISPLAY && !env.WAYLAND_DISPLAY) return;
+      if (!has("notify-send")) return;
+      exec("notify-send", notifySendArgs(n));
+    }
   } catch {
   }
 }
@@ -5479,13 +5624,16 @@ function parseNotificationPrefs(rawConfig) {
     enabled: pickBool2(n.enabled, DEFAULT_NOTIFICATION_PREFS.enabled),
     toast: base.toast,
     macos: base.macos,
+    terminal: base.terminal,
+    delaySeconds: base.delaySeconds,
+    sound: base.sound,
     onBlocked: pickBool2(n.onBlocked, DEFAULT_NOTIFICATION_PREFS.onBlocked),
     onDone: pickBool2(n.onDone, DEFAULT_NOTIFICATION_PREFS.onDone),
     quietHours: parseQuietHours(n.quietHours)
   };
 }
 function applyKillSwitch(prefs, envValue) {
-  return envValue === "0" ? { ...prefs, enabled: false, toast: false, macos: false } : prefs;
+  return envValue === "0" ? { ...prefs, enabled: false, toast: false, macos: false, terminal: false, sound: "none" } : prefs;
 }
 function notifyConfigPath() {
   return appConfigPath();
@@ -5502,23 +5650,29 @@ function readRawConfig() {
 function readNotificationPrefs() {
   return applyKillSwitch(parseNotificationPrefs(readRawConfig()), process.env.TMUX_IDE_NOTIFY);
 }
-var NOTIFY_STATES, NOTIFY_DEBOUNCE_MS, NOTIFY_MAX_LEN, APP_FOCUS_OPTION, APP_FOCUS_STALE_MS, APP_JUMP_OPTION, DEFAULT_NOTIFICATION_PREFS;
+var NOTIFY_STATES, NOTIFY_DEBOUNCE_MS, NOTIFY_MAX_LEN, APP_FOCUS_OPTION, APP_FOCUS_STALE_MS, DARWIN_SOUND_FILE, LINUX_SOUND_FILE, APP_JUMP_OPTION, DEFAULT_NOTIFICATION_PREFS;
 var init_notify = __esm({
   "packages/daemon/src/tui/chrome/notify.ts"() {
     "use strict";
     init_src();
     init_app_config();
     init_hosted();
+    init_selection();
     NOTIFY_STATES = /* @__PURE__ */ new Set(["blocked", "done"]);
     NOTIFY_DEBOUNCE_MS = 3e4;
     NOTIFY_MAX_LEN = 120;
     APP_FOCUS_OPTION = "@tmux_ide_app_focus";
     APP_FOCUS_STALE_MS = 15e3;
+    DARWIN_SOUND_FILE = "/System/Library/Sounds/Tink.aiff";
+    LINUX_SOUND_FILE = "/usr/share/sounds/freedesktop/stereo/complete.oga";
     APP_JUMP_OPTION = "@tmux_ide_app_jump";
     DEFAULT_NOTIFICATION_PREFS = {
       enabled: true,
       toast: true,
       macos: false,
+      terminal: true,
+      delaySeconds: 2,
+      sound: "blocked",
       onBlocked: true,
       onDone: true,
       quietHours: null
@@ -5882,6 +6036,7 @@ function runUpdaterTick(deps2) {
     if (events.length > 0) deps2.appendEvents(events);
   }
   if (deps2.prevPaneState) {
+    firePendingOsPings(deps2, panes);
     const events = diffPaneTransitions(deps2.prevPaneState, panes, deps2.locatePane);
     if (events.length > 0) dispatchNotifications(deps2, events);
   }
@@ -5920,11 +6075,14 @@ function diffPaneTransitions(prev, panes, locate) {
   for (const [paneId, status2] of next) prev.set(paneId, status2);
   return events;
 }
+function anyChannelOn(prefs) {
+  return prefs.toast || prefs.macos || prefs.terminal || prefs.sound !== "none";
+}
 function dispatchNotifications(deps2, events) {
-  const { listClients, lastNotified, now, prefs, sendToasts: toast, sendSystem } = deps2;
+  const { listClients, lastNotified, now, prefs, sendToasts: toast } = deps2;
   if (!listClients || !lastNotified || !now || !prefs) return;
   if (!prefs.enabled) return;
-  if (!prefs.toast && !prefs.macos) return;
+  if (!anyChannelOn(prefs)) return;
   const nowMs = now();
   const decision = decideNotifications(
     events,
@@ -5938,8 +6096,47 @@ function dispatchNotifications(deps2, events) {
   for (const [key, ts] of decision.nextLastNotified) lastNotified.set(key, ts);
   if (decision.system.length > 0) deps2.persistNotified?.(lastNotified);
   if (prefs.toast && toast) toast(decision.toasts);
-  if (prefs.macos && sendSystem && !inQuietHours(new Date(nowMs), prefs.quietHours)) {
-    for (const n of decision.system) sendSystem(n);
+  if (decision.system.length === 0) return;
+  const delayMs = prefs.delaySeconds * 1e3;
+  if (delayMs > 0 && deps2.pendingPings) {
+    for (const n of decision.system) deps2.pendingPings.push({ ...n, dueAtMs: nowMs + delayMs });
+  } else {
+    fireOsChannels(deps2, prefs, decision.system, nowMs);
+  }
+}
+function firePendingOsPings(deps2, panes) {
+  const { pendingPings: pending, now, prefs } = deps2;
+  if (!pending || pending.length === 0 || !now || !prefs) return;
+  const nowMs = now();
+  const due = [];
+  const keep = [];
+  for (const p of pending) (p.dueAtMs <= nowMs ? due : keep).push(p);
+  if (due.length === 0) return;
+  pending.length = 0;
+  for (const p of keep) pending.push(p);
+  if (!prefs.enabled) return;
+  const statusByPane = new Map(panes.map((p) => [p.paneId, p.status]));
+  const focus = deps2.appFocus?.() ?? null;
+  const confirmed = due.filter((p) => {
+    if (p.paneId !== null && statusByPane.get(p.paneId) !== p.state) return false;
+    if (focus?.attached && p.paneId !== null && focus.panes.includes(p.paneId)) return false;
+    return true;
+  });
+  fireOsChannels(deps2, prefs, confirmed, nowMs);
+}
+function fireOsChannels(deps2, prefs, entries, nowMs) {
+  if (entries.length === 0) return;
+  if (inQuietHours(new Date(nowMs), prefs.quietHours)) return;
+  if (prefs.macos && deps2.sendSystem) {
+    for (const n of entries) deps2.sendSystem(n);
+  }
+  if ((prefs.terminal || prefs.sound !== "none") && deps2.sendTerminal && deps2.listClients) {
+    const clients = deps2.listClients();
+    const writes = entries.flatMap((n) => decideTtyWrites(n, clients, prefs));
+    if (writes.length > 0) deps2.sendTerminal(writes);
+  }
+  if (deps2.playSound && entries.some((n) => soundEligible(n.state, prefs.sound))) {
+    deps2.playSound();
   }
 }
 function paneLocation(paneId) {
@@ -6037,6 +6234,7 @@ function runUpdaterLoop() {
   const prevState = /* @__PURE__ */ new Map();
   const prevPaneState = /* @__PURE__ */ new Map();
   const lastNotified = loadLastNotified();
+  const pendingPings = [];
   const chipCache = /* @__PURE__ */ new Map();
   const capturer = createSessionIdCapturer({
     // Throwing is fine here — the capturer treats a failed stamp as "retry on
@@ -6068,6 +6266,9 @@ function runUpdaterLoop() {
         prefs: readNotificationPrefs(),
         sendToasts,
         sendSystem: sendSystemNotification,
+        sendTerminal: writeTtys,
+        playSound: playPingSound,
+        pendingPings,
         locatePane: paneLocation,
         appFocus: () => readAppFocus(),
         persistNotified: (map) => saveLastNotified(map),
@@ -10127,7 +10328,7 @@ var init_dispatcher = __esm({
 });
 
 // packages/daemon/src/lib/project-init-runner.ts
-import { spawn as spawn5 } from "node:child_process";
+import { spawn as spawn6 } from "node:child_process";
 function lineStreamer(onChunk) {
   let pending = "";
   return {
@@ -10149,7 +10350,7 @@ function lineStreamer(onChunk) {
   };
 }
 async function runInit(options) {
-  const spawnFn = options.spawnFn ?? spawn5;
+  const spawnFn = options.spawnFn ?? spawn6;
   const command2 = options.command ?? "tmux-ide";
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const args = ["init"];
@@ -15628,7 +15829,7 @@ try {
       break;
     }
     case "events": {
-      const { readFileSync: readFileSync23, existsSync: existsSync37, statSync: statSync7, openSync, readSync, closeSync } = await import("node:fs");
+      const { readFileSync: readFileSync23, existsSync: existsSync37, statSync: statSync7, openSync: openSync2, readSync, closeSync: closeSync2 } = await import("node:fs");
       const { eventsPath: eventsPath2, formatEventLine: formatEventLine2 } = await Promise.resolve().then(() => (init_events(), events_exports));
       const path2 = eventsPath2();
       const paintStatus = (status2, text) => {
@@ -15689,7 +15890,7 @@ try {
           leftover = "";
         }
         if (size <= offset) return;
-        const fd = openSync(path2, "r");
+        const fd = openSync2(path2, "r");
         try {
           const buf = Buffer.alloc(size - offset);
           readSync(fd, buf, 0, buf.length, offset);
@@ -15698,7 +15899,7 @@ try {
           leftover = parts.pop() ?? "";
           for (const line of parts) if (line.trim().length > 0) printLine(line);
         } finally {
-          closeSync(fd);
+          closeSync2(fd);
         }
       }, 500);
       process.on("SIGINT", () => {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5251,20 +5251,28 @@ function hostCreateArgv(opts) {
   return ["new-session", "-d", "-s", APP_HOST_SESSION, "-c", opts.cwd, opts.commandLine];
 }
 function hostSetupArgvs() {
+  const heal = `set-option -w -t ${APP_HOST_SESSION}: window-size latest`;
   return [
     ["set-option", "-t", APP_HOST_SESSION, "status", "off"],
-    ["set-option", "-w", "-t", `${APP_HOST_SESSION}:`, "window-size", "latest"]
+    ["set-option", "-w", "-t", `${APP_HOST_SESSION}:`, "window-size", "latest"],
+    ["set-option", "-s", "focus-events", "on"],
+    ...HOST_RESIZE_HOOKS.map((hook) => ["set-hook", "-t", APP_HOST_SESSION, hook, heal])
   ];
 }
 function hostAttachArgv(insideTmux) {
   return insideTmux ? ["switch-client", "-t", `=${APP_HOST_SESSION}`] : ["attach-session", "-t", `=${APP_HOST_SESSION}`];
 }
-var APP_HOST_SESSION, HOSTED_ENV;
+var APP_HOST_SESSION, HOSTED_ENV, HOST_RESIZE_HOOKS;
 var init_hosted = __esm({
   "packages/daemon/src/tui/mirror/hosted.ts"() {
     "use strict";
     APP_HOST_SESSION = "_tmux-ide-app";
     HOSTED_ENV = "TMUX_IDE_HOSTED";
+    HOST_RESIZE_HOOKS = [
+      "client-attached",
+      "client-focus-in",
+      "client-session-changed"
+    ];
   }
 });
 
@@ -15316,8 +15324,8 @@ Install bun (https://bun.sh) \u2014 the TUI surfaces run on it. Sources ship wit
       })
     );
     execFileSync15("tmux", hostCreateArgv({ cwd, commandLine }), { stdio: "ignore" });
-    for (const args of hostSetupArgvs()) execFileSync15("tmux", args, { stdio: "ignore" });
   }
+  for (const args of hostSetupArgvs()) execFileSync15("tmux", args, { stdio: "ignore" });
   execFileSync15("tmux", hostAttachArgv(Boolean(process.env.TMUX)), { stdio: "inherit" });
 }
 async function printFleetJson() {

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -371,8 +371,13 @@ function launchHostedApp(scriptPath: string, appArgs: string[]): void {
       }),
     );
     execFileSync("tmux", hostCreateArgv({ cwd, commandLine }), { stdio: "ignore" });
-    for (const args of hostSetupArgvs()) execFileSync("tmux", args, { stdio: "ignore" });
   }
+  // Setup runs on EVERY ensure, not just create (M25.5): the list is
+  // idempotent, so this upgrades a host created by an older tmux-ide (no
+  // resize hooks yet) and re-asserts `window-size latest` on a host a stray
+  // `resize-window` flipped to manual — the measured way a cockpit gets stuck
+  // at a departed client's size.
+  for (const args of hostSetupArgvs()) execFileSync("tmux", args, { stdio: "ignore" });
   execFileSync("tmux", hostAttachArgv(Boolean(process.env.TMUX)), { stdio: "inherit" });
 }
 

--- a/docs/content/docs/app-surfaces.mdx
+++ b/docs/content/docs/app-surfaces.mdx
@@ -149,7 +149,9 @@ Two things change in this mode:
   you came from. To actually stop the cockpit, press **F5** and run **Quit**.
 - If two terminals of different sizes are attached at once, tmux sizes the
   cockpit to the one you used last (the smaller view wins while you're on it —
-  standard tmux behavior).
+  standard tmux behavior). The cockpit follows the terminal you're actually
+  using: attach from anywhere — or just come back to a terminal you left
+  attached — and it resizes to you.
 
 Set `app.detachable: true` in `~/.tmux-ide/config.json` to make plain
 `tmux-ide app` (and the `app.frontDoor` entry) always work this way.

--- a/packages/daemon/src/lib/app-config.test.ts
+++ b/packages/daemon/src/lib/app-config.test.ts
@@ -153,10 +153,27 @@ describe("parseAppConfig — mistyped fields fall back to default", () => {
       DEFAULT_APP_CONFIG.restore,
     );
     expect(parseAppConfig({ updates: { check: 0 } }).updates).toEqual(DEFAULT_APP_CONFIG.updates);
-    // valid booleans apply
+    // valid values apply (unnamed fields keep their defaults)
     expect(parseAppConfig({ notifications: { toast: false, macos: true } }).notifications).toEqual({
+      ...DEFAULT_APP_CONFIG.notifications,
       toast: false,
       macos: true,
+    });
+    // the M25.2 channel fields: bad values fall back, good ones apply, 0 delay is valid
+    expect(
+      parseAppConfig({
+        notifications: { terminal: "on", delaySeconds: 1.5, sound: "loud" },
+      }).notifications,
+    ).toEqual(DEFAULT_APP_CONFIG.notifications);
+    expect(
+      parseAppConfig({
+        notifications: { terminal: false, delaySeconds: 0, sound: "none" },
+      }).notifications,
+    ).toEqual({
+      ...DEFAULT_APP_CONFIG.notifications,
+      terminal: false,
+      delaySeconds: 0,
+      sound: "none",
     });
     expect(parseAppConfig({ updates: { check: false } }).updates).toEqual({
       check: false,

--- a/packages/daemon/src/lib/app-config.ts
+++ b/packages/daemon/src/lib/app-config.ts
@@ -96,10 +96,30 @@ export interface AppUpdater {
   snapshotEvery: number;
 }
 
+/** The sound channel's states: ping sound on blocked only, on every ping, or never. */
+export type NotificationSound = "blocked" | "all" | "none";
+
 /** Notification channel toggles. */
 export interface AppNotifications {
   toast: boolean;
   macos: boolean;
+  /**
+   * Terminal-native banners (M25.2): an OSC 9 (kitty: OSC 99) escape written to
+   * each eligible attached client's tty, so terminals that surface them (iTerm2,
+   * Ghostty, WezTerm, kitty) show a native notification even over ssh. Default
+   * true — terminals without support ignore the sequence entirely.
+   */
+  terminal: boolean;
+  /**
+   * Seconds the OS-LEVEL channels (banner / terminal escape / sound / BEL) wait
+   * before firing, re-verifying the pane is STILL in the notified state — a
+   * blocked→working flap inside the window fires nothing. 0 fires immediately.
+   * The in-app toast never waits. Tick-native: the delay rounds up to the
+   * updater's next tick at or after `delaySeconds`.
+   */
+  delaySeconds: number;
+  /** Sound channel (M25.2) — `afplay`/`paplay` + a BEL to eligible client ttys. */
+  sound: NotificationSound;
 }
 
 /** Restore behaviour toggles. */
@@ -244,7 +264,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
     glyphs: { active: "●", inactive: "○" },
   },
   updater: { tickMs: 2000, snapshotEvery: 15 },
-  notifications: { toast: true, macos: false },
+  notifications: { toast: true, macos: false, terminal: true, delaySeconds: 2, sound: "blocked" },
   restore: { resumeAgents: false },
   updates: { check: true, manifests: false },
   welcome: { show: true },
@@ -289,6 +309,11 @@ function pickBool(value: unknown, fallback: boolean): boolean {
 /** A positive integer, else the default. */
 function pickPosInt(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+/** A non-negative integer (0 allowed — e.g. "no delay"), else the default. */
+function pickNonNegInt(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : fallback;
 }
 
 /** One of the allowed literals, else the default. */
@@ -356,6 +381,9 @@ export function parseAppConfig(input: unknown): AppConfig {
     notifications: {
       toast: pickBool(notifications.toast, D.notifications.toast),
       macos: pickBool(notifications.macos, D.notifications.macos),
+      terminal: pickBool(notifications.terminal, D.notifications.terminal),
+      delaySeconds: pickNonNegInt(notifications.delaySeconds, D.notifications.delaySeconds),
+      sound: pickChoice(notifications.sound, ["blocked", "all", "none"], D.notifications.sound),
     },
     restore: { resumeAgents: pickBool(restore.resumeAgents, D.restore.resumeAgents) },
     updates: {

--- a/packages/daemon/src/tui/chrome/notify.test.ts
+++ b/packages/daemon/src/tui/chrome/notify.test.ts
@@ -9,29 +9,45 @@ import {
   APP_FOCUS_STALE_MS,
   applyKillSwitch,
   buildAppFocusValue,
+  DARWIN_SOUND_FILE,
   decideNotifications,
+  decideTtyWrites,
   DEFAULT_NOTIFICATION_PREFS,
   enabledStates,
   inQuietHours,
+  LINUX_SOUND_FILE,
   notifierExecuteCommand,
   notifyDebounceKey,
   notifyMessage,
+  notifySendArgs,
   NOTIFY_DEBOUNCE_MS,
   NOTIFY_MAX_LEN,
+  osc9Notification,
+  osc99Notification,
   parseAppFocus,
   parseHHMM,
   parseNotificationPrefs,
   parseClients,
+  sendSystemNotification,
+  soundArgv,
+  soundEligible,
   suppressToastFor,
   terminalNotifierArgs,
+  terminalNotifyEscape,
   type AppFocus,
   type AttachedClient,
   type NotificationPrefs,
   type NotifyEvent,
+  type SystemNotification,
 } from "./notify.ts";
 
 function ev(session: string, to: NotifyEvent["to"], extra: Partial<NotifyEvent> = {}): NotifyEvent {
   return { session, from: "working", to, ...extra };
+}
+
+/** The expected system entry for a pane-less `ev()` transition. */
+function sys(session: string, state: NotifyEvent["to"], message: string) {
+  return { message, session, state, paneId: null, windowIndex: null };
 }
 
 describe("notifyMessage", () => {
@@ -98,15 +114,15 @@ describe("decideNotifications", () => {
     // No clients → no toasts, but a system entry per qualifying event.
     expect(toasts).toEqual([]);
     expect(system).toEqual([
-      { message: "agent blocked · a — needs input", session: "a" },
-      { message: "agent done · b — finished", session: "b" },
+      sys("a", "blocked", "agent blocked · a — needs input"),
+      sys("b", "done", "agent done · b — finished"),
     ]);
   });
 
   it("honors the passed-in `states` set (onBlocked/onDone gating)", () => {
     const events = [ev("a", "blocked"), ev("b", "done")];
     const { system } = decideNotifications(events, [], new Map(), 0, new Set(["blocked"]));
-    expect(system).toEqual([{ message: "agent blocked · a — needs input", session: "a" }]);
+    expect(system).toEqual([sys("a", "blocked", "agent blocked · a — needs input")]);
   });
 
   it("uses the enriched agent/location in the toast text", () => {
@@ -129,15 +145,15 @@ describe("decideNotifications", () => {
     ];
     const { toasts, system } = decideNotifications([ev("web", "blocked")], clients, new Map(), 0);
     expect(toasts).toEqual([{ client: "other", message: "agent blocked · web — needs input" }]);
-    // The system (macOS) entry is still produced regardless of viewers.
-    expect(system).toEqual([{ message: "agent blocked · web — needs input", session: "web" }]);
+    // The system (banner) entry is still produced regardless of viewers.
+    expect(system).toEqual([sys("web", "blocked", "agent blocked · web — needs input")]);
   });
 
   it("suppresses toasts entirely when the only client is viewing the session, but keeps the system entry", () => {
     const clients: AttachedClient[] = [{ client: "viewer", session: "web" }];
     const { toasts, system } = decideNotifications([ev("web", "blocked")], clients, new Map(), 0);
     expect(toasts).toEqual([]);
-    expect(system).toEqual([{ message: "agent blocked · web — needs input", session: "web" }]);
+    expect(system).toEqual([sys("web", "blocked", "agent blocked · web — needs input")]);
   });
 
   it("debounces the same session+state within the window and allows it after", () => {
@@ -332,19 +348,37 @@ describe("app focus record", () => {
 });
 
 describe("parseClients", () => {
-  it("parses client\\tsession\\twindow lines and drops malformed ones", () => {
+  it("parses client\\tsession\\twindow\\ttty\\ttermname lines and drops malformed ones", () => {
     expect(
-      parseClients(["/dev/ttys000\tweb\t2", "/dev/ttys001\tapi\t0", "", "lonely", "\tdangling\t1"]),
+      parseClients([
+        "/dev/ttys000\tweb\t2\t/dev/ttys000\txterm-256color",
+        "/dev/ttys001\tapi\t0\t/dev/ttys001\txterm-kitty",
+        "",
+        "lonely",
+        "\tdangling\t1",
+      ]),
     ).toEqual([
-      { client: "/dev/ttys000", session: "web", windowIndex: 2 },
-      { client: "/dev/ttys001", session: "api", windowIndex: 0 },
+      {
+        client: "/dev/ttys000",
+        session: "web",
+        windowIndex: 2,
+        tty: "/dev/ttys000",
+        termname: "xterm-256color",
+      },
+      {
+        client: "/dev/ttys001",
+        session: "api",
+        windowIndex: 0,
+        tty: "/dev/ttys001",
+        termname: "xterm-kitty",
+      },
     ]);
   });
 
-  it("parses a missing/garbage window field as null (session-granular fallback)", () => {
+  it("parses missing/garbage optional fields as null (session-granular, escape-less fallback)", () => {
     expect(parseClients(["/dev/ttys000\tweb", "/dev/ttys001\tapi\tx"])).toEqual([
-      { client: "/dev/ttys000", session: "web", windowIndex: null },
-      { client: "/dev/ttys001", session: "api", windowIndex: null },
+      { client: "/dev/ttys000", session: "web", windowIndex: null, tty: null, termname: null },
+      { client: "/dev/ttys001", session: "api", windowIndex: null, tty: null, termname: null },
     ]);
   });
 });
@@ -409,6 +443,9 @@ describe("parseNotificationPrefs", () => {
           enabled: false,
           toast: false,
           macos: true,
+          terminal: false,
+          delaySeconds: 5,
+          sound: "all",
           onBlocked: false,
           onDone: true,
           quietHours: { start: "22:00", end: "08:00" },
@@ -418,10 +455,20 @@ describe("parseNotificationPrefs", () => {
       enabled: false,
       toast: false,
       macos: true,
+      terminal: false,
+      delaySeconds: 5,
+      sound: "all",
       onBlocked: false,
       onDone: true,
       quietHours: { start: "22:00", end: "08:00" },
     });
+    // Mistyped M25.2 fields fall back to their defaults (delay 0 is VALID).
+    expect(
+      parseNotificationPrefs({
+        notifications: { terminal: "yes", delaySeconds: -3, sound: "loud" },
+      }),
+    ).toMatchObject({ terminal: true, delaySeconds: 2, sound: "blocked" });
+    expect(parseNotificationPrefs({ notifications: { delaySeconds: 0 } }).delaySeconds).toBe(0);
     // A malformed quietHours block resolves to null (disabled).
     expect(
       parseNotificationPrefs({ notifications: { quietHours: { start: "nope" } } }).quietHours,
@@ -437,17 +484,22 @@ describe("applyKillSwitch", () => {
     enabled: true,
     toast: true,
     macos: true,
+    terminal: true,
+    delaySeconds: 2,
+    sound: "all",
     onBlocked: true,
     onDone: true,
     quietHours: null,
   };
 
-  it("TMUX_IDE_NOTIFY=0 disables the master switch and both channels", () => {
+  it("TMUX_IDE_NOTIFY=0 disables the master switch and every channel", () => {
     expect(applyKillSwitch(full, "0")).toEqual({
       ...full,
       enabled: false,
       toast: false,
       macos: false,
+      terminal: false,
+      sound: "none",
     });
   });
 
@@ -475,11 +527,21 @@ describe("notifierExecuteCommand", () => {
   });
 });
 
+/** A full SystemNotification for the channel-arg tests. */
+function sysN(over: Partial<SystemNotification> = {}): SystemNotification {
+  return {
+    message: "claude blocked · web:1.2 — needs input",
+    session: "web",
+    state: "blocked",
+    paneId: "%1",
+    windowIndex: 1,
+    ...over,
+  };
+}
+
 describe("terminalNotifierArgs", () => {
   it("builds a click-through banner whose -execute is the jump command", () => {
-    expect(
-      terminalNotifierArgs({ message: "claude blocked · web:1.2 — needs input", session: "web" }),
-    ).toEqual([
+    expect(terminalNotifierArgs(sysN())).toEqual([
       "-title",
       "tmux-ide",
       "-message",
@@ -487,5 +549,159 @@ describe("terminalNotifierArgs", () => {
       "-execute",
       notifierExecuteCommand("web"),
     ]);
+  });
+});
+
+describe("notifySendArgs (Linux banners)", () => {
+  it("marks blocked critical; done stays default urgency", () => {
+    expect(notifySendArgs(sysN())).toEqual([
+      "--app-name=tmux-ide",
+      "--urgency=critical",
+      "tmux-ide",
+      "claude blocked · web:1.2 — needs input",
+    ]);
+    expect(notifySendArgs(sysN({ state: "done", message: "m" }))).toEqual([
+      "--app-name=tmux-ide",
+      "tmux-ide",
+      "m",
+    ]);
+  });
+});
+
+describe("sendSystemNotification routing (injected io)", () => {
+  const calls = () => {
+    const seen: Array<{ cmd: string; args: string[] }> = [];
+    return {
+      seen,
+      exec: (cmd: string, args: string[]) => {
+        seen.push({ cmd, args });
+      },
+    };
+  };
+
+  it("linux + desktop env + notify-send on PATH → notify-send with the banner args", () => {
+    const { seen, exec } = calls();
+    sendSystemNotification(sysN(), {
+      platform: "linux",
+      env: { DISPLAY: ":0" },
+      exec,
+      hasBinary: (n) => n === "notify-send",
+    });
+    expect(seen).toEqual([{ cmd: "notify-send", args: notifySendArgs(sysN()) }]);
+  });
+
+  it("linux honors WAYLAND_DISPLAY too, and skips silently when headless or binary-less", () => {
+    const { seen, exec } = calls();
+    const io = { platform: "linux" as const, exec, hasBinary: () => true };
+    sendSystemNotification(sysN(), { ...io, env: { WAYLAND_DISPLAY: "wayland-0" } });
+    expect(seen).toHaveLength(1);
+    sendSystemNotification(sysN(), { ...io, env: {} }); // headless
+    sendSystemNotification(sysN(), {
+      ...io,
+      env: { DISPLAY: ":0" },
+      hasBinary: () => false, // no notify-send
+    });
+    expect(seen).toHaveLength(1);
+  });
+
+  it("darwin prefers terminal-notifier and falls back to osascript", () => {
+    const { seen, exec } = calls();
+    sendSystemNotification(sysN(), {
+      platform: "darwin",
+      exec,
+      hasBinary: (n) => n === "terminal-notifier",
+    });
+    expect(seen[0]).toEqual({ cmd: "terminal-notifier", args: terminalNotifierArgs(sysN()) });
+    sendSystemNotification(sysN(), { platform: "darwin", exec, hasBinary: () => false });
+    expect(seen[1]?.cmd).toBe("osascript");
+    expect(seen[1]?.args[1]).toContain("claude blocked");
+  });
+
+  it("other platforms are a no-op", () => {
+    const { seen, exec } = calls();
+    sendSystemNotification(sysN(), { platform: "win32", exec, hasBinary: () => true });
+    expect(seen).toEqual([]);
+  });
+});
+
+describe("terminal escapes (M25.2)", () => {
+  it("OSC 9 is BEL-terminated; OSC 99 is kitty's ST form with urgency on blocked", () => {
+    expect(osc9Notification("hi")).toBe("\x1b]9;hi\x07");
+    expect(osc99Notification("hi", false)).toBe("\x1b]99;;hi\x1b\\");
+    expect(osc99Notification("hi", true)).toBe("\x1b]99;u=2;hi\x1b\\");
+  });
+
+  it("picks the form by termname: kitty → OSC 99, nested tmux/screen → passthrough, else raw OSC 9", () => {
+    expect(terminalNotifyEscape("xterm-kitty", "m", true)).toBe(osc99Notification("m", true));
+    expect(terminalNotifyEscape("xterm-256color", "m", true)).toBe(osc9Notification("m"));
+    expect(terminalNotifyEscape(null, "m", false)).toBe(osc9Notification("m"));
+    // nested: the envelope with the inner ESC doubled, so the OUTER mux unwraps it
+    expect(terminalNotifyEscape("tmux-256color", "m", false)).toBe(
+      "\x1bPtmux;\x1b\x1b]9;m\x07\x1b\\",
+    );
+    expect(terminalNotifyEscape("screen-256color", "m", false)).toBe(
+      "\x1bPtmux;\x1b\x1b]9;m\x07\x1b\\",
+    );
+  });
+});
+
+describe("decideTtyWrites", () => {
+  const prefs = { terminal: true, sound: "blocked" as const };
+  const clients: AttachedClient[] = [
+    { client: "c1", session: "other", windowIndex: 0, tty: "/dev/t1", termname: "xterm-256color" },
+    { client: "c2", session: "web", windowIndex: 1, tty: "/dev/t2", termname: "xterm-kitty" },
+    { client: "c3", session: "other", windowIndex: 0, tty: null, termname: "xterm" },
+  ];
+
+  it("writes escape + BEL to every non-viewing client with a known tty", () => {
+    const n = sysN({ message: "m" });
+    expect(decideTtyWrites(n, clients, prefs)).toEqual([
+      // c1: not viewing web → raw OSC 9 + BEL (blocked)
+      { tty: "/dev/t1", data: `${osc9Notification("m")}\x07` },
+      // c2 IS viewing web:1 (the event's window) → suppressed; c3 has no tty
+    ]);
+  });
+
+  it("kitty client gets the OSC 99 form", () => {
+    const n = sysN({ message: "m", session: "api", windowIndex: 0 });
+    const writes = decideTtyWrites(n, clients, prefs);
+    expect(writes.find((w) => w.tty === "/dev/t2")?.data).toBe(
+      `${osc99Notification("m", true)}\x07`,
+    );
+  });
+
+  it("BEL rides only blocked and only while sound is on; escapes ride prefs.terminal", () => {
+    const done = sysN({ message: "m", state: "done" });
+    expect(decideTtyWrites(done, [clients[0]!], prefs)).toEqual([
+      { tty: "/dev/t1", data: osc9Notification("m") }, // no BEL on done
+    ]);
+    expect(
+      decideTtyWrites(sysN({ message: "m" }), [clients[0]!], { ...prefs, sound: "none" }),
+    ).toEqual([{ tty: "/dev/t1", data: osc9Notification("m") }]);
+    // terminal off, sound on → the BEL still lands alone on blocked
+    expect(
+      decideTtyWrites(sysN({ message: "m" }), [clients[0]!], { terminal: false, sound: "blocked" }),
+    ).toEqual([{ tty: "/dev/t1", data: "\x07" }]);
+    // both channels off → nothing at all
+    expect(
+      decideTtyWrites(sysN({ message: "m" }), [clients[0]!], { terminal: false, sound: "none" }),
+    ).toEqual([]);
+  });
+});
+
+describe("sound routing (M25.2)", () => {
+  it("soundEligible follows the tri-state", () => {
+    expect(soundEligible("blocked", "blocked")).toBe(true);
+    expect(soundEligible("done", "blocked")).toBe(false);
+    expect(soundEligible("done", "all")).toBe(true);
+    expect(soundEligible("blocked", "all")).toBe(true);
+    expect(soundEligible("blocked", "none")).toBe(false);
+    expect(soundEligible("working", "all")).toBe(false);
+  });
+
+  it("soundArgv picks the platform player (null elsewhere)", () => {
+    expect(soundArgv("darwin")).toEqual(["afplay", DARWIN_SOUND_FILE]);
+    expect(soundArgv("linux")).toEqual(["paplay", LINUX_SOUND_FILE]);
+    expect(soundArgv("win32")).toBeNull();
   });
 });

--- a/packages/daemon/src/tui/chrome/notify.ts
+++ b/packages/daemon/src/tui/chrome/notify.ts
@@ -7,20 +7,36 @@
  * signals out to the human: a tmux toast on each attached client
  * (`display-message -c`), and optionally a macOS notification.
  *
+ * Since M25.2 the fan-out spans FIVE channels: the in-app toast, the system
+ * banner (macOS `terminal-notifier`/`osascript`, Linux `notify-send`), the
+ * terminal-native OSC 9/99 escape written straight to each eligible client's
+ * tty, a ping sound, and a BEL on blocked. The OS-level channels (everything
+ * but the toast) are quiet-hours gated and delay/re-verified by the updater.
+ *
  * Split as usual: {@link decideNotifications} + {@link notifyMessage} +
  * {@link enabledStates} + {@link inQuietHours} + {@link parseNotificationPrefs}
  * + {@link applyKillSwitch} + {@link parseClients} + {@link terminalNotifierArgs}
- * are PURE (unit-tested without a live tmux / filesystem); {@link sendToasts},
- * {@link sendSystemNotification}, {@link hasTerminalNotifier},
- * {@link listAttachedClients} and {@link readNotificationPrefs} are the thin io
+ * + {@link terminalNotifyEscape} + {@link decideTtyWrites} + {@link notifySendArgs}
+ * + {@link soundEligible} + {@link soundArgv} are PURE (unit-tested without a
+ * live tmux / filesystem); {@link sendToasts}, {@link sendSystemNotification},
+ * {@link hasTerminalNotifier}, {@link listAttachedClients}, {@link writeTtys},
+ * {@link playPingSound} and {@link readNotificationPrefs} are the thin io
  * wrappers. Every io path is best-effort — a failed ping must never break the
  * updater loop.
  */
-import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+import {
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  openSync,
+  readFileSync,
+  writeSync,
+} from "node:fs";
 import { runTmux } from "@tmux-ide/tmux-bridge";
-import { appConfigPath, parseAppConfig } from "../../lib/app-config.ts";
+import { appConfigPath, parseAppConfig, type NotificationSound } from "../../lib/app-config.ts";
 import { APP_HOST_SESSION } from "../mirror/hosted.ts";
+import { tmuxPassthrough } from "../mirror/selection.ts";
 import type { AgentStatus } from "../detect/classify.ts";
 
 /**
@@ -51,11 +67,18 @@ export interface NotifyEvent {
 
 /** An attached tmux client, the session it's viewing, and that session's
  *  CURRENT window (null when the caller couldn't resolve it — suppression then
- *  degrades to session granularity for that client). */
+ *  degrades to session granularity for that client). `tty`/`termname` (M25.2)
+ *  are what the terminal-escape channel needs — the device to write and which
+ *  escape form the terminal behind it understands; null/absent means the
+ *  caller couldn't resolve them and that client just gets no escapes. */
 export interface AttachedClient {
   client: string;
   session: string;
   windowIndex?: number | null;
+  /** `#{client_tty}` — the device the escape/BEL bytes are written to. */
+  tty?: string | null;
+  /** `#{client_termname}` — picks OSC 99 (kitty) / passthrough (nested tmux). */
+  termname?: string | null;
 }
 
 /** A toast destined for one client's status line. */
@@ -65,12 +88,22 @@ export interface ToastTarget {
 }
 
 /**
- * A macOS-notification payload. `session` rides along so the click-through path
- * ({@link terminalNotifierArgs}) can focus the right session on click.
+ * One OS-level ping. `session` rides along so the click-through path
+ * ({@link terminalNotifierArgs}) can focus the right session on click; since
+ * M25.2 the payload also carries the transition's `state` (urgency + sound
+ * routing) and its pane identity (`paneId`/`windowIndex`) so the delayed
+ * re-verify can confirm the pane is STILL in that state and the terminal-escape
+ * channel can re-apply per-client suppression at fire time.
  */
 export interface SystemNotification {
   message: string;
   session: string;
+  /** The state that was pinged — must still hold when a delayed ping fires. */
+  state: AgentStatus;
+  /** The pane behind the ping (null: session-granular caller — unverifiable). */
+  paneId: string | null;
+  /** The pane's window — per-client escape suppression wants it. */
+  windowIndex: number | null;
 }
 
 /** The verdict of {@link decideNotifications}. */
@@ -191,30 +224,47 @@ export function decideNotifications(
       if (suppressToastFor(c, ev)) continue;
       toasts.push({ client: c.client, message });
     }
-    system.push({ message, session: ev.session });
+    system.push({
+      message,
+      session: ev.session,
+      state: ev.to,
+      paneId: ev.paneId ?? null,
+      windowIndex: ev.windowIndex ?? null,
+    });
   }
   return { toasts, system, nextLastNotified };
 }
 
-/** PURE — parse `list-clients -F '#{client_name}\t#{session_name}\t#{window_index}'`
- *  output (the third field is the client's session's CURRENT window; missing/
- *  non-numeric parses as null so old two-field callers degrade gracefully). */
+/** PURE — parse `list-clients -F '#{client_name}\t#{session_name}\t#{window_index}
+ *  \t#{client_tty}\t#{client_termname}'` output (fields three-plus are optional;
+ *  missing/non-numeric window parses as null so shorter-format callers degrade
+ *  gracefully, and a missing tty/termname just disables that client's escapes). */
 export function parseClients(lines: string[]): AttachedClient[] {
   const out: AttachedClient[] = [];
   for (const line of lines) {
-    const [client = "", session = "", win = ""] = line.split("\t");
+    const [client = "", session = "", win = "", tty = "", termname = ""] = line.split("\t");
     if (!client || !session) continue;
     const n = Number.parseInt(win, 10);
-    out.push({ client, session, windowIndex: Number.isInteger(n) ? n : null });
+    out.push({
+      client,
+      session,
+      windowIndex: Number.isInteger(n) ? n : null,
+      tty: tty || null,
+      termname: termname || null,
+    });
   }
   return out;
 }
 
-/** io — enumerate attached clients (+ their current window) from the live tmux
- *  server. Never throws. */
+/** io — enumerate attached clients (+ their current window, tty, termname) from
+ *  the live tmux server. Never throws. */
 export function listAttachedClients(): AttachedClient[] {
   try {
-    const raw = runTmux(["list-clients", "-F", "#{client_name}\t#{session_name}\t#{window_index}"])
+    const raw = runTmux([
+      "list-clients",
+      "-F",
+      "#{client_name}\t#{session_name}\t#{window_index}\t#{client_tty}\t#{client_termname}",
+    ])
       .toString()
       .trim();
     return raw ? parseClients(raw.split("\n")) : [];
@@ -309,10 +359,177 @@ export function sendToasts(toasts: ToastTarget[]): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// The terminal-escape + sound channels (M25.2)
+// ---------------------------------------------------------------------------
+
+/**
+ * PURE — the OSC 9 desktop-notification escape (iTerm2 / Ghostty / WezTerm and
+ * friends; BEL-terminated). Terminals without support ignore it entirely.
+ */
+export function osc9Notification(text: string): string {
+  return `\x1b]9;${text}\x07`;
+}
+
+/**
+ * PURE — kitty's richer OSC 99 form (ST-terminated; the empty-metadata payload
+ * is the notification title). Blocked pings carry `u=2` (critical urgency) —
+ * kitty ignores metadata keys it doesn't know, so this is safe on older kitties.
+ */
+export function osc99Notification(text: string, urgent: boolean): string {
+  return `\x1b]99;${urgent ? "u=2" : ""};${text}\x1b\\`;
+}
+
+/**
+ * PURE — the escape a client's terminal actually understands, by
+ * `#{client_termname}` (conservative, MEASURED — see {@link writeClientTty}):
+ *
+ *   - `*kitty*` → OSC 99 (kitty ignores OSC 9's text form);
+ *   - `tmux-*` / `screen*` → the OSC 9 wrapped in the tmux passthrough envelope
+ *     ({@link tmuxPassthrough}): that termname means the client is itself INSIDE
+ *     another tmux/screen, so our bytes land as pane OUTPUT of the outer mux and
+ *     only the envelope (plus the outer mux's `allow-passthrough`, which is the
+ *     user's to set — we can't reach a foreign server) carries them further;
+ *   - anything else → raw OSC 9. A direct client-tty write BYPASSES our own
+ *     tmux server entirely (measured: bytes arrive on the tty stream verbatim),
+ *     so for a directly-attached terminal the RAW escape is the correct form —
+ *     an envelope there would be ignored by the terminal, not unwrapped.
+ */
+export function terminalNotifyEscape(
+  termname: string | null | undefined,
+  text: string,
+  urgent: boolean,
+): string {
+  const t = termname ?? "";
+  if (t.includes("kitty")) return osc99Notification(text, urgent);
+  if (t.startsWith("tmux") || t.startsWith("screen")) {
+    return tmuxPassthrough(osc9Notification(text));
+  }
+  return osc9Notification(text);
+}
+
+/** One pending write to a client's tty device. */
+export interface TtyWrite {
+  tty: string;
+  data: string;
+}
+
+/** PURE — should the sound channel fire for this state under this pref? */
+export function soundEligible(state: AgentStatus, sound: NotificationSound): boolean {
+  if (sound === "none") return false;
+  if (sound === "all") return state === "blocked" || state === "done";
+  return state === "blocked";
+}
+
+/** BEL rings the terminal's attention marker — `blocked` only, and it rides the
+ *  sound pref (a user who turned sound off asked for silence). */
+function belEligible(state: AgentStatus, sound: NotificationSound): boolean {
+  return state === "blocked" && sound !== "none";
+}
+
+/**
+ * PURE — the tty writes for one OS-level ping: for every attached client that
+ * is NOT already looking at the transition (the SAME suppression rule as toasts,
+ * {@link suppressToastFor}) and whose tty we know, the terminal-notification
+ * escape (when `prefs.terminal`) plus a BEL on blocked (when the sound pref
+ * allows). Clients contribute nothing when both channels are off for them.
+ */
+export function decideTtyWrites(
+  n: SystemNotification,
+  clients: AttachedClient[],
+  prefs: Pick<NotificationPrefs, "terminal" | "sound">,
+): TtyWrite[] {
+  const asEvent: NotifyEvent = {
+    session: n.session,
+    from: null,
+    to: n.state,
+    paneId: n.paneId,
+    windowIndex: n.windowIndex,
+  };
+  const bel = belEligible(n.state, prefs.sound) ? "\x07" : "";
+  const out: TtyWrite[] = [];
+  for (const c of clients) {
+    if (!c.tty) continue;
+    if (suppressToastFor(c, asEvent)) continue;
+    const escape = prefs.terminal
+      ? terminalNotifyEscape(c.termname, n.message, n.state === "blocked")
+      : "";
+    const data = escape + bel;
+    if (data) out.push({ tty: c.tty, data });
+  }
+  return out;
+}
+
+/**
+ * io — write escape/BEL bytes straight to a client's tty device. This is the
+ * delivery mechanism (MEASURED against a recorded client tty): the write goes
+ * to the pty the tmux client sits on, so the bytes reach the outer terminal
+ * verbatim without our tmux server ever seeing them — no `allow-passthrough`
+ * needed on this server, no `run-shell`/`display-message` indirection.
+ * Non-blocking open so a flow-stopped tty (^S) can never stall the updater
+ * tick; any failure just drops that client's ping.
+ */
+export function writeClientTty(write: TtyWrite): void {
+  let fd: number | null = null;
+  try {
+    fd = openSync(write.tty, fsConstants.O_WRONLY | fsConstants.O_NOCTTY | fsConstants.O_NONBLOCK);
+    writeSync(fd, write.data);
+  } catch {
+    // client gone / tty unwritable — never fatal
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // best-effort
+      }
+    }
+  }
+}
+
+/** io — dispatch a batch of tty writes, each best-effort. */
+export function writeTtys(writes: TtyWrite[]): void {
+  for (const w of writes) writeClientTty(w);
+}
+
+/** The calm default ping sounds — a short macOS system chime and the standard
+ *  freedesktop completion sound (skipped silently when absent). */
+export const DARWIN_SOUND_FILE = "/System/Library/Sounds/Tink.aiff";
+export const LINUX_SOUND_FILE = "/usr/share/sounds/freedesktop/stereo/complete.oga";
+
+/** PURE — the sound-player argv for a platform, or null when it has none. */
+export function soundArgv(platform: NodeJS.Platform): string[] | null {
+  if (platform === "darwin") return ["afplay", DARWIN_SOUND_FILE];
+  if (platform === "linux") return ["paplay", LINUX_SOUND_FILE];
+  return null;
+}
+
+/**
+ * io — play the platform ping sound, fire-and-forget (a sync wait would stall
+ * the updater tick for the clip's duration). Missing sound file or player →
+ * silent skip.
+ */
+export function playPingSound(platform: NodeJS.Platform = process.platform): void {
+  const argv = soundArgv(platform);
+  if (!argv || !existsSync(argv[1]!)) return;
+  try {
+    const child = spawn(argv[0]!, argv.slice(1), { stdio: "ignore", detached: true });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // no player — never fatal
+  }
+}
+
 /** io — whether `terminal-notifier` is on PATH (enables click-through banners). */
 export function hasTerminalNotifier(): boolean {
+  return hasBinary("terminal-notifier");
+}
+
+/** io — whether a binary resolves on PATH. */
+function hasBinary(name: string): boolean {
   try {
-    execFileSync("which", ["terminal-notifier"], { stdio: "ignore" });
+    execFileSync("which", [name], { stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -372,25 +589,58 @@ export function terminalNotifierArgs(n: SystemNotification): string[] {
 }
 
 /**
- * io — fire a macOS notification. macOS-only (guarded), best-effort. When
- * `terminal-notifier` is available we use it for a CLICK-THROUGH banner
- * ({@link terminalNotifierArgs}) that focuses the session on click; otherwise we
- * fall back to `osascript`, whose `display notification` has NO click action —
- * so on a stock machine the banner informs but can't be clicked to jump.
+ * PURE — the `notify-send` argv for a Linux desktop banner: app-named, blocked
+ * pings marked critical so they persist until dismissed (that's the "an agent
+ * is stuck waiting on you" contract).
  */
-export function sendSystemNotification(n: SystemNotification): void {
-  if (process.platform !== "darwin") return;
+export function notifySendArgs(n: SystemNotification): string[] {
+  const args = ["--app-name=tmux-ide"];
+  if (n.state === "blocked") args.push("--urgency=critical");
+  args.push("tmux-ide", n.message);
+  return args;
+}
+
+/** The io {@link sendSystemNotification} needs — injectable so the per-platform
+ *  routing is unit-tested without firing real banners. */
+export interface SystemNotifyIo {
+  platform?: NodeJS.Platform;
+  env?: Record<string, string | undefined>;
+  exec?: (cmd: string, args: string[]) => void;
+  hasBinary?: (name: string) => boolean;
+}
+
+/**
+ * io — fire a system notification, best-effort. macOS: `terminal-notifier` when
+ * available (a CLICK-THROUGH banner — {@link terminalNotifierArgs} focuses the
+ * session on click), else `osascript`, whose `display notification` has NO
+ * click action — the banner informs but can't jump. Linux (M25.2): under a
+ * desktop session (DISPLAY / WAYLAND_DISPLAY) with `notify-send` on PATH, the
+ * same title/body (+ critical urgency for blocked — {@link notifySendArgs});
+ * anything missing → silent skip. Other platforms: no-op.
+ */
+export function sendSystemNotification(n: SystemNotification, io: SystemNotifyIo = {}): void {
+  const platform = io.platform ?? process.platform;
+  const exec =
+    io.exec ?? ((cmd: string, args: string[]) => execFileSync(cmd, args, { stdio: "ignore" }));
+  const has = io.hasBinary ?? hasBinary;
   try {
-    if (hasTerminalNotifier()) {
-      execFileSync("terminal-notifier", terminalNotifierArgs(n), { stdio: "ignore" });
+    if (platform === "darwin") {
+      if (has("terminal-notifier")) {
+        exec("terminal-notifier", terminalNotifierArgs(n));
+        return;
+      }
+      const escaped = n.message.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      exec("osascript", ["-e", `display notification "${escaped}" with title "tmux-ide"`]);
       return;
     }
-    const escaped = n.message.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-    execFileSync("osascript", ["-e", `display notification "${escaped}" with title "tmux-ide"`], {
-      stdio: "ignore",
-    });
+    if (platform === "linux") {
+      const env = io.env ?? process.env;
+      if (!env.DISPLAY && !env.WAYLAND_DISPLAY) return; // headless — nowhere to banner
+      if (!has("notify-send")) return;
+      exec("notify-send", notifySendArgs(n));
+    }
   } catch {
-    // osascript / terminal-notifier missing or notification blocked — never fatal
+    // notifier missing or notification blocked — never fatal
   }
 }
 
@@ -408,21 +658,33 @@ export interface NotificationPrefs {
   enabled: boolean;
   /** In-terminal status-line toasts. */
   toast: boolean;
-  /** macOS system banners. */
+  /** System banners (macOS `terminal-notifier`/`osascript`, Linux `notify-send`). */
   macos: boolean;
+  /** Terminal-native banners — OSC 9/99 escapes to eligible client ttys (M25.2). */
+  terminal: boolean;
+  /** Seconds the OS-level channels wait + re-verify before firing (0 = immediate). */
+  delaySeconds: number;
+  /** Sound channel — ping sound + BEL routing (M25.2). */
+  sound: NotificationSound;
   /** Ping when an agent goes `blocked`. */
   onBlocked: boolean;
   /** Ping when an agent goes `done`. */
   onDone: boolean;
-  /** Optional local-time window that suppresses macOS banners (events still record). */
+  /** Optional local-time window that suppresses every OS-LEVEL channel (banner,
+   *  terminal escape, sound, BEL — since M25.2). In-app toasts and the event
+   *  log stay on. */
   quietHours: QuietHours | null;
 }
 
-/** Defaults: enabled, tmux toasts on, macOS banners off, both states pinged, no quiet window. */
+/** Defaults: enabled, tmux toasts + terminal escapes on, system banners off,
+ *  sound on blocked, a 2s re-verify delay, both states pinged, no quiet window. */
 export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
   enabled: true,
   toast: true,
   macos: false,
+  terminal: true,
+  delaySeconds: 2,
+  sound: "blocked",
   onBlocked: true,
   onDone: true,
   quietHours: null,
@@ -492,6 +754,9 @@ export function parseNotificationPrefs(rawConfig: unknown): NotificationPrefs {
     enabled: pickBool(n.enabled, DEFAULT_NOTIFICATION_PREFS.enabled),
     toast: base.toast,
     macos: base.macos,
+    terminal: base.terminal,
+    delaySeconds: base.delaySeconds,
+    sound: base.sound,
     onBlocked: pickBool(n.onBlocked, DEFAULT_NOTIFICATION_PREFS.onBlocked),
     onDone: pickBool(n.onDone, DEFAULT_NOTIFICATION_PREFS.onDone),
     quietHours: parseQuietHours(n.quietHours),
@@ -503,7 +768,9 @@ export function applyKillSwitch(
   prefs: NotificationPrefs,
   envValue: string | undefined,
 ): NotificationPrefs {
-  return envValue === "0" ? { ...prefs, enabled: false, toast: false, macos: false } : prefs;
+  return envValue === "0"
+    ? { ...prefs, enabled: false, toast: false, macos: false, terminal: false, sound: "none" }
+    : prefs;
 }
 
 /** Absolute path to the shared config (honors `TMUX_IDE_CONFIG`). */

--- a/packages/daemon/src/tui/chrome/updater.test.ts
+++ b/packages/daemon/src/tui/chrome/updater.test.ts
@@ -13,6 +13,7 @@ import {
   UPDATER_SESSION,
   UPDATER_UNREACHABLE_EXIT_TICKS,
   updateSegment,
+  type PendingOsPing,
 } from "./updater.ts";
 import { buildStatusline } from "./statusline.ts";
 import { DEFAULT_THEME } from "../../lib/app-config.ts";
@@ -27,13 +28,19 @@ import type {
   NotificationPrefs,
   SystemNotification,
   ToastTarget,
+  TtyWrite,
 } from "./notify.ts";
 
-/** A fully-enabled prefs object for the notification-dispatch tests. */
+/** A fully-enabled prefs object for the notification-dispatch tests. The
+ *  M25.2 channels default OFF/immediate here so the M25.1 tests keep asserting
+ *  the immediate paths; the M25.2 suite opts in per test. */
 const FULL_PREFS: NotificationPrefs = {
   enabled: true,
   toast: true,
   macos: false,
+  terminal: false,
+  delaySeconds: 0,
+  sound: "none",
   onBlocked: true,
   onDone: true,
   quietHours: null,
@@ -343,7 +350,210 @@ describe("runUpdaterTick", () => {
       prefs: { ...FULL_PREFS, macos: true, quietHours: { start: "22:00", end: "08:00" } },
       now: dayMs,
     });
-    expect(system).toEqual([{ message: "agent blocked · web — needs input", session: "web" }]);
+    expect(system).toEqual([
+      {
+        message: "agent blocked · web — needs input",
+        session: "web",
+        state: "blocked",
+        paneId: "%1",
+        windowIndex: 0,
+      },
+    ]);
+  });
+});
+
+describe("runUpdaterTick — delayed, re-verified OS channels (M25.2)", () => {
+  /** The M25.2 channels all on: banner + terminal escape + sound-on-blocked. */
+  const OS_PREFS: NotificationPrefs = {
+    ...FULL_PREFS,
+    macos: true,
+    terminal: true,
+    sound: "blocked",
+    delaySeconds: 2,
+  };
+
+  /**
+   * A minimal multi-tick rig: one agent pane whose status/existence the test
+   * mutates between ticks, every channel captured, the pending queue and the
+   * debounce/pane maps persistent across ticks — the loop's real shape.
+   */
+  function tickRig(prefs: NotificationPrefs) {
+    const state = {
+      status: "working" as AgentStatus,
+      paneGone: false,
+      now: 0,
+      prefs,
+      focusPanes: null as string[] | null,
+    };
+    const prevPaneState = new Map<string, AgentStatus>();
+    const pendingPings: PendingOsPing[] = [];
+    const lastNotified = new Map<string, number>();
+    const toasts: ToastTarget[][] = [];
+    const system: SystemNotification[] = [];
+    const ttyWrites: TtyWrite[][] = [];
+    let sounds = 0;
+    const tick = () =>
+      runUpdaterTick({
+        listAdopted: () => ["web"],
+        computeProjects: (onPane) => {
+          if (!state.paneGone) {
+            onPane(pd({ sessionName: "web", paneId: "%1", agent: "claude", status: state.status }));
+          }
+          return [project("web")];
+        },
+        writeStatus: () => {},
+        prevPaneState,
+        pendingPings,
+        listClients: () => [
+          {
+            client: "c1",
+            session: "other",
+            windowIndex: 0,
+            tty: "/dev/t1",
+            termname: "xterm-256color",
+          },
+        ],
+        lastNotified,
+        now: () => state.now,
+        prefs: state.prefs,
+        sendToasts: (t) => toasts.push(t),
+        sendSystem: (n) => system.push(n),
+        sendTerminal: (w) => ttyWrites.push(w),
+        playSound: () => {
+          sounds += 1;
+        },
+        appFocus: () =>
+          state.focusPanes
+            ? { ts: state.now, attached: true, session: "web", panes: state.focusPanes }
+            : null,
+      });
+    return {
+      state,
+      pendingPings,
+      toasts,
+      system,
+      ttyWrites,
+      sounds: () => sounds,
+      tick,
+    };
+  }
+
+  it("toasts immediately but queues the OS channels, firing them once the state HELD", () => {
+    const rig = tickRig(OS_PREFS);
+    rig.tick(); // first sight — working, nothing pings
+    rig.state.status = "blocked";
+    rig.state.now = 1000;
+    rig.tick(); // the transition: toast now, OS channels queued for +2s
+    expect(rig.toasts.flat()).toHaveLength(1);
+    expect(rig.system).toEqual([]);
+    expect(rig.ttyWrites).toEqual([]);
+    expect(rig.sounds()).toBe(0);
+    expect(rig.pendingPings).toHaveLength(1);
+    rig.state.now = 2000;
+    rig.tick(); // not due yet
+    expect(rig.system).toEqual([]);
+    rig.state.now = 3200; // past dueAt (1000 + 2000)
+    rig.tick(); // still blocked → everything fires
+    expect(rig.system).toHaveLength(1);
+    expect(rig.system[0]).toMatchObject({ state: "blocked", paneId: "%1", session: "web" });
+    expect(rig.ttyWrites).toHaveLength(1);
+    expect(rig.ttyWrites[0]![0]!.tty).toBe("/dev/t1");
+    expect(rig.ttyWrites[0]![0]!.data).toContain("\x1b]9;");
+    expect(rig.ttyWrites[0]![0]!.data.endsWith("\x07\x07")).toBe(true); // OSC 9 BEL + the bell BEL
+    expect(rig.sounds()).toBe(1);
+    expect(rig.pendingPings).toEqual([]);
+    // no double fire on the next tick
+    rig.state.now = 5000;
+    rig.tick();
+    expect(rig.system).toHaveLength(1);
+  });
+
+  it("a flap inside the window fires NOTHING OS-level (the toast already informed)", () => {
+    const rig = tickRig(OS_PREFS);
+    rig.tick();
+    rig.state.status = "blocked";
+    rig.state.now = 1000;
+    rig.tick(); // blocked → queued
+    expect(rig.toasts.flat()).toHaveLength(1);
+    rig.state.status = "working";
+    rig.state.now = 1800; // flips back within 1s of the stamp
+    rig.tick();
+    rig.state.now = 3200;
+    rig.tick(); // due — but the pane is working again
+    expect(rig.system).toEqual([]);
+    expect(rig.ttyWrites).toEqual([]);
+    expect(rig.sounds()).toBe(0);
+    expect(rig.pendingPings).toEqual([]);
+  });
+
+  it("a vanished pane cancels its pending ping", () => {
+    const rig = tickRig(OS_PREFS);
+    rig.tick();
+    rig.state.status = "blocked";
+    rig.state.now = 1000;
+    rig.tick();
+    rig.state.paneGone = true;
+    rig.state.now = 3200;
+    rig.tick();
+    expect(rig.system).toEqual([]);
+    expect(rig.pendingPings).toEqual([]);
+  });
+
+  it("delaySeconds 0 fires the OS channels immediately", () => {
+    const rig = tickRig({ ...OS_PREFS, delaySeconds: 0 });
+    rig.tick();
+    rig.state.status = "blocked";
+    rig.state.now = 1000;
+    rig.tick();
+    expect(rig.system).toHaveLength(1);
+    expect(rig.ttyWrites).toHaveLength(1);
+    expect(rig.sounds()).toBe(1);
+    expect(rig.pendingPings).toEqual([]);
+  });
+
+  it("quiet hours gate EVERY OS channel but never the toast", () => {
+    const night = new Date(2026, 0, 1, 2, 0).getTime(); // inside 22:00–08:00
+    const rig = tickRig({
+      ...OS_PREFS,
+      delaySeconds: 0,
+      quietHours: { start: "22:00", end: "08:00" },
+    });
+    rig.state.now = night;
+    rig.tick();
+    rig.state.status = "blocked";
+    rig.state.now = night + 1000;
+    rig.tick();
+    expect(rig.toasts.flat()).toHaveLength(1); // the in-app note stays on
+    expect(rig.system).toEqual([]);
+    expect(rig.ttyWrites).toEqual([]);
+    expect(rig.sounds()).toBe(0);
+  });
+
+  it("app focus at FIRE time cancels a queued ping (the user got there on their own)", () => {
+    const rig = tickRig(OS_PREFS);
+    rig.tick();
+    rig.state.status = "blocked";
+    rig.state.now = 1000;
+    rig.tick(); // queued (no focus yet)
+    rig.state.focusPanes = ["%1"]; // user opens the app on that pane
+    rig.state.now = 3200;
+    rig.tick();
+    expect(rig.system).toEqual([]);
+    expect(rig.pendingPings).toEqual([]);
+  });
+
+  it("the sound tri-state routes at fire time: 'all' rings on done, 'blocked' stays quiet", () => {
+    const onDone = (sound: NotificationPrefs["sound"]) => {
+      const rig = tickRig({ ...OS_PREFS, delaySeconds: 0, sound });
+      rig.tick();
+      rig.state.status = "done";
+      rig.state.now = 1000;
+      rig.tick();
+      return rig.sounds();
+    };
+    expect(onDone("all")).toBe(1);
+    expect(onDone("blocked")).toBe(0);
+    expect(onDone("none")).toBe(0);
   });
 });
 

--- a/packages/daemon/src/tui/chrome/updater.ts
+++ b/packages/daemon/src/tui/chrome/updater.ts
@@ -36,19 +36,24 @@ import { paneChip } from "./chip.ts";
 import { appendEvents, diffFleet, type AgentEventInit } from "./events.ts";
 import {
   decideNotifications,
+  decideTtyWrites,
   enabledStates,
   inQuietHours,
   listAttachedClients,
+  playPingSound,
   readAppFocus,
   readNotificationPrefs,
   sendSystemNotification,
   sendToasts,
+  soundEligible,
+  writeTtys,
   type AppFocus,
   type AttachedClient,
   type NotificationPrefs,
   type NotifyEvent,
   type SystemNotification,
   type ToastTarget,
+  type TtyWrite,
 } from "./notify.ts";
 import { loadLastNotified, saveLastNotified } from "./notify-state.ts";
 import {
@@ -167,6 +172,26 @@ export interface UpdaterTickDeps {
   prefs?: NotificationPrefs;
   sendToasts?: (toasts: ToastTarget[]) => void;
   sendSystem?: (n: SystemNotification) => void;
+  /**
+   * The OS-level channel io (M25.2), both optional and deps-injected like the
+   * rest: `sendTerminal` writes OSC 9/99 + BEL bytes to client ttys
+   * ({@link writeTtys}); `playSound` fires the platform ping sound
+   * ({@link playPingSound}). Which clients/states qualify is decided purely
+   * ({@link decideTtyWrites} / {@link soundEligible}).
+   */
+  sendTerminal?: (writes: TtyWrite[]) => void;
+  playSound?: () => void;
+  /**
+   * The DELAYED RE-VERIFY queue (M25.2), loop-owned and mutated in place like
+   * `prevPaneState`. With `notifications.delaySeconds > 0`, a notify-eligible
+   * transition queues its OS-LEVEL channels here instead of firing them; each
+   * tick {@link firePendingOsPings} fires the due entries whose pane is STILL
+   * in the notified state (this tick's scan is the re-verify — no setTimeout
+   * racing the tick), so a flappy blocked→working inside the window fires
+   * nothing OS-level. Toasts never queue — the in-app note stays immediate.
+   * Omitted (tests, delay 0) → OS channels fire immediately.
+   */
+  pendingPings?: PendingOsPing[];
   /** The unified app's focus record (see {@link AppFocus}) — pings for panes
    *  on the app's screen are suppressed. Wired to {@link readAppFocus}. */
   appFocus?: () => AppFocus | null;
@@ -255,8 +280,11 @@ export function runUpdaterTick(deps: UpdaterTickDeps): void {
   }
   // Notifications ride PANE transitions (M25.1), not the session rollup — a
   // second agent blocking in an already-blocked session is invisible at the
-  // session level but is exactly who the user needs to hear about.
+  // session level but is exactly who the user needs to hear about. Due delayed
+  // pings re-verify against THIS tick's pane states before the diff mutates
+  // anything (M25.2).
   if (deps.prevPaneState) {
+    firePendingOsPings(deps, panes);
     const events = diffPaneTransitions(deps.prevPaneState, panes, deps.locatePane);
     if (events.length > 0) dispatchNotifications(deps, events);
   }
@@ -326,19 +354,34 @@ export function diffPaneTransitions(
   return events;
 }
 
+/** A queued OS-level ping: the {@link SystemNotification} payload plus when it
+ *  becomes due. Fires only if its pane is STILL in `state` at fire time. */
+export interface PendingOsPing extends SystemNotification {
+  dueAtMs: number;
+}
+
+/** PURE — whether ANY channel beyond the master switch is on; an all-off
+ *  config costs the tick nothing. */
+function anyChannelOn(prefs: NotificationPrefs): boolean {
+  return prefs.toast || prefs.macos || prefs.terminal || prefs.sound !== "none";
+}
+
 /**
  * Ping the user about who needs them from this tick's transitions. Only runs
  * when the notification deps are wired, notifications are `enabled`, AND at
  * least one channel is on. `lastNotified` is mutated in place so the debounce
- * (the flap guard) persists across ticks. The macOS banner is additionally
- * gated on QUIET HOURS — inside the window the banner is skipped, but the event
- * has already been recorded to the log by the caller, so history stays honest.
+ * (the flap guard) persists across ticks. The in-app toast fires IMMEDIATELY
+ * (cheap, low-annoyance); the OS-LEVEL channels (banner / terminal escape /
+ * sound / BEL) either fire now (`delaySeconds` 0 or no queue wired) or queue
+ * onto `pendingPings` for the delayed re-verify (M25.2). The debounce stamp
+ * lands at DECIDE time either way — a flap that later cancels its OS ping
+ * already toasted, so it spent its debounce slot honestly.
  */
 function dispatchNotifications(deps: UpdaterTickDeps, events: NotifyEvent[]): void {
-  const { listClients, lastNotified, now, prefs, sendToasts: toast, sendSystem } = deps;
+  const { listClients, lastNotified, now, prefs, sendToasts: toast } = deps;
   if (!listClients || !lastNotified || !now || !prefs) return;
   if (!prefs.enabled) return;
-  if (!prefs.toast && !prefs.macos) return;
+  if (!anyChannelOn(prefs)) return;
   const nowMs = now();
   const decision = decideNotifications(
     events,
@@ -354,8 +397,71 @@ function dispatchNotifications(deps: UpdaterTickDeps, events: NotifyEvent[]): vo
   // debounce map), so this is exactly "the map changed — persist it".
   if (decision.system.length > 0) deps.persistNotified?.(lastNotified);
   if (prefs.toast && toast) toast(decision.toasts);
-  if (prefs.macos && sendSystem && !inQuietHours(new Date(nowMs), prefs.quietHours)) {
-    for (const n of decision.system) sendSystem(n);
+  if (decision.system.length === 0) return;
+  const delayMs = prefs.delaySeconds * 1000;
+  if (delayMs > 0 && deps.pendingPings) {
+    for (const n of decision.system) deps.pendingPings.push({ ...n, dueAtMs: nowMs + delayMs });
+  } else {
+    fireOsChannels(deps, prefs, decision.system, nowMs);
+  }
+}
+
+/**
+ * Fire the DUE queued OS pings whose transition still holds (M25.2). The
+ * re-verify is tick-native: this tick's fresh pane scan is the source of truth
+ * — a pane that flapped out of the notified state, vanished, or is now on the
+ * unified app's screen ({@link AppFocus} — the user got there on their own)
+ * fires nothing and is dropped. Prefs are the CURRENT tick's fresh read, so a
+ * config change during the delay is honored. Runs before this tick's diff so
+ * "the next tick's pane states" is literally what confirms each ping.
+ */
+function firePendingOsPings(deps: UpdaterTickDeps, panes: PaneDetail[]): void {
+  const { pendingPings: pending, now, prefs } = deps;
+  if (!pending || pending.length === 0 || !now || !prefs) return;
+  const nowMs = now();
+  const due: PendingOsPing[] = [];
+  const keep: PendingOsPing[] = [];
+  for (const p of pending) (p.dueAtMs <= nowMs ? due : keep).push(p);
+  if (due.length === 0) return;
+  pending.length = 0;
+  for (const p of keep) pending.push(p);
+  if (!prefs.enabled) return;
+  const statusByPane = new Map(panes.map((p) => [p.paneId, p.status]));
+  const focus = deps.appFocus?.() ?? null;
+  const confirmed = due.filter((p) => {
+    // A pane-less ping (session-granular caller) can't be re-verified — fire it.
+    if (p.paneId !== null && statusByPane.get(p.paneId) !== p.state) return false;
+    if (focus?.attached && p.paneId !== null && focus.panes.includes(p.paneId)) return false;
+    return true;
+  });
+  fireOsChannels(deps, prefs, confirmed, nowMs);
+}
+
+/**
+ * The OS-LEVEL fan-out (M25.2): system banner, terminal escapes + BEL to
+ * eligible client ttys, and the ping sound (at most ONE sound per batch — a
+ * fleet-wide flap must not ring a carillon). ALL of it is gated on quiet hours
+ * — inside the window nothing OS-level fires (the in-app toast and the event
+ * log have already surfaced the transition, so history stays honest).
+ */
+function fireOsChannels(
+  deps: UpdaterTickDeps,
+  prefs: NotificationPrefs,
+  entries: SystemNotification[],
+  nowMs: number,
+): void {
+  if (entries.length === 0) return;
+  if (inQuietHours(new Date(nowMs), prefs.quietHours)) return;
+  if (prefs.macos && deps.sendSystem) {
+    for (const n of entries) deps.sendSystem(n);
+  }
+  if ((prefs.terminal || prefs.sound !== "none") && deps.sendTerminal && deps.listClients) {
+    const clients = deps.listClients();
+    const writes = entries.flatMap((n) => decideTtyWrites(n, clients, prefs));
+    if (writes.length > 0) deps.sendTerminal(writes);
+  }
+  if (deps.playSound && entries.some((n) => soundEligible(n.state, prefs.sound))) {
+    deps.playSound();
   }
 }
 
@@ -532,6 +638,9 @@ export function runUpdaterLoop(): void {
   // The notification debounce map — restored from disk so a restart can't
   // re-ping inside the window, persisted back on every ping.
   const lastNotified = loadLastNotified();
+  // Queued OS-level pings awaiting their delayed re-verify (M25.2). In-memory
+  // only: the window is seconds, so a restart just drops the queue.
+  const pendingPings: PendingOsPing[] = [];
   // Persistent per-pane chip cache so we only rewrite a chip when it changed.
   const chipCache = new Map<string, string>();
   // Session-id capture for kinds without a hook integration (codex/cursor):
@@ -569,6 +678,9 @@ export function runUpdaterLoop(): void {
         prefs: readNotificationPrefs(),
         sendToasts,
         sendSystem: sendSystemNotification,
+        sendTerminal: writeTtys,
+        playSound: playPingSound,
+        pendingPings,
         locatePane: paneLocation,
         appFocus: () => readAppFocus(),
         persistNotified: (map) => saveLastNotified(map),

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -315,6 +315,7 @@ import {
   HINT_CHROME_RESTART,
   HINT_LIVE,
   HINT_READOPT,
+  delaySecondsPatch,
   keybindingItems,
   notificationItems,
   notificationTogglePatch,
@@ -323,6 +324,9 @@ import {
   quietHoursOffPatch,
   quietHoursPatch,
   resetSettingsPatch,
+  soundItems,
+  soundPatch,
+  validateDelaySeconds,
   restoreItems,
   restorePatch,
   settingsRootItems,
@@ -3206,7 +3210,7 @@ render(
       const choice = await DialogSelect.show({
         title: "Quiet hours",
         items: quietHoursItems(prefs),
-        footerHint: "silences macOS banners during the window",
+        footerHint: "silences banners, sounds & bells during the window",
       });
       if (!choice) return false;
       if (choice.item.id === "off") {
@@ -3251,6 +3255,31 @@ render(
         if (choice.item.id === "quietHours") {
           await runQuietHours();
           continue; // back to the list with fresh details either way
+        }
+        if (choice.item.id === "sound") {
+          const picked = await DialogSelect.show({
+            title: "Notification sound",
+            items: soundItems(prefs),
+            footerHint: HINT_LIVE,
+          });
+          if (picked) {
+            updateAppConfig(soundPatch(picked.item.id));
+            setStatusNote(`sound: ${picked.item.label} — ${HINT_LIVE}`);
+          }
+          continue;
+        }
+        if (choice.item.id === "delaySeconds") {
+          const v = await DialogPrompt.show({
+            title: "Alert delay (seconds)",
+            initial: String(prefs.delaySeconds),
+            validate: validateDelaySeconds,
+            footerHint: `waits, then re-checks the agent still needs you · ${HINT_LIVE}`,
+          });
+          if (v !== null) {
+            updateAppConfig(delaySecondsPatch(v));
+            setStatusNote(`alert delay ${v.trim()} s — ${HINT_LIVE}`);
+          }
+          continue;
         }
         const id = choice.item.id as NotificationToggleId;
         updateAppConfig(notificationTogglePatch(id, prefs));

--- a/packages/daemon/src/tui/mirror/hosted.test.ts
+++ b/packages/daemon/src/tui/mirror/hosted.test.ts
@@ -10,6 +10,7 @@ import {
   hostCreateArgv,
   hostSetupArgvs,
   hostAttachArgv,
+  HOST_RESIZE_HOOKS,
 } from "./hosted.ts";
 
 const noEntry = {
@@ -115,10 +116,37 @@ describe("tmux argv builders", () => {
   });
 
   it("setup turns status off and pins window-size latest (no `=` — set-option rejects it)", () => {
-    expect(hostSetupArgvs()).toEqual([
+    expect(hostSetupArgvs().slice(0, 2)).toEqual([
       ["set-option", "-t", APP_HOST_SESSION, "status", "off"],
       ["set-option", "-w", "-t", `${APP_HOST_SESSION}:`, "window-size", "latest"],
     ]);
+  });
+
+  it("setup enables focus-events so a returning terminal's focus re-adopts its size (M25.5)", () => {
+    expect(hostSetupArgvs()).toContainEqual(["set-option", "-s", "focus-events", "on"]);
+  });
+
+  it("setup installs one session-scoped self-heal hook per client event (M25.5)", () => {
+    const argvs = hostSetupArgvs();
+    const heal = `set-option -w -t ${APP_HOST_SESSION}: window-size latest`;
+    for (const hook of HOST_RESIZE_HOOKS) {
+      expect(argvs).toContainEqual(["set-hook", "-t", APP_HOST_SESSION, hook, heal]);
+    }
+    // and nothing else rides along — status/window-size/focus-events + the hooks
+    expect(argvs).toHaveLength(3 + HOST_RESIZE_HOOKS.length);
+  });
+
+  it("the heal is never resize-window (any form flips window-size to manual — the stuck state)", () => {
+    for (const argv of hostSetupArgvs()) {
+      expect(argv).not.toContain("resize-window");
+      expect(argv.join(" ")).not.toMatch(/resize-window/);
+    }
+  });
+
+  it("hook commands are tmux-native — no run-shell (run-shell hooks serialize the server)", () => {
+    for (const argv of hostSetupArgvs()) {
+      expect(argv.join(" ")).not.toMatch(/run-shell/);
+    }
   });
 
   it("attach from a plain terminal, switch-client from inside tmux", () => {

--- a/packages/daemon/src/tui/mirror/hosted.ts
+++ b/packages/daemon/src/tui/mirror/hosted.ts
@@ -113,22 +113,82 @@ export function hostCreateArgv(opts: { cwd: string; commandLine: string }): stri
 }
 
 /**
- * PURE — the post-create session setup: status OFF so the app owns every row
- * (under `status on` the host steals the bottom row and the app renders one
- * short), and `window-size latest` pinned explicitly so the most recently
- * active client dictates the size — a smaller second client letterboxes the
- * larger one (tmux's own dot-fill), which is the documented behavior.
+ * The client events that re-assert `window-size latest` on the host (M25.5).
+ * Each hook's effect was MEASURED on tmux 3.7b in an isolated two-client rig
+ * (220x60 local + 120x40 ssh-sim):
+ *
+ * - `client-attached` / `client-focus-in` / `client-session-changed`: tmux
+ *   3.7b already re-adopts the event client's size natively on all of these
+ *   (attach ~8ms, focus-in ~17ms, switch-client ~17ms — window-resized hook
+ *   timestamps; detach of the latest client also re-adopts natively, ~13ms).
+ *   The hooks are NOT what makes those paths work; they are the SELF-HEAL for
+ *   the one measured way the host gets permanently stuck: any `resize-window`
+ *   against it (a stray tool or user command) flips `window-size` to manual —
+ *   after which NO client event re-adopts, ever (measured: a fresh 220x60
+ *   attach left a manually-80x24 host at 80x24). Re-asserting the option is
+ *   the heal (measured: instant re-adopt) — and it is safe to fire
+ *   redundantly: setting `window-size latest` when it is already latest just
+ *   recomputes the same size. Fire counts are bounded and linear (measured:
+ *   10 rapid focus alternations → exactly 20 focus-in fires; 10 attach cycles
+ *   → 10 attached + 10 session-changed fires — attach fires both — each a
+ *   single in-server set-option, no storm).
+ *
+ * NO `client-detached` hook: measured on 3.7b it never fires as a SESSION
+ * hook (the detaching client has already left the session when hooks are
+ * resolved — 0 fires across 10 detach cycles while the same rig's global
+ * hook logged every one), and the native detach re-adopt covers the path.
+ *
+ * Deliberately NOT `resize-window -a`: per the tmux manual, EVERY
+ * resize-window form — -a included — "will automatically set window-size to
+ * manual", i.e. it would cause the exact stuck state it is meant to fix. And
+ * no `run-shell`: these are tmux-native commands executed in-server
+ * (run-shell hooks serialize the server — prior measurement).
+ */
+export const HOST_RESIZE_HOOKS = [
+  "client-attached",
+  "client-focus-in",
+  "client-session-changed",
+] as const;
+
+/**
+ * PURE — the post-create/ensure session setup: status OFF so the app owns
+ * every row (under `status on` the host steals the bottom row and the app
+ * renders one short), and `window-size latest` pinned explicitly so the most
+ * recently active client dictates the size — a smaller second client
+ * letterboxes the larger one (tmux's own dot-fill), which is the documented
+ * behavior.
+ *
+ * M25.5 additions (each measured on 3.7b — see {@link HOST_RESIZE_HOOKS}):
+ *
+ * - `focus-events on` (server option — the ONE non-session-scoped line, and
+ *   the load-bearing one): it defaults OFF, so real terminals are never asked
+ *   for focus reporting and `client-focus-in` never fires. With it on, coming
+ *   BACK to a terminal that stayed attached re-adopts that client's size on
+ *   the focus event alone (measured: focus-in → client-active →
+ *   window-resized in ~17ms) — no keystroke needed. This is the user's exact
+ *   "reopen it on my computer locally" moment when the local client never
+ *   detached. Side effect is the widely-recommended one (panes that request
+ *   focus, e.g. editors, start receiving it).
+ * - the {@link HOST_RESIZE_HOOKS} self-heal hooks, session-scoped to the host
+ *   (zero effect on user sessions).
+ *
+ * The whole list is idempotent — the CLI applies it on EVERY ensure, not just
+ * create, so upgrading tmux-ide fixes an already-running cockpit on its next
+ * `tmux-ide app` (and un-sticks a manually-resized host).
  *
  * No `=` exact-match prefix here: tmux (measured on 3.7b) rejects it on
  * `set-option` session targets ("no such session") even though has-session
  * and attach accept it. Plain names are safe in THIS builder only because
- * setup runs right after create — the exact session exists, and tmux prefers
- * an exact match over a prefix match when one does.
+ * setup runs right after the exists-probe/create — the exact session exists,
+ * and tmux prefers an exact match over a prefix match when one does.
  */
 export function hostSetupArgvs(): string[][] {
+  const heal = `set-option -w -t ${APP_HOST_SESSION}: window-size latest`;
   return [
     ["set-option", "-t", APP_HOST_SESSION, "status", "off"],
     ["set-option", "-w", "-t", `${APP_HOST_SESSION}:`, "window-size", "latest"],
+    ["set-option", "-s", "focus-events", "on"],
+    ...HOST_RESIZE_HOOKS.map((hook) => ["set-hook", "-t", APP_HOST_SESSION, hook, heal]),
   ];
 }
 

--- a/packages/daemon/src/tui/mirror/settings-model.test.ts
+++ b/packages/daemon/src/tui/mirror/settings-model.test.ts
@@ -1,13 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_APP_CONFIG,
   DEFAULT_KEYS as CHROME_DEFAULT_KEYS,
+  _resetForTests,
   parseAppConfig,
   mergeConfigPatch,
+  updateAppConfig,
 } from "../../lib/app-config.ts";
 import {
   DEFAULT_NOTIFICATION_PREFS,
   parseNotificationPrefs,
+  readNotificationPrefs,
   type NotificationPrefs,
 } from "../chrome/notify.ts";
 import { prefixKeyBinds } from "../chrome/statusline.ts";
@@ -15,6 +21,8 @@ import {
   PALETTE_KEYCAPS,
   SETTINGS_PALETTE_COMMANDS,
   THEME_PRESETS,
+  delaySecondsPatch,
+  delaySummary,
   keybindingItems,
   notificationItems,
   notificationTogglePatch,
@@ -25,6 +33,10 @@ import {
   quietHoursPatch,
   quietHoursSummary,
   resetSettingsPatch,
+  soundItems,
+  soundPatch,
+  soundSummary,
+  validateDelaySeconds,
   restoreItems,
   restorePatch,
   settingsRootItems,
@@ -80,17 +92,49 @@ describe("notifications", () => {
       "enabled",
       "toast",
       "macos",
+      "terminal",
       "onBlocked",
       "onDone",
+      "sound",
+      "delaySeconds",
       "quietHours",
     ]);
     expect(rows.find((r) => r.id === "macos")?.detail).toBe("off");
+    expect(rows.find((r) => r.id === "terminal")?.detail).toBe("on");
+    expect(rows.find((r) => r.id === "sound")?.detail).toBe("when blocked");
+    expect(rows.find((r) => r.id === "delaySeconds")?.detail).toBe("2 s");
     expect(rows.find((r) => r.id === "quietHours")?.detail).toBe("off");
   });
   it("toggle patches flip the current value and survive the raw round-trip", () => {
     expect(notificationTogglePatch("macos", PREFS)).toEqual({ notifications: { macos: true } });
+    expect(notificationTogglePatch("terminal", PREFS)).toEqual({
+      notifications: { terminal: false },
+    });
     const raw = mergeConfigPatch({}, notificationTogglePatch("onBlocked", PREFS));
     expect(parseNotificationPrefs(raw).onBlocked).toBe(false);
+  });
+  it("sound: summary words, chooser marking, patch round-trip", () => {
+    expect(soundSummary(PREFS)).toBe("when blocked");
+    expect(soundSummary({ ...PREFS, sound: "all" })).toBe("always");
+    expect(soundSummary({ ...PREFS, sound: "none" })).toBe("off");
+    expect(soundItems(PREFS).find((i) => i.current)?.id).toBe("blocked");
+    expect(soundItems({ ...PREFS, sound: "none" }).find((i) => i.current)?.id).toBe("none");
+    const raw = mergeConfigPatch({}, soundPatch("all"));
+    expect(parseNotificationPrefs(raw).sound).toBe("all");
+  });
+  it("delay: summary, 0–60 whole-second validation, patch round-trip (0 = immediate)", () => {
+    expect(delaySummary(PREFS)).toBe("2 s");
+    expect(delaySummary({ ...PREFS, delaySeconds: 0 })).toBe("immediately");
+    expect(validateDelaySeconds("0")).toBeNull();
+    expect(validateDelaySeconds(" 60 ")).toBeNull();
+    expect(validateDelaySeconds("61")).toContain("between 0 and 60");
+    expect(validateDelaySeconds("2.5")).toContain("whole number");
+    expect(validateDelaySeconds("soon")).toContain("whole number");
+    const raw = mergeConfigPatch({}, delaySecondsPatch(" 5 "));
+    expect(parseNotificationPrefs(raw).delaySeconds).toBe(5);
+    expect(parseNotificationPrefs(mergeConfigPatch(raw, delaySecondsPatch("0"))).delaySeconds).toBe(
+      0,
+    );
   });
   it("quiet hours: summary, chooser marking, HH:MM validation, on/off patches", () => {
     const withWindow: NotificationPrefs = {
@@ -234,5 +278,35 @@ describe("umbrella + reset", () => {
     expect(merged).toEqual({ keys: { popup: "M-o" }, somethingUserAdded: { keep: "me" } });
     expect(parseAppConfig(merged).theme.accent).toBe(CFG.theme.accent);
     expect(parseAppConfig(merged).keys.popup).toBe("M-o");
+  });
+});
+
+describe("M25.2 channel fields round-trip through the real config file", () => {
+  let dir: string | null = null;
+  const savedEnv = process.env.TMUX_IDE_CONFIG;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env.TMUX_IDE_CONFIG;
+    else process.env.TMUX_IDE_CONFIG = savedEnv;
+    _resetForTests();
+  });
+
+  it("the dialogs' patches land in the file and read back through the live prefs path", () => {
+    dir = mkdtempSync(join(tmpdir(), "settings-m252-"));
+    process.env.TMUX_IDE_CONFIG = join(dir, "config.json");
+    _resetForTests();
+    updateAppConfig(notificationTogglePatch("terminal", DEFAULT_NOTIFICATION_PREFS));
+    updateAppConfig(soundPatch("all"));
+    updateAppConfig(delaySecondsPatch("7"));
+    const prefs = readNotificationPrefs();
+    expect(prefs.terminal).toBe(false);
+    expect(prefs.sound).toBe("all");
+    expect(prefs.delaySeconds).toBe(7);
+    // and the settings rows render the persisted values
+    const rows = notificationItems(prefs);
+    expect(rows.find((r) => r.id === "terminal")?.detail).toBe("off");
+    expect(rows.find((r) => r.id === "sound")?.detail).toBe("always");
+    expect(rows.find((r) => r.id === "delaySeconds")?.detail).toBe("7 s");
   });
 });

--- a/packages/daemon/src/tui/mirror/settings-model.ts
+++ b/packages/daemon/src/tui/mirror/settings-model.ts
@@ -107,22 +107,81 @@ export function themePatch(accent: string): AppConfigPatch {
 
 // ── Notifications ────────────────────────────────────────────────────────────
 
-export type NotificationToggleId = "enabled" | "toast" | "macos" | "onBlocked" | "onDone";
+export type NotificationToggleId =
+  | "enabled"
+  | "toast"
+  | "macos"
+  | "terminal"
+  | "onBlocked"
+  | "onDone";
 
 const onOff = (v: boolean) => (v ? "on" : "off");
 
 /** PURE — the notification toggle rows (the REAL fields notify.ts reads: the
- *  typed toast/macos plus the polish-era raw fields), and a quiet-hours row
- *  that descends into its own flow. Enter toggles in place. */
+ *  typed channel fields plus the polish-era raw fields), plus the rows that
+ *  descend into their own flows (sound tri-choice, delay prompt, quiet hours).
+ *  Enter toggles the boolean rows in place. */
 export function notificationItems(prefs: NotificationPrefs): DialogSelectItem[] {
   return [
     { id: "enabled", label: "All notifications", detail: onOff(prefs.enabled) },
     { id: "toast", label: "In-terminal toasts", detail: onOff(prefs.toast) },
-    { id: "macos", label: "macOS banners", detail: onOff(prefs.macos) },
+    { id: "macos", label: "System banners", detail: onOff(prefs.macos) },
+    { id: "terminal", label: "Terminal banners (OSC)", detail: onOff(prefs.terminal) },
     { id: "onBlocked", label: "Alert when an agent needs you", detail: onOff(prefs.onBlocked) },
     { id: "onDone", label: "Alert when an agent finishes", detail: onOff(prefs.onDone) },
+    { id: "sound", label: "Sound…", detail: soundSummary(prefs) },
+    { id: "delaySeconds", label: "Alert delay…", detail: delaySummary(prefs) },
     { id: "quietHours", label: "Quiet hours…", detail: quietHoursSummary(prefs) },
   ];
+}
+
+/** PURE — plain words for the sound tri-state. */
+export function soundSummary(prefs: NotificationPrefs): string {
+  return prefs.sound === "blocked" ? "when blocked" : prefs.sound === "all" ? "always" : "off";
+}
+
+/** PURE — the sound chooser rows (● on the saved choice). */
+export function soundItems(prefs: NotificationPrefs): DialogSelectItem[] {
+  return [
+    {
+      id: "blocked",
+      label: "When an agent needs you",
+      detail: "sound + terminal bell on blocked",
+      current: prefs.sound === "blocked",
+    },
+    {
+      id: "all",
+      label: "Every alert",
+      detail: "blocked and finished",
+      current: prefs.sound === "all",
+    },
+    { id: "none", label: "Off — no sound", current: prefs.sound === "none" },
+  ];
+}
+
+/** PURE — persist a picked sound mode. */
+export function soundPatch(id: string): AppConfigPatch {
+  return { notifications: { sound: id } };
+}
+
+/** PURE — "2 s" / "immediately". */
+export function delaySummary(prefs: NotificationPrefs): string {
+  return prefs.delaySeconds > 0 ? `${prefs.delaySeconds} s` : "immediately";
+}
+
+/** PURE — 0–60 whole seconds (0 = fire immediately; the delay exists to swallow
+ *  flappy transitions, and a minute is already generous). */
+export function validateDelaySeconds(value: string): string | null {
+  const n = Number(value.trim());
+  if (!Number.isInteger(n) || n < 0 || n > 60) {
+    return "Use a whole number of seconds between 0 and 60 (0 alerts immediately)";
+  }
+  return null;
+}
+
+/** PURE — persist a validated delay. */
+export function delaySecondsPatch(value: string): AppConfigPatch {
+  return { notifications: { delaySeconds: Number(value.trim()) } };
 }
 
 /** PURE — flip one notification toggle. */
@@ -144,7 +203,7 @@ export function quietHoursItems(prefs: NotificationPrefs): DialogSelectItem[] {
     { id: "off", label: "Off — always notify", current: prefs.quietHours === null },
     {
       id: "window",
-      label: "Silence banners during a daily window…",
+      label: "Silence banners & sounds during a daily window…",
       detail: prefs.quietHours ? quietHoursSummary(prefs) : undefined,
       current: prefs.quietHours !== null,
     },

--- a/packages/daemon/src/tui/mirror/size-truth.ts
+++ b/packages/daemon/src/tui/mirror/size-truth.ts
@@ -10,6 +10,18 @@
  * mismatch from the pane layout, center the grid inside the canvas, and format
  * the quiet honest hint. No tmux, no render loop — unit-tested in isolation; the
  * app reads the pane geometry and the pinned canvas size and wires the rest.
+ *
+ * KNOWN GAP, measured (M25.5, tmux 3.7b): when TWO app processes mirror the
+ * same session (one per terminal — the non-hosted double-open), the later
+ * control client's boot pin wins `window-size latest`, and the other app can
+ * NEVER re-win it by interaction — the keys/mouse it forwards travel as
+ * control-client `send-keys` commands, which do not update tmux's
+ * latest-client
+ * bookkeeping (measured: local keystroke and wheel left the window at the
+ * other app's pin). The hint + the palette's "Resize to fit" verb are the
+ * designed escape; the structural fix is the hosted cockpit (`--detachable`),
+ * where one app process serves every terminal and REAL clients attach to the
+ * host session, whose native latest handling re-adopts on attach/focus/detach.
  */
 
 export interface Size {


### PR DESCRIPTION
The M25 closers: OS-level pings for every terminal kind (direct-tty OSC 9/99 with measured raw-vs-passthrough correctness, Linux notify-send, sound + BEL, tick-native delayed re-verify, quiet hours over everything) and the hosted cockpit following the active client (focus-events + self-heal hooks; 31-46ms re-adopt; the resize-window manual-flip trap healed on ensure). 1569 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)