### PR TITLE
feat: selection survives scrolling — absolute anchoring (M25.6)

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -35,6 +35,21 @@
  * wheel outside select mode); pure logic in selection.ts (paneDragDefault /
  * routePanePress).
  *
+ * SELECTION SURVIVES SCROLLING (M25.6): mirror selections anchor in ABSOLUTE
+ * xterm buffer lines (absLine = scrollbackDepth − scrollOffset + viewportRow),
+ * not viewport cells — so scrolling mid-drag keeps the highlight on its text
+ * and a selection can span many screens. While a drag is live the wheel over
+ * the pane always scrolls the LOCAL scrollback (never forwarded, never cancels
+ * — even on app-mouse panes), and holding the pointer at the pane's top/bottom
+ * content row auto-scrolls ~1 row per 8ms state tick (clamped at the
+ * scrollback top / the live bottom). The release copy extracts the FULL
+ * absolute span straight from the pane's buffer (SessionMirror.extractText,
+ * built capped so a runaway span never materializes unbounded — the 1 MB
+ * clipboard cap still refuses over-limit selections). Buffer rotation at the
+ * scrollback cap mid-drag is compensated via PaneMirror.lineTrim (the anchor
+ * follows its content); both plain drags and M22.9/M24.2 select-mode /
+ * shift / deferred-press entries share this machinery.
+ *
  * SURFACE TABS (M18.4): a persistent top row — [⌂ Home][❯ Terminal][▤ Files]
  * [± Diff] — makes the app a real IDE. F1..F4 switch (F-keys encode reliably;
  * ctrl+digit/alt do NOT — measured); the tab bar is also clickable (fixed x-span
@@ -465,6 +480,7 @@ import {
   orderCells,
   rowSelectionRange,
   extractSelection,
+  trimAdjustCell,
   wordRangeAt,
   lineRangeAt,
   clickCount,
@@ -926,15 +942,27 @@ render(
     const [sel, setSel] = createSignal(0);
     const [status, setStatus] = createSignal(bareHome ? "home" : "attaching…");
 
-    // ── SELECTION & CLIPBOARD (M19.4) ────────────────────────────────────────
+    // ── SELECTION & CLIPBOARD (M19.4; absolute-space M25.6) ──────────────────
     // The visible selection (drives inverse-tint on the mirror/editor render) and
     // the gesture state machine driving it. `selecting` marks a drag in progress
     // (null = none, discrete word/line selections leave it null); `selAnchor` is
-    // where the drag began; `lastClick` tracks click-count for double/triple. A
-    // transient `note` reuses the status channel for "copied/pasted N chars".
+    // where the drag began — for the MIRROR that's an ABSOLUTE buffer cell
+    // (M25.6), fixed at press; `selTrimBase` records the pane's lineTrim() at
+    // that moment so a buffer rotating past its scrollback cap mid-drag keeps
+    // the anchor on its content (trimAdjustCell subtracts the drift at each
+    // extend). `lastClick` tracks click-count for double/triple. A transient
+    // `note` reuses the status channel for "copied/pasted N chars".
     const [selection, setSelection] = createSignal<Selection | null>(null);
     let selecting: { surface: "mirror"; paneId: string } | { surface: "editor" } | null = null;
     let selAnchor: Cell = { row: 0, col: 0 };
+    let selTrimBase = 0;
+    // Edge auto-scroll (M25.6): armed by extendSelection when the drag pointer
+    // sits at/beyond the selecting pane's top/bottom content row; the 8ms state
+    // tick then scrolls 1 row per tick and re-extends at the LAST pointer —
+    // no new timers. Cleared on release/escape (clearSelection) and whenever
+    // the pointer moves back inside the pane body.
+    let dragAutoScroll: "up" | "down" | null = null;
+    let lastDragPointer = { x: 0, y: 0 };
     let lastClick: { row: number; col: number; ts: number; count: number } | null = null;
     const [note, setNote] = createSignal("");
     let noteTimer: ReturnType<typeof setTimeout> | null = null;
@@ -945,6 +973,7 @@ render(
     };
     const clearSelection = () => {
       selecting = null;
+      dragAutoScroll = null;
       if (selection() !== null) setSelection(null);
     };
 
@@ -1076,9 +1105,18 @@ render(
     // release lands in the same cell, the owed SGR press/release pair is
     // forwarded then — a click, which is how agents like claude are driven.
     // Coordinates are frozen at press so the forwarded pair is exactly the
-    // cell the user pressed. Only one of {pendingPress, selecting, dragging}
-    // is ever live.
-    let pendingPress: { paneId: string; x: number; gy: number; cell: Cell } | null = null;
+    // cell the user pressed. `absCell`/`trimBase` freeze the press's ABSOLUTE
+    // buffer cell (M25.6) so a selection born from the deferred press anchors
+    // exactly where the button went down. Only one of {pendingPress, selecting,
+    // dragging} is ever live.
+    let pendingPress: {
+      paneId: string;
+      x: number;
+      gy: number;
+      cell: Cell;
+      absCell: Cell;
+      trimBase: number;
+    } | null = null;
     // The pane whose app is OWED a release because its press was forwarded.
     // OpenTUI synthesizes SEVERAL release-type events per physical release
     // (drag-end, up, drop, up — measured live), so the release forward must be
@@ -3462,6 +3500,22 @@ render(
       if (mode() === "diff") refreshStatus();
       if (mode() === "mirror" && curTarget()) attach(curTarget());
       const t = setInterval(() => {
+        // Edge auto-scroll (M25.6): while a mirror drag parks the pointer at
+        // the pane's top/bottom content row, extend ~1 row per state tick —
+        // the existing 8ms cadence, no new timers. The clamps stop it at the
+        // scrollback top (up) / the live bottom (down); release or escape
+        // clears the gesture (clearSelection / the release branch in `route`).
+        if (mirror && dragAutoScroll && selecting?.surface === "mirror") {
+          const paneId = selecting.paneId;
+          const depth = mirror.scrollbackDepth(paneId);
+          const cur = Math.min(scrollOffsets.get(paneId) ?? 0, depth);
+          const next = dragAutoScroll === "up" ? Math.min(cur + 1, depth) : Math.max(cur - 1, 0);
+          if (next !== cur) {
+            scrollOffsets.set(paneId, next);
+            extendSelection(lastDragPointer.x, lastDragPointer.y);
+            dirty = true;
+          }
+        }
         if (!dirty || !mirror) return;
         dirty = false;
         const t0 = performance.now();
@@ -3797,8 +3851,13 @@ render(
       return p.snapshot.rows.map((runs) => runs.map((r) => r.text).join(""));
     };
     const commitMirrorCopy = (paneId: string, anchor: Cell, head: Cell) => {
+      // Cells are ABSOLUTE buffer coordinates (M25.6); the extractor reads the
+      // full span straight from the pane's buffer — scrollback included — with
+      // the same trim/collapse as the old visible-rows path, built capped so a
+      // runaway span never materializes unbounded (copyText still refuses over
+      // MAX_CLIP_BYTES, with the honest over-limit byte count).
       const { start, end } = orderCells(anchor, head);
-      const text = extractSelection(paneRowTexts(paneId), start, end);
+      const text = mirror?.extractText(paneId, start, end, MAX_CLIP_BYTES) ?? "";
       if (text.length > 0) {
         copyText(text);
         // A completed copy ends the pane's select mode (M22.9) — forwarding
@@ -3854,10 +3913,13 @@ render(
       }
       const s = selection();
       if (s && s.surface === "mirror" && s.paneId === pane.id) {
+        // Selection cells are ABSOLUTE buffer lines (M25.6) — map each visible
+        // row through the same baseY the search pass uses above.
+        const baseY = pane.scrollbackDepth - pane.snapshot.scrollOffset;
         const { start, end } = orderCells(s.anchor, s.head);
         rows = rows.map((runs, r) => {
           const rowLen = runs.reduce((n, run) => n + run.text.length, 0);
-          const range = rowSelectionRange(r, rowLen, start, end);
+          const range = rowSelectionRange(baseY + r, rowLen, start, end);
           return range ? tintRunsInverse(runs, range.from, range.to) : runs;
         });
       }
@@ -3865,7 +3927,10 @@ render(
     };
 
     // FB-path twins of the two paneSelRows passes, shaped as <pane_surface> props
-    // (cell-column based; the renderable applies them over the blitted cells).
+    // (the renderable applies them over the blitted cells). Both are ABSOLUTE-
+    // space inputs (M25.6): the selection range is absolute buffer cells and the
+    // search matches absolute lines — the surface maps them to visible rows
+    // per-frame against the pane's current baseY, so highlights ride the scroll.
     // Reading selection()/paneSearches() here subscribes the surface so the prop
     // re-sets — and the blit re-runs — only when they actually change.
     const mirrorSelForPane = (paneId: string): { start: Cell; end: Cell } | null => {
@@ -3888,6 +3953,19 @@ render(
       col: Math.max(0, Math.min(pane.width - 1, gx - sidebarW() - pane.left)),
       row: Math.max(0, Math.min(pane.height - 1, gy - HEADER_ROWS - pane.top)),
     });
+    /** The view's current absolute top for a pane (M25.6): live scrollback
+     *  depth − the clamped LOCAL offset, both read from the mirror/offset map
+     *  at EVENT time — the LivePane snapshot lags one 8ms tick, and a wheel
+     *  that just moved the offset must map the very next pointer cell right. */
+    const paneBaseY = (paneId: string): number => {
+      const depth = mirror?.scrollbackDepth(paneId) ?? 0;
+      return depth - Math.max(0, Math.min(scrollOffsets.get(paneId) ?? 0, depth));
+    };
+    /** A pointer position as an ABSOLUTE buffer cell of `pane` (M25.6). */
+    const paneAbsCell = (pane: LivePane, gx: number, gy: number): Cell => {
+      const cell = paneCell(pane, gx, gy);
+      return { row: paneBaseY(pane.id) + cell.row, col: cell.col };
+    };
 
     // ── SCROLLBARS (M19.5) ────────────────────────────────────────────────────
     // The scroll geometry for one surface: the global column its 1-col track sits
@@ -5171,7 +5249,11 @@ render(
      *  sidebar, main). Geometry is ours. The tab bar is the top screen row; every
      *  other region is offset below it, so we subtract TABBAR_H once (`gy`) and the
      *  per-mode math below is exactly as it was before the bar existed. */
-    /** Extend a live selection's head to the pointer (surface-local cells). */
+    /** Extend a live selection's head to the pointer. Mirror cells are ABSOLUTE
+     *  (M25.6): the head derives from the pointer + the pane's CURRENT view
+     *  offset, the anchor is re-based over any scrollback-cap rotation since
+     *  the press, and the pointer parking at/beyond the pane's top/bottom
+     *  content row arms the edge auto-scroll the 8ms tick drives. */
     const extendSelection = (x: number, y: number) => {
       if (!selecting) return;
       const gy = y - TABBAR_H;
@@ -5179,11 +5261,14 @@ render(
         const paneId = selecting.paneId;
         const pane = panes().find((p) => p.id === paneId);
         if (!pane) return;
+        lastDragPointer = { x, y };
+        const rawRow = gy - HEADER_ROWS - pane.top;
+        dragAutoScroll = rawRow <= 0 ? "up" : rawRow >= pane.height - 1 ? "down" : null;
         setSelection({
           surface: "mirror",
           paneId: pane.id,
-          anchor: selAnchor,
-          head: paneCell(pane, x, gy),
+          anchor: trimAdjustCell(selAnchor, (mirror?.lineTrim(paneId) ?? 0) - selTrimBase),
+          head: paneAbsCell(pane, x, gy),
         });
       } else {
         const { line, col } = editorCellAt(x, gy);
@@ -5451,9 +5536,12 @@ render(
           const cell = paneCell(pane, x, y - TABBAR_H);
           if (cell.row !== pp.cell.row || cell.col !== pp.cell.col) {
             pendingPress = null;
-            selAnchor = pp.cell;
+            // Anchor at the press's frozen ABSOLUTE cell (M25.6); the extend
+            // derives the head from the pointer's current absolute cell.
+            selAnchor = pp.absCell;
+            selTrimBase = pp.trimBase;
             selecting = { surface: "mirror", paneId: pane.id };
-            setSelection({ surface: "mirror", paneId: pane.id, anchor: pp.cell, head: cell });
+            extendSelection(x, y);
           }
           return;
         }
@@ -5481,6 +5569,27 @@ render(
         extendSelection(x, y);
         return;
       }
+      // The wheel during a live MIRROR selection (M25.6): the drag owns it. It
+      // adjusts the selecting pane's LOCAL offset — never forwarded to the
+      // pane's app (even on app-mouse panes), never cancels the drag — and the
+      // head re-derives at the pointer's new absolute cell, so the highlight
+      // extends across the scroll. The scroll badge updates via the same tick.
+      if (type === "scroll" && selecting && selecting.surface === "mirror") {
+        const dir = e.scroll?.direction;
+        if (dir === "up" || dir === "down") {
+          const paneId = selecting.paneId;
+          const depth = mirror?.scrollbackDepth(paneId) ?? 0;
+          const cur = Math.min(scrollOffsets.get(paneId) ?? 0, depth);
+          const next =
+            dir === "up" ? Math.min(cur + SCROLL_STEP, depth) : Math.max(cur - SCROLL_STEP, 0);
+          if (next !== cur) {
+            scrollOffsets.set(paneId, next);
+            markDirty();
+          }
+          extendSelection(x, y);
+        }
+        return;
+      }
       if (type === "move" || type === "over" || type === "drag") {
         resolveHover(x, y);
         return;
@@ -5494,6 +5603,7 @@ render(
           if (s && s.surface === "mirror" && selecting.surface === "mirror")
             commitMirrorCopy(s.paneId, s.anchor, s.head);
           selecting = null;
+          dragAutoScroll = null;
           return;
         }
         // A FORWARDED press's release: pay the debt to the pane that got the
@@ -5728,11 +5838,20 @@ render(
           return;
         }
         if (routing === "defer") {
-          pendingPress = { paneId: pane.id, x, gy, cell: paneCell(pane, x, gy) };
+          pendingPress = {
+            paneId: pane.id,
+            x,
+            gy,
+            cell: paneCell(pane, x, gy),
+            absCell: paneAbsCell(pane, x, gy),
+            trimBase: mirror?.lineTrim(pane.id) ?? 0,
+          };
           return;
         }
         // Begin a drag selection, or on a repeat click select
-        // the word (double) / line (triple) and copy it immediately.
+        // the word (double) / line (triple) and copy it immediately. Click
+        // cadence tracks in VIEWPORT cells (the same physical spot); the
+        // selection itself anchors in ABSOLUTE buffer cells (M25.6).
         const cell = paneCell(pane, x, gy);
         const now = Date.now();
         const count = clickCount(lastClick, cell, now, CLICK_MS);
@@ -5740,13 +5859,15 @@ render(
         if (count >= 2) {
           const rowText = paneRowTexts(pane.id)[cell.row] ?? "";
           const r = count === 2 ? wordRangeAt(rowText, cell.col) : lineRangeAt(rowText);
-          const anchor = { row: cell.row, col: r.from };
-          const head = { row: cell.row, col: r.to };
+          const absRow = paneBaseY(pane.id) + cell.row;
+          const anchor = { row: absRow, col: r.from };
+          const head = { row: absRow, col: r.to };
           setSelection({ surface: "mirror", paneId: pane.id, anchor, head });
           selecting = null;
           commitMirrorCopy(pane.id, anchor, head);
         } else {
-          selAnchor = cell;
+          selAnchor = paneAbsCell(pane, x, gy);
+          selTrimBase = mirror?.lineTrim(pane.id) ?? 0;
           selecting = { surface: "mirror", paneId: pane.id };
           setSelection(null);
         }

--- a/packages/daemon/src/tui/mirror/pane-mirror.test.ts
+++ b/packages/daemon/src/tui/mirror/pane-mirror.test.ts
@@ -150,3 +150,96 @@ describe("PaneMirror.blit — incremental (M21.4)", () => {
     m.dispose();
   });
 });
+
+describe("PaneMirror.extractAbsoluteText + lineTrim (M25.6)", () => {
+  /** Write numbered lines 1..n ("line 1".."line n") and wait for the last. */
+  async function seeded(cols: number, rows: number, n: number): Promise<PaneMirror> {
+    const m = new PaneMirror(cols, rows);
+    m.write(Array.from({ length: n }, (_, i) => `line ${i + 1}`).join("\r\n"));
+    await flushed(m, `line ${n}`);
+    return m;
+  }
+
+  it("extracts a single visible line byte-identically to the visible-rows path", async () => {
+    const m = await seeded(20, 4, 4); // no scrollback yet: absolute == visible
+    expect(m.scrollbackDepth()).toBe(0);
+    const abs = m.extractAbsoluteText({ row: 1, col: 0 }, { row: 1, col: 5 }, 1_000_000);
+    expect(abs).toBe("line 2");
+    m.dispose();
+  });
+
+  it("a single-screen extraction equals extractSelection over visibleRowTexts", async () => {
+    const m = await seeded(20, 4, 10); // depth 6, viewport = lines 7..10
+    const depth = m.scrollbackDepth();
+    expect(depth).toBe(6);
+    // Select visible rows 1..2 (absolute depth+1 .. depth+2) mid-column.
+    const visible = m.visibleRowTexts(0);
+    const legacy = [
+      visible[1]!.slice(2).replace(/\s+$/u, ""),
+      visible[2]!.slice(0, 4).replace(/\s+$/u, ""),
+    ].join("\n");
+    const abs = m.extractAbsoluteText(
+      { row: depth + 1, col: 2 },
+      { row: depth + 2, col: 3 },
+      1_000_000,
+    );
+    expect(abs).toBe(legacy);
+    m.dispose();
+  });
+
+  it("extracts a span far beyond one screen, oldest scrollback included", async () => {
+    const m = await seeded(20, 4, 30);
+    const text = m.extractAbsoluteText({ row: 0, col: 0 }, { row: 29, col: 19 }, 1_000_000);
+    const lines = text.split("\n");
+    expect(lines[0]).toBe("line 1");
+    expect(lines[29]).toBe("line 30");
+    expect(lines).toHaveLength(30);
+    m.dispose();
+  });
+
+  it("clamps out-of-buffer endpoints and selects edge-to-edge across them", async () => {
+    const m = await seeded(20, 4, 5);
+    // start.row negative → col resets to 0; end.row beyond the buffer → full last line.
+    const text = m.extractAbsoluteText({ row: -3, col: 9 }, { row: 999, col: 0 }, 1_000_000);
+    expect(text.split("\n")[0]).toBe("line 1");
+    expect(text.split("\n")).toContain("line 5");
+    m.dispose();
+  });
+
+  it("stops accumulating once the byte cap is exceeded (over-cap result, never unbounded)", async () => {
+    const m = await seeded(20, 4, 40);
+    const capped = m.extractAbsoluteText({ row: 0, col: 0 }, { row: 39, col: 19 }, 30);
+    const bytes = Buffer.byteLength(capped, "utf8");
+    expect(bytes).toBeGreaterThan(30); // the caller's clipboard cap still refuses
+    expect(capped.split("\n").length).toBeLessThan(40); // but the build stopped early
+    m.dispose();
+  });
+
+  it("collapses wide-glyph spacers exactly like visibleRowTexts", async () => {
+    const m = new PaneMirror(20, 3);
+    m.write("你好 world");
+    await flushed(m, "world");
+    // The CJK chars occupy 2 cells each but ONE char in the extracted text.
+    const text = m.extractAbsoluteText({ row: 0, col: 0 }, { row: 0, col: 19 }, 1_000_000);
+    expect(text).toBe("你好 world");
+    expect(text).toBe(m.visibleRowTexts(0)[0]);
+    m.dispose();
+  });
+
+  it("lineTrim stays 0 below the cap and counts rotations at the cap", async () => {
+    const m = await seeded(20, 4, 20);
+    expect(m.lineTrim()).toBe(0); // depth 16, nowhere near the 5000 cap
+    m.dispose();
+    // A tiny scrollback (10) saturates fast: 20 lines into a 4-row viewport
+    // leaves 16 scrolled; the first 10 grow viewportY, the last 6 rotate.
+    const small = new PaneMirror(20, 4, 10);
+    small.write(Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join("\r\n"));
+    await flushed(small, "line 20");
+    expect(small.scrollbackDepth()).toBe(10); // saturated at the cap
+    expect(small.lineTrim()).toBe(6);
+    // The absolute index of surviving content shifted by exactly the trim:
+    // buffer line 0 is now "line 7" (lines 1..6 rotated out).
+    expect(small.bufferLines()[0]).toBe("line 7");
+    small.dispose();
+  });
+});

--- a/packages/daemon/src/tui/mirror/pane-mirror.ts
+++ b/packages/daemon/src/tui/mirror/pane-mirror.ts
@@ -40,6 +40,7 @@ import {
   type GraphemeOverride,
 } from "./blit.ts";
 import { AckWriter } from "./ack-writer.ts";
+import { extractSelection, type Cell } from "./selection.ts";
 
 /** OpenTUI TextAttributes bit values (kept literal to avoid the dep here). */
 const ATTR_BOLD = 1;
@@ -163,6 +164,18 @@ export class PaneMirror {
    *  fast path. Counted from xterm's onScroll (which fires once per scrolled
    *  line and keeps firing at the scrollback cap, unlike the saturating payload). */
   private _pendingScroll = 0;
+  // ── Absolute-line stability (M25.6) ────────────────────────────────────────
+  /** Lines TRIMMED off the top of the scrollback (monotonic): once viewportY
+   *  saturates at the scrollback cap, each further scroll rotates one line out
+   *  and every retained line's absolute index drops by one. An absolute-space
+   *  consumer (the drag selection) records `lineTrim()` when it anchors and
+   *  subtracts the delta later, so its anchor keeps naming the same content.
+   *  Detected as "onScroll fired but viewportY did not grow". A scrollback
+   *  clear (`clear-history` / ED3) collapses viewportY instead — that index
+   *  shift is NOT counted; stale absolute cells then clamp into the buffer
+   *  (the selection was over content that no longer exists anyway). */
+  private _trimmed = 0;
+  private _lastViewportY = 0;
   /** The alt/normal buffer swapped (`?1049h/l`) — the whole grid is new. */
   private _bufferSwapped = false;
   /** Shadow of the last-blitted rows' raw xterm cell data (`_line._data`,
@@ -175,12 +188,19 @@ export class PaneMirror {
    *  incremental. */
   private _incremental = true;
 
-  constructor(cols: number, rows: number) {
+  constructor(cols: number, rows: number, scrollback = 5000) {
     this.cols = cols;
     this.rows = rows;
-    this.term = new Terminal({ cols, rows, allowProposedApi: true, scrollback: 5000 });
+    this.term = new Terminal({ cols, rows, allowProposedApi: true, scrollback });
     this.term.onWriteParsed(() => this._version++);
-    this.term.onScroll(() => this._pendingScroll++);
+    this.term.onScroll(() => {
+      this._pendingScroll++;
+      // Trim detection (M25.6): below the cap each scroll grows viewportY by
+      // one; at the cap it stays put and the oldest line rotated out.
+      const vy = this.term.buffer.active.viewportY;
+      if (vy === this._lastViewportY) this._trimmed++;
+      else this._lastViewportY = vy;
+    });
     this.term.buffer.onBufferChange(() => {
       this._bufferSwapped = true;
       this._version++;
@@ -234,7 +254,18 @@ export class PaneMirror {
     this._shadow = null;
     this._pendingScroll = 0;
     this._bufferSwapped = false;
+    // Reflow moved viewportY without scrolls — re-baseline the trim detector so
+    // the first post-resize scroll isn't miscounted as a cap rotation. (Reflow
+    // also re-indexes wrapped lines; a mid-resize drag selection is approximate
+    // by nature and clamps safely.)
+    this._lastViewportY = this.term.buffer.active.viewportY;
     this._version++;
+  }
+
+  /** Monotonic count of lines trimmed off the scrollback top (M25.6) — the
+   *  absolute-line drift an anchored consumer must subtract. See {@link _trimmed}. */
+  lineTrim(): number {
+    return this._trimmed;
   }
 
   /** Lines available above the live viewport (how far back scroll can go). */
@@ -558,6 +589,48 @@ export class PaneMirror {
       out.push(line ? line.translateToString(true) : "");
     }
     return out;
+  }
+
+  /**
+   * Extract the text of an ORDERED absolute-line range (M25.6) — the release
+   * path of a selection that may span far beyond the viewport. Each buffer
+   * line reads via `translateToString(true)` — the SAME trim/collapse as
+   * {@link visibleRowTexts} (wide-glyph spacers collapse, trailing blanks trim)
+   * — and the columns/joining go through {@link extractSelection}, so a
+   * selection that happens to fit one screen extracts byte-identically to the
+   * old visible-rows path. Wrapped lines stay separate visual rows joined with
+   * "\n", exactly as the on-screen copy always has.
+   *
+   * `maxBytes` bounds the string BUILT here: accumulation stops once the raw
+   * line total strictly exceeds it, so a runaway span never materializes tens
+   * of MB — the caller's clipboard cap (which refuses anything over the limit)
+   * still sees an over-limit byte count and refuses honestly.
+   */
+  extractAbsoluteText(start: Cell, end: Cell, maxBytes: number): string {
+    const buf = this.term.buffer.active;
+    const last = buf.length - 1;
+    if (last < 0 || end.row < 0 || start.row > last) return "";
+    const lo = Math.max(0, Math.min(start.row, last));
+    const hi = Math.max(0, Math.min(end.row, last));
+    const rowTexts: string[] = [];
+    let bytes = 0;
+    for (let y = lo; y <= hi; y++) {
+      const line = buf.getLine(y);
+      const text = line ? line.translateToString(true) : "";
+      rowTexts.push(text);
+      bytes += Buffer.byteLength(text, "utf8") + 1; // +1 for the joining "\n"
+      if (bytes > maxBytes) break;
+    }
+    // Shift the range to the accumulated slice. A clamped start selects from
+    // column 0 (its true start line is gone/off-buffer); a clamped or
+    // byte-truncated end extends to its last line's end (Infinity clamps to
+    // the row length inside rowSelectionRange).
+    const lastRowAbs = lo + rowTexts.length - 1;
+    return extractSelection(
+      rowTexts,
+      { row: 0, col: start.row === lo ? start.col : 0 },
+      { row: rowTexts.length - 1, col: lastRowAbs === end.row ? end.col : Infinity },
+    );
   }
 
   dispose(): void {

--- a/packages/daemon/src/tui/mirror/pane-surface.tsx
+++ b/packages/daemon/src/tui/mirror/pane-surface.tsx
@@ -31,7 +31,7 @@ import { appendFileSync } from "node:fs";
 import type { SessionMirror } from "./session-mirror.ts";
 import type { CursorState } from "./pane-mirror.ts";
 import { swapCells, paintBg, type GraphemeOverride } from "./blit.ts";
-import { rowSelectionRange, type Cell } from "./selection.ts";
+import { rowSelectionRange, visibleSelRows, type Cell } from "./selection.ts";
 import type { SearchMatch } from "./search-model.ts";
 
 /** The scrollback-search highlight payload for one pane: matches keyed by
@@ -60,7 +60,10 @@ export interface PaneSurfaceOptions extends RenderableOptions<FrameBufferRendera
   paneFocused?: boolean;
   /** Bumps (coalesced, once per state tick) when this pane's content changed. */
   contentVersion?: number;
-  /** The drag selection on THIS pane (already surface/pane-filtered), or null. */
+  /** The drag selection on THIS pane (already surface/pane-filtered and
+   *  ordered), or null. ABSOLUTE buffer lines (M25.6): the walk maps them to
+   *  visible rows per-frame against the pane's live baseY (depth − offset), so
+   *  the highlight stays glued to its content while the view scrolls. */
   selRange?: { start: Cell; end: Cell } | null;
   search?: PaneSearchHighlight | null;
 }
@@ -234,7 +237,14 @@ class PaneSurfaceRenderable extends FrameBufferRenderable {
     this._lastScroll = this._scrollOffset;
     this._lastFocused = this._focusedPane;
 
-    const newSelRows = this.selRows(h);
+    // The view's absolute→visible mapping (M25.6), re-read every walk: both the
+    // selection (absolute cells) and the search matches (absolute lines) resolve
+    // to visible rows against the CURRENT baseY, so a scroll — or new content
+    // pushing the depth — moves the highlights with their text. Same clamping as
+    // the blit's own offset math (depth here == viewportY there).
+    const depth = this._mirror.scrollbackDepth(this._paneId);
+    const baseY = depth - Math.min(Math.max(0, this._scrollOffset), depth);
+    const newSelRows = this.selRows(h, baseY);
     const newSearchRows = this.searchRows(h);
     // The live cursor (M21.6): the focused pane drives the hardware cursor; an
     // unfocused pane paints a quiet marker on its cursor cell. Read once.
@@ -309,7 +319,7 @@ class PaneSurfaceRenderable extends FrameBufferRenderable {
     if (sel) {
       for (let i = 0; i < newSelRows.length; i++) {
         const y = newSelRows[i]!;
-        const r = rowSelectionRange(y, w, sel.start, sel.end);
+        const r = rowSelectionRange(baseY + y, w, sel.start, sel.end);
         if (r) swapCells(buffers, w, y, r.from, r.to);
       }
     }
@@ -370,15 +380,12 @@ class PaneSurfaceRenderable extends FrameBufferRenderable {
   }
 
   /** Visible rows covered by the current drag selection (clamped), or []. The
-   *  range arrives ordered (app.tsx passes `orderCells`). */
-  private selRows(height: number): number[] {
+   *  range arrives ordered (app.tsx passes `orderCells`) in ABSOLUTE buffer
+   *  lines; `baseY` is the view's current absolute top (M25.6). */
+  private selRows(height: number, baseY: number): number[] {
     const sel = this._sel;
     if (!sel) return [];
-    const lo = Math.max(0, sel.start.row);
-    const hi = Math.min(height - 1, sel.end.row);
-    const out: number[] = [];
-    for (let y = lo; y <= hi; y++) out.push(y);
-    return out;
+    return visibleSelRows(sel.start, sel.end, baseY, height);
   }
 
   /** Distinct visible rows carrying a search match (clamped), or []. */

--- a/packages/daemon/src/tui/mirror/selection.test.ts
+++ b/packages/daemon/src/tui/mirror/selection.test.ts
@@ -15,6 +15,9 @@ import {
   wheelScrollsLocal,
   selectBadgeLabel,
   chunkByBytes,
+  visibleSelRows,
+  visibleSelectionSpans,
+  trimAdjustCell,
   ATTR_INVERSE,
   type Cell,
 } from "./selection.ts";
@@ -229,6 +232,116 @@ describe("chunkByBytes", () => {
   it("reassembles to the original", () => {
     const s = "the quick brown fox — jumped over 42 lazy dogs";
     expect(chunkByBytes(s, 5).join("")).toBe(s);
+  });
+});
+
+describe("absolute-space mapping (M25.6)", () => {
+  // A 4-row pane over a buffer whose live viewport starts at absolute line 100
+  // when at the bottom (scrollbackDepth 100, offset 0 → baseY 100).
+  const H = 4;
+
+  describe("visibleSelRows", () => {
+    it("maps a fully visible range to its viewport rows", () => {
+      expect(visibleSelRows({ row: 101, col: 0 }, { row: 102, col: 5 }, 100, H)).toEqual([1, 2]);
+    });
+    it("clamps a range extending above the view (start off-screen)", () => {
+      expect(visibleSelRows({ row: 90, col: 3 }, { row: 101, col: 2 }, 100, H)).toEqual([0, 1]);
+    });
+    it("clamps a range extending below the view (end off-screen)", () => {
+      expect(visibleSelRows({ row: 102, col: 0 }, { row: 300, col: 9 }, 100, H)).toEqual([2, 3]);
+    });
+    it("covers the whole viewport when both ends are off-screen", () => {
+      expect(visibleSelRows({ row: 10, col: 4 }, { row: 900, col: 0 }, 100, H)).toEqual([
+        0, 1, 2, 3,
+      ]);
+    });
+    it("is empty when the range is entirely above or below the view", () => {
+      expect(visibleSelRows({ row: 10, col: 0 }, { row: 50, col: 9 }, 100, H)).toEqual([]);
+      expect(visibleSelRows({ row: 200, col: 0 }, { row: 250, col: 9 }, 100, H)).toEqual([]);
+    });
+  });
+
+  describe("visibleSelectionSpans", () => {
+    const len = (n: number) => () => n;
+    it("full-width middle rows, column-clipped first/last rows", () => {
+      const spans = visibleSelectionSpans(
+        { row: 100, col: 3 },
+        { row: 103, col: 6 },
+        100,
+        H,
+        len(10),
+      );
+      expect(spans).toEqual([
+        { row: 0, from: 3, to: 9 },
+        { row: 1, from: 0, to: 9 },
+        { row: 2, from: 0, to: 9 },
+        { row: 3, from: 0, to: 6 },
+      ]);
+    });
+    it("off-screen endpoints select the visible rows edge-to-edge", () => {
+      const spans = visibleSelectionSpans(
+        { row: 90, col: 7 },
+        { row: 200, col: 1 },
+        100,
+        H,
+        len(8),
+      );
+      expect(spans).toEqual([
+        { row: 0, from: 0, to: 7 },
+        { row: 1, from: 0, to: 7 },
+        { row: 2, from: 0, to: 7 },
+        { row: 3, from: 0, to: 7 },
+      ]);
+    });
+    it("a partially visible single-row selection keeps its column interval", () => {
+      const spans = visibleSelectionSpans(
+        { row: 100, col: 2 },
+        { row: 100, col: 5 },
+        98,
+        H,
+        len(10),
+      );
+      expect(spans).toEqual([{ row: 2, from: 2, to: 5 }]);
+    });
+    it("wide-glyph rows: a shorter char-space rowLen clamps the columns into it", () => {
+      // The pane is 10 cells wide but the row's TEXT is 6 chars (wide glyphs
+      // collapse to one char each) — a grid-column head at 9 clamps to char 5.
+      const spans = visibleSelectionSpans(
+        { row: 100, col: 1 },
+        { row: 100, col: 9 },
+        100,
+        H,
+        len(6),
+      );
+      expect(spans).toEqual([{ row: 0, from: 1, to: 5 }]);
+    });
+    it("omits zero-length rows entirely", () => {
+      const rowLen = (r: number) => (r === 1 ? 0 : 10);
+      const spans = visibleSelectionSpans(
+        { row: 100, col: 0 },
+        { row: 102, col: 9 },
+        100,
+        H,
+        rowLen,
+      );
+      expect(spans).toEqual([
+        { row: 0, from: 0, to: 9 },
+        { row: 2, from: 0, to: 9 },
+      ]);
+    });
+  });
+
+  describe("trimAdjustCell", () => {
+    it("no trim → the cell is untouched (same object)", () => {
+      const c: Cell = { row: 42, col: 3 };
+      expect(trimAdjustCell(c, 0)).toBe(c);
+    });
+    it("follows the content down by the trimmed line count", () => {
+      expect(trimAdjustCell({ row: 42, col: 3 }, 5)).toEqual({ row: 37, col: 3 });
+    });
+    it("a cell whose line was trimmed away pins to the oldest retained line", () => {
+      expect(trimAdjustCell({ row: 4, col: 7 }, 10)).toEqual({ row: 0, col: 0 });
+    });
   });
 });
 

--- a/packages/daemon/src/tui/mirror/selection.ts
+++ b/packages/daemon/src/tui/mirror/selection.ts
@@ -11,15 +11,21 @@
  * cell is selected if it falls between the anchor and head in row-major order.
  */
 
-/** A cell in surface-local coordinates: mirror = snapshot row + pane column;
- *  editor = buffer line + buffer column. */
+/** A cell in surface-local coordinates. Mirror (M25.6): ABSOLUTE xterm buffer
+ *  line (0 = oldest scrollback line) + pane column — anchored to CONTENT, so
+ *  the selection survives scrolling mid-drag and can span many screens. Editor:
+ *  buffer line + buffer column (already absolute by nature). A visible pane row
+ *  `r` at scroll offset `off` maps to absolute line `baseY + r` where
+ *  `baseY = scrollbackDepth − off` (the search path's existing arithmetic —
+ *  see PaneMirror.bufferLines). */
 export interface Cell {
   row: number;
   col: number;
 }
 
 /** An active selection on one surface. `anchor` is where the drag began, `head`
- *  the current/last pointer cell; either may precede the other. */
+ *  the current/last pointer cell; either may precede the other. Mirror cells
+ *  are in ABSOLUTE buffer coordinates (see {@link Cell}). */
 export type Selection =
   | { surface: "mirror"; paneId: string; anchor: Cell; head: Cell }
   | { surface: "editor"; anchor: Cell; head: Cell };
@@ -76,6 +82,68 @@ export function extractSelection(
     out.push(seg);
   }
   return out.join("\n");
+}
+
+// ── Absolute-space mapping (M25.6) ──────────────────────────────────────────
+// The selection model is anchored to ABSOLUTE buffer lines; the render works in
+// visible pane rows. These mappers are the one bridge: given the pane's current
+// baseY (scrollbackDepth − scrollOffset) and height, an absolute range resolves
+// to the visible rows it covers and the per-row column spans to highlight.
+
+/** A highlighted span on one VISIBLE pane row (row is viewport-relative). */
+export interface VisibleSpan {
+  row: number;
+  from: number;
+  to: number;
+}
+
+/** Visible pane rows [0,height) covered by an ORDERED absolute range at the
+ *  current view (`baseY` = scrollbackDepth − scrollOffset). Empty when the
+ *  whole range is scrolled off either edge. */
+export function visibleSelRows(start: Cell, end: Cell, baseY: number, height: number): number[] {
+  const lo = Math.max(0, start.row - baseY);
+  const hi = Math.min(height - 1, end.row - baseY);
+  const out: number[] = [];
+  for (let r = lo; r <= hi; r++) out.push(r);
+  return out;
+}
+
+/**
+ * Map an ORDERED absolute range to the visible per-row column spans at the
+ * current view. `rowLen(viewRow)` supplies each visible row's selectable cell
+ * count (grid width for the framebuffer swap; the row's char count for run
+ * tinting — wide glyphs collapse to one char there, so the two callers pass
+ * different lengths and each gets spans clamped to ITS space). Rows whose
+ * span is empty (zero-length row, or a first/last-row column interval that
+ * falls outside it) are omitted.
+ */
+export function visibleSelectionSpans(
+  start: Cell,
+  end: Cell,
+  baseY: number,
+  height: number,
+  rowLen: (viewRow: number) => number,
+): VisibleSpan[] {
+  const out: VisibleSpan[] = [];
+  for (const r of visibleSelRows(start, end, baseY, height)) {
+    const range = rowSelectionRange(baseY + r, rowLen(r), start, end);
+    if (range) out.push({ row: r, from: range.from, to: range.to });
+  }
+  return out;
+}
+
+/**
+ * Re-anchor an absolute cell after the buffer trimmed `trimDelta` lines off its
+ * top (the scrollback cap rotating mid-drag): every retained line's index
+ * dropped by the trim, so the cell follows its content down. A cell whose line
+ * was trimmed away clamps to the oldest retained line (row 0), col 0 — the
+ * selection top pins to the oldest text still in the buffer.
+ */
+export function trimAdjustCell(cell: Cell, trimDelta: number): Cell {
+  if (trimDelta <= 0) return cell;
+  const row = cell.row - trimDelta;
+  if (row < 0) return { row: 0, col: 0 };
+  return { row, col: cell.col };
 }
 
 /**

--- a/packages/daemon/src/tui/mirror/session-mirror.ts
+++ b/packages/daemon/src/tui/mirror/session-mirror.ts
@@ -448,6 +448,30 @@ export class SessionMirror {
     return this.mirrors.get(id)?.visibleRowTexts(scrollOffset) ?? [];
   }
 
+  /** A pane's LIVE scrollback depth (M25.6) — read at event time by the drag
+   *  machine, ahead of the 8ms tick's LivePane snapshot. 0 for an unknown pane. */
+  scrollbackDepth(id: string): number {
+    return this.mirrors.get(id)?.scrollbackDepth() ?? 0;
+  }
+
+  /** A pane's monotonic trimmed-lines counter (M25.6) — see
+   *  {@link PaneMirror.lineTrim}. 0 for an unknown pane. */
+  lineTrim(id: string): number {
+    return this.mirrors.get(id)?.lineTrim() ?? 0;
+  }
+
+  /** Extract an ORDERED absolute-line range from a pane's buffer (M25.6) — the
+   *  selection release path. Empty for an unknown pane. See
+   *  {@link PaneMirror.extractAbsoluteText}. */
+  extractText(
+    id: string,
+    start: { row: number; col: number },
+    end: { row: number; col: number },
+    maxBytes: number,
+  ): string {
+    return this.mirrors.get(id)?.extractAbsoluteText(start, end, maxBytes) ?? "";
+  }
+
   /** A pane's live cursor state (position + DECTCEM/DECSCUSR), for the hardware
    *  cursor (M21.6). Null for an unknown pane. */
   cursorState(id: string): CursorState | null {


### PR DESCRIPTION
Card #114, the M25 closer: selection anchored in absolute buffer space — scroll while selecting, edge auto-scroll, multi-screen copies byte-compared to capture-pane truth, scrollback-rotation drift handled. 1593 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)