### PR TITLE
feat(core): add canonical project resolver

### DIFF
--- a/packages/daemon/src/lib/__tests__/project-resolver.test.ts
+++ b/packages/daemon/src/lib/__tests__/project-resolver.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  resolveProject,
+  type ProjectResolverIo,
+  type ResolveProjectOptions,
+} from "../project-resolver.ts";
+
+interface FakeIoOptions {
+  files?: string[];
+  realpaths?: Record<string, string>;
+  runGit?: ProjectResolverIo["runGit"];
+}
+
+function fakeIo(options: FakeIoOptions = {}): ProjectResolverIo {
+  const files = new Set(options.files ?? []);
+  return {
+    exists: (path) => files.has(path),
+    realpath: (path) => options.realpaths?.[path] ?? path,
+    runGit: options.runGit ?? (async () => null),
+  };
+}
+
+function gitIo(topLevel: string, commonDir: string): ProjectResolverIo {
+  return fakeIo({
+    runGit: async (args) => {
+      if (args.includes("--show-toplevel")) return topLevel;
+      if (args.includes("--git-common-dir")) return commonDir;
+      return null;
+    },
+  });
+}
+
+async function resolveWithIo(
+  dir: string,
+  io: ProjectResolverIo,
+  options: Omit<ResolveProjectOptions, "io"> = {},
+) {
+  return resolveProject(dir, { ...options, io });
+}
+
+describe("resolveProject", () => {
+  it("resolves a nested Git directory to its canonical working-tree root", async () => {
+    const result = await resolveWithIo("/repo/apps/web", gitIo("/repo", ".git"));
+
+    expect(result.inputDir).toBe("/repo/apps/web");
+    expect(result.projectRoot).toBe("/repo");
+    expect(result.identitySource).toBe("git-common-dir");
+    expect(result.identityAnchor).toBe("/repo/.git");
+    expect(result.identityKey).toMatch(/^git-[a-f0-9]{64}$/);
+  });
+
+  it("gives a linked worktree and main checkout one identity but separate roots", async () => {
+    const main = await resolveWithIo("/repo", gitIo("/repo", ".git"));
+    const linked = await resolveWithIo(
+      "/worktrees/feature/src",
+      gitIo("/worktrees/feature", "/repo/.git"),
+    );
+
+    expect(linked.projectRoot).not.toBe(main.projectRoot);
+    expect(linked.identityKey).toBe(main.identityKey);
+    expect(linked.identityAnchor).toBe(main.identityAnchor);
+  });
+
+  it("prefers the nearest workspace config over the nearest legacy config", async () => {
+    const io = fakeIo({
+      files: ["/repo/.tmux-ide/workspace.yml", "/repo/apps/api/ide.yml"],
+    });
+    const result = await resolveWithIo("/repo/apps/api/src", io);
+
+    expect(result.config).toEqual({
+      kind: "workspace",
+      path: "/repo/.tmux-ide/workspace.yml",
+      explicit: false,
+    });
+    expect(result.workspaceConfigPath).toBe("/repo/.tmux-ide/workspace.yml");
+    expect(result.legacyConfigPath).toBe("/repo/apps/api/ide.yml");
+    expect(result.projectRoot).toBe("/repo");
+  });
+
+  it("lets an explicit config path win over discovered files", async () => {
+    const io = fakeIo({ files: ["/repo/.tmux-ide/workspace.yml", "/repo/ide.yml"] });
+    const result = await resolveWithIo("/repo/apps/api", io, {
+      explicitConfigPath: "../../config/custom.yml",
+    });
+
+    expect(result.config).toEqual({
+      kind: "workspace",
+      path: "/repo/config/custom.yml",
+      explicit: true,
+    });
+    expect(result.projectRoot).toBe("/repo/config");
+  });
+
+  it("uses canonical config paths and a canonical-realpath identity outside Git", async () => {
+    const io = fakeIo({
+      files: ["/actual/project/ide.yml"],
+      realpaths: {
+        "/alias/project": "/actual/project",
+        "/actual/project/ide.yml": "/actual/project/ide.yml",
+      },
+    });
+    const result = await resolveWithIo("/alias/project", io);
+
+    expect(result.inputDir).toBe("/actual/project");
+    expect(result.projectRoot).toBe("/actual/project");
+    expect(result.identitySource).toBe("canonical-realpath");
+    expect(result.identityAnchor).toBe("/actual/project");
+    expect(result.identityKey).toMatch(/^path-[a-f0-9]{64}$/);
+    expect(result.config.kind).toBe("legacy");
+  });
+
+  it("falls back to the canonical input directory for a config-free non-Git project", async () => {
+    const io = fakeIo({ realpaths: { "/alias/project": "/actual/project" } });
+    const result = await resolveWithIo("/alias/project", io);
+
+    expect(result.projectRoot).toBe("/actual/project");
+    expect(result.config).toEqual({ kind: "none", path: null, explicit: false });
+  });
+
+  it("handles unavailable Git and malformed output safely and deterministically", async () => {
+    const unavailable = fakeIo({
+      runGit: async () => {
+        throw new Error("ENOENT");
+      },
+    });
+    const malformed = fakeIo({
+      runGit: async (args) => (args.includes("--show-toplevel") ? "/repo\n/untrusted" : null),
+    });
+
+    const unavailableResult = await resolveWithIo("/repo/app", unavailable);
+    const malformedA = await resolveWithIo("/repo/app", malformed);
+    const malformedB = await resolveWithIo("/repo/app", malformed);
+
+    expect(unavailableResult.identitySource).toBe("canonical-realpath");
+    expect(unavailableResult.projectRoot).toBe("/repo/app");
+    expect(malformedA.identitySource).toBe("canonical-realpath");
+    expect(malformedA.identityKey).toBe(malformedB.identityKey);
+  });
+
+  it("shares identity across real temporary Git worktrees", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "tmux-ide-resolver-"));
+    const main = join(tempRoot, "main");
+    const linked = join(tempRoot, "linked");
+
+    try {
+      mkdirSync(main);
+      execFileSync("git", ["init", "--quiet", main]);
+      execFileSync("git", [
+        "-C",
+        main,
+        "-c",
+        "user.name=tmux-ide-test",
+        "-c",
+        "user.email=test@tmux-ide.invalid",
+        "commit",
+        "--quiet",
+        "--allow-empty",
+        "-m",
+        "init",
+      ]);
+      execFileSync("git", ["-C", main, "worktree", "add", "--quiet", "-b", "linked", linked]);
+
+      const mainResult = await resolveProject(main);
+      const linkedResult = await resolveProject(linked);
+
+      expect(mainResult.projectRoot).toBe(realpathSync(main));
+      expect(linkedResult.projectRoot).toBe(realpathSync(linked));
+      expect(linkedResult.identitySource).toBe("git-common-dir");
+      expect(linkedResult.identityKey).toBe(mainResult.identityKey);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/daemon/src/lib/project-probe.test.ts
+++ b/packages/daemon/src/lib/project-probe.test.ts
@@ -49,6 +49,14 @@ describe("probeProject", () => {
     expect(probe.hasIdeYml).toBe(false);
   });
 
+  it("preserves hasIdeYml semantics for the input directory while using discovery", async () => {
+    const probe = await probeProject(
+      "/work/foo/nested",
+      makeIo({ exists: (path) => path === "/work/foo/ide.yml" }),
+    );
+    expect(probe.hasIdeYml).toBe(false);
+  });
+
   it("captures git origin + branch when both git calls succeed", async () => {
     const probe = await probeProject(
       "/work/foo",

--- a/packages/daemon/src/lib/project-probe.ts
+++ b/packages/daemon/src/lib/project-probe.ts
@@ -1,18 +1,19 @@
 /**
  * Project probe — inspects a directory and returns identity facts (name from
- * basename, ide.yml presence, git origin/branch). Pure-ish wrapper over a few
- * filesystem and git child-process calls; the io functions are pluggable for
- * tests so we don't need a full mock filesystem.
+ * basename, legacy ide.yml presence, git origin/branch). Canonical path and
+ * config facts delegate to project-resolver; the io functions remain
+ * pluggable so tests don't need a full mock filesystem.
  *
  * All git invocations are hard-bounded by a 2s timeout — we never want a
  * single misbehaving repo to hang an HTTP request.
  */
 
-import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
 import { basename, isAbsolute, resolve } from "node:path";
-
-const GIT_TIMEOUT_MS = 2_000;
+import {
+  defaultProjectResolverIo,
+  resolveProject,
+  type ProjectResolverIo,
+} from "./project-resolver.ts";
 
 export interface ProjectProbe {
   name: string;
@@ -29,26 +30,10 @@ export interface ProjectProbe {
 export interface ProbeIo {
   exists(path: string): boolean;
   runGit(args: string[], cwd: string): Promise<string | null>;
+  realpath?: ProjectResolverIo["realpath"];
 }
 
-const realIo: ProbeIo = {
-  exists: existsSync,
-  runGit: (args, cwd) =>
-    new Promise((resolveResult) => {
-      execFile(
-        "git",
-        ["-C", cwd, ...args],
-        { timeout: GIT_TIMEOUT_MS, encoding: "utf-8" },
-        (err, stdout) => {
-          if (err) {
-            resolveResult(null);
-            return;
-          }
-          resolveResult(stdout.trim());
-        },
-      );
-    }),
-};
+const realIo: ProbeIo = defaultProjectResolverIo;
 
 /**
  * Replace dangerous filename characters and collapse whitespace so the
@@ -69,24 +54,38 @@ export function sanitizeName(raw: string): string {
  */
 export async function probeProject(dir: string, io: ProbeIo = realIo): Promise<ProjectProbe> {
   const absoluteDir = isAbsolute(dir) ? dir : resolve(dir);
+  const resolution = await resolveProject(dir, {
+    // Existing injected ProbeIo values predate canonicalization. Treat their
+    // paths as canonical unless they explicitly provide a realpath operation,
+    // so the probe remains a fully injected seam rather than touching real fs.
+    io: { ...io, realpath: io.realpath ?? ((path) => path) },
+  });
   const rawName = basename(absoluteDir);
   const sanitized = sanitizeName(rawName);
   const name = sanitized.length > 0 ? sanitized : "project";
 
-  const hasIdeYml = io.exists(`${absoluteDir}/ide.yml`);
-
   const [gitOrigin, gitBranch] = await Promise.all([
-    io.runGit(["config", "--get", "remote.origin.url"], absoluteDir),
-    io.runGit(["branch", "--show-current"], absoluteDir),
+    runGitSafely(io, ["config", "--get", "remote.origin.url"], absoluteDir),
+    runGitSafely(io, ["branch", "--show-current"], absoluteDir),
   ]);
 
   return {
     name,
+    // Preserve the public probe/command-center contract: this is the absolute
+    // caller path, while canonical roots live on ProjectResolution.
     dir: absoluteDir,
-    hasIdeYml,
+    hasIdeYml: resolution.hasLegacyConfigAtInput,
     // Treat empty string as null — branch --show-current returns "" on a
     // detached HEAD.
     gitOrigin: gitOrigin && gitOrigin.length > 0 ? gitOrigin : null,
     gitBranch: gitBranch && gitBranch.length > 0 ? gitBranch : null,
   };
+}
+
+async function runGitSafely(io: ProbeIo, args: string[], cwd: string): Promise<string | null> {
+  try {
+    return await io.runGit(args, cwd);
+  } catch {
+    return null;
+  }
 }

--- a/packages/daemon/src/lib/project-resolver.ts
+++ b/packages/daemon/src/lib/project-resolver.ts
@@ -1,0 +1,265 @@
+/**
+ * Canonical project identity and configuration discovery.
+ *
+ * A working tree keeps its own project root, while linked Git worktrees share
+ * an identity through Git's common directory. Non-Git projects use the root
+ * selected by their nearest config (or the canonical input directory when no
+ * config exists). All filesystem and process I/O is injectable for focused,
+ * deterministic tests.
+ */
+
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+
+const GIT_TIMEOUT_MS = 2_000;
+
+export type ProjectIdentitySource = "git-common-dir" | "canonical-realpath";
+export type ProjectConfigKind = "workspace" | "legacy" | "none";
+
+export type ProjectConfigSource =
+  | { kind: "workspace" | "legacy"; path: string; explicit: boolean }
+  | { kind: "none"; path: null; explicit: false };
+
+export interface ProjectResolution {
+  /** Canonical form of the directory supplied by the caller. */
+  inputDir: string;
+  /** Canonical root of this checkout/config project. Linked worktrees differ here. */
+  projectRoot: string;
+  /** Filesystem-safe stable key for user-scoped project state. */
+  identityKey: string;
+  /** The rule used to derive `identityKey`. */
+  identitySource: ProjectIdentitySource;
+  /** Canonical path hashed into `identityKey`. Useful for diagnostics/relinking. */
+  identityAnchor: string;
+  /** Winning declarative config source after applying precedence. */
+  config: ProjectConfigSource;
+  /** Nearest workspace candidate, even when an explicit path wins. */
+  workspaceConfigPath: string | null;
+  /** Nearest legacy candidate, even when a workspace/explicit path wins. */
+  legacyConfigPath: string | null;
+  /** Compatibility fact used by the existing project-probe wire contract. */
+  hasLegacyConfigAtInput: boolean;
+}
+
+export interface ProjectResolverIo {
+  exists(path: string): boolean;
+  realpath(path: string): string;
+  runGit(args: string[], cwd: string): Promise<string | null>;
+}
+
+export interface ResolveProjectOptions {
+  /** Caller-selected config. Relative paths resolve from the canonical input directory. */
+  explicitConfigPath?: string | null;
+  /** Override any subset of filesystem/process operations. */
+  io?: Partial<ProjectResolverIo>;
+}
+
+export const defaultProjectResolverIo: ProjectResolverIo = {
+  exists: existsSync,
+  realpath: realpathSync,
+  runGit: (args, cwd) =>
+    new Promise((resolveResult) => {
+      execFile(
+        "git",
+        ["-C", cwd, ...args],
+        {
+          encoding: "utf-8",
+          maxBuffer: 64 * 1024,
+          timeout: GIT_TIMEOUT_MS,
+          windowsHide: true,
+        },
+        (error, stdout) => {
+          if (error) {
+            resolveResult(null);
+            return;
+          }
+          resolveResult(stdout.trim());
+        },
+      );
+    }),
+};
+
+interface DiscoveredConfigs {
+  workspacePath: string | null;
+  legacyPath: string | null;
+  hasLegacyAtInput: boolean;
+}
+
+function safeExists(path: string, io: ProjectResolverIo): boolean {
+  try {
+    return io.exists(path);
+  } catch {
+    return false;
+  }
+}
+
+/** Canonicalize when possible and retain a deterministic absolute fallback. */
+function canonicalize(path: string, io: ProjectResolverIo): string {
+  const absolute = resolve(path);
+  try {
+    return io.realpath(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+/** Git-derived paths must exist so malformed output never becomes an identity. */
+function canonicalizeGitPath(path: string, io: ProjectResolverIo): string | null {
+  try {
+    return io.realpath(resolve(path));
+  } catch {
+    return null;
+  }
+}
+
+function isWithin(path: string, root: string): boolean {
+  const fromRoot = relative(root, path);
+  return (
+    fromRoot === "" ||
+    (fromRoot !== ".." && !fromRoot.startsWith(`..${sep}`) && !isAbsolute(fromRoot))
+  );
+}
+
+async function resolveGitPath(
+  args: string[],
+  cwd: string,
+  allowRelative: boolean,
+  io: ProjectResolverIo,
+): Promise<string | null> {
+  let output: string | null;
+  try {
+    output = await io.runGit(args, cwd);
+  } catch {
+    return null;
+  }
+  if (!output) return null;
+
+  const path = output.trim();
+  if (path.length === 0 || path.includes("\0") || /[\r\n]/.test(path)) return null;
+  if (!isAbsolute(path) && !allowRelative) return null;
+
+  return canonicalizeGitPath(isAbsolute(path) ? path : resolve(cwd, path), io);
+}
+
+function discoverConfigs(
+  inputDir: string,
+  gitProjectRoot: string | null,
+  io: ProjectResolverIo,
+): DiscoveredConfigs {
+  let current = inputDir;
+  let workspacePath: string | null = null;
+  let legacyPath: string | null = null;
+  let hasLegacyAtInput = false;
+
+  while (true) {
+    const workspaceCandidate = join(current, ".tmux-ide", "workspace.yml");
+    const legacyCandidate = join(current, "ide.yml");
+
+    if (!workspacePath && safeExists(workspaceCandidate, io)) {
+      workspacePath = canonicalize(workspaceCandidate, io);
+    }
+    if (!legacyPath && safeExists(legacyCandidate, io)) {
+      legacyPath = canonicalize(legacyCandidate, io);
+      hasLegacyAtInput = current === inputDir;
+    }
+
+    if (workspacePath && legacyPath) break;
+    if (gitProjectRoot && current === gitProjectRoot) break;
+
+    const parent = dirname(current);
+    if (parent === current) break;
+    if (gitProjectRoot && !isWithin(parent, gitProjectRoot)) break;
+    current = parent;
+  }
+
+  return { workspacePath, legacyPath, hasLegacyAtInput };
+}
+
+function explicitConfigSource(
+  explicitPath: string,
+  inputDir: string,
+  io: ProjectResolverIo,
+): ProjectConfigSource {
+  const absolute = isAbsolute(explicitPath) ? explicitPath : resolve(inputDir, explicitPath);
+  const path = canonicalize(absolute, io);
+  return {
+    kind: basename(path) === "ide.yml" ? "legacy" : "workspace",
+    path,
+    explicit: true,
+  };
+}
+
+function chooseConfig(
+  explicitPath: string | null | undefined,
+  inputDir: string,
+  discovered: DiscoveredConfigs,
+  io: ProjectResolverIo,
+): ProjectConfigSource {
+  if (explicitPath && explicitPath.trim().length > 0) {
+    return explicitConfigSource(explicitPath, inputDir, io);
+  }
+  if (discovered.workspacePath) {
+    return { kind: "workspace", path: discovered.workspacePath, explicit: false };
+  }
+  if (discovered.legacyPath) {
+    return { kind: "legacy", path: discovered.legacyPath, explicit: false };
+  }
+  return { kind: "none", path: null, explicit: false };
+}
+
+function configProjectRoot(config: ProjectConfigSource, inputDir: string): string {
+  if (config.kind === "none") return inputDir;
+  const configDir = dirname(config.path);
+  if (config.kind === "workspace" && basename(configDir) === ".tmux-ide") {
+    return dirname(configDir);
+  }
+  return configDir;
+}
+
+function projectIdentityKey(source: ProjectIdentitySource, anchor: string): string {
+  const prefix = source === "git-common-dir" ? "git" : "path";
+  const digest = createHash("sha256").update(source).update("\0").update(anchor).digest("hex");
+  return `${prefix}-${digest}`;
+}
+
+/**
+ * Resolve the canonical project root, shared identity, and winning config for
+ * `dir`. Git failures (including missing executables and malformed output)
+ * degrade to canonical-realpath identity without throwing.
+ */
+export async function resolveProject(
+  dir: string,
+  options: ResolveProjectOptions = {},
+): Promise<ProjectResolution> {
+  const io: ProjectResolverIo = { ...defaultProjectResolverIo, ...options.io };
+  const inputDir = canonicalize(dir, io);
+
+  const gitTopLevel = await resolveGitPath(["rev-parse", "--show-toplevel"], inputDir, false, io);
+  const gitProjectRoot = gitTopLevel && isWithin(inputDir, gitTopLevel) ? gitTopLevel : null;
+
+  const gitCommonDir = gitProjectRoot
+    ? await resolveGitPath(["rev-parse", "--git-common-dir"], gitProjectRoot, true, io)
+    : null;
+
+  const discovered = discoverConfigs(inputDir, gitProjectRoot, io);
+  const config = chooseConfig(options.explicitConfigPath, inputDir, discovered, io);
+  const projectRoot = gitProjectRoot ?? configProjectRoot(config, inputDir);
+  const identitySource: ProjectIdentitySource = gitCommonDir
+    ? "git-common-dir"
+    : "canonical-realpath";
+  const identityAnchor = gitCommonDir ?? projectRoot;
+
+  return {
+    inputDir,
+    projectRoot,
+    identityKey: projectIdentityKey(identitySource, identityAnchor),
+    identitySource,
+    identityAnchor,
+    config,
+    workspaceConfigPath: discovered.workspacePath,
+    legacyConfigPath: discovered.legacyPath,
+    hasLegacyConfigAtInput: discovered.hasLegacyAtInput,
+  };
+}


### PR DESCRIPTION
## Summary
- add canonical project root and config-source discovery
- derive one stable identity across linked Git worktrees
- route the existing project probe through the new resolver without changing its public contract
- cover explicit config precedence, non-Git fallback, malformed Git output, and real linked worktrees

## Verification
- resolver tests: 8 passed
- probe and inspect tests: 19 passed
- real checkout smoke test across 4 worktrees
- pnpm check

Sfora: tmux-ide task #110 / C01