### PR TITLE
feat: add deterministic mission board and history projections

### DIFF
--- a/packages/contracts/src/__tests__/mission-projections.test.ts
+++ b/packages/contracts/src/__tests__/mission-projections.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  MissionBoardViewSchemaZ,
+  MissionDetailViewSchemaZ,
+  MissionHistorySummarySchemaZ,
+  MissionTimelineEntrySchemaZ,
+  type MissionCardView,
+  type MissionProofSummary,
+} from "../mission-projections.ts";
+
+const proofSummary: MissionProofSummary = {
+  proofIds: ["prf_one"],
+  hasProof: true,
+  noProofReasons: [],
+  notesCount: 1,
+  tests: { suites: 1, passed: 1, failed: 0, skipped: 0, total: 3 },
+  commits: ["abcdef1"],
+  diff: {
+    summaries: ["Added read models"],
+    urls: ["https://example.test/diff"],
+    filesChanged: 2,
+    insertions: 10,
+    deletions: 1,
+  },
+  prs: [{ number: 116, url: "https://example.test/pr/116", status: "open" }],
+  artifacts: [{ name: "log", uri: "artifact://log", kind: "text" }],
+};
+
+const missionCard: MissionCardView = {
+  version: 1,
+  id: "mis_alpha",
+  title: "Alpha",
+  summary: "Ship alpha",
+  status: "completed",
+  column: "done",
+  labels: ["m27"],
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:10.000Z",
+  startedAt: "2026-01-01T00:00:01.000Z",
+  finishedAt: "2026-01-01T00:00:10.000Z",
+  durationMs: 9000,
+  progress: {
+    total: 1,
+    planned: 0,
+    running: 0,
+    blocked: 0,
+    review: 0,
+    completed: 1,
+    failed: 0,
+    cancelled: 0,
+    done: 1,
+  },
+  blockedBy: [],
+  latestAttempt: {
+    id: "att_one",
+    taskId: "tsk_one",
+    status: "approved",
+    outcome: "approved",
+    agent: "agent/a",
+    harness: "generic",
+    startedAt: "2026-01-01T00:00:02.000Z",
+    updatedAt: "2026-01-01T00:00:09.000Z",
+    finishedAt: "2026-01-01T00:00:09.000Z",
+    durationMs: 7000,
+    proofIds: ["prf_one"],
+  },
+  proofSummary,
+  refs: {
+    missionId: "mis_alpha",
+    taskIds: ["tsk_one"],
+    attemptIds: ["att_one"],
+    proofIds: ["prf_one"],
+  },
+};
+
+describe("mission projection contracts", () => {
+  it("strictly parses versioned board, detail, history, and timeline views", () => {
+    const task = {
+      version: 1,
+      id: "tsk_one",
+      missionId: "mis_alpha",
+      title: "Task",
+      summary: "Task",
+      status: "completed",
+      column: "done",
+      priority: 1,
+      dependencies: [],
+      blockedBy: [],
+      createdAt: "2026-01-01T00:00:01.000Z",
+      updatedAt: "2026-01-01T00:00:09.000Z",
+      startedAt: "2026-01-01T00:00:02.000Z",
+      finishedAt: "2026-01-01T00:00:09.000Z",
+      durationMs: 7000,
+      latestAttempt: missionCard.latestAttempt,
+      proofSummary,
+      refs: {
+        missionId: "mis_alpha",
+        taskId: "tsk_one",
+        attemptIds: ["att_one"],
+        proofIds: ["prf_one"],
+      },
+    };
+    const timeline = {
+      version: 1,
+      sequence: 1,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      missionId: "mis_alpha",
+      type: "mission.created",
+      label: "Mission created",
+      actor: { type: "user", id: "pm" },
+      refs: { missionId: "mis_alpha" },
+    };
+
+    expect(
+      MissionBoardViewSchemaZ.parse({
+        version: 1,
+        columns: { planned: [], running: [], blocked: [], review: [], done: [missionCard] },
+        counts: { planned: 0, running: 0, blocked: 0, review: 0, done: 1, total: 1 },
+      }),
+    ).toMatchObject({ counts: { total: 1 } });
+    expect(
+      MissionDetailViewSchemaZ.parse({
+        version: 1,
+        mission: missionCard,
+        taskBoard: {
+          columns: { planned: [], running: [], blocked: [], review: [], done: [task] },
+          counts: { planned: 0, running: 0, blocked: 0, review: 0, done: 1, total: 1 },
+        },
+        attempts: [missionCard.latestAttempt],
+        proofSummary,
+        progress: missionCard.progress,
+        timeline: [timeline],
+      }),
+    ).toMatchObject({ mission: { id: "mis_alpha" } });
+    expect(MissionTimelineEntrySchemaZ.parse(timeline)).toEqual(timeline);
+    expect(
+      MissionHistorySummarySchemaZ.parse({
+        version: 1,
+        mission: missionCard,
+        outcome: "completed",
+        startedAt: "2026-01-01T00:00:01.000Z",
+        finishedAt: "2026-01-01T00:00:10.000Z",
+        durationMs: 9000,
+        taskTotals: missionCard.progress,
+        attemptTotals: {
+          total: 1,
+          submitted: 0,
+          approved: 1,
+          rejected: 0,
+          failed: 0,
+          interrupted: 0,
+          running: 0,
+        },
+        proofSummary,
+        lastEvent: timeline,
+      }),
+    ).toMatchObject({ outcome: "completed" });
+  });
+
+  it("rejects stale versions, arbitrary raw fields, and duplicate navigation references", () => {
+    expect(MissionBoardViewSchemaZ.safeParse({ version: 2, columns: {}, counts: {} }).success).toBe(
+      false,
+    );
+    expect(MissionBoardViewSchemaZ.safeParse({ ...missionCard, rawEvidence: {} }).success).toBe(
+      false,
+    );
+    expect(
+      MissionBoardViewSchemaZ.safeParse({
+        version: 1,
+        columns: {
+          planned: [],
+          running: [],
+          blocked: [],
+          review: [],
+          done: [
+            {
+              ...missionCard,
+              refs: { ...missionCard.refs, proofIds: ["prf_one", "prf_one"] },
+            },
+          ],
+        },
+        counts: { planned: 0, running: 0, blocked: 0, review: 0, done: 1, total: 1 },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -17,6 +17,7 @@ export * from "./lib-internal/auth.ts";
 export * from "./lib-internal/hq.ts";
 export * from "./ide-config.ts";
 export * from "./domain.ts";
+export * from "./mission-projections.ts";
 export * from "./tmux.ts";
 export * from "./workspace.ts";
 export * from "./workspace-config.ts";

--- a/packages/contracts/src/mission-projections.ts
+++ b/packages/contracts/src/mission-projections.ts
@@ -1,0 +1,268 @@
+import { z } from "zod";
+import {
+  MissionActorSchemaZ,
+  MissionAttemptIdSchemaZ,
+  MissionAttemptStatusSchemaZ,
+  MissionIdSchemaZ,
+  MissionProofIdSchemaZ,
+  MissionReferenceIdSchemaZ,
+  MissionStatusSchemaZ,
+  MissionTaskIdSchemaZ,
+  MissionTaskStatusSchemaZ,
+} from "./domain.ts";
+
+const TimestampSchemaZ = z.string().refine(
+  (value) => {
+    try {
+      return new Date(value).toISOString() === value;
+    } catch {
+      return false;
+    }
+  },
+  { message: "must be a canonical ISO timestamp" },
+);
+
+const UniqueStringArraySchemaZ = <T extends z.ZodString>(item: T) =>
+  z.array(item).superRefine((values, ctx) => {
+    const seen = new Set<string>();
+    for (const [index, value] of values.entries()) {
+      if (seen.has(value)) {
+        ctx.addIssue({
+          code: "custom",
+          path: [index],
+          message: "duplicate references are not allowed",
+        });
+      }
+      seen.add(value);
+    }
+  });
+
+export const MissionProjectionVersionSchemaZ = z.literal(1);
+export const MissionBoardColumnSchemaZ = z.enum([
+  "planned",
+  "running",
+  "blocked",
+  "review",
+  "done",
+]);
+
+export const MissionProgressSummarySchemaZ = z.strictObject({
+  total: z.number().int().nonnegative(),
+  planned: z.number().int().nonnegative(),
+  running: z.number().int().nonnegative(),
+  blocked: z.number().int().nonnegative(),
+  review: z.number().int().nonnegative(),
+  completed: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  cancelled: z.number().int().nonnegative(),
+  done: z.number().int().nonnegative(),
+});
+
+export const MissionProofSummarySchemaZ = z.strictObject({
+  proofIds: UniqueStringArraySchemaZ(MissionProofIdSchemaZ),
+  hasProof: z.boolean(),
+  noProofReasons: z.array(z.string().min(1)),
+  notesCount: z.number().int().nonnegative(),
+  tests: z.strictObject({
+    suites: z.number().int().nonnegative(),
+    passed: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+    skipped: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+  }),
+  commits: UniqueStringArraySchemaZ(z.string().min(1)),
+  diff: z.strictObject({
+    summaries: UniqueStringArraySchemaZ(z.string().min(1)),
+    urls: UniqueStringArraySchemaZ(z.string().url()),
+    filesChanged: z.number().int().nonnegative(),
+    insertions: z.number().int().nonnegative(),
+    deletions: z.number().int().nonnegative(),
+  }),
+  prs: z.array(
+    z.strictObject({
+      number: z.number().int().positive().optional(),
+      url: z.string().url().optional(),
+      status: z.enum(["draft", "open", "merged", "closed"]).optional(),
+    }),
+  ),
+  artifacts: z.array(
+    z.strictObject({
+      name: z.string().min(1),
+      uri: z.string().min(1),
+      kind: z.string().min(1).optional(),
+    }),
+  ),
+});
+
+export const MissionAttemptSummarySchemaZ = z.strictObject({
+  id: MissionAttemptIdSchemaZ,
+  taskId: MissionTaskIdSchemaZ,
+  status: MissionAttemptStatusSchemaZ,
+  outcome: z.enum(["submitted", "approved", "rejected", "failed", "interrupted"]).optional(),
+  agent: MissionReferenceIdSchemaZ,
+  harness: MissionReferenceIdSchemaZ,
+  model: MissionReferenceIdSchemaZ.optional(),
+  terminal: MissionReferenceIdSchemaZ.optional(),
+  session: MissionReferenceIdSchemaZ.optional(),
+  worktree: z.string().min(1).optional(),
+  startedAt: TimestampSchemaZ,
+  updatedAt: TimestampSchemaZ,
+  finishedAt: TimestampSchemaZ.optional(),
+  durationMs: z.number().int().nonnegative().nullable(),
+  proofIds: UniqueStringArraySchemaZ(MissionProofIdSchemaZ),
+});
+
+export const TaskCardViewSchemaZ = z.strictObject({
+  version: MissionProjectionVersionSchemaZ,
+  id: MissionTaskIdSchemaZ,
+  missionId: MissionIdSchemaZ,
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  status: MissionTaskStatusSchemaZ,
+  column: MissionBoardColumnSchemaZ,
+  priority: z.number().int(),
+  assignee: MissionReferenceIdSchemaZ.optional(),
+  dependencies: UniqueStringArraySchemaZ(MissionTaskIdSchemaZ),
+  blockedBy: UniqueStringArraySchemaZ(MissionTaskIdSchemaZ),
+  createdAt: TimestampSchemaZ,
+  updatedAt: TimestampSchemaZ,
+  startedAt: TimestampSchemaZ.optional(),
+  finishedAt: TimestampSchemaZ.optional(),
+  durationMs: z.number().int().nonnegative().nullable(),
+  latestAttempt: MissionAttemptSummarySchemaZ.nullable(),
+  proofSummary: MissionProofSummarySchemaZ,
+  refs: z.strictObject({
+    missionId: MissionIdSchemaZ,
+    taskId: MissionTaskIdSchemaZ,
+    attemptIds: UniqueStringArraySchemaZ(MissionAttemptIdSchemaZ),
+    proofIds: UniqueStringArraySchemaZ(MissionProofIdSchemaZ),
+    terminal: MissionReferenceIdSchemaZ.optional(),
+    session: MissionReferenceIdSchemaZ.optional(),
+    worktree: z.string().min(1).optional(),
+  }),
+});
+
+export const MissionCardViewSchemaZ = z.strictObject({
+  version: MissionProjectionVersionSchemaZ,
+  id: MissionIdSchemaZ,
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  status: MissionStatusSchemaZ,
+  column: MissionBoardColumnSchemaZ,
+  labels: z.array(z.string().min(1)),
+  createdAt: TimestampSchemaZ,
+  updatedAt: TimestampSchemaZ,
+  startedAt: TimestampSchemaZ.optional(),
+  finishedAt: TimestampSchemaZ.optional(),
+  durationMs: z.number().int().nonnegative().nullable(),
+  progress: MissionProgressSummarySchemaZ,
+  blockedBy: UniqueStringArraySchemaZ(MissionTaskIdSchemaZ),
+  latestAttempt: MissionAttemptSummarySchemaZ.nullable(),
+  proofSummary: MissionProofSummarySchemaZ,
+  refs: z.strictObject({
+    missionId: MissionIdSchemaZ,
+    taskIds: UniqueStringArraySchemaZ(MissionTaskIdSchemaZ),
+    attemptIds: UniqueStringArraySchemaZ(MissionAttemptIdSchemaZ),
+    proofIds: UniqueStringArraySchemaZ(MissionProofIdSchemaZ),
+  }),
+});
+
+export const MissionBoardViewSchemaZ = z.strictObject({
+  version: MissionProjectionVersionSchemaZ,
+  columns: z.strictObject({
+    planned: z.array(MissionCardViewSchemaZ),
+    running: z.array(MissionCardViewSchemaZ),
+    blocked: z.array(MissionCardViewSchemaZ),
+    review: z.array(MissionCardViewSchemaZ),
+    done: z.array(MissionCardViewSchemaZ),
+  }),
+  counts: z.strictObject({
+    planned: z.number().int().nonnegative(),
+    running: z.number().int().nonnegative(),
+    blocked: z.number().int().nonnegative(),
+    review: z.number().int().nonnegative(),
+    done: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+  }),
+});
+
+export const MissionTimelineEntrySchemaZ = z.strictObject({
+  version: MissionProjectionVersionSchemaZ,
+  sequence: z.number().int().positive(),
+  timestamp: TimestampSchemaZ,
+  missionId: MissionIdSchemaZ,
+  taskId: MissionTaskIdSchemaZ.optional(),
+  attemptId: MissionAttemptIdSchemaZ.optional(),
+  proofId: MissionProofIdSchemaZ.optional(),
+  type: z.string().min(1),
+  label: z.string().min(1),
+  actor: MissionActorSchemaZ,
+  reason: z.string().min(1).optional(),
+  refs: z.strictObject({
+    missionId: MissionIdSchemaZ,
+    taskId: MissionTaskIdSchemaZ.optional(),
+    attemptId: MissionAttemptIdSchemaZ.optional(),
+    proofId: MissionProofIdSchemaZ.optional(),
+    terminal: MissionReferenceIdSchemaZ.optional(),
+    session: MissionReferenceIdSchemaZ.optional(),
+    worktree: z.string().min(1).optional(),
+  }),
+});
+
+export const MissionHistorySummarySchemaZ = z.strictObject({
+  version: MissionProjectionVersionSchemaZ,
+  mission: MissionCardViewSchemaZ,
+  outcome: z.enum(["completed", "failed", "cancelled"]),
+  startedAt: TimestampSchemaZ.optional(),
+  finishedAt: TimestampSchemaZ,
+  durationMs: z.number().int().nonnegative().nullable(),
+  taskTotals: MissionProgressSummarySchemaZ,
+  attemptTotals: z.strictObject({
+    total: z.number().int().nonnegative(),
+    submitted: z.number().int().nonnegative(),
+    approved: z.number().int().nonnegative(),
+    rejected: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+    interrupted: z.number().int().nonnegative(),
+    running: z.number().int().nonnegative(),
+  }),
+  proofSummary: MissionProofSummarySchemaZ,
+  lastEvent: MissionTimelineEntrySchemaZ.nullable(),
+});
+
+export const MissionDetailViewSchemaZ = z.strictObject({
+  version: MissionProjectionVersionSchemaZ,
+  mission: MissionCardViewSchemaZ,
+  taskBoard: z.strictObject({
+    columns: z.strictObject({
+      planned: z.array(TaskCardViewSchemaZ),
+      running: z.array(TaskCardViewSchemaZ),
+      blocked: z.array(TaskCardViewSchemaZ),
+      review: z.array(TaskCardViewSchemaZ),
+      done: z.array(TaskCardViewSchemaZ),
+    }),
+    counts: z.strictObject({
+      planned: z.number().int().nonnegative(),
+      running: z.number().int().nonnegative(),
+      blocked: z.number().int().nonnegative(),
+      review: z.number().int().nonnegative(),
+      done: z.number().int().nonnegative(),
+      total: z.number().int().nonnegative(),
+    }),
+  }),
+  attempts: z.array(MissionAttemptSummarySchemaZ),
+  proofSummary: MissionProofSummarySchemaZ,
+  progress: MissionProgressSummarySchemaZ,
+  timeline: z.array(MissionTimelineEntrySchemaZ),
+});
+
+export type MissionBoardColumn = z.infer<typeof MissionBoardColumnSchemaZ>;
+export type MissionProgressSummary = z.infer<typeof MissionProgressSummarySchemaZ>;
+export type MissionProofSummary = z.infer<typeof MissionProofSummarySchemaZ>;
+export type MissionAttemptSummary = z.infer<typeof MissionAttemptSummarySchemaZ>;
+export type MissionCardView = z.infer<typeof MissionCardViewSchemaZ>;
+export type TaskCardView = z.infer<typeof TaskCardViewSchemaZ>;
+export type MissionBoardView = z.infer<typeof MissionBoardViewSchemaZ>;
+export type MissionTimelineEntry = z.infer<typeof MissionTimelineEntrySchemaZ>;
+export type MissionHistorySummary = z.infer<typeof MissionHistorySummarySchemaZ>;
+export type MissionDetailView = z.infer<typeof MissionDetailViewSchemaZ>;

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -21,3 +21,14 @@ export {
   type MissionSnapshot,
   type MissionTask,
 } from "./lib/mission-repository.ts";
+export {
+  MissionProjectionError,
+  missionStatusToBoardColumn,
+  projectMissionBoard,
+  projectMissionDetail,
+  projectMissionHistory,
+  projectMissionTimeline,
+  taskStatusToBoardColumn,
+  type MissionProjectionErrorCode,
+  type MissionProjectionOptions,
+} from "./lib/mission-projections.ts";

--- a/packages/daemon/src/lib/__tests__/mission-projections.test.ts
+++ b/packages/daemon/src/lib/__tests__/mission-projections.test.ts
@@ -1,0 +1,1039 @@
+import { describe, expect, it } from "vitest";
+import type { MissionEvent, MissionHistoryEntry, MissionProjectState } from "@tmux-ide/contracts";
+import {
+  MissionBoardViewSchemaZ,
+  MissionDetailViewSchemaZ,
+  MissionHistorySummarySchemaZ,
+  MissionTimelineEntrySchemaZ,
+} from "@tmux-ide/contracts";
+import { replayMissionEvents } from "../mission-repository.ts";
+import {
+  MissionProjectionError,
+  missionStatusToBoardColumn,
+  projectMissionBoard,
+  projectMissionDetail,
+  projectMissionHistory,
+  projectMissionTimeline,
+  taskStatusToBoardColumn,
+} from "../mission-projections.ts";
+
+const actor = { type: "user" as const, id: "pm", displayName: "PM" };
+
+function at(second: number): string {
+  return `2026-01-01T00:00:${String(second).padStart(2, "0")}.000Z`;
+}
+
+function entry(sequence: number, event: MissionEvent): MissionHistoryEntry {
+  return entryAt(sequence, at(sequence), event);
+}
+
+function entryAt(sequence: number, timestamp: string, event: MissionEvent): MissionHistoryEntry {
+  return { sequence, timestamp, event };
+}
+
+function runtime(history: MissionHistoryEntry[]) {
+  return history.map((item) => ({
+    version: 1 as const,
+    sequence: item.sequence,
+    timestamp: item.timestamp,
+    payload: item.event,
+  }));
+}
+
+function stateFrom(history: MissionHistoryEntry[]): MissionProjectState {
+  return replayMissionEvents(runtime(history));
+}
+
+function richHistory(): MissionHistoryEntry[] {
+  return [
+    entry(1, {
+      version: 1,
+      type: "mission.created",
+      missionId: "mis_alpha",
+      title: "Alpha",
+      objective: "Ship alpha",
+      acceptanceCriteria: ["tests"],
+      constraints: ["deterministic"],
+      labels: ["m27", "ui"],
+      source: { type: "user", id: "card-116" },
+      actor,
+    }),
+    entry(2, { version: 1, type: "mission.started", missionId: "mis_alpha", actor }),
+    entry(3, {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      title: "Setup",
+      description: "Prepare contracts",
+      priority: 2,
+      dependencies: [],
+      actor,
+    }),
+    entry(4, {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      title: "Finish",
+      priority: 1,
+      dependencies: ["tsk_setup"],
+      actor,
+    }),
+    entry(5, {
+      version: 1,
+      type: "task.ready",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      actor,
+    }),
+    entry(6, {
+      version: 1,
+      type: "task.claimed",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      assignee: "agent/a",
+      actor,
+    }),
+    entry(7, {
+      version: 1,
+      type: "task.started",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      actor,
+    }),
+    entry(8, {
+      version: 1,
+      type: "attempt.started",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      attemptId: "att_setup",
+      agent: "agent/a",
+      harness: "generic",
+      model: "model/a",
+      terminal: "term-1",
+      session: "session-1",
+      worktree: "worktrees/setup",
+      actor,
+    }),
+    entry(9, {
+      version: 1,
+      type: "proof.recorded",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      attemptId: "att_setup",
+      proofId: "prf_setup",
+      proof: {
+        tests: [{ name: "unit", status: "passed", passed: 3, total: 3 }],
+        commits: [{ sha: "abcdef1" }],
+        diff: {
+          summary: "Contracts added",
+          url: "https://example.test/diff",
+          stats: { filesChanged: 2, insertions: 10, deletions: 1 },
+        },
+        pr: { number: 116, url: "https://example.test/pr/116", status: "open" },
+        artifacts: [{ name: "log", uri: "artifact://setup", kind: "text" }],
+        notes: "evidence",
+      },
+      actor,
+    }),
+    entry(10, {
+      version: 1,
+      type: "attempt.submitted",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      attemptId: "att_setup",
+      proofId: "prf_setup",
+      actor,
+    }),
+    entry(11, {
+      version: 1,
+      type: "attempt.approved",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      attemptId: "att_setup",
+      proofId: "prf_setup",
+      actor,
+    }),
+    entry(12, {
+      version: 1,
+      type: "task.submitted",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      proofId: "prf_setup",
+      actor,
+    }),
+    entry(13, {
+      version: 1,
+      type: "task.completed",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      proofId: "prf_setup",
+      actor,
+    }),
+    entry(14, {
+      version: 1,
+      type: "task.ready",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      actor,
+    }),
+    entry(15, {
+      version: 1,
+      type: "task.claimed",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      assignee: "agent/a",
+      actor,
+    }),
+    entry(16, {
+      version: 1,
+      type: "task.started",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      actor,
+    }),
+    entry(17, {
+      version: 1,
+      type: "attempt.started",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      attemptId: "att_retry",
+      agent: "agent/a",
+      harness: "generic",
+      actor,
+    }),
+    entry(18, {
+      version: 1,
+      type: "attempt.interrupted",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      attemptId: "att_retry",
+      reason: "terminal closed",
+      actor,
+    }),
+    entry(19, {
+      version: 1,
+      type: "attempt.started",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      attemptId: "att_finish",
+      agent: "agent/a",
+      harness: "generic",
+      terminal: "term-2",
+      session: "session-1",
+      worktree: "worktrees/finish",
+      actor,
+    }),
+    entry(20, {
+      version: 1,
+      type: "proof.recorded",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      attemptId: "att_finish",
+      proofId: "prf_finish",
+      proof: {
+        noProofReason: "Manual review accepted",
+        commits: [{ sha: "1234567" }, { sha: "1234567" }],
+        artifacts: [
+          { name: "report", uri: "artifact://report" },
+          { name: "report", uri: "artifact://report" },
+        ],
+      },
+      actor,
+    }),
+    entry(21, {
+      version: 1,
+      type: "attempt.submitted",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      attemptId: "att_finish",
+      proofId: "prf_finish",
+      actor,
+    }),
+    entry(22, {
+      version: 1,
+      type: "attempt.approved",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      attemptId: "att_finish",
+      proofId: "prf_finish",
+      actor,
+    }),
+    entry(23, {
+      version: 1,
+      type: "task.submitted",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      proofId: "prf_finish",
+      actor,
+    }),
+    entry(24, {
+      version: 1,
+      type: "task.completed",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      proofId: "prf_finish",
+      actor,
+    }),
+    entry(25, { version: 1, type: "mission.review", missionId: "mis_alpha", actor }),
+    entry(26, { version: 1, type: "mission.completed", missionId: "mis_alpha", actor }),
+  ];
+}
+
+describe("mission projection mappings", () => {
+  it("maps every mission and task status to fixed board columns", () => {
+    expect(
+      Object.fromEntries(
+        [
+          "created",
+          "planned",
+          "started",
+          "blocked",
+          "review",
+          "completed",
+          "failed",
+          "cancelled",
+        ].map((status) => [status, missionStatusToBoardColumn(status as never)]),
+      ),
+    ).toEqual({
+      created: "planned",
+      planned: "planned",
+      started: "running",
+      blocked: "blocked",
+      review: "review",
+      completed: "done",
+      failed: "done",
+      cancelled: "done",
+    });
+    expect(
+      Object.fromEntries(
+        [
+          "added",
+          "ready",
+          "claimed",
+          "started",
+          "blocked",
+          "submitted",
+          "completed",
+          "failed",
+          "cancelled",
+        ].map((status) => [status, taskStatusToBoardColumn(status as never)]),
+      ),
+    ).toEqual({
+      added: "planned",
+      ready: "planned",
+      claimed: "running",
+      started: "running",
+      blocked: "blocked",
+      submitted: "review",
+      completed: "done",
+      failed: "done",
+      cancelled: "done",
+    });
+  });
+});
+
+describe("mission board projections", () => {
+  it("sorts columns deterministically by mission creation time then id regardless of record order", () => {
+    const first = richHistory();
+    const extra = [
+      entryAt(27, at(30), {
+        version: 1,
+        type: "mission.created",
+        missionId: "mis_beta",
+        title: "Beta",
+        objective: "same timestamp",
+        acceptanceCriteria: [],
+        constraints: [],
+        labels: [],
+        source: { type: "user" },
+        actor,
+      }),
+      entryAt(28, at(30), {
+        version: 1,
+        type: "mission.created",
+        missionId: "mis_aaa",
+        title: "AAA",
+        objective: "same timestamp",
+        acceptanceCriteria: [],
+        constraints: [],
+        labels: [],
+        source: { type: "user" },
+        actor,
+      }),
+    ];
+    const state = stateFrom([...first, ...extra]);
+    const shuffled: MissionProjectState = {
+      sequence: state.sequence,
+      missions: {
+        mis_beta: state.missions.mis_beta!,
+        mis_alpha: state.missions.mis_alpha!,
+        mis_aaa: state.missions.mis_aaa!,
+      },
+    };
+
+    const board = projectMissionBoard(shuffled, [...first, ...extra]);
+
+    expect(MissionBoardViewSchemaZ.parse(board)).toEqual(board);
+    expect(board.columns.planned.map((card) => card.id)).toEqual(["mis_aaa", "mis_beta"]);
+    expect(board.columns.done.map((card) => card.id)).toEqual(["mis_alpha"]);
+    expect(board.counts).toEqual({
+      planned: 2,
+      running: 0,
+      blocked: 0,
+      review: 0,
+      done: 1,
+      total: 3,
+    });
+  });
+
+  it("derives dependency blockers and progress summaries from state", () => {
+    const history = blockedDependencyHistory();
+    const state = stateFrom(history);
+
+    const detail = projectMissionDetail(state, history, "mis_alpha", {
+      asOf: "2026-01-01T00:01:00.000Z",
+    });
+
+    expect(detail.progress).toMatchObject({ total: 2, running: 1, planned: 1, completed: 0 });
+    expect(detail.progress.done).toBe(0);
+    expect(detail.taskBoard.columns.planned[0]?.blockedBy).toEqual(["tsk_setup"]);
+    expect(detail.mission.blockedBy).toEqual(["tsk_setup"]);
+    expect(detail.mission.durationMs).toBe(58_000);
+  });
+
+  it("rejects board state/history mismatch with a stable typed projection error", () => {
+    const history = richHistory();
+    const state = stateFrom(history);
+    const mismatch = structuredClone(state);
+    mismatch.missions.mis_alpha!.title = "changed";
+
+    expect(() => projectMissionBoard(mismatch, history)).toThrow(MissionProjectionError);
+    try {
+      projectMissionBoard(mismatch, history);
+    } catch (error) {
+      expect(error).toMatchObject({ code: "MISSION_HISTORY_MISMATCH" });
+    }
+  });
+
+  it("selects mission latest attempt by last attempt.started event across misleading task sort fields", () => {
+    const history = latestAttemptOrderingHistory();
+    const state = stateFrom(history);
+    const board = projectMissionBoard(state, history);
+
+    expect(board.columns.running[0]?.latestAttempt?.id).toBe("att_low");
+    expect(board.columns.running[0]?.latestAttempt?.taskId).toBe("tsk_low");
+  });
+
+  it("orders task cards by priority descending, creation time, then id", () => {
+    const history = taskOrderingHistory();
+    const detail = projectMissionDetail(stateFrom(history), history, "mis_sort");
+
+    expect(detail.taskBoard.columns.planned.map((task) => task.id)).toEqual([
+      "tsk_high",
+      "tsk_aaa",
+      "tsk_bbb",
+      "tsk_low",
+    ]);
+  });
+});
+
+describe("mission detail, proofs, and timeline projections", () => {
+  it("selects latest attempts by task attemptIds, keeps retries, and aggregates proof facts with dedupe", () => {
+    const history = richHistory();
+    const state = stateFrom(history);
+    const detail = projectMissionDetail(state, history, "mis_alpha");
+
+    expect(MissionDetailViewSchemaZ.parse(detail)).toEqual(detail);
+    expect(
+      detail.taskBoard.columns.done.find((task) => task.id === "tsk_finish")?.latestAttempt?.id,
+    ).toBe("att_finish");
+    expect(detail.attempts.map((attempt) => attempt.id)).toEqual([
+      "att_setup",
+      "att_retry",
+      "att_finish",
+    ]);
+    expect(detail.proofSummary.commits).toEqual(["1234567", "abcdef1"]);
+    expect(detail.proofSummary.diff).toMatchObject({
+      filesChanged: 2,
+      insertions: 10,
+      deletions: 1,
+    });
+    expect(detail.proofSummary.prs).toEqual([
+      { number: 116, url: "https://example.test/pr/116", status: "open" },
+    ]);
+    expect(detail.proofSummary.artifacts).toEqual([
+      { name: "log", uri: "artifact://setup", kind: "text" },
+      { name: "report", uri: "artifact://report" },
+    ]);
+    expect(detail.proofSummary.noProofReasons).toEqual(["Manual review accepted"]);
+  });
+
+  it("projects task failed/cancelled and attempt rejected/failed/interrupted states compactly", () => {
+    const history = terminalTaskAndAttemptHistory();
+    const detail = projectMissionDetail(stateFrom(history), history, "mis_terminal");
+
+    expect(detail.taskBoard.columns.done.map((task) => [task.id, task.status])).toEqual([
+      ["tsk_cancel", "cancelled"],
+      ["tsk_fail", "failed"],
+      ["tsk_reject", "failed"],
+      ["tsk_attempt_fail", "failed"],
+      ["tsk_interrupt", "failed"],
+    ]);
+    expect(detail.attempts.map((attempt) => [attempt.id, attempt.status, attempt.outcome])).toEqual(
+      [
+        ["att_reject", "rejected", "rejected"],
+        ["att_fail", "failed", "failed"],
+        ["att_interrupt", "interrupted", "interrupted"],
+      ],
+    );
+    expect(detail.progress).toMatchObject({
+      total: 5,
+      failed: 4,
+      cancelled: 1,
+      done: 5,
+    });
+    expect(detail.proofSummary.noProofReasons).toEqual(["rejected evidence"]);
+  });
+
+  it("accepts shuffled record-key insertion order when state and history are semantically equal", () => {
+    const history = richHistory();
+    const state = stateFrom(history);
+    const mission = state.missions.mis_alpha!;
+    const shuffled: MissionProjectState = {
+      sequence: state.sequence,
+      missions: {
+        mis_alpha: {
+          ...mission,
+          tasks: {
+            tsk_finish: mission.tasks.tsk_finish!,
+            tsk_setup: mission.tasks.tsk_setup!,
+          },
+          attempts: {
+            att_finish: mission.attempts.att_finish!,
+            att_retry: mission.attempts.att_retry!,
+            att_setup: mission.attempts.att_setup!,
+          },
+          proofs: {
+            prf_finish: mission.proofs.prf_finish!,
+            prf_setup: mission.proofs.prf_setup!,
+          },
+        },
+      },
+    };
+
+    expect(projectMissionDetail(shuffled, history, "mis_alpha")).toEqual(
+      projectMissionDetail(state, history, "mis_alpha"),
+    );
+  });
+
+  it("filters timeline by mission, preserves sequence order, labels events, and carries actor/navigation refs", () => {
+    const history = [
+      ...richHistory(),
+      entry(27, {
+        version: 1,
+        type: "mission.created",
+        missionId: "mis_other",
+        title: "Other",
+        objective: "other",
+        acceptanceCriteria: [],
+        constraints: [],
+        labels: [],
+        source: { type: "user" },
+        actor,
+      }),
+    ];
+    const state = stateFrom(history);
+    const timeline = projectMissionTimeline(state, history, "mis_alpha");
+
+    expect(timeline).toHaveLength(26);
+    expect(timeline[0]).toMatchObject({ sequence: 1, label: "Mission created", actor });
+    expect(timeline.find((item) => item.attemptId === "att_setup")).toMatchObject({
+      refs: { terminal: "term-1", session: "session-1", worktree: "worktrees/setup" },
+    });
+    for (const item of timeline) expect(MissionTimelineEntrySchemaZ.parse(item)).toEqual(item);
+  });
+});
+
+describe("mission history projections", () => {
+  it("summarizes completed, failed, and cancelled terminal outcomes with stored durations", () => {
+    const history = [
+      ...richHistory(),
+      entry(27, {
+        version: 1,
+        type: "mission.created",
+        missionId: "mis_failed",
+        title: "Failed",
+        objective: "fail",
+        acceptanceCriteria: [],
+        constraints: [],
+        labels: ["x"],
+        source: { type: "user" },
+        actor,
+      }),
+      entry(28, { version: 1, type: "mission.started", missionId: "mis_failed", actor }),
+      entry(29, {
+        version: 1,
+        type: "mission.failed",
+        missionId: "mis_failed",
+        reason: "nope",
+        actor,
+      }),
+      entry(30, {
+        version: 1,
+        type: "mission.created",
+        missionId: "mis_cancelled",
+        title: "Cancelled",
+        objective: "cancel",
+        acceptanceCriteria: [],
+        constraints: [],
+        labels: [],
+        source: { type: "user" },
+        actor,
+      }),
+      entry(31, {
+        version: 1,
+        type: "mission.cancelled",
+        missionId: "mis_cancelled",
+        reason: "duplicate",
+        actor,
+      }),
+    ];
+    const summaries = projectMissionHistory(stateFrom(history), history);
+
+    expect(summaries.map((summary) => summary.outcome)).toEqual([
+      "completed",
+      "failed",
+      "cancelled",
+    ]);
+    expect(summaries[0]?.durationMs).toBe(24_000);
+    expect(summaries[0]?.taskTotals.done).toBe(2);
+    expect(summaries[1]?.durationMs).toBe(1_000);
+    expect(summaries[2]?.durationMs).toBeNull();
+    expect(summaries[1]?.lastEvent?.reason).toBe("nope");
+    for (const summary of summaries)
+      expect(MissionHistorySummarySchemaZ.parse(summary)).toEqual(summary);
+  });
+});
+
+describe("mission projection safety", () => {
+  it("handles empty/minimal states and returns detached repeated-call stable values", () => {
+    const empty: MissionProjectState = { sequence: 0, missions: {} };
+    expect(projectMissionBoard(empty, [])).toEqual({
+      version: 1,
+      columns: { planned: [], running: [], blocked: [], review: [], done: [] },
+      counts: { planned: 0, running: 0, blocked: 0, review: 0, done: 0, total: 0 },
+    });
+
+    const history = [richHistory()[0]!];
+    const state = stateFrom(history);
+    const before = JSON.stringify(state);
+    const one = projectMissionBoard(state, history);
+    const two = projectMissionBoard(state, history);
+    expect(one).toEqual(two);
+    one.columns.planned[0]!.title = "mutated";
+    expect(projectMissionBoard(state, history).columns.planned[0]?.title).toBe("Alpha");
+    expect(JSON.stringify(state)).toBe(before);
+  });
+
+  it("rejects corrupt state and state/history mismatch with stable typed projection errors", () => {
+    const history = richHistory();
+    const state = stateFrom(history);
+    const mismatch = structuredClone(state);
+    mismatch.missions.mis_alpha!.title = "changed";
+
+    expect(() => projectMissionDetail(mismatch, history, "mis_alpha")).toThrow(
+      MissionProjectionError,
+    );
+    try {
+      projectMissionDetail(mismatch, history, "mis_alpha");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "MISSION_HISTORY_MISMATCH" });
+    }
+
+    const corrupt = structuredClone(state);
+    corrupt.missions.mis_alpha!.tasks.tsk_finish!.dependencies = ["tsk_missing" as never];
+    expect(() => projectMissionBoard(corrupt, history)).toThrow(MissionProjectionError);
+  });
+
+  it("rejects invalid history and as-of duration inputs with stable typed projection errors", () => {
+    const state = stateFrom(blockedDependencyHistory());
+    const invalidHistory = blockedDependencyHistory();
+    invalidHistory[1] = { ...invalidHistory[1]!, sequence: 99 };
+    expect(() => projectMissionDetail(state, invalidHistory, "mis_alpha")).toThrow(
+      MissionProjectionError,
+    );
+    try {
+      projectMissionDetail(state, invalidHistory, "mis_alpha");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "MISSION_PROJECTION_INVALID" });
+    }
+
+    const history = blockedDependencyHistory();
+    expect(() => projectMissionBoard(state, history, { asOf: "2026-01-01T00:00:01.000Z" })).toThrow(
+      MissionProjectionError,
+    );
+    try {
+      projectMissionBoard(state, history, { asOf: "2026-01-01T00:00:01.000Z" });
+    } catch (error) {
+      expect(error).toMatchObject({ code: "MISSION_PROJECTION_INVALID" });
+    }
+  });
+});
+
+function latestAttemptOrderingHistory(): MissionHistoryEntry[] {
+  return [
+    entry(1, {
+      version: 1,
+      type: "mission.created",
+      missionId: "mis_order",
+      title: "Order",
+      objective: "Order attempts",
+      acceptanceCriteria: [],
+      constraints: [],
+      labels: [],
+      source: { type: "user" },
+      actor,
+    }),
+    entry(2, { version: 1, type: "mission.started", missionId: "mis_order", actor }),
+    entry(3, {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_order",
+      taskId: "tsk_high",
+      title: "High priority",
+      priority: 99,
+      dependencies: [],
+      actor,
+    }),
+    entry(4, {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_order",
+      taskId: "tsk_low",
+      title: "Low priority",
+      priority: 1,
+      dependencies: [],
+      actor,
+    }),
+    entry(5, { version: 1, type: "task.ready", missionId: "mis_order", taskId: "tsk_high", actor }),
+    entry(6, {
+      version: 1,
+      type: "task.claimed",
+      missionId: "mis_order",
+      taskId: "tsk_high",
+      assignee: "agent/a",
+      actor,
+    }),
+    entry(7, {
+      version: 1,
+      type: "task.started",
+      missionId: "mis_order",
+      taskId: "tsk_high",
+      actor,
+    }),
+    entry(8, {
+      version: 1,
+      type: "attempt.started",
+      missionId: "mis_order",
+      taskId: "tsk_high",
+      attemptId: "att_high",
+      agent: "agent/a",
+      harness: "generic",
+      actor,
+    }),
+    entry(9, { version: 1, type: "task.ready", missionId: "mis_order", taskId: "tsk_low", actor }),
+    entry(10, {
+      version: 1,
+      type: "task.claimed",
+      missionId: "mis_order",
+      taskId: "tsk_low",
+      assignee: "agent/a",
+      actor,
+    }),
+    entry(11, {
+      version: 1,
+      type: "task.started",
+      missionId: "mis_order",
+      taskId: "tsk_low",
+      actor,
+    }),
+    entry(12, {
+      version: 1,
+      type: "attempt.started",
+      missionId: "mis_order",
+      taskId: "tsk_low",
+      attemptId: "att_low",
+      agent: "agent/a",
+      harness: "generic",
+      actor,
+    }),
+    entry(13, {
+      version: 1,
+      type: "task.updated",
+      missionId: "mis_order",
+      taskId: "tsk_high",
+      title: "High priority updated later",
+      actor,
+    }),
+  ];
+}
+
+function taskOrderingHistory(): MissionHistoryEntry[] {
+  return [
+    entry(1, {
+      version: 1,
+      type: "mission.created",
+      missionId: "mis_sort",
+      title: "Sort",
+      objective: "Sort tasks",
+      acceptanceCriteria: [],
+      constraints: [],
+      labels: [],
+      source: { type: "user" },
+      actor,
+    }),
+    entry(2, {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_sort",
+      taskId: "tsk_low",
+      title: "Low",
+      priority: 0,
+      dependencies: [],
+      actor,
+    }),
+    entryAt(3, at(3), {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_sort",
+      taskId: "tsk_bbb",
+      title: "B",
+      priority: 1,
+      dependencies: [],
+      actor,
+    }),
+    entryAt(4, at(3), {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_sort",
+      taskId: "tsk_aaa",
+      title: "A",
+      priority: 1,
+      dependencies: [],
+      actor,
+    }),
+    entry(5, {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_sort",
+      taskId: "tsk_high",
+      title: "High",
+      priority: 2,
+      dependencies: [],
+      actor,
+    }),
+  ];
+}
+
+function terminalTaskAndAttemptHistory(): MissionHistoryEntry[] {
+  return [
+    entry(1, {
+      version: 1,
+      type: "mission.created",
+      missionId: "mis_terminal",
+      title: "Terminal",
+      objective: "Terminal projections",
+      acceptanceCriteria: [],
+      constraints: [],
+      labels: [],
+      source: { type: "user" },
+      actor,
+    }),
+    entry(2, { version: 1, type: "mission.started", missionId: "mis_terminal", actor }),
+    ...terminalTaskEvents(3, "tsk_cancel", "task.cancelled"),
+    ...terminalTaskEvents(5, "tsk_fail", "task.failed"),
+    ...attemptTerminalEvents(7, "tsk_reject", "att_reject", "attempt.rejected", "prf_reject"),
+    ...attemptTerminalEvents(16, "tsk_attempt_fail", "att_fail", "attempt.failed"),
+    ...attemptTerminalEvents(23, "tsk_interrupt", "att_interrupt", "attempt.interrupted"),
+  ];
+}
+
+function terminalTaskEvents(
+  start: number,
+  taskId: "tsk_cancel" | "tsk_fail",
+  terminalType: "task.cancelled" | "task.failed",
+): MissionHistoryEntry[] {
+  return [
+    entry(start, {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_terminal",
+      taskId,
+      title: taskId,
+      priority: 0,
+      dependencies: [],
+      actor,
+    }),
+    entry(start + 1, { version: 1, type: terminalType, missionId: "mis_terminal", taskId, actor }),
+  ];
+}
+
+function attemptTerminalEvents(
+  start: number,
+  taskId: "tsk_reject" | "tsk_attempt_fail" | "tsk_interrupt",
+  attemptId: "att_reject" | "att_fail" | "att_interrupt",
+  terminalType: "attempt.rejected" | "attempt.failed" | "attempt.interrupted",
+  proofId?: "prf_reject",
+): MissionHistoryEntry[] {
+  const base: MissionHistoryEntry[] = [
+    entry(start, {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_terminal",
+      taskId,
+      title: taskId,
+      priority: 0,
+      dependencies: [],
+      actor,
+    }),
+    entry(start + 1, { version: 1, type: "task.ready", missionId: "mis_terminal", taskId, actor }),
+    entry(start + 2, {
+      version: 1,
+      type: "task.claimed",
+      missionId: "mis_terminal",
+      taskId,
+      assignee: "agent/a",
+      actor,
+    }),
+    entry(start + 3, {
+      version: 1,
+      type: "task.started",
+      missionId: "mis_terminal",
+      taskId,
+      actor,
+    }),
+    entry(start + 4, {
+      version: 1,
+      type: "attempt.started",
+      missionId: "mis_terminal",
+      taskId,
+      attemptId,
+      agent: "agent/a",
+      harness: "generic",
+      actor,
+    }),
+  ];
+  if (proofId) {
+    base.push(
+      entry(start + 5, {
+        version: 1,
+        type: "proof.recorded",
+        missionId: "mis_terminal",
+        taskId,
+        attemptId,
+        proofId,
+        proof: { noProofReason: "rejected evidence" },
+        actor,
+      }),
+      entry(start + 6, {
+        version: 1,
+        type: "attempt.submitted",
+        missionId: "mis_terminal",
+        taskId,
+        attemptId,
+        proofId,
+        actor,
+      }),
+      entry(start + 7, {
+        version: 1,
+        type: terminalType,
+        missionId: "mis_terminal",
+        taskId,
+        attemptId,
+        actor,
+      }),
+      entry(start + 8, {
+        version: 1,
+        type: "task.failed",
+        missionId: "mis_terminal",
+        taskId,
+        actor,
+      }),
+    );
+    return base;
+  }
+  base.push(
+    entry(start + 5, {
+      version: 1,
+      type: terminalType,
+      missionId: "mis_terminal",
+      taskId,
+      attemptId,
+      actor,
+    }),
+    entry(start + 6, { version: 1, type: "task.failed", missionId: "mis_terminal", taskId, actor }),
+  );
+  return base;
+}
+
+function blockedDependencyHistory(): MissionHistoryEntry[] {
+  return [
+    entry(1, {
+      version: 1,
+      type: "mission.created",
+      missionId: "mis_alpha",
+      title: "Alpha",
+      objective: "Ship alpha",
+      acceptanceCriteria: [],
+      constraints: [],
+      labels: [],
+      source: { type: "user" },
+      actor,
+    }),
+    entry(2, { version: 1, type: "mission.started", missionId: "mis_alpha", actor }),
+    entry(3, {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      title: "Setup",
+      priority: 2,
+      dependencies: [],
+      actor,
+    }),
+    entry(4, {
+      version: 1,
+      type: "task.added",
+      missionId: "mis_alpha",
+      taskId: "tsk_finish",
+      title: "Finish",
+      priority: 1,
+      dependencies: ["tsk_setup"],
+      actor,
+    }),
+    entry(5, {
+      version: 1,
+      type: "task.ready",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      actor,
+    }),
+    entry(6, {
+      version: 1,
+      type: "task.claimed",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      assignee: "agent/a",
+      actor,
+    }),
+    entry(7, {
+      version: 1,
+      type: "task.started",
+      missionId: "mis_alpha",
+      taskId: "tsk_setup",
+      actor,
+    }),
+  ];
+}

--- a/packages/daemon/src/lib/mission-projections.ts
+++ b/packages/daemon/src/lib/mission-projections.ts
@@ -1,0 +1,759 @@
+import {
+  MissionBoardViewSchemaZ,
+  MissionDetailViewSchemaZ,
+  MissionHistorySummarySchemaZ,
+  MissionProjectStateSchemaZ,
+  MissionTimelineEntrySchemaZ,
+  type MissionActor,
+  type MissionAttempt,
+  type MissionAttemptId,
+  type MissionBoardColumn,
+  type MissionBoardView,
+  type MissionCardView,
+  type MissionDetailView,
+  type MissionEvent,
+  type MissionHistoryEntry,
+  type MissionHistorySummary,
+  type MissionId,
+  type MissionProgressSummary,
+  type MissionProof,
+  type MissionProofId,
+  type MissionProofSummary,
+  type MissionProjectState,
+  type MissionSnapshot,
+  type MissionStatus,
+  type MissionTask,
+  type MissionTaskId,
+  type MissionTaskStatus,
+  type MissionTimelineEntry,
+  type TaskCardView,
+} from "@tmux-ide/contracts";
+import { IdeError } from "./errors.ts";
+import { replayMissionEvents } from "./mission-repository.ts";
+
+export type MissionProjectionErrorCode =
+  | "MISSION_PROJECTION_INVALID"
+  | "MISSION_NOT_FOUND"
+  | "MISSION_HISTORY_MISMATCH";
+
+export class MissionProjectionError extends IdeError {
+  readonly projectionCode: MissionProjectionErrorCode;
+
+  constructor(
+    message: string,
+    code: MissionProjectionErrorCode,
+    { cause }: { cause?: Error } = {},
+  ) {
+    super(message, { code, cause });
+    this.name = "MissionProjectionError";
+    this.projectionCode = code;
+  }
+}
+
+export interface MissionProjectionOptions {
+  asOf?: string;
+}
+
+const BOARD_COLUMNS = ["planned", "running", "blocked", "review", "done"] as const;
+const TERMINAL_MISSION_STATUSES = ["completed", "failed", "cancelled"] as const;
+const TERMINAL_TASK_STATUSES = ["completed", "failed", "cancelled"] as const;
+
+export function projectMissionBoard(
+  state: MissionProjectState,
+  history: MissionHistoryEntry[],
+  options: MissionProjectionOptions = {},
+): MissionBoardView {
+  const parsed = validateStateAndHistory(state, history);
+  const asOf = parseAsOf(options.asOf);
+  const columns = emptyColumns<MissionCardView>();
+  for (const mission of sortedMissions(parsed)) {
+    const card = missionCard(mission, asOf, history);
+    columns[card.column].push(card);
+  }
+  for (const column of BOARD_COLUMNS) columns[column].sort(compareMissionCards);
+  return parseBoard({ version: 1, columns, counts: countsFor(columns) });
+}
+
+export function projectMissionDetail(
+  state: MissionProjectState,
+  history: MissionHistoryEntry[],
+  missionId: MissionId,
+  options: MissionProjectionOptions = {},
+): MissionDetailView {
+  const parsed = validateStateAndHistory(state, history);
+  const mission = parsed.missions[missionId];
+  if (!mission) {
+    throw new MissionProjectionError(`Mission "${missionId}" not found`, "MISSION_NOT_FOUND");
+  }
+  const asOf = parseAsOf(options.asOf);
+  const columns = emptyColumns<TaskCardView>();
+  for (const task of sortedTasks(mission)) {
+    const card = taskCard(mission, task, asOf);
+    columns[card.column].push(card);
+  }
+  for (const column of BOARD_COLUMNS) columns[column].sort(compareTaskCards);
+  const timeline = projectMissionTimeline(parsed, history, missionId);
+  const detail = {
+    version: 1 as const,
+    mission: missionCard(mission, asOf, history),
+    taskBoard: { columns, counts: countsFor(columns) },
+    attempts: sortedAttempts(mission).map((attempt) => attemptSummary(attempt, asOf)),
+    proofSummary: proofSummary(mission.proofs, sortedProofIds(Object.keys(mission.proofs))),
+    progress: taskProgress(sortedTasks(mission)),
+    timeline,
+  };
+  return parseDetail(detail);
+}
+
+export function projectMissionHistory(
+  state: MissionProjectState,
+  history: MissionHistoryEntry[],
+  options: MissionProjectionOptions = {},
+): MissionHistorySummary[] {
+  const parsed = validateStateAndHistory(state, history);
+  const asOf = parseAsOf(options.asOf);
+  return sortedMissions(parsed)
+    .filter((mission) => isTerminalMission(mission.status))
+    .map((mission) => {
+      const timeline = projectMissionTimeline(parsed, history, mission.id);
+      const lastEvent = lastMeaningfulTimelineEntry(timeline);
+      const outcome = terminalMissionOutcome(mission);
+      const summary = {
+        version: 1 as const,
+        mission: missionCard(mission, asOf, history),
+        outcome,
+        startedAt: mission.startedAt,
+        finishedAt: mission.finishedAt!,
+        durationMs: durationMs(mission.startedAt, mission.finishedAt, undefined),
+        taskTotals: taskProgress(sortedTasks(mission)),
+        attemptTotals: attemptTotals(sortedAttempts(mission)),
+        proofSummary: proofSummary(mission.proofs, sortedProofIds(Object.keys(mission.proofs))),
+        lastEvent,
+      };
+      return parseHistorySummary(summary);
+    });
+}
+
+export function projectMissionTimeline(
+  state: MissionProjectState,
+  history: MissionHistoryEntry[],
+  missionId: MissionId,
+): MissionTimelineEntry[] {
+  const parsed = validateStateAndHistory(state, history);
+  if (!parsed.missions[missionId]) {
+    throw new MissionProjectionError(`Mission "${missionId}" not found`, "MISSION_NOT_FOUND");
+  }
+  const entries = history
+    .filter((entry) => entry.event.missionId === missionId)
+    .sort((a, b) => a.sequence - b.sequence)
+    .map((entry) => timelineEntry(parsed.missions[missionId]!, entry));
+  return entries.map(parseTimelineEntry);
+}
+
+export function missionStatusToBoardColumn(status: MissionStatus): MissionBoardColumn {
+  switch (status) {
+    case "created":
+    case "planned":
+      return "planned";
+    case "started":
+      return "running";
+    case "blocked":
+      return "blocked";
+    case "review":
+      return "review";
+    case "completed":
+    case "failed":
+    case "cancelled":
+      return "done";
+  }
+}
+
+export function taskStatusToBoardColumn(status: MissionTaskStatus): MissionBoardColumn {
+  switch (status) {
+    case "added":
+    case "ready":
+      return "planned";
+    case "claimed":
+    case "started":
+      return "running";
+    case "blocked":
+      return "blocked";
+    case "submitted":
+      return "review";
+    case "completed":
+    case "failed":
+    case "cancelled":
+      return "done";
+  }
+}
+
+function missionCard(
+  mission: MissionSnapshot,
+  asOf: string | undefined,
+  history: MissionHistoryEntry[],
+): MissionCardView {
+  const taskIds = sortedTasks(mission).map((task) => task.id);
+  const attemptIds = sortedAttempts(mission).map((attempt) => attempt.id);
+  const proofIds = sortedProofIds(Object.keys(mission.proofs));
+  const latest = latestMissionAttemptFromHistory(mission, history);
+  return {
+    version: 1,
+    id: mission.id,
+    title: mission.title,
+    summary: mission.objective,
+    status: mission.status,
+    column: missionStatusToBoardColumn(mission.status),
+    labels: [...mission.labels].sort(compareStrings),
+    createdAt: mission.createdAt,
+    updatedAt: mission.updatedAt,
+    ...(mission.startedAt === undefined ? {} : { startedAt: mission.startedAt }),
+    ...(mission.finishedAt === undefined ? {} : { finishedAt: mission.finishedAt }),
+    durationMs: durationMs(mission.startedAt, mission.finishedAt, asOf),
+    progress: taskProgress(sortedTasks(mission)),
+    blockedBy: missionBlockedBy(mission),
+    latestAttempt: latest ? attemptSummary(latest, asOf) : null,
+    proofSummary: proofSummary(mission.proofs, proofIds),
+    refs: {
+      missionId: mission.id,
+      taskIds,
+      attemptIds,
+      proofIds,
+    },
+  };
+}
+
+function taskCard(
+  mission: MissionSnapshot,
+  task: MissionTask,
+  asOf: string | undefined,
+): TaskCardView {
+  const latest = latestAttemptForTask(mission, task);
+  return {
+    version: 1,
+    id: task.id,
+    missionId: mission.id,
+    title: task.title,
+    summary: task.description ?? task.title,
+    status: task.status,
+    column: taskStatusToBoardColumn(task.status),
+    priority: task.priority,
+    ...(task.assignee === undefined ? {} : { assignee: task.assignee }),
+    dependencies: [...task.dependencies],
+    blockedBy: taskBlockedBy(mission, task),
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+    ...(task.startedAt === undefined ? {} : { startedAt: task.startedAt }),
+    ...(task.finishedAt === undefined ? {} : { finishedAt: task.finishedAt }),
+    durationMs: durationMs(task.startedAt, task.finishedAt, asOf),
+    latestAttempt: latest ? attemptSummary(latest, asOf) : null,
+    proofSummary: proofSummary(mission.proofs, task.proofIds),
+    refs: {
+      missionId: mission.id,
+      taskId: task.id,
+      attemptIds: [...task.attemptIds],
+      proofIds: [...task.proofIds],
+      ...(latest?.terminal === undefined ? {} : { terminal: latest.terminal }),
+      ...(latest?.session === undefined ? {} : { session: latest.session }),
+      ...(latest?.worktree === undefined ? {} : { worktree: latest.worktree }),
+    },
+  };
+}
+
+function latestAttemptForTask(mission: MissionSnapshot, task: MissionTask): MissionAttempt | null {
+  const latestId = task.attemptIds.at(-1);
+  return latestId ? (mission.attempts[latestId] ?? null) : null;
+}
+
+function latestMissionAttemptFromHistory(
+  mission: MissionSnapshot,
+  history: MissionHistoryEntry[],
+): MissionAttempt | null {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const event = history[index]!.event;
+    if (event.type !== "attempt.started" || event.missionId !== mission.id) continue;
+    return mission.attempts[event.attemptId] ?? null;
+  }
+  return null;
+}
+
+function attemptSummary(attempt: MissionAttempt, asOf: string | undefined) {
+  return {
+    id: attempt.id,
+    taskId: attempt.taskId,
+    status: attempt.status,
+    ...(attempt.outcome === undefined ? {} : { outcome: attempt.outcome }),
+    agent: attempt.agent,
+    harness: attempt.harness,
+    ...(attempt.model === undefined ? {} : { model: attempt.model }),
+    ...(attempt.terminal === undefined ? {} : { terminal: attempt.terminal }),
+    ...(attempt.session === undefined ? {} : { session: attempt.session }),
+    ...(attempt.worktree === undefined ? {} : { worktree: attempt.worktree }),
+    startedAt: attempt.startedAt,
+    updatedAt: attempt.updatedAt,
+    ...(attempt.finishedAt === undefined ? {} : { finishedAt: attempt.finishedAt }),
+    durationMs: durationMs(attempt.startedAt, attempt.finishedAt, asOf),
+    proofIds: [...attempt.proofIds],
+  };
+}
+
+function proofSummary(
+  proofs: Record<string, MissionProof>,
+  proofIds: string[],
+): MissionProofSummary {
+  const ids = sortedProofIds(proofIds);
+  const noProofReasons: string[] = [];
+  const commits = new Set<string>();
+  const diffSummaries = new Set<string>();
+  const diffUrls = new Set<string>();
+  const prs = new Map<
+    string,
+    { number?: number; url?: string; status?: "draft" | "open" | "merged" | "closed" }
+  >();
+  const artifacts = new Map<string, { name: string; uri: string; kind?: string }>();
+  let notesCount = 0;
+  let suites = 0;
+  let passed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let total = 0;
+  let filesChanged = 0;
+  let insertions = 0;
+  let deletions = 0;
+
+  for (const id of ids) {
+    const proof = proofs[id];
+    if (!proof) continue;
+    if (proof.noProofReason) noProofReasons.push(proof.noProofReason);
+    if (proof.notes) notesCount += 1;
+    for (const test of proof.tests ?? []) {
+      suites += 1;
+      if (test.status === "passed") passed += 1;
+      if (test.status === "failed") failed += 1;
+      if (test.status === "skipped") skipped += 1;
+      total += test.total ?? 0;
+    }
+    for (const commit of proof.commits ?? []) commits.add(commit.sha);
+    if (proof.diff?.summary) diffSummaries.add(proof.diff.summary);
+    if (proof.diff?.url) diffUrls.add(proof.diff.url);
+    filesChanged += proof.diff?.stats?.filesChanged ?? 0;
+    insertions += proof.diff?.stats?.insertions ?? 0;
+    deletions += proof.diff?.stats?.deletions ?? 0;
+    if (proof.pr) {
+      const key = proof.pr.url ?? String(proof.pr.number ?? proof.pr.status ?? "unknown");
+      prs.set(key, proof.pr);
+    }
+    for (const artifact of proof.artifacts ?? []) {
+      artifacts.set(`${artifact.name}\u0000${artifact.uri}\u0000${artifact.kind ?? ""}`, artifact);
+    }
+  }
+
+  return {
+    proofIds: ids,
+    hasProof: ids.length > 0,
+    noProofReasons,
+    notesCount,
+    tests: { suites, passed, failed, skipped, total },
+    commits: [...commits].sort(compareStrings),
+    diff: {
+      summaries: [...diffSummaries].sort(compareStrings),
+      urls: [...diffUrls].sort(compareStrings),
+      filesChanged,
+      insertions,
+      deletions,
+    },
+    prs: [...prs.values()].sort(comparePrs),
+    artifacts: [...artifacts.values()].sort(compareArtifacts),
+  };
+}
+
+function taskProgress(tasks: MissionTask[]): MissionProgressSummary {
+  const progress: MissionProgressSummary = {
+    total: tasks.length,
+    planned: 0,
+    running: 0,
+    blocked: 0,
+    review: 0,
+    completed: 0,
+    failed: 0,
+    cancelled: 0,
+    done: 0,
+  };
+  for (const task of tasks) {
+    const column = taskStatusToBoardColumn(task.status);
+    progress[column] += 1;
+    if (task.status === "completed") progress.completed += 1;
+    if (task.status === "failed") progress.failed += 1;
+    if (task.status === "cancelled") progress.cancelled += 1;
+  }
+  return progress;
+}
+
+function attemptTotals(attempts: MissionAttempt[]) {
+  const totals = {
+    total: attempts.length,
+    submitted: 0,
+    approved: 0,
+    rejected: 0,
+    failed: 0,
+    interrupted: 0,
+    running: 0,
+  };
+  for (const attempt of attempts) {
+    if (attempt.status === "started") totals.running += 1;
+    else totals[attempt.status] += 1;
+  }
+  return totals;
+}
+
+function taskBlockedBy(mission: MissionSnapshot, task: MissionTask): MissionTaskId[] {
+  return task.dependencies
+    .filter((dependencyId) => mission.tasks[dependencyId]?.status !== "completed")
+    .sort(compareStrings);
+}
+
+function missionBlockedBy(mission: MissionSnapshot): MissionTaskId[] {
+  const blocked = new Set<MissionTaskId>();
+  for (const task of Object.values(mission.tasks)) {
+    for (const dependencyId of taskBlockedBy(mission, task)) blocked.add(dependencyId);
+  }
+  return [...blocked].sort(compareStrings);
+}
+
+function timelineEntry(mission: MissionSnapshot, entry: MissionHistoryEntry): MissionTimelineEntry {
+  const event = entry.event;
+  const taskId = "taskId" in event ? event.taskId : undefined;
+  const attemptId = "attemptId" in event ? event.attemptId : undefined;
+  const proofId = "proofId" in event ? event.proofId : undefined;
+  const attempt = attemptId ? mission.attempts[attemptId] : null;
+  return {
+    version: 1,
+    sequence: entry.sequence,
+    timestamp: entry.timestamp,
+    missionId: event.missionId,
+    ...(taskId === undefined ? {} : { taskId }),
+    ...(attemptId === undefined ? {} : { attemptId }),
+    ...(proofId === undefined ? {} : { proofId }),
+    type: event.type,
+    label: labelForEvent(event),
+    actor: clone(event.actor) as MissionActor,
+    ...("reason" in event && event.reason !== undefined ? { reason: event.reason } : {}),
+    refs: {
+      missionId: event.missionId,
+      ...(taskId === undefined ? {} : { taskId }),
+      ...(attemptId === undefined ? {} : { attemptId }),
+      ...(proofId === undefined ? {} : { proofId }),
+      ...(attempt?.terminal === undefined ? {} : { terminal: attempt.terminal }),
+      ...(attempt?.session === undefined ? {} : { session: attempt.session }),
+      ...(attempt?.worktree === undefined ? {} : { worktree: attempt.worktree }),
+    },
+  };
+}
+
+function labelForEvent(event: MissionEvent): string {
+  switch (event.type) {
+    case "mission.created":
+      return "Mission created";
+    case "mission.planned":
+      return "Mission planned";
+    case "mission.started":
+      return "Mission started";
+    case "mission.blocked":
+      return "Mission blocked";
+    case "mission.review":
+      return "Mission moved to review";
+    case "mission.completed":
+      return "Mission completed";
+    case "mission.failed":
+      return "Mission failed";
+    case "mission.cancelled":
+      return "Mission cancelled";
+    case "task.added":
+      return "Task added";
+    case "task.updated":
+      return "Task updated";
+    case "task.ready":
+      return "Task ready";
+    case "task.claimed":
+      return "Task claimed";
+    case "task.started":
+      return "Task started";
+    case "task.blocked":
+      return "Task blocked";
+    case "task.submitted":
+      return "Task submitted";
+    case "task.completed":
+      return "Task completed";
+    case "task.failed":
+      return "Task failed";
+    case "task.cancelled":
+      return "Task cancelled";
+    case "attempt.started":
+      return "Attempt started";
+    case "attempt.submitted":
+      return "Attempt submitted";
+    case "attempt.approved":
+      return "Attempt approved";
+    case "attempt.rejected":
+      return "Attempt rejected";
+    case "attempt.failed":
+      return "Attempt failed";
+    case "attempt.interrupted":
+      return "Attempt interrupted";
+    case "proof.recorded":
+      return "Proof recorded";
+  }
+}
+
+function validateStateAndHistory(
+  state: MissionProjectState,
+  history: MissionHistoryEntry[],
+): MissionProjectState {
+  const parsed = parseState(state);
+  const replayed = replayHistory(history);
+  if (stableJson(replayed) !== stableJson(parsed)) {
+    throw new MissionProjectionError(
+      "Mission projection state does not match mission history replay",
+      "MISSION_HISTORY_MISMATCH",
+    );
+  }
+  return parsed;
+}
+
+function replayHistory(history: MissionHistoryEntry[]): MissionProjectState {
+  try {
+    return replayMissionEvents(
+      history.map((entry) => ({
+        version: 1 as const,
+        sequence: entry.sequence,
+        timestamp: entry.timestamp,
+        payload: entry.event,
+      })),
+    );
+  } catch (error) {
+    throw new MissionProjectionError(
+      `Invalid mission projection history: ${error instanceof Error ? error.message : String(error)}`,
+      "MISSION_PROJECTION_INVALID",
+      { cause: error instanceof Error ? error : undefined },
+    );
+  }
+}
+
+function parseState(state: MissionProjectState): MissionProjectState {
+  const parsed = MissionProjectStateSchemaZ.safeParse(clone(state));
+  if (!parsed.success) {
+    throw new MissionProjectionError(
+      `Invalid mission projection state: ${parsed.error.issues.map((issue) => issue.message).join("; ")}`,
+      "MISSION_PROJECTION_INVALID",
+    );
+  }
+  return parsed.data;
+}
+
+function parseAsOf(asOf: string | undefined): string | undefined {
+  if (asOf === undefined) return undefined;
+  if (!isCanonicalTimestamp(asOf)) {
+    throw new MissionProjectionError(
+      "Invalid projection asOf timestamp",
+      "MISSION_PROJECTION_INVALID",
+    );
+  }
+  return asOf;
+}
+
+function sortedMissions(state: MissionProjectState): MissionSnapshot[] {
+  return Object.keys(state.missions)
+    .sort(compareStrings)
+    .map((id) => state.missions[id]!)
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+}
+
+function sortedTasks(mission: MissionSnapshot): MissionTask[] {
+  return Object.keys(mission.tasks)
+    .sort(compareStrings)
+    .map((id) => mission.tasks[id]!)
+    .sort(compareTasks);
+}
+
+function sortedAttempts(mission: MissionSnapshot): MissionAttempt[] {
+  const order = new Map<MissionAttemptId, number>();
+  for (const task of sortedTasks(mission)) {
+    task.attemptIds.forEach((attemptId, index) => {
+      order.set(attemptId, order.size * 100000 + index);
+    });
+  }
+  return Object.keys(mission.attempts)
+    .sort(compareStrings)
+    .map((id) => mission.attempts[id]!)
+    .sort(
+      (a, b) =>
+        (order.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+          (order.get(b.id) ?? Number.MAX_SAFE_INTEGER) ||
+        a.startedAt.localeCompare(b.startedAt) ||
+        a.id.localeCompare(b.id),
+    );
+}
+
+function compareTasks(a: MissionTask, b: MissionTask): number {
+  return (
+    b.priority - a.priority || a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id)
+  );
+}
+
+function compareMissionCards(a: MissionCardView, b: MissionCardView): number {
+  return (
+    Number(isTerminalMission(a.status)) - Number(isTerminalMission(b.status)) ||
+    a.createdAt.localeCompare(b.createdAt) ||
+    a.id.localeCompare(b.id)
+  );
+}
+
+function compareTaskCards(a: TaskCardView, b: TaskCardView): number {
+  return (
+    Number(isTerminalTask(a.status)) - Number(isTerminalTask(b.status)) ||
+    b.priority - a.priority ||
+    a.createdAt.localeCompare(b.createdAt) ||
+    a.id.localeCompare(b.id)
+  );
+}
+
+function comparePrs(
+  a: { number?: number; url?: string; status?: string },
+  b: { number?: number; url?: string; status?: string },
+): number {
+  return (
+    (a.number ?? 0) - (b.number ?? 0) ||
+    (a.url ?? "").localeCompare(b.url ?? "") ||
+    (a.status ?? "").localeCompare(b.status ?? "")
+  );
+}
+
+function compareArtifacts(
+  a: { name: string; uri: string; kind?: string },
+  b: { name: string; uri: string; kind?: string },
+): number {
+  return (
+    a.name.localeCompare(b.name) ||
+    a.uri.localeCompare(b.uri) ||
+    (a.kind ?? "").localeCompare(b.kind ?? "")
+  );
+}
+
+function sortedProofIds(ids: string[]): MissionProofId[] {
+  return [...new Set(ids)].sort(compareStrings) as MissionProofId[];
+}
+
+function countsFor<T>(columns: Record<MissionBoardColumn, T[]>) {
+  return {
+    planned: columns.planned.length,
+    running: columns.running.length,
+    blocked: columns.blocked.length,
+    review: columns.review.length,
+    done: columns.done.length,
+    total: BOARD_COLUMNS.reduce((sum, column) => sum + columns[column].length, 0),
+  };
+}
+
+function emptyColumns<T>(): Record<MissionBoardColumn, T[]> {
+  return { planned: [], running: [], blocked: [], review: [], done: [] };
+}
+
+function durationMs(
+  startedAt: string | undefined,
+  finishedAt: string | undefined,
+  asOf: string | undefined,
+): number | null {
+  if (!startedAt) return null;
+  const end = finishedAt ?? asOf;
+  if (!end) return null;
+  return Date.parse(end) - Date.parse(startedAt);
+}
+
+function lastMeaningfulTimelineEntry(entries: MissionTimelineEntry[]): MissionTimelineEntry | null {
+  return entries.at(-1) ?? null;
+}
+
+function isTerminalMission(
+  status: MissionStatus,
+): status is (typeof TERMINAL_MISSION_STATUSES)[number] {
+  return TERMINAL_MISSION_STATUSES.includes(status as (typeof TERMINAL_MISSION_STATUSES)[number]);
+}
+
+function terminalMissionOutcome(
+  mission: MissionSnapshot,
+): (typeof TERMINAL_MISSION_STATUSES)[number] {
+  if (isTerminalMission(mission.status)) return mission.status;
+  throw new MissionProjectionError(
+    `Mission "${mission.id}" is not terminal`,
+    "MISSION_PROJECTION_INVALID",
+  );
+}
+
+function isTerminalTask(
+  status: MissionTaskStatus,
+): status is (typeof TERMINAL_TASK_STATUSES)[number] {
+  return TERMINAL_TASK_STATUSES.includes(status as (typeof TERMINAL_TASK_STATUSES)[number]);
+}
+
+function isCanonicalTimestamp(value: string): boolean {
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}
+
+function compareStrings(a: string, b: string): number {
+  return a.localeCompare(b);
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortObject(value));
+}
+
+function sortObject(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortObject);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, item]) => [key, sortObject(item)]),
+    );
+  }
+  return value;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function parseBoard(value: MissionBoardView): MissionBoardView {
+  const parsed = MissionBoardViewSchemaZ.safeParse(clone(value));
+  if (!parsed.success) throw projectionValidationError("board", parsed.error);
+  return parsed.data;
+}
+
+function parseDetail(value: MissionDetailView): MissionDetailView {
+  const parsed = MissionDetailViewSchemaZ.safeParse(clone(value));
+  if (!parsed.success) throw projectionValidationError("detail", parsed.error);
+  return parsed.data;
+}
+
+function parseHistorySummary(value: MissionHistorySummary): MissionHistorySummary {
+  const parsed = MissionHistorySummarySchemaZ.safeParse(clone(value));
+  if (!parsed.success) throw projectionValidationError("history summary", parsed.error);
+  return parsed.data;
+}
+
+function parseTimelineEntry(value: MissionTimelineEntry): MissionTimelineEntry {
+  const parsed = MissionTimelineEntrySchemaZ.safeParse(clone(value));
+  if (!parsed.success) throw projectionValidationError("timeline entry", parsed.error);
+  return parsed.data;
+}
+
+function projectionValidationError(label: string, cause: Error): MissionProjectionError {
+  return new MissionProjectionError(
+    `Invalid mission projection ${label}: ${cause.message}`,
+    "MISSION_PROJECTION_INVALID",
+    { cause },
+  );
+}


### PR DESCRIPTION
## Summary
- add strict versioned Missions board, card, detail, history, proof, attempt, and timeline contracts
- add pure deterministic projections over validated C08 state and ordered event history
- derive blockers, progress, retries, proof summaries, navigation references, outcomes, durations, and stable ordering
- reject corrupt or mismatched state/history with typed projection errors

## Validation
- focused contracts + daemon projection/repository suites: 36 tests passed
- daemon typecheck + build:tsc passed
- full `pnpm check` passed (contracts 41, daemon 1724)
- `git diff --check` passed

Sfora: #116 / C09