### PR TITLE
feat(tui): persist project workspace view state

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -293,6 +293,7 @@ import {
 } from "./folder-picker.ts";
 import { registerProject, ProjectAlreadyRegisteredError } from "../../lib/project-registry.ts";
 import { resolveProjectConfigContext } from "../../lib/config-context.ts";
+import { createProjectRuntimeRepository } from "../../lib/project-runtime-repository.ts";
 import { separatorAt, resizedSize, resizeCommand, type Separator } from "./resize-model.ts";
 import {
   effectiveWindowSize,
@@ -323,6 +324,7 @@ import {
   PanelHostLoadGeneration,
   findFirstHostedViewForPanel,
   findHostedViewById,
+  hostedActivationEffects,
   initialHostedSelection,
   isHostedPanelInert,
   legacyTabFromPanelKind,
@@ -339,6 +341,19 @@ import {
   type HostedPanelKind,
   type HostedPanelView,
 } from "./panel-host.ts";
+import {
+  WorkspaceUiStateController,
+  absoluteProjectPath,
+  chooseInitialWorkspaceView,
+  defaultWorkspaceUiState,
+  loadWorkspaceUiState,
+  relativeProjectPath,
+  serializeWorkspaceUiState,
+  shouldHydrateWorkspaceView,
+  viewStateFor,
+  type WorkspaceUiStateV1,
+  type WorkspaceViewState,
+} from "./workspace-ui-state.ts";
 import {
   DIALOG_W,
   DIALOG_ROWS,
@@ -904,10 +919,9 @@ try {
     // The first-run tip line — the user's ACTUAL keybindings, read once at launch
     // (loadAppConfig honors TMUX_IDE_CONFIG). Cheap + pure, computed once.
     const welcomeTip = firstRunTip(loadAppConfig().keys);
-    // C05 hosted panel views are loaded through the resolved-config pipeline.
-    // Persistence remains the legacy four-value `lastTab` until C06; the active
-    // runtime identity is the configured view ID so duplicate panel kinds switch
-    // and highlight independently.
+    // Hosted panel views are loaded through the resolved-config pipeline. C06
+    // stores per-project active view + per-view surface memory in C04 runtime
+    // state; legacy app-state remains as first-run fallback and global prefs.
     const requestedPanel: HostedPanelKind | null = startDiff
       ? "diff"
       : values.edit !== undefined
@@ -921,6 +935,14 @@ try {
     const [hostedViews, setHostedViews] = createSignal<HostedPanelView[]>(
       viewsFromResolvedConfig(null),
     );
+    const [workspaceUiState, setWorkspaceUiState] =
+      createSignal<WorkspaceUiStateV1>(defaultWorkspaceUiState());
+    const workspaceUiController = new WorkspaceUiStateController();
+    const touchedWorkspaceViewIds = new Set<string>();
+    let currentWorkspaceUiIdentity: string | null = null;
+    let workspaceUiSaveTimer: ReturnType<typeof setTimeout> | null = null;
+    let snapshotActiveWorkspaceView = () => {};
+    let hydrateActiveWorkspaceView = (_options: { firstProjectLoad?: boolean } = {}) => {};
     const initialView = initialHostedSelection(
       hostedViews(),
       requestedPanel,
@@ -1040,8 +1062,10 @@ try {
         return false;
       }
       clearSelection();
+      snapshotActiveWorkspaceView();
       runActivationEffects(plan.effects);
       setActiveViewId(plan.activeViewId);
+      hydrateActiveWorkspaceView();
       refreshFocusRecord();
       return true;
     };
@@ -1061,34 +1085,58 @@ try {
     let panelHostResolved = false;
     const loadPanelHostForDir = (dir: string) => {
       const generation = panelGeneration.next();
+      const uiGeneration = workspaceUiController.beginLoad();
       void resolveProjectConfigContext(dir)
         .then((context) => {
           if (!panelGeneration.isCurrent(generation)) return;
+          const resolved = context.resolved;
+          if (!resolved) return;
+          const repository = createProjectRuntimeRepository(resolved.resolution);
+          const loadedUi = loadWorkspaceUiState(repository);
+          if (!workspaceUiController.completeLoad(uiGeneration, repository, loadedUi)) return;
+          setWorkspaceUiState(loadedUi.state);
+          const loadDiagnostic = loadedUi.diagnostics.find((entry) => entry.code !== "MISSING");
+          if (loadDiagnostic) setStatusNote(loadDiagnostic.message);
           const previous = {
             id: activeViewId(),
             panel: activePanel(),
           };
-          const nextViews = viewsFromResolvedConfig(context.resolved);
+          const nextViews = viewsFromResolvedConfig(resolved);
           const state = {
             filesLoaded: fileNodes().length > 0,
             diffLoaded: diffEntries().length > 0,
           };
-          const nextPlan = panelHostResolved
-            ? planHostedReconciledActivation(nextViews, previous, state)
-            : planHostedInitialActivation(
-                nextViews,
-                requestedPanel,
-                bareHome ? persistedPanel : null,
-                state,
-                previous.panel,
-              );
+          const identityChanged = currentWorkspaceUiIdentity !== repository.metadata.identityKey;
+          currentWorkspaceUiIdentity = repository.metadata.identityKey;
+          const firstProjectLoad = !panelHostResolved || identityChanged;
+          const initialChoice = firstProjectLoad
+            ? chooseInitialWorkspaceView(nextViews, {
+                requestedPanel: !panelHostResolved ? requestedPanel : null,
+                persisted: loadedUi.state,
+                legacyLastTab: bareHome ? persisted.lastTab : null,
+              })
+            : null;
+          const nextPlan = initialChoice
+            ? {
+                activeViewId: initialChoice.view?.id ?? null,
+                view: initialChoice.view,
+                effects:
+                  initialChoice.view && previous.panel !== initialChoice.view.panel
+                    ? hostedActivationEffects(initialChoice.view.panel, state)
+                    : [],
+                note: null,
+              }
+            : planHostedReconciledActivation(nextViews, previous, state);
           setHostedViews(nextViews);
           runActivationEffects(nextPlan.effects);
           if (nextPlan.activeViewId) setActiveViewId(nextPlan.activeViewId);
+          hydrateActiveWorkspaceView({ firstProjectLoad });
           panelHostResolved = true;
         })
         .catch((error) => {
           if (!panelGeneration.isCurrent(generation)) return;
+          workspaceUiController.failLoad(uiGeneration);
+          setWorkspaceUiState(defaultWorkspaceUiState());
           const previous = {
             id: activeViewId(),
             panel: activePanel(),
@@ -1553,7 +1601,7 @@ try {
       setEditorMsg("");
       setEditorRev((r) => r + 1);
       setFilesFocus("editor");
-      setTab("files");
+      if (activePanel() !== "files") setTab("files");
     };
 
     const toggleEditor = () => {
@@ -2047,6 +2095,7 @@ try {
     // to restore when the filter is escaped lives beside it (not reactive).
     const [filesQuery, setFilesQuery] = createSignal<string | null>(null);
     let filesPreFilterPath: string | null = null;
+    let pendingFilesSelectionPath: string | null = null;
     // Which half of the Files tab has the keyboard: the file LIST (j/k/enter) or
     // the EDITOR (typing). Opening a file hands focus to the editor; esc hands it
     // back to the list.
@@ -2148,6 +2197,9 @@ try {
             setFileSel(0);
             setFileTop(0);
             setFilesQuery(null);
+            const pending = pendingFilesSelectionPath;
+            pendingFilesSelectionPath = null;
+            if (pending) void revealPath(pending);
           })
           .catch(() => setFileNodes([])),
       );
@@ -2273,6 +2325,87 @@ try {
       const curRel = cur ? relPath(top, cur.path) || null : null;
       const next = nextChangedPath(walk, curRel, dir);
       if (next) void revealPath(join(top, next));
+    };
+
+    const workspaceUiProjectRoot = (): string =>
+      workspaceUiController.snapshot().repository?.metadata.projectRoot ?? workspaceDir();
+    const currentWorkspaceViewState = (): WorkspaceViewState => {
+      const panel = activePanel();
+      const root = workspaceUiProjectRoot();
+      if (panel === "files") {
+        return {
+          panel,
+          openPath: relativeProjectPath(root, editorPath()),
+          selectedPath: relativeProjectPath(root, visibleFiles()[fileSel()]?.node.path ?? null),
+        };
+      }
+      if (panel === "diff") {
+        return {
+          panel,
+          selectedPath: diffVisibleFiles()[diffSel()]?.path ?? null,
+        };
+      }
+      if (panel === "missions") {
+        const existing = viewStateFor(workspaceUiState(), activeView());
+        return existing?.panel === "missions"
+          ? existing
+          : { panel, selectedMissionId: null, selectedTaskId: null };
+      }
+      return { panel };
+    };
+    const stateWithCurrentWorkspaceView = (): WorkspaceUiStateV1 => {
+      const view = activeView();
+      return {
+        version: 1,
+        active: { viewId: view.id, panel: view.panel },
+        views: {
+          ...workspaceUiState().views,
+          [view.id]: currentWorkspaceViewState(),
+        },
+      };
+    };
+    snapshotActiveWorkspaceView = () => {
+      const view = activeView();
+      touchedWorkspaceViewIds.add(view.id);
+      const next = stateWithCurrentWorkspaceView();
+      setWorkspaceUiState(next);
+    };
+    hydrateActiveWorkspaceView = ({ firstProjectLoad = false } = {}) => {
+      const view = activeView();
+      const entry = viewStateFor(workspaceUiState(), view);
+      if (!entry) return;
+      if (
+        !shouldHydrateWorkspaceView({
+          firstProjectLoad,
+          explicitEditPath: values.edit ?? null,
+          view,
+          entry,
+        })
+      ) {
+        return;
+      }
+      const root = workspaceUiProjectRoot();
+      if (entry.panel === "files") {
+        const selectedPath = absoluteProjectPath(root, entry.selectedPath);
+        pendingFilesSelectionPath = selectedPath;
+        if (fileNodes().length > 0 && selectedPath) {
+          pendingFilesSelectionPath = null;
+          void revealPath(selectedPath);
+        }
+        const openPath = absoluteProjectPath(root, entry.openPath);
+        if (openPath) openEditor(openPath);
+      } else if (entry.panel === "diff") {
+        pendingDiffFile = entry.selectedPath;
+        if (entry.selectedPath && diffVisibleFiles().length > 0) {
+          const idx = diffVisibleFiles().findIndex((file) => file.path === entry.selectedPath);
+          if (idx !== -1) {
+            pendingDiffFile = null;
+            selectDiffFile(idx);
+            return;
+          }
+        }
+        if (mode() === "diff") refreshStatus();
+      }
     };
 
     // ── WATCHER PUSH REFRESH (M24.6) ─────────────────────────────────────────
@@ -3609,6 +3742,31 @@ try {
       if (saveTimer) clearTimeout(saveTimer);
       saveTimer = setTimeout(() => void saveAppState(snapshot), 400);
     });
+    createEffect(() => {
+      activeViewId();
+      editorPath();
+      visibleFiles()[fileSel()]?.node.path;
+      diffVisibleFiles()[diffSel()]?.path;
+      workspaceUiState();
+      const controllerSnapshot = workspaceUiController.snapshot();
+      if (!controllerSnapshot.loaded || !controllerSnapshot.repository) return;
+      const next = stateWithCurrentWorkspaceView();
+      if (serializeWorkspaceUiState(next) === serializeWorkspaceUiState(controllerSnapshot.state))
+        return;
+      touchedWorkspaceViewIds.add(activeViewId());
+      const generation = controllerSnapshot.generation;
+      if (workspaceUiSaveTimer) clearTimeout(workspaceUiSaveTimer);
+      workspaceUiSaveTimer = setTimeout(() => {
+        const result = workspaceUiController.save(generation, next, touchedWorkspaceViewIds);
+        if (result.saved) {
+          touchedWorkspaceViewIds.clear();
+          setWorkspaceUiState(workspaceUiController.snapshot().state);
+        } else if (!result.skipped) {
+          const message = result.diagnostics.at(-1)?.message;
+          if (message) setStatusNote(message);
+        }
+      }, 400);
+    });
 
     onMount(() => {
       // Copy relies on the surrounding tmux capturing our OSC52: turn on
@@ -3743,6 +3901,7 @@ try {
         clearInterval(fleetTimer);
         clearInterval(diffTimer);
         if (saveTimer) clearTimeout(saveTimer);
+        if (workspaceUiSaveTimer) clearTimeout(workspaceUiSaveTimer);
         if (noteTimer) clearTimeout(noteTimer);
         mirror?.dispose();
         editBuffer?.destroy();

--- a/packages/daemon/src/tui/mirror/workspace-ui-state.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace-ui-state.test.ts
@@ -1,0 +1,486 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ProjectResolution } from "../../lib/project-resolver.ts";
+import { createProjectRuntimeRepository } from "../../lib/project-runtime-repository.ts";
+import type { HostedPanelView } from "./panel-host.ts";
+import {
+  WORKSPACE_UI_STATE_MAX_VIEWS,
+  WORKSPACE_UI_STATE_PATH,
+  WorkspaceUiStateController,
+  absoluteProjectPath,
+  chooseInitialWorkspaceView,
+  defaultWorkspaceUiState,
+  loadWorkspaceUiState,
+  mergeWorkspaceUiStateForSave,
+  missionsSelection,
+  parseWorkspaceUiStateJson,
+  relativeProjectPath,
+  serializeWorkspaceUiState,
+  setMissionsSelection,
+  shouldHydrateWorkspaceView,
+  viewStateFor,
+  writeWorkspaceUiStateWithRetry,
+  type WorkspaceUiStateV1,
+} from "./workspace-ui-state.ts";
+
+const roots: string[] = [];
+const IDENTITY_KEY = `git-${"b".repeat(64)}`;
+
+function temporaryRoot(prefix = "tmux-ide-ui-state-"): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function resolution(
+  projectRoot: string,
+  overrides: Partial<ProjectResolution> = {},
+): ProjectResolution {
+  return {
+    inputDir: projectRoot,
+    projectRoot,
+    identityKey: IDENTITY_KEY,
+    identitySource: "git-common-dir",
+    identityAnchor: join(projectRoot, ".git"),
+    config: { kind: "none", path: null, explicit: false },
+    workspaceConfigPath: null,
+    legacyConfigPath: null,
+    hasLegacyConfigAtInput: false,
+    ...overrides,
+  };
+}
+
+function views(): HostedPanelView[] {
+  return [
+    { id: "home", title: "Home", panel: "home", glyph: "⌂", order: 0, shortcut: null },
+    { id: "files-a", title: "Files A", panel: "files", glyph: "▤", order: 1, shortcut: null },
+    { id: "diff-a", title: "Diff A", panel: "diff", glyph: "±", order: 2, shortcut: null },
+    { id: "files-b", title: "Files B", panel: "files", glyph: "▤", order: 3, shortcut: null },
+    { id: "missions", title: "Missions", panel: "missions", glyph: "◆", order: 4, shortcut: null },
+  ];
+}
+
+function writeRaw(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents, "utf-8");
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("workspace UI-state contract", () => {
+  it("parses defaults, malformed input, unsupported versions, caps, and mistyped fields", () => {
+    expect(parseWorkspaceUiStateJson("{").state).toEqual(defaultWorkspaceUiState());
+    expect(parseWorkspaceUiStateJson('{"version":2,"active":null,"views":{}}')).toMatchObject({
+      state: defaultWorkspaceUiState(),
+      diagnostics: [{ code: "UNSUPPORTED_VERSION", path: "$.version" }],
+    });
+
+    const oversizedViews: Record<string, unknown> = {};
+    for (let i = 0; i < WORKSPACE_UI_STATE_MAX_VIEWS + 2; i++) {
+      oversizedViews[`view-${i}`] = { panel: "files", openPath: `src/${i}.ts`, selectedPath: 1 };
+    }
+    oversizedViews["bad\0id"] = { panel: "diff", selectedPath: "x" };
+    const parsed = parseWorkspaceUiStateJson(
+      JSON.stringify({
+        version: 1,
+        active: { viewId: "", panel: "files" },
+        views: oversizedViews,
+      }),
+    );
+
+    expect(Object.keys(parsed.state.views)).toHaveLength(WORKSPACE_UI_STATE_MAX_VIEWS);
+    expect(parsed.state.views["view-0"]).toEqual({
+      panel: "files",
+      openPath: "src/0.ts",
+      selectedPath: null,
+    });
+    expect(parsed.diagnostics.map((entry) => entry.code)).toContain("OVERSIZED");
+    expect(parsed.diagnostics.map((entry) => entry.code)).toContain("INVALID_FIELD");
+  });
+
+  it("serializes with stable keys, stable field order, and detached output", () => {
+    const state: WorkspaceUiStateV1 = {
+      version: 1,
+      active: { viewId: "z", panel: "diff" },
+      views: {
+        z: { panel: "diff", selectedPath: "z.ts" },
+        a: { panel: "missions", selectedMissionId: "m1", selectedTaskId: "t1" },
+      },
+    };
+
+    const serialized = serializeWorkspaceUiState(state);
+
+    expect(serialized).toBe(
+      [
+        "{",
+        '  "version": 1,',
+        '  "active": {',
+        '    "viewId": "z",',
+        '    "panel": "diff"',
+        "  },",
+        '  "views": {',
+        '    "a": {',
+        '      "panel": "missions",',
+        '      "selectedMissionId": "m1",',
+        '      "selectedTaskId": "t1"',
+        "    },",
+        '    "z": {',
+        '      "panel": "diff",',
+        '      "selectedPath": "z.ts"',
+        "    }",
+        "  }",
+        "}\n",
+      ].join("\n"),
+    );
+
+    const reparsed = parseWorkspaceUiStateJson(serialized).state;
+    reparsed.views.z = { panel: "diff", selectedPath: "changed.ts" };
+    expect(state.views.z).toEqual({ panel: "diff", selectedPath: "z.ts" });
+  });
+
+  it("rejects hostile object keys without prototype mutation or inherited view state", () => {
+    const parsed = parseWorkspaceUiStateJson(
+      '{"version":1,"active":null,"views":{"__proto__":{"panel":"files","openPath":"polluted.ts","selectedPath":null},"prototype":{"panel":"diff","selectedPath":"polluted.ts"},"constructor":{"panel":"missions","selectedMissionId":"m","selectedTaskId":"t"},"safe":{"panel":"diff","selectedPath":"safe.ts"}}}',
+    );
+
+    expect(parsed.state.views).toEqual({ safe: { panel: "diff", selectedPath: "safe.ts" } });
+    expect(Object.prototype).not.toHaveProperty("panel");
+    expect(Object.prototype).not.toHaveProperty("openPath");
+    expect("polluted" in parsed.state.views).toBe(false);
+    expect(parsed.state.views.__proto__).not.toEqual({
+      panel: "files",
+      openPath: "polluted.ts",
+      selectedPath: null,
+    });
+    expect(parsed.diagnostics.filter((entry) => entry.code === "INVALID_FIELD")).toHaveLength(3);
+  });
+
+  it("round-trips reserved missions selection helpers without mission runtime data", () => {
+    const state = setMissionsSelection(
+      defaultWorkspaceUiState(),
+      "missions",
+      "mission-1",
+      "task-1",
+    );
+
+    expect(missionsSelection(state, "missions")).toEqual({
+      selectedMissionId: "mission-1",
+      selectedTaskId: "task-1",
+    });
+    expect(missionsSelection(state, "other")).toEqual({
+      selectedMissionId: null,
+      selectedTaskId: null,
+    });
+  });
+
+  it("chooses initial restore deterministically and rejects ID/panel mismatches", () => {
+    expect(
+      chooseInitialWorkspaceView(views(), {
+        requestedPanel: "diff",
+        persisted: {
+          version: 1,
+          active: { viewId: "files-a", panel: "files" },
+          views: {},
+        },
+        legacyLastTab: "files",
+      }),
+    ).toMatchObject({ reason: "explicit", view: { id: "diff-a" } });
+
+    expect(
+      chooseInitialWorkspaceView(views(), {
+        requestedPanel: null,
+        persisted: { version: 1, active: { viewId: "files-b", panel: "files" }, views: {} },
+        legacyLastTab: "diff",
+      }),
+    ).toMatchObject({ reason: "persisted-id", view: { id: "files-b" } });
+
+    expect(
+      chooseInitialWorkspaceView(views(), {
+        requestedPanel: null,
+        persisted: { version: 1, active: { viewId: "diff-a", panel: "files" }, views: {} },
+        legacyLastTab: "diff",
+      }),
+    ).toMatchObject({ reason: "persisted-panel", view: { id: "files-a" } });
+
+    expect(
+      chooseInitialWorkspaceView(views(), {
+        requestedPanel: null,
+        persisted: defaultWorkspaceUiState(),
+        legacyLastTab: "diff",
+      }),
+    ).toMatchObject({ reason: "legacy-tab", view: { id: "diff-a" } });
+  });
+
+  it("hydrates only matching per-view panel state for duplicate views", () => {
+    const state: WorkspaceUiStateV1 = {
+      version: 1,
+      active: null,
+      views: {
+        "files-a": { panel: "files", openPath: "src/a.ts", selectedPath: "src" },
+        "files-b": { panel: "files", openPath: "src/b.ts", selectedPath: "src/b.ts" },
+        "diff-a": { panel: "files", openPath: "wrong.ts", selectedPath: null },
+      },
+    };
+
+    expect(viewStateFor(state, views()[1])).toEqual({
+      panel: "files",
+      openPath: "src/a.ts",
+      selectedPath: "src",
+    });
+    expect(viewStateFor(state, views()[3])).toEqual({
+      panel: "files",
+      openPath: "src/b.ts",
+      selectedPath: "src/b.ts",
+    });
+    expect(viewStateFor(state, views()[2])).toBeNull();
+  });
+
+  it("converts project-relative paths safely", () => {
+    const root = temporaryRoot();
+    expect(relativeProjectPath(root, join(root, "src/a.ts"))).toBe("src/a.ts");
+    expect(relativeProjectPath(root, join(root, "..env"))).toBe("..env");
+    expect(relativeProjectPath(root, dirname(root))).toBeNull();
+    expect(absoluteProjectPath(root, "src/a.ts")).toBe(join(root, "src/a.ts"));
+    expect(absoluteProjectPath(root, "..env")).toBe(join(root, "..env"));
+    expect(absoluteProjectPath(root, "/tmp/a.ts")).toBeNull();
+    expect(absoluteProjectPath(root, "../outside.ts")).toBeNull();
+    expect(absoluteProjectPath(root, "src/../../outside.ts")).toBeNull();
+    expect(absoluteProjectPath(root, "src/../inside.ts")).toBe(join(root, "inside.ts"));
+    expect(absoluteProjectPath(root, "src/\0bad.ts")).toBeNull();
+  });
+
+  it("keeps explicit --edit file intent ahead of first-load persisted Files hydration", () => {
+    const view = views()[1]!;
+    const entry = { panel: "files" as const, openPath: "persisted.ts", selectedPath: "src" };
+
+    expect(
+      shouldHydrateWorkspaceView({
+        firstProjectLoad: true,
+        explicitEditPath: "cli.ts",
+        view,
+        entry,
+      }),
+    ).toBe(false);
+    expect(
+      shouldHydrateWorkspaceView({
+        firstProjectLoad: false,
+        explicitEditPath: "cli.ts",
+        view,
+        entry,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHydrateWorkspaceView({
+        firstProjectLoad: true,
+        explicitEditPath: "cli.ts",
+        view,
+        entry: { panel: "files", openPath: null, selectedPath: "src" },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("workspace UI-state repository", () => {
+  it("uses C04 ui/workspace.json and isolates or shares by C01 identity", () => {
+    const home = temporaryRoot();
+    const main = temporaryRoot();
+    const linked = temporaryRoot();
+    const other = temporaryRoot();
+    const commonAnchor = join(main, ".git");
+    const first = createProjectRuntimeRepository(
+      resolution(main, { identityAnchor: commonAnchor }),
+      { home },
+    );
+    const second = createProjectRuntimeRepository(
+      resolution(linked, { identityAnchor: commonAnchor }),
+      { home },
+    );
+    const isolated = createProjectRuntimeRepository(
+      resolution(other, {
+        identityKey: `path-${"c".repeat(64)}`,
+        identitySource: "canonical-realpath",
+        identityAnchor: other,
+      }),
+      { home },
+    );
+
+    const state: WorkspaceUiStateV1 = {
+      version: 1,
+      active: { viewId: "files-a", panel: "files" },
+      views: { "files-a": { panel: "files", openPath: "src/a.ts", selectedPath: null } },
+    };
+    writeWorkspaceUiStateWithRetry({
+      repository: first,
+      revision: null,
+      current: defaultWorkspaceUiState(),
+      next: state,
+      touchedViewIds: new Set(["files-a"]),
+    });
+
+    expect(existsSync(join(first.runtimeRoot, WORKSPACE_UI_STATE_PATH))).toBe(true);
+    expect(loadWorkspaceUiState(second).state).toEqual(state);
+    expect(loadWorkspaceUiState(isolated).state).toEqual(defaultWorkspaceUiState());
+    expect(existsSync(join(main, ".tmux-ide"))).toBe(false);
+  });
+
+  it("creates, reads, updates, reopens, and retries a bounded revision-conflict merge", () => {
+    const home = temporaryRoot();
+    const project = temporaryRoot();
+    const first = createProjectRuntimeRepository(resolution(project), { home });
+    const second = createProjectRuntimeRepository(resolution(project), { home });
+
+    const firstState: WorkspaceUiStateV1 = {
+      version: 1,
+      active: { viewId: "files-a", panel: "files" },
+      views: { "files-a": { panel: "files", openPath: "a.ts", selectedPath: null } },
+    };
+    const created = writeWorkspaceUiStateWithRetry({
+      repository: first,
+      revision: null,
+      current: defaultWorkspaceUiState(),
+      next: firstState,
+      touchedViewIds: new Set(["files-a"]),
+    });
+    expect(created.revision).toBe(1);
+
+    const loadedSecond = loadWorkspaceUiState(second);
+    const latestState: WorkspaceUiStateV1 = {
+      version: 1,
+      active: { viewId: "diff-a", panel: "diff" },
+      views: {
+        ...firstState.views,
+        "diff-a": { panel: "diff", selectedPath: "b.ts" },
+      },
+    };
+    const updated = writeWorkspaceUiStateWithRetry({
+      repository: first,
+      revision: created.revision,
+      current: firstState,
+      next: latestState,
+      touchedViewIds: new Set(["diff-a"]),
+    });
+    expect(updated.revision).toBe(2);
+
+    const localSecond: WorkspaceUiStateV1 = {
+      version: 1,
+      active: { viewId: "files-a", panel: "files" },
+      views: {
+        "files-a": { panel: "files", openPath: "a2.ts", selectedPath: "src" },
+      },
+    };
+    const retried = writeWorkspaceUiStateWithRetry({
+      repository: second,
+      revision: loadedSecond.revision,
+      current: loadedSecond.state,
+      next: localSecond,
+      touchedViewIds: new Set(["files-a"]),
+    });
+
+    expect(retried.revision).toBe(3);
+    expect(loadWorkspaceUiState(first).state).toEqual({
+      version: 1,
+      active: { viewId: "files-a", panel: "files" },
+      views: {
+        "files-a": { panel: "files", openPath: "a2.ts", selectedPath: "src" },
+        "diff-a": { panel: "diff", selectedPath: "b.ts" },
+      },
+    });
+  });
+
+  it("tolerates missing, malformed, and unreadable runtime documents", () => {
+    const home = temporaryRoot();
+    const project = temporaryRoot();
+    const repository = createProjectRuntimeRepository(resolution(project), { home });
+    expect(loadWorkspaceUiState(repository)).toMatchObject({
+      state: defaultWorkspaceUiState(),
+      revision: null,
+      diagnostics: [{ code: "MISSING" }],
+    });
+
+    writeRaw(join(repository.runtimeRoot, WORKSPACE_UI_STATE_PATH), "not-json");
+    expect(loadWorkspaceUiState(repository)).toMatchObject({
+      state: defaultWorkspaceUiState(),
+      revision: null,
+      diagnostics: [{ code: "READ_FAILED" }],
+    });
+  });
+
+  it("merges untouched latest view entries only when requested", () => {
+    const merged = mergeWorkspaceUiStateForSave(
+      {
+        version: 1,
+        active: { viewId: "diff-a", panel: "diff" },
+        views: {
+          "files-a": { panel: "files", openPath: "old.ts", selectedPath: null },
+          "diff-a": { panel: "diff", selectedPath: "latest.ts" },
+        },
+      },
+      {
+        version: 1,
+        active: { viewId: "files-a", panel: "files" },
+        views: {
+          "files-a": { panel: "files", openPath: "local.ts", selectedPath: null },
+          "diff-a": { panel: "diff", selectedPath: "stale.ts" },
+        },
+      },
+      new Set(["files-a"]),
+    );
+
+    expect(merged).toEqual({
+      version: 1,
+      active: { viewId: "files-a", panel: "files" },
+      views: {
+        "files-a": { panel: "files", openPath: "local.ts", selectedPath: null },
+        "diff-a": { panel: "diff", selectedPath: "latest.ts" },
+      },
+    });
+  });
+});
+
+describe("workspace UI-state controller", () => {
+  it("does not write before load and rejects stale async load/save generations", () => {
+    const home = temporaryRoot();
+    const project = temporaryRoot();
+    const first = createProjectRuntimeRepository(resolution(project), { home });
+    const second = createProjectRuntimeRepository(
+      resolution(project, { identityKey: `git-${"d".repeat(64)}` }),
+      { home },
+    );
+    const controller = new WorkspaceUiStateController();
+    const stale = controller.beginLoad();
+    const current = controller.beginLoad();
+
+    expect(controller.save(current, defaultWorkspaceUiState(), new Set(["files-a"]))).toMatchObject(
+      {
+        saved: false,
+        skipped: true,
+        diagnostics: [{ code: "NOT_LOADED" }],
+      },
+    );
+
+    expect(controller.completeLoad(stale, first, loadWorkspaceUiState(first))).toBe(false);
+    expect(controller.completeLoad(current, second, loadWorkspaceUiState(second))).toBe(true);
+    const next: WorkspaceUiStateV1 = {
+      version: 1,
+      active: { viewId: "files-a", panel: "files" },
+      views: { "files-a": { panel: "files", openPath: "a.ts", selectedPath: null } },
+    };
+    expect(controller.save(stale, next, new Set(["files-a"]))).toMatchObject({
+      saved: false,
+      skipped: true,
+      diagnostics: [{ code: "STALE" }],
+    });
+    expect(controller.save(current, next, new Set(["files-a"]))).toMatchObject({
+      saved: true,
+      skipped: false,
+    });
+    expect(readFileSync(join(second.runtimeRoot, WORKSPACE_UI_STATE_PATH), "utf-8")).toContain(
+      "a.ts",
+    );
+    expect(existsSync(join(first.runtimeRoot, WORKSPACE_UI_STATE_PATH))).toBe(false);
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace-ui-state.ts
+++ b/packages/daemon/src/tui/mirror/workspace-ui-state.ts
@@ -1,0 +1,614 @@
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+import {
+  RevisionConflictError,
+  type JsonValue,
+  type ProjectRuntimeDocument,
+  type ProjectRuntimeRepository,
+} from "../../lib/project-runtime-repository.ts";
+import type { HostedPanelKind, HostedPanelView } from "./panel-host.ts";
+import { findFirstHostedViewForPanel, findHostedViewById } from "./panel-host.ts";
+import type { Tab } from "./app-state.ts";
+import { panelKindFromLegacyTab } from "./panel-host.ts";
+
+export const WORKSPACE_UI_STATE_PATH = "ui/workspace.json";
+export const WORKSPACE_UI_STATE_VERSION = 1;
+export const WORKSPACE_UI_STATE_MAX_VIEWS = 64;
+export const WORKSPACE_UI_STATE_MAX_ID_LENGTH = 128;
+export const WORKSPACE_UI_STATE_MAX_PATH_LENGTH = 4096;
+
+export type WorkspaceUiStateDiagnosticCode =
+  | "MISSING"
+  | "MALFORMED"
+  | "UNSUPPORTED_VERSION"
+  | "OVERSIZED"
+  | "INVALID_FIELD"
+  | "READ_FAILED"
+  | "WRITE_FAILED"
+  | "STALE"
+  | "NOT_LOADED";
+
+export interface WorkspaceUiStateDiagnostic {
+  code: WorkspaceUiStateDiagnosticCode;
+  path: string;
+  message: string;
+}
+
+export interface WorkspaceActiveViewState {
+  viewId: string;
+  panel: HostedPanelKind;
+}
+
+export interface WorkspaceFilesViewState {
+  panel: "files";
+  openPath: string | null;
+  selectedPath: string | null;
+}
+
+export interface WorkspaceDiffViewState {
+  panel: "diff";
+  selectedPath: string | null;
+}
+
+export interface WorkspaceMissionsViewState {
+  panel: "missions";
+  selectedMissionId: string | null;
+  selectedTaskId: string | null;
+}
+
+export interface WorkspaceEmptyViewState {
+  panel: "home" | "terminals";
+}
+
+export type WorkspaceViewState =
+  | WorkspaceFilesViewState
+  | WorkspaceDiffViewState
+  | WorkspaceMissionsViewState
+  | WorkspaceEmptyViewState;
+
+export interface WorkspaceUiStateV1 {
+  version: typeof WORKSPACE_UI_STATE_VERSION;
+  active: WorkspaceActiveViewState | null;
+  views: Record<string, WorkspaceViewState>;
+}
+
+export interface ParsedWorkspaceUiState {
+  state: WorkspaceUiStateV1;
+  diagnostics: WorkspaceUiStateDiagnostic[];
+}
+
+export interface LoadedWorkspaceUiState extends ParsedWorkspaceUiState {
+  revision: number | null;
+}
+
+export interface WriteWorkspaceUiStateResult {
+  state: WorkspaceUiStateV1;
+  revision: number | null;
+  diagnostics: WorkspaceUiStateDiagnostic[];
+}
+
+export interface WorkspaceViewRestoreChoice {
+  view: HostedPanelView | null;
+  reason: "explicit" | "persisted-id" | "persisted-panel" | "legacy-tab" | "first" | "none";
+}
+
+export interface WorkspaceUiSaveRequest {
+  repository: ProjectRuntimeRepository;
+  revision: number | null;
+  current: WorkspaceUiStateV1;
+  next: WorkspaceUiStateV1;
+  touchedViewIds: ReadonlySet<string>;
+}
+
+export interface WorkspaceUiControllerSnapshot {
+  loaded: boolean;
+  repository: ProjectRuntimeRepository | null;
+  revision: number | null;
+  state: WorkspaceUiStateV1;
+  generation: number;
+}
+
+export interface WorkspaceUiControllerSaveResult {
+  saved: boolean;
+  skipped: boolean;
+  diagnostics: WorkspaceUiStateDiagnostic[];
+}
+
+const PANELS: readonly HostedPanelKind[] = ["home", "terminals", "files", "diff", "missions"];
+const RESERVED_OBJECT_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+export const DEFAULT_WORKSPACE_UI_STATE: WorkspaceUiStateV1 = Object.freeze({
+  version: WORKSPACE_UI_STATE_VERSION,
+  active: null,
+  views: Object.freeze({}),
+});
+
+function diagnostic(
+  code: WorkspaceUiStateDiagnosticCode,
+  path: string,
+  message: string,
+): WorkspaceUiStateDiagnostic {
+  return { code, path, message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPanel(value: unknown): value is HostedPanelKind {
+  return typeof value === "string" && (PANELS as readonly string[]).includes(value);
+}
+
+function cleanId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  if (value.length === 0 || value.length > WORKSPACE_UI_STATE_MAX_ID_LENGTH) return null;
+  if (value.includes("\0")) return null;
+  if (RESERVED_OBJECT_KEYS.has(value)) return null;
+  return value;
+}
+
+function isOutsideRoot(relativePath: string): boolean {
+  return relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath);
+}
+
+function cleanPath(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") return null;
+  if (value.length === 0 || value.length > WORKSPACE_UI_STATE_MAX_PATH_LENGTH) return null;
+  if (value.includes("\0")) return null;
+  return value;
+}
+
+function cleanActive(
+  value: unknown,
+  diagnostics: WorkspaceUiStateDiagnostic[],
+): WorkspaceActiveViewState | null {
+  if (value === null || value === undefined) return null;
+  if (!isRecord(value)) {
+    diagnostics.push(diagnostic("INVALID_FIELD", "$.active", "active view must be an object"));
+    return null;
+  }
+  const viewId = cleanId(value.viewId);
+  const panel = value.panel;
+  if (!viewId || !isPanel(panel)) {
+    diagnostics.push(
+      diagnostic("INVALID_FIELD", "$.active", "active view requires a bounded viewId and panel"),
+    );
+    return null;
+  }
+  return { viewId, panel };
+}
+
+function cleanViewState(
+  key: string,
+  value: unknown,
+  diagnostics: WorkspaceUiStateDiagnostic[],
+): WorkspaceViewState | null {
+  if (!isRecord(value)) {
+    diagnostics.push(diagnostic("INVALID_FIELD", `$.views.${key}`, "view state must be an object"));
+    return null;
+  }
+  const panel = value.panel;
+  if (!isPanel(panel)) {
+    diagnostics.push(diagnostic("INVALID_FIELD", `$.views.${key}.panel`, "panel is unsupported"));
+    return null;
+  }
+  if (panel === "files") {
+    return {
+      panel,
+      openPath: cleanPath(value.openPath),
+      selectedPath: cleanPath(value.selectedPath),
+    };
+  }
+  if (panel === "diff") {
+    return {
+      panel,
+      selectedPath: cleanPath(value.selectedPath),
+    };
+  }
+  if (panel === "missions") {
+    return {
+      panel,
+      selectedMissionId: cleanId(value.selectedMissionId),
+      selectedTaskId: cleanId(value.selectedTaskId),
+    };
+  }
+  return { panel };
+}
+
+function cloneState(state: WorkspaceUiStateV1): WorkspaceUiStateV1 {
+  return parseWorkspaceUiStateJson(serializeWorkspaceUiState(state)).state;
+}
+
+export function defaultWorkspaceUiState(): WorkspaceUiStateV1 {
+  return { version: WORKSPACE_UI_STATE_VERSION, active: null, views: {} };
+}
+
+export function parseWorkspaceUiStateJson(raw: string): ParsedWorkspaceUiState {
+  const diagnostics: WorkspaceUiStateDiagnostic[] = [];
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return {
+      state: defaultWorkspaceUiState(),
+      diagnostics: [diagnostic("MALFORMED", "$", "workspace UI state is not valid JSON")],
+    };
+  }
+  return parseWorkspaceUiStateValue(value, diagnostics);
+}
+
+export function parseWorkspaceUiStateValue(
+  value: unknown,
+  diagnostics: WorkspaceUiStateDiagnostic[] = [],
+): ParsedWorkspaceUiState {
+  if (!isRecord(value)) {
+    diagnostics.push(diagnostic("MALFORMED", "$", "workspace UI state must be an object"));
+    return { state: defaultWorkspaceUiState(), diagnostics };
+  }
+  if (value.version !== WORKSPACE_UI_STATE_VERSION) {
+    diagnostics.push(
+      diagnostic(
+        Number.isInteger(value.version) ? "UNSUPPORTED_VERSION" : "MALFORMED",
+        "$.version",
+        `unsupported workspace UI state version ${String(value.version)}`,
+      ),
+    );
+    return { state: defaultWorkspaceUiState(), diagnostics };
+  }
+
+  const views: Record<string, WorkspaceViewState> = {};
+  if (isRecord(value.views)) {
+    const entries = Object.entries(value.views);
+    if (entries.length > WORKSPACE_UI_STATE_MAX_VIEWS) {
+      diagnostics.push(
+        diagnostic(
+          "OVERSIZED",
+          "$.views",
+          `workspace UI state kept the first ${WORKSPACE_UI_STATE_MAX_VIEWS} views`,
+        ),
+      );
+    }
+    for (const [key, rawView] of entries.slice(0, WORKSPACE_UI_STATE_MAX_VIEWS)) {
+      const id = cleanId(key);
+      if (!id) {
+        diagnostics.push(diagnostic("INVALID_FIELD", "$.views", "dropped invalid view id"));
+        continue;
+      }
+      const clean = cleanViewState(id, rawView, diagnostics);
+      if (clean) views[id] = clean;
+    }
+  } else if (value.views !== undefined) {
+    diagnostics.push(diagnostic("INVALID_FIELD", "$.views", "views must be an object"));
+  }
+
+  return {
+    state: {
+      version: WORKSPACE_UI_STATE_VERSION,
+      active: cleanActive(value.active, diagnostics),
+      views,
+    },
+    diagnostics,
+  };
+}
+
+export function serializeWorkspaceUiState(state: WorkspaceUiStateV1): string {
+  const parsed = parseWorkspaceUiStateValue(state).state;
+  const orderedViews: Record<string, WorkspaceViewState> = {};
+  for (const id of Object.keys(parsed.views).sort()) {
+    const view = parsed.views[id]!;
+    if (view.panel === "files") {
+      orderedViews[id] = {
+        panel: "files",
+        openPath: view.openPath,
+        selectedPath: view.selectedPath,
+      };
+    } else if (view.panel === "diff") {
+      orderedViews[id] = { panel: "diff", selectedPath: view.selectedPath };
+    } else if (view.panel === "missions") {
+      orderedViews[id] = {
+        panel: "missions",
+        selectedMissionId: view.selectedMissionId,
+        selectedTaskId: view.selectedTaskId,
+      };
+    } else {
+      orderedViews[id] = { panel: view.panel };
+    }
+  }
+  const clean: WorkspaceUiStateV1 = {
+    version: WORKSPACE_UI_STATE_VERSION,
+    active: parsed.active ? { viewId: parsed.active.viewId, panel: parsed.active.panel } : null,
+    views: orderedViews,
+  };
+  return `${JSON.stringify(clean, null, 2)}\n`;
+}
+
+export function workspaceUiStateToJsonValue(state: WorkspaceUiStateV1): JsonValue {
+  return JSON.parse(serializeWorkspaceUiState(state)) as JsonValue;
+}
+
+export function loadWorkspaceUiState(repository: ProjectRuntimeRepository): LoadedWorkspaceUiState {
+  let document: ProjectRuntimeDocument<JsonValue>;
+  try {
+    document = repository.readDocument<JsonValue>(WORKSPACE_UI_STATE_PATH);
+  } catch (error) {
+    return {
+      state: defaultWorkspaceUiState(),
+      revision: null,
+      diagnostics: [
+        diagnostic(
+          "READ_FAILED",
+          WORKSPACE_UI_STATE_PATH,
+          `workspace UI state could not be read: ${(error as Error).message}`,
+        ),
+      ],
+    };
+  }
+  if (!document.found) {
+    return {
+      state: defaultWorkspaceUiState(),
+      revision: null,
+      diagnostics: [diagnostic("MISSING", WORKSPACE_UI_STATE_PATH, "workspace UI state is absent")],
+    };
+  }
+  const parsed = parseWorkspaceUiStateValue(document.payload);
+  return { ...parsed, revision: document.revision };
+}
+
+export function mergeWorkspaceUiStateForSave(
+  latest: WorkspaceUiStateV1,
+  local: WorkspaceUiStateV1,
+  touchedViewIds: ReadonlySet<string>,
+): WorkspaceUiStateV1 {
+  const views: Record<string, WorkspaceViewState> = { ...latest.views };
+  for (const id of touchedViewIds) {
+    const localView = local.views[id];
+    if (localView) views[id] = localView;
+  }
+  return {
+    version: WORKSPACE_UI_STATE_VERSION,
+    active: local.active ? { ...local.active } : null,
+    views,
+  };
+}
+
+export function writeWorkspaceUiStateWithRetry(
+  request: WorkspaceUiSaveRequest,
+): WriteWorkspaceUiStateResult {
+  const diagnostics: WorkspaceUiStateDiagnostic[] = [];
+  const writePayload = (state: WorkspaceUiStateV1, revision: number | null) =>
+    request.repository.writeDocument(WORKSPACE_UI_STATE_PATH, workspaceUiStateToJsonValue(state), {
+      expectedRevision: revision,
+    });
+  try {
+    const written = writePayload(request.next, request.revision);
+    return { state: cloneState(request.next), revision: written.revision, diagnostics };
+  } catch (error) {
+    if (!(error instanceof RevisionConflictError)) {
+      return {
+        state: request.current,
+        revision: request.revision,
+        diagnostics: [
+          diagnostic(
+            "WRITE_FAILED",
+            WORKSPACE_UI_STATE_PATH,
+            `workspace UI state could not be saved: ${(error as Error).message}`,
+          ),
+        ],
+      };
+    }
+  }
+
+  const latest = loadWorkspaceUiState(request.repository);
+  diagnostics.push(...latest.diagnostics.filter((entry) => entry.code !== "MISSING"));
+  const merged = mergeWorkspaceUiStateForSave(latest.state, request.next, request.touchedViewIds);
+  try {
+    const written = writePayload(merged, latest.revision);
+    return { state: cloneState(merged), revision: written.revision, diagnostics };
+  } catch (error) {
+    return {
+      state: request.current,
+      revision: request.revision,
+      diagnostics: [
+        ...diagnostics,
+        diagnostic(
+          "WRITE_FAILED",
+          WORKSPACE_UI_STATE_PATH,
+          `workspace UI state retry failed: ${(error as Error).message}`,
+        ),
+      ],
+    };
+  }
+}
+
+export function chooseInitialWorkspaceView(
+  views: readonly HostedPanelView[],
+  options: {
+    requestedPanel: HostedPanelKind | null | undefined;
+    persisted: WorkspaceUiStateV1 | null | undefined;
+    legacyLastTab: Tab | null | undefined;
+  },
+): WorkspaceViewRestoreChoice {
+  const requested = findFirstHostedViewForPanel(views, options.requestedPanel);
+  if (requested) return { view: requested, reason: "explicit" };
+
+  const persistedActive = options.persisted?.active;
+  if (persistedActive) {
+    const exact = findHostedViewById(views, persistedActive.viewId);
+    if (exact && exact.panel === persistedActive.panel) {
+      return { view: exact, reason: "persisted-id" };
+    }
+    const byPanel = findFirstHostedViewForPanel(views, persistedActive.panel);
+    if (byPanel) return { view: byPanel, reason: "persisted-panel" };
+  }
+
+  const legacyPanel = panelKindFromLegacyTab(options.legacyLastTab);
+  const legacy = findFirstHostedViewForPanel(views, legacyPanel);
+  if (legacy) return { view: legacy, reason: "legacy-tab" };
+
+  return { view: views[0] ?? null, reason: views[0] ? "first" : "none" };
+}
+
+export function viewStateFor(
+  state: WorkspaceUiStateV1,
+  view: Pick<HostedPanelView, "id" | "panel"> | null | undefined,
+): WorkspaceViewState | null {
+  if (!view) return null;
+  const entry = state.views[view.id];
+  return entry && entry.panel === view.panel ? entry : null;
+}
+
+export function setMissionsSelection(
+  state: WorkspaceUiStateV1,
+  viewId: string,
+  missionId: string | null,
+  taskId: string | null,
+): WorkspaceUiStateV1 {
+  const id = cleanId(viewId);
+  if (!id) return cloneState(state);
+  return {
+    version: WORKSPACE_UI_STATE_VERSION,
+    active: state.active ? { ...state.active } : null,
+    views: {
+      ...state.views,
+      [id]: {
+        panel: "missions",
+        selectedMissionId: cleanId(missionId),
+        selectedTaskId: cleanId(taskId),
+      },
+    },
+  };
+}
+
+export function missionsSelection(
+  state: WorkspaceUiStateV1,
+  viewId: string,
+): Pick<WorkspaceMissionsViewState, "selectedMissionId" | "selectedTaskId"> {
+  const entry = state.views[viewId];
+  if (entry?.panel !== "missions") return { selectedMissionId: null, selectedTaskId: null };
+  return { selectedMissionId: entry.selectedMissionId, selectedTaskId: entry.selectedTaskId };
+}
+
+export function relativeProjectPath(projectRoot: string, path: string | null): string | null {
+  if (!path) return null;
+  const absolute = resolve(path);
+  const root = resolve(projectRoot);
+  const rel = relative(root, absolute);
+  if (rel === "") return null;
+  if (isOutsideRoot(rel)) return null;
+  return cleanPath(rel);
+}
+
+export function absoluteProjectPath(projectRoot: string, path: string | null): string | null {
+  const clean = cleanPath(path);
+  if (!clean) return null;
+  if (isAbsolute(clean)) return null;
+  const root = resolve(projectRoot);
+  const absolute = resolve(root, clean);
+  const rel = relative(root, absolute);
+  if (rel === "" || isOutsideRoot(rel)) return null;
+  return absolute;
+}
+
+export function shouldHydrateWorkspaceView(options: {
+  firstProjectLoad: boolean;
+  explicitEditPath: string | null | undefined;
+  view: Pick<HostedPanelView, "panel"> | null | undefined;
+  entry: WorkspaceViewState | null | undefined;
+}): boolean {
+  if (
+    options.firstProjectLoad &&
+    options.explicitEditPath &&
+    options.view?.panel === "files" &&
+    options.entry?.panel === "files" &&
+    options.entry.openPath
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export class WorkspaceUiStateController {
+  #generation = 0;
+  #repository: ProjectRuntimeRepository | null = null;
+  #revision: number | null = null;
+  #state: WorkspaceUiStateV1 = defaultWorkspaceUiState();
+  #loaded = false;
+
+  beginLoad(): number {
+    this.#generation += 1;
+    this.#loaded = false;
+    this.#repository = null;
+    this.#revision = null;
+    this.#state = defaultWorkspaceUiState();
+    return this.#generation;
+  }
+
+  completeLoad(
+    generation: number,
+    repository: ProjectRuntimeRepository,
+    loaded: LoadedWorkspaceUiState,
+  ): boolean {
+    if (generation !== this.#generation) return false;
+    this.#repository = repository;
+    this.#revision = loaded.revision;
+    this.#state = cloneState(loaded.state);
+    this.#loaded = true;
+    return true;
+  }
+
+  failLoad(generation: number): boolean {
+    if (generation !== this.#generation) return false;
+    this.#repository = null;
+    this.#revision = null;
+    this.#state = defaultWorkspaceUiState();
+    this.#loaded = true;
+    return true;
+  }
+
+  snapshot(): WorkspaceUiControllerSnapshot {
+    return {
+      loaded: this.#loaded,
+      repository: this.#repository,
+      revision: this.#revision,
+      state: cloneState(this.#state),
+      generation: this.#generation,
+    };
+  }
+
+  save(
+    generation: number,
+    next: WorkspaceUiStateV1,
+    touchedViewIds: ReadonlySet<string>,
+  ): WorkspaceUiControllerSaveResult {
+    if (generation !== this.#generation) {
+      return {
+        saved: false,
+        skipped: true,
+        diagnostics: [diagnostic("STALE", WORKSPACE_UI_STATE_PATH, "stale UI state save skipped")],
+      };
+    }
+    if (!this.#loaded || !this.#repository) {
+      return {
+        saved: false,
+        skipped: true,
+        diagnostics: [
+          diagnostic("NOT_LOADED", WORKSPACE_UI_STATE_PATH, "UI state has not loaded yet"),
+        ],
+      };
+    }
+    const result = writeWorkspaceUiStateWithRetry({
+      repository: this.#repository,
+      revision: this.#revision,
+      current: this.#state,
+      next,
+      touchedViewIds,
+    });
+    if (result.diagnostics.some((entry) => entry.code === "WRITE_FAILED")) {
+      return { saved: false, skipped: false, diagnostics: result.diagnostics };
+    }
+    this.#state = cloneState(result.state);
+    this.#revision = result.revision;
+    return { saved: true, skipped: false, diagnostics: result.diagnostics };
+  }
+}


### PR DESCRIPTION
## Summary

- add versioned, bounded project-scoped workspace UI memory at `ui/workspace.json` through the C04 runtime repository
- restore stable configured view identity with explicit CLI intent first, then exact ID/panel, panel fallback, legacy tab, and first-view fallback
- persist independent Files, Diff, and reserved Missions selection state per configured view ID
- add optimistic revision conflict merge/retry and generation-safe load/save isolation across project context changes
- keep global preferences and legacy state fallback intact while preventing stale, traversal, hostile-key, and teardown edge cases

## Validation

- focused workspace/panel/palette suite: 76 tests passed
- daemon typecheck and build passed
- compiled TUI build passed
- full `pnpm check` passed (41 contracts + 1,755 daemon tests, docs, pack, native deps)
- `git diff --check` passed

Sfora: #118