### PR TITLE
feat(config): add WorkspaceConfigV1 and local overlays

### DIFF
--- a/packages/contracts/src/__tests__/workspace-config.test.ts
+++ b/packages/contracts/src/__tests__/workspace-config.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { WorkspaceConfigV1SchemaZ } from "../workspace-config.ts";
+
+describe("WorkspaceConfigV1SchemaZ", () => {
+  it("accepts a minimal versioned workspace", () => {
+    expect(WorkspaceConfigV1SchemaZ.parse({ version: 1 })).toEqual({ version: 1 });
+  });
+
+  it("keeps harnesses, adapters, commands, and models provider-neutral", () => {
+    const result = WorkspaceConfigV1SchemaZ.parse({
+      version: 1,
+      name: "Mixed agents",
+      terminal: {
+        rows: [
+          {
+            size: "70%",
+            panes: [{ title: "Lead", command: "claude", focus: true }],
+          },
+        ],
+        theme: { accent: "colour75" },
+      },
+      app: {
+        views: [
+          { id: "home", panel: "home" },
+          { id: "terminal", title: "IDE", panel: "terminals" },
+          { id: "mission-board", panel: "missions" },
+        ],
+      },
+      harnesses: {
+        claude: { adapter: "claude-code", command: ["claude"] },
+        codex: { adapter: "codex", command: ["codex", "--ask-for-approval", "never"] },
+        droid: { adapter: "droid", command: "droid" },
+        custom: {
+          adapter: "acme/custom-v4",
+          command: ["my-review-agent", "--interactive"],
+          env: { REVIEW_MODE: "strict" },
+        },
+      },
+      agents: {
+        lead: { harness: "claude", model: "claude-fable-5", role: "manager" },
+        worker: { harness: "codex", model: "gpt-5.5", role: "implementer" },
+        researcher: { harness: "droid", model: "anything/new", role: "researcher" },
+        reviewer: { harness: "custom", role: "reviewer" },
+      },
+      missions: {
+        manager: "lead",
+        workers: ["worker", "researcher"],
+        reviewer: "reviewer",
+        isolation: "worktree",
+        max_concurrent_tasks: 2,
+      },
+    });
+
+    expect(result.harnesses?.custom?.adapter).toBe("acme/custom-v4");
+    expect(result.agents?.researcher?.model).toBe("anything/new");
+  });
+
+  it("rejects unknown keys at every object boundary", () => {
+    expect(() => WorkspaceConfigV1SchemaZ.parse({ version: 1, versoin: 1 })).toThrow();
+    expect(() =>
+      WorkspaceConfigV1SchemaZ.parse({
+        version: 1,
+        harnesses: { custom: { adapter: "generic", command: ["agent"], typo: true } },
+      }),
+    ).toThrow();
+    expect(() =>
+      WorkspaceConfigV1SchemaZ.parse({
+        version: 1,
+        terminal: { rows: [{ panes: [{ command: "shell", task: "legacy metadata" }] }] },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid panel, role, isolation, and concurrency values", () => {
+    const invalidValues = [
+      { version: 1, app: { views: [{ id: "bad", panel: "unknown" }] } },
+      {
+        version: 1,
+        harnesses: { h: { adapter: "custom", command: "agent" } },
+        agents: { a: { harness: "h", role: "lead" } },
+      },
+      { version: 1, missions: { isolation: "container" } },
+      { version: 1, missions: { max_concurrent_tasks: 0 } },
+      { version: 1, missions: { max_concurrent_tasks: 1.5 } },
+    ];
+
+    for (const value of invalidValues) {
+      expect(WorkspaceConfigV1SchemaZ.safeParse(value).success).toBe(false);
+    }
+  });
+
+  it("rejects broken harness and mission agent references with useful paths", () => {
+    const result = WorkspaceConfigV1SchemaZ.safeParse({
+      version: 1,
+      agents: {
+        worker: { harness: "missing-harness", role: "implementer" },
+      },
+      missions: {
+        manager: "missing-manager",
+        workers: ["worker", "missing-worker"],
+        reviewer: "missing-reviewer",
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.map((issue) => issue.path.join("."))).toEqual(
+      expect.arrayContaining([
+        "agents.worker.harness",
+        "missions.manager",
+        "missions.workers.1",
+        "missions.reviewer",
+      ]),
+    );
+  });
+
+  it("requires unique stable view IDs", () => {
+    const result = WorkspaceConfigV1SchemaZ.safeParse({
+      version: 1,
+      app: {
+        views: [
+          { id: "ide", panel: "terminals" },
+          { id: "ide", panel: "files" },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues[0]?.message).toContain("Duplicate view id");
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -19,6 +19,7 @@ export * from "./ide-config.ts";
 export * from "./domain.ts";
 export * from "./tmux.ts";
 export * from "./workspace.ts";
+export * from "./workspace-config.ts";
 export * from "./actions-contract.ts";
 export * from "./actions-errors.ts";
 export * from "./terminals.ts";

--- a/packages/contracts/src/workspace-config.ts
+++ b/packages/contracts/src/workspace-config.ts
@@ -1,0 +1,157 @@
+/**
+ * Repository-scoped `.tmux-ide/workspace.yml` contract.
+ *
+ * This is intentionally separate from both the legacy `IdeConfigSchema` and
+ * the daemon's runtime `WorkspaceSchemaZ` registry record. V1 describes
+ * declarative workspace composition only; it has no runtime/task state and no
+ * provider-specific harness or model enums.
+ */
+
+import { z } from "zod";
+import { PaneSchema, RowSchema, ThemeConfigSchema } from "./ide-config.ts";
+
+const NonEmptyStringSchema = z.string().min(1);
+const ProfileNameSchema = z.string().min(1);
+
+/** A shell command or an explicit executable/argv vector. */
+export const WorkspaceCommandSchemaZ = z.union([
+  NonEmptyStringSchema,
+  z.array(NonEmptyStringSchema).min(1),
+]);
+
+/**
+ * Reuse stable legacy terminal-pane validators without carrying agent-team
+ * role/task/specialty/skill metadata into the new workspace contract.
+ */
+export const WorkspaceTerminalPaneSchemaZ = PaneSchema.pick({
+  title: true,
+  command: true,
+  type: true,
+  target: true,
+  dir: true,
+  size: true,
+  focus: true,
+  env: true,
+}).strict();
+
+export const WorkspaceTerminalRowSchemaZ = z.strictObject({
+  size: RowSchema.shape.size,
+  panes: z.array(WorkspaceTerminalPaneSchemaZ).min(1),
+});
+
+export const WorkspaceTerminalConfigSchemaZ = z.strictObject({
+  rows: z.array(WorkspaceTerminalRowSchemaZ).min(1),
+  theme: ThemeConfigSchema.strict().optional(),
+});
+
+export const WorkspacePanelKindSchemaZ = z.enum(["home", "terminals", "files", "diff", "missions"]);
+
+/** V1 views are deliberately full-panel; split/tab layout trees belong to C07. */
+export const WorkspaceFullPanelViewSchemaZ = z.strictObject({
+  id: NonEmptyStringSchema,
+  title: NonEmptyStringSchema.optional(),
+  panel: WorkspacePanelKindSchemaZ,
+});
+
+export const WorkspaceAppConfigSchemaZ = z.strictObject({
+  views: z.array(WorkspaceFullPanelViewSchemaZ).min(1),
+});
+
+export const WorkspaceHarnessProfileSchemaZ = z.strictObject({
+  adapter: NonEmptyStringSchema,
+  command: WorkspaceCommandSchemaZ,
+  env: z.record(NonEmptyStringSchema, z.string()).optional(),
+});
+
+export const WorkspaceAgentRoleSchemaZ = z.enum([
+  "manager",
+  "implementer",
+  "reviewer",
+  "researcher",
+  "validator",
+]);
+
+export const WorkspaceAgentProfileSchemaZ = z.strictObject({
+  harness: ProfileNameSchema,
+  model: NonEmptyStringSchema.optional(),
+  role: WorkspaceAgentRoleSchemaZ,
+});
+
+export const WorkspaceMissionDefaultsSchemaZ = z.strictObject({
+  manager: ProfileNameSchema.optional(),
+  workers: z.array(ProfileNameSchema).optional(),
+  reviewer: ProfileNameSchema.optional(),
+  isolation: z.enum(["shared", "worktree"]).optional(),
+  max_concurrent_tasks: z.number().int().positive().optional(),
+});
+
+const WorkspaceConfigV1ObjectSchemaZ = z.strictObject({
+  version: z.literal(1),
+  name: NonEmptyStringSchema.optional(),
+  terminal: WorkspaceTerminalConfigSchemaZ.optional(),
+  app: WorkspaceAppConfigSchemaZ.optional(),
+  harnesses: z.record(ProfileNameSchema, WorkspaceHarnessProfileSchemaZ).optional(),
+  agents: z.record(ProfileNameSchema, WorkspaceAgentProfileSchemaZ).optional(),
+  missions: WorkspaceMissionDefaultsSchemaZ.optional(),
+});
+
+/**
+ * Strict V1 workspace config plus references that can be checked using only
+ * the loaded document. Installed binaries/models are deliberately not probed.
+ */
+export const WorkspaceConfigV1SchemaZ = WorkspaceConfigV1ObjectSchemaZ.superRefine(
+  (config, context) => {
+    const harnessNames = new Set(Object.keys(config.harnesses ?? {}));
+    for (const [agentName, agent] of Object.entries(config.agents ?? {})) {
+      if (!harnessNames.has(agent.harness)) {
+        context.addIssue({
+          code: "custom",
+          path: ["agents", agentName, "harness"],
+          message: `Unknown harness profile "${agent.harness}"`,
+        });
+      }
+    }
+
+    const agentNames = new Set(Object.keys(config.agents ?? {}));
+    const checkAgentReference = (name: string | undefined, path: (string | number)[]) => {
+      if (name !== undefined && !agentNames.has(name)) {
+        context.addIssue({
+          code: "custom",
+          path,
+          message: `Unknown agent profile "${name}"`,
+        });
+      }
+    };
+
+    checkAgentReference(config.missions?.manager, ["missions", "manager"]);
+    checkAgentReference(config.missions?.reviewer, ["missions", "reviewer"]);
+    for (const [index, worker] of (config.missions?.workers ?? []).entries()) {
+      checkAgentReference(worker, ["missions", "workers", index]);
+    }
+
+    const viewIds = new Set<string>();
+    for (const [index, view] of (config.app?.views ?? []).entries()) {
+      if (viewIds.has(view.id)) {
+        context.addIssue({
+          code: "custom",
+          path: ["app", "views", index, "id"],
+          message: `Duplicate view id "${view.id}"`,
+        });
+      }
+      viewIds.add(view.id);
+    }
+  },
+);
+
+export type WorkspaceCommand = z.infer<typeof WorkspaceCommandSchemaZ>;
+export type WorkspaceTerminalPane = z.infer<typeof WorkspaceTerminalPaneSchemaZ>;
+export type WorkspaceTerminalRow = z.infer<typeof WorkspaceTerminalRowSchemaZ>;
+export type WorkspaceTerminalConfig = z.infer<typeof WorkspaceTerminalConfigSchemaZ>;
+export type WorkspacePanelKind = z.infer<typeof WorkspacePanelKindSchemaZ>;
+export type WorkspaceFullPanelView = z.infer<typeof WorkspaceFullPanelViewSchemaZ>;
+export type WorkspaceAppConfig = z.infer<typeof WorkspaceAppConfigSchemaZ>;
+export type WorkspaceHarnessProfile = z.infer<typeof WorkspaceHarnessProfileSchemaZ>;
+export type WorkspaceAgentRole = z.infer<typeof WorkspaceAgentRoleSchemaZ>;
+export type WorkspaceAgentProfile = z.infer<typeof WorkspaceAgentProfileSchemaZ>;
+export type WorkspaceMissionDefaults = z.infer<typeof WorkspaceMissionDefaultsSchemaZ>;
+export type WorkspaceConfigV1 = z.infer<typeof WorkspaceConfigV1SchemaZ>;

--- a/packages/daemon/src/lib/__tests__/workspace-config-loader.test.ts
+++ b/packages/daemon/src/lib/__tests__/workspace-config-loader.test.ts
@@ -1,0 +1,367 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ProjectConfigSource,
+  ProjectResolution,
+  ResolveProjectOptions,
+} from "../project-resolver.ts";
+import {
+  loadWorkspaceConfig,
+  mergeWorkspaceConfigValues,
+  WorkspaceConfigLoadError,
+  WorkspaceConfigMergeError,
+  type LoadWorkspaceConfigOptions,
+  type WorkspaceConfigLoaderIo,
+} from "../workspace-config-loader.ts";
+
+const BASE_PATH = "/repo/.tmux-ide/workspace.yml";
+const LOCAL_PATH = "/repo/.tmux-ide/workspace.local.yml";
+
+function resolution(config: ProjectConfigSource): ProjectResolution {
+  return {
+    inputDir: "/repo",
+    projectRoot: "/repo",
+    identityKey: "git-test",
+    identitySource: "git-common-dir",
+    identityAnchor: "/repo/.git",
+    config,
+    workspaceConfigPath: config.kind === "workspace" ? config.path : null,
+    legacyConfigPath: config.kind === "legacy" ? config.path : null,
+    hasLegacyConfigAtInput: config.kind === "legacy",
+  };
+}
+
+function workspaceResolution(): ProjectResolution {
+  return resolution({ kind: "workspace", path: BASE_PATH, explicit: false });
+}
+
+function loaderIo(
+  files: Record<string, string>,
+  resolved: ProjectResolution = workspaceResolution(),
+  onResolve?: (options: ResolveProjectOptions) => void,
+): WorkspaceConfigLoaderIo {
+  return {
+    exists: (path) => Object.hasOwn(files, path),
+    readFile: (path) => {
+      if (!Object.hasOwn(files, path)) throw new Error("ENOENT");
+      return files[path]!;
+    },
+    realpath: (path) => path,
+    resolveProject: async (_dir, options) => {
+      onResolve?.(options ?? {});
+      return resolved;
+    },
+  };
+}
+
+async function load(
+  files: Record<string, string>,
+  options: Omit<LoadWorkspaceConfigOptions, "io"> = {},
+) {
+  return loadWorkspaceConfig("/repo", { ...options, io: loaderIo(files) });
+}
+
+async function expectLoadError(
+  promise: Promise<unknown>,
+  code: WorkspaceConfigLoadError["code"],
+  stage: WorkspaceConfigLoadError["stage"],
+) {
+  try {
+    await promise;
+    throw new Error("Expected loadWorkspaceConfig to reject");
+  } catch (error) {
+    expect(error).toBeInstanceOf(WorkspaceConfigLoadError);
+    const typed = error as WorkspaceConfigLoadError;
+    expect(typed.code).toBe(code);
+    expect(typed.stage).toBe(stage);
+    return typed;
+  }
+}
+
+describe("loadWorkspaceConfig", () => {
+  it("loads a minimal V1 workspace and reports source paths", async () => {
+    const result = await load({ [BASE_PATH]: "version: 1\n" });
+
+    expect(result.config).toEqual({ version: 1 });
+    expect(result.source.basePath).toBe(BASE_PATH);
+    expect(result.source.localPath).toBeNull();
+    expect(result.source.resolution.identityKey).toBe("git-test");
+  });
+
+  it("passes an explicit config path through to the C01 resolver", async () => {
+    let explicitConfigPath: string | null | undefined;
+    const io = loaderIo({ [BASE_PATH]: "version: 1\n" }, workspaceResolution(), (options) => {
+      explicitConfigPath = options.explicitConfigPath;
+    });
+
+    await loadWorkspaceConfig("/repo", {
+      explicitConfigPath: "/selected/workspace.yml",
+      io,
+    });
+
+    expect(explicitConfigPath).toBe("/selected/workspace.yml");
+  });
+
+  it("merges nested local objects while retaining untouched base fields", async () => {
+    const result = await load({
+      [BASE_PATH]: `
+version: 1
+terminal:
+  rows:
+    - panes:
+        - title: Shell
+  theme:
+    accent: blue
+    border: grey
+harnesses:
+  custom:
+    adapter: generic-pty
+    command: [my-agent, --interactive]
+    env:
+      MODE: base
+      KEEP: yes
+`,
+      [LOCAL_PATH]: `
+terminal:
+  theme:
+    accent: red
+harnesses:
+  custom:
+    env:
+      MODE: local
+`,
+    });
+
+    expect(result.config.terminal?.theme).toEqual({ accent: "red", border: "grey" });
+    expect(result.config.terminal?.rows[0]?.panes[0]?.title).toBe("Shell");
+    expect(result.config.harnesses?.custom).toEqual({
+      adapter: "generic-pty",
+      command: ["my-agent", "--interactive"],
+      env: { MODE: "local", KEEP: "yes" },
+    });
+    expect(result.source.localPath).toBe(LOCAL_PATH);
+  });
+
+  it("replaces arrays wholesale instead of concatenating them", async () => {
+    const result = await load({
+      [BASE_PATH]: `
+version: 1
+app:
+  views:
+    - { id: home, panel: home }
+    - { id: files, panel: files }
+harnesses:
+  generic: { adapter: generic-pty, command: agent }
+agents:
+  first: { harness: generic, role: implementer }
+  second: { harness: generic, role: implementer }
+missions:
+  workers: [first]
+`,
+      [LOCAL_PATH]: `
+app:
+  views:
+    - { id: missions, panel: missions }
+missions:
+  workers: [second]
+`,
+    });
+
+    expect(result.config.app?.views).toEqual([{ id: "missions", panel: "missions" }]);
+    expect(result.config.missions?.workers).toEqual(["second"]);
+  });
+
+  it("validates only after merge so a local document can supply a partial subtree", async () => {
+    const result = await load({
+      [BASE_PATH]: `
+version: 1
+harnesses:
+  custom:
+    adapter: generic-pty
+`,
+      [LOCAL_PATH]: `
+harnesses:
+  custom:
+    command: [agent]
+`,
+    });
+
+    expect(result.config.harnesses?.custom).toEqual({
+      adapter: "generic-pty",
+      command: ["agent"],
+    });
+  });
+
+  it("returns cloned data and never mutates base or overlay inputs", () => {
+    const base = {
+      terminal: { theme: { accent: "blue", border: "grey" } },
+      views: [{ id: "base" }],
+      nullable: "base",
+    };
+    const overlay = {
+      terminal: { theme: { accent: "red" } },
+      views: [{ id: "local" }],
+      nullable: null,
+    };
+    const baseSnapshot = structuredClone(base);
+    const overlaySnapshot = structuredClone(overlay);
+
+    const merged = mergeWorkspaceConfigValues(base, overlay) as typeof overlay & typeof base;
+
+    expect(base).toEqual(baseSnapshot);
+    expect(overlay).toEqual(overlaySnapshot);
+    expect(merged).not.toBe(base);
+    expect(merged.terminal).not.toBe(base.terminal);
+    expect(merged.views).not.toBe(overlay.views);
+    expect(merged).toEqual({
+      terminal: { theme: { accent: "red", border: "grey" } },
+      views: [{ id: "local" }],
+      nullable: null,
+    });
+  });
+
+  it.each(["base", "overlay"] as const)(
+    "rejects cyclic programmatic %s input without overflowing",
+    (side) => {
+      const cyclic: Record<string, unknown> = {};
+      cyclic.self = cyclic;
+
+      const invoke = () =>
+        side === "base"
+          ? mergeWorkspaceConfigValues(cyclic, {})
+          : mergeWorkspaceConfigValues({}, cyclic);
+
+      expect(invoke).toThrow(WorkspaceConfigMergeError);
+      try {
+        invoke();
+      } catch (error) {
+        expect(error).not.toBeInstanceOf(RangeError);
+        expect((error as WorkspaceConfigMergeError).code).toBe("CYCLIC_VALUE");
+        expect((error as WorkspaceConfigMergeError).path).toEqual(["self"]);
+      }
+    },
+  );
+
+  it("allows repeated references that do not form a cycle", () => {
+    const shared = { value: "shared" };
+    const merged = mergeWorkspaceConfigValues({ first: shared, second: shared }, {}) as {
+      first: typeof shared;
+      second: typeof shared;
+    };
+
+    expect(merged).toEqual({ first: shared, second: shared });
+    expect(merged.first).not.toBe(shared);
+    expect(merged.second).not.toBe(shared);
+  });
+
+  it("reports useful final validation issues for strict keys and values", async () => {
+    const error = await expectLoadError(
+      load({
+        [BASE_PATH]: `
+version: 1
+unknown_key: true
+missions:
+  max_concurrent_tasks: 0
+`,
+      }),
+      "FINAL_VALIDATION_FAILED",
+      "validation",
+    );
+
+    expect(error.issues.map((issue) => issue.path.join("."))).toEqual(
+      expect.arrayContaining(["missions.max_concurrent_tasks", ""]),
+    );
+    expect(error.message).toContain("Effective workspace config is invalid");
+  });
+
+  it("reports broken document-local references during final validation", async () => {
+    const error = await expectLoadError(
+      load({
+        [BASE_PATH]: `
+version: 1
+agents:
+  worker: { harness: missing, role: implementer }
+missions:
+  workers: [missing-worker]
+`,
+      }),
+      "FINAL_VALIDATION_FAILED",
+      "validation",
+    );
+
+    expect(error.issues.map((issue) => issue.path.join("."))).toEqual(
+      expect.arrayContaining(["agents.worker.harness", "missions.workers.0"]),
+    );
+  });
+
+  it.each([
+    ["version: [\n", "BASE_YAML_INVALID", "base"],
+    ["- version: 1\n", "BASE_NOT_MAPPING", "base"],
+    ["name: missing-version\n", "BASE_VERSION_INVALID", "base"],
+    ["version: 2\n", "BASE_VERSION_INVALID", "base"],
+  ] as const)("types base document failures for %j", async (base, code, stage) => {
+    await expectLoadError(load({ [BASE_PATH]: base }), code, stage);
+  });
+
+  it.each([
+    ["value: [\n", "LOCAL_YAML_INVALID", "local"],
+    ["- partial\n", "LOCAL_NOT_MAPPING", "local"],
+    ["version: 2\n", "LOCAL_VERSION_INVALID", "local"],
+    ["version: null\n", "LOCAL_VERSION_INVALID", "local"],
+  ] as const)("types local document failures for %j", async (local, code, stage) => {
+    await expectLoadError(load({ [BASE_PATH]: "version: 1\n", [LOCAL_PATH]: local }), code, stage);
+  });
+
+  it("types a recursive alias in the base document at the base stage", async () => {
+    const error = await expectLoadError(
+      load({
+        [BASE_PATH]: `
+version: 1
+recursive: &recursive
+  self: *recursive
+`,
+      }),
+      "BASE_CYCLIC_REFERENCE",
+      "base",
+    );
+
+    expect(error.path).toBe(BASE_PATH);
+    expect(error.message).toContain("recursive YAML alias");
+  });
+
+  it("types a recursive alias in the local document at the local stage", async () => {
+    const error = await expectLoadError(
+      load({
+        [BASE_PATH]: "version: 1\n",
+        [LOCAL_PATH]: `
+recursive: &recursive
+  self: *recursive
+`,
+      }),
+      "LOCAL_CYCLIC_REFERENCE",
+      "local",
+    );
+
+    expect(error.path).toBe(LOCAL_PATH);
+    expect(error.message).toContain("recursive YAML alias");
+  });
+
+  it("allows a local document to repeat version: 1 without changing it", async () => {
+    const result = await load({
+      [BASE_PATH]: "version: 1\nname: base\n",
+      [LOCAL_PATH]: "version: 1\nname: local\n",
+    });
+    expect(result.config).toEqual({ version: 1, name: "local" });
+  });
+
+  it.each([
+    [resolution({ kind: "legacy", path: "/repo/ide.yml", explicit: false }), "Found legacy config"],
+    [resolution({ kind: "none", path: null, explicit: false }), "No .tmux-ide/workspace.yml"],
+  ])("rejects legacy/none discovery", async (resolved, message) => {
+    const error = await expectLoadError(
+      loadWorkspaceConfig("/repo", { io: loaderIo({}, resolved) }),
+      "WORKSPACE_CONFIG_REQUIRED",
+      "resolution",
+    );
+    expect(error.message).toContain(message);
+  });
+});

--- a/packages/daemon/src/lib/workspace-config-loader.ts
+++ b/packages/daemon/src/lib/workspace-config-loader.ts
@@ -1,0 +1,379 @@
+/**
+ * Side-effect-free loader for repository-scoped WorkspaceConfigV1 files.
+ *
+ * Project/config discovery delegates to C01. This module only reads the
+ * winning workspace file, optionally composes its sibling
+ * `workspace.local.yml`, and validates the final effective value.
+ */
+
+import { WorkspaceConfigV1SchemaZ, type WorkspaceConfigV1 } from "@tmux-ide/contracts";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import yaml from "js-yaml";
+import {
+  resolveProject,
+  type ProjectResolution,
+  type ProjectResolverIo,
+  type ResolveProjectOptions,
+} from "./project-resolver.ts";
+
+export type WorkspaceConfigLoadStage = "resolution" | "base" | "local" | "validation";
+
+export type WorkspaceConfigLoadErrorCode =
+  | "RESOLUTION_FAILED"
+  | "WORKSPACE_CONFIG_REQUIRED"
+  | "BASE_READ_FAILED"
+  | "BASE_YAML_INVALID"
+  | "BASE_NOT_MAPPING"
+  | "BASE_CYCLIC_REFERENCE"
+  | "BASE_VERSION_INVALID"
+  | "LOCAL_READ_FAILED"
+  | "LOCAL_YAML_INVALID"
+  | "LOCAL_NOT_MAPPING"
+  | "LOCAL_CYCLIC_REFERENCE"
+  | "LOCAL_VERSION_INVALID"
+  | "FINAL_VALIDATION_FAILED";
+
+export interface WorkspaceConfigValidationIssue {
+  path: (string | number)[];
+  code: string;
+  message: string;
+}
+
+export class WorkspaceConfigLoadError extends Error {
+  readonly code: WorkspaceConfigLoadErrorCode;
+  readonly stage: WorkspaceConfigLoadStage;
+  readonly path: string | null;
+  readonly issues: readonly WorkspaceConfigValidationIssue[];
+
+  constructor(input: {
+    code: WorkspaceConfigLoadErrorCode;
+    stage: WorkspaceConfigLoadStage;
+    message: string;
+    path?: string | null;
+    issues?: readonly WorkspaceConfigValidationIssue[];
+    cause?: unknown;
+  }) {
+    super(input.message, input.cause === undefined ? undefined : { cause: input.cause });
+    this.name = "WorkspaceConfigLoadError";
+    this.code = input.code;
+    this.stage = input.stage;
+    this.path = input.path ?? null;
+    this.issues = input.issues ?? [];
+  }
+}
+
+/** Programmatic merge input contained a true object/array reference cycle. */
+export class WorkspaceConfigMergeError extends Error {
+  readonly code = "CYCLIC_VALUE";
+  readonly path: readonly (string | number)[];
+
+  constructor(path: readonly (string | number)[]) {
+    const location = path.length > 0 ? path.join(".") : "<root>";
+    super(`Workspace config value contains a cyclic reference at ${location}`);
+    this.name = "WorkspaceConfigMergeError";
+    this.path = [...path];
+  }
+}
+
+export interface WorkspaceConfigSourceMetadata {
+  basePath: string;
+  localPath: string | null;
+  resolution: ProjectResolution;
+}
+
+export interface LoadedWorkspaceConfig {
+  config: WorkspaceConfigV1;
+  source: WorkspaceConfigSourceMetadata;
+}
+
+export interface WorkspaceConfigLoaderIo {
+  exists(path: string): boolean;
+  readFile(path: string): string;
+  realpath(path: string): string;
+  resolveProject(dir: string, options?: ResolveProjectOptions): Promise<ProjectResolution>;
+}
+
+export interface LoadWorkspaceConfigOptions {
+  explicitConfigPath?: string | null;
+  /** Filesystem and resolver injection for deterministic loader tests/callers. */
+  io?: Partial<WorkspaceConfigLoaderIo>;
+  /** Passed through when using the C01 resolver implementation. */
+  resolverIo?: Partial<ProjectResolverIo>;
+}
+
+const defaultLoaderIo: WorkspaceConfigLoaderIo = {
+  exists: existsSync,
+  readFile: (path) => readFileSync(path, "utf-8"),
+  realpath: realpathSync,
+  resolveProject,
+};
+
+type PlainObject = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is PlainObject {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function defineValue(target: PlainObject, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/**
+ * Reject true cycles while allowing the same acyclic YAML alias/object to be
+ * referenced by multiple siblings. `visited` avoids re-walking shared DAGs;
+ * `ancestors` identifies only back-edges on the active traversal path.
+ */
+function assertAcyclicWorkspaceValue(
+  value: unknown,
+  ancestors = new Set<object>(),
+  visited = new WeakSet<object>(),
+  path: (string | number)[] = [],
+): void {
+  if (!Array.isArray(value) && !isPlainObject(value)) return;
+  const container: object = value;
+
+  if (ancestors.has(container)) throw new WorkspaceConfigMergeError(path);
+  if (visited.has(container)) return;
+
+  ancestors.add(container);
+  if (Array.isArray(value)) {
+    for (const [index, nestedValue] of value.entries()) {
+      assertAcyclicWorkspaceValue(nestedValue, ancestors, visited, [...path, index]);
+    }
+  } else {
+    for (const [key, nestedValue] of Object.entries(value)) {
+      assertAcyclicWorkspaceValue(nestedValue, ancestors, visited, [...path, key]);
+    }
+  }
+  ancestors.delete(container);
+  visited.add(container);
+}
+
+function cloneWorkspaceConfigValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(cloneWorkspaceConfigValue);
+  if (!isPlainObject(value)) return value;
+
+  const clone: PlainObject = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    defineValue(clone, key, cloneWorkspaceConfigValue(nestedValue));
+  }
+  return clone;
+}
+
+function mergeAcyclicWorkspaceConfigValues(base: unknown, overlay: unknown): unknown {
+  if (!isPlainObject(overlay)) return cloneWorkspaceConfigValue(overlay);
+
+  const merged: PlainObject = {};
+  if (isPlainObject(base)) {
+    for (const [key, baseValue] of Object.entries(base)) {
+      defineValue(merged, key, cloneWorkspaceConfigValue(baseValue));
+    }
+  }
+
+  for (const [key, overlayValue] of Object.entries(overlay)) {
+    const baseValue = isPlainObject(base) ? base[key] : undefined;
+    defineValue(merged, key, mergeAcyclicWorkspaceConfigValues(baseValue, overlayValue));
+  }
+  return merged;
+}
+
+/**
+ * Deterministic overlay merge: recurse through plain objects, replace arrays
+ * wholesale, and replace scalars/null. Neither input is mutated or reused in
+ * the returned object graph. Cyclic inputs throw WorkspaceConfigMergeError.
+ */
+export function mergeWorkspaceConfigValues(base: unknown, overlay: unknown): unknown {
+  assertAcyclicWorkspaceValue(base);
+  assertAcyclicWorkspaceValue(overlay);
+  return mergeAcyclicWorkspaceConfigValues(base, overlay);
+}
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readText(path: string, stage: "base" | "local", io: WorkspaceConfigLoaderIo): string {
+  try {
+    return io.readFile(path);
+  } catch (cause) {
+    throw new WorkspaceConfigLoadError({
+      code: stage === "base" ? "BASE_READ_FAILED" : "LOCAL_READ_FAILED",
+      stage,
+      path,
+      message: `Cannot read ${stage} workspace config at ${path}: ${errorDetail(cause)}`,
+      cause,
+    });
+  }
+}
+
+function parseMapping(raw: string, path: string, stage: "base" | "local"): PlainObject {
+  let document: unknown;
+  try {
+    document = yaml.load(raw);
+  } catch (cause) {
+    throw new WorkspaceConfigLoadError({
+      code: stage === "base" ? "BASE_YAML_INVALID" : "LOCAL_YAML_INVALID",
+      stage,
+      path,
+      message: `Invalid YAML in ${stage} workspace config at ${path}: ${errorDetail(cause)}`,
+      cause,
+    });
+  }
+
+  if (!isPlainObject(document)) {
+    throw new WorkspaceConfigLoadError({
+      code: stage === "base" ? "BASE_NOT_MAPPING" : "LOCAL_NOT_MAPPING",
+      stage,
+      path,
+      message: `The ${stage} workspace config at ${path} must contain a YAML mapping`,
+    });
+  }
+
+  try {
+    assertAcyclicWorkspaceValue(document);
+  } catch (cause) {
+    if (!(cause instanceof WorkspaceConfigMergeError)) throw cause;
+    throw new WorkspaceConfigLoadError({
+      code: stage === "base" ? "BASE_CYCLIC_REFERENCE" : "LOCAL_CYCLIC_REFERENCE",
+      stage,
+      path,
+      message: `The ${stage} workspace config at ${path} contains a recursive YAML alias at ${cause.path.join(".") || "<root>"}`,
+      cause,
+    });
+  }
+  return document;
+}
+
+function assertBaseVersion(document: PlainObject, path: string): void {
+  if (document.version !== 1) {
+    throw new WorkspaceConfigLoadError({
+      code: "BASE_VERSION_INVALID",
+      stage: "base",
+      path,
+      message: `The base workspace config at ${path} must declare version: 1`,
+    });
+  }
+}
+
+function assertLocalVersion(document: PlainObject, path: string): void {
+  if (Object.hasOwn(document, "version") && document.version !== 1) {
+    throw new WorkspaceConfigLoadError({
+      code: "LOCAL_VERSION_INVALID",
+      stage: "local",
+      path,
+      message: `The local workspace config at ${path} cannot change version from 1`,
+    });
+  }
+}
+
+function safeExists(path: string, io: WorkspaceConfigLoaderIo): boolean {
+  try {
+    return io.exists(path);
+  } catch {
+    return false;
+  }
+}
+
+function canonicalizeExisting(path: string, io: WorkspaceConfigLoaderIo): string {
+  try {
+    return io.realpath(path);
+  } catch {
+    return path;
+  }
+}
+
+function validationIssues(error: {
+  issues: readonly {
+    path: readonly PropertyKey[];
+    code: string;
+    message: string;
+  }[];
+}): WorkspaceConfigValidationIssue[] {
+  return error.issues.map((issue) => ({
+    path: issue.path.map((part) => (typeof part === "symbol" ? part.toString() : part)),
+    code: issue.code,
+    message: issue.message,
+  }));
+}
+
+/**
+ * Load and validate the effective WorkspaceConfigV1 for `dir`. Legacy or
+ * missing discovery is intentionally rejected until C03 adds compatibility.
+ */
+export async function loadWorkspaceConfig(
+  dir: string,
+  options: LoadWorkspaceConfigOptions = {},
+): Promise<LoadedWorkspaceConfig> {
+  const io: WorkspaceConfigLoaderIo = { ...defaultLoaderIo, ...options.io };
+
+  let resolution: ProjectResolution;
+  try {
+    resolution = await io.resolveProject(dir, {
+      explicitConfigPath: options.explicitConfigPath,
+      io: options.resolverIo,
+    });
+  } catch (cause) {
+    throw new WorkspaceConfigLoadError({
+      code: "RESOLUTION_FAILED",
+      stage: "resolution",
+      message: `Cannot resolve a workspace config for ${dir}: ${errorDetail(cause)}`,
+      cause,
+    });
+  }
+
+  if (resolution.config.kind !== "workspace") {
+    const message =
+      resolution.config.kind === "legacy"
+        ? `Found legacy config at ${resolution.config.path}; a .tmux-ide/workspace.yml config is required until C03 migration support is available`
+        : `No .tmux-ide/workspace.yml config was found for ${resolution.inputDir}`;
+    throw new WorkspaceConfigLoadError({
+      code: "WORKSPACE_CONFIG_REQUIRED",
+      stage: "resolution",
+      path: resolution.config.path,
+      message,
+    });
+  }
+
+  const basePath = resolution.config.path;
+  const baseDocument = parseMapping(readText(basePath, "base", io), basePath, "base");
+  assertBaseVersion(baseDocument, basePath);
+
+  const localCandidate = join(dirname(basePath), "workspace.local.yml");
+  let localPath: string | null = null;
+  let effectiveValue: unknown = cloneWorkspaceConfigValue(baseDocument);
+
+  if (safeExists(localCandidate, io)) {
+    localPath = canonicalizeExisting(localCandidate, io);
+    const localDocument = parseMapping(readText(localPath, "local", io), localPath, "local");
+    assertLocalVersion(localDocument, localPath);
+    effectiveValue = mergeWorkspaceConfigValues(baseDocument, localDocument);
+  }
+
+  const validated = WorkspaceConfigV1SchemaZ.safeParse(effectiveValue);
+  if (!validated.success) {
+    const issues = validationIssues(validated.error);
+    throw new WorkspaceConfigLoadError({
+      code: "FINAL_VALIDATION_FAILED",
+      stage: "validation",
+      path: basePath,
+      issues,
+      message: `Effective workspace config is invalid: ${issues
+        .slice(0, 3)
+        .map((issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
+        .join("; ")}`,
+    });
+  }
+
+  return {
+    config: validated.data,
+    source: { basePath, localPath, resolution },
+  };
+}


### PR DESCRIPTION
## Summary
- add a strict, provider-neutral WorkspaceConfigV1 contract for terminals, app views, harnesses, agents, and mission defaults
- load canonical workspace config through the C01 project resolver and deterministically merge a sibling workspace.local.yml overlay
- validate merged references and surface typed YAML, version, validation, and cyclic-value errors
- keep legacy migration, launch integration, runtime state, and TUI changes outside this slice

## Verification
- pnpm check
- contracts workspace-config suite: 6 tests
- daemon suite: 90 files / 1,634 tests
- focused loader/resolver suite: 32 tests
- filesystem discovery + local overlay smoke test
- cyclic YAML alias regression probe

Sfora: tmux-ide #111 (M26.2 / C02)