### PR TITLE
fix(tui): forward Ctrl-C to focused pane

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -819,6 +819,10 @@ const packedToRgba = (packed: number | null, fallback: RGBA): RGBA => {
 // synchronous fd write because queued stdout is not reliable during `exit`.
 let hostAutowrap: HostAutowrapGuard | null = null;
 const appRenderer = await createCliRenderer({
+  // Ctrl-C belongs to the focused terminal/editor. The app's explicit global
+  // exit is Ctrl-Q; OpenTUI otherwise destroys the renderer before Ctrl-C can
+  // reliably pass through to the mirrored pane.
+  exitOnCtrlC: false,
   // targetFps stays EXPLICIT: @opentui 0.4.3 silently defaults it to 30
   // (maxFps already defaults to 60). Re-confirmed on the 0.4.3 bump (M21.2).
   targetFps: 60,

--- a/scripts/perf-mirror.mjs
+++ b/scripts/perf-mirror.mjs
@@ -214,10 +214,10 @@ async function scenarioInput() {
   }
   await sleep(400);
   const out = { echo: readCol(INPUT_LOG, 1), paint: readCol(INPUT_LOG, 2) };
-  // Drop the half-typed line by interrupting the TARGET pane directly. NEVER
-  // send C-c to the host: the app exits on ctrl-c, which would kill the mirror
-  // and silence every later scenario.
-  tmuxQuiet(["send-keys", "-t", TARGET, "C-c"]);
+  // Drop the half-typed line through the app. This is also the harness's
+  // regression check that Ctrl-C reaches the focused pane without exiting the
+  // mirror; every later scenario depends on the host staying alive.
+  sendHostKey("C-c");
   return out;
 }
 


### PR DESCRIPTION
## Summary
- disable OpenTUI's global Ctrl-C exit behavior
- preserve Ctrl-Q as the explicit quit or detach shortcut
- exercise Ctrl-C forwarding through the live mirror performance harness

## Verification
- pnpm check
- shortened live perf-mirror run, including the Ctrl-C regression path