### PR TITLE
feat(runtime): add atomic project runtime repository

### DIFF
--- a/packages/daemon/src/lib/__tests__/project-runtime-repository.test.ts
+++ b/packages/daemon/src/lib/__tests__/project-runtime-repository.test.ts
@@ -1,0 +1,536 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ProjectResolution } from "../project-resolver.ts";
+import {
+  CorruptEventLogError,
+  DocumentRevisionConflictError,
+  EventSequenceConflictError,
+  ProjectRuntimeRepositoryError,
+  createProjectRuntimeRepository,
+  openProjectRuntimeRepository,
+  type JsonValue,
+} from "../project-runtime-repository.ts";
+
+const roots: string[] = [];
+const IDENTITY_KEY = `git-${"a".repeat(64)}`;
+
+function temporaryRoot(prefix = "tmux-ide-runtime-"): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function resolution(
+  projectRoot: string,
+  overrides: Partial<ProjectResolution> = {},
+): ProjectResolution {
+  return {
+    inputDir: projectRoot,
+    projectRoot,
+    identityKey: IDENTITY_KEY,
+    identitySource: "git-common-dir",
+    identityAnchor: join(projectRoot, ".git"),
+    config: { kind: "none", path: null, explicit: false },
+    workspaceConfigPath: null,
+    legacyConfigPath: null,
+    hasLegacyConfigAtInput: false,
+    ...overrides,
+  };
+}
+
+function writeRaw(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents, "utf-8");
+}
+
+function caughtError(action: () => unknown): unknown {
+  try {
+    action();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected action to throw");
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("ProjectRuntimeRepository identity and location", () => {
+  it("stores runtime data below TMUX_IDE_HOME and never pollutes the checkout", () => {
+    const project = temporaryRoot("tmux-ide-project-");
+    const home = temporaryRoot("tmux-ide-home-");
+    const previous = process.env.TMUX_IDE_HOME;
+    process.env.TMUX_IDE_HOME = home;
+    try {
+      const repository = createProjectRuntimeRepository(resolution(project));
+
+      expect(repository.metadata.runtimeRoot).toBe(join(home, "projects", IDENTITY_KEY));
+      repository.writeDocument("ui-state.json", { selected: "T-1" }, { expectedRevision: null });
+
+      expect(existsSync(join(home, "projects", IDENTITY_KEY, "ui-state.json"))).toBe(true);
+      expect(existsSync(join(project, ".tmux-ide"))).toBe(false);
+      expect(existsSync(join(project, ".tasks"))).toBe(false);
+    } finally {
+      if (previous === undefined) delete process.env.TMUX_IDE_HOME;
+      else process.env.TMUX_IDE_HOME = previous;
+    }
+  });
+
+  it("maps linked worktrees with one C01 identity to the same runtime root", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const main = temporaryRoot("tmux-ide-main-");
+    const linked = temporaryRoot("tmux-ide-linked-");
+    const commonAnchor = join(main, ".git");
+    const first = createProjectRuntimeRepository(
+      resolution(main, { identityAnchor: commonAnchor }),
+      { home },
+    );
+    const second = createProjectRuntimeRepository(
+      resolution(linked, { identityAnchor: commonAnchor }),
+      { home },
+    );
+
+    expect(first.metadata.runtimeRoot).toBe(second.metadata.runtimeRoot);
+    expect(first.metadata.projectRoot).not.toBe(second.metadata.projectRoot);
+  });
+
+  it("offers a convenience opener backed by the C01 resolver", async () => {
+    const project = temporaryRoot("tmux-ide-project-");
+    const home = temporaryRoot("tmux-ide-home-");
+    const repository = await openProjectRuntimeRepository(project, {
+      home,
+      resolverIo: {
+        exists: () => false,
+        realpath: (path) => path,
+        runGit: async () => null,
+      },
+    });
+
+    expect(repository.metadata.identitySource).toBe("canonical-realpath");
+    expect(repository.metadata.runtimeRoot).toContain(join(home, "projects", "path-"));
+  });
+});
+
+describe("ProjectRuntimeRepository documents", () => {
+  it("creates, reads, updates, reopens, and detaches values", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const project = temporaryRoot("tmux-ide-project-");
+    const first = createProjectRuntimeRepository(resolution(project), { home });
+    const input = { nested: { count: 1 }, labels: ["a"] };
+
+    const created = first.writeDocument("missions/m-1/mission.json", input, {
+      expectedRevision: null,
+    });
+    input.nested.count = 99;
+    created.payload.labels.push("returned-mutation");
+
+    const read = first.readRequiredDocument<typeof input>("missions/m-1/mission.json");
+    expect(read).toMatchObject({
+      revision: 1,
+      payload: { nested: { count: 1 }, labels: ["a"] },
+    });
+    read.payload.nested.count = 42;
+
+    const second = createProjectRuntimeRepository(resolution(project), { home });
+    const updated = second.writeDocument(
+      "missions/m-1/mission.json",
+      { nested: { count: 2 }, labels: ["b"] },
+      { expectedRevision: 1 },
+    );
+    expect(updated.revision).toBe(2);
+    expect(first.readRequiredDocument("missions/m-1/mission.json")).toMatchObject({
+      revision: 2,
+      payload: { nested: { count: 2 }, labels: ["b"] },
+    });
+    expect(first.readDocument("missing.json")).toEqual({
+      found: false,
+      path: "missing.json",
+      revision: null,
+    });
+    expect(caughtError(() => first.readRequiredDocument("missing.json"))).toMatchObject({
+      code: "DOCUMENT_MISSING",
+      path: "missing.json",
+    });
+  });
+
+  it("uses a unique temp file and cleans it after an injected rename failure", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const project = temporaryRoot("tmux-ide-project-");
+    const operations: string[] = [];
+    const repository = createProjectRuntimeRepository(resolution(project), {
+      home,
+      io: {
+        randomId: () => "attempt-1",
+        writeFile: (path, contents) => {
+          operations.push(`write:${path}`);
+          writeFileSync(path, contents, "utf-8");
+        },
+        rename: (from, to) => {
+          operations.push(`rename:${from}->${to}`);
+          throw new Error("injected rename failure");
+        },
+      },
+    });
+
+    expect(
+      caughtError(() =>
+        repository.writeDocument("bindings.json", { task: "T-1" }, { expectedRevision: null }),
+      ),
+    ).toMatchObject({ code: "IO_ERROR", path: "bindings.json" });
+    const directory = join(home, "projects", IDENTITY_KEY);
+    expect(readdirSync(directory)).toEqual([]);
+    expect(operations[0]).toContain("write:");
+    expect(operations[0]).toContain(".tmp-");
+    expect(operations[1]).toContain("rename:");
+    expect(existsSync(join(directory, "bindings.json"))).toBe(false);
+  });
+
+  it("detects create-only and stale revision conflicts across instances", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const project = temporaryRoot("tmux-ide-project-");
+    const first = createProjectRuntimeRepository(resolution(project), { home });
+    const second = createProjectRuntimeRepository(resolution(project), { home });
+    first.writeDocument("ui-state.json", { tab: "home" }, { expectedRevision: null });
+
+    expect(() =>
+      second.writeDocument("ui-state.json", { tab: "files" }, { expectedRevision: null }),
+    ).toThrow(DocumentRevisionConflictError);
+    try {
+      second.writeDocument("ui-state.json", { tab: "files" }, { expectedRevision: null });
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: "REVISION_CONFLICT",
+        path: "ui-state.json",
+        expectedRevision: null,
+        actualRevision: 1,
+      });
+    }
+
+    first.writeDocument("ui-state.json", { tab: "files" }, { expectedRevision: 1 });
+    expect(
+      caughtError(() =>
+        second.writeDocument("ui-state.json", { tab: "diff" }, { expectedRevision: 1 }),
+      ),
+    ).toMatchObject({ expectedRevision: 1, actualRevision: 2 });
+  });
+
+  it.each(["../escape.json", "/tmp/escape.json", "a//b.json", "a/./b.json", "a\\b.json", "bad\0x"])(
+    "rejects unsafe document path %j",
+    (path) => {
+      const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), {
+        home: temporaryRoot(),
+      });
+      expect(caughtError(() => repository.readDocument(path))).toMatchObject({
+        code: "INVALID_PATH",
+        path,
+      });
+    },
+  );
+
+  it("reserves events/ for event streams", () => {
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), {
+      home: temporaryRoot(),
+    });
+    expect(caughtError(() => repository.readDocument("events/mission-1.jsonl"))).toMatchObject({
+      code: "INVALID_PATH",
+      path: "events/mission-1.jsonl",
+    });
+  });
+
+  it("rejects an existing symbolic-link segment that escapes the runtime root", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const outside = temporaryRoot("tmux-ide-outside-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    mkdirSync(repository.metadata.runtimeRoot, { recursive: true });
+    symlinkSync(outside, join(repository.metadata.runtimeRoot, "linked"), "dir");
+    writeRaw(
+      join(outside, "secret.json"),
+      JSON.stringify({ version: 1, revision: 1, payload: {} }),
+    );
+
+    expect(caughtError(() => repository.readDocument("linked/secret.json"))).toMatchObject({
+      code: "INVALID_PATH",
+      path: "linked/secret.json",
+    });
+    expect(
+      caughtError(() =>
+        repository.writeDocument("linked/new.json", {}, { expectedRevision: null }),
+      ),
+    ).toMatchObject({ code: "INVALID_PATH", path: "linked/new.json" });
+    expect(existsSync(join(outside, "new.json"))).toBe(false);
+  });
+
+  it("wraps non-missing read failures in a typed IO error", () => {
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), {
+      home: temporaryRoot(),
+      io: {
+        readFile: () => {
+          throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+        },
+      },
+    });
+    expect(caughtError(() => repository.readDocument("ui-state.json"))).toMatchObject({
+      code: "IO_ERROR",
+      path: "ui-state.json",
+    });
+  });
+
+  it("distinguishes malformed and unsupported document envelopes from missing data", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const root = repository.metadata.runtimeRoot;
+
+    writeRaw(join(root, "broken.json"), "{not-json\n");
+    expect(caughtError(() => repository.readDocument("broken.json"))).toMatchObject({
+      code: "DOCUMENT_CORRUPT",
+      path: "broken.json",
+    });
+
+    writeRaw(join(root, "future.json"), JSON.stringify({ version: 2, revision: 1, payload: {} }));
+    expect(caughtError(() => repository.readDocument("future.json"))).toMatchObject({
+      code: "UNSUPPORTED_DOCUMENT_VERSION",
+      path: "future.json",
+    });
+
+    writeRaw(
+      join(root, "bad-revision.json"),
+      JSON.stringify({ version: 1, revision: 0, payload: {} }),
+    );
+    expect(caughtError(() => repository.readDocument("bad-revision.json"))).toMatchObject({
+      code: "DOCUMENT_CORRUPT",
+      path: "bad-revision.json",
+    });
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["bigint", 1n],
+    ["infinity", Number.POSITIVE_INFINITY],
+    ["date", new Date()],
+    ["function", () => undefined],
+    ["sparse array", new Array(1)],
+  ])("rejects %s payloads without writing", (_label, value) => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    expect(
+      caughtError(() =>
+        repository.writeDocument("invalid.json", value as never, { expectedRevision: null }),
+      ),
+    ).toMatchObject({ code: "INVALID_JSON_VALUE" });
+    expect(existsSync(join(repository.metadata.runtimeRoot, "invalid.json"))).toBe(false);
+  });
+
+  it("rejects cyclic payloads with a typed error instead of RangeError", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    let caught: unknown;
+    try {
+      repository.writeDocument("cyclic.json", cyclic as JsonValue, { expectedRevision: null });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ProjectRuntimeRepositoryError);
+    expect(caught).not.toBeInstanceOf(RangeError);
+    expect(caught).toMatchObject({ code: "INVALID_JSON_VALUE", valuePath: "$.self" });
+  });
+});
+
+describe("ProjectRuntimeRepository event streams", () => {
+  it("assigns durable ordered sequences across reopen and separate instances", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const project = temporaryRoot("tmux-ide-project-");
+    const times = [
+      new Date("2026-07-17T10:00:00.000Z"),
+      new Date("2026-07-17T10:00:01.000Z"),
+      new Date("2026-07-17T10:00:02.000Z"),
+    ];
+    const first = createProjectRuntimeRepository(resolution(project), {
+      home,
+      io: { now: () => times.shift()! },
+    });
+    const input = { type: "created", nested: { id: "T-1" } };
+    const event1 = first.appendEvent("mission-1", input, { expectedPreviousSequence: 0 });
+    input.nested.id = "mutated";
+    event1.payload.nested.id = "returned-mutation";
+    first.appendEvent("mission-1", { type: "claimed" }, { expectedPreviousSequence: 1 });
+
+    const reopened = createProjectRuntimeRepository(resolution(project), {
+      home,
+      io: { now: () => times.shift()! },
+    });
+    const event3 = reopened.appendEvent(
+      "mission-1",
+      { type: "submitted" },
+      {
+        expectedPreviousSequence: 2,
+      },
+    );
+    expect(event3.sequence).toBe(3);
+    expect(first.readEvents("mission-1")).toEqual([
+      {
+        version: 1,
+        sequence: 1,
+        timestamp: "2026-07-17T10:00:00.000Z",
+        payload: { type: "created", nested: { id: "T-1" } },
+      },
+      {
+        version: 1,
+        sequence: 2,
+        timestamp: "2026-07-17T10:00:01.000Z",
+        payload: { type: "claimed" },
+      },
+      {
+        version: 1,
+        sequence: 3,
+        timestamp: "2026-07-17T10:00:02.000Z",
+        payload: { type: "submitted" },
+      },
+    ]);
+  });
+
+  it("raises a typed expected-sequence conflict", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    repository.appendEvent("mission-1", { type: "created" });
+
+    expect(() =>
+      repository.appendEvent("mission-1", { type: "stale" }, { expectedPreviousSequence: 0 }),
+    ).toThrow(EventSequenceConflictError);
+    try {
+      repository.appendEvent("mission-1", { type: "stale" }, { expectedPreviousSequence: 0 });
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: "EVENT_SEQUENCE_CONFLICT",
+        stream: "mission-1",
+        expectedPreviousSequence: 0,
+        actualPreviousSequence: 1,
+      });
+    }
+  });
+
+  it.each(["../escape", "nested/stream", "\\escape", ".", "", "bad\0id"])(
+    "rejects unsafe event stream id %j",
+    (stream) => {
+      const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), {
+        home: temporaryRoot(),
+      });
+      expect(caughtError(() => repository.readEvents(stream))).toMatchObject({
+        code: "INVALID_PATH",
+        stream,
+      });
+    },
+  );
+
+  it.each([
+    ["malformed JSON", "{nope\n", 1],
+    [
+      "duplicate sequence",
+      [
+        { version: 1, sequence: 1, timestamp: "2026-01-01T00:00:00.000Z", payload: {} },
+        { version: 1, sequence: 1, timestamp: "2026-01-01T00:00:01.000Z", payload: {} },
+      ]
+        .map(JSON.stringify)
+        .join("\n") + "\n",
+      2,
+    ],
+    [
+      "gapped sequence",
+      [
+        { version: 1, sequence: 1, timestamp: "2026-01-01T00:00:00.000Z", payload: {} },
+        { version: 1, sequence: 3, timestamp: "2026-01-01T00:00:01.000Z", payload: {} },
+      ]
+        .map(JSON.stringify)
+        .join("\n") + "\n",
+      2,
+    ],
+    [
+      "out-of-order sequence",
+      [
+        { version: 1, sequence: 2, timestamp: "2026-01-01T00:00:00.000Z", payload: {} },
+        { version: 1, sequence: 1, timestamp: "2026-01-01T00:00:01.000Z", payload: {} },
+      ]
+        .map(JSON.stringify)
+        .join("\n") + "\n",
+      1,
+    ],
+  ])("rejects %s with stream and line context", (_label, contents, line) => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    writeRaw(join(repository.metadata.runtimeRoot, "events", "mission-1.jsonl"), contents);
+
+    let caught: unknown;
+    try {
+      repository.readEvents("mission-1");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(CorruptEventLogError);
+    expect(caught).toMatchObject({
+      code: "EVENT_LOG_CORRUPT",
+      stream: "mission-1",
+      lineNumber: line,
+    });
+  });
+
+  it.each([
+    [
+      "unsupported event version",
+      { version: 2, sequence: 1, timestamp: "2026-01-01T00:00:00.000Z", payload: {} },
+    ],
+    [
+      "non-canonical timestamp",
+      { version: 1, sequence: 1, timestamp: "January 1, 2026", payload: {} },
+    ],
+  ])("rejects %s with typed event-log corruption", (_label, record) => {
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), {
+      home: temporaryRoot(),
+    });
+    writeRaw(
+      join(repository.metadata.runtimeRoot, "events", "mission-1.jsonl"),
+      `${JSON.stringify(record)}\n`,
+    );
+    expect(caughtError(() => repository.readEvents("mission-1"))).toMatchObject({
+      code: "EVENT_LOG_CORRUPT",
+      stream: "mission-1",
+      lineNumber: 1,
+    });
+  });
+
+  it("atomically replaces the JSONL stream without leaving temp files", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const project = temporaryRoot("tmux-ide-project-");
+    const operations: string[] = [];
+    const repository = createProjectRuntimeRepository(resolution(project), {
+      home,
+      io: {
+        randomId: () => "event-write",
+        rename: (from, to) => {
+          operations.push(`${from}->${to}`);
+          renameSync(from, to);
+        },
+      },
+    });
+    repository.appendEvent("mission-1", { type: "created" });
+
+    const eventsDir = join(repository.metadata.runtimeRoot, "events");
+    expect(operations).toHaveLength(1);
+    expect(operations[0]).toContain(".tmp-");
+    expect(readdirSync(eventsDir)).toEqual(["mission-1.jsonl"]);
+    expect(readFileSync(join(eventsDir, "mission-1.jsonl"), "utf-8")).toMatch(/"sequence":1/u);
+  });
+});

--- a/packages/daemon/src/lib/project-runtime-repository.ts
+++ b/packages/daemon/src/lib/project-runtime-repository.ts
@@ -1,0 +1,689 @@
+import { randomUUID } from "node:crypto";
+import { lstatSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, relative, resolve, sep, win32 } from "node:path";
+
+import type { ProjectResolution, ResolveProjectOptions } from "./project-resolver.js";
+import { resolveProject } from "./project-resolver.js";
+import { stateHome } from "./state-home.js";
+
+const DOCUMENT_ENVELOPE_VERSION = 1;
+const EVENT_ENVELOPE_VERSION = 1;
+const SAFE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export type ProjectRuntimeErrorCode =
+  | "INVALID_PATH"
+  | "DOCUMENT_MISSING"
+  | "DOCUMENT_CORRUPT"
+  | "UNSUPPORTED_DOCUMENT_VERSION"
+  | "INVALID_JSON_VALUE"
+  | "REVISION_CONFLICT"
+  | "EVENT_SEQUENCE_CONFLICT"
+  | "EVENT_LOG_CORRUPT"
+  | "IO_ERROR";
+
+export interface ProjectRuntimeRepositoryIo {
+  readFile(path: string): string;
+  writeFile(path: string, data: string): void;
+  mkdir(path: string): void;
+  rename(from: string, to: string): void;
+  unlink(path: string): void;
+  isSymbolicLink(path: string): boolean;
+  now(): Date;
+  randomId(): string;
+}
+
+export interface ProjectRuntimeRepositoryOptions {
+  /** Preferred state-home override. */
+  home?: string;
+  /** @deprecated Use `home`; retained for callers that adopted the C04 draft API. */
+  stateHome?: string;
+  io?: Partial<ProjectRuntimeRepositoryIo>;
+}
+
+export interface OpenProjectRuntimeRepositoryOptions extends ProjectRuntimeRepositoryOptions {
+  explicitConfigPath?: string | null;
+  resolverIo?: ResolveProjectOptions["io"];
+  resolveOptions?: ResolveProjectOptions;
+  resolver?: (dir: string, options?: ResolveProjectOptions) => Promise<ProjectResolution>;
+}
+
+export interface ProjectRuntimeMetadata {
+  identityKey: string;
+  identitySource: ProjectResolution["identitySource"];
+  identityAnchor: string;
+  projectRoot: string;
+  runtimeRoot: string;
+}
+
+export type ProjectRuntimeDocument<T> =
+  | { found: false; path: string; revision: null }
+  | {
+      found: true;
+      path: string;
+      version: typeof DOCUMENT_ENVELOPE_VERSION;
+      revision: number;
+      payload: T;
+    };
+
+export interface WriteDocumentOptions {
+  /** `null` means create-only; a number must match the current on-disk revision. */
+  expectedRevision: number | null;
+}
+
+export interface WriteDocumentResult<T> {
+  path: string;
+  version: typeof DOCUMENT_ENVELOPE_VERSION;
+  revision: number;
+  payload: T;
+}
+
+export interface RuntimeEvent<T> {
+  version: typeof EVENT_ENVELOPE_VERSION;
+  sequence: number;
+  timestamp: string;
+  payload: T;
+}
+
+export interface AppendEventOptions {
+  expectedPreviousSequence?: number;
+}
+
+export class ProjectRuntimeRepositoryError extends Error {
+  readonly code: ProjectRuntimeErrorCode;
+
+  constructor(code: ProjectRuntimeErrorCode, message: string) {
+    super(message);
+    this.name = new.target.name;
+    this.code = code;
+  }
+}
+
+export class InvalidRuntimePathError extends ProjectRuntimeRepositoryError {
+  readonly path: string;
+
+  constructor(path: string, reason: string) {
+    super("INVALID_PATH", `Invalid runtime path "${path}": ${reason}`);
+    this.path = path;
+  }
+}
+
+export class InvalidEventStreamError extends InvalidRuntimePathError {
+  readonly stream: string;
+
+  constructor(stream: string, reason: string) {
+    super(stream, reason);
+    this.name = "InvalidEventStreamError";
+    this.stream = stream;
+  }
+}
+
+export class MissingRuntimeDocumentError extends ProjectRuntimeRepositoryError {
+  readonly path: string;
+
+  constructor(path: string) {
+    super("DOCUMENT_MISSING", `Runtime document "${path}" does not exist`);
+    this.path = path;
+  }
+}
+
+export class CorruptRuntimeDocumentError extends ProjectRuntimeRepositoryError {
+  readonly path: string;
+  readonly reason: string;
+
+  constructor(path: string, reason: string) {
+    super("DOCUMENT_CORRUPT", `Runtime document "${path}" is corrupt: ${reason}`);
+    this.path = path;
+    this.reason = reason;
+  }
+}
+
+export class UnsupportedRuntimeDocumentVersionError extends ProjectRuntimeRepositoryError {
+  readonly path: string;
+  readonly version: unknown;
+
+  constructor(path: string, version: unknown) {
+    super(
+      "UNSUPPORTED_DOCUMENT_VERSION",
+      `Runtime document "${path}" uses unsupported envelope version ${String(version)}`,
+    );
+    this.path = path;
+    this.version = version;
+  }
+}
+
+export class InvalidJsonValueError extends ProjectRuntimeRepositoryError {
+  readonly valuePath: string;
+  readonly reason: string;
+
+  constructor(valuePath: string, reason: string) {
+    super("INVALID_JSON_VALUE", `Invalid JSON value at ${valuePath}: ${reason}`);
+    this.valuePath = valuePath;
+    this.reason = reason;
+  }
+}
+
+export class RevisionConflictError extends ProjectRuntimeRepositoryError {
+  readonly path: string;
+  readonly expectedRevision: number | null;
+  readonly actualRevision: number | null;
+
+  constructor(path: string, expectedRevision: number | null, actualRevision: number | null) {
+    super(
+      "REVISION_CONFLICT",
+      `Revision conflict for "${path}": expected ${String(expectedRevision)}, actual ${String(
+        actualRevision,
+      )}`,
+    );
+    this.path = path;
+    this.expectedRevision = expectedRevision;
+    this.actualRevision = actualRevision;
+  }
+}
+
+export class EventSequenceConflictError extends ProjectRuntimeRepositoryError {
+  readonly stream: string;
+  readonly expectedPreviousSequence: number;
+  readonly actualPreviousSequence: number;
+
+  constructor(stream: string, expectedPreviousSequence: number, actualPreviousSequence: number) {
+    super(
+      "EVENT_SEQUENCE_CONFLICT",
+      `Event sequence conflict for "${stream}": expected previous ${expectedPreviousSequence}, actual previous ${actualPreviousSequence}`,
+    );
+    this.stream = stream;
+    this.expectedPreviousSequence = expectedPreviousSequence;
+    this.actualPreviousSequence = actualPreviousSequence;
+  }
+}
+
+export class CorruptEventLogError extends ProjectRuntimeRepositoryError {
+  readonly stream: string;
+  readonly lineNumber: number;
+  readonly reason: string;
+
+  constructor(stream: string, lineNumber: number, reason: string) {
+    super("EVENT_LOG_CORRUPT", `Event log "${stream}" is corrupt at line ${lineNumber}: ${reason}`);
+    this.stream = stream;
+    this.lineNumber = lineNumber;
+    this.reason = reason;
+  }
+}
+
+export class ProjectRuntimeIoError extends ProjectRuntimeRepositoryError {
+  readonly path: string;
+  override readonly cause: unknown;
+
+  constructor(path: string, operation: string, cause: unknown) {
+    super("IO_ERROR", `Unable to ${operation} runtime path "${path}"`);
+    this.path = path;
+    this.cause = cause;
+  }
+}
+
+interface DocumentEnvelope {
+  version: typeof DOCUMENT_ENVELOPE_VERSION;
+  revision: number;
+  payload: JsonValue;
+}
+
+interface EventEnvelope {
+  version: typeof EVENT_ENVELOPE_VERSION;
+  sequence: number;
+  timestamp: string;
+  payload: JsonValue;
+}
+
+const defaultIo: ProjectRuntimeRepositoryIo = {
+  readFile: (path) => readFileSync(path, "utf-8"),
+  writeFile: (path, data) => writeFileSync(path, data, "utf-8"),
+  mkdir: (path) => mkdirSync(path, { recursive: true }),
+  rename: renameSync,
+  unlink: unlinkSync,
+  isSymbolicLink: (path) => {
+    try {
+      return lstatSync(path).isSymbolicLink();
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") return false;
+      throw error;
+    }
+  },
+  now: () => new Date(),
+  randomId: randomUUID,
+};
+
+let tempCounter = 0;
+
+export class ProjectRuntimeRepository {
+  readonly resolution: ProjectResolution;
+  readonly runtimeRoot: string;
+  readonly metadata: ProjectRuntimeMetadata;
+
+  private readonly io: ProjectRuntimeRepositoryIo;
+
+  constructor(resolution: ProjectResolution, options: ProjectRuntimeRepositoryOptions = {}) {
+    validateSafeId(resolution.identityKey, "identity key");
+    this.resolution = resolution;
+    this.io = { ...defaultIo, ...options.io };
+    this.runtimeRoot = join(
+      resolve(options.home ?? options.stateHome ?? stateHome()),
+      "projects",
+      resolution.identityKey,
+    );
+    this.metadata = {
+      identityKey: resolution.identityKey,
+      identitySource: resolution.identitySource,
+      identityAnchor: resolution.identityAnchor,
+      projectRoot: resolution.projectRoot,
+      runtimeRoot: this.runtimeRoot,
+    };
+  }
+
+  readDocument<T = JsonValue>(path: string): ProjectRuntimeDocument<T> {
+    const target = this.resolveRuntimePath(path);
+    const raw = this.readOptionalFile(target, path);
+    if (raw === null) return { found: false, path, revision: null };
+    const envelope = parseDocumentEnvelope(path, raw);
+    return {
+      found: true,
+      path,
+      version: DOCUMENT_ENVELOPE_VERSION,
+      revision: envelope.revision,
+      payload: cloneJson(envelope.payload) as T,
+    };
+  }
+
+  readRequiredDocument<T = JsonValue>(path: string): WriteDocumentResult<T> {
+    const document = this.readDocument<T>(path);
+    if (!document.found) throw new MissingRuntimeDocumentError(path);
+    return {
+      path: document.path,
+      version: document.version,
+      revision: document.revision,
+      payload: document.payload,
+    };
+  }
+
+  writeDocument<T>(
+    path: string,
+    payload: T,
+    options: WriteDocumentOptions,
+  ): WriteDocumentResult<T> {
+    if (
+      options.expectedRevision !== null &&
+      (!Number.isSafeInteger(options.expectedRevision) || options.expectedRevision < 1)
+    ) {
+      throw new RevisionConflictError(path, options.expectedRevision, null);
+    }
+    const target = this.resolveRuntimePath(path);
+    const existing = this.readOptionalFile(target, path);
+    const current = existing === null ? null : parseDocumentEnvelope(path, existing);
+    const actualRevision = current?.revision ?? null;
+
+    if (options.expectedRevision !== actualRevision) {
+      throw new RevisionConflictError(path, options.expectedRevision, actualRevision);
+    }
+
+    const serializedPayload = serializeJsonPayload(payload);
+    const envelope: DocumentEnvelope = {
+      version: DOCUMENT_ENVELOPE_VERSION,
+      revision: actualRevision === null ? 1 : actualRevision + 1,
+      payload: serializedPayload,
+    };
+    this.atomicWrite(target, `${JSON.stringify(envelope, null, 2)}\n`, path);
+    return {
+      path,
+      version: DOCUMENT_ENVELOPE_VERSION,
+      revision: envelope.revision,
+      payload: cloneJson(serializedPayload) as T,
+    };
+  }
+
+  readEvents<T = JsonValue>(stream: string): RuntimeEvent<T>[] {
+    const target = this.resolveEventPath(stream);
+    const raw = this.readOptionalFile(target, `events/${stream}.jsonl`);
+    if (raw === null) return [];
+    return parseEventLog<T>(stream, raw);
+  }
+
+  appendEvent<T>(stream: string, payload: T, options: AppendEventOptions = {}): RuntimeEvent<T> {
+    if (
+      options.expectedPreviousSequence !== undefined &&
+      (!Number.isSafeInteger(options.expectedPreviousSequence) ||
+        options.expectedPreviousSequence < 0)
+    ) {
+      throw new EventSequenceConflictError(stream, options.expectedPreviousSequence, 0);
+    }
+    const target = this.resolveEventPath(stream);
+    const raw = this.readOptionalFile(target, `events/${stream}.jsonl`);
+    const events = raw === null ? [] : parseEventLog<JsonValue>(stream, raw);
+    const actualPreviousSequence = events.at(-1)?.sequence ?? 0;
+
+    if (
+      options.expectedPreviousSequence !== undefined &&
+      options.expectedPreviousSequence !== actualPreviousSequence
+    ) {
+      throw new EventSequenceConflictError(
+        stream,
+        options.expectedPreviousSequence,
+        actualPreviousSequence,
+      );
+    }
+
+    const now = this.io.now();
+    if (!Number.isFinite(now.getTime())) {
+      throw new InvalidJsonValueError("$.timestamp", "timestamp must be a valid date");
+    }
+    const event: EventEnvelope = {
+      version: EVENT_ENVELOPE_VERSION,
+      sequence: actualPreviousSequence + 1,
+      timestamp: now.toISOString(),
+      payload: serializeJsonPayload(payload),
+    };
+    this.atomicWrite(
+      target,
+      `${[...events, event].map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+      `events/${stream}.jsonl`,
+    );
+    return cloneJson(event) as RuntimeEvent<T>;
+  }
+
+  private resolveRuntimePath(path: string, allowEventNamespace = false): string {
+    if (path.length === 0) throw new InvalidRuntimePathError(path, "path must not be empty");
+    if (path.includes("\0")) throw new InvalidRuntimePathError(path, "path must not contain NUL");
+    if (path.includes("\\")) {
+      throw new InvalidRuntimePathError(path, "path must use forward slashes");
+    }
+    if (isAbsolute(path) || win32.isAbsolute(path)) {
+      throw new InvalidRuntimePathError(path, "path must be relative");
+    }
+    const parts = path.split("/");
+    if (parts.some((part) => part.length === 0 || part === "." || part === "..")) {
+      throw new InvalidRuntimePathError(path, "path contains an unsafe segment");
+    }
+    if (!allowEventNamespace && parts[0] === "events") {
+      throw new InvalidRuntimePathError(path, "the events namespace is reserved for event streams");
+    }
+    const target = resolve(this.runtimeRoot, ...parts);
+    if (!isWithinDirectory(target, this.runtimeRoot)) {
+      throw new InvalidRuntimePathError(path, "path escapes the runtime root");
+    }
+    this.assertNoSymbolicLink(path, parts);
+    return target;
+  }
+
+  private resolveEventPath(stream: string): string {
+    validateSafeStreamId(stream);
+    return this.resolveRuntimePath(`events/${stream}.jsonl`, true);
+  }
+
+  private assertNoSymbolicLink(displayPath: string, parts: string[]): void {
+    let current = this.runtimeRoot;
+    for (const part of parts) {
+      current = join(current, part);
+      try {
+        if (this.io.isSymbolicLink(current)) {
+          throw new InvalidRuntimePathError(displayPath, "symbolic links are not allowed");
+        }
+      } catch (error) {
+        if (error instanceof ProjectRuntimeRepositoryError) throw error;
+        throw new ProjectRuntimeIoError(displayPath, "inspect", error);
+      }
+    }
+  }
+
+  private readOptionalFile(path: string, displayPath: string): string | null {
+    try {
+      return this.io.readFile(path);
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") return null;
+      throw new ProjectRuntimeIoError(displayPath, "read", error);
+    }
+  }
+
+  private atomicWrite(target: string, data: string, displayPath: string): void {
+    const destinationDir = resolve(target, "..");
+    this.io.mkdir(destinationDir);
+    const tempPath = join(
+      destinationDir,
+      `.tmp-${process.pid}-${tempCounter++}-${safeTempId(this.io.randomId())}`,
+    );
+    try {
+      this.io.writeFile(tempPath, data);
+      this.io.rename(tempPath, target);
+    } catch (error) {
+      try {
+        this.io.unlink(tempPath);
+      } catch (cleanupError) {
+        if (!isNodeError(cleanupError) || cleanupError.code !== "ENOENT") {
+          // Preserve the write/rename failure; cleanup is best-effort.
+        }
+      }
+      throw new ProjectRuntimeIoError(displayPath, "atomically write", error);
+    }
+  }
+}
+
+export function createProjectRuntimeRepository(
+  resolution: ProjectResolution,
+  options: ProjectRuntimeRepositoryOptions = {},
+): ProjectRuntimeRepository {
+  return new ProjectRuntimeRepository(resolution, options);
+}
+
+export async function openProjectRuntimeRepository(
+  dir: string,
+  options: OpenProjectRuntimeRepositoryOptions = {},
+): Promise<ProjectRuntimeRepository> {
+  const resolver = options.resolver ?? resolveProject;
+  const resolution = await resolver(dir, {
+    ...options.resolveOptions,
+    explicitConfigPath: options.explicitConfigPath ?? options.resolveOptions?.explicitConfigPath,
+    io: options.resolverIo ?? options.resolveOptions?.io,
+  });
+  return createProjectRuntimeRepository(resolution, options);
+}
+
+function parseDocumentEnvelope(path: string, raw: string): DocumentEnvelope {
+  const value = parseJson(raw, () => new CorruptRuntimeDocumentError(path, "invalid JSON"));
+  if (!isRecord(value)) throw new CorruptRuntimeDocumentError(path, "envelope must be an object");
+  if (!sameKeys(Object.keys(value), ["version", "revision", "payload"])) {
+    throw new CorruptRuntimeDocumentError(path, "envelope has invalid keys");
+  }
+  if (value.version !== DOCUMENT_ENVELOPE_VERSION) {
+    if (Number.isInteger(value.version)) {
+      throw new UnsupportedRuntimeDocumentVersionError(path, value.version);
+    }
+    throw new CorruptRuntimeDocumentError(path, "envelope version must be a supported integer");
+  }
+  const revision = value.revision;
+  if (typeof revision !== "number" || !Number.isSafeInteger(revision) || revision < 1) {
+    throw new CorruptRuntimeDocumentError(path, "revision must be a positive safe integer");
+  }
+  assertJsonPayload(value.payload);
+  return {
+    version: DOCUMENT_ENVELOPE_VERSION,
+    revision,
+    payload: cloneJson(value.payload),
+  };
+}
+
+function parseEventLog<T>(stream: string, raw: string): RuntimeEvent<T>[] {
+  if (raw.length === 0) return [];
+  const lines = raw.endsWith("\n") ? raw.slice(0, -1).split("\n") : raw.split("\n");
+  if (lines.length === 1 && lines[0] === "") return [];
+
+  return lines.map((line, index) => {
+    const lineNumber = index + 1;
+    if (line.trim().length === 0) {
+      throw new CorruptEventLogError(stream, lineNumber, "blank lines are not allowed");
+    }
+    const value = parseJson(
+      line,
+      () => new CorruptEventLogError(stream, lineNumber, "invalid JSON"),
+    );
+    if (!isRecord(value))
+      throw new CorruptEventLogError(stream, lineNumber, "event must be an object");
+    if (!sameKeys(Object.keys(value), ["version", "sequence", "timestamp", "payload"])) {
+      throw new CorruptEventLogError(stream, lineNumber, "event has invalid keys");
+    }
+    if (value.version !== EVENT_ENVELOPE_VERSION) {
+      throw new CorruptEventLogError(stream, lineNumber, "unsupported event version");
+    }
+    if (value.sequence !== lineNumber) {
+      throw new CorruptEventLogError(stream, lineNumber, "event sequence must be continuous");
+    }
+    if (typeof value.timestamp !== "string" || !isCanonicalTimestamp(value.timestamp)) {
+      throw new CorruptEventLogError(
+        stream,
+        lineNumber,
+        "timestamp must be a canonical ISO string",
+      );
+    }
+    assertJsonPayload(
+      value.payload,
+      (payloadPath, reason) =>
+        new CorruptEventLogError(stream, lineNumber, `${payloadPath}: ${reason}`),
+    );
+    return {
+      version: EVENT_ENVELOPE_VERSION,
+      sequence: value.sequence,
+      timestamp: value.timestamp,
+      payload: cloneJson(value.payload) as T,
+    };
+  });
+}
+
+function parseJson<TError extends Error>(raw: string, errorFactory: () => TError): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    throw errorFactory();
+  }
+}
+
+function serializeJsonPayload(value: unknown): JsonValue {
+  assertJsonPayload(value);
+  return cloneJson(value);
+}
+
+function assertJsonPayload(
+  value: unknown,
+  errorFactory: (path: string, reason: string) => Error = (path, reason) =>
+    new InvalidJsonValueError(path, reason),
+): asserts value is JsonValue {
+  const stack = new Set<object>();
+
+  function visit(candidate: unknown, path: string): void {
+    if (candidate === null) return;
+    if (typeof candidate === "string" || typeof candidate === "boolean") return;
+    if (typeof candidate === "number") {
+      if (!Number.isFinite(candidate)) throw errorFactory(path, "number must be finite");
+      return;
+    }
+    if (typeof candidate === "undefined") throw errorFactory(path, "undefined is not JSON");
+    if (typeof candidate === "bigint") throw errorFactory(path, "bigint is not JSON");
+    if (typeof candidate === "function") throw errorFactory(path, "function is not JSON");
+    if (typeof candidate === "symbol") throw errorFactory(path, "symbol is not JSON");
+    if (typeof candidate !== "object") throw errorFactory(path, "value is not JSON");
+
+    if (stack.has(candidate)) throw errorFactory(path, "cyclic values are not JSON");
+    stack.add(candidate);
+    try {
+      if (Array.isArray(candidate)) {
+        for (let index = 0; index < candidate.length; index += 1) {
+          if (!Object.hasOwn(candidate, index)) {
+            throw errorFactory(`${path}[${index}]`, "sparse arrays are not JSON");
+          }
+          visit(candidate[index], `${path}[${index}]`);
+        }
+        const customKeys = Reflect.ownKeys(candidate).filter((key) => {
+          if (key === "length") return false;
+          return typeof key === "symbol" || !/^(?:0|[1-9]\d*)$/.test(String(key));
+        });
+        if (customKeys.length > 0) throw errorFactory(path, "arrays must not have custom keys");
+        return;
+      }
+      if (Object.getPrototypeOf(candidate) !== Object.prototype) {
+        throw errorFactory(path, "object must be a plain object");
+      }
+      for (const key of Reflect.ownKeys(candidate)) {
+        if (typeof key === "symbol") throw errorFactory(path, "symbol keys are not JSON");
+        const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
+        if (!descriptor) continue;
+        if ("get" in descriptor || "set" in descriptor) {
+          throw errorFactory(`${path}.${key}`, "accessors are not JSON");
+        }
+        visit((candidate as Record<string, unknown>)[key], `${path}.${key}`);
+      }
+    } finally {
+      stack.delete(candidate);
+    }
+  }
+
+  visit(value, "$");
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sameKeys(actual: string[], expected: string[]): boolean {
+  if (actual.length !== expected.length) return false;
+  const actualSet = new Set(actual);
+  return expected.every((key) => actualSet.has(key));
+}
+
+function validateSafeId(value: string, label: string): void {
+  if (
+    !SAFE_ID_PATTERN.test(value) ||
+    value === "." ||
+    value === ".." ||
+    value.includes("..") ||
+    value.includes("\0")
+  ) {
+    throw new InvalidRuntimePathError(value, `${label} must be a safe filesystem id`);
+  }
+}
+
+function validateSafeStreamId(value: string): void {
+  if (
+    !SAFE_ID_PATTERN.test(value) ||
+    value === "." ||
+    value === ".." ||
+    value.includes("..") ||
+    value.includes("\0")
+  ) {
+    throw new InvalidEventStreamError(value, "event stream must be a safe filesystem id");
+  }
+}
+
+function isWithinDirectory(path: string, root: string): boolean {
+  const fromRoot = relative(root, path);
+  return (
+    fromRoot === "" ||
+    (fromRoot !== ".." && !fromRoot.startsWith(`..${sep}`) && !isAbsolute(fromRoot))
+  );
+}
+
+function safeTempId(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, "_");
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function isCanonicalTimestamp(value: string): boolean {
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add a project-identity-scoped runtime repository under the tmux-ide state home
- provide atomic, revision-checked JSON documents and ordered JSONL event streams
- enforce typed corruption/conflict errors, path traversal and symlink defenses, and deterministic injected I/O primitives
- keep all runtime state outside the project checkout

## Validation
- 38 focused repository tests
- 91 daemon test files / 1,672 tests
- `pnpm check`
- `git diff --check`

Tracks Sfora card #112 (M26.3 / C04).