### PR TITLE
fix(team-tui): guard <Show> children against null prompt/activeProj on launch

### DIFF
--- a/packages/daemon/src/tui/team/index.tsx
+++ b/packages/daemon/src/tui/team/index.tsx
@@ -1020,11 +1020,13 @@ render(() => {
   function promptRow() {
     return (
       <Show when={prompt()}>
-        <box paddingLeft={1} paddingRight={1} flexDirection="row" gap={1}>
-          <text fg={toRGBA(theme.accent)}>{promptLabel(prompt()!.kind)}</text>
-          <text fg={toRGBA(theme.fg)}>{prompt()!.value}</text>
-          <text fg={toRGBA(theme.fgMuted)}>_</text>
-        </box>
+        {(p) => (
+          <box paddingLeft={1} paddingRight={1} flexDirection="row" gap={1}>
+            <text fg={toRGBA(theme.accent)}>{promptLabel(p().kind)}</text>
+            <text fg={toRGBA(theme.fg)}>{p().value}</text>
+            <text fg={toRGBA(theme.fgMuted)}>_</text>
+          </box>
+        )}
       </Show>
     );
   }
@@ -1401,11 +1403,11 @@ render(() => {
                     {/* header: name · dir · branch · ide.yml */}
                     <box flexDirection="row" gap={1} paddingRight={1}>
                       <text fg={toRGBA(theme.accent)} attributes={TextAttributes.BOLD}>
-                        {activeProj()!.name}
+                        {activeProj()?.name ?? ""}
                       </text>
-                      <text fg={toRGBA(theme.fgMuted)}>{activeProj()!.dir ?? ""}</text>
-                      <text fg={toRGBA(theme.fgMuted)}>{activeProj()!.gitBranch ?? ""}</text>
-                      <Show when={activeProj()!.hasIdeYml}>
+                      <text fg={toRGBA(theme.fgMuted)}>{activeProj()?.dir ?? ""}</text>
+                      <text fg={toRGBA(theme.fgMuted)}>{activeProj()?.gitBranch ?? ""}</text>
+                      <Show when={activeProj()?.hasIdeYml}>
                         <text fg={toRGBA(theme.fgMuted)}>ide.yml</text>
                       </Show>
                     </box>


### PR DESCRIPTION
> **Heads-up: this is an AI-generated PR.** It's less a polished contribution and more a **note documenting what was required to get the team cockpit (`tmux-ide`) running** on a fresh install (v2.8.0, Node v22.14.0, macOS). Treat the framing/tone as a report; the code change itself is small and verified. Please adjust to taste.

## What happened

On `tmux-ide` (the team/cockpit TUI) the app crashed immediately on launch:

```
[ERROR] TypeError: null is not an object (evaluating 'prompt().kind')
    at promptRow (packages/daemon/src/tui/team/index.tsx:1024)
    at FullApp   (packages/daemon/src/tui/team/index.tsx:1308)
```

After fixing that, the next render hit the same class of bug:

```
[ERROR] TypeError: undefined is not an object (evaluating 'activeProj().name')
    at FullApp (packages/daemon/src/tui/team/index.tsx:1406)
```

Both stack traces run through `solid-js/dist/server.js` (`children` → `createMemo` → `runComputation`).

## Root cause

`<Show when={...}>` with **plain-JSX children** instantiates those children eagerly — they are created during render regardless of whether `when` is truthy. So on first render, while the guarded signal is still `null`/`undefined`:

- `promptRow()` dereferences `prompt()!.kind` / `prompt()!.value`
- the active-project header dereferences `activeProj()!.name` / `.dir` / `.gitBranch` / `.hasIdeYml`

…and each throws before the guard can suppress it.

## Fix

- **`promptRow`** — switch to Solid's callback-child form (`<Show>{(p) => …}</Show>`), so children only evaluate when `prompt()` is truthy and get a non-null accessor.
- **active-project header** — use optional chaining, matching the block's own existing style a few lines down (`activeProj()?.sessions ?? []`).

```diff
       <Show when={prompt()}>
-        <box …>
-          <text …>{promptLabel(prompt()!.kind)}</text>
-          <text …>{prompt()!.value}</text>
-        </box>
+        {(p) => (
+          <box …>
+            <text …>{promptLabel(p().kind)}</text>
+            <text …>{p().value}</text>
+          </box>
+        )}
       </Show>
...
-        {activeProj()!.name}
+        {activeProj()?.name ?? ""}
-        <Show when={activeProj()!.hasIdeYml}>
+        <Show when={activeProj()?.hasIdeYml}>
```

I swept the rest of the file for the same shape (`grep '()!\.'`). The only other two hits — `prompt()!.value` in the key handler and `confirm()!.message` in `statusRow` — are inside synchronous `if`/ternary guards, not eager JSX children, so they're safe and left untouched.

## Verification

Transpile-checked with `Bun.Transpiler({loader:'tsx'})` (syntax OK). Not exercised end-to-end in a full TTY session — the change is the standard Solid idiom for exactly this crash, so a maintainer sanity-check on the live cockpit is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
