### PR TITLE
feat(tui): add responsive Missions board and history

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -18,6 +18,7 @@ export {
   type MissionAttempt,
   type MissionHistoryEntry,
   type MissionProjectState,
+  type MissionRepositorySnapshot,
   type MissionSnapshot,
   type MissionTask,
 } from "./lib/mission-repository.ts";

--- a/packages/daemon/src/lib/__tests__/mission-repository.test.ts
+++ b/packages/daemon/src/lib/__tests__/mission-repository.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   EventSequenceConflictError,
   createProjectRuntimeRepository,
@@ -242,6 +242,17 @@ describe("MissionRepository replay and persistence", () => {
     const detached = missions.get("mis_alpha")!;
     detached.tasks.tsk_setup!.title = "mutated";
     expect(missions.get("mis_alpha")?.tasks.tsk_setup?.title).toBe("Setup");
+  });
+
+  it("returns history and state from one event-log read in snapshot()", () => {
+    const { runtime, missions } = repository();
+    missions.create({ id: "mis_single", title: "Single", objective: "single read", actor });
+    const readEvents = vi.spyOn(runtime, "readEvents");
+    const snapshot = missions.snapshot();
+    expect(readEvents).toHaveBeenCalledTimes(1);
+    expect(snapshot.history.map((entry) => entry.sequence)).toEqual([1]);
+    expect(snapshot.state.sequence).toBe(1);
+    expect(snapshot.state.missions.mis_single?.title).toBe("Single");
   });
 
   it("reopens with byte-equivalent logical state and keeps multiple missions isolated", () => {

--- a/packages/daemon/src/lib/mission-repository.ts
+++ b/packages/daemon/src/lib/mission-repository.ts
@@ -70,6 +70,11 @@ export interface MissionMutationOptions {
   expectedPreviousSequence?: number;
 }
 
+export interface MissionRepositorySnapshot {
+  history: MissionHistoryEntry[];
+  state: MissionProjectState;
+}
+
 export interface CreateMissionInput {
   id?: MissionId;
   title: string;
@@ -153,6 +158,19 @@ export class MissionRepository {
 
   state(): MissionProjectState {
     return clone(replayMissionEvents(this.readHistory()));
+  }
+
+  snapshot(): MissionRepositorySnapshot {
+    const history = this.readHistory();
+    const state = replayMissionEvents(history);
+    return {
+      history: history.map(({ sequence, timestamp, payload }) => ({
+        sequence,
+        timestamp,
+        event: clone(payload),
+      })),
+      state: clone(state),
+    };
   }
 
   list(): MissionSnapshot[] {

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -320,7 +320,6 @@ import {
   type TmuxBuffer,
 } from "./palette.ts";
 import {
-  MISSIONS_PLACEHOLDER_LINES,
   PanelHostLoadGeneration,
   findFirstHostedViewForPanel,
   findHostedViewById,
@@ -341,6 +340,26 @@ import {
   type HostedPanelKind,
   type HostedPanelView,
 } from "./panel-host.ts";
+import {
+  MissionWorkspaceLoader,
+  applyMissionWorkspaceHit,
+  clipTerminal,
+  cycleMissionDensity,
+  defaultMissionWorkspaceModel,
+  invalidatedMissionWorkspaceLoadState,
+  missionSelectionFromWorkspaceState,
+  missionWorkspaceHitTest,
+  missionWorkspaceLayout,
+  moveMissionSelection,
+  readMissionWorkspace,
+  reconcileMissionWorkspaceModel,
+  scrollMissionWorkspace,
+  setMissionWorkspaceMode,
+  workspaceStateWithMissionSelection,
+  type MissionWorkspaceLoadState,
+  type MissionWorkspaceModel,
+  type MissionWorkspaceSnapshot,
+} from "./missions-workspace.ts";
 import {
   WorkspaceUiStateController,
   absoluteProjectPath,
@@ -661,6 +680,10 @@ type HoverRegion =
   | "homeagentchip"
   | "welcomeopen"
   | "sidebtn"
+  | "missionmode"
+  | "missioncard"
+  | "missionhistory"
+  | "missionbutton"
   // M24.1: the AGENTS header row (click → Team dialog) and its right-aligned
   // [+ agent] chip (index 0 = header row, 1 = the empty-state row's twin).
   | "agentshdr"
@@ -939,8 +962,11 @@ try {
       createSignal<WorkspaceUiStateV1>(defaultWorkspaceUiState());
     const workspaceUiController = new WorkspaceUiStateController();
     const touchedWorkspaceViewIds = new Set<string>();
+    const missionWorkspaceLoader = new MissionWorkspaceLoader();
     let currentWorkspaceUiIdentity: string | null = null;
+    let currentMissionsLoadIdentity: string | null = null;
     let workspaceUiSaveTimer: ReturnType<typeof setTimeout> | null = null;
+    let missionsRefreshTimer: ReturnType<typeof setInterval> | null = null;
     let snapshotActiveWorkspaceView = () => {};
     let hydrateActiveWorkspaceView = (_options: { firstProjectLoad?: boolean } = {}) => {};
     const initialView = initialHostedSelection(
@@ -957,6 +983,18 @@ try {
     const tab = (): Tab => legacyTabFromPanelKind(activePanel());
     const mode = (): "home" | "mirror" | "editor" | "diff" | "missions" => panelMode(activePanel());
     const surfaceSpans = createMemo(() => panelSpans(hostedViews()));
+    const [missionWorkspaceLoad, setMissionWorkspaceLoad] = createSignal<MissionWorkspaceLoadState>(
+      {
+        status: "loading",
+        generation: 0,
+        projectKey: null,
+      },
+    );
+    const [missionWorkspaceSnapshot, setMissionWorkspaceSnapshot] =
+      createSignal<MissionWorkspaceSnapshot | null>(null);
+    const [missionWorkspaceModel, setMissionWorkspaceModel] = createSignal<MissionWorkspaceModel>(
+      defaultMissionWorkspaceModel(),
+    );
 
     // ── WORKSPACE CONTEXT ────────────────────────────────────────────────────
     // One context per session: choosing a session on Home (or via the palette)
@@ -1052,6 +1090,74 @@ try {
         else if (effect === "enter-diff") prepareDiff(workspaceDir());
       }
     };
+    const missionLayoutSize = () => ({
+      width: canvasCols(),
+      height: Math.max(4, dims().height - TABBAR_H),
+    });
+    const persistMissionSelection = (missionId: string | null) => {
+      const view = activeView();
+      if (view.panel !== "missions") return;
+      touchedWorkspaceViewIds.add(view.id);
+      setWorkspaceUiState((state) => workspaceStateWithMissionSelection(state, view.id, missionId));
+    };
+    const updateMissionModel = (
+      updater: (model: MissionWorkspaceModel) => MissionWorkspaceModel,
+    ) => {
+      setMissionWorkspaceModel((current) => {
+        const next = updater(current);
+        if (next.selectedMissionId !== current.selectedMissionId)
+          persistMissionSelection(next.selectedMissionId);
+        return next;
+      });
+    };
+    const loadMissionsWorkspace = (reason: "activation" | "refresh" | "cadence" | "project") => {
+      if (mode() !== "missions") return;
+      const repository = workspaceUiController.snapshot().repository;
+      if (!repository) {
+        setMissionWorkspaceLoad({ status: "loading", generation: 0, projectKey: null });
+        return;
+      }
+      const priorSnapshot =
+        reason === "refresh" || reason === "cadence" ? missionWorkspaceSnapshot() : null;
+      const start = missionWorkspaceLoader.begin(repository.metadata.identityKey, priorSnapshot);
+      setMissionWorkspaceLoad(start);
+      const projectKey = repository.metadata.identityKey;
+      currentMissionsLoadIdentity = projectKey;
+      void Promise.resolve()
+        .then(() => readMissionWorkspace(repository))
+        .then((snapshot) => {
+          const accepted = missionWorkspaceLoader.accept(start.generation, projectKey, snapshot);
+          if (!accepted) return;
+          setMissionWorkspaceSnapshot(snapshot);
+          updateMissionModel((current) =>
+            reconcileMissionWorkspaceModel(current, snapshot, {
+              persistedMissionId: missionSelectionFromWorkspaceState(
+                workspaceUiState(),
+                activeViewId(),
+              ),
+              ...missionLayoutSize(),
+            }),
+          );
+          setMissionWorkspaceLoad(accepted);
+          if (reason === "refresh") setStatusNote("missions refreshed");
+        })
+        .catch((error) => {
+          const rejected = missionWorkspaceLoader.reject(start.generation, projectKey, error);
+          if (!rejected) return;
+          if (start.status === "refreshing") {
+            setMissionWorkspaceSnapshot(start.snapshot);
+            setMissionWorkspaceLoad({ ...rejected, snapshot: start.snapshot });
+          } else {
+            setMissionWorkspaceSnapshot(null);
+            setMissionWorkspaceLoad(rejected);
+          }
+          if (reason === "refresh" && rejected.status === "error") setStatusNote(rejected.message);
+        });
+    };
+    const ensureMissionsLoaded = () => {
+      if (mode() !== "missions") return;
+      loadMissionsWorkspace("activation");
+    };
     const selectView = (viewId: string) => {
       const plan = planHostedViewActivation(hostedViews(), viewId, {
         filesLoaded: fileNodes().length > 0,
@@ -1063,9 +1169,14 @@ try {
       }
       clearSelection();
       snapshotActiveWorkspaceView();
+      if (activePanel() === "missions" && plan.view.panel !== "missions") {
+        missionWorkspaceLoader.cancel();
+        currentMissionsLoadIdentity = null;
+      }
       runActivationEffects(plan.effects);
       setActiveViewId(plan.activeViewId);
       hydrateActiveWorkspaceView();
+      if (plan.view.panel === "missions") ensureMissionsLoaded();
       refreshFocusRecord();
       return true;
     };
@@ -1086,6 +1197,10 @@ try {
     const loadPanelHostForDir = (dir: string) => {
       const generation = panelGeneration.next();
       const uiGeneration = workspaceUiController.beginLoad();
+      missionWorkspaceLoader.cancel();
+      currentMissionsLoadIdentity = null;
+      setMissionWorkspaceSnapshot(null);
+      setMissionWorkspaceLoad(invalidatedMissionWorkspaceLoadState());
       void resolveProjectConfigContext(dir)
         .then((context) => {
           if (!panelGeneration.isCurrent(generation)) return;
@@ -1131,6 +1246,7 @@ try {
           runActivationEffects(nextPlan.effects);
           if (nextPlan.activeViewId) setActiveViewId(nextPlan.activeViewId);
           hydrateActiveWorkspaceView({ firstProjectLoad });
+          if (nextPlan.view?.panel === "missions") loadMissionsWorkspace("project");
           panelHostResolved = true;
         })
         .catch((error) => {
@@ -1151,6 +1267,23 @@ try {
     };
     createEffect(() => {
       loadPanelHostForDir(contextDir() || invokeCwd);
+    });
+    createEffect(() => {
+      workspaceUiState();
+      const repository = workspaceUiController.snapshot().repository;
+      if (
+        mode() === "missions" &&
+        repository &&
+        repository.metadata.identityKey !== currentMissionsLoadIdentity
+      ) {
+        loadMissionsWorkspace("project");
+      }
+    });
+    missionsRefreshTimer = setInterval(() => {
+      if (mode() === "missions") loadMissionsWorkspace("cadence");
+    }, 10_000);
+    onCleanup(() => {
+      if (missionsRefreshTimer) clearInterval(missionsRefreshTimer);
     });
 
     // ── SELECT MODE on app-mouse panes (M22.9) ───────────────────────────────
@@ -2346,10 +2479,13 @@ try {
         };
       }
       if (panel === "missions") {
-        const existing = viewStateFor(workspaceUiState(), activeView());
-        return existing?.panel === "missions"
-          ? existing
-          : { panel, selectedMissionId: null, selectedTaskId: null };
+        return {
+          panel,
+          selectedMissionId:
+            missionWorkspaceModel().selectedMissionId ??
+            missionSelectionFromWorkspaceState(workspaceUiState(), activeView().id),
+          selectedTaskId: null,
+        };
       }
       return { panel };
     };
@@ -2405,7 +2541,109 @@ try {
           }
         }
         if (mode() === "diff") refreshStatus();
+      } else if (entry.panel === "missions") {
+        setMissionWorkspaceModel((current) =>
+          reconcileMissionWorkspaceModel(
+            { ...current, selectedMissionId: entry.selectedMissionId },
+            missionWorkspaceSnapshot(),
+            missionLayoutSize(),
+          ),
+        );
       }
+    };
+    const missionSnapshotForModel = () => missionWorkspaceSnapshot();
+    const handleMissionsKey = (evt: {
+      name: string;
+      ctrl: boolean;
+      meta: boolean;
+      shift: boolean;
+    }): boolean => {
+      const snapshot = missionSnapshotForModel();
+      if (evt.name === "r") {
+        loadMissionsWorkspace("refresh");
+        return true;
+      }
+      if (evt.name === "z") {
+        updateMissionModel((model) => cycleMissionDensity(model, snapshot, missionLayoutSize()));
+        return true;
+      }
+      if (!snapshot) return true;
+      if (evt.name === "tab") {
+        updateMissionModel((model) =>
+          setMissionWorkspaceMode(
+            model,
+            snapshot,
+            model.mode === "board" ? "history" : "board",
+            missionLayoutSize(),
+          ),
+        );
+        return true;
+      }
+      if (evt.name === "b" || evt.name === "y") {
+        updateMissionModel((model) =>
+          setMissionWorkspaceMode(
+            model,
+            snapshot,
+            evt.name === "b" ? "board" : "history",
+            missionLayoutSize(),
+          ),
+        );
+        return true;
+      }
+      const movement =
+        evt.name === "left" || evt.name === "h"
+          ? "left"
+          : evt.name === "right" || evt.name === "l"
+            ? "right"
+            : evt.name === "up" || evt.name === "k"
+              ? "up"
+              : evt.name === "down" || evt.name === "j"
+                ? "down"
+                : evt.name === "home"
+                  ? "home"
+                  : evt.name === "end"
+                    ? "end"
+                    : null;
+      if (movement) {
+        updateMissionModel((model) =>
+          moveMissionSelection(model, snapshot, movement, missionLayoutSize()),
+        );
+        return true;
+      }
+      if (evt.name === "return") {
+        const selected = missionWorkspaceModel().selectedMissionId;
+        if (selected) {
+          persistMissionSelection(selected);
+          setStatusNote("Mission details arrive next (C11)");
+        }
+        return true;
+      }
+      return true;
+    };
+    const missionLoadErrorMessage = (): string => {
+      const state = missionWorkspaceLoad();
+      return state.status === "error" ? state.message : "";
+    };
+    const missionProjectLabel = (): string =>
+      workspaceUiController.snapshot().repository?.metadata.projectRoot ?? workspaceDir();
+    const missionLayoutPresentation = () => ({
+      loadStatus: missionWorkspaceLoad().status,
+      projectLabel: missionProjectLabel(),
+      errorMessage: missionLoadErrorMessage(),
+      quitHint: QUIT_HINT,
+    });
+    const missionsLayout = createMemo(() =>
+      missionWorkspaceLayout(
+        canvasCols(),
+        Math.max(4, dims().height - TABBAR_H),
+        missionWorkspaceModel(),
+        missionWorkspaceSnapshot(),
+        missionLayoutPresentation(),
+      ),
+    );
+    const missionHitAt = (x: number, y: number) => {
+      const gy = y - TABBAR_H;
+      return missionWorkspaceHitTest(missionsLayout(), x - sidebarW(), gy);
     };
 
     // ── WATCHER PUSH REFRESH (M24.6) ─────────────────────────────────────────
@@ -4908,6 +5146,10 @@ try {
         if (mode() !== "home") goHome();
         return;
       }
+      if (mode() === "missions") {
+        handleMissionsKey(evt);
+        return;
+      }
       if (isHostedPanelInert(activePanel())) return;
       // ^e — from the diff panel, open the SELECTED file in the editor at the
       // first changed line of the top-visible hunk (M24.5); elsewhere toggle the
@@ -5522,7 +5764,26 @@ try {
         return;
       }
       if (m === "missions") {
-        setHoverIf(null);
+        const hit = missionHitAt(x, y);
+        if (hit?.kind === "mode") {
+          setHoverIf({ region: "missionmode", index: hit.mode === "board" ? 0 : 1 });
+        } else if (
+          hit?.kind === "refresh" ||
+          hit?.kind === "density" ||
+          hit?.kind === "horizontal"
+        ) {
+          setHoverIf({
+            region: "missionbutton",
+            index:
+              hit.kind === "refresh" ? 0 : hit.kind === "density" ? 1 : hit.direction < 0 ? 2 : 3,
+          });
+        } else if (hit?.kind === "card") {
+          setHoverIf({ region: "missioncard", index: hit.hoverKey });
+        } else if (hit?.kind === "history") {
+          setHoverIf({ region: "missionhistory", index: hit.hoverKey });
+        } else {
+          setHoverIf(null);
+        }
         return;
       }
       // mirror mode: the per-window strip lives on gy=1, with the [+ split] button
@@ -5723,6 +5984,24 @@ try {
           resolveHover(x, y);
           return;
         }
+        if (mode() === "missions" && type === "scroll") {
+          const snapshot = missionWorkspaceSnapshot();
+          if (!snapshot) return;
+          const hit = missionHitAt(x, y);
+          const direction = e.scroll?.direction;
+          if (direction !== "up" && direction !== "down") return;
+          const delta = direction === "up" ? -SCROLL_STEP : SCROLL_STEP;
+          const target =
+            hit?.kind === "card" || hit?.kind === "column"
+              ? hit.column
+              : missionWorkspaceModel().mode === "history"
+                ? "history"
+                : missionWorkspaceModel().selectedColumn;
+          updateMissionModel((model) =>
+            scrollMissionWorkspace(model, snapshot, target, delta, missionLayoutSize()),
+          );
+          return;
+        }
         if (type !== "down") return;
         if (y === 0) {
           const tb = tabbarButtons();
@@ -5753,6 +6032,18 @@ try {
             else void manageTeamFlow();
           } else if (hit?.kind === "agents-empty") {
             if (spanHit(agentsChipSpans(), x) === 0) void newAgentFlow(currentNewAgentContext());
+          }
+          return;
+        }
+        if (mode() === "missions") {
+          const snapshot = missionWorkspaceSnapshot();
+          const hit = missionHitAt(x, y);
+          if (hit?.kind === "refresh") {
+            loadMissionsWorkspace("refresh");
+          } else if (hit && snapshot) {
+            updateMissionModel((model) =>
+              applyMissionWorkspaceHit(model, snapshot, hit, missionLayoutSize()),
+            );
           }
         }
         return;
@@ -7002,21 +7293,156 @@ try {
               </box>
             </Show>
             <Show when={mode() === "missions"}>
-              <box paddingLeft={1} flexDirection="row" gap={1}>
-                <text fg={ACCENT} attributes={1}>
-                  Missions
+              <box width={canvasCols()} flexDirection="row" gap={1}>
+                <For each={missionsLayout().header.rows[0] ?? []}>
+                  {(chip) => (
+                    <text
+                      fg={DEFAULT_FG}
+                      bg={
+                        chip.kind === "mode" && chip.mode === missionWorkspaceModel().mode
+                          ? BUTTON_ACTIVE_BG
+                          : chip.kind === "mode" &&
+                              isHovered("missionmode", chip.mode === "board" ? 0 : 1)
+                            ? BUTTON_HOVER_BG
+                            : chip.kind === "refresh" && isHovered("missionbutton", 0)
+                              ? BUTTON_HOVER_BG
+                              : chip.kind === "density" && isHovered("missionbutton", 1)
+                                ? BUTTON_HOVER_BG
+                                : BUTTON_BG
+                      }
+                    >
+                      {chip.label}
+                    </text>
+                  )}
+                </For>
+              </box>
+              <box width={canvasCols()} flexDirection="row">
+                <text
+                  fg={BUTTON_FG}
+                  bg={isHovered("missionbutton", 2) ? BUTTON_HOVER_BG : BUTTON_BG}
+                >
+                  {"<"}
                 </text>
-                <text fg={MUTED}>deterministic mission data is available</text>
+                <text fg={MUTED}>
+                  {clipTerminal(
+                    missionsLayout().header.labels[1].slice(1, -1),
+                    Math.max(0, canvasCols() - 2),
+                  )}
+                </text>
+                <Show when={canvasCols() > 1}>
+                  <text
+                    fg={BUTTON_FG}
+                    bg={isHovered("missionbutton", 3) ? BUTTON_HOVER_BG : BUTTON_BG}
+                  >
+                    {">"}
+                  </text>
+                </Show>
               </box>
-              <text fg={MUTED}>{"─".repeat(Math.max(4, canvasCols() - 2))}</text>
-              <box flexDirection="column" flexGrow={1} paddingLeft={1}>
-                <box height={1} />
-                <text fg={DEFAULT_FG}>{MISSIONS_PLACEHOLDER_LINES[0]}</text>
-                <text fg={MUTED}>{MISSIONS_PLACEHOLDER_LINES[1]}</text>
-                <text fg={MUTED}>{MISSIONS_PLACEHOLDER_LINES[2]}</text>
-                <box flexGrow={1} />
-                <text fg={MUTED}>{`^g home · F5 palette · ${QUIT_HINT}`}</text>
-              </box>
+              <Show when={missionWorkspaceLoad().status === "loading"}>
+                <box flexDirection="column" flexGrow={1}>
+                  <box height={1} />
+                  <text fg={DEFAULT_FG}>Loading missions…</text>
+                  <text fg={MUTED}>Mission history is read from the active project runtime.</text>
+                </box>
+              </Show>
+              <Show when={missionWorkspaceLoad().status === "error" && !missionWorkspaceSnapshot()}>
+                <box flexDirection="column" flexGrow={1}>
+                  <box height={1} />
+                  <text fg={BANNER_FG}>Mission data could not be loaded.</text>
+                  <text fg={MUTED}>{missionLoadErrorMessage()}</text>
+                  <text fg={MUTED}>Press r to retry. Other workspace views remain available.</text>
+                </box>
+              </Show>
+              <Show when={missionWorkspaceLoad().status === "empty"}>
+                <box flexDirection="column" flexGrow={1}>
+                  <box height={1} />
+                  <text fg={DEFAULT_FG}>No missions yet.</text>
+                  <text fg={MUTED}>
+                    This read-only board will populate from durable mission history.
+                  </text>
+                </box>
+              </Show>
+              <Show
+                when={
+                  missionWorkspaceSnapshot() &&
+                  missionWorkspaceLoad().status !== "loading" &&
+                  !(missionWorkspaceLoad().status === "error" && !missionWorkspaceSnapshot()) &&
+                  missionWorkspaceLoad().status !== "empty"
+                }
+              >
+                <Show when={missionWorkspaceModel().mode === "board"}>
+                  <box flexDirection="row" flexGrow={1} gap={1}>
+                    <For each={missionsLayout().board.columns}>
+                      {(column) => (
+                        <box flexDirection="column" width={column.width}>
+                          <text fg={ACCENT}>
+                            {clipTerminal(`${column.label} (${column.count})`, column.width)}
+                          </text>
+                          <For each={column.cards}>
+                            {(cardLayout) => {
+                              const selected =
+                                missionWorkspaceModel().selectedMissionId === cardLayout.missionId;
+                              return (
+                                <box
+                                  flexDirection="column"
+                                  height={cardLayout.height}
+                                  backgroundColor={
+                                    selected
+                                      ? BADGE_BG
+                                      : isHovered("missioncard", cardLayout.hoverKey)
+                                        ? HOVER_BG
+                                        : DEFAULT_BG
+                                  }
+                                >
+                                  <For each={cardLayout.lines}>
+                                    {(line, lineIndex) => (
+                                      <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>
+                                        {clipTerminal(line, cardLayout.width)}
+                                      </text>
+                                    )}
+                                  </For>
+                                </box>
+                              );
+                            }}
+                          </For>
+                        </box>
+                      )}
+                    </For>
+                  </box>
+                </Show>
+                <Show when={missionWorkspaceModel().mode === "history"}>
+                  <box flexDirection="column" flexGrow={1}>
+                    <For each={missionsLayout().history.rows}>
+                      {(row) => {
+                        const selected =
+                          missionWorkspaceModel().selectedMissionId === row.missionId;
+                        return (
+                          <box
+                            flexDirection="column"
+                            height={row.height}
+                            backgroundColor={
+                              selected
+                                ? BADGE_BG
+                                : isHovered("missionhistory", row.hoverKey)
+                                  ? HOVER_BG
+                                  : DEFAULT_BG
+                            }
+                          >
+                            <For each={row.lines}>
+                              {(line, lineIndex) => (
+                                <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>
+                                  {clipTerminal(line, row.width)}
+                                </text>
+                              )}
+                            </For>
+                          </box>
+                        );
+                      }}
+                    </For>
+                  </box>
+                </Show>
+              </Show>
+              <text fg={MUTED}>{missionsLayout().footer.label}</text>
             </Show>
           </box>
         </box>

--- a/packages/daemon/src/tui/mirror/missions-workspace.test.ts
+++ b/packages/daemon/src/tui/mirror/missions-workspace.test.ts
@@ -1,0 +1,619 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type {
+  MissionBoardColumn,
+  MissionBoardView,
+  MissionCardView,
+  MissionHistorySummary,
+  MissionProgressSummary,
+  MissionProofSummary,
+} from "@tmux-ide/contracts";
+import type { ProjectResolution } from "../../lib/project-resolver.ts";
+import { createProjectRuntimeRepository } from "../../lib/project-runtime-repository.ts";
+import {
+  MISSION_BOARD_COLUMNS,
+  MISSION_COLUMN_LABELS,
+  MISSION_FOOTER_ROWS,
+  MISSION_HEADER_ROWS,
+  MissionWorkspaceLoader,
+  applyMissionWorkspaceHit,
+  clipTerminal,
+  cycleMissionDensity,
+  defaultMissionWorkspaceModel,
+  invalidatedMissionWorkspaceLoadState,
+  missionCardLines,
+  missionHistoryLines,
+  missionSelectionFromWorkspaceState,
+  missionWorkspaceHitTest,
+  missionWorkspaceLayout,
+  moveMissionSelection,
+  readMissionWorkspace,
+  reconcileMissionWorkspaceModel,
+  scrollMissionWorkspace,
+  setMissionWorkspaceMode,
+  workspaceStateWithMissionSelection,
+} from "./missions-workspace.ts";
+import { defaultWorkspaceUiState, serializeWorkspaceUiState } from "./workspace-ui-state.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+
+function progress(overrides: Partial<MissionProgressSummary> = {}): MissionProgressSummary {
+  return {
+    total: 4,
+    planned: 1,
+    running: 1,
+    blocked: 0,
+    review: 0,
+    completed: 2,
+    failed: 0,
+    cancelled: 0,
+    done: 2,
+    ...overrides,
+  };
+}
+
+function proof(overrides: Partial<MissionProofSummary> = {}): MissionProofSummary {
+  return {
+    proofIds: [],
+    hasProof: false,
+    noProofReasons: [],
+    notesCount: 0,
+    tests: { suites: 0, passed: 0, failed: 0, skipped: 0, total: 0 },
+    commits: [],
+    diff: { summaries: [], urls: [], filesChanged: 0, insertions: 0, deletions: 0 },
+    prs: [],
+    artifacts: [],
+    ...overrides,
+  };
+}
+
+function card(
+  id: string,
+  column: MissionBoardColumn,
+  title = id,
+  overrides: Partial<MissionCardView> = {},
+): MissionCardView {
+  return {
+    version: 1,
+    id,
+    title,
+    summary: `summary ${id}`,
+    status:
+      column === "planned"
+        ? "planned"
+        : column === "running"
+          ? "started"
+          : column === "blocked"
+            ? "blocked"
+            : column === "review"
+              ? "review"
+              : "completed",
+    column,
+    labels: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    durationMs: null,
+    progress: progress(),
+    blockedBy: [],
+    latestAttempt: null,
+    proofSummary: proof(),
+    refs: { missionId: id, taskIds: [], attemptIds: [], proofIds: [] },
+    ...overrides,
+  };
+}
+
+function board(columns: Partial<Record<MissionBoardColumn, MissionCardView[]>>): MissionBoardView {
+  const full = Object.fromEntries(
+    MISSION_BOARD_COLUMNS.map((column) => [column, columns[column] ?? []]),
+  ) as MissionBoardView["columns"];
+  return {
+    version: 1,
+    columns: full,
+    counts: {
+      planned: full.planned.length,
+      running: full.running.length,
+      blocked: full.blocked.length,
+      review: full.review.length,
+      done: full.done.length,
+      total: MISSION_BOARD_COLUMNS.reduce((sum, column) => sum + full[column].length, 0),
+    },
+  };
+}
+
+function history(
+  id: string,
+  outcome: MissionHistorySummary["outcome"] = "completed",
+): MissionHistorySummary {
+  const mission = card(id, "done", `History ${id}`);
+  return {
+    version: 1,
+    mission,
+    outcome,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    finishedAt: "2026-01-01T00:05:00.000Z",
+    durationMs: 300_000,
+    taskTotals: progress({ total: 2, done: 2, completed: 2, planned: 0, running: 0 }),
+    attemptTotals: {
+      total: 3,
+      submitted: 1,
+      approved: 1,
+      rejected: 1,
+      failed: 0,
+      interrupted: 0,
+      running: 0,
+    },
+    proofSummary: proof({
+      proofIds: ["prf_one"],
+      hasProof: true,
+      tests: { suites: 1, passed: 9, failed: 0, skipped: 1, total: 10 },
+      diff: {
+        summaries: ["changed files"],
+        urls: [],
+        filesChanged: 3,
+        insertions: 10,
+        deletions: 2,
+      },
+      prs: [{ number: 122, status: "merged" }],
+    }),
+    lastEvent: {
+      version: 1,
+      sequence: 9,
+      timestamp: "2026-01-01T00:05:00.000Z",
+      missionId: id,
+      type: "mission.completed",
+      label: "Mission completed",
+      actor: { type: "user", id: "pm" },
+      refs: { missionId: id },
+    },
+  };
+}
+
+function snapshot(boardView = board({}), historyView: MissionHistorySummary[] = []) {
+  return {
+    board: boardView,
+    history: historyView,
+    project: { identityKey: "git-abc", projectRoot: "/repo" },
+    loadedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function resolution(projectRoot: string): ProjectResolution {
+  return {
+    inputDir: projectRoot,
+    projectRoot,
+    identityKey: `git-${"c".repeat(64)}`,
+    identitySource: "git-common-dir",
+    identityAnchor: join(projectRoot, ".git"),
+    config: { kind: "none", path: null, explicit: false },
+    workspaceConfigPath: null,
+    legacyConfigPath: null,
+    hasLegacyConfigAtInput: false,
+  };
+}
+
+describe("missions workspace loader/model", () => {
+  it("loads missing mission history as an empty detached snapshot", () => {
+    const root = mkdtempSync(join(tmpdir(), "tmux-ide-missions-"));
+    try {
+      const repository = createProjectRuntimeRepository(resolution(root), {
+        home: join(root, ".state"),
+      });
+      const loaded = readMissionWorkspace(repository, () => new Date("2026-01-01T00:00:00.000Z"));
+      expect(loaded.board.counts.total).toBe(0);
+      expect(loaded.history).toEqual([]);
+      expect(loaded.project.identityKey).toBe(repository.metadata.identityKey);
+      loaded.history.push(history("mis_later"));
+      expect(readMissionWorkspace(repository).history).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps loading/error/empty/ready states generation-safe across project changes", () => {
+    const loader = new MissionWorkspaceLoader();
+    const slow = loader.begin("project-a");
+    const fast = loader.begin("project-b");
+    expect(loader.accept(slow.generation, "project-a", snapshot())).toBeNull();
+    const empty = loader.accept(fast.generation, "project-b", snapshot());
+    expect(empty?.status).toBe("empty");
+    const readyStart = loader.begin("project-b");
+    const ready = loader.accept(
+      readyStart.generation,
+      "project-b",
+      snapshot(board({ planned: [card("mis_a", "planned")] })),
+    );
+    expect(ready?.status).toBe("ready");
+    expect(loader.reject(slow.generation, "project-a", new Error("bad"))).toBeNull();
+    expect(loader.reject(readyStart.generation, "project-b", new Error("corrupt"))).toMatchObject({
+      status: "error",
+      message: "corrupt",
+    });
+    const prior = {
+      ...snapshot(board({ planned: [card("mis_prior", "planned")] })),
+      project: { identityKey: "project-b", projectRoot: "/repo" },
+    };
+    const refreshing = loader.begin("project-b", prior);
+    expect(refreshing).toMatchObject({ status: "refreshing", snapshot: prior });
+    const otherProjectPrior = {
+      ...prior,
+      project: { identityKey: "project-a", projectRoot: "/repo-a" },
+    };
+    expect(loader.begin("project-b", otherProjectPrior).status).toBe("loading");
+    loader.cancel();
+    expect(loader.accept(refreshing.generation, "project-b", snapshot())).toBeNull();
+    expect(invalidatedMissionWorkspaceLoadState()).toEqual({
+      status: "loading",
+      generation: 0,
+      projectKey: null,
+    });
+  });
+
+  it("consumes projected board column labels/counts/order without re-sorting", () => {
+    const view = board({
+      planned: [card("mis_two", "planned"), card("mis_one", "planned")],
+      blocked: [card("mis_blocked", "blocked")],
+    });
+    expect(MISSION_BOARD_COLUMNS.map((column) => MISSION_COLUMN_LABELS[column])).toEqual([
+      "Planned",
+      "Running",
+      "Blocked",
+      "Review",
+      "Done",
+    ]);
+    expect(view.columns.planned.map((item) => item.id)).toEqual(["mis_two", "mis_one"]);
+    expect(view.counts).toMatchObject({ planned: 2, running: 0, blocked: 1, total: 3 });
+  });
+
+  it("restores selection by mission id and reconciles removal, terminal transition, and empty data", () => {
+    const active = snapshot(
+      board({ planned: [card("mis_a", "planned")], running: [card("mis_b", "running")] }),
+    );
+    const restored = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel(), active, {
+      persistedMissionId: "mis_b",
+    });
+    expect(restored.selectedMissionId).toBe("mis_b");
+    expect(restored.selectedColumn).toBe("running");
+
+    const removed = reconcileMissionWorkspaceModel(
+      restored,
+      snapshot(board({ blocked: [card("mis_c", "blocked")] })),
+    );
+    expect(removed.selectedMissionId).toBe("mis_c");
+    expect(removed.selectedColumn).toBe("blocked");
+
+    const terminal = setMissionWorkspaceMode(
+      restored,
+      snapshot(board({}), [history("mis_b"), history("mis_done_2")]),
+      "history",
+    );
+    expect(terminal.selectedMissionId).toBe("mis_b");
+
+    const empty = reconcileMissionWorkspaceModel(terminal, snapshot(board({}), []));
+    expect(empty.selectedMissionId).toBeNull();
+  });
+
+  it("moves selection while skipping empty columns, preserving nearest row, and following horizontal viewport", () => {
+    const view = snapshot(
+      board({
+        planned: [card("mis_p0", "planned"), card("mis_p1", "planned")],
+        blocked: [card("mis_b0", "blocked")],
+        done: [card("mis_d0", "done"), card("mis_d1", "done"), card("mis_d2", "done")],
+      }),
+    );
+    let model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel(), view, {
+      persistedMissionId: "mis_p1",
+      width: 50,
+      height: 8,
+    });
+    model = moveMissionSelection(model, view, "right", { width: 50, height: 8 });
+    expect(model.selectedMissionId).toBe("mis_b0");
+    expect(model.selectedColumn).toBe("blocked");
+    model = moveMissionSelection(model, view, "right", { width: 50, height: 8 });
+    expect(model.selectedMissionId).toBe("mis_d0");
+    expect(model.horizontalOffset).toBeGreaterThan(0);
+    model = moveMissionSelection(model, view, "end", { width: 50, height: 8 });
+    expect(model.selectedMissionId).toBe("mis_d2");
+    model = moveMissionSelection(model, view, "up", { width: 50, height: 8 });
+    expect(model.selectedMissionId).toBe("mis_d1");
+  });
+
+  it("computes narrow/medium/wide geometry, density heights, and exact Unicode clipping", () => {
+    const model = defaultMissionWorkspaceModel("mis_a");
+    const view = snapshot(
+      board({ planned: [card("mis_a", "planned", "Pair 👨‍💻 and Flag 🇳🇱 key 1️⃣ 分析 Café")] }),
+    );
+    const narrow = missionWorkspaceLayout(
+      30,
+      12,
+      reconcileMissionWorkspaceModel(model, view, { width: 30, height: 12 }),
+      view,
+    );
+    const medium = missionWorkspaceLayout(72, 12, model, view);
+    const wide = missionWorkspaceLayout(180, 12, model, view);
+    expect(narrow.board.visibleColumns.length).toBe(1);
+    expect(medium.board.visibleColumns.length).toBeGreaterThan(1);
+    expect(wide.board.visibleColumns).toEqual([...MISSION_BOARD_COLUMNS]);
+    expect(cycleMissionDensity(model, view).density).toBe("detailed");
+    const clipped = clipTerminal("ASCII 分析 Café 👨‍💻 🇳🇱 1️⃣", 14);
+    expect(terminalWidth(clipped)).toBeLessThanOrEqual(14);
+    expect(
+      missionCardLines(view.board.columns.planned[0]!, "detailed", 18).every(
+        (line) => terminalWidth(line) <= 18,
+      ),
+    ).toBe(true);
+  });
+
+  it("uses density-aware item capacity and never overflows into the footer", () => {
+    const many = Array.from({ length: 8 }, (_, index) => card(`mis_${index}`, "planned"));
+    const view = snapshot(
+      board({ planned: many }),
+      many.map((item) => history(item.id)),
+    );
+    for (const density of ["compact", "comfortable", "detailed"] as const) {
+      const model = reconcileMissionWorkspaceModel(
+        { ...defaultMissionWorkspaceModel("mis_7"), density },
+        view,
+        { height: 9 },
+      );
+      const layout = missionWorkspaceLayout(40, 9, model, view);
+      const footerTop = layout.height - MISSION_FOOTER_ROWS;
+      for (const column of layout.board.columns) {
+        expect(column.cards.length).toBeLessThanOrEqual(layout.board.itemCapacity);
+        for (const item of column.cards) {
+          expect(item.y + item.height).toBeLessThanOrEqual(footerTop);
+        }
+      }
+      const historyModel = setMissionWorkspaceMode(model, view, "history", { height: 9 });
+      const historyLayout = missionWorkspaceLayout(40, 9, historyModel, view);
+      expect(historyLayout.history.rows.length).toBeLessThanOrEqual(
+        historyLayout.history.itemCapacity,
+      );
+      for (const row of historyLayout.history.rows) {
+        expect(row.y + row.height).toBeLessThanOrEqual(footerTop);
+      }
+    }
+  });
+
+  it("keeps whole narrow columns within canvas and follows selected offscreen columns", () => {
+    const view = snapshot(board({ done: [card("mis_done", "done")] }));
+    const model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_done"), view, {
+      width: 20,
+      height: 10,
+    });
+    expect(model.horizontalOffset).toBe(4);
+    for (const width of [1, 20, 22]) {
+      const layout = missionWorkspaceLayout(width, 10, model, view);
+      expect(layout.board.visibleColumns.length).toBe(1);
+      for (const column of layout.board.columns) {
+        expect(column.width).toBeLessThanOrEqual(layout.width);
+        expect(column.x + column.width).toBeLessThanOrEqual(layout.width);
+        for (const item of column.cards)
+          expect(item.x + item.width).toBeLessThanOrEqual(layout.width);
+      }
+      const historyModel = setMissionWorkspaceMode(model, view, "history", { width, height: 10 });
+      const historyLayout = missionWorkspaceLayout(width, 10, historyModel, view);
+      for (const row of historyLayout.history.rows) {
+        expect(row.x + row.width).toBeLessThanOrEqual(historyLayout.width);
+      }
+    }
+  });
+
+  it("keeps independent column/history scroll state and clamps after shrink", () => {
+    const view = snapshot(
+      board({
+        planned: [card("mis_a", "planned"), card("mis_b", "planned"), card("mis_c", "planned")],
+        done: [card("mis_d", "done")],
+      }),
+      [history("mis_h1"), history("mis_h2"), history("mis_h3")],
+    );
+    let model = scrollMissionWorkspace(defaultMissionWorkspaceModel("mis_c"), view, "planned", 10, {
+      height: 4,
+    });
+    model = scrollMissionWorkspace(model, view, "history", 10, { height: 4 });
+    expect(model.columnScroll.planned).toBeGreaterThan(0);
+    expect(model.columnScroll.done).toBe(0);
+    model.selectedMissionId = "mis_h3";
+    model = setMissionWorkspaceMode(model, view, "history", { height: 4 });
+    expect(model.historyScroll).toBeGreaterThan(0);
+    const shrunk = snapshot(board({ planned: [card("mis_a", "planned")] }), [history("mis_h1")]);
+    const clamped = reconcileMissionWorkspaceModel(model, shrunk, { height: 24 });
+    expect(clamped.columnScroll.planned).toBe(0);
+    expect(clamped.historyScroll).toBe(0);
+  });
+
+  it("formats history projected outcome/duration/task/attempt/proof/diff/test/pr/last event fields", () => {
+    const lines = missionHistoryLines(history("mis_done", "failed"), "detailed", 120).join("\n");
+    expect(lines).toContain("failed");
+    expect(lines).toContain("5m");
+    expect(lines).toContain("2/2 tasks");
+    expect(lines).toContain("approved");
+    expect(lines).toContain("submitted");
+    expect(lines).toContain("rejected");
+    expect(lines).toContain("tests 9/10");
+    expect(lines).toContain("diff 3");
+    expect(lines).toContain("PR 122");
+    expect(lines).toContain("Mission completed");
+  });
+
+  it("hit-tests mode chips, cards, history rows, and horizontal affordances against layout", () => {
+    const view = snapshot(board({ planned: [card("mis_a", "planned")] }), [history("mis_h1")]);
+    let model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_a"), view);
+    let layout = missionWorkspaceLayout(80, 20, model, view);
+    const boardChip = layout.header.rows[0]!.find((chip) => chip.mode === "board")!;
+    const refreshChip = layout.header.rows[0]!.find((chip) => chip.kind === "refresh")!;
+    const rightChip = layout.header.rows[1]!.find((chip) => chip.direction === 1)!;
+    expect(missionWorkspaceHitTest(layout, boardChip.start, boardChip.row)).toEqual({
+      kind: "mode",
+      mode: "board",
+    });
+    expect(missionWorkspaceHitTest(layout, refreshChip.start, refreshChip.row)).toEqual({
+      kind: "refresh",
+    });
+    expect(missionWorkspaceHitTest(layout, rightChip.start, rightChip.row)).toEqual({
+      kind: "horizontal",
+      direction: 1,
+    });
+    expect(missionWorkspaceHitTest(layout, 1, 3)).toEqual({
+      kind: "card",
+      missionId: "mis_a",
+      column: "planned",
+      index: 0,
+      hoverKey: 0,
+    });
+    model = setMissionWorkspaceMode(model, view, "history");
+    layout = missionWorkspaceLayout(80, 20, model, view);
+    expect(missionWorkspaceHitTest(layout, 1, MISSION_HEADER_ROWS)).toEqual({
+      kind: "history",
+      missionId: "mis_h1",
+      index: 0,
+      hoverKey: 0,
+    });
+  });
+
+  it("assigns unique card hover keys across visible columns", () => {
+    const view = snapshot(
+      board({
+        planned: [
+          card("mis_p0", "planned"),
+          card("mis_p1", "planned"),
+          ...Array.from({ length: 9_999 }, (_, index) => card(`mis_px_${index}`, "planned")),
+          card("mis_p10000", "planned"),
+        ],
+        running: [card("mis_r0", "running"), card("mis_r1", "running")],
+      }),
+    );
+    const layout = missionWorkspaceLayout(
+      80,
+      20,
+      {
+        ...defaultMissionWorkspaceModel("mis_p10000"),
+        columnScroll: { planned: 10_000, running: 0, blocked: 0, review: 0, done: 0 },
+      },
+      view,
+    );
+    const keys = layout.board.columns.flatMap((column) =>
+      column.cards.map((item) => item.hoverKey),
+    );
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toContain(50_000);
+    expect(keys).toContain(1);
+  });
+
+  it("applies pointer hits deterministically, including column header first-card selection", () => {
+    const view = snapshot(
+      board({
+        planned: [card("mis_a", "planned")],
+        blocked: [card("mis_b", "blocked"), card("mis_c", "blocked")],
+      }),
+    );
+    let model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_a"), view);
+    model = applyMissionWorkspaceHit(model, view, { kind: "column", column: "blocked" });
+    expect(model.selectedMissionId).toBe("mis_b");
+    model = applyMissionWorkspaceHit(model, view, {
+      kind: "card",
+      missionId: "mis_c",
+      column: "blocked",
+      index: 1,
+      hoverKey: 7,
+    });
+    expect(model.selectedMissionId).toBe("mis_c");
+  });
+
+  it("keeps header chip spans non-overlapping at narrow, medium, and wide widths", () => {
+    for (const width of [20, 56, 72, 120, 180]) {
+      const layout = missionWorkspaceLayout(width, 10, defaultMissionWorkspaceModel(), snapshot());
+      expect(layout.header.labels).toHaveLength(2);
+      expect(layout.header.labels.every((label) => terminalWidth(label) <= width)).toBe(true);
+      expect(terminalWidth(layout.header.labels[1])).toBe(width);
+      expect(terminalWidth(layout.footer.label)).toBe(width);
+      if (width >= 56) {
+        expect(layout.header.rows[0]!.map((chip) => chip.kind)).toEqual([
+          "mode",
+          "mode",
+          "density",
+          "refresh",
+        ]);
+      }
+      for (const row of layout.header.rows) {
+        const sorted = [...row].sort((a, b) => a.start - b.start);
+        for (const [index, chip] of sorted.entries()) {
+          expect(chip.start).toBeGreaterThanOrEqual(0);
+          expect(chip.start + chip.width).toBeLessThanOrEqual(layout.width);
+          const previous = sorted[index - 1];
+          if (previous) expect(chip.start).toBeGreaterThanOrEqual(previous.start + previous.width);
+        }
+      }
+    }
+  });
+
+  it("keeps presentation context/status/footer bounded at smoke widths", () => {
+    const loaded = snapshot(board({ planned: [card("mis_a", "planned")] }), [
+      history("mis_done"),
+      history("mis_failed", "failed"),
+    ]);
+    for (const width of [20, 56, 120]) {
+      const layout = missionWorkspaceLayout(width, 10, defaultMissionWorkspaceModel(), loaded, {
+        loadStatus: "refreshing",
+        projectLabel: "/repo/apps/api",
+        quitHint: "^q detach",
+      });
+      expect(terminalWidth(layout.header.labels[0])).toBeLessThanOrEqual(width);
+      expect(terminalWidth(layout.header.labels[1])).toBe(width);
+      expect(terminalWidth(layout.footer.label)).toBe(width);
+      expect(layout.header.labels[1].startsWith("<")).toBe(true);
+      expect(layout.header.labels[1].endsWith(">")).toBe(true);
+      expect(layout.footer.label.startsWith("^q detach")).toBe(true);
+      expect(layout.header.rows[1]).toEqual([
+        { kind: "horizontal", direction: -1, label: "<", row: 1, start: 0, width: 1 },
+        { kind: "horizontal", direction: 1, label: ">", row: 1, start: width - 1, width: 1 },
+      ]);
+    }
+    const wide = missionWorkspaceLayout(120, 10, defaultMissionWorkspaceModel(), loaded, {
+      loadStatus: "refreshing",
+      projectLabel: "/repo/apps/api",
+      quitHint: "^q detach",
+    });
+    expect(wide.header.labels[1]).toContain("refreshing");
+    expect(wide.header.labels[1]).toContain("api");
+    expect(wide.header.labels[1]).toContain("1 total");
+    expect(wide.header.labels[1]).toContain("2 finished");
+  });
+
+  it("persists reconciled fallback selection when refreshed data removes the prior mission", () => {
+    const initial = snapshot(board({ planned: [card("mis_old", "planned")] }));
+    const refreshed = snapshot(board({ running: [card("mis_new", "running")] }));
+    const model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel(), initial, {
+      persistedMissionId: "mis_old",
+    });
+    const reconciled = reconcileMissionWorkspaceModel(model, refreshed, {
+      persistedMissionId: "mis_old",
+    });
+    const state = workspaceStateWithMissionSelection(
+      defaultWorkspaceUiState(),
+      "missions-a",
+      reconciled.selectedMissionId,
+    );
+    expect(missionSelectionFromWorkspaceState(state, "missions-a")).toBe("mis_new");
+  });
+
+  it("persists only selectedMissionId per exact missions view without projection blobs", () => {
+    const state = workspaceStateWithMissionSelection(
+      defaultWorkspaceUiState(),
+      "mission-a",
+      "mis_one",
+    );
+    const next = workspaceStateWithMissionSelection(state, "mission-b", "mis_two");
+    expect(missionSelectionFromWorkspaceState(next, "mission-a")).toBe("mis_one");
+    expect(missionSelectionFromWorkspaceState(next, "mission-b")).toBe("mis_two");
+    const json = serializeWorkspaceUiState(next);
+    expect(json).toContain('"selectedTaskId": null');
+    expect(json).not.toContain("columns");
+    expect(json).not.toContain("history");
+    expect(json).not.toContain("projection");
+  });
+});
+
+function terminalWidth(value: string): number {
+  return terminalDisplayWidth(value);
+}

--- a/packages/daemon/src/tui/mirror/missions-workspace.ts
+++ b/packages/daemon/src/tui/mirror/missions-workspace.ts
@@ -1,0 +1,956 @@
+import type {
+  MissionBoardColumn,
+  MissionBoardView,
+  MissionCardView,
+  MissionHistorySummary,
+} from "@tmux-ide/contracts";
+
+import {
+  MissionProjectionError,
+  projectMissionBoard,
+  projectMissionHistory,
+} from "../../lib/mission-projections.ts";
+import { MissionRepository, MissionRepositoryError } from "../../lib/mission-repository.ts";
+import type { ProjectRuntimeRepository } from "../../lib/project-runtime-repository.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import type { WorkspaceUiStateV1 } from "./workspace-ui-state.ts";
+import { missionsSelection, setMissionsSelection } from "./workspace-ui-state.ts";
+
+export const MISSION_BOARD_COLUMNS = ["planned", "running", "blocked", "review", "done"] as const;
+export const MISSION_COLUMN_LABELS: Readonly<Record<MissionBoardColumn, string>> = {
+  planned: "Planned",
+  running: "Running",
+  blocked: "Blocked",
+  review: "Review",
+  done: "Done",
+};
+export const MISSION_DENSITIES = ["compact", "comfortable", "detailed"] as const;
+export const MISSION_MIN_COLUMN_WIDTH = 22;
+export const MISSION_MAX_COLUMN_WIDTH = 34;
+export const MISSION_COLUMN_GAP = 1;
+export const MISSION_HEADER_ROWS = 2;
+export const MISSION_FOOTER_ROWS = 1;
+
+export type MissionWorkspaceMode = "board" | "history";
+export type MissionWorkspaceDensity = (typeof MISSION_DENSITIES)[number];
+export type MissionWorkspaceLoadStatus = "loading" | "empty" | "error" | "ready";
+
+export interface MissionWorkspaceSnapshot {
+  board: MissionBoardView;
+  history: MissionHistorySummary[];
+  project: {
+    identityKey: string;
+    projectRoot: string;
+  };
+  loadedAt: string;
+}
+
+export type MissionWorkspaceLoadState =
+  | { status: "loading"; generation: number; projectKey: string | null }
+  | {
+      status: "refreshing";
+      generation: number;
+      projectKey: string;
+      snapshot: MissionWorkspaceSnapshot;
+    }
+  | { status: "empty"; generation: number; snapshot: MissionWorkspaceSnapshot }
+  | { status: "ready"; generation: number; snapshot: MissionWorkspaceSnapshot }
+  | {
+      status: "error";
+      generation: number;
+      projectKey: string | null;
+      message: string;
+      snapshot?: MissionWorkspaceSnapshot;
+    };
+
+export interface MissionWorkspaceModel {
+  mode: MissionWorkspaceMode;
+  density: MissionWorkspaceDensity;
+  selectedMissionId: string | null;
+  selectedColumn: MissionBoardColumn;
+  preferredRow: number;
+  columnScroll: Record<MissionBoardColumn, number>;
+  historyScroll: number;
+  horizontalOffset: number;
+}
+
+export interface MissionWorkspaceLayout {
+  width: number;
+  height: number;
+  mode: MissionWorkspaceMode;
+  header: MissionHeaderLayout;
+  footer: {
+    label: string;
+    width: number;
+  };
+  board: {
+    availableRows: number;
+    itemCapacity: number;
+    columnWidth: number;
+    visibleColumns: MissionBoardColumn[];
+    columns: MissionColumnLayout[];
+  };
+  history: {
+    availableRows: number;
+    itemCapacity: number;
+    rows: MissionHistoryRowLayout[];
+  };
+}
+
+export interface MissionWorkspacePresentationOptions {
+  loadStatus?: MissionWorkspaceLoadStatus | "refreshing";
+  projectLabel?: string | null;
+  errorMessage?: string | null;
+  quitHint?: string | null;
+}
+
+export interface MissionHeaderLayout {
+  rows: MissionHeaderChip[][];
+  labels: [string, string];
+}
+
+export interface MissionHeaderChip {
+  kind: "mode" | "density" | "refresh" | "horizontal";
+  label: string;
+  row: number;
+  start: number;
+  width: number;
+  mode?: MissionWorkspaceMode;
+  direction?: -1 | 1;
+}
+
+export interface MissionColumnLayout {
+  column: MissionBoardColumn;
+  label: string;
+  x: number;
+  width: number;
+  count: number;
+  scroll: number;
+  cards: MissionCardLayout[];
+}
+
+export interface MissionCardLayout {
+  missionId: string;
+  column: MissionBoardColumn;
+  index: number;
+  hoverKey: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  lines: string[];
+}
+
+export interface MissionHistoryRowLayout {
+  missionId: string;
+  index: number;
+  hoverKey: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  lines: string[];
+}
+
+export type MissionWorkspaceHit =
+  | { kind: "mode"; mode: MissionWorkspaceMode }
+  | { kind: "density" }
+  | { kind: "refresh" }
+  | { kind: "horizontal"; direction: -1 | 1 }
+  | { kind: "column"; column: MissionBoardColumn }
+  | { kind: "card"; missionId: string; column: MissionBoardColumn; index: number; hoverKey: number }
+  | { kind: "history"; missionId: string; index: number; hoverKey: number }
+  | null;
+
+export class MissionWorkspaceLoader {
+  #generation = 0;
+  #activeProjectKey: string | null = null;
+
+  begin(
+    projectKey: string | null,
+    priorSnapshot?: MissionWorkspaceSnapshot | null,
+  ): MissionWorkspaceLoadState {
+    this.#generation += 1;
+    this.#activeProjectKey = projectKey;
+    if (projectKey && priorSnapshot?.project.identityKey === projectKey) {
+      return {
+        status: "refreshing",
+        generation: this.#generation,
+        projectKey,
+        snapshot: priorSnapshot,
+      };
+    }
+    return { status: "loading", generation: this.#generation, projectKey };
+  }
+
+  cancel(): void {
+    this.#generation += 1;
+    this.#activeProjectKey = null;
+  }
+
+  accept(
+    generation: number,
+    projectKey: string,
+    snapshot: MissionWorkspaceSnapshot,
+  ): MissionWorkspaceLoadState | null {
+    if (generation !== this.#generation || projectKey !== this.#activeProjectKey) return null;
+    const status =
+      snapshot.board.counts.total === 0 && snapshot.history.length === 0 ? "empty" : "ready";
+    return { status, generation, snapshot };
+  }
+
+  reject(
+    generation: number,
+    projectKey: string | null,
+    error: unknown,
+  ): MissionWorkspaceLoadState | null {
+    if (generation !== this.#generation || projectKey !== this.#activeProjectKey) return null;
+    return { status: "error", generation, projectKey, message: missionErrorMessage(error) };
+  }
+
+  isCurrent(generation: number, projectKey: string | null): boolean {
+    return generation === this.#generation && projectKey === this.#activeProjectKey;
+  }
+}
+
+export function invalidatedMissionWorkspaceLoadState(): MissionWorkspaceLoadState {
+  return { status: "loading", generation: 0, projectKey: null };
+}
+
+export function readMissionWorkspace(
+  repository: ProjectRuntimeRepository,
+  now: () => Date = () => new Date(),
+): MissionWorkspaceSnapshot {
+  const missions = new MissionRepository(repository);
+  const { history, state } = missions.snapshot();
+  const board = projectMissionBoard(state, history);
+  const completed = projectMissionHistory(state, history);
+  return {
+    board,
+    history: completed.map((entry) => detached(entry)),
+    project: {
+      identityKey: repository.metadata.identityKey,
+      projectRoot: repository.metadata.projectRoot,
+    },
+    loadedAt: now().toISOString(),
+  };
+}
+
+export function defaultMissionWorkspaceModel(
+  selectedMissionId: string | null = null,
+): MissionWorkspaceModel {
+  return {
+    mode: "board",
+    density: "comfortable",
+    selectedMissionId,
+    selectedColumn: "planned",
+    preferredRow: 0,
+    columnScroll: emptyScrolls(),
+    historyScroll: 0,
+    horizontalOffset: 0,
+  };
+}
+
+export function reconcileMissionWorkspaceModel(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history"> | null,
+  options: { persistedMissionId?: string | null; width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  let next = cloneModel(model);
+  const preferred = options.persistedMissionId ?? next.selectedMissionId;
+  if (!snapshot) {
+    next.selectedMissionId = preferred ?? null;
+    return next;
+  }
+  if (next.mode === "history") {
+    next.selectedMissionId = selectHistoryMission(snapshot.history, preferred);
+    next.historyScroll = clampTop(
+      next.historyScroll,
+      snapshot.history.length,
+      historyItemCapacity(options.height, next.density),
+    );
+  } else {
+    const found = findMissionInBoard(snapshot.board, preferred);
+    const fallback = found ?? firstBoardMission(snapshot.board);
+    next.selectedMissionId = fallback?.id ?? null;
+    next.selectedColumn = fallback?.column ?? next.selectedColumn;
+    next.preferredRow = fallback?.index ?? 0;
+  }
+  next = clampMissionWorkspaceModel(next, snapshot, options);
+  return next;
+}
+
+export function clampMissionWorkspaceModel(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
+  options: { width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  const next = cloneModel(model);
+  const rows = boardItemCapacity(options.height, next.density);
+  for (const column of MISSION_BOARD_COLUMNS) {
+    next.columnScroll[column] = clampTop(
+      next.columnScroll[column],
+      snapshot.board.columns[column].length,
+      rows,
+    );
+  }
+  const selected = findMissionInBoard(snapshot.board, next.selectedMissionId);
+  if (selected) {
+    next.selectedColumn = selected.column;
+    next.preferredRow = selected.index;
+    next.columnScroll[selected.column] = scrollToIndex(
+      selected.index,
+      next.columnScroll[selected.column],
+      rows,
+    );
+    next.horizontalOffset = followColumnOffset(
+      columnIndex(selected.column),
+      next.horizontalOffset,
+      visibleColumnCount(options.width),
+    );
+  } else if (next.mode === "board") {
+    const fallback = firstBoardMission(snapshot.board);
+    next.selectedMissionId = fallback?.id ?? null;
+    next.selectedColumn = fallback?.column ?? next.selectedColumn;
+    next.preferredRow = fallback?.index ?? 0;
+    if (fallback) {
+      next.horizontalOffset = followColumnOffset(
+        columnIndex(fallback.column),
+        next.horizontalOffset,
+        visibleColumnCount(options.width),
+      );
+    }
+  }
+  if (next.mode === "history") {
+    next.selectedMissionId = selectHistoryMission(snapshot.history, next.selectedMissionId);
+    const idx = snapshot.history.findIndex((entry) => entry.mission.id === next.selectedMissionId);
+    if (idx >= 0)
+      next.historyScroll = scrollToIndex(
+        idx,
+        next.historyScroll,
+        historyItemCapacity(options.height, next.density),
+      );
+    next.historyScroll = clampTop(
+      next.historyScroll,
+      snapshot.history.length,
+      historyItemCapacity(options.height, next.density),
+    );
+  }
+  next.horizontalOffset = Math.min(
+    Math.max(0, next.horizontalOffset),
+    Math.max(0, MISSION_BOARD_COLUMNS.length - visibleColumnCount(options.width)),
+  );
+  return next;
+}
+
+export function moveMissionSelection(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
+  action: "left" | "right" | "up" | "down" | "home" | "end",
+  options: { width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  const next = cloneModel(model);
+  if (next.mode === "history") {
+    const current = Math.max(
+      0,
+      snapshot.history.findIndex((entry) => entry.mission.id === next.selectedMissionId),
+    );
+    const last = Math.max(0, snapshot.history.length - 1);
+    const index =
+      action === "up"
+        ? Math.max(0, current - 1)
+        : action === "down"
+          ? Math.min(last, current + 1)
+          : action === "home"
+            ? 0
+            : action === "end"
+              ? last
+              : current;
+    next.selectedMissionId = snapshot.history[index]?.mission.id ?? null;
+    return clampMissionWorkspaceModel(next, snapshot, options);
+  }
+  const located = findMissionInBoard(snapshot.board, next.selectedMissionId);
+  const currentColumn = located?.column ?? next.selectedColumn;
+  const currentIndex = located?.index ?? next.preferredRow;
+  if (action === "up" || action === "down" || action === "home" || action === "end") {
+    const cards = snapshot.board.columns[currentColumn];
+    if (cards.length > 0) {
+      const index =
+        action === "up"
+          ? Math.max(0, currentIndex - 1)
+          : action === "down"
+            ? Math.min(cards.length - 1, currentIndex + 1)
+            : action === "home"
+              ? 0
+              : cards.length - 1;
+      next.selectedMissionId = cards[index]?.id ?? null;
+      next.selectedColumn = currentColumn;
+      next.preferredRow = index;
+    }
+  } else {
+    const target = nearestNonEmptyColumn(snapshot.board, currentColumn, action === "left" ? -1 : 1);
+    if (target) {
+      const cards = snapshot.board.columns[target];
+      const index = Math.min(currentIndex, cards.length - 1);
+      next.selectedMissionId = cards[index]?.id ?? null;
+      next.selectedColumn = target;
+      next.preferredRow = index;
+    }
+  }
+  return clampMissionWorkspaceModel(next, snapshot, options);
+}
+
+export function setMissionWorkspaceMode(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
+  mode: MissionWorkspaceMode,
+  options: { width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  return reconcileMissionWorkspaceModel({ ...cloneModel(model), mode }, snapshot, options);
+}
+
+export function cycleMissionDensity(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history"> | null,
+  options: { width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  const index = MISSION_DENSITIES.indexOf(model.density);
+  const next = {
+    ...cloneModel(model),
+    density: MISSION_DENSITIES[(index + 1) % MISSION_DENSITIES.length]!,
+  };
+  return snapshot ? clampMissionWorkspaceModel(next, snapshot, options) : next;
+}
+
+export function scrollMissionWorkspace(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
+  target: MissionBoardColumn | "history",
+  delta: number,
+  options: { width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  const next = cloneModel(model);
+  if (target === "history") next.historyScroll += delta;
+  else next.columnScroll[target] += delta;
+  return clampMissionWorkspaceModel(next, snapshot, options);
+}
+
+export function applyMissionWorkspaceHit(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
+  hit: Exclude<MissionWorkspaceHit, { kind: "refresh" } | null>,
+  options: { width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  if (hit.kind === "mode") return setMissionWorkspaceMode(model, snapshot, hit.mode, options);
+  if (hit.kind === "density") return cycleMissionDensity(model, snapshot, options);
+  if (hit.kind === "horizontal") {
+    return moveMissionSelection(model, snapshot, hit.direction < 0 ? "left" : "right", options);
+  }
+  if (hit.kind === "column") {
+    const first = snapshot.board.columns[hit.column][0];
+    return first
+      ? reconcileMissionWorkspaceModel(
+          { ...cloneModel(model), selectedMissionId: first.id },
+          snapshot,
+          options,
+        )
+      : clampMissionWorkspaceModel(
+          { ...cloneModel(model), selectedColumn: hit.column },
+          snapshot,
+          options,
+        );
+  }
+  return reconcileMissionWorkspaceModel(
+    { ...cloneModel(model), selectedMissionId: hit.missionId },
+    snapshot,
+    options,
+  );
+}
+
+export function missionWorkspaceLayout(
+  width: number,
+  height: number,
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history"> | null,
+  presentation: MissionWorkspacePresentationOptions = {},
+): MissionWorkspaceLayout {
+  const safeWidth = Math.max(1, width);
+  const safeHeight = Math.max(1, height);
+  const visibleCount = visibleColumnCount(safeWidth);
+  const horizontalOffset = Math.min(
+    Math.max(0, model.horizontalOffset),
+    Math.max(0, MISSION_BOARD_COLUMNS.length - visibleCount),
+  );
+  const visibleColumns = MISSION_BOARD_COLUMNS.slice(
+    horizontalOffset,
+    horizontalOffset + visibleCount,
+  );
+  const gapTotal = Math.max(0, visibleColumns.length - 1) * MISSION_COLUMN_GAP;
+  const columnWidth = Math.min(
+    MISSION_MAX_COLUMN_WIDTH,
+    Math.max(1, Math.floor((safeWidth - gapTotal) / Math.max(1, visibleColumns.length))),
+  );
+  const cardHeight = missionCardHeight(model.density);
+  const availableRows = boardRows(safeHeight);
+  const boardCapacity = boardItemCapacity(safeHeight, model.density);
+  const columns: MissionColumnLayout[] = [];
+  let x = 0;
+  for (const column of visibleColumns) {
+    const cards = snapshot?.board.columns[column] ?? [];
+    const start = Math.max(0, model.columnScroll[column]);
+    const visibleCards = cards.slice(start, start + boardCapacity);
+    columns.push({
+      column,
+      label: MISSION_COLUMN_LABELS[column],
+      x,
+      width: columnWidth,
+      count: snapshot?.board.counts[column] ?? 0,
+      scroll: start,
+      cards: visibleCards.map((card, visibleIndex) => ({
+        missionId: card.id,
+        column,
+        index: start + visibleIndex,
+        hoverKey: missionCardHoverKey(column, start + visibleIndex),
+        x,
+        y: MISSION_HEADER_ROWS + 1 + visibleIndex * cardHeight,
+        width: columnWidth,
+        height: cardHeight,
+        lines: missionCardLines(card, model.density, columnWidth),
+      })),
+    });
+    x += columnWidth + MISSION_COLUMN_GAP;
+  }
+  const historyAvailableRows = historyRows(safeHeight);
+  const historyStart = Math.max(0, model.historyScroll);
+  const rowHeight = missionHistoryRowHeight(model.density);
+  const historyCapacity = historyItemCapacity(safeHeight, model.density);
+  const header = missionHeaderLayout(safeWidth, model, snapshot, presentation);
+  return {
+    width: safeWidth,
+    height: safeHeight,
+    mode: model.mode,
+    header,
+    footer: {
+      label: missionFooterLabel(safeWidth, presentation.quitHint),
+      width: safeWidth,
+    },
+    board: { availableRows, itemCapacity: boardCapacity, columnWidth, visibleColumns, columns },
+    history: {
+      availableRows: historyAvailableRows,
+      itemCapacity: historyCapacity,
+      rows: (snapshot?.history ?? [])
+        .slice(historyStart, historyStart + historyCapacity)
+        .map((entry, visibleIndex) => ({
+          missionId: entry.mission.id,
+          index: historyStart + visibleIndex,
+          hoverKey: historyStart + visibleIndex,
+          x: 0,
+          y: MISSION_HEADER_ROWS + visibleIndex * rowHeight,
+          width: safeWidth,
+          height: rowHeight,
+          lines: missionHistoryLines(entry, model.density, safeWidth),
+        })),
+    },
+  };
+}
+
+export function missionWorkspaceHitTest(
+  layout: MissionWorkspaceLayout,
+  x: number,
+  y: number,
+): MissionWorkspaceHit {
+  if (y === 0) {
+    const hit = missionHeaderHit(layout.header, x, y);
+    if (hit) return hit;
+  } else if (y === 1) {
+    const hit = missionHeaderHit(layout.header, x, y);
+    if (hit) return hit;
+  }
+  if (layout.mode === "board") {
+    for (const column of layout.board.columns) {
+      if (y === MISSION_HEADER_ROWS && x >= column.x && x < column.x + column.width)
+        return { kind: "column", column: column.column };
+      for (const card of column.cards) {
+        if (x >= card.x && x < card.x + card.width && y >= card.y && y < card.y + card.height) {
+          return {
+            kind: "card",
+            missionId: card.missionId,
+            column: card.column,
+            index: card.index,
+            hoverKey: card.hoverKey,
+          };
+        }
+      }
+    }
+    return null;
+  }
+  for (const row of layout.history.rows) {
+    if (x >= row.x && x < row.x + row.width && y >= row.y && y < row.y + row.height) {
+      return {
+        kind: "history",
+        missionId: row.missionId,
+        index: row.index,
+        hoverKey: row.hoverKey,
+      };
+    }
+  }
+  return null;
+}
+
+export function missionCardLines(
+  card: MissionCardView,
+  density: MissionWorkspaceDensity,
+  width: number,
+): string[] {
+  const progress =
+    card.progress.total > 0 ? `${card.progress.done}/${card.progress.total}` : "no tasks";
+  const lines = [card.title, `${card.status} · ${progress}`];
+  if (density !== "compact") {
+    if (card.blockedBy.length > 0) lines.push(`blocked by ${card.blockedBy.length}`);
+    if (card.latestAttempt)
+      lines.push(`attempt ${card.latestAttempt.agent}/${card.latestAttempt.harness}`);
+    const proof = proofSignal(card.proofSummary);
+    if (proof) lines.push(proof);
+  }
+  if (density === "detailed") {
+    if (card.durationMs !== null) lines.push(`duration ${formatDuration(card.durationMs)}`);
+    if (card.labels.length > 0) lines.push(`# ${card.labels.join(", ")}`);
+  }
+  return lines.slice(0, missionCardHeight(density)).map((line) => clipTerminal(line, width));
+}
+
+export function missionHistoryLines(
+  entry: MissionHistorySummary,
+  density: MissionWorkspaceDensity,
+  width: number,
+): string[] {
+  const lines = [
+    `${entry.outcome} · ${entry.mission.title}`,
+    `finished ${entry.finishedAt} · ${entry.taskTotals.done}/${entry.taskTotals.total} tasks · ${formatDuration(entry.durationMs)}`,
+  ];
+  if (density !== "compact") {
+    lines.push(
+      `attempts ${attemptSignals(entry)}${entry.lastEvent ? ` · ${entry.lastEvent.label}` : ""}`,
+    );
+    const proof = proofSignal(entry.proofSummary);
+    if (proof) lines.push(proof);
+  }
+  if (density === "detailed") lines.push(`mission ${entry.mission.id}`);
+  return lines.slice(0, missionHistoryRowHeight(density)).map((line) => clipTerminal(line, width));
+}
+
+export function missionModeLabel(mode: MissionWorkspaceMode, active: boolean): string {
+  return active ? `[${mode}]` : ` ${mode} `;
+}
+
+export function densityLabel(density: MissionWorkspaceDensity): string {
+  return `z ${density}`;
+}
+
+export function missionSelectionFromWorkspaceState(
+  state: WorkspaceUiStateV1,
+  viewId: string,
+): string | null {
+  return missionsSelection(state, viewId).selectedMissionId;
+}
+
+export function workspaceStateWithMissionSelection(
+  state: WorkspaceUiStateV1,
+  viewId: string,
+  missionId: string | null,
+): WorkspaceUiStateV1 {
+  return setMissionsSelection(state, viewId, missionId, null);
+}
+
+export function clipTerminal(text: string, width: number): string {
+  if (width <= 0) return "";
+  if (terminalDisplayWidth(text) <= width) return text;
+  const ellipsis = "…";
+  const limit = Math.max(0, width - terminalDisplayWidth(ellipsis));
+  let out = "";
+  let used = 0;
+  for (const segment of graphemes(text)) {
+    const segmentWidth = terminalDisplayWidth(segment);
+    if (used + segmentWidth > limit) break;
+    out += segment;
+    used += segmentWidth;
+  }
+  return out + ellipsis;
+}
+
+function missionErrorMessage(error: unknown): string {
+  if (error instanceof MissionRepositoryError || error instanceof MissionProjectionError) {
+    return error.message;
+  }
+  if (error instanceof Error) return error.message;
+  return "mission data could not be loaded";
+}
+
+function detached<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function emptyScrolls(): Record<MissionBoardColumn, number> {
+  return { planned: 0, running: 0, blocked: 0, review: 0, done: 0 };
+}
+
+function cloneModel(model: MissionWorkspaceModel): MissionWorkspaceModel {
+  return { ...model, columnScroll: { ...model.columnScroll } };
+}
+
+function findMissionInBoard(board: MissionBoardView, missionId: string | null | undefined) {
+  if (!missionId) return null;
+  for (const column of MISSION_BOARD_COLUMNS) {
+    const index = board.columns[column].findIndex((card) => card.id === missionId);
+    if (index >= 0) return { id: missionId, column, index };
+  }
+  return null;
+}
+
+function firstBoardMission(board: MissionBoardView) {
+  for (const column of MISSION_BOARD_COLUMNS) {
+    const card = board.columns[column][0];
+    if (card) return { id: card.id, column, index: 0 };
+  }
+  return null;
+}
+
+function selectHistoryMission(
+  history: readonly MissionHistorySummary[],
+  missionId: string | null | undefined,
+): string | null {
+  if (missionId && history.some((entry) => entry.mission.id === missionId)) return missionId;
+  return history[0]?.mission.id ?? null;
+}
+
+function nearestNonEmptyColumn(
+  board: MissionBoardView,
+  from: MissionBoardColumn,
+  direction: -1 | 1,
+): MissionBoardColumn | null {
+  for (
+    let index = columnIndex(from) + direction;
+    index >= 0 && index < MISSION_BOARD_COLUMNS.length;
+    index += direction
+  ) {
+    const column = MISSION_BOARD_COLUMNS[index]!;
+    if (board.columns[column].length > 0) return column;
+  }
+  return null;
+}
+
+function columnIndex(column: MissionBoardColumn): number {
+  return MISSION_BOARD_COLUMNS.indexOf(column);
+}
+
+function missionCardHoverKey(column: MissionBoardColumn, index: number): number {
+  return index * MISSION_BOARD_COLUMNS.length + columnIndex(column);
+}
+
+function visibleColumnCount(width: number | undefined): number {
+  const safeWidth = Math.max(1, width ?? 120);
+  const max = Math.floor(
+    (safeWidth + MISSION_COLUMN_GAP) / (MISSION_MIN_COLUMN_WIDTH + MISSION_COLUMN_GAP),
+  );
+  return Math.max(1, Math.min(MISSION_BOARD_COLUMNS.length, max));
+}
+
+function followColumnOffset(index: number, offset: number, count: number): number {
+  if (index < offset) return index;
+  if (index >= offset + count) return index - count + 1;
+  return offset;
+}
+
+function boardRows(height: number | undefined): number {
+  return Math.max(0, (height ?? 24) - MISSION_HEADER_ROWS - 1 - MISSION_FOOTER_ROWS);
+}
+
+function historyRows(height: number | undefined): number {
+  return Math.max(0, (height ?? 24) - MISSION_HEADER_ROWS - MISSION_FOOTER_ROWS);
+}
+
+function boardItemCapacity(height: number | undefined, density: MissionWorkspaceDensity): number {
+  return Math.max(0, Math.floor(boardRows(height) / missionCardHeight(density)));
+}
+
+function historyItemCapacity(height: number | undefined, density: MissionWorkspaceDensity): number {
+  return Math.max(0, Math.floor(historyRows(height) / missionHistoryRowHeight(density)));
+}
+
+function clampTop(top: number, total: number, rows: number): number {
+  return Math.max(0, Math.min(Math.max(0, total - Math.max(1, rows)), top));
+}
+
+function scrollToIndex(index: number, top: number, rows: number): number {
+  if (index < top) return index;
+  if (index >= top + rows) return Math.max(0, index - rows + 1);
+  return top;
+}
+
+function missionCardHeight(density: MissionWorkspaceDensity): number {
+  if (density === "compact") return 2;
+  if (density === "comfortable") return 4;
+  return 6;
+}
+
+function missionHistoryRowHeight(density: MissionWorkspaceDensity): number {
+  if (density === "compact") return 2;
+  if (density === "comfortable") return 4;
+  return 5;
+}
+
+function missionHeaderLayout(
+  width: number,
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history"> | null,
+  presentation: MissionWorkspacePresentationOptions,
+): MissionHeaderLayout {
+  const firstRow: MissionHeaderChip[] = [];
+  let cursor = 0;
+  let firstLabel = "";
+  const addFirst = (
+    chip: Omit<MissionHeaderChip, "row" | "start" | "width">,
+  ): MissionHeaderChip | null => {
+    const label = clipTerminal(chip.label, Math.max(0, width - cursor));
+    const chipWidth = terminalDisplayWidth(label);
+    if (chipWidth <= 0 || cursor + chipWidth > width) return null;
+    const placed = { ...chip, label, row: 0, start: cursor, width: chipWidth };
+    firstRow.push(placed);
+    firstLabel = `${firstLabel}${firstLabel ? " " : ""}${label}`;
+    cursor += chipWidth + 1;
+    return placed;
+  };
+  addFirst({
+    kind: "mode",
+    mode: "board",
+    label: missionModeLabel("board", model.mode === "board"),
+  });
+  addFirst({
+    kind: "mode",
+    mode: "history",
+    label: missionModeLabel("history", model.mode === "history"),
+  });
+  addFirst({ kind: "density", label: densityLabel(model.density) });
+  addFirst({ kind: "refresh", label: "r refresh" });
+
+  const secondRow: MissionHeaderChip[] = [];
+  const left = "<";
+  const right = ">";
+  if (width >= 1) {
+    secondRow.push({ kind: "horizontal", direction: -1, label: left, row: 1, start: 0, width: 1 });
+  }
+  if (width >= 2) {
+    secondRow.push({
+      kind: "horizontal",
+      direction: 1,
+      label: right,
+      row: 1,
+      start: width - 1,
+      width: 1,
+    });
+  }
+  const secondLabel = missionSecondHeaderLabel(width, snapshot, presentation);
+  return { rows: [firstRow, secondRow], labels: [clipTerminal(firstLabel, width), secondLabel] };
+}
+
+function missionSecondHeaderLabel(
+  width: number,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history"> | null,
+  presentation: MissionWorkspacePresentationOptions,
+): string {
+  if (width <= 0) return "";
+  if (width === 1) return "<";
+  const status = missionLoadStatusLabel(presentation);
+  const project = presentation.projectLabel
+    ? ` · ${projectBasename(presentation.projectLabel)}`
+    : "";
+  const summary = snapshot
+    ? `${status}${project} · ${snapshot.board.counts.total} total · ${snapshot.history.length} finished`
+    : `${status}${project}`;
+  return `<${fitTerminal(` ${summary} `, Math.max(0, width - 2))}>`;
+}
+
+function missionFooterLabel(width: number, quitHint: string | null | undefined): string {
+  const quit = quitHint?.trim() || "^q quit";
+  return fitTerminal(
+    `${quit} · tab mode · arrows move · z density · r refresh · enter details next`,
+    width,
+  );
+}
+
+function fitTerminal(text: string, width: number): string {
+  if (width <= 0) return "";
+  const clipped = clipTerminal(text, width);
+  return `${clipped}${" ".repeat(Math.max(0, width - terminalDisplayWidth(clipped)))}`;
+}
+
+function missionLoadStatusLabel(presentation: MissionWorkspacePresentationOptions): string {
+  if (presentation.loadStatus === "refreshing") return "refreshing";
+  if (presentation.loadStatus === "loading") return "loading";
+  if (presentation.loadStatus === "error") return presentation.errorMessage ?? "error";
+  if (presentation.loadStatus === "empty") return "empty";
+  return "ready";
+}
+
+function projectBasename(projectLabel: string): string {
+  const trimmed = projectLabel.replace(/[\\/]+$/u, "");
+  const parts = trimmed.split(/[\\/]/u).filter(Boolean);
+  return parts.at(-1) ?? trimmed;
+}
+
+function missionHeaderHit(header: MissionHeaderLayout, x: number, y: number): MissionWorkspaceHit {
+  const row = header.rows[y];
+  if (!row) return null;
+  for (const chip of row) {
+    if (x < chip.start || x >= chip.start + chip.width) continue;
+    if (chip.kind === "mode" && chip.mode) return { kind: "mode", mode: chip.mode };
+    if (chip.kind === "density") return { kind: "density" };
+    if (chip.kind === "refresh") return { kind: "refresh" };
+    if (chip.kind === "horizontal" && chip.direction) {
+      return { kind: "horizontal", direction: chip.direction };
+    }
+  }
+  return null;
+}
+
+function proofSignal(proof: MissionCardView["proofSummary"]): string | null {
+  const parts: string[] = [];
+  if (proof.tests.total > 0) parts.push(`tests ${proof.tests.passed}/${proof.tests.total}`);
+  if (proof.diff.filesChanged > 0) parts.push(`diff ${proof.diff.filesChanged}`);
+  if (proof.prs.length > 0)
+    parts.push(`PR ${proof.prs.map((pr) => pr.number ?? pr.status ?? "link").join(",")}`);
+  if (proof.hasProof && parts.length === 0) parts.push(`${proof.proofIds.length} proof`);
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+function attemptSignals(entry: MissionHistorySummary): string {
+  const totals = entry.attemptTotals;
+  const parts = [
+    totals.submitted > 0 ? `${totals.submitted} submitted` : "",
+    totals.approved > 0 ? `${totals.approved} approved` : "",
+    totals.rejected > 0 ? `${totals.rejected} rejected` : "",
+    totals.failed > 0 ? `${totals.failed} failed` : "",
+    totals.interrupted > 0 ? `${totals.interrupted} interrupted` : "",
+    totals.running > 0 ? `${totals.running} running` : "",
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(", ") : `${totals.total} total`;
+}
+
+function formatDuration(durationMs: number | null): string {
+  if (durationMs === null) return "n/a";
+  const seconds = Math.floor(durationMs / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+function graphemes(text: string): string[] {
+  const Segmenter = Intl.Segmenter;
+  if (Segmenter)
+    return [...new Segmenter(undefined, { granularity: "grapheme" }).segment(text)].map(
+      (entry) => entry.segment,
+    );
+  return [...text];
+}

--- a/packages/daemon/src/tui/mirror/panel-host.test.ts
+++ b/packages/daemon/src/tui/mirror/panel-host.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import type { WorkspaceConfigV1, WorkspaceFullPanelView } from "@tmux-ide/contracts";
 import {
   CANONICAL_PANEL_VIEWS,
-  MISSIONS_PLACEHOLDER_LINES,
   PanelHostLoadGeneration,
   buildHostedPanelViews,
   findFirstHostedViewForPanel,
@@ -382,11 +381,8 @@ describe("panel-host", () => {
     });
   });
 
-  it("keeps Missions as an honest placeholder surface until C10", () => {
-    expect(MISSIONS_PLACEHOLDER_LINES.join("\n")).toContain(
-      "interactive Missions board arrives in C10",
-    );
-    expect(MISSIONS_PLACEHOLDER_LINES.join("\n")).toContain("does not start harnesses");
+  it("keeps Missions first-class but inert to hidden terminal panes", () => {
+    expect(panelMode("missions")).toBe("missions");
     expect(isHostedPanelInert("missions")).toBe(true);
     expect(isHostedPanelInert("terminals")).toBe(false);
   });

--- a/packages/daemon/src/tui/mirror/panel-host.ts
+++ b/packages/daemon/src/tui/mirror/panel-host.ts
@@ -74,12 +74,6 @@ export const CANONICAL_PANEL_VIEWS: readonly WorkspaceFullPanelView[] = [
   { id: "missions", title: "Missions", panel: "missions" },
 ];
 
-export const MISSIONS_PLACEHOLDER_LINES = [
-  "Mission workspace view",
-  "Mission state, proof history, board, and timeline projections are ready.",
-  "The interactive Missions board arrives in C10; this placeholder does not start harnesses or read mission runtime data.",
-] as const;
-
 export const HOSTED_VIEW_SHORTCUT_KEYS = [
   "f1",
   "f2",


### PR DESCRIPTION
## Summary
- replace the Missions placeholder with a responsive five-column board and completed/failed run history
- derive read-only UI snapshots from one coherent durable mission repository read and deterministic projections
- add keyboard/mouse navigation, density and scroll controls, bounded refreshes, stale-load suppression, and per-view persisted mission selection
- keep exact two-row header/one-row footer geometry across narrow and wide terminals with project/load/count context

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm check` (1,773 daemon tests; 41 contract tests; lint, format, typecheck, docs, pack, native deps)
- `pnpm build:tui`
- `git diff --check`
- live isolated tmux smoke at 80x24 and 140x40 with all board columns, completed/failed history, persisted mission selection, and Ctrl+Q isolation

Sfora: #119 / C10