### PR TITLE
feat(missions): add durable mission domain

### DIFF
--- a/packages/contracts/src/__tests__/missions.test.ts
+++ b/packages/contracts/src/__tests__/missions.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+import {
+  MissionActorSchemaZ,
+  MissionAttemptIdSchemaZ,
+  MissionEventSchemaZ,
+  MissionIdSchemaZ,
+  MissionAttemptSchemaZ,
+  MissionProjectStateSchemaZ,
+  MissionSnapshotSchemaZ,
+  MissionProofSchemaZ,
+  MissionReferenceIdSchemaZ,
+  MissionStatusSchemaZ,
+  MissionTaskSchemaZ,
+  MissionTaskIdSchemaZ,
+  MissionTaskStatusSchemaZ,
+} from "../domain.ts";
+
+const actor = { type: "user" as const, id: "pm" };
+
+describe("mission domain contracts", () => {
+  it("round-trips provider-neutral mission, task, attempt, and proof events", () => {
+    const events = [
+      {
+        version: 1,
+        type: "mission.created",
+        missionId: "mis_alpha",
+        title: "Ship durable missions",
+        objective: "Persist mission state",
+        acceptanceCriteria: ["replayable"],
+        constraints: ["harness-neutral"],
+        labels: ["m27"],
+        source: { type: "user", id: "sfora-card-114" },
+        actor,
+      },
+      {
+        version: 1,
+        type: "task.added",
+        missionId: "mis_alpha",
+        taskId: "tsk_contracts",
+        title: "Add contracts",
+        priority: 1,
+        dependencies: [],
+        assignee: "worker.profile",
+        actor,
+      },
+      {
+        version: 1,
+        type: "attempt.started",
+        missionId: "mis_alpha",
+        taskId: "tsk_contracts",
+        attemptId: "att_first",
+        agent: "worker.profile",
+        harness: "generic-harness",
+        model: "opaque/model-ref",
+        terminal: "term_1",
+        session: "session_1",
+        worktree: "worktrees/task",
+        actor,
+      },
+      {
+        version: 1,
+        type: "proof.recorded",
+        missionId: "mis_alpha",
+        taskId: "tsk_contracts",
+        attemptId: "att_first",
+        proofId: "prf_tests",
+        proof: {
+          tests: [{ name: "contracts", status: "passed", passed: 12, total: 12 }],
+          commits: [{ sha: "abcdef1" }],
+          diff: { summary: "Added schemas", stats: { filesChanged: 2 } },
+          pr: { number: 114, status: "open" },
+          artifacts: [{ name: "log", uri: "runtime://artifact/log" }],
+          notes: "All checks passed",
+        },
+        actor,
+      },
+    ];
+
+    for (const event of events) {
+      expect(MissionEventSchemaZ.parse(event)).toEqual(event);
+    }
+  });
+
+  it("rejects malformed IDs, references, statuses, proofs, and event payloads", () => {
+    expect(MissionIdSchemaZ.safeParse("../mis").success).toBe(false);
+    expect(MissionTaskIdSchemaZ.safeParse("task-1").success).toBe(false);
+    expect(MissionAttemptIdSchemaZ.safeParse("att space").success).toBe(false);
+    expect(MissionReferenceIdSchemaZ.safeParse("../profile").success).toBe(false);
+    expect(MissionStatusSchemaZ.safeParse("dispatching").success).toBe(false);
+    expect(MissionTaskStatusSchemaZ.safeParse("updated").success).toBe(false);
+    expect(MissionActorSchemaZ.safeParse({ type: "claude" }).success).toBe(false);
+    expect(MissionProofSchemaZ.safeParse({}).success).toBe(false);
+    expect(
+      MissionProofSchemaZ.safeParse({
+        tests: [{ name: "unit", status: "passed", passed: 2, total: 1 }],
+      }).success,
+    ).toBe(false);
+    expect(MissionProofSchemaZ.safeParse({ tests: [{ name: "", status: "passed" }] }).success).toBe(
+      false,
+    );
+    expect(
+      MissionEventSchemaZ.safeParse({
+        version: 2,
+        type: "mission.created",
+        missionId: "mis_alpha",
+        title: "x",
+        objective: "x",
+        acceptanceCriteria: [],
+        constraints: [],
+        labels: [],
+        source: { type: "user" },
+        actor,
+      }).success,
+    ).toBe(false);
+    expect(
+      MissionEventSchemaZ.safeParse({
+        version: 1,
+        type: "provider.claude.spawned",
+        missionId: "mis_alpha",
+        actor,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("strictly parses projected task, attempt, and mission snapshots", () => {
+    const task = {
+      id: "tsk_contracts",
+      missionId: "mis_alpha",
+      title: "Contracts",
+      priority: 1,
+      dependencies: [],
+      status: "completed",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      proofIds: ["prf_tests"],
+      attemptIds: ["att_first"],
+    };
+    const attempt = {
+      id: "att_first",
+      missionId: "mis_alpha",
+      taskId: "tsk_contracts",
+      agent: "worker",
+      harness: "generic",
+      status: "approved",
+      outcome: "approved",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      proofIds: ["prf_tests"],
+    };
+
+    expect(MissionTaskSchemaZ.parse(task)).toEqual(task);
+    expect(MissionAttemptSchemaZ.parse(attempt)).toEqual(attempt);
+    expect(
+      MissionSnapshotSchemaZ.parse({
+        id: "mis_alpha",
+        title: "Alpha",
+        objective: "Ship",
+        acceptanceCriteria: [],
+        constraints: [],
+        labels: [],
+        source: { type: "user" },
+        status: "completed",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:01.000Z",
+        tasks: { tsk_contracts: task },
+        attempts: { att_first: attempt },
+        proofs: { prf_tests: { noProofReason: "manual acceptance" } },
+      }),
+    ).toMatchObject({ tasks: { tsk_contracts: { status: "completed" } } });
+
+    expect(MissionTaskSchemaZ.safeParse({ ...task, extra: true }).success).toBe(false);
+    expect(MissionAttemptSchemaZ.safeParse({ ...attempt, provider: "claude" }).success).toBe(false);
+  });
+
+  it("rejects projected state with broken keys, references, or duplicate reference arrays", () => {
+    const validTask = {
+      id: "tsk_contracts",
+      missionId: "mis_alpha",
+      title: "Contracts",
+      priority: 1,
+      dependencies: [],
+      status: "completed",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      proofIds: ["prf_tests"],
+      attemptIds: ["att_first"],
+    };
+    const validAttempt = {
+      id: "att_first",
+      missionId: "mis_alpha",
+      taskId: "tsk_contracts",
+      agent: "worker",
+      harness: "generic",
+      status: "approved",
+      outcome: "approved",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      proofIds: ["prf_tests"],
+    };
+    const validMission = {
+      id: "mis_alpha",
+      title: "Alpha",
+      objective: "Ship",
+      acceptanceCriteria: [],
+      constraints: [],
+      labels: [],
+      source: { type: "user" },
+      status: "completed",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      tasks: { tsk_contracts: validTask },
+      attempts: { att_first: validAttempt },
+      proofs: { prf_tests: { noProofReason: "manual acceptance" } },
+    };
+
+    expect(
+      MissionProjectStateSchemaZ.safeParse({
+        sequence: 1,
+        missions: { mis_other: validMission },
+      }).success,
+    ).toBe(false);
+    expect(
+      MissionSnapshotSchemaZ.safeParse({
+        ...validMission,
+        tasks: { tsk_wrong: validTask },
+      }).success,
+    ).toBe(false);
+    expect(
+      MissionSnapshotSchemaZ.safeParse({
+        ...validMission,
+        tasks: {
+          tsk_contracts: {
+            ...validTask,
+            proofIds: ["prf_tests", "prf_tests"],
+          },
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      MissionSnapshotSchemaZ.safeParse({
+        ...validMission,
+        attempts: { att_first: { ...validAttempt, taskId: "tsk_missing" } },
+      }).success,
+    ).toBe(false);
+    expect(
+      MissionSnapshotSchemaZ.safeParse({
+        ...validMission,
+        tasks: {
+          tsk_contracts: {
+            ...validTask,
+            attemptIds: ["att_first"],
+          },
+        },
+        attempts: { att_first: { ...validAttempt, taskId: "tsk_missing" } },
+      }).success,
+    ).toBe(false);
+    expect(
+      MissionSnapshotSchemaZ.safeParse({
+        ...validMission,
+        attempts: { att_first: { ...validAttempt, proofIds: ["prf_missing"] } },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -1,5 +1,490 @@
 import { z } from "zod";
 
+const MissionIdPattern = /^mis_[A-Za-z0-9][A-Za-z0-9_-]{0,96}$/u;
+const TaskIdPattern = /^tsk_[A-Za-z0-9][A-Za-z0-9_-]{0,96}$/u;
+const AttemptIdPattern = /^att_[A-Za-z0-9][A-Za-z0-9_-]{0,96}$/u;
+const ProofIdPattern = /^prf_[A-Za-z0-9][A-Za-z0-9_-]{0,96}$/u;
+const ReferenceIdPattern = /^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,127}$/u;
+const TimestampSchemaZ = z.string().refine(
+  (value) => {
+    try {
+      return new Date(value).toISOString() === value;
+    } catch {
+      return false;
+    }
+  },
+  { message: "must be a canonical ISO timestamp" },
+);
+
+function checkUnique(
+  values: string[],
+  path: Array<string | number>,
+  label: string,
+  ctx: z.RefinementCtx,
+): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      ctx.addIssue({
+        code: "custom",
+        path,
+        message: `duplicate ${label} are not allowed`,
+      });
+      return;
+    }
+    seen.add(value);
+  }
+}
+
+export const MissionDomainVersionSchemaZ = z.literal(1);
+export const MissionIdSchemaZ = z.string().regex(MissionIdPattern);
+export const MissionTaskIdSchemaZ = z.string().regex(TaskIdPattern);
+export const MissionAttemptIdSchemaZ = z.string().regex(AttemptIdPattern);
+export const MissionProofIdSchemaZ = z.string().regex(ProofIdPattern);
+export const MissionReferenceIdSchemaZ = z.string().regex(ReferenceIdPattern);
+
+export const MissionActorSchemaZ = z.strictObject({
+  type: z.enum(["user", "system", "agent", "service"]),
+  id: MissionReferenceIdSchemaZ.optional(),
+  profile: MissionReferenceIdSchemaZ.optional(),
+  displayName: z.string().min(1).max(200).optional(),
+});
+
+export const MissionSourceSchemaZ = z.strictObject({
+  type: z.enum(["user", "system", "import", "service"]),
+  id: MissionReferenceIdSchemaZ.optional(),
+});
+
+export const MissionStatusSchemaZ = z.enum([
+  "created",
+  "planned",
+  "started",
+  "blocked",
+  "review",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+export const MissionTaskStatusSchemaZ = z.enum([
+  "added",
+  "ready",
+  "claimed",
+  "started",
+  "blocked",
+  "submitted",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+export const MissionAttemptStatusSchemaZ = z.enum([
+  "started",
+  "submitted",
+  "approved",
+  "rejected",
+  "failed",
+  "interrupted",
+]);
+
+export const MissionAttemptOutcomeSchemaZ = z.enum([
+  "submitted",
+  "approved",
+  "rejected",
+  "failed",
+  "interrupted",
+]);
+
+const MissionProofTestSchemaZ = z
+  .strictObject({
+    name: z.string().min(1),
+    status: z.enum(["passed", "failed", "skipped"]),
+    passed: z.number().int().nonnegative().optional(),
+    total: z.number().int().nonnegative().optional(),
+    url: z.string().url().optional(),
+    notes: z.string().min(1).optional(),
+  })
+  .superRefine((test, ctx) => {
+    if (test.passed !== undefined && test.total !== undefined && test.passed > test.total) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["passed"],
+        message: "passed must not exceed total",
+      });
+    }
+  });
+
+export const MissionProofSchemaZ = z
+  .strictObject({
+    tests: z.array(MissionProofTestSchemaZ).optional(),
+    commits: z
+      .array(
+        z.strictObject({
+          sha: z.string().regex(/^[A-Fa-f0-9]{7,64}$/u),
+          repo: MissionReferenceIdSchemaZ.optional(),
+          url: z.string().url().optional(),
+        }),
+      )
+      .optional(),
+    diff: z
+      .strictObject({
+        summary: z.string().min(1).optional(),
+        stats: z
+          .strictObject({
+            filesChanged: z.number().int().nonnegative().optional(),
+            insertions: z.number().int().nonnegative().optional(),
+            deletions: z.number().int().nonnegative().optional(),
+          })
+          .optional(),
+        url: z.string().url().optional(),
+      })
+      .optional(),
+    pr: z
+      .strictObject({
+        number: z.number().int().positive().optional(),
+        url: z.string().url().optional(),
+        status: z.enum(["draft", "open", "merged", "closed"]).optional(),
+      })
+      .optional(),
+    artifacts: z
+      .array(
+        z.strictObject({
+          name: z.string().min(1),
+          uri: z.string().min(1),
+          kind: z.string().min(1).optional(),
+        }),
+      )
+      .optional(),
+    notes: z.string().min(1).optional(),
+    noProofReason: z.string().min(1).optional(),
+  })
+  .superRefine((proof, ctx) => {
+    const hasEvidence = Boolean(
+      proof.noProofReason ||
+      proof.notes ||
+      (proof.tests?.length ?? 0) > 0 ||
+      (proof.commits?.length ?? 0) > 0 ||
+      proof.diff?.summary ||
+      proof.diff?.url ||
+      proof.diff?.stats?.filesChanged !== undefined ||
+      proof.diff?.stats?.insertions !== undefined ||
+      proof.diff?.stats?.deletions !== undefined ||
+      proof.pr?.url ||
+      proof.pr?.number ||
+      proof.pr?.status ||
+      (proof.artifacts?.length ?? 0) > 0,
+    );
+    if (!hasEvidence) {
+      ctx.addIssue({
+        code: "custom",
+        message: "proof must include meaningful evidence or an explicit noProofReason",
+      });
+    }
+  });
+
+const MissionEventBaseSchemaZ = z.strictObject({
+  version: MissionDomainVersionSchemaZ,
+  actor: MissionActorSchemaZ,
+});
+
+const MissionEventSchemas = [
+  MissionEventBaseSchemaZ.extend({
+    type: z.literal("mission.created"),
+    missionId: MissionIdSchemaZ,
+    title: z.string().min(1),
+    objective: z.string().min(1),
+    acceptanceCriteria: z.array(z.string().min(1)).default([]),
+    constraints: z.array(z.string().min(1)).default([]),
+    labels: z.array(z.string().min(1)).default([]),
+    source: MissionSourceSchemaZ,
+  }),
+  MissionEventBaseSchemaZ.extend({
+    type: z.enum([
+      "mission.planned",
+      "mission.started",
+      "mission.review",
+      "mission.completed",
+      "mission.failed",
+      "mission.cancelled",
+    ]),
+    missionId: MissionIdSchemaZ,
+    reason: z.string().min(1).optional(),
+    proofId: MissionProofIdSchemaZ.optional(),
+  }),
+  MissionEventBaseSchemaZ.extend({
+    type: z.literal("mission.blocked"),
+    missionId: MissionIdSchemaZ,
+    reason: z.string().min(1),
+  }),
+  MissionEventBaseSchemaZ.extend({
+    type: z.literal("task.added"),
+    missionId: MissionIdSchemaZ,
+    taskId: MissionTaskIdSchemaZ,
+    title: z.string().min(1),
+    description: z.string().min(1).optional(),
+    priority: z.number().int().default(0),
+    dependencies: z.array(MissionTaskIdSchemaZ).default([]),
+    assignee: MissionReferenceIdSchemaZ.optional(),
+  }),
+  MissionEventBaseSchemaZ.extend({
+    type: z.literal("task.updated"),
+    missionId: MissionIdSchemaZ,
+    taskId: MissionTaskIdSchemaZ,
+    title: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
+    priority: z.number().int().optional(),
+    dependencies: z.array(MissionTaskIdSchemaZ).optional(),
+    assignee: MissionReferenceIdSchemaZ.nullable().optional(),
+  }),
+  MissionEventBaseSchemaZ.extend({
+    type: z.enum([
+      "task.ready",
+      "task.started",
+      "task.submitted",
+      "task.completed",
+      "task.failed",
+      "task.cancelled",
+    ]),
+    missionId: MissionIdSchemaZ,
+    taskId: MissionTaskIdSchemaZ,
+    reason: z.string().min(1).optional(),
+    proofId: MissionProofIdSchemaZ.optional(),
+  }),
+  MissionEventBaseSchemaZ.extend({
+    type: z.literal("task.claimed"),
+    missionId: MissionIdSchemaZ,
+    taskId: MissionTaskIdSchemaZ,
+    assignee: MissionReferenceIdSchemaZ,
+  }),
+  MissionEventBaseSchemaZ.extend({
+    type: z.literal("task.blocked"),
+    missionId: MissionIdSchemaZ,
+    taskId: MissionTaskIdSchemaZ,
+    reason: z.string().min(1),
+  }),
+  MissionEventBaseSchemaZ.extend({
+    type: z.literal("attempt.started"),
+    missionId: MissionIdSchemaZ,
+    taskId: MissionTaskIdSchemaZ,
+    attemptId: MissionAttemptIdSchemaZ,
+    agent: MissionReferenceIdSchemaZ,
+    harness: MissionReferenceIdSchemaZ,
+    model: MissionReferenceIdSchemaZ.optional(),
+    terminal: MissionReferenceIdSchemaZ.optional(),
+    session: MissionReferenceIdSchemaZ.optional(),
+    worktree: z.string().min(1).optional(),
+  }),
+  MissionEventBaseSchemaZ.extend({
+    type: z.enum([
+      "attempt.submitted",
+      "attempt.approved",
+      "attempt.rejected",
+      "attempt.failed",
+      "attempt.interrupted",
+    ]),
+    missionId: MissionIdSchemaZ,
+    taskId: MissionTaskIdSchemaZ,
+    attemptId: MissionAttemptIdSchemaZ,
+    proofId: MissionProofIdSchemaZ.optional(),
+    reason: z.string().min(1).optional(),
+  }),
+  MissionEventBaseSchemaZ.extend({
+    type: z.literal("proof.recorded"),
+    missionId: MissionIdSchemaZ,
+    taskId: MissionTaskIdSchemaZ.optional(),
+    attemptId: MissionAttemptIdSchemaZ.optional(),
+    proofId: MissionProofIdSchemaZ,
+    proof: MissionProofSchemaZ,
+  }),
+] as const;
+
+export const MissionEventSchemaZ = z.discriminatedUnion("type", MissionEventSchemas);
+
+export const MissionTaskSchemaZ = z.strictObject({
+  id: MissionTaskIdSchemaZ,
+  missionId: MissionIdSchemaZ,
+  title: z.string().min(1),
+  description: z.string().min(1).optional(),
+  priority: z.number().int(),
+  dependencies: z.array(MissionTaskIdSchemaZ),
+  assignee: MissionReferenceIdSchemaZ.optional(),
+  status: MissionTaskStatusSchemaZ,
+  createdAt: TimestampSchemaZ,
+  updatedAt: TimestampSchemaZ,
+  startedAt: TimestampSchemaZ.optional(),
+  finishedAt: TimestampSchemaZ.optional(),
+  proofIds: z.array(MissionProofIdSchemaZ),
+  attemptIds: z.array(MissionAttemptIdSchemaZ),
+});
+
+export const MissionAttemptSchemaZ = z.strictObject({
+  id: MissionAttemptIdSchemaZ,
+  missionId: MissionIdSchemaZ,
+  taskId: MissionTaskIdSchemaZ,
+  agent: MissionReferenceIdSchemaZ,
+  harness: MissionReferenceIdSchemaZ,
+  model: MissionReferenceIdSchemaZ.optional(),
+  terminal: MissionReferenceIdSchemaZ.optional(),
+  session: MissionReferenceIdSchemaZ.optional(),
+  worktree: z.string().min(1).optional(),
+  status: MissionAttemptStatusSchemaZ,
+  outcome: MissionAttemptOutcomeSchemaZ.optional(),
+  startedAt: TimestampSchemaZ,
+  updatedAt: TimestampSchemaZ,
+  finishedAt: TimestampSchemaZ.optional(),
+  proofIds: z.array(MissionProofIdSchemaZ),
+});
+
+export const MissionSnapshotSchemaZ = z
+  .strictObject({
+    id: MissionIdSchemaZ,
+    title: z.string().min(1),
+    objective: z.string().min(1),
+    acceptanceCriteria: z.array(z.string().min(1)),
+    constraints: z.array(z.string().min(1)),
+    labels: z.array(z.string().min(1)),
+    source: MissionSourceSchemaZ,
+    status: MissionStatusSchemaZ,
+    createdAt: TimestampSchemaZ,
+    updatedAt: TimestampSchemaZ,
+    startedAt: TimestampSchemaZ.optional(),
+    finishedAt: TimestampSchemaZ.optional(),
+    tasks: z.record(MissionTaskIdSchemaZ, MissionTaskSchemaZ),
+    attempts: z.record(MissionAttemptIdSchemaZ, MissionAttemptSchemaZ),
+    proofs: z.record(MissionProofIdSchemaZ, MissionProofSchemaZ),
+  })
+  .superRefine((mission, ctx) => {
+    for (const [taskKey, task] of Object.entries(mission.tasks)) {
+      if (taskKey !== task.id) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["tasks", taskKey, "id"],
+          message: "task record key must equal task id",
+        });
+      }
+      if (task.missionId !== mission.id) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["tasks", taskKey, "missionId"],
+          message: "task missionId must equal parent mission id",
+        });
+      }
+      checkUnique(task.dependencies, ["tasks", taskKey, "dependencies"], "dependency ids", ctx);
+      checkUnique(task.proofIds, ["tasks", taskKey, "proofIds"], "proof ids", ctx);
+      checkUnique(task.attemptIds, ["tasks", taskKey, "attemptIds"], "attempt ids", ctx);
+      for (const dependencyId of task.dependencies) {
+        if (!mission.tasks[dependencyId]) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["tasks", taskKey, "dependencies"],
+            message: `dependency ${dependencyId} must resolve to a task`,
+          });
+        }
+      }
+      for (const proofId of task.proofIds) {
+        if (!mission.proofs[proofId]) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["tasks", taskKey, "proofIds"],
+            message: `proof ${proofId} must resolve`,
+          });
+        }
+      }
+      for (const attemptId of task.attemptIds) {
+        const attempt = mission.attempts[attemptId];
+        if (!attempt) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["tasks", taskKey, "attemptIds"],
+            message: `attempt ${attemptId} must resolve`,
+          });
+        } else if (attempt.taskId !== task.id) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["tasks", taskKey, "attemptIds"],
+            message: `attempt ${attemptId} must point back to task ${task.id}`,
+          });
+        }
+      }
+    }
+
+    for (const [attemptKey, attempt] of Object.entries(mission.attempts)) {
+      if (attemptKey !== attempt.id) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["attempts", attemptKey, "id"],
+          message: "attempt record key must equal attempt id",
+        });
+      }
+      if (attempt.missionId !== mission.id) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["attempts", attemptKey, "missionId"],
+          message: "attempt missionId must equal parent mission id",
+        });
+      }
+      if (!mission.tasks[attempt.taskId]) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["attempts", attemptKey, "taskId"],
+          message: "attempt taskId must resolve to a task",
+        });
+      }
+      checkUnique(attempt.proofIds, ["attempts", attemptKey, "proofIds"], "proof ids", ctx);
+      for (const proofId of attempt.proofIds) {
+        if (!mission.proofs[proofId]) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["attempts", attemptKey, "proofIds"],
+            message: `proof ${proofId} must resolve`,
+          });
+        }
+      }
+    }
+  });
+
+export const MissionProjectStateSchemaZ = z
+  .strictObject({
+    sequence: z.number().int().nonnegative(),
+    missions: z.record(MissionIdSchemaZ, MissionSnapshotSchemaZ),
+  })
+  .superRefine((state, ctx) => {
+    for (const [missionKey, mission] of Object.entries(state.missions)) {
+      if (missionKey !== mission.id) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["missions", missionKey, "id"],
+          message: "mission record key must equal mission id",
+        });
+      }
+    }
+  });
+
+export const MissionHistoryEntrySchemaZ = z.strictObject({
+  sequence: z.number().int().positive(),
+  timestamp: TimestampSchemaZ,
+  event: MissionEventSchemaZ,
+});
+
+export type MissionDomainVersion = z.infer<typeof MissionDomainVersionSchemaZ>;
+export type MissionId = z.infer<typeof MissionIdSchemaZ>;
+export type MissionTaskId = z.infer<typeof MissionTaskIdSchemaZ>;
+export type MissionAttemptId = z.infer<typeof MissionAttemptIdSchemaZ>;
+export type MissionProofId = z.infer<typeof MissionProofIdSchemaZ>;
+export type MissionActor = z.infer<typeof MissionActorSchemaZ>;
+export type MissionSource = z.infer<typeof MissionSourceSchemaZ>;
+export type MissionStatus = z.infer<typeof MissionStatusSchemaZ>;
+export type MissionTaskStatus = z.infer<typeof MissionTaskStatusSchemaZ>;
+export type MissionAttemptStatus = z.infer<typeof MissionAttemptStatusSchemaZ>;
+export type MissionAttemptOutcome = z.infer<typeof MissionAttemptOutcomeSchemaZ>;
+export type MissionProof = z.infer<typeof MissionProofSchemaZ>;
+export type MissionEvent = z.infer<typeof MissionEventSchemaZ>;
+export type MissionTask = z.infer<typeof MissionTaskSchemaZ>;
+export type MissionAttempt = z.infer<typeof MissionAttemptSchemaZ>;
+export type MissionSnapshot = z.infer<typeof MissionSnapshotSchemaZ>;
+export type MissionProjectState = z.infer<typeof MissionProjectStateSchemaZ>;
+export type MissionHistoryEntry = z.infer<typeof MissionHistoryEntrySchemaZ>;
+
 // ---------------------------------------------------------------------------
 // PaneInfo — live tmux pane metadata (from src/command-center/discovery.ts)
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -10,3 +10,14 @@ export {
   writeCanonicalDaemonInfo,
 } from "./canonical.ts";
 export type { CanonicalDaemonInfo } from "./canonical.ts";
+export {
+  MissionRepository,
+  MissionRepositoryError,
+  applyMissionEvent,
+  replayMissionEvents,
+  type MissionAttempt,
+  type MissionHistoryEntry,
+  type MissionProjectState,
+  type MissionSnapshot,
+  type MissionTask,
+} from "./lib/mission-repository.ts";

--- a/packages/daemon/src/lib/__tests__/mission-repository.test.ts
+++ b/packages/daemon/src/lib/__tests__/mission-repository.test.ts
@@ -1,0 +1,789 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  EventSequenceConflictError,
+  createProjectRuntimeRepository,
+  type ProjectRuntimeRepository,
+  type RuntimeEvent,
+} from "../project-runtime-repository.ts";
+import type { ProjectResolution } from "../project-resolver.ts";
+import {
+  applyMissionEvent,
+  MissionRepository,
+  MissionRepositoryError,
+  replayMissionEvents,
+  type MissionProjectState,
+} from "../mission-repository.ts";
+
+const roots: string[] = [];
+const actor = { type: "user" as const, id: "pm" };
+
+function temporaryRoot(prefix = "tmux-ide-mission-"): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function resolution(
+  projectRoot: string,
+  overrides: Partial<ProjectResolution> = {},
+): ProjectResolution {
+  return {
+    inputDir: projectRoot,
+    projectRoot,
+    identityKey: `git-${"b".repeat(64)}`,
+    identitySource: "git-common-dir",
+    identityAnchor: join(projectRoot, ".git"),
+    config: { kind: "none", path: null, explicit: false },
+    workspaceConfigPath: null,
+    legacyConfigPath: null,
+    hasLegacyConfigAtInput: false,
+    ...overrides,
+  };
+}
+
+function repository(
+  project = temporaryRoot("tmux-ide-project-"),
+  home = temporaryRoot("tmux-ide-home-"),
+  overrides: Partial<ProjectResolution> = {},
+): {
+  runtime: ProjectRuntimeRepository;
+  missions: MissionRepository;
+  home: string;
+  project: string;
+} {
+  const runtime = createProjectRuntimeRepository(resolution(project, overrides), { home });
+  return { runtime, missions: new MissionRepository(runtime), home, project };
+}
+
+function expectNoAppend(missions: MissionRepository, action: () => unknown, code: string): void {
+  const before = missions.history().length;
+  expect(action).toThrow(MissionRepositoryError);
+  try {
+    action();
+  } catch (error) {
+    expect(error).toMatchObject({ code });
+  }
+  expect(missions.history()).toHaveLength(before);
+}
+
+function writeRaw(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents, "utf-8");
+}
+
+function rawEvent(sequence: number, payload: unknown): string {
+  return JSON.stringify({
+    version: 1,
+    sequence,
+    timestamp: `2026-01-01T00:00:0${sequence}.000Z`,
+    payload,
+  });
+}
+
+function missionCreated(missionId = "mis_raw"): Record<string, unknown> {
+  return {
+    version: 1,
+    type: "mission.created",
+    missionId,
+    title: "Raw",
+    objective: "Raw replay",
+    acceptanceCriteria: [],
+    constraints: [],
+    labels: [],
+    source: { type: "user" },
+    actor,
+  };
+}
+
+function taskAdded(
+  taskId = "tsk_raw",
+  dependencies: string[] = [],
+  missionId = "mis_raw",
+): Record<string, unknown> {
+  return {
+    version: 1,
+    type: "task.added",
+    missionId,
+    taskId,
+    title: taskId,
+    priority: 0,
+    dependencies,
+    actor,
+  };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("MissionRepository replay and persistence", () => {
+  it("creates missions, tasks, attempts, retries, proof, and deterministic state from one event stream", () => {
+    const { missions } = repository();
+
+    const mission = missions.create({
+      id: "mis_alpha",
+      title: "Mission Alpha",
+      objective: "Prove durable replay",
+      acceptanceCriteria: ["all tests pass"],
+      constraints: ["harness-neutral"],
+      labels: ["m27"],
+      source: { type: "user", id: "card-114" },
+      actor,
+    });
+    expect(mission.status).toBe("created");
+    missions.planMission("mis_alpha", actor);
+    missions.startMission("mis_alpha", actor);
+    missions.addTask({
+      id: "tsk_setup",
+      missionId: "mis_alpha",
+      title: "Setup",
+      priority: 1,
+      actor,
+    });
+    missions.addTask({
+      id: "tsk_finish",
+      missionId: "mis_alpha",
+      title: "Finish",
+      dependencies: ["tsk_setup"],
+      actor,
+    });
+    missions.readyTask("mis_alpha", "tsk_setup", actor);
+    missions.claimTask("mis_alpha", "tsk_setup", "worker", actor);
+    missions.startTask("mis_alpha", "tsk_setup", actor);
+    missions.startAttempt({
+      id: "att_first",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      agent: "worker",
+      harness: "generic",
+      model: "opaque/model",
+      actor,
+    });
+    const proof = missions.recordProof({
+      id: "prf_first",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      attemptId: "att_first",
+      proof: { tests: [{ name: "unit", status: "passed", passed: 1, total: 1 }] },
+      actor,
+    });
+    expect(proof.tests?.[0]?.name).toBe("unit");
+    missions.submitAttempt("mis_alpha", "tsk_setup", "att_first", actor, { proofId: "prf_first" });
+    missions.approveAttempt("mis_alpha", "tsk_setup", "att_first", actor, { proofId: "prf_first" });
+    missions.submitTask("mis_alpha", "tsk_setup", actor, { proofId: "prf_first" });
+    missions.completeTask("mis_alpha", "tsk_setup", actor, { proofId: "prf_first" });
+    missions.readyTask("mis_alpha", "tsk_finish", actor);
+    missions.claimTask("mis_alpha", "tsk_finish", "worker", actor);
+    missions.startTask("mis_alpha", "tsk_finish", actor);
+    missions.startAttempt({
+      id: "att_retry",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      agent: "worker",
+      harness: "generic",
+      actor,
+    });
+    missions.interruptAttempt("mis_alpha", "tsk_finish", "att_retry", actor, {
+      reason: "terminal closed",
+    });
+    missions.startAttempt({
+      id: "att_second",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      agent: "worker",
+      harness: "generic",
+      actor,
+    });
+    missions.recordProof({
+      id: "prf_second",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      attemptId: "att_second",
+      proof: { noProofReason: "Manual verification accepted" },
+      actor,
+    });
+    missions.submitAttempt("mis_alpha", "tsk_finish", "att_second", actor, {
+      proofId: "prf_second",
+    });
+    missions.approveAttempt("mis_alpha", "tsk_finish", "att_second", actor, {
+      proofId: "prf_second",
+    });
+    missions.submitTask("mis_alpha", "tsk_finish", actor, { proofId: "prf_second" });
+    missions.completeTask("mis_alpha", "tsk_finish", actor, { proofId: "prf_second" });
+    missions.reviewMission("mis_alpha", actor);
+    missions.completeMission("mis_alpha", actor);
+
+    const stateA = missions.state();
+    const stateB = replayMissionEvents(
+      missions.history().map(
+        (entry) =>
+          ({
+            version: 1,
+            sequence: entry.sequence,
+            timestamp: entry.timestamp,
+            payload: entry.event,
+          }) satisfies RuntimeEvent<never>,
+      ),
+    );
+    expect(stateB).toEqual(stateA);
+    expect(stateA.missions.mis_alpha?.status).toBe("completed");
+    expect(stateA.missions.mis_alpha?.tasks.tsk_finish?.dependencies).toEqual(["tsk_setup"]);
+    expect(stateA.missions.mis_alpha?.attempts.att_retry?.status).toBe("interrupted");
+    expect(stateA.missions.mis_alpha?.attempts.att_second?.status).toBe("approved");
+    expect(stateA.missions.mis_alpha?.tasks.tsk_setup?.proofIds).toEqual(["prf_first"]);
+    expect(stateA.missions.mis_alpha?.attempts.att_first?.proofIds).toEqual(["prf_first"]);
+    expect(missions.history().map((entry) => entry.sequence)).toEqual(
+      Array.from({ length: missions.history().length }, (_, index) => index + 1),
+    );
+
+    const detached = missions.get("mis_alpha")!;
+    detached.tasks.tsk_setup!.title = "mutated";
+    expect(missions.get("mis_alpha")?.tasks.tsk_setup?.title).toBe("Setup");
+  });
+
+  it("reopens with byte-equivalent logical state and keeps multiple missions isolated", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const project = temporaryRoot("tmux-ide-project-");
+    const first = repository(project, home).missions;
+    first.create({ id: "mis_one", title: "One", objective: "one", actor });
+    first.create({ id: "mis_two", title: "Two", objective: "two", actor });
+
+    const reopened = repository(project, home).missions;
+    expect(JSON.stringify(reopened.state())).toBe(JSON.stringify(first.state()));
+    expect(reopened.list().map((mission) => mission.id)).toEqual(["mis_one", "mis_two"]);
+  });
+});
+
+describe("MissionRepository guards and corruption handling", () => {
+  it("enforces dependency and mission-completion invariants without appending events", () => {
+    const { missions } = repository();
+    missions.create({ id: "mis_guard", title: "Guard", objective: "guard", actor });
+    missions.startMission("mis_guard", actor);
+    missions.addTask({ id: "tsk_a", missionId: "mis_guard", title: "A", actor });
+    missions.addTask({
+      id: "tsk_b",
+      missionId: "mis_guard",
+      title: "B",
+      dependencies: ["tsk_a"],
+      actor,
+    });
+
+    expectNoAppend(
+      missions,
+      () => missions.readyTask("mis_guard", "tsk_b", actor),
+      "TASK_DEPENDENCY_UNMET",
+    );
+    expectNoAppend(
+      missions,
+      () => missions.completeMission("mis_guard", actor),
+      "MISSION_HISTORY_INVALID",
+    );
+  });
+
+  it("requires review and complete tasks before mission completion", () => {
+    const { missions } = repository();
+    missions.create({ id: "mis_complete", title: "Complete", objective: "complete", actor });
+    missions.startMission("mis_complete", actor);
+    missions.addTask({ id: "tsk_complete", missionId: "mis_complete", title: "Complete", actor });
+    expectNoAppend(
+      missions,
+      () => missions.completeMission("mis_complete", actor),
+      "MISSION_HISTORY_INVALID",
+    );
+    missions.reviewMission("mis_complete", actor);
+    expectNoAppend(
+      missions,
+      () => missions.completeMission("mis_complete", actor),
+      "MISSION_INCOMPLETE_TASKS",
+    );
+  });
+
+  it("returns stable typed errors for invalid lifecycle transitions and preserves history", () => {
+    const { missions } = repository();
+    missions.create({ id: "mis_invalid", title: "Invalid", objective: "invalid", actor });
+    missions.addTask({ id: "tsk_invalid", missionId: "mis_invalid", title: "Invalid", actor });
+
+    expectNoAppend(
+      missions,
+      () => missions.startTask("mis_invalid", "tsk_invalid", actor),
+      "TASK_INVALID_TRANSITION",
+    );
+    expectNoAppend(
+      missions,
+      () =>
+        missions.startAttempt({
+          id: "att_invalid",
+          missionId: "mis_invalid",
+          taskId: "tsk_invalid",
+          agent: "worker",
+          harness: "generic",
+          actor,
+        }),
+      "TASK_INVALID_TRANSITION",
+    );
+    missions.readyTask("mis_invalid", "tsk_invalid", actor);
+    missions.claimTask("mis_invalid", "tsk_invalid", "worker", actor);
+    missions.startTask("mis_invalid", "tsk_invalid", actor);
+    missions.startAttempt({
+      id: "att_invalid",
+      missionId: "mis_invalid",
+      taskId: "tsk_invalid",
+      agent: "worker",
+      harness: "generic",
+      actor,
+    });
+    expectNoAppend(
+      missions,
+      () => missions.approveAttempt("mis_invalid", "tsk_invalid", "att_invalid", actor),
+      "ATTEMPT_INVALID_TRANSITION",
+    );
+    expectNoAppend(
+      missions,
+      () => missions.submitAttempt("mis_invalid", "tsk_invalid", "att_invalid", actor),
+      "PROOF_REQUIRED",
+    );
+  });
+
+  it("preserves task status on task.updated and rejects dependency edits after execution begins", () => {
+    const { missions } = repository();
+    missions.create({ id: "mis_update", title: "Update", objective: "update", actor });
+    missions.addTask({ id: "tsk_dep", missionId: "mis_update", title: "Dependency", actor });
+    missions.addTask({ id: "tsk_update", missionId: "mis_update", title: "Update", actor });
+    missions.updateTask({
+      missionId: "mis_update",
+      taskId: "tsk_update",
+      title: "Updated title",
+      actor,
+    });
+    expect(missions.get("mis_update")?.tasks.tsk_update?.status).toBe("added");
+    missions.readyTask("mis_update", "tsk_update", actor);
+    missions.claimTask("mis_update", "tsk_update", "worker", actor);
+    expectNoAppend(
+      missions,
+      () =>
+        missions.updateTask({
+          missionId: "mis_update",
+          taskId: "tsk_update",
+          dependencies: ["tsk_dep"],
+          actor,
+        }),
+      "TASK_INVALID_TRANSITION",
+    );
+  });
+
+  it("rejects empty proof and invalid mutation input with stable mission errors", () => {
+    const { missions } = repository();
+    missions.create({ id: "mis_proof", title: "Proof", objective: "proof", actor });
+    expectNoAppend(
+      missions,
+      () =>
+        missions.recordProof({
+          id: "prf_empty",
+          missionId: "mis_proof",
+          proof: {},
+          actor,
+        }),
+      "MISSION_HISTORY_INVALID",
+    );
+    expectNoAppend(
+      missions,
+      () =>
+        missions.recordProof({
+          id: "prf_bad",
+          missionId: "mis_proof",
+          proof: { tests: [{ name: "unit", status: "passed", passed: 2, total: 1 }] },
+          actor,
+        }),
+      "MISSION_HISTORY_INVALID",
+    );
+  });
+
+  it("rejects dependency duplicate, self, cycle, and blocked-path bypass", () => {
+    const { missions } = repository();
+    missions.create({ id: "mis_deps", title: "Deps", objective: "deps", actor });
+    missions.addTask({ id: "tsk_a", missionId: "mis_deps", title: "A", actor });
+    missions.addTask({ id: "tsk_b", missionId: "mis_deps", title: "B", actor });
+    expectNoAppend(
+      missions,
+      () =>
+        missions.updateTask({
+          missionId: "mis_deps",
+          taskId: "tsk_b",
+          dependencies: ["tsk_a", "tsk_a"],
+          actor,
+        }),
+      "TASK_DEPENDENCY_UNMET",
+    );
+    expectNoAppend(
+      missions,
+      () =>
+        missions.updateTask({
+          missionId: "mis_deps",
+          taskId: "tsk_b",
+          dependencies: ["tsk_b"],
+          actor,
+        }),
+      "TASK_DEPENDENCY_UNMET",
+    );
+    missions.updateTask({
+      missionId: "mis_deps",
+      taskId: "tsk_b",
+      dependencies: ["tsk_a"],
+      actor,
+    });
+    expectNoAppend(
+      missions,
+      () =>
+        missions.updateTask({
+          missionId: "mis_deps",
+          taskId: "tsk_a",
+          dependencies: ["tsk_b"],
+          actor,
+        }),
+      "TASK_DEPENDENCY_UNMET",
+    );
+    missions.blockTask("mis_deps", "tsk_b", "waiting", actor);
+    expectNoAppend(
+      missions,
+      () => missions.claimTask("mis_deps", "tsk_b", "worker", actor),
+      "TASK_DEPENDENCY_UNMET",
+    );
+  });
+
+  it("rejects mutations after a terminal mission state", () => {
+    const { missions } = repository();
+    missions.create({ id: "mis_terminal", title: "Terminal", objective: "terminal", actor });
+    missions.cancelMission("mis_terminal", actor);
+    expectNoAppend(
+      missions,
+      () => missions.addTask({ id: "tsk_late", missionId: "mis_terminal", title: "Late", actor }),
+      "MISSION_TERMINAL",
+    );
+    expectNoAppend(
+      missions,
+      () =>
+        missions.recordProof({
+          id: "prf_late",
+          missionId: "mis_terminal",
+          proof: { noProofReason: "late" },
+          actor,
+        }),
+      "MISSION_TERMINAL",
+    );
+  });
+
+  it("fails stale concurrent sequence writes instead of overwriting", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const project = temporaryRoot("tmux-ide-project-");
+    const first = repository(project, home).missions;
+    const second = repository(project, home).missions;
+
+    first.create({ id: "mis_concurrent", title: "Concurrent", objective: "concurrent", actor });
+    expect(() =>
+      second.create(
+        { id: "mis_stale", title: "Stale", objective: "stale", actor },
+        { expectedPreviousSequence: 0 },
+      ),
+    ).toThrow(EventSequenceConflictError);
+  });
+
+  it("surfaces unknown-version and unknown-event history instead of healing it", () => {
+    const { runtime, missions } = repository();
+    writeRaw(
+      join(runtime.metadata.runtimeRoot, "events", "missions.jsonl"),
+      `${JSON.stringify({
+        version: 1,
+        sequence: 1,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        payload: { version: 2, type: "mission.created" },
+      })}\n`,
+    );
+    expect(() => missions.state()).toThrow(MissionRepositoryError);
+    try {
+      missions.state();
+    } catch (error) {
+      expect(error).toMatchObject({ code: "MISSION_HISTORY_INVALID" });
+    }
+
+    writeRaw(
+      join(runtime.metadata.runtimeRoot, "events", "missions.jsonl"),
+      `${JSON.stringify({
+        version: 1,
+        sequence: 1,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        payload: { version: 1, type: "mission.teleported", actor },
+      })}\n`,
+    );
+    expect(() => missions.history()).toThrow(MissionRepositoryError);
+  });
+
+  it("replayMissionEvents rejects non-contiguous sequences and invalid timestamps", () => {
+    const first = {
+      version: 1,
+      sequence: 1,
+      timestamp: "2026-01-01T00:00:01.000Z",
+      payload: missionCreated(),
+    } satisfies RuntimeEvent<never>;
+    expect(() =>
+      replayMissionEvents([
+        first,
+        {
+          ...first,
+          sequence: 3,
+          timestamp: "2026-01-01T00:00:03.000Z",
+        },
+      ]),
+    ).toThrow(MissionRepositoryError);
+    try {
+      replayMissionEvents([{ ...first, timestamp: "not-a-date" }]);
+    } catch (error) {
+      expect(error).toMatchObject({ code: "MISSION_HISTORY_INVALID" });
+    }
+  });
+
+  it("history replay-validates semantic corruption before returning", () => {
+    const { runtime, missions } = repository();
+    writeRaw(
+      join(runtime.metadata.runtimeRoot, "events", "missions.jsonl"),
+      [rawEvent(1, missionCreated()), rawEvent(2, missionCreated())].join("\n") + "\n",
+    );
+    expect(() => missions.history()).toThrow(MissionRepositoryError);
+    try {
+      missions.history();
+    } catch (error) {
+      expect(error).toMatchObject({ code: "MISSION_ALREADY_EXISTS" });
+    }
+  });
+
+  it("applyMissionEvent leaves caller state byte-identical when proof.recorded validation fails", () => {
+    const state: MissionProjectState = {
+      sequence: 1,
+      missions: {
+        mis_apply: {
+          id: "mis_apply",
+          title: "Apply",
+          objective: "Apply validation",
+          acceptanceCriteria: [],
+          constraints: [],
+          labels: [],
+          source: { type: "user" },
+          status: "created",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          updatedAt: "2026-01-01T00:00:01.000Z",
+          tasks: {
+            tsk_apply: {
+              id: "tsk_apply",
+              missionId: "mis_apply",
+              title: "Apply task",
+              priority: 0,
+              dependencies: [],
+              status: "added",
+              createdAt: "2026-01-01T00:00:01.000Z",
+              updatedAt: "2026-01-01T00:00:01.000Z",
+              proofIds: [],
+              attemptIds: [],
+            },
+          },
+          attempts: {},
+          proofs: {},
+        },
+      },
+    };
+    const before = JSON.stringify(state);
+
+    expect(() =>
+      applyMissionEvent(state, {
+        version: 1,
+        sequence: 2,
+        timestamp: "2026-01-01T00:00:02.000Z",
+        payload: {
+          version: 1,
+          type: "proof.recorded",
+          missionId: "mis_apply",
+          taskId: "tsk_apply",
+          attemptId: "att_missing",
+          proofId: "prf_apply",
+          proof: { noProofReason: "manual" },
+          actor,
+        },
+      }),
+    ).toThrow(MissionRepositoryError);
+    expect(JSON.stringify(state)).toBe(before);
+  });
+
+  it("rejects schema-valid but semantically corrupt replay without partially mutating state", () => {
+    const cases: Array<{ name: string; payloads: unknown[]; code: string }> = [
+      {
+        name: "duplicate mission",
+        payloads: [missionCreated(), missionCreated()],
+        code: "MISSION_ALREADY_EXISTS",
+      },
+      {
+        name: "duplicate task",
+        payloads: [missionCreated(), taskAdded("tsk_dup"), taskAdded("tsk_dup")],
+        code: "TASK_ALREADY_EXISTS",
+      },
+      {
+        name: "duplicate proof",
+        payloads: [
+          missionCreated(),
+          {
+            version: 1,
+            type: "proof.recorded",
+            missionId: "mis_raw",
+            proofId: "prf_dup",
+            proof: { noProofReason: "one" },
+            actor,
+          },
+          {
+            version: 1,
+            type: "proof.recorded",
+            missionId: "mis_raw",
+            proofId: "prf_dup",
+            proof: { noProofReason: "two" },
+            actor,
+          },
+        ],
+        code: "PROOF_ALREADY_EXISTS",
+      },
+      {
+        name: "duplicate attempt",
+        payloads: [
+          missionCreated(),
+          taskAdded("tsk_raw"),
+          {
+            version: 1,
+            type: "task.claimed",
+            missionId: "mis_raw",
+            taskId: "tsk_raw",
+            assignee: "worker",
+            actor,
+          },
+          {
+            version: 1,
+            type: "attempt.started",
+            missionId: "mis_raw",
+            taskId: "tsk_raw",
+            attemptId: "att_dup",
+            agent: "worker",
+            harness: "generic",
+            actor,
+          },
+          {
+            version: 1,
+            type: "attempt.started",
+            missionId: "mis_raw",
+            taskId: "tsk_raw",
+            attemptId: "att_dup",
+            agent: "worker",
+            harness: "generic",
+            actor,
+          },
+        ],
+        code: "ATTEMPT_ALREADY_EXISTS",
+      },
+      {
+        name: "invalid transition",
+        payloads: [
+          missionCreated(),
+          { version: 1, type: "mission.completed", missionId: "mis_raw", actor },
+        ],
+        code: "MISSION_HISTORY_INVALID",
+      },
+      {
+        name: "missing proof reference",
+        payloads: [
+          missionCreated(),
+          taskAdded("tsk_raw"),
+          { version: 1, type: "task.ready", missionId: "mis_raw", taskId: "tsk_raw", actor },
+          {
+            version: 1,
+            type: "task.claimed",
+            missionId: "mis_raw",
+            taskId: "tsk_raw",
+            assignee: "worker",
+            actor,
+          },
+          { version: 1, type: "task.started", missionId: "mis_raw", taskId: "tsk_raw", actor },
+          {
+            version: 1,
+            type: "task.submitted",
+            missionId: "mis_raw",
+            taskId: "tsk_raw",
+            proofId: "prf_missing",
+            actor,
+          },
+        ],
+        code: "PROOF_NOT_FOUND",
+      },
+      {
+        name: "ownership mismatch",
+        payloads: [
+          missionCreated(),
+          taskAdded("tsk_raw"),
+          {
+            version: 1,
+            type: "task.claimed",
+            missionId: "mis_raw",
+            taskId: "tsk_raw",
+            assignee: "worker-a",
+            actor,
+          },
+          {
+            version: 1,
+            type: "attempt.started",
+            missionId: "mis_raw",
+            taskId: "tsk_raw",
+            attemptId: "att_wrong",
+            agent: "worker-b",
+            harness: "generic",
+            actor,
+          },
+        ],
+        code: "ATTEMPT_OWNERSHIP_CONFLICT",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const { runtime, missions } = repository();
+      writeRaw(
+        join(runtime.metadata.runtimeRoot, "events", "missions.jsonl"),
+        testCase.payloads.map((payload, index) => rawEvent(index + 1, payload)).join("\n") + "\n",
+      );
+      expect(() => missions.state(), testCase.name).toThrow(MissionRepositoryError);
+      try {
+        missions.state();
+      } catch (error) {
+        expect(error, testCase.name).toMatchObject({ code: testCase.code });
+      }
+    }
+  });
+
+  it("shares history across linked worktree identities and isolates unrelated projects", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const main = temporaryRoot("tmux-ide-main-");
+    const linked = temporaryRoot("tmux-ide-linked-");
+    const unrelated = temporaryRoot("tmux-ide-unrelated-");
+    const identity = `git-${"c".repeat(64)}`;
+    const first = repository(main, home, {
+      identityKey: identity,
+      identityAnchor: join(main, ".git"),
+    }).missions;
+    const second = repository(linked, home, {
+      identityKey: identity,
+      identityAnchor: join(main, ".git"),
+    }).missions;
+    const third = repository(unrelated, home, {
+      identityKey: `git-${"d".repeat(64)}`,
+      identityAnchor: join(unrelated, ".git"),
+    }).missions;
+
+    first.create({ id: "mis_shared", title: "Shared", objective: "shared", actor });
+    expect(second.get("mis_shared")?.title).toBe("Shared");
+    expect(third.get("mis_shared")).toBeNull();
+    expect(existsSync(join(home, "projects", identity, "events", "missions.jsonl"))).toBe(true);
+  });
+});

--- a/packages/daemon/src/lib/mission-repository.ts
+++ b/packages/daemon/src/lib/mission-repository.ts
@@ -1,0 +1,1293 @@
+import { randomUUID } from "node:crypto";
+import {
+  MissionEventSchemaZ,
+  MissionProjectStateSchemaZ,
+  type MissionActor,
+  type MissionAttempt,
+  type MissionAttemptId,
+  type MissionAttemptStatus,
+  type MissionEvent,
+  type MissionHistoryEntry,
+  type MissionId,
+  type MissionProjectState,
+  type MissionProof,
+  type MissionProofId,
+  type MissionSnapshot,
+  type MissionSource,
+  type MissionStatus,
+  type MissionTask,
+  type MissionTaskId,
+  type MissionTaskStatus,
+} from "@tmux-ide/contracts";
+
+import { IdeError } from "./errors.ts";
+import {
+  openProjectRuntimeRepository,
+  type OpenProjectRuntimeRepositoryOptions,
+  type ProjectRuntimeRepository,
+  type RuntimeEvent,
+} from "./project-runtime-repository.ts";
+
+const MISSIONS_STREAM = "missions";
+
+export type MissionRepositoryErrorCode =
+  | "MISSION_HISTORY_INVALID"
+  | "MISSION_NOT_FOUND"
+  | "MISSION_ALREADY_EXISTS"
+  | "MISSION_TERMINAL"
+  | "MISSION_INCOMPLETE_TASKS"
+  | "TASK_NOT_FOUND"
+  | "TASK_ALREADY_EXISTS"
+  | "TASK_DEPENDENCY_NOT_FOUND"
+  | "TASK_DEPENDENCY_UNMET"
+  | "TASK_TERMINAL"
+  | "TASK_INVALID_TRANSITION"
+  | "TASK_OWNERSHIP_CONFLICT"
+  | "ATTEMPT_NOT_FOUND"
+  | "ATTEMPT_ALREADY_EXISTS"
+  | "ATTEMPT_TERMINAL"
+  | "ATTEMPT_INVALID_TRANSITION"
+  | "ATTEMPT_OWNERSHIP_CONFLICT"
+  | "PROOF_NOT_FOUND"
+  | "PROOF_ALREADY_EXISTS"
+  | "PROOF_REQUIRED";
+
+export class MissionRepositoryError extends IdeError {
+  readonly missionCode: MissionRepositoryErrorCode;
+
+  constructor(
+    message: string,
+    code: MissionRepositoryErrorCode,
+    { cause }: { cause?: Error } = {},
+  ) {
+    super(message, { code, cause });
+    this.name = "MissionRepositoryError";
+    this.missionCode = code;
+  }
+}
+
+export interface MissionMutationOptions {
+  expectedPreviousSequence?: number;
+}
+
+export interface CreateMissionInput {
+  id?: MissionId;
+  title: string;
+  objective: string;
+  acceptanceCriteria?: string[];
+  constraints?: string[];
+  labels?: string[];
+  source?: MissionSource;
+  actor: MissionActor;
+}
+
+export interface AddTaskInput {
+  id?: MissionTaskId;
+  missionId: MissionId;
+  title: string;
+  description?: string;
+  priority?: number;
+  dependencies?: MissionTaskId[];
+  assignee?: string;
+  actor: MissionActor;
+}
+
+export interface UpdateTaskInput {
+  missionId: MissionId;
+  taskId: MissionTaskId;
+  title?: string;
+  description?: string;
+  priority?: number;
+  dependencies?: MissionTaskId[];
+  assignee?: string | null;
+  actor: MissionActor;
+}
+
+export interface StartAttemptInput {
+  id?: MissionAttemptId;
+  missionId: MissionId;
+  taskId: MissionTaskId;
+  agent: string;
+  harness: string;
+  model?: string;
+  terminal?: string;
+  session?: string;
+  worktree?: string;
+  actor: MissionActor;
+}
+
+export interface RecordProofInput {
+  id?: MissionProofId;
+  missionId: MissionId;
+  taskId?: MissionTaskId;
+  attemptId?: MissionAttemptId;
+  proof: MissionProof;
+  actor: MissionActor;
+}
+
+type RuntimeMissionEvent = RuntimeEvent<MissionEvent>;
+
+export class MissionRepository {
+  constructor(private readonly runtime: ProjectRuntimeRepository) {}
+
+  static async open(
+    dir: string,
+    options: OpenProjectRuntimeRepositoryOptions = {},
+  ): Promise<MissionRepository> {
+    return new MissionRepository(await openProjectRuntimeRepository(dir, options));
+  }
+
+  metadata(): ProjectRuntimeRepository["metadata"] {
+    return clone(this.runtime.metadata);
+  }
+
+  history(): MissionHistoryEntry[] {
+    const history = this.readHistory();
+    replayMissionEvents(history);
+    return history.map(({ sequence, timestamp, payload }) => ({
+      sequence,
+      timestamp,
+      event: clone(payload),
+    }));
+  }
+
+  state(): MissionProjectState {
+    return clone(replayMissionEvents(this.readHistory()));
+  }
+
+  list(): MissionSnapshot[] {
+    return Object.values(this.state().missions)
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id))
+      .map(clone);
+  }
+
+  get(missionId: MissionId): MissionSnapshot | null {
+    return clone(this.state().missions[missionId] ?? null);
+  }
+
+  create(input: CreateMissionInput, options: MissionMutationOptions = {}): MissionSnapshot {
+    const missionId = input.id ?? makeId("mis");
+    return this.appendGuarded(
+      {
+        version: 1,
+        type: "mission.created",
+        missionId,
+        title: input.title,
+        objective: input.objective,
+        acceptanceCriteria: input.acceptanceCriteria ?? [],
+        constraints: input.constraints ?? [],
+        labels: input.labels ?? [],
+        source: input.source ?? { type: "user" },
+        actor: input.actor,
+      },
+      options,
+      (state) => {
+        if (state.missions[missionId]) {
+          throw new MissionRepositoryError(
+            `Mission "${missionId}" already exists`,
+            "MISSION_ALREADY_EXISTS",
+          );
+        }
+      },
+      (state) => state.missions[missionId]!,
+    );
+  }
+
+  planMission(missionId: MissionId, actor: MissionActor, options: MissionMutationOptions = {}) {
+    return this.transitionMission(missionId, "mission.planned", "planned", actor, options);
+  }
+
+  startMission(missionId: MissionId, actor: MissionActor, options: MissionMutationOptions = {}) {
+    return this.transitionMission(missionId, "mission.started", "started", actor, options);
+  }
+
+  blockMission(
+    missionId: MissionId,
+    reason: string,
+    actor: MissionActor,
+    options: MissionMutationOptions = {},
+  ) {
+    return this.transitionMission(missionId, "mission.blocked", "blocked", actor, options, {
+      reason,
+    });
+  }
+
+  reviewMission(missionId: MissionId, actor: MissionActor, options: MissionMutationOptions = {}) {
+    return this.transitionMission(missionId, "mission.review", "review", actor, options);
+  }
+
+  completeMission(
+    missionId: MissionId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { proofId?: MissionProofId; reason?: string } = {},
+  ) {
+    return this.transitionMission(missionId, "mission.completed", "completed", actor, options, {
+      proofId: options.proofId,
+      reason: options.reason,
+    });
+  }
+
+  failMission(
+    missionId: MissionId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { reason?: string } = {},
+  ) {
+    return this.transitionMission(missionId, "mission.failed", "failed", actor, options, {
+      reason: options.reason,
+    });
+  }
+
+  cancelMission(
+    missionId: MissionId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { reason?: string } = {},
+  ) {
+    return this.transitionMission(missionId, "mission.cancelled", "cancelled", actor, options, {
+      reason: options.reason,
+    });
+  }
+
+  addTask(input: AddTaskInput, options: MissionMutationOptions = {}): MissionTask {
+    const taskId = input.id ?? makeId("tsk");
+    return this.appendGuarded(
+      {
+        version: 1,
+        type: "task.added",
+        missionId: input.missionId,
+        taskId,
+        title: input.title,
+        ...(input.description === undefined ? {} : { description: input.description }),
+        priority: input.priority ?? 0,
+        dependencies: input.dependencies ?? [],
+        ...(input.assignee === undefined ? {} : { assignee: input.assignee }),
+        actor: input.actor,
+      },
+      options,
+      (state) => {
+        const mission = requireMission(state, input.missionId);
+        ensureMissionOpen(mission);
+        if (mission.tasks[taskId]) {
+          throw new MissionRepositoryError(
+            `Task "${taskId}" already exists`,
+            "TASK_ALREADY_EXISTS",
+          );
+        }
+        ensureDependenciesValid(mission, input.dependencies ?? [], taskId);
+      },
+      (state) => state.missions[input.missionId]!.tasks[taskId]!,
+    );
+  }
+
+  updateTask(input: UpdateTaskInput, options: MissionMutationOptions = {}): MissionTask {
+    return this.appendGuarded(
+      {
+        version: 1,
+        type: "task.updated",
+        missionId: input.missionId,
+        taskId: input.taskId,
+        ...(input.title === undefined ? {} : { title: input.title }),
+        ...(input.description === undefined ? {} : { description: input.description }),
+        ...(input.priority === undefined ? {} : { priority: input.priority }),
+        ...(input.dependencies === undefined ? {} : { dependencies: input.dependencies }),
+        ...(input.assignee === undefined ? {} : { assignee: input.assignee }),
+        actor: input.actor,
+      },
+      options,
+      (state) => {
+        const mission = requireMission(state, input.missionId);
+        ensureMissionOpen(mission);
+        const task = ensureTask(mission, input.taskId);
+        if (input.dependencies) {
+          ensureTaskMetadataCanChangeDependencies(task);
+          ensureDependenciesValid(mission, input.dependencies, input.taskId);
+        }
+      },
+      (state) => state.missions[input.missionId]!.tasks[input.taskId]!,
+    );
+  }
+
+  readyTask(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    actor: MissionActor,
+    options: MissionMutationOptions = {},
+  ) {
+    return this.transitionTask(missionId, taskId, "task.ready", "ready", actor, options);
+  }
+
+  claimTask(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    assignee: string,
+    actor: MissionActor,
+    options: MissionMutationOptions = {},
+  ) {
+    return this.appendGuarded(
+      { version: 1, type: "task.claimed", missionId, taskId, assignee, actor },
+      options,
+      (state) => {
+        const mission = requireMission(state, missionId);
+        ensureMissionOpen(mission);
+        const task = ensureTask(mission, taskId);
+        ensureTaskCanTransition(task, ["added", "ready", "blocked"], "claimed");
+        if (task.status === "blocked") ensureTaskDependenciesComplete(mission, task);
+        if (task.assignee && task.assignee !== assignee) {
+          throw new MissionRepositoryError(
+            `Task "${taskId}" is already assigned to "${task.assignee}"`,
+            "TASK_OWNERSHIP_CONFLICT",
+          );
+        }
+      },
+      (state) => state.missions[missionId]!.tasks[taskId]!,
+    );
+  }
+
+  startTask(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    actor: MissionActor,
+    options: MissionMutationOptions = {},
+  ) {
+    return this.transitionTask(missionId, taskId, "task.started", "started", actor, options);
+  }
+
+  blockTask(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    reason: string,
+    actor: MissionActor,
+    options: MissionMutationOptions = {},
+  ) {
+    return this.transitionTask(missionId, taskId, "task.blocked", "blocked", actor, options, {
+      reason,
+    });
+  }
+
+  submitTask(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { proofId?: MissionProofId; reason?: string } = {},
+  ) {
+    return this.transitionTask(missionId, taskId, "task.submitted", "submitted", actor, options, {
+      proofId: options.proofId,
+      reason: options.reason,
+    });
+  }
+
+  completeTask(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { proofId?: MissionProofId; reason?: string } = {},
+  ) {
+    return this.transitionTask(missionId, taskId, "task.completed", "completed", actor, options, {
+      proofId: options.proofId,
+      reason: options.reason,
+    });
+  }
+
+  failTask(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { reason?: string } = {},
+  ) {
+    return this.transitionTask(missionId, taskId, "task.failed", "failed", actor, options, {
+      reason: options.reason,
+    });
+  }
+
+  cancelTask(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { reason?: string } = {},
+  ) {
+    return this.transitionTask(missionId, taskId, "task.cancelled", "cancelled", actor, options, {
+      reason: options.reason,
+    });
+  }
+
+  startAttempt(input: StartAttemptInput, options: MissionMutationOptions = {}): MissionAttempt {
+    const attemptId = input.id ?? makeId("att");
+    return this.appendGuarded(
+      {
+        version: 1,
+        type: "attempt.started",
+        missionId: input.missionId,
+        taskId: input.taskId,
+        attemptId,
+        agent: input.agent,
+        harness: input.harness,
+        ...(input.model === undefined ? {} : { model: input.model }),
+        ...(input.terminal === undefined ? {} : { terminal: input.terminal }),
+        ...(input.session === undefined ? {} : { session: input.session }),
+        ...(input.worktree === undefined ? {} : { worktree: input.worktree }),
+        actor: input.actor,
+      },
+      options,
+      (state) => {
+        const mission = requireMission(state, input.missionId);
+        ensureMissionOpen(mission);
+        const task = ensureTask(mission, input.taskId);
+        ensureTaskCanTransition(task, ["claimed", "started", "blocked"], "attempt.started");
+        ensureTaskDependenciesComplete(mission, task);
+        if (task.assignee && task.assignee !== input.agent) {
+          throw new MissionRepositoryError(
+            `Attempt agent "${input.agent}" does not match task assignee "${task.assignee}"`,
+            "ATTEMPT_OWNERSHIP_CONFLICT",
+          );
+        }
+        if (mission.attempts[attemptId]) {
+          throw new MissionRepositoryError(
+            `Attempt "${attemptId}" already exists`,
+            "ATTEMPT_ALREADY_EXISTS",
+          );
+        }
+      },
+      (state) => state.missions[input.missionId]!.attempts[attemptId]!,
+    );
+  }
+
+  submitAttempt(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    attemptId: MissionAttemptId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { proofId?: MissionProofId; reason?: string } = {},
+  ) {
+    return this.transitionAttempt(
+      missionId,
+      taskId,
+      attemptId,
+      "attempt.submitted",
+      "submitted",
+      actor,
+      options,
+    );
+  }
+
+  approveAttempt(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    attemptId: MissionAttemptId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { proofId?: MissionProofId; reason?: string } = {},
+  ) {
+    return this.transitionAttempt(
+      missionId,
+      taskId,
+      attemptId,
+      "attempt.approved",
+      "approved",
+      actor,
+      options,
+    );
+  }
+
+  rejectAttempt(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    attemptId: MissionAttemptId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { proofId?: MissionProofId; reason?: string } = {},
+  ) {
+    return this.transitionAttempt(
+      missionId,
+      taskId,
+      attemptId,
+      "attempt.rejected",
+      "rejected",
+      actor,
+      options,
+    );
+  }
+
+  failAttempt(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    attemptId: MissionAttemptId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { proofId?: MissionProofId; reason?: string } = {},
+  ) {
+    return this.transitionAttempt(
+      missionId,
+      taskId,
+      attemptId,
+      "attempt.failed",
+      "failed",
+      actor,
+      options,
+    );
+  }
+
+  interruptAttempt(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    attemptId: MissionAttemptId,
+    actor: MissionActor,
+    options: MissionMutationOptions & { proofId?: MissionProofId; reason?: string } = {},
+  ) {
+    return this.transitionAttempt(
+      missionId,
+      taskId,
+      attemptId,
+      "attempt.interrupted",
+      "interrupted",
+      actor,
+      options,
+    );
+  }
+
+  recordProof(input: RecordProofInput, options: MissionMutationOptions = {}): MissionProof {
+    const proofId = input.id ?? makeId("prf");
+    return this.appendGuarded(
+      {
+        version: 1,
+        type: "proof.recorded",
+        missionId: input.missionId,
+        ...(input.taskId === undefined ? {} : { taskId: input.taskId }),
+        ...(input.attemptId === undefined ? {} : { attemptId: input.attemptId }),
+        proofId,
+        proof: input.proof,
+        actor: input.actor,
+      },
+      options,
+      (state) => {
+        const mission = requireMission(state, input.missionId);
+        ensureMissionOpen(mission);
+        if (mission.proofs[proofId]) {
+          throw new MissionRepositoryError(
+            `Proof "${proofId}" already exists`,
+            "PROOF_ALREADY_EXISTS",
+          );
+        }
+        if (input.taskId) ensureTask(mission, input.taskId);
+        if (input.attemptId) {
+          const attempt = ensureAttempt(mission, input.attemptId);
+          if (input.taskId && attempt.taskId !== input.taskId) {
+            throw new MissionRepositoryError(
+              `Attempt "${input.attemptId}" does not belong to task "${input.taskId}"`,
+              "ATTEMPT_OWNERSHIP_CONFLICT",
+            );
+          }
+        }
+      },
+      (state) => state.missions[input.missionId]!.proofs[proofId]!,
+    );
+  }
+
+  private transitionMission(
+    missionId: MissionId,
+    eventType: MissionEvent["type"],
+    nextStatus: MissionStatus,
+    actor: MissionActor,
+    options: MissionMutationOptions = {},
+    extras: { proofId?: MissionProofId; reason?: string } = {},
+  ): MissionSnapshot {
+    return this.appendGuarded(
+      { version: 1, type: eventType, missionId, actor, ...definedExtras(extras) } as MissionEvent,
+      options,
+      (state) => {
+        const mission = requireMission(state, missionId);
+        validateMissionTransition(mission, nextStatus, extras.proofId);
+      },
+      (state) => state.missions[missionId]!,
+    );
+  }
+
+  private transitionTask(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    eventType: MissionEvent["type"],
+    nextStatus: MissionTaskStatus,
+    actor: MissionActor,
+    options: MissionMutationOptions = {},
+    extras: { proofId?: MissionProofId; reason?: string } = {},
+  ): MissionTask {
+    return this.appendGuarded(
+      {
+        version: 1,
+        type: eventType,
+        missionId,
+        taskId,
+        actor,
+        ...definedExtras(extras),
+      } as MissionEvent,
+      options,
+      (state) => {
+        const mission = requireMission(state, missionId);
+        ensureMissionOpen(mission);
+        const task = ensureTask(mission, taskId);
+        validateTaskTransition(mission, task, nextStatus, extras.proofId);
+      },
+      (state) => state.missions[missionId]!.tasks[taskId]!,
+    );
+  }
+
+  private transitionAttempt(
+    missionId: MissionId,
+    taskId: MissionTaskId,
+    attemptId: MissionAttemptId,
+    eventType: MissionEvent["type"],
+    nextStatus: MissionAttemptStatus,
+    actor: MissionActor,
+    options: MissionMutationOptions & { proofId?: MissionProofId; reason?: string } = {},
+  ): MissionAttempt {
+    return this.appendGuarded(
+      {
+        version: 1,
+        type: eventType,
+        missionId,
+        taskId,
+        attemptId,
+        actor,
+        ...definedExtras({ proofId: options.proofId, reason: options.reason }),
+      } as MissionEvent,
+      options,
+      (state) => {
+        const mission = requireMission(state, missionId);
+        ensureMissionOpen(mission);
+        const task = ensureTask(mission, taskId);
+        const attempt = ensureAttempt(mission, attemptId);
+        if (attempt.taskId !== task.id) {
+          throw new MissionRepositoryError(
+            `Attempt "${attemptId}" does not belong to task "${taskId}"`,
+            "ATTEMPT_OWNERSHIP_CONFLICT",
+          );
+        }
+        ensureAttemptCanTransition(attempt, nextStatus);
+        if (nextStatus === "submitted" || nextStatus === "approved") {
+          ensureTaskDependenciesComplete(mission, task);
+        }
+        if ((nextStatus === "submitted" || nextStatus === "approved") && !options.proofId) {
+          throw new MissionRepositoryError(
+            `Attempt "${attemptId}" requires proof or an explicit no-proof reason`,
+            "PROOF_REQUIRED",
+          );
+        }
+        if (options.proofId && !mission.proofs[options.proofId]) {
+          throw new MissionRepositoryError(
+            `Proof "${options.proofId}" does not exist`,
+            "PROOF_NOT_FOUND",
+          );
+        }
+      },
+      (state) => state.missions[missionId]!.attempts[attemptId]!,
+    );
+  }
+
+  private appendGuarded<T>(
+    event: MissionEvent,
+    options: MissionMutationOptions,
+    guard: (state: MissionProjectState) => void,
+    select: (state: MissionProjectState) => T,
+  ): T {
+    const history = this.readHistory();
+    const state = replayMissionEvents(history);
+    guard(state);
+    const expectedPreviousSequence = options.expectedPreviousSequence ?? state.sequence;
+    const appended = this.runtime.appendEvent(MISSIONS_STREAM, parseMissionEventInput(event), {
+      expectedPreviousSequence,
+    });
+    const nextState = replayMissionEvents([...history, parseRuntimeEvent(appended)]);
+    return clone(select(nextState));
+  }
+
+  private readHistory(): RuntimeMissionEvent[] {
+    return this.runtime.readEvents(MISSIONS_STREAM).map(parseRuntimeEvent);
+  }
+}
+
+export function replayMissionEvents(events: RuntimeMissionEvent[]): MissionProjectState {
+  const state: MissionProjectState = { sequence: 0, missions: {} };
+  for (const runtimeEvent of events) {
+    const parsed = parseRuntimeEvent(runtimeEvent);
+    validateRuntimeEventEnvelope(parsed, state.sequence + 1);
+    applyMissionEvent(state, parsed);
+  }
+  return parseProjectedState(state);
+}
+
+export function applyMissionEvent(
+  state: MissionProjectState,
+  runtimeEvent: RuntimeMissionEvent,
+): void {
+  validateRuntimeEventEnvelope(runtimeEvent);
+  const event = runtimeEvent.payload;
+  const timestamp = runtimeEvent.timestamp;
+
+  switch (event.type) {
+    case "mission.created":
+      if (state.missions[event.missionId]) {
+        throw new MissionRepositoryError(
+          `Mission "${event.missionId}" already exists`,
+          "MISSION_ALREADY_EXISTS",
+        );
+      }
+      state.missions[event.missionId] = {
+        id: event.missionId,
+        title: event.title,
+        objective: event.objective,
+        acceptanceCriteria: [...event.acceptanceCriteria],
+        constraints: [...event.constraints],
+        labels: [...event.labels],
+        source: clone(event.source),
+        status: "created",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        tasks: {},
+        attempts: {},
+        proofs: {},
+      };
+      state.sequence = runtimeEvent.sequence;
+      return;
+    case "mission.planned":
+    case "mission.started":
+    case "mission.blocked":
+    case "mission.review":
+    case "mission.completed":
+    case "mission.failed":
+    case "mission.cancelled": {
+      const mission = requireMission(state, event.missionId);
+      const nextStatus = event.type.split(".")[1] as MissionStatus;
+      validateMissionTransition(
+        mission,
+        nextStatus,
+        "proofId" in event ? event.proofId : undefined,
+      );
+      mission.status = nextStatus;
+      mission.updatedAt = timestamp;
+      if (event.type === "mission.started") mission.startedAt = timestamp;
+      if (["mission.completed", "mission.failed", "mission.cancelled"].includes(event.type)) {
+        mission.finishedAt = timestamp;
+      }
+      state.sequence = runtimeEvent.sequence;
+      return;
+    }
+    case "task.added": {
+      const mission = requireMission(state, event.missionId);
+      ensureMissionOpen(mission);
+      if (mission.tasks[event.taskId]) {
+        throw new MissionRepositoryError(
+          `Task "${event.taskId}" already exists`,
+          "TASK_ALREADY_EXISTS",
+        );
+      }
+      ensureDependenciesValid(mission, event.dependencies, event.taskId);
+      mission.tasks[event.taskId] = {
+        id: event.taskId,
+        missionId: event.missionId,
+        title: event.title,
+        ...(event.description === undefined ? {} : { description: event.description }),
+        priority: event.priority,
+        dependencies: [...event.dependencies],
+        ...(event.assignee === undefined ? {} : { assignee: event.assignee }),
+        status: "added",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        proofIds: [],
+        attemptIds: [],
+      };
+      mission.updatedAt = timestamp;
+      state.sequence = runtimeEvent.sequence;
+      return;
+    }
+    case "task.updated": {
+      const mission = requireMission(state, event.missionId);
+      ensureMissionOpen(mission);
+      const task = ensureTask(mission, event.taskId);
+      if (event.dependencies !== undefined) {
+        ensureTaskMetadataCanChangeDependencies(task);
+        ensureDependenciesValid(mission, event.dependencies, event.taskId);
+      }
+      if (event.title !== undefined) task.title = event.title;
+      if (event.description !== undefined) task.description = event.description;
+      if (event.priority !== undefined) task.priority = event.priority;
+      if (event.dependencies !== undefined) task.dependencies = [...event.dependencies];
+      if ("assignee" in event) {
+        if (event.assignee === null) delete task.assignee;
+        else task.assignee = event.assignee;
+      }
+      task.updatedAt = timestamp;
+      mission.updatedAt = timestamp;
+      state.sequence = runtimeEvent.sequence;
+      return;
+    }
+    case "task.ready":
+    case "task.claimed":
+    case "task.started":
+    case "task.blocked":
+    case "task.submitted":
+    case "task.completed":
+    case "task.failed":
+    case "task.cancelled": {
+      const mission = requireMission(state, event.missionId);
+      ensureMissionOpen(mission);
+      const task = ensureTask(mission, event.taskId);
+      const nextStatus = event.type.split(".")[1] as MissionTaskStatus;
+      validateTaskTransition(
+        mission,
+        task,
+        nextStatus,
+        "proofId" in event ? event.proofId : undefined,
+      );
+      if (event.type === "task.claimed" && task.status === "blocked") {
+        ensureTaskDependenciesComplete(mission, task);
+      }
+      task.status = nextStatus;
+      if (event.type === "task.claimed") task.assignee = event.assignee;
+      if (event.type === "task.started") task.startedAt = timestamp;
+      if (event.type === "task.submitted" || event.type === "task.completed") {
+        if (event.proofId) pushUnique(task.proofIds, event.proofId);
+      }
+      if (["task.completed", "task.failed", "task.cancelled"].includes(event.type)) {
+        task.finishedAt = timestamp;
+      }
+      task.updatedAt = timestamp;
+      mission.updatedAt = timestamp;
+      state.sequence = runtimeEvent.sequence;
+      return;
+    }
+    case "attempt.started": {
+      const mission = requireMission(state, event.missionId);
+      ensureMissionOpen(mission);
+      const task = ensureTask(mission, event.taskId);
+      if (mission.attempts[event.attemptId]) {
+        throw new MissionRepositoryError(
+          `Attempt "${event.attemptId}" already exists`,
+          "ATTEMPT_ALREADY_EXISTS",
+        );
+      }
+      ensureTaskCanTransition(task, ["claimed", "started", "blocked"], "attempt.started");
+      ensureTaskDependenciesComplete(mission, task);
+      if (task.assignee && task.assignee !== event.agent) {
+        throw new MissionRepositoryError(
+          `Attempt agent "${event.agent}" does not match task assignee "${task.assignee}"`,
+          "ATTEMPT_OWNERSHIP_CONFLICT",
+        );
+      }
+      mission.attempts[event.attemptId] = {
+        id: event.attemptId,
+        missionId: event.missionId,
+        taskId: event.taskId,
+        agent: event.agent,
+        harness: event.harness,
+        ...(event.model === undefined ? {} : { model: event.model }),
+        ...(event.terminal === undefined ? {} : { terminal: event.terminal }),
+        ...(event.session === undefined ? {} : { session: event.session }),
+        ...(event.worktree === undefined ? {} : { worktree: event.worktree }),
+        status: "started",
+        startedAt: timestamp,
+        updatedAt: timestamp,
+        proofIds: [],
+      };
+      task.attemptIds.push(event.attemptId);
+      task.updatedAt = timestamp;
+      mission.updatedAt = timestamp;
+      state.sequence = runtimeEvent.sequence;
+      return;
+    }
+    case "attempt.submitted":
+    case "attempt.approved":
+    case "attempt.rejected":
+    case "attempt.failed":
+    case "attempt.interrupted": {
+      const mission = requireMission(state, event.missionId);
+      ensureMissionOpen(mission);
+      const task = ensureTask(mission, event.taskId);
+      const attempt = ensureAttempt(mission, event.attemptId);
+      if (attempt.taskId !== task.id) {
+        throw new MissionRepositoryError(
+          `Attempt "${event.attemptId}" does not belong to task "${event.taskId}"`,
+          "ATTEMPT_OWNERSHIP_CONFLICT",
+        );
+      }
+      const nextStatus = event.type.split(".")[1] as MissionAttemptStatus;
+      validateAttemptTransition(mission, attempt, nextStatus, event.proofId);
+      attempt.status = nextStatus;
+      if (nextStatus !== "started") attempt.outcome = nextStatus;
+      if (event.proofId) pushUnique(attempt.proofIds, event.proofId);
+      if (
+        ["attempt.approved", "attempt.rejected", "attempt.failed", "attempt.interrupted"].includes(
+          event.type,
+        )
+      ) {
+        attempt.finishedAt = timestamp;
+      }
+      attempt.updatedAt = timestamp;
+      mission.updatedAt = timestamp;
+      state.sequence = runtimeEvent.sequence;
+      return;
+    }
+    case "proof.recorded": {
+      const mission = requireMission(state, event.missionId);
+      ensureMissionOpen(mission);
+      if (mission.proofs[event.proofId]) {
+        throw new MissionRepositoryError(
+          `Proof "${event.proofId}" already exists`,
+          "PROOF_ALREADY_EXISTS",
+        );
+      }
+      const task = event.taskId ? ensureTask(mission, event.taskId) : null;
+      const attempt = event.attemptId ? ensureAttempt(mission, event.attemptId) : null;
+      if (task && attempt && attempt.taskId !== task.id) {
+        throw new MissionRepositoryError(
+          `Attempt "${event.attemptId}" does not belong to task "${event.taskId}"`,
+          "ATTEMPT_OWNERSHIP_CONFLICT",
+        );
+      }
+      mission.proofs[event.proofId] = clone(event.proof);
+      if (event.taskId) {
+        pushUnique(task!.proofIds, event.proofId);
+        task!.updatedAt = timestamp;
+      }
+      if (event.attemptId) {
+        pushUnique(attempt!.proofIds, event.proofId);
+        attempt!.updatedAt = timestamp;
+      }
+      mission.updatedAt = timestamp;
+      state.sequence = runtimeEvent.sequence;
+      return;
+    }
+  }
+}
+
+function parseRuntimeEvent(event: RuntimeEvent<unknown>): RuntimeMissionEvent {
+  validateRuntimeEventEnvelope(event);
+  const parsed = MissionEventSchemaZ.safeParse(event.payload);
+  if (!parsed.success) {
+    throw new MissionRepositoryError(
+      `Invalid mission event at sequence ${event.sequence}: ${parsed.error.issues.map((issue) => issue.message).join("; ")}`,
+      "MISSION_HISTORY_INVALID",
+    );
+  }
+  return { ...event, payload: parsed.data };
+}
+
+function validateRuntimeEventEnvelope(
+  event: RuntimeEvent<unknown>,
+  expectedSequence?: number,
+): void {
+  if (event.version !== 1) {
+    throw new MissionRepositoryError(
+      `Invalid mission event envelope version ${String(event.version)}`,
+      "MISSION_HISTORY_INVALID",
+    );
+  }
+  if (
+    !Number.isSafeInteger(event.sequence) ||
+    event.sequence < 1 ||
+    (expectedSequence !== undefined && event.sequence !== expectedSequence)
+  ) {
+    throw new MissionRepositoryError(
+      `Invalid mission event sequence ${String(event.sequence)}`,
+      "MISSION_HISTORY_INVALID",
+    );
+  }
+  if (!isCanonicalTimestamp(event.timestamp)) {
+    throw new MissionRepositoryError(
+      `Invalid mission event timestamp at sequence ${event.sequence}`,
+      "MISSION_HISTORY_INVALID",
+    );
+  }
+}
+
+function requireMission(state: MissionProjectState, missionId: MissionId): MissionSnapshot {
+  const mission = state.missions[missionId];
+  if (!mission)
+    throw new MissionRepositoryError(`Mission "${missionId}" not found`, "MISSION_NOT_FOUND");
+  return mission;
+}
+
+function ensureTask(mission: MissionSnapshot, taskId: MissionTaskId): MissionTask {
+  const task = mission.tasks[taskId];
+  if (!task) throw new MissionRepositoryError(`Task "${taskId}" not found`, "TASK_NOT_FOUND");
+  return task;
+}
+
+function ensureAttempt(mission: MissionSnapshot, attemptId: MissionAttemptId): MissionAttempt {
+  const attempt = mission.attempts[attemptId];
+  if (!attempt) {
+    throw new MissionRepositoryError(`Attempt "${attemptId}" not found`, "ATTEMPT_NOT_FOUND");
+  }
+  return attempt;
+}
+
+function ensureMissionOpen(mission: MissionSnapshot): void {
+  if (["completed", "failed", "cancelled"].includes(mission.status)) {
+    throw new MissionRepositoryError(`Mission "${mission.id}" is terminal`, "MISSION_TERMINAL");
+  }
+}
+
+const MISSION_TRANSITIONS: Record<MissionStatus, MissionStatus[]> = {
+  created: ["planned", "started", "cancelled"],
+  planned: ["started", "blocked", "cancelled"],
+  started: ["blocked", "review", "failed", "cancelled"],
+  blocked: ["started", "failed", "cancelled"],
+  review: ["started", "completed", "failed", "cancelled"],
+  completed: [],
+  failed: [],
+  cancelled: [],
+};
+
+const TASK_TRANSITIONS: Record<MissionTaskStatus, MissionTaskStatus[]> = {
+  added: ["ready", "claimed", "blocked", "failed", "cancelled"],
+  ready: ["claimed", "blocked", "failed", "cancelled"],
+  claimed: ["started", "blocked", "failed", "cancelled"],
+  started: ["blocked", "submitted", "failed", "cancelled"],
+  blocked: ["ready", "claimed", "started", "failed", "cancelled"],
+  submitted: ["blocked", "completed", "failed", "cancelled"],
+  completed: [],
+  failed: [],
+  cancelled: [],
+};
+
+function validateMissionTransition(
+  mission: MissionSnapshot,
+  next: MissionStatus,
+  proofId?: MissionProofId,
+): void {
+  ensureMissionOpen(mission);
+  if (!MISSION_TRANSITIONS[mission.status].includes(next)) {
+    throw new MissionRepositoryError(
+      `Mission "${mission.id}" cannot transition from ${mission.status} to ${next}`,
+      "MISSION_HISTORY_INVALID",
+    );
+  }
+  if (next === "completed") {
+    if (mission.status !== "review") {
+      throw new MissionRepositoryError(
+        `Mission "${mission.id}" must be in review before completion`,
+        "MISSION_HISTORY_INVALID",
+      );
+    }
+    const incomplete = Object.values(mission.tasks).filter((task) => task.status !== "completed");
+    if (incomplete.length > 0) {
+      throw new MissionRepositoryError(
+        `Mission "${mission.id}" cannot complete with incomplete tasks`,
+        "MISSION_INCOMPLETE_TASKS",
+      );
+    }
+    if (proofId && !mission.proofs[proofId]) {
+      throw new MissionRepositoryError(`Proof "${proofId}" does not exist`, "PROOF_NOT_FOUND");
+    }
+  }
+}
+
+function ensureDependenciesValid(
+  mission: MissionSnapshot,
+  dependencies: MissionTaskId[],
+  self?: MissionTaskId,
+): void {
+  const seen = new Set<MissionTaskId>();
+  for (const dependency of dependencies) {
+    if (dependency === self) {
+      throw new MissionRepositoryError("Task cannot depend on itself", "TASK_DEPENDENCY_UNMET");
+    }
+    if (seen.has(dependency)) {
+      throw new MissionRepositoryError(
+        `Task dependency "${dependency}" is duplicated`,
+        "TASK_DEPENDENCY_UNMET",
+      );
+    }
+    seen.add(dependency);
+    if (!mission.tasks[dependency]) {
+      throw new MissionRepositoryError(
+        `Dependency task "${dependency}" not found`,
+        "TASK_DEPENDENCY_NOT_FOUND",
+      );
+    }
+  }
+  if (self) ensureNoDependencyCycle(mission, self, dependencies);
+}
+
+function ensureNoDependencyCycle(
+  mission: MissionSnapshot,
+  taskId: MissionTaskId,
+  nextDependencies: MissionTaskId[],
+): void {
+  const dependenciesFor = (candidate: MissionTaskId): MissionTaskId[] =>
+    candidate === taskId ? nextDependencies : (mission.tasks[candidate]?.dependencies ?? []);
+
+  const visiting = new Set<MissionTaskId>();
+  const visited = new Set<MissionTaskId>();
+
+  function visit(candidate: MissionTaskId): void {
+    if (visiting.has(candidate)) {
+      throw new MissionRepositoryError(
+        "Task dependencies must not contain a cycle",
+        "TASK_DEPENDENCY_UNMET",
+      );
+    }
+    if (visited.has(candidate)) return;
+    visiting.add(candidate);
+    for (const dependency of dependenciesFor(candidate)) visit(dependency);
+    visiting.delete(candidate);
+    visited.add(candidate);
+  }
+
+  visit(taskId);
+}
+
+function ensureTaskMetadataCanChangeDependencies(task: MissionTask): void {
+  if (!["added", "ready", "blocked"].includes(task.status)) {
+    throw new MissionRepositoryError(
+      `Task "${task.id}" dependencies cannot change after execution begins`,
+      "TASK_INVALID_TRANSITION",
+    );
+  }
+}
+
+function validateTaskTransition(
+  mission: MissionSnapshot,
+  task: MissionTask,
+  next: MissionTaskStatus,
+  proofId?: MissionProofId,
+): void {
+  if (["completed", "failed", "cancelled"].includes(task.status)) {
+    throw new MissionRepositoryError(`Task "${task.id}" is terminal`, "TASK_TERMINAL");
+  }
+  if (!TASK_TRANSITIONS[task.status].includes(next)) {
+    throw new MissionRepositoryError(
+      `Task "${task.id}" cannot transition from ${task.status} to ${next}`,
+      "TASK_INVALID_TRANSITION",
+    );
+  }
+  if (["ready", "started", "submitted", "completed"].includes(next)) {
+    ensureTaskDependenciesComplete(mission, task);
+  }
+  if ((next === "submitted" || next === "completed") && !proofId) {
+    throw new MissionRepositoryError(
+      `Task "${task.id}" requires proof or an explicit no-proof reason`,
+      "PROOF_REQUIRED",
+    );
+  }
+  if (proofId && !mission.proofs[proofId]) {
+    throw new MissionRepositoryError(`Proof "${proofId}" does not exist`, "PROOF_NOT_FOUND");
+  }
+}
+
+function ensureTaskDependenciesComplete(mission: MissionSnapshot, task: MissionTask): void {
+  for (const dependencyId of task.dependencies) {
+    const dependency = ensureTask(mission, dependencyId);
+    if (dependency.status !== "completed") {
+      throw new MissionRepositoryError(
+        `Task "${task.id}" dependency "${dependencyId}" is not complete`,
+        "TASK_DEPENDENCY_UNMET",
+      );
+    }
+  }
+}
+
+function ensureTaskCanTransition(
+  task: MissionTask,
+  allowed: MissionTaskStatus[],
+  next: string,
+): void {
+  if (["completed", "failed", "cancelled"].includes(task.status)) {
+    throw new MissionRepositoryError(`Task "${task.id}" is terminal`, "TASK_TERMINAL");
+  }
+  if (!allowed.includes(task.status)) {
+    throw new MissionRepositoryError(
+      `Task "${task.id}" cannot transition from ${task.status} to ${next}`,
+      "TASK_INVALID_TRANSITION",
+    );
+  }
+}
+
+function validateAttemptTransition(
+  mission: MissionSnapshot,
+  attempt: MissionAttempt,
+  next: MissionAttemptStatus,
+  proofId?: MissionProofId,
+): void {
+  ensureAttemptCanTransition(attempt, next);
+  if ((next === "submitted" || next === "approved") && !proofId) {
+    throw new MissionRepositoryError(
+      `Attempt "${attempt.id}" requires proof or an explicit no-proof reason`,
+      "PROOF_REQUIRED",
+    );
+  }
+  if (proofId && !mission.proofs[proofId]) {
+    throw new MissionRepositoryError(`Proof "${proofId}" does not exist`, "PROOF_NOT_FOUND");
+  }
+}
+
+function ensureAttemptCanTransition(attempt: MissionAttempt, next: MissionAttemptStatus): void {
+  if (["approved", "rejected", "failed", "interrupted"].includes(attempt.status)) {
+    throw new MissionRepositoryError(`Attempt "${attempt.id}" is terminal`, "ATTEMPT_TERMINAL");
+  }
+  const allowed: Record<MissionAttemptStatus, MissionAttemptStatus[]> = {
+    started: [],
+    submitted: ["started"],
+    approved: ["submitted"],
+    rejected: ["submitted"],
+    failed: ["started", "submitted"],
+    interrupted: ["started", "submitted"],
+  };
+  if (!allowed[next].includes(attempt.status)) {
+    throw new MissionRepositoryError(
+      `Attempt "${attempt.id}" cannot transition from ${attempt.status} to ${next}`,
+      "ATTEMPT_INVALID_TRANSITION",
+    );
+  }
+}
+
+function parseMissionEventInput(event: MissionEvent): MissionEvent {
+  const parsed = MissionEventSchemaZ.safeParse(event);
+  if (!parsed.success) {
+    throw new MissionRepositoryError(
+      `Invalid mission event input: ${parsed.error.issues.map((issue) => issue.message).join("; ")}`,
+      "MISSION_HISTORY_INVALID",
+    );
+  }
+  return parsed.data;
+}
+
+function parseProjectedState(state: MissionProjectState): MissionProjectState {
+  const parsed = MissionProjectStateSchemaZ.safeParse(state);
+  if (!parsed.success) {
+    throw new MissionRepositoryError(
+      `Invalid projected mission state: ${parsed.error.issues.map((issue) => issue.message).join("; ")}`,
+      "MISSION_HISTORY_INVALID",
+    );
+  }
+  return parsed.data;
+}
+
+function definedExtras<T extends Record<string, unknown>>(extras: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(extras).filter(([, value]) => value !== undefined),
+  ) as Partial<T>;
+}
+
+function pushUnique<T>(values: T[], value: T): void {
+  if (!values.includes(value)) values.push(value);
+}
+
+function makeId(prefix: "mis" | "tsk" | "att" | "prf"): string {
+  return `${prefix}_${randomUUID()}`;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isCanonicalTimestamp(value: string): boolean {
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}
+
+export { MISSIONS_STREAM };
+export type {
+  MissionAttempt,
+  MissionHistoryEntry,
+  MissionProjectState,
+  MissionSnapshot,
+  MissionTask,
+} from "@tmux-ide/contracts";


### PR DESCRIPTION
## Summary

- add strict harness-neutral Mission, Task, Attempt, Proof, Event, Snapshot, and ProjectState contracts
- persist one authoritative per-project missions event stream through ProjectRuntimeRepository
- add guarded lifecycle mutations, deterministic replay, sequence checks, semantic corruption detection, and cross-reference validation
- preserve complete retry/proof history with detached projected state

## Verification

- `pnpm check`
- focused contracts/runtime/mission suites: 58 tests passed
- `git diff --check`