### PR TITLE
feat(tui): add mission details and safe deep links

### DIFF
--- a/packages/contracts/src/__tests__/missions.test.ts
+++ b/packages/contracts/src/__tests__/missions.test.ts
@@ -13,6 +13,7 @@ import {
   MissionTaskSchemaZ,
   MissionTaskIdSchemaZ,
   MissionTaskStatusSchemaZ,
+  MissionTerminalReferenceSchemaZ,
 } from "../domain.ts";
 
 const actor = { type: "user" as const, id: "pm" };
@@ -52,7 +53,7 @@ describe("mission domain contracts", () => {
         agent: "worker.profile",
         harness: "generic-harness",
         model: "opaque/model-ref",
-        terminal: "term_1",
+        terminal: "%7",
         session: "session_1",
         worktree: "worktrees/task",
         actor,
@@ -86,6 +87,13 @@ describe("mission domain contracts", () => {
     expect(MissionTaskIdSchemaZ.safeParse("task-1").success).toBe(false);
     expect(MissionAttemptIdSchemaZ.safeParse("att space").success).toBe(false);
     expect(MissionReferenceIdSchemaZ.safeParse("../profile").success).toBe(false);
+    expect(MissionReferenceIdSchemaZ.safeParse("%7").success).toBe(false);
+    expect(MissionTerminalReferenceSchemaZ.safeParse("%7").success).toBe(true);
+    expect(MissionTerminalReferenceSchemaZ.safeParse("term_1").success).toBe(true);
+    for (const value of ["%", "%-1", "%abc", "%7 bad", "%7;send-keys", "%7\n"]) {
+      expect(MissionTerminalReferenceSchemaZ.safeParse(value).success).toBe(false);
+    }
+    expect(MissionTerminalReferenceSchemaZ.safeParse(`%${"7".repeat(21)}`).success).toBe(false);
     expect(MissionStatusSchemaZ.safeParse("dispatching").success).toBe(false);
     expect(MissionTaskStatusSchemaZ.safeParse("updated").success).toBe(false);
     expect(MissionActorSchemaZ.safeParse({ type: "claude" }).success).toBe(false);

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -5,6 +5,7 @@ const TaskIdPattern = /^tsk_[A-Za-z0-9][A-Za-z0-9_-]{0,96}$/u;
 const AttemptIdPattern = /^att_[A-Za-z0-9][A-Za-z0-9_-]{0,96}$/u;
 const ProofIdPattern = /^prf_[A-Za-z0-9][A-Za-z0-9_-]{0,96}$/u;
 const ReferenceIdPattern = /^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,127}$/u;
+const TmuxPaneIdPattern = /^%[0-9]{1,20}$/u;
 const TimestampSchemaZ = z.string().refine(
   (value) => {
     try {
@@ -42,6 +43,11 @@ export const MissionTaskIdSchemaZ = z.string().regex(TaskIdPattern);
 export const MissionAttemptIdSchemaZ = z.string().regex(AttemptIdPattern);
 export const MissionProofIdSchemaZ = z.string().regex(ProofIdPattern);
 export const MissionReferenceIdSchemaZ = z.string().regex(ReferenceIdPattern);
+export const MissionTerminalReferenceSchemaZ = z
+  .string()
+  .refine((value) => ReferenceIdPattern.test(value) || TmuxPaneIdPattern.test(value), {
+    message: "must be a mission reference id or canonical tmux pane id",
+  });
 
 export const MissionActorSchemaZ = z.strictObject({
   type: z.enum(["user", "system", "agent", "service"]),
@@ -270,7 +276,7 @@ const MissionEventSchemas = [
     agent: MissionReferenceIdSchemaZ,
     harness: MissionReferenceIdSchemaZ,
     model: MissionReferenceIdSchemaZ.optional(),
-    terminal: MissionReferenceIdSchemaZ.optional(),
+    terminal: MissionTerminalReferenceSchemaZ.optional(),
     session: MissionReferenceIdSchemaZ.optional(),
     worktree: z.string().min(1).optional(),
   }),
@@ -324,7 +330,7 @@ export const MissionAttemptSchemaZ = z.strictObject({
   agent: MissionReferenceIdSchemaZ,
   harness: MissionReferenceIdSchemaZ,
   model: MissionReferenceIdSchemaZ.optional(),
-  terminal: MissionReferenceIdSchemaZ.optional(),
+  terminal: MissionTerminalReferenceSchemaZ.optional(),
   session: MissionReferenceIdSchemaZ.optional(),
   worktree: z.string().min(1).optional(),
   status: MissionAttemptStatusSchemaZ,
@@ -471,6 +477,8 @@ export type MissionId = z.infer<typeof MissionIdSchemaZ>;
 export type MissionTaskId = z.infer<typeof MissionTaskIdSchemaZ>;
 export type MissionAttemptId = z.infer<typeof MissionAttemptIdSchemaZ>;
 export type MissionProofId = z.infer<typeof MissionProofIdSchemaZ>;
+export type MissionReferenceId = z.infer<typeof MissionReferenceIdSchemaZ>;
+export type MissionTerminalReference = z.infer<typeof MissionTerminalReferenceSchemaZ>;
 export type MissionActor = z.infer<typeof MissionActorSchemaZ>;
 export type MissionSource = z.infer<typeof MissionSourceSchemaZ>;
 export type MissionStatus = z.infer<typeof MissionStatusSchemaZ>;

--- a/packages/contracts/src/mission-projections.ts
+++ b/packages/contracts/src/mission-projections.ts
@@ -9,6 +9,7 @@ import {
   MissionStatusSchemaZ,
   MissionTaskIdSchemaZ,
   MissionTaskStatusSchemaZ,
+  MissionTerminalReferenceSchemaZ,
 } from "./domain.ts";
 
 const TimestampSchemaZ = z.string().refine(
@@ -102,7 +103,7 @@ export const MissionAttemptSummarySchemaZ = z.strictObject({
   agent: MissionReferenceIdSchemaZ,
   harness: MissionReferenceIdSchemaZ,
   model: MissionReferenceIdSchemaZ.optional(),
-  terminal: MissionReferenceIdSchemaZ.optional(),
+  terminal: MissionTerminalReferenceSchemaZ.optional(),
   session: MissionReferenceIdSchemaZ.optional(),
   worktree: z.string().min(1).optional(),
   startedAt: TimestampSchemaZ,
@@ -136,7 +137,7 @@ export const TaskCardViewSchemaZ = z.strictObject({
     taskId: MissionTaskIdSchemaZ,
     attemptIds: UniqueStringArraySchemaZ(MissionAttemptIdSchemaZ),
     proofIds: UniqueStringArraySchemaZ(MissionProofIdSchemaZ),
-    terminal: MissionReferenceIdSchemaZ.optional(),
+    terminal: MissionTerminalReferenceSchemaZ.optional(),
     session: MissionReferenceIdSchemaZ.optional(),
     worktree: z.string().min(1).optional(),
   }),
@@ -203,7 +204,7 @@ export const MissionTimelineEntrySchemaZ = z.strictObject({
     taskId: MissionTaskIdSchemaZ.optional(),
     attemptId: MissionAttemptIdSchemaZ.optional(),
     proofId: MissionProofIdSchemaZ.optional(),
-    terminal: MissionReferenceIdSchemaZ.optional(),
+    terminal: MissionTerminalReferenceSchemaZ.optional(),
     session: MissionReferenceIdSchemaZ.optional(),
     worktree: z.string().min(1).optional(),
   }),

--- a/packages/daemon/src/lib/__tests__/mission-projections.test.ts
+++ b/packages/daemon/src/lib/__tests__/mission-projections.test.ts
@@ -111,7 +111,7 @@ function richHistory(): MissionHistoryEntry[] {
       agent: "agent/a",
       harness: "generic",
       model: "model/a",
-      terminal: "term-1",
+      terminal: "%7",
       session: "session-1",
       worktree: "worktrees/setup",
       actor,
@@ -220,7 +220,7 @@ function richHistory(): MissionHistoryEntry[] {
       attemptId: "att_finish",
       agent: "agent/a",
       harness: "generic",
-      terminal: "term-2",
+      terminal: "%25",
       session: "session-1",
       worktree: "worktrees/finish",
       actor,
@@ -550,7 +550,7 @@ describe("mission detail, proofs, and timeline projections", () => {
     expect(timeline).toHaveLength(26);
     expect(timeline[0]).toMatchObject({ sequence: 1, label: "Mission created", actor });
     expect(timeline.find((item) => item.attemptId === "att_setup")).toMatchObject({
-      refs: { terminal: "term-1", session: "session-1", worktree: "worktrees/setup" },
+      refs: { terminal: "%7", session: "session-1", worktree: "worktrees/setup" },
     });
     for (const item of timeline) expect(MissionTimelineEntrySchemaZ.parse(item)).toEqual(item);
   });

--- a/packages/daemon/src/lib/__tests__/mission-repository.test.ts
+++ b/packages/daemon/src/lib/__tests__/mission-repository.test.ts
@@ -255,6 +255,32 @@ describe("MissionRepository replay and persistence", () => {
     expect(snapshot.state.missions.mis_single?.title).toBe("Single");
   });
 
+  it("round-trips canonical tmux pane IDs in attempt terminal refs", () => {
+    const { missions } = repository();
+    missions.create({ id: "mis_tmux", title: "Tmux", objective: "tmux pane ids", actor });
+    missions.planMission("mis_tmux", actor);
+    missions.startMission("mis_tmux", actor);
+    missions.addTask({ id: "tsk_tmux", missionId: "mis_tmux", title: "Use pane", actor });
+    missions.readyTask("mis_tmux", "tsk_tmux", actor);
+    missions.claimTask("mis_tmux", "tsk_tmux", "worker", actor);
+    missions.startTask("mis_tmux", "tsk_tmux", actor);
+    missions.startAttempt({
+      id: "att_tmux",
+      missionId: "mis_tmux",
+      taskId: "tsk_tmux",
+      agent: "worker",
+      harness: "generic",
+      terminal: "%7",
+      session: "session_1",
+      actor,
+    });
+
+    expect(missions.state().missions.mis_tmux?.attempts.att_tmux?.terminal).toBe("%7");
+    expect(
+      missions.history().find((entry) => entry.event.type === "attempt.started")?.event,
+    ).toMatchObject({ terminal: "%7" });
+  });
+
   it("reopens with byte-equivalent logical state and keeps multiple missions isolated", () => {
     const home = temporaryRoot("tmux-ide-home-");
     const project = temporaryRoot("tmux-ide-project-");

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -343,19 +343,28 @@ import {
 import {
   MissionWorkspaceLoader,
   applyMissionWorkspaceHit,
+  closeMissionDetail,
   clipTerminal,
   cycleMissionDensity,
+  cycleMissionDetailSection,
   defaultMissionWorkspaceModel,
   invalidatedMissionWorkspaceLoadState,
   missionSelectionFromWorkspaceState,
+  missionTmuxPanePreflightMatches,
+  missionTmuxPreflightCommands,
   missionWorkspaceHitTest,
   missionWorkspaceLayout,
   moveMissionSelection,
+  openMissionDetail,
   readMissionWorkspace,
   reconcileMissionWorkspaceModel,
+  resolveMissionDeepLink,
   scrollMissionWorkspace,
+  setMissionDetailSection,
   setMissionWorkspaceMode,
   workspaceStateWithMissionSelection,
+  type MissionDeepLinkKind,
+  type MissionDeepLinkResolution,
   type MissionWorkspaceLoadState,
   type MissionWorkspaceModel,
   type MissionWorkspaceSnapshot,
@@ -1094,19 +1103,28 @@ try {
       width: canvasCols(),
       height: Math.max(4, dims().height - TABBAR_H),
     });
-    const persistMissionSelection = (missionId: string | null) => {
+    const persistMissionSelection = (missionId: string | null, taskId: string | null = null) => {
       const view = activeView();
       if (view.panel !== "missions") return;
       touchedWorkspaceViewIds.add(view.id);
-      setWorkspaceUiState((state) => workspaceStateWithMissionSelection(state, view.id, missionId));
+      setWorkspaceUiState((state) =>
+        workspaceStateWithMissionSelection(state, view.id, missionId, taskId),
+      );
     };
     const updateMissionModel = (
       updater: (model: MissionWorkspaceModel) => MissionWorkspaceModel,
     ) => {
       setMissionWorkspaceModel((current) => {
-        const next = updater(current);
-        if (next.selectedMissionId !== current.selectedMissionId)
-          persistMissionSelection(next.selectedMissionId);
+        const updated = updater(current);
+        const next =
+          updated.mode !== "detail" && updated.selectedMissionId !== current.selectedMissionId
+            ? { ...updated, selectedTaskId: null }
+            : updated;
+        if (
+          next.selectedMissionId !== current.selectedMissionId ||
+          next.selectedTaskId !== current.selectedTaskId
+        )
+          persistMissionSelection(next.selectedMissionId, next.selectedTaskId);
         return next;
       });
     };
@@ -1122,19 +1140,25 @@ try {
       const start = missionWorkspaceLoader.begin(repository.metadata.identityKey, priorSnapshot);
       setMissionWorkspaceLoad(start);
       const projectKey = repository.metadata.identityKey;
+      const persistedSelection = missionSelectionFromWorkspaceState(
+        workspaceUiState(),
+        activeViewId(),
+      );
+      const selectedForDetail =
+        missionWorkspaceModel().mode === "detail"
+          ? (missionWorkspaceModel().selectedMissionId ?? persistedSelection.selectedMissionId)
+          : null;
       currentMissionsLoadIdentity = projectKey;
       void Promise.resolve()
-        .then(() => readMissionWorkspace(repository))
+        .then(() => readMissionWorkspace(repository, selectedForDetail))
         .then((snapshot) => {
           const accepted = missionWorkspaceLoader.accept(start.generation, projectKey, snapshot);
           if (!accepted) return;
           setMissionWorkspaceSnapshot(snapshot);
           updateMissionModel((current) =>
             reconcileMissionWorkspaceModel(current, snapshot, {
-              persistedMissionId: missionSelectionFromWorkspaceState(
-                workspaceUiState(),
-                activeViewId(),
-              ),
+              persistedMissionId: persistedSelection.selectedMissionId,
+              persistedTaskId: persistedSelection.selectedTaskId,
               ...missionLayoutSize(),
             }),
           );
@@ -2479,12 +2503,12 @@ try {
         };
       }
       if (panel === "missions") {
+        const existing = missionSelectionFromWorkspaceState(workspaceUiState(), activeView().id);
         return {
           panel,
           selectedMissionId:
-            missionWorkspaceModel().selectedMissionId ??
-            missionSelectionFromWorkspaceState(workspaceUiState(), activeView().id),
-          selectedTaskId: null,
+            missionWorkspaceModel().selectedMissionId ?? existing.selectedMissionId,
+          selectedTaskId: missionWorkspaceModel().selectedTaskId ?? existing.selectedTaskId,
         };
       }
       return { panel };
@@ -2544,7 +2568,11 @@ try {
       } else if (entry.panel === "missions") {
         setMissionWorkspaceModel((current) =>
           reconcileMissionWorkspaceModel(
-            { ...current, selectedMissionId: entry.selectedMissionId },
+            {
+              ...current,
+              selectedMissionId: entry.selectedMissionId,
+              selectedTaskId: entry.selectedTaskId,
+            },
             missionWorkspaceSnapshot(),
             missionLayoutSize(),
           ),
@@ -2552,6 +2580,82 @@ try {
       }
     };
     const missionSnapshotForModel = () => missionWorkspaceSnapshot();
+    const missionDeepLink = (kind: MissionDeepLinkKind): MissionDeepLinkResolution =>
+      resolveMissionDeepLink(
+        kind,
+        missionWorkspaceSnapshot()?.detail ?? null,
+        missionWorkspaceModel(),
+        {
+          projectRoot: workspaceUiProjectRoot(),
+          views: hostedViews(),
+          resolveProjectPath: absoluteProjectPath,
+        },
+      );
+    const execFileChecked = (file: string, args: string[]): Promise<string> =>
+      new Promise((resolvePromise, rejectPromise) => {
+        execFile(file, args, (error, stdout) => {
+          if (error) rejectPromise(error);
+          else resolvePromise(stdout);
+        });
+      });
+    const followMissionDeepLink = (kind: MissionDeepLinkKind) => {
+      const resolved = missionDeepLink(kind);
+      if (!resolved.available) {
+        setStatusNote(resolved.reason);
+        return;
+      }
+      const intent = resolved.intent;
+      if (intent.kind === "terminal") {
+        const preflight = missionTmuxPreflightCommands(intent);
+        void execFileChecked(preflight[0]!.file, preflight[0]!.args)
+          .then(async () => {
+            const panePreflight = preflight.find((command) => command.kind === "pane");
+            if (panePreflight && intent.paneId) {
+              const output = await execFileChecked(panePreflight.file, panePreflight.args);
+              if (!missionTmuxPanePreflightMatches(output, intent.session, intent.paneId)) {
+                throw new Error("pane does not belong to target session");
+              }
+            }
+          })
+          .then(() => {
+            snapshotActiveWorkspaceView();
+            setCurTarget(intent.session);
+            selectView(intent.viewId);
+            attach(intent.session);
+            if (intent.paneId) {
+              execFile("tmux", ["select-pane", "-t", intent.paneId], (error) => {
+                if (error) setStatusNote(`pane unavailable: ${intent.paneId}`);
+              });
+            }
+          })
+          .catch(() => {
+            setStatusNote(
+              intent.paneId
+                ? `pane unavailable for session ${intent.session}: ${intent.paneId}`
+                : `session unavailable: ${intent.session}`,
+            );
+          });
+        return;
+      }
+      if (intent.kind === "files") {
+        void stat(intent.path)
+          .then((info) => {
+            snapshotActiveWorkspaceView();
+            selectView(intent.viewId);
+            if (info.isFile() && intent.mode === "open") openEditor(intent.path);
+            else void revealPath(intent.path);
+          })
+          .catch(() => setStatusNote(`file target unavailable: ${intent.path}`));
+        return;
+      }
+      void stat(intent.path)
+        .then((info) => {
+          snapshotActiveWorkspaceView();
+          selectView(intent.viewId);
+          prepareDiff(info.isDirectory() ? intent.path : dirname(intent.path));
+        })
+        .catch(() => setStatusNote(`diff target unavailable: ${intent.path}`));
+    };
     const handleMissionsKey = (evt: {
       name: string;
       ctrl: boolean;
@@ -2563,11 +2667,43 @@ try {
         loadMissionsWorkspace("refresh");
         return true;
       }
+      if (evt.name === "t" || evt.name === "f" || evt.name === "d") {
+        followMissionDeepLink(evt.name === "t" ? "terminal" : evt.name === "f" ? "files" : "diff");
+        return true;
+      }
       if (evt.name === "z") {
         updateMissionModel((model) => cycleMissionDensity(model, snapshot, missionLayoutSize()));
         return true;
       }
       if (!snapshot) return true;
+      if (missionWorkspaceModel().mode === "detail") {
+        if (evt.name === "escape" || evt.name === "backspace") {
+          updateMissionModel(closeMissionDetail);
+          return true;
+        }
+        if (evt.name === "tab") {
+          updateMissionModel((model) =>
+            cycleMissionDetailSection(model, snapshot, evt.shift ? -1 : 1, missionLayoutSize()),
+          );
+          return true;
+        }
+        const sectionKey =
+          evt.name === "1"
+            ? "tasks"
+            : evt.name === "2"
+              ? "timeline"
+              : evt.name === "3"
+                ? "attempts"
+                : evt.name === "4"
+                  ? "proof"
+                  : null;
+        if (sectionKey) {
+          updateMissionModel((model) =>
+            setMissionDetailSection(model, snapshot, sectionKey, missionLayoutSize()),
+          );
+          return true;
+        }
+      }
       if (evt.name === "tab") {
         updateMissionModel((model) =>
           setMissionWorkspaceMode(
@@ -2613,8 +2749,17 @@ try {
       if (evt.name === "return") {
         const selected = missionWorkspaceModel().selectedMissionId;
         if (selected) {
-          persistMissionSelection(selected);
-          setStatusNote("Mission details arrive next (C11)");
+          persistMissionSelection(selected, missionWorkspaceModel().selectedTaskId);
+          updateMissionModel((model) =>
+            openMissionDetail(model, snapshot, {
+              persistedTaskId: missionSelectionFromWorkspaceState(
+                workspaceUiState(),
+                activeViewId(),
+              ).selectedTaskId,
+              ...missionLayoutSize(),
+            }),
+          );
+          if (snapshot.detail?.mission.id !== selected) loadMissionsWorkspace("refresh");
         }
         return true;
       }
@@ -5781,6 +5926,26 @@ try {
           setHoverIf({ region: "missioncard", index: hit.hoverKey });
         } else if (hit?.kind === "history") {
           setHoverIf({ region: "missionhistory", index: hit.hoverKey });
+        } else if (hit?.kind === "detail-section") {
+          setHoverIf({
+            region: "missionbutton",
+            index:
+              10 +
+              (hit.section === "tasks"
+                ? 0
+                : hit.section === "timeline"
+                  ? 1
+                  : hit.section === "attempts"
+                    ? 2
+                    : 3),
+          });
+        } else if (hit?.kind === "deep-link") {
+          setHoverIf({
+            region: "missionbutton",
+            index: hit.link === "terminal" ? 20 : hit.link === "files" ? 21 : 22,
+          });
+        } else if (hit?.kind === "detail-row") {
+          setHoverIf({ region: "missionhistory", index: hit.hoverKey });
         } else {
           setHoverIf(null);
         }
@@ -5992,11 +6157,15 @@ try {
           if (direction !== "up" && direction !== "down") return;
           const delta = direction === "up" ? -SCROLL_STEP : SCROLL_STEP;
           const target =
-            hit?.kind === "card" || hit?.kind === "column"
-              ? hit.column
-              : missionWorkspaceModel().mode === "history"
-                ? "history"
-                : missionWorkspaceModel().selectedColumn;
+            hit?.kind === "detail-row"
+              ? hit.section
+              : missionWorkspaceModel().mode === "detail"
+                ? missionWorkspaceModel().detailSection
+                : hit?.kind === "card" || hit?.kind === "column"
+                  ? hit.column
+                  : missionWorkspaceModel().mode === "history"
+                    ? "history"
+                    : missionWorkspaceModel().selectedColumn;
           updateMissionModel((model) =>
             scrollMissionWorkspace(model, snapshot, target, delta, missionLayoutSize()),
           );
@@ -6040,10 +6209,22 @@ try {
           const hit = missionHitAt(x, y);
           if (hit?.kind === "refresh") {
             loadMissionsWorkspace("refresh");
+          } else if (hit?.kind === "deep-link") {
+            followMissionDeepLink(hit.link);
+          } else if (hit?.kind === "detail-section" && snapshot) {
+            updateMissionModel((model) =>
+              setMissionDetailSection(model, snapshot, hit.section, missionLayoutSize()),
+            );
           } else if (hit && snapshot) {
             updateMissionModel((model) =>
               applyMissionWorkspaceHit(model, snapshot, hit, missionLayoutSize()),
             );
+            if (hit.kind === "card" || hit.kind === "history") {
+              updateMissionModel((model) =>
+                openMissionDetail(model, snapshot, missionLayoutSize()),
+              );
+              loadMissionsWorkspace("refresh");
+            }
           }
         }
         return;
@@ -7439,6 +7620,107 @@ try {
                         );
                       }}
                     </For>
+                  </box>
+                </Show>
+                <Show when={missionWorkspaceModel().mode === "detail"}>
+                  <box flexDirection="column" flexGrow={1}>
+                    <box width={canvasCols()} flexDirection="row" gap={1}>
+                      <For each={missionsLayout().detail.sections}>
+                        {(chip) => (
+                          <text
+                            fg={DEFAULT_FG}
+                            bg={
+                              chip.section === missionWorkspaceModel().detailSection ||
+                              isHovered(
+                                "missionbutton",
+                                10 + missionsLayout().detail.sections.indexOf(chip),
+                              )
+                                ? BUTTON_ACTIVE_BG
+                                : BUTTON_BG
+                            }
+                          >
+                            {chip.label}
+                          </text>
+                        )}
+                      </For>
+                      <box flexGrow={1} />
+                      <For each={missionsLayout().detail.links}>
+                        {(chip) => {
+                          const resolved = chip.link ? missionDeepLink(chip.link) : null;
+                          return (
+                            <text
+                              fg={resolved?.available ? BUTTON_FG : MUTED}
+                              bg={
+                                chip.link &&
+                                isHovered(
+                                  "missionbutton",
+                                  20 + missionsLayout().detail.links.indexOf(chip),
+                                )
+                                  ? BUTTON_HOVER_BG
+                                  : BUTTON_BG
+                              }
+                            >
+                              {chip.label}
+                            </text>
+                          );
+                        }}
+                      </For>
+                    </box>
+                    <Show
+                      when={missionWorkspaceSnapshot()?.detail}
+                      fallback={
+                        <box flexDirection="column" flexGrow={1}>
+                          <text fg={DEFAULT_FG}>Loading mission detail…</text>
+                          <text fg={MUTED}>Press r to refresh if this does not resolve.</text>
+                        </box>
+                      }
+                    >
+                      <box flexDirection="row" flexGrow={1} gap={1}>
+                        <Show when={missionsLayout().detail.wide}>
+                          <box flexDirection="column" width={missionsLayout().detail.contextWidth}>
+                            <For each={missionsLayout().detail.contextRows}>
+                              {(row) => (
+                                <For each={row.lines}>
+                                  {(line, lineIndex) => (
+                                    <text fg={lineIndex() === 0 ? ACCENT : MUTED}>{line}</text>
+                                  )}
+                                </For>
+                              )}
+                            </For>
+                          </box>
+                        </Show>
+                        <box flexDirection="column" width={missionsLayout().detail.sectionWidth}>
+                          <For each={missionsLayout().detail.rows}>
+                            {(row) => {
+                              const selected =
+                                row.kind === "tasks" &&
+                                missionWorkspaceModel().selectedTaskId === row.id;
+                              return (
+                                <box
+                                  flexDirection="column"
+                                  height={row.height}
+                                  backgroundColor={
+                                    selected
+                                      ? BADGE_BG
+                                      : isHovered("missionhistory", row.hoverKey)
+                                        ? HOVER_BG
+                                        : DEFAULT_BG
+                                  }
+                                >
+                                  <For each={row.lines}>
+                                    {(line, lineIndex) => (
+                                      <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>
+                                        {line}
+                                      </text>
+                                    )}
+                                  </For>
+                                </box>
+                              );
+                            }}
+                          </For>
+                        </box>
+                      </box>
+                    </Show>
                   </box>
                 </Show>
               </Show>

--- a/packages/daemon/src/tui/mirror/missions-workspace.test.ts
+++ b/packages/daemon/src/tui/mirror/missions-workspace.test.ts
@@ -6,9 +6,11 @@ import type {
   MissionBoardColumn,
   MissionBoardView,
   MissionCardView,
+  MissionDetailView,
   MissionHistorySummary,
   MissionProgressSummary,
   MissionProofSummary,
+  TaskCardView,
 } from "@tmux-ide/contracts";
 import type { ProjectResolution } from "../../lib/project-resolver.ts";
 import { createProjectRuntimeRepository } from "../../lib/project-runtime-repository.ts";
@@ -21,21 +23,35 @@ import {
   applyMissionWorkspaceHit,
   clipTerminal,
   cycleMissionDensity,
+  closeMissionDetail,
   defaultMissionWorkspaceModel,
   invalidatedMissionWorkspaceLoadState,
   missionCardLines,
+  missionDetailAttemptLines,
+  missionDetailProofLines,
+  missionDetailTaskLines,
+  missionDetailTimelineLines,
   missionHistoryLines,
   missionSelectionFromWorkspaceState,
+  missionTmuxPanePreflightMatches,
+  missionTmuxPreflightCommands,
   missionWorkspaceHitTest,
   missionWorkspaceLayout,
   moveMissionSelection,
+  openMissionDetail,
   readMissionWorkspace,
   reconcileMissionWorkspaceModel,
+  resolveMissionDeepLink,
   scrollMissionWorkspace,
+  setMissionDetailSection,
   setMissionWorkspaceMode,
   workspaceStateWithMissionSelection,
 } from "./missions-workspace.ts";
-import { defaultWorkspaceUiState, serializeWorkspaceUiState } from "./workspace-ui-state.ts";
+import {
+  absoluteProjectPath,
+  defaultWorkspaceUiState,
+  serializeWorkspaceUiState,
+} from "./workspace-ui-state.ts";
 import { terminalDisplayWidth } from "./panel-host.ts";
 
 function progress(overrides: Partial<MissionProgressSummary> = {}): MissionProgressSummary {
@@ -169,10 +185,157 @@ function history(
   };
 }
 
-function snapshot(boardView = board({}), historyView: MissionHistorySummary[] = []) {
+function task(
+  id: string,
+  column: MissionBoardColumn,
+  overrides: Partial<TaskCardView> = {},
+): TaskCardView {
+  return {
+    version: 1,
+    id,
+    missionId: "mis_detail",
+    title: `Task ${id}`,
+    summary: `summary ${id}`,
+    status:
+      column === "planned"
+        ? "ready"
+        : column === "running"
+          ? "started"
+          : column === "blocked"
+            ? "blocked"
+            : column === "review"
+              ? "submitted"
+              : "completed",
+    column,
+    priority: 1,
+    dependencies: [],
+    blockedBy: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    durationMs: null,
+    latestAttempt: null,
+    proofSummary: proof(),
+    refs: { missionId: "mis_detail", taskId: id, attemptIds: [], proofIds: [] },
+    ...overrides,
+  };
+}
+
+function detail(overrides: Partial<MissionDetailView> = {}): MissionDetailView {
+  const setup = task("tsk_setup", "planned", {
+    latestAttempt: {
+      id: "att_setup",
+      taskId: "tsk_setup",
+      status: "approved",
+      outcome: "approved",
+      agent: "worker",
+      harness: "codex",
+      model: "gpt-5",
+      terminal: "%7",
+      session: "proj",
+      worktree: "apps/api",
+      startedAt: "2026-01-01T00:01:00.000Z",
+      updatedAt: "2026-01-01T00:02:00.000Z",
+      finishedAt: "2026-01-01T00:02:00.000Z",
+      durationMs: 60_000,
+      proofIds: ["prf_one"],
+    },
+    proofSummary: proof({
+      proofIds: ["prf_one"],
+      hasProof: true,
+      tests: { suites: 1, passed: 4, failed: 0, skipped: 0, total: 4 },
+      diff: {
+        summaries: ["apps/api/index.ts"],
+        urls: [],
+        filesChanged: 1,
+        insertions: 5,
+        deletions: 1,
+      },
+      artifacts: [{ name: "source", uri: "apps/api/index.ts" }],
+    }),
+    refs: {
+      missionId: "mis_detail",
+      taskId: "tsk_setup",
+      attemptIds: ["att_setup"],
+      proofIds: ["prf_one"],
+      terminal: "%7",
+      session: "proj",
+      worktree: "apps/api",
+    },
+  });
+  const finish = task("tsk_finish", "done", { priority: 2 });
+  return {
+    version: 1,
+    mission: card("mis_detail", "running", "Mission detail", {
+      latestAttempt: setup.latestAttempt,
+      progress: progress({ total: 2, running: 1, completed: 1, done: 1, planned: 0 }),
+      proofSummary: setup.proofSummary,
+      refs: {
+        missionId: "mis_detail",
+        taskIds: ["tsk_setup", "tsk_finish"],
+        attemptIds: ["att_setup"],
+        proofIds: ["prf_one"],
+      },
+    }),
+    taskBoard: {
+      columns: {
+        planned: [setup],
+        running: [],
+        blocked: [],
+        review: [],
+        done: [finish],
+      },
+      counts: { planned: 1, running: 0, blocked: 0, review: 0, done: 1, total: 2 },
+    },
+    attempts: [setup.latestAttempt!],
+    proofSummary: setup.proofSummary,
+    progress: progress({ total: 2, running: 1, completed: 1, done: 1, planned: 0 }),
+    timeline: [
+      {
+        version: 1,
+        sequence: 1,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        missionId: "mis_detail",
+        type: "mission.created",
+        label: "Mission created",
+        actor: { type: "user", id: "pm" },
+        refs: { missionId: "mis_detail" },
+      },
+      {
+        version: 1,
+        sequence: 2,
+        timestamp: "2026-01-01T00:01:00.000Z",
+        missionId: "mis_detail",
+        taskId: "tsk_setup",
+        attemptId: "att_setup",
+        proofId: "prf_one",
+        type: "attempt.approved",
+        label: "Attempt approved",
+        actor: { type: "agent", id: "worker" },
+        reason: "tests passed",
+        refs: {
+          missionId: "mis_detail",
+          taskId: "tsk_setup",
+          attemptId: "att_setup",
+          proofId: "prf_one",
+          terminal: "%7",
+          session: "proj",
+          worktree: "apps/api",
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function snapshot(
+  boardView = board({}),
+  historyView: MissionHistorySummary[] = [],
+  detailView: MissionDetailView | null = null,
+) {
   return {
     board: boardView,
     history: historyView,
+    detail: detailView,
     project: { identityKey: "git-abc", projectRoot: "/repo" },
     loadedAt: "2026-01-01T00:00:00.000Z",
   };
@@ -199,7 +362,11 @@ describe("missions workspace loader/model", () => {
       const repository = createProjectRuntimeRepository(resolution(root), {
         home: join(root, ".state"),
       });
-      const loaded = readMissionWorkspace(repository, () => new Date("2026-01-01T00:00:00.000Z"));
+      const loaded = readMissionWorkspace(
+        repository,
+        null,
+        () => new Date("2026-01-01T00:00:00.000Z"),
+      );
       expect(loaded.board.counts.total).toBe(0);
       expect(loaded.history).toEqual([]);
       expect(loaded.project.identityKey).toBe(repository.metadata.identityKey);
@@ -594,18 +761,503 @@ describe("missions workspace loader/model", () => {
       "missions-a",
       reconciled.selectedMissionId,
     );
-    expect(missionSelectionFromWorkspaceState(state, "missions-a")).toBe("mis_new");
+    expect(missionSelectionFromWorkspaceState(state, "missions-a")).toEqual({
+      selectedMissionId: "mis_new",
+      selectedTaskId: null,
+    });
   });
 
-  it("persists only selectedMissionId per exact missions view without projection blobs", () => {
+  it("opens detail from board/history and returns to the originating surface", () => {
+    const view = snapshot(
+      board({ running: [card("mis_detail", "running")] }),
+      [history("mis_done")],
+      detail(),
+    );
+    let model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_detail"), view);
+    model = openMissionDetail(model, view, { persistedTaskId: "tsk_setup" });
+    expect(model.mode).toBe("detail");
+    expect(model.detailReturnMode).toBe("board");
+    expect(model.selectedTaskId).toBe("tsk_setup");
+    expect(closeMissionDetail(model).mode).toBe("board");
+
+    model = setMissionWorkspaceMode(model, view, "history");
+    model = openMissionDetail(model, view);
+    expect(model.detailReturnMode).toBe("history");
+    expect(closeMissionDetail(model).mode).toBe("history");
+  });
+
+  it("keeps detail mode active while selected detail is loading for an existing mission", () => {
+    const boardOnly = snapshot(
+      board({
+        planned: [card("mis_other", "planned")],
+        running: [card("mis_detail", "running")],
+      }),
+    );
+    const model = openMissionDetail(defaultMissionWorkspaceModel("mis_detail"), boardOnly);
+    expect(model.mode).toBe("detail");
+    expect(model.selectedMissionId).toBe("mis_detail");
+    const loading = reconcileMissionWorkspaceModel(model, boardOnly, {
+      persistedMissionId: "mis_other",
+    });
+    expect(loading.mode).toBe("detail");
+    expect(loading.selectedMissionId).toBe("mis_detail");
+    const loaded = reconcileMissionWorkspaceModel(
+      loading,
+      snapshot(boardOnly.board, [], detail()),
+      { persistedMissionId: "mis_other" },
+    );
+    expect(loaded.mode).toBe("detail");
+    expect(loaded.selectedMissionId).toBe("mis_detail");
+    const missing = reconcileMissionWorkspaceModel(model, snapshot(board({})));
+    expect(missing.mode).toBe("board");
+  });
+
+  it("flattens task-board order, restores task by id, and falls back after removal", () => {
+    const view = snapshot(board({ running: [card("mis_detail", "running")] }), [], detail());
+    const restored = reconcileMissionWorkspaceModel(
+      { ...defaultMissionWorkspaceModel("mis_detail", "tsk_finish"), mode: "detail" },
+      view,
+    );
+    expect(restored.selectedTaskId).toBe("tsk_finish");
+    const shrunk = snapshot(
+      board({ running: [card("mis_detail", "running")] }),
+      [],
+      detail({
+        taskBoard: {
+          columns: {
+            planned: [task("tsk_only", "planned")],
+            running: [],
+            blocked: [],
+            review: [],
+            done: [],
+          },
+          counts: { planned: 1, running: 0, blocked: 0, review: 0, done: 0, total: 1 },
+        },
+      }),
+    );
+    const fallback = reconcileMissionWorkspaceModel(restored, shrunk);
+    expect(fallback.selectedTaskId).toBe("tsk_only");
+  });
+
+  it("renders bounded detail sections, hits section/rows/links, and clips Unicode safely", () => {
+    const view = snapshot(board({ running: [card("mis_detail", "running")] }), [], detail());
+    let model = openMissionDetail(defaultMissionWorkspaceModel("mis_detail"), view);
+    for (const width of [20, 56, 72, 120]) {
+      const layout = missionWorkspaceLayout(width, 10, model, view);
+      expect(layout.detail.rows.every((row) => row.x + row.width <= layout.width)).toBe(true);
+      expect(layout.detail.rows.every((row) => row.y + row.height <= layout.height - 1)).toBe(true);
+      expect(layout.detail.rows.some((row) => row.kind === "context")).toBe(width < 72);
+      expect(layout.detail.sections.map((chip) => chip.section)).toEqual([
+        "tasks",
+        "timeline",
+        "attempts",
+        "proof",
+      ]);
+      const chips = [...layout.detail.sections, ...layout.detail.links].sort(
+        (a, b) => a.start - b.start,
+      );
+      for (const [index, chip] of chips.entries()) {
+        expect(chip.start).toBeGreaterThanOrEqual(0);
+        expect(chip.start + chip.width).toBeLessThanOrEqual(layout.width);
+        const previous = chips[index - 1];
+        if (previous) expect(chip.start).toBeGreaterThanOrEqual(previous.start + previous.width);
+      }
+      for (const section of layout.detail.sections) {
+        expect(missionWorkspaceHitTest(layout, section.start, section.row)).toEqual({
+          kind: "detail-section",
+          section: section.section,
+        });
+      }
+      for (const link of layout.detail.links) {
+        expect(missionWorkspaceHitTest(layout, link.start, link.row)).toEqual({
+          kind: "deep-link",
+          link: link.link,
+        });
+      }
+      const row = layout.detail.rows[0]!;
+      const hit = missionWorkspaceHitTest(layout, row.x, row.y);
+      if (row.kind === "context") {
+        expect(hit).toBeNull();
+      } else {
+        expect(hit).toMatchObject({
+          kind: "detail-row",
+          section: "tasks",
+          id: "tsk_setup",
+        });
+      }
+      expect(row.lines.every((line) => terminalWidth(line) <= row.width)).toBe(true);
+    }
+    const lines = [
+      missionDetailTaskLines(view.detail!.taskBoard.columns.planned[0]!, "detailed", 80).join("\n"),
+      missionDetailTimelineLines(view.detail!.timeline[1]!, 80).join("\n"),
+      missionDetailAttemptLines(view.detail!.attempts[0]!, "detailed", 80).join("\n"),
+      missionDetailProofLines(view.detail!, "detailed", 80).join("\n"),
+    ].join("\n");
+    expect(lines).toContain("codex");
+    expect(lines).toContain("Attempt approved");
+    expect(lines).toContain("pane %7");
+    expect(lines).toContain("tests 4/4");
+    expect(missionDetailProofLines(view.detail!, "comfortable", 80)).toHaveLength(4);
+    expect(missionDetailProofLines(view.detail!, "detailed", 80)).toHaveLength(5);
+    expect(missionWorkspaceLayout(120, 24, model, view).footer.label).toContain("esc back");
+    expect(missionWorkspaceLayout(120, 24, model, view).footer.label).toContain("t/f/d open");
+  });
+
+  it("keeps narrow detail scroll and selected task visibility width-aware", () => {
+    const tasks = Array.from({ length: 6 }, (_, index) => task(`tsk_${index}`, "planned"));
+    const view = snapshot(
+      board({ running: [card("mis_detail", "running")] }),
+      [],
+      detail({
+        taskBoard: {
+          columns: { planned: tasks, running: [], blocked: [], review: [], done: [] },
+          counts: { planned: 6, running: 0, blocked: 0, review: 0, done: 0, total: 6 },
+        },
+      }),
+    );
+    let model = reconcileMissionWorkspaceModel(
+      { ...defaultMissionWorkspaceModel("mis_detail", "tsk_5"), mode: "detail" },
+      view,
+      { width: 56, height: 24 },
+    );
+    expect(model.detailScroll.tasks).toBe(2);
+    let layout = missionWorkspaceLayout(56, 24, model, view);
+    expect(layout.detail.itemCapacity).toBe(4);
+    expect(layout.detail.rows.filter((row) => row.kind === "tasks").map((row) => row.id)).toEqual([
+      "tsk_2",
+      "tsk_3",
+      "tsk_4",
+      "tsk_5",
+    ]);
+
+    model = moveMissionSelection(model, view, "home", { width: 56, height: 24 });
+    expect(model.selectedTaskId).toBe("tsk_0");
+    expect(model.detailScroll.tasks).toBe(0);
+    model = moveMissionSelection(model, view, "end", { width: 56, height: 24 });
+    expect(model.selectedTaskId).toBe("tsk_5");
+    expect(model.detailScroll.tasks).toBe(2);
+
+    layout = missionWorkspaceLayout(56, 6, model, view);
+    expect(layout.detail.itemCapacity).toBe(0);
+    expect(layout.detail.rows.length).toBeGreaterThan(0);
+    expect(layout.detail.rows.every((row) => row.kind === "context")).toBe(true);
+    expect(
+      missionWorkspaceHitTest(layout, layout.detail.rows[0]!.x, layout.detail.rows[0]!.y),
+    ).toBeNull();
+  });
+
+  it("keeps narrow mission context visible when the active detail section is empty", () => {
+    const view = snapshot(
+      board({ running: [card("mis_detail", "running")] }),
+      [],
+      detail({ attempts: [] }),
+    );
+    const model = setMissionDetailSection(
+      openMissionDetail(defaultMissionWorkspaceModel("mis_detail"), view),
+      view,
+      "attempts",
+    );
+    const layout = missionWorkspaceLayout(56, 24, model, view);
+    expect(layout.detail.itemCapacity).toBe(0);
+    expect(layout.detail.rows.map((row) => row.kind)).toEqual(["context", "context"]);
+    expect(layout.detail.rows[0]!.lines[0]).toContain("Mission detail");
+  });
+
+  it("keeps proof-section navigation deterministic when no proof is recorded", () => {
+    const noProof = detail({ proofSummary: proof() });
+    const view = snapshot(board({ running: [card("mis_detail", "running")] }), [], noProof);
+    const model = setMissionDetailSection(
+      openMissionDetail(defaultMissionWorkspaceModel("mis_detail"), view),
+      view,
+      "proof",
+    );
+    const layout = missionWorkspaceLayout(56, 10, model, view);
+    expect(layout.detail.itemCapacity).toBeGreaterThan(0);
+    const proofRow = layout.detail.rows.find((row) => row.kind === "proof");
+    expect(proofRow).toMatchObject({ kind: "proof", id: "proof", index: 0 });
+    expect(proofRow!.lines.join("\n")).toContain("no proof recorded");
+    const scrolled = scrollMissionWorkspace(model, view, "proof", 10, { height: 10 });
+    expect(scrolled.detailScroll.proof).toBe(0);
+  });
+
+  it("resolves safe deep-link intents and rejects missing, outside, traversal, and unsupported URI refs", () => {
+    const views = [
+      { id: "term", title: "Term", panel: "terminals" as const },
+      { id: "files", title: "Files", panel: "files" as const },
+      { id: "diff", title: "Diff", panel: "diff" as const },
+    ];
+    const model = defaultMissionWorkspaceModel("mis_detail", "tsk_setup");
+    const projected = detail();
+    expect(
+      resolveMissionDeepLink("terminal", projected, model, {
+        projectRoot: "/repo",
+        views,
+        resolveProjectPath: absoluteProjectPath,
+      }),
+    ).toMatchObject({
+      available: true,
+      intent: { kind: "terminal", session: "proj", paneId: "%7", viewId: "term" },
+    });
+    expect(
+      resolveMissionDeepLink("files", projected, model, {
+        projectRoot: "/repo",
+        views,
+        resolveProjectPath: absoluteProjectPath,
+      }),
+    ).toMatchObject({
+      available: true,
+      intent: { kind: "files", path: "/repo/apps/api/index.ts", mode: "open" },
+    });
+    expect(
+      resolveMissionDeepLink(
+        "files",
+        detail({
+          taskBoard: {
+            columns: {
+              planned: [
+                task("tsk_setup", "planned", {
+                  proofSummary: proof(),
+                  refs: {
+                    missionId: "mis_detail",
+                    taskId: "tsk_setup",
+                    attemptIds: [],
+                    proofIds: [],
+                    worktree: "apps/api",
+                  },
+                }),
+              ],
+              running: [],
+              blocked: [],
+              review: [],
+              done: [],
+            },
+            counts: { planned: 1, running: 0, blocked: 0, review: 0, done: 0, total: 1 },
+          },
+        }),
+        model,
+        {
+          projectRoot: "/repo",
+          views,
+          resolveProjectPath: absoluteProjectPath,
+        },
+      ),
+    ).toMatchObject({
+      available: true,
+      intent: { kind: "files", path: "/repo/apps/api", mode: "reveal" },
+    });
+    expect(
+      resolveMissionDeepLink("diff", projected, model, {
+        projectRoot: "/repo",
+        views,
+        resolveProjectPath: absoluteProjectPath,
+      }),
+    ).toMatchObject({ available: true, intent: { kind: "diff", path: "/repo/apps/api" } });
+    const unsafe = detail({
+      proofSummary: proof({
+        hasProof: true,
+        proofIds: ["prf_bad"],
+        artifacts: [{ name: "bad", uri: "https://example.com/file" }],
+      }),
+      taskBoard: {
+        columns: {
+          planned: [
+            task("tsk_setup", "planned", {
+              refs: {
+                missionId: "mis_detail",
+                taskId: "tsk_setup",
+                attemptIds: [],
+                proofIds: [],
+                worktree: "../outside",
+              },
+            }),
+          ],
+          running: [],
+          blocked: [],
+          review: [],
+          done: [],
+        },
+        counts: { planned: 1, running: 0, blocked: 0, review: 0, done: 0, total: 1 },
+      },
+    });
+    expect(
+      resolveMissionDeepLink("files", unsafe, model, {
+        projectRoot: "/repo",
+        views,
+        resolveProjectPath: absoluteProjectPath,
+      }),
+    ).toMatchObject({ available: false });
+    expect(
+      resolveMissionDeepLink("terminal", projected, model, {
+        projectRoot: "/repo",
+        views: views.filter((view) => view.panel !== "terminals"),
+        resolveProjectPath: absoluteProjectPath,
+      }),
+    ).toMatchObject({ available: false, reason: "no configured Terminals view" });
+  });
+
+  it("scopes detail deep links to selected task refs and fails closed without them", () => {
+    const views = [
+      { id: "term", title: "Term", panel: "terminals" as const },
+      { id: "files", title: "Files", panel: "files" as const },
+      { id: "diff", title: "Diff", panel: "diff" as const },
+    ];
+    const selected = task("tsk_selected", "planned", {
+      latestAttempt: {
+        id: "att_selected",
+        taskId: "tsk_selected",
+        status: "approved",
+        outcome: "approved",
+        agent: "worker",
+        harness: "codex",
+        model: "gpt-5",
+        terminal: "%selected",
+        session: "selected-session",
+        worktree: "apps/selected",
+        startedAt: "2026-01-01T00:01:00.000Z",
+        updatedAt: "2026-01-01T00:02:00.000Z",
+        finishedAt: "2026-01-01T00:02:00.000Z",
+        durationMs: 60_000,
+        proofIds: ["prf_selected"],
+      },
+      proofSummary: proof({
+        proofIds: ["prf_selected"],
+        hasProof: true,
+        artifacts: [{ name: "selected", uri: "apps/selected/file.ts" }],
+      }),
+      refs: {
+        missionId: "mis_detail",
+        taskId: "tsk_selected",
+        attemptIds: ["att_selected"],
+        proofIds: ["prf_selected"],
+        terminal: "%selected",
+        session: "selected-session",
+        worktree: "apps/selected",
+      },
+    });
+    const sibling = task("tsk_sibling", "done", {
+      latestAttempt: {
+        ...selected.latestAttempt!,
+        id: "att_sibling",
+        taskId: "tsk_sibling",
+        terminal: "%sibling",
+        session: "sibling-session",
+        worktree: "apps/sibling",
+      },
+      proofSummary: proof({
+        proofIds: ["prf_sibling"],
+        hasProof: true,
+        artifacts: [{ name: "sibling", uri: "apps/sibling/file.ts" }],
+      }),
+      refs: {
+        missionId: "mis_detail",
+        taskId: "tsk_sibling",
+        attemptIds: ["att_sibling"],
+        proofIds: ["prf_sibling"],
+        terminal: "%sibling",
+        session: "sibling-session",
+        worktree: "apps/sibling",
+      },
+    });
+    const noRefs = task("tsk_no_refs", "blocked");
+    const projected = detail({
+      mission: card("mis_detail", "running", "Mission detail", {
+        latestAttempt: sibling.latestAttempt,
+        proofSummary: sibling.proofSummary,
+      }),
+      taskBoard: {
+        columns: {
+          planned: [selected, noRefs],
+          running: [],
+          blocked: [],
+          review: [],
+          done: [sibling],
+        },
+        counts: { planned: 2, running: 0, blocked: 0, review: 0, done: 1, total: 3 },
+      },
+      attempts: [selected.latestAttempt!, sibling.latestAttempt!],
+      proofSummary: sibling.proofSummary,
+    });
+    const selectedModel = defaultMissionWorkspaceModel("mis_detail", "tsk_selected");
+    expect(
+      resolveMissionDeepLink("terminal", projected, selectedModel, {
+        projectRoot: "/repo",
+        views,
+        resolveProjectPath: absoluteProjectPath,
+      }),
+    ).toMatchObject({
+      available: true,
+      intent: { kind: "terminal", session: "selected-session", paneId: "%selected" },
+    });
+    expect(
+      resolveMissionDeepLink("files", projected, selectedModel, {
+        projectRoot: "/repo",
+        views,
+        resolveProjectPath: absoluteProjectPath,
+      }),
+    ).toMatchObject({
+      available: true,
+      intent: { kind: "files", path: "/repo/apps/selected/file.ts", mode: "open" },
+    });
+
+    const noRefModel = defaultMissionWorkspaceModel("mis_detail", "tsk_no_refs");
+    for (const link of ["terminal", "files", "diff"] as const) {
+      expect(
+        resolveMissionDeepLink(link, projected, noRefModel, {
+          projectRoot: "/repo",
+          views,
+          resolveProjectPath: absoluteProjectPath,
+        }),
+      ).toMatchObject({ available: false });
+    }
+  });
+
+  it("plans terminal deep-link preflight with hostile-looking values as single argv elements", () => {
+    const commands = missionTmuxPreflightCommands({
+      kind: "terminal",
+      session: "proj; rm -rf /",
+      paneId: "%7; send-keys pwn",
+      viewId: "term",
+    });
+    expect(commands).toEqual([
+      { kind: "session", file: "tmux", args: ["has-session", "-t", "=proj; rm -rf /"] },
+      {
+        kind: "pane",
+        file: "tmux",
+        args: ["display-message", "-p", "-t", "%7; send-keys pwn", "#{session_name}\t#{pane_id}"],
+      },
+    ]);
+    expect(
+      missionTmuxPanePreflightMatches(
+        "proj; rm -rf /\t%7; send-keys pwn\n",
+        commands[0]!.args[2].slice(1),
+        "%7; send-keys pwn",
+      ),
+    ).toBe(true);
+    expect(
+      missionTmuxPanePreflightMatches(
+        "other\t%7; send-keys pwn\n",
+        commands[0]!.args[2].slice(1),
+        "%7; send-keys pwn",
+      ),
+    ).toBe(false);
+  });
+
+  it("persists only selectedMissionId and selectedTaskId per exact missions view without projection blobs", () => {
     const state = workspaceStateWithMissionSelection(
       defaultWorkspaceUiState(),
       "mission-a",
       "mis_one",
+      "tsk_one",
     );
     const next = workspaceStateWithMissionSelection(state, "mission-b", "mis_two");
-    expect(missionSelectionFromWorkspaceState(next, "mission-a")).toBe("mis_one");
-    expect(missionSelectionFromWorkspaceState(next, "mission-b")).toBe("mis_two");
+    expect(missionSelectionFromWorkspaceState(next, "mission-a")).toEqual({
+      selectedMissionId: "mis_one",
+      selectedTaskId: "tsk_one",
+    });
+    expect(missionSelectionFromWorkspaceState(next, "mission-b")).toEqual({
+      selectedMissionId: "mis_two",
+      selectedTaskId: null,
+    });
     const json = serializeWorkspaceUiState(next);
     expect(json).toContain('"selectedTaskId": null');
     expect(json).not.toContain("columns");

--- a/packages/daemon/src/tui/mirror/missions-workspace.ts
+++ b/packages/daemon/src/tui/mirror/missions-workspace.ts
@@ -1,18 +1,25 @@
 import type {
+  MissionAttemptSummary,
   MissionBoardColumn,
   MissionBoardView,
   MissionCardView,
+  MissionDetailView,
   MissionHistorySummary,
+  MissionProofSummary,
+  MissionTimelineEntry,
+  TaskCardView,
 } from "@tmux-ide/contracts";
 
 import {
   MissionProjectionError,
   projectMissionBoard,
+  projectMissionDetail,
   projectMissionHistory,
 } from "../../lib/mission-projections.ts";
 import { MissionRepository, MissionRepositoryError } from "../../lib/mission-repository.ts";
 import type { ProjectRuntimeRepository } from "../../lib/project-runtime-repository.ts";
-import { terminalDisplayWidth } from "./panel-host.ts";
+import type { HostedPanelView } from "./panel-host.ts";
+import { findFirstHostedViewForPanel, terminalDisplayWidth } from "./panel-host.ts";
 import type { WorkspaceUiStateV1 } from "./workspace-ui-state.ts";
 import { missionsSelection, setMissionsSelection } from "./workspace-ui-state.ts";
 
@@ -31,13 +38,16 @@ export const MISSION_COLUMN_GAP = 1;
 export const MISSION_HEADER_ROWS = 2;
 export const MISSION_FOOTER_ROWS = 1;
 
-export type MissionWorkspaceMode = "board" | "history";
+export type MissionWorkspaceMode = "board" | "history" | "detail";
 export type MissionWorkspaceDensity = (typeof MISSION_DENSITIES)[number];
 export type MissionWorkspaceLoadStatus = "loading" | "empty" | "error" | "ready";
+export type MissionDetailSection = "tasks" | "timeline" | "attempts" | "proof";
+export const MISSION_DETAIL_SECTIONS = ["tasks", "timeline", "attempts", "proof"] as const;
 
 export interface MissionWorkspaceSnapshot {
   board: MissionBoardView;
   history: MissionHistorySummary[];
+  detail: MissionDetailView | null;
   project: {
     identityKey: string;
     projectRoot: string;
@@ -72,6 +82,10 @@ export interface MissionWorkspaceModel {
   columnScroll: Record<MissionBoardColumn, number>;
   historyScroll: number;
   horizontalOffset: number;
+  detailReturnMode: "board" | "history";
+  selectedTaskId: string | null;
+  detailSection: MissionDetailSection;
+  detailScroll: Record<MissionDetailSection, number>;
 }
 
 export interface MissionWorkspaceLayout {
@@ -95,6 +109,7 @@ export interface MissionWorkspaceLayout {
     itemCapacity: number;
     rows: MissionHistoryRowLayout[];
   };
+  detail: MissionDetailLayout;
 }
 
 export interface MissionWorkspacePresentationOptions {
@@ -110,13 +125,15 @@ export interface MissionHeaderLayout {
 }
 
 export interface MissionHeaderChip {
-  kind: "mode" | "density" | "refresh" | "horizontal";
+  kind: "mode" | "density" | "refresh" | "horizontal" | "section" | "deep-link";
   label: string;
   row: number;
   start: number;
   width: number;
   mode?: MissionWorkspaceMode;
   direction?: -1 | 1;
+  section?: MissionDetailSection;
+  link?: MissionDeepLinkKind;
 }
 
 export interface MissionColumnLayout {
@@ -152,6 +169,46 @@ export interface MissionHistoryRowLayout {
   lines: string[];
 }
 
+export interface MissionDetailRowLayout {
+  kind: MissionDetailSection | "context";
+  id: string;
+  index: number;
+  hoverKey: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  lines: string[];
+}
+
+export interface MissionDetailLayout {
+  wide: boolean;
+  contextWidth: number;
+  sectionX: number;
+  sectionWidth: number;
+  availableRows: number;
+  itemCapacity: number;
+  sections: MissionHeaderChip[];
+  links: MissionHeaderChip[];
+  contextRows: MissionDetailRowLayout[];
+  rows: MissionDetailRowLayout[];
+}
+
+export type MissionDeepLinkKind = "terminal" | "files" | "diff";
+
+export type MissionDeepLinkIntent =
+  | { kind: "terminal"; session: string; paneId: string | null; viewId: string }
+  | { kind: "files"; path: string; viewId: string; mode: "open" | "reveal" }
+  | { kind: "diff"; path: string; viewId: string };
+
+export type MissionDeepLinkResolution =
+  | { available: true; kind: MissionDeepLinkKind; intent: MissionDeepLinkIntent; label: string }
+  | { available: false; kind: MissionDeepLinkKind; reason: string; label: string };
+
+export type MissionTmuxPreflightCommand =
+  | { kind: "session"; file: "tmux"; args: ["has-session", "-t", string] }
+  | { kind: "pane"; file: "tmux"; args: ["display-message", "-p", "-t", string, string] };
+
 export type MissionWorkspaceHit =
   | { kind: "mode"; mode: MissionWorkspaceMode }
   | { kind: "density" }
@@ -160,6 +217,15 @@ export type MissionWorkspaceHit =
   | { kind: "column"; column: MissionBoardColumn }
   | { kind: "card"; missionId: string; column: MissionBoardColumn; index: number; hoverKey: number }
   | { kind: "history"; missionId: string; index: number; hoverKey: number }
+  | { kind: "detail-section"; section: MissionDetailSection }
+  | {
+      kind: "detail-row";
+      section: MissionDetailSection;
+      id: string;
+      index: number;
+      hoverKey: number;
+    }
+  | { kind: "deep-link"; link: MissionDeepLinkKind }
   | null;
 
 export class MissionWorkspaceLoader {
@@ -219,15 +285,18 @@ export function invalidatedMissionWorkspaceLoadState(): MissionWorkspaceLoadStat
 
 export function readMissionWorkspace(
   repository: ProjectRuntimeRepository,
+  selectedMissionId: string | null = null,
   now: () => Date = () => new Date(),
 ): MissionWorkspaceSnapshot {
   const missions = new MissionRepository(repository);
   const { history, state } = missions.snapshot();
   const board = projectMissionBoard(state, history);
   const completed = projectMissionHistory(state, history);
+  const detail = selectedMissionId ? projectDetailOrNull(state, history, selectedMissionId) : null;
   return {
     board,
     history: completed.map((entry) => detached(entry)),
+    detail: detail ? detached(detail) : null,
     project: {
       identityKey: repository.metadata.identityKey,
       projectRoot: repository.metadata.projectRoot,
@@ -238,6 +307,7 @@ export function readMissionWorkspace(
 
 export function defaultMissionWorkspaceModel(
   selectedMissionId: string | null = null,
+  selectedTaskId: string | null = null,
 ): MissionWorkspaceModel {
   return {
     mode: "board",
@@ -248,19 +318,47 @@ export function defaultMissionWorkspaceModel(
     columnScroll: emptyScrolls(),
     historyScroll: 0,
     horizontalOffset: 0,
+    detailReturnMode: "board",
+    selectedTaskId,
+    detailSection: "tasks",
+    detailScroll: emptyDetailScrolls(),
   };
 }
 
 export function reconcileMissionWorkspaceModel(
   model: MissionWorkspaceModel,
-  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history"> | null,
-  options: { persistedMissionId?: string | null; width?: number; height?: number } = {},
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail"> | null,
+  options: {
+    persistedMissionId?: string | null;
+    persistedTaskId?: string | null;
+    width?: number;
+    height?: number;
+  } = {},
 ): MissionWorkspaceModel {
   let next = cloneModel(model);
   const preferred = options.persistedMissionId ?? next.selectedMissionId;
   if (!snapshot) {
     next.selectedMissionId = preferred ?? null;
+    next.selectedTaskId = options.persistedTaskId ?? next.selectedTaskId ?? null;
     return next;
+  }
+  if (next.mode === "detail") {
+    const detailMission = snapshot.detail?.mission.id;
+    if (detailMission) {
+      next.selectedMissionId = detailMission;
+      next.selectedTaskId = selectDetailTask(
+        snapshot.detail,
+        detailMission === model.selectedMissionId
+          ? (next.selectedTaskId ?? options.persistedTaskId)
+          : options.persistedTaskId,
+      );
+      return clampMissionWorkspaceModel(next, snapshot, options);
+    }
+    if (missionExists(snapshot, next.selectedMissionId)) {
+      return clampMissionWorkspaceModel(next, snapshot, options);
+    }
+    next.mode = next.detailReturnMode;
+    next.selectedTaskId = null;
   }
   if (next.mode === "history") {
     next.selectedMissionId = selectHistoryMission(snapshot.history, preferred);
@@ -269,20 +367,19 @@ export function reconcileMissionWorkspaceModel(
       snapshot.history.length,
       historyItemCapacity(options.height, next.density),
     );
-  } else {
-    const found = findMissionInBoard(snapshot.board, preferred);
-    const fallback = found ?? firstBoardMission(snapshot.board);
-    next.selectedMissionId = fallback?.id ?? null;
-    next.selectedColumn = fallback?.column ?? next.selectedColumn;
-    next.preferredRow = fallback?.index ?? 0;
+    return clampMissionWorkspaceModel(next, snapshot, options);
   }
-  next = clampMissionWorkspaceModel(next, snapshot, options);
-  return next;
+  const found = findMissionInBoard(snapshot.board, preferred);
+  const fallback = found ?? firstBoardMission(snapshot.board);
+  next.selectedMissionId = fallback?.id ?? null;
+  next.selectedColumn = fallback?.column ?? next.selectedColumn;
+  next.preferredRow = fallback?.index ?? 0;
+  return clampMissionWorkspaceModel(next, snapshot, options);
 }
 
 export function clampMissionWorkspaceModel(
   model: MissionWorkspaceModel,
-  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail">,
   options: { width?: number; height?: number } = {},
 ): MissionWorkspaceModel {
   const next = cloneModel(model);
@@ -336,6 +433,30 @@ export function clampMissionWorkspaceModel(
       historyItemCapacity(options.height, next.density),
     );
   }
+  if (next.mode === "detail" && snapshot.detail) {
+    next.selectedTaskId = selectDetailTask(snapshot.detail, next.selectedTaskId);
+    for (const section of MISSION_DETAIL_SECTIONS) {
+      const itemCount = detailSectionItems(snapshot.detail, section).length;
+      next.detailScroll[section] = clampTop(
+        next.detailScroll[section],
+        itemCount,
+        effectiveDetailItemCapacity(options.width, options.height, next.density, itemCount),
+      );
+    }
+    if (next.detailSection === "tasks") {
+      const idx = flattenedTasks(snapshot.detail).findIndex(
+        (task) => task.id === next.selectedTaskId,
+      );
+      if (idx >= 0) {
+        const itemCount = flattenedTasks(snapshot.detail).length;
+        next.detailScroll.tasks = scrollToIndex(
+          idx,
+          next.detailScroll.tasks,
+          effectiveDetailItemCapacity(options.width, options.height, next.density, itemCount),
+        );
+      }
+    }
+  }
   next.horizontalOffset = Math.min(
     Math.max(0, next.horizontalOffset),
     Math.max(0, MISSION_BOARD_COLUMNS.length - visibleColumnCount(options.width)),
@@ -345,11 +466,12 @@ export function clampMissionWorkspaceModel(
 
 export function moveMissionSelection(
   model: MissionWorkspaceModel,
-  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail">,
   action: "left" | "right" | "up" | "down" | "home" | "end",
   options: { width?: number; height?: number } = {},
 ): MissionWorkspaceModel {
   const next = cloneModel(model);
+  if (next.mode === "detail") return moveMissionDetailSelection(next, snapshot, action, options);
   if (next.mode === "history") {
     const current = Math.max(
       0,
@@ -402,7 +524,7 @@ export function moveMissionSelection(
 
 export function setMissionWorkspaceMode(
   model: MissionWorkspaceModel,
-  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail">,
   mode: MissionWorkspaceMode,
   options: { width?: number; height?: number } = {},
 ): MissionWorkspaceModel {
@@ -411,7 +533,7 @@ export function setMissionWorkspaceMode(
 
 export function cycleMissionDensity(
   model: MissionWorkspaceModel,
-  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history"> | null,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail"> | null,
   options: { width?: number; height?: number } = {},
 ): MissionWorkspaceModel {
   const index = MISSION_DENSITIES.indexOf(model.density);
@@ -424,25 +546,38 @@ export function cycleMissionDensity(
 
 export function scrollMissionWorkspace(
   model: MissionWorkspaceModel,
-  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
-  target: MissionBoardColumn | "history",
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail">,
+  target: MissionBoardColumn | "history" | MissionDetailSection,
   delta: number,
   options: { width?: number; height?: number } = {},
 ): MissionWorkspaceModel {
   const next = cloneModel(model);
-  if (target === "history") next.historyScroll += delta;
+  if (isDetailSection(target)) next.detailScroll[target] += delta;
+  else if (target === "history") next.historyScroll += delta;
   else next.columnScroll[target] += delta;
   return clampMissionWorkspaceModel(next, snapshot, options);
 }
 
 export function applyMissionWorkspaceHit(
   model: MissionWorkspaceModel,
-  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail">,
   hit: Exclude<MissionWorkspaceHit, { kind: "refresh" } | null>,
   options: { width?: number; height?: number } = {},
 ): MissionWorkspaceModel {
   if (hit.kind === "mode") return setMissionWorkspaceMode(model, snapshot, hit.mode, options);
   if (hit.kind === "density") return cycleMissionDensity(model, snapshot, options);
+  if (hit.kind === "detail-section")
+    return clampMissionWorkspaceModel(
+      { ...cloneModel(model), detailSection: hit.section },
+      snapshot,
+      options,
+    );
+  if (hit.kind === "detail-row") {
+    const next = cloneModel(model);
+    if (hit.section === "tasks") next.selectedTaskId = hit.id;
+    return clampMissionWorkspaceModel(next, snapshot, options);
+  }
+  if (hit.kind === "deep-link") return model;
   if (hit.kind === "horizontal") {
     return moveMissionSelection(model, snapshot, hit.direction < 0 ? "left" : "right", options);
   }
@@ -467,11 +602,62 @@ export function applyMissionWorkspaceHit(
   );
 }
 
+export function openMissionDetail(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail">,
+  options: { persistedTaskId?: string | null; width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  if (!model.selectedMissionId) return model;
+  return reconcileMissionWorkspaceModel(
+    {
+      ...cloneModel(model),
+      mode: "detail",
+      detailReturnMode: model.mode === "history" ? "history" : "board",
+      selectedTaskId: options.persistedTaskId ?? model.selectedTaskId,
+    },
+    snapshot,
+    options,
+  );
+}
+
+export function closeMissionDetail(model: MissionWorkspaceModel): MissionWorkspaceModel {
+  const next = cloneModel(model);
+  if (next.mode === "detail") next.mode = next.detailReturnMode;
+  return next;
+}
+
+export function setMissionDetailSection(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail">,
+  section: MissionDetailSection,
+  options: { width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  return clampMissionWorkspaceModel(
+    { ...cloneModel(model), detailSection: section },
+    snapshot,
+    options,
+  );
+}
+
+export function cycleMissionDetailSection(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail">,
+  direction: -1 | 1,
+  options: { width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  const index = MISSION_DETAIL_SECTIONS.indexOf(model.detailSection);
+  const next =
+    MISSION_DETAIL_SECTIONS[
+      (index + direction + MISSION_DETAIL_SECTIONS.length) % MISSION_DETAIL_SECTIONS.length
+    ]!;
+  return setMissionDetailSection(model, snapshot, next, options);
+}
+
 export function missionWorkspaceLayout(
   width: number,
   height: number,
   model: MissionWorkspaceModel,
-  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history"> | null,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail"> | null,
   presentation: MissionWorkspacePresentationOptions = {},
 ): MissionWorkspaceLayout {
   const safeWidth = Math.max(1, width);
@@ -525,13 +711,14 @@ export function missionWorkspaceLayout(
   const rowHeight = missionHistoryRowHeight(model.density);
   const historyCapacity = historyItemCapacity(safeHeight, model.density);
   const header = missionHeaderLayout(safeWidth, model, snapshot, presentation);
+  const detail = missionDetailLayout(safeWidth, safeHeight, model, snapshot?.detail ?? null);
   return {
     width: safeWidth,
     height: safeHeight,
     mode: model.mode,
     header,
     footer: {
-      label: missionFooterLabel(safeWidth, presentation.quitHint),
+      label: missionFooterLabel(safeWidth, model, presentation.quitHint),
       width: safeWidth,
     },
     board: { availableRows, itemCapacity: boardCapacity, columnWidth, visibleColumns, columns },
@@ -551,6 +738,7 @@ export function missionWorkspaceLayout(
           lines: missionHistoryLines(entry, model.density, safeWidth),
         })),
     },
+    detail,
   };
 }
 
@@ -584,14 +772,40 @@ export function missionWorkspaceHitTest(
     }
     return null;
   }
-  for (const row of layout.history.rows) {
-    if (x >= row.x && x < row.x + row.width && y >= row.y && y < row.y + row.height) {
-      return {
-        kind: "history",
-        missionId: row.missionId,
-        index: row.index,
-        hoverKey: row.hoverKey,
-      };
+  if (layout.mode === "history") {
+    for (const row of layout.history.rows) {
+      if (x >= row.x && x < row.x + row.width && y >= row.y && y < row.y + row.height) {
+        return {
+          kind: "history",
+          missionId: row.missionId,
+          index: row.index,
+          hoverKey: row.hoverKey,
+        };
+      }
+    }
+  }
+  if (layout.mode === "detail") {
+    for (const section of layout.detail.sections) {
+      if (x >= section.start && x < section.start + section.width && y === section.row) {
+        return section.section ? { kind: "detail-section", section: section.section } : null;
+      }
+    }
+    for (const link of layout.detail.links) {
+      if (x >= link.start && x < link.start + link.width && y === link.row) {
+        return link.link ? { kind: "deep-link", link: link.link } : null;
+      }
+    }
+    for (const row of layout.detail.rows) {
+      if (x >= row.x && x < row.x + row.width && y >= row.y && y < row.y + row.height) {
+        if (row.kind === "context") return null;
+        return {
+          kind: "detail-row",
+          section: row.kind,
+          id: row.id,
+          index: row.index,
+          hoverKey: row.hoverKey,
+        };
+      }
     }
   }
   return null;
@@ -639,6 +853,212 @@ export function missionHistoryLines(
   return lines.slice(0, missionHistoryRowHeight(density)).map((line) => clipTerminal(line, width));
 }
 
+export function missionDetailContextLines(detail: MissionDetailView, width: number): string[] {
+  const mission = detail.mission;
+  const lines = [
+    mission.title,
+    `${mission.status} · ${detail.progress.done}/${detail.progress.total} tasks · ${formatDuration(mission.durationMs)}`,
+    mission.summary,
+  ];
+  if (mission.labels.length > 0) lines.push(`# ${mission.labels.join(", ")}`);
+  if (mission.blockedBy.length > 0) lines.push(`blocked by ${mission.blockedBy.join(", ")}`);
+  if (mission.latestAttempt)
+    lines.push(`latest ${mission.latestAttempt.agent}/${mission.latestAttempt.harness}`);
+  const proof = proofSignal(mission.proofSummary);
+  if (proof) lines.push(proof);
+  return lines.map((line) => clipTerminal(line, width));
+}
+
+export function missionDetailTaskLines(
+  task: TaskCardView,
+  density: MissionWorkspaceDensity,
+  width: number,
+): string[] {
+  const lines = [
+    `${task.title}`,
+    `${task.column} · ${task.status} · p${task.priority}${task.assignee ? ` · ${task.assignee}` : ""}`,
+  ];
+  if (density !== "compact") {
+    if (task.dependencies.length > 0) lines.push(`depends ${task.dependencies.join(", ")}`);
+    if (task.blockedBy.length > 0) lines.push(`blocked by ${task.blockedBy.join(", ")}`);
+    if (task.latestAttempt)
+      lines.push(
+        `attempt ${task.latestAttempt.agent}/${task.latestAttempt.harness}${task.latestAttempt.model ? `/${task.latestAttempt.model}` : ""}`,
+      );
+    const proof = proofSignal(task.proofSummary);
+    if (proof) lines.push(proof);
+  }
+  if (density === "detailed")
+    lines.push(`task ${task.id} · duration ${formatDuration(task.durationMs)}`);
+  return lines.slice(0, missionDetailRowHeight(density)).map((line) => clipTerminal(line, width));
+}
+
+export function missionDetailTimelineLines(entry: MissionTimelineEntry, width: number): string[] {
+  const refs = [
+    entry.taskId ? `task ${entry.taskId}` : "",
+    entry.attemptId ? `attempt ${entry.attemptId}` : "",
+    entry.proofId ? `proof ${entry.proofId}` : "",
+  ].filter(Boolean);
+  return [
+    `#${entry.sequence} ${entry.timestamp} · ${entry.label}`,
+    `${entry.type} · ${entry.actor.type}:${entry.actor.id}${refs.length ? ` · ${refs.join(" · ")}` : ""}`,
+    entry.reason ? `reason ${entry.reason}` : "",
+  ]
+    .filter(Boolean)
+    .slice(0, 3)
+    .map((line) => clipTerminal(line, width));
+}
+
+export function missionDetailAttemptLines(
+  attempt: MissionAttemptSummary,
+  density: MissionWorkspaceDensity,
+  width: number,
+): string[] {
+  const lines = [
+    `${attempt.status}${attempt.outcome ? `/${attempt.outcome}` : ""} · task ${attempt.taskId}`,
+    `${attempt.agent}/${attempt.harness}${attempt.model ? ` · ${attempt.model}` : ""} · ${formatDuration(attempt.durationMs)}`,
+  ];
+  if (density !== "compact") {
+    if (attempt.session) lines.push(`session ${attempt.session}`);
+    if (attempt.terminal) lines.push(`pane ${attempt.terminal}`);
+    if (attempt.worktree) lines.push(`worktree ${attempt.worktree}`);
+    if (attempt.proofIds.length > 0) lines.push(`${attempt.proofIds.length} proof`);
+  }
+  return lines.slice(0, missionDetailRowHeight(density)).map((line) => clipTerminal(line, width));
+}
+
+export function missionDetailProofLines(
+  detail: MissionDetailView,
+  density: MissionWorkspaceDensity,
+  width: number,
+): string[] {
+  const proof = detail.proofSummary;
+  const lines = [
+    proof.hasProof ? `${proof.proofIds.length} proof item(s)` : "no proof recorded",
+    proof.noProofReasons.length ? `no-proof ${proof.noProofReasons.join(", ")}` : "",
+    proof.notesCount > 0 ? `${proof.notesCount} note(s)` : "",
+    proof.tests.total > 0 ? `tests ${proof.tests.passed}/${proof.tests.total}` : "",
+    proof.commits.length > 0 ? `commits ${proof.commits.join(", ")}` : "",
+    proof.diff.filesChanged > 0
+      ? `diff ${proof.diff.filesChanged} files +${proof.diff.insertions}/-${proof.diff.deletions}`
+      : "",
+    proof.diff.summaries.length > 0 ? `diff ${proof.diff.summaries.join(", ")}` : "",
+    proof.prs.length > 0
+      ? `PR ${proof.prs.map((pr) => pr.number ?? pr.status ?? pr.url ?? "link").join(", ")}`
+      : "",
+    proof.artifacts.length > 0
+      ? `artifacts ${proof.artifacts.map((artifact) => artifact.name).join(", ")}`
+      : "",
+  ].filter(Boolean);
+  return lines.slice(0, missionDetailRowHeight(density)).map((line) => clipTerminal(line, width));
+}
+
+export function resolveMissionDeepLink(
+  kind: MissionDeepLinkKind,
+  detail: MissionDetailView | null,
+  model: Pick<MissionWorkspaceModel, "selectedTaskId">,
+  options: {
+    projectRoot: string;
+    views: readonly HostedPanelView[];
+    resolveProjectPath: (projectRoot: string, path: string | null) => string | null;
+  },
+): MissionDeepLinkResolution {
+  const label = kind === "terminal" ? "t terminal" : kind === "files" ? "f files" : "d diff";
+  if (!detail) return { available: false, kind, label, reason: "mission detail is not loaded" };
+  const tasks = flattenedTasks(detail);
+  const task = tasks.length > 0 ? selectedDetailTask(detail, model.selectedTaskId) : null;
+  const attempt = task
+    ? task.latestAttempt
+    : (detail.mission.latestAttempt ?? detail.attempts[0] ?? null);
+  if (kind === "terminal") {
+    const view = findFirstHostedViewForPanel(options.views, "terminals");
+    if (!view) return { available: false, kind, label, reason: "no configured Terminals view" };
+    if (!attempt?.session)
+      return { available: false, kind, label, reason: "selected task has no terminal session ref" };
+    return {
+      available: true,
+      kind,
+      label,
+      intent: {
+        kind,
+        session: attempt.session,
+        paneId: attempt.terminal ?? null,
+        viewId: view.id,
+      },
+    };
+  }
+  if (kind === "files") {
+    const view = findFirstHostedViewForPanel(options.views, "files");
+    if (!view) return { available: false, kind, label, reason: "no configured Files view" };
+    const artifactPath = safeProjectedPath(
+      task
+        ? firstProjectedFilePath(task.proofSummary)
+        : firstProjectedFilePath(detail.mission.proofSummary),
+      options,
+    );
+    const fallbackPath = safeProjectedPath(task?.refs.worktree ?? attempt?.worktree, options);
+    const path = artifactPath ?? fallbackPath;
+    if (!path) return { available: false, kind, label, reason: "no safe in-project file ref" };
+    return {
+      available: true,
+      kind,
+      label,
+      intent: {
+        kind,
+        path,
+        viewId: view.id,
+        mode: artifactPath ? "open" : "reveal",
+      },
+    };
+  }
+  const view = findFirstHostedViewForPanel(options.views, "diff");
+  if (!view) return { available: false, kind, label, reason: "no configured Diff view" };
+  const path =
+    safeProjectedPath(task?.refs.worktree ?? attempt?.worktree, options) ??
+    safeProjectedPath(
+      task
+        ? firstProjectedFilePath(task.proofSummary)
+        : firstProjectedFilePath(detail.mission.proofSummary),
+      options,
+    );
+  if (!path) return { available: false, kind, label, reason: "no safe in-project diff ref" };
+  return { available: true, kind, label, intent: { kind, path, viewId: view.id } };
+}
+
+export function missionTmuxPreflightCommands(
+  intent: Extract<MissionDeepLinkIntent, { kind: "terminal" }>,
+): MissionTmuxPreflightCommand[] {
+  const commands: MissionTmuxPreflightCommand[] = [
+    { kind: "session", file: "tmux", args: ["has-session", "-t", `=${intent.session}`] },
+  ];
+  if (intent.paneId) {
+    commands.push({
+      kind: "pane",
+      file: "tmux",
+      args: ["display-message", "-p", "-t", intent.paneId, "#{session_name}\t#{pane_id}"],
+    });
+  }
+  return commands;
+}
+
+export function missionTmuxPanePreflightMatches(
+  output: string,
+  session: string,
+  paneId: string,
+): boolean {
+  return output.trimEnd() === `${session}\t${paneId}`;
+}
+
+export function selectedDetailTask(
+  detail: MissionDetailView | null,
+  taskId: string | null | undefined,
+): TaskCardView | null {
+  if (!detail) return null;
+  return (
+    flattenedTasks(detail).find((task) => task.id === taskId) ?? flattenedTasks(detail)[0] ?? null
+  );
+}
+
 export function missionModeLabel(mode: MissionWorkspaceMode, active: boolean): string {
   return active ? `[${mode}]` : ` ${mode} `;
 }
@@ -650,16 +1070,17 @@ export function densityLabel(density: MissionWorkspaceDensity): string {
 export function missionSelectionFromWorkspaceState(
   state: WorkspaceUiStateV1,
   viewId: string,
-): string | null {
-  return missionsSelection(state, viewId).selectedMissionId;
+): { selectedMissionId: string | null; selectedTaskId: string | null } {
+  return missionsSelection(state, viewId);
 }
 
 export function workspaceStateWithMissionSelection(
   state: WorkspaceUiStateV1,
   viewId: string,
   missionId: string | null,
+  taskId: string | null = null,
 ): WorkspaceUiStateV1 {
-  return setMissionsSelection(state, viewId, missionId, null);
+  return setMissionsSelection(state, viewId, missionId, taskId);
 }
 
 export function clipTerminal(text: string, width: number): string {
@@ -686,6 +1107,21 @@ function missionErrorMessage(error: unknown): string {
   return "mission data could not be loaded";
 }
 
+function projectDetailOrNull(
+  state: Parameters<typeof projectMissionDetail>[0],
+  history: Parameters<typeof projectMissionDetail>[1],
+  missionId: MissionCardView["id"],
+): MissionDetailView | null {
+  try {
+    return projectMissionDetail(state, history, missionId);
+  } catch (error) {
+    if (error instanceof MissionProjectionError && error.projectionCode === "MISSION_NOT_FOUND") {
+      return null;
+    }
+    throw error;
+  }
+}
+
 function detached<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
@@ -694,8 +1130,16 @@ function emptyScrolls(): Record<MissionBoardColumn, number> {
   return { planned: 0, running: 0, blocked: 0, review: 0, done: 0 };
 }
 
+function emptyDetailScrolls(): Record<MissionDetailSection, number> {
+  return { tasks: 0, timeline: 0, attempts: 0, proof: 0 };
+}
+
 function cloneModel(model: MissionWorkspaceModel): MissionWorkspaceModel {
-  return { ...model, columnScroll: { ...model.columnScroll } };
+  return {
+    ...model,
+    columnScroll: { ...model.columnScroll },
+    detailScroll: { ...model.detailScroll },
+  };
 }
 
 function findMissionInBoard(board: MissionBoardView, missionId: string | null | undefined) {
@@ -715,12 +1159,128 @@ function firstBoardMission(board: MissionBoardView) {
   return null;
 }
 
+function missionExists(
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history">,
+  missionId: string | null | undefined,
+): boolean {
+  if (!missionId) return false;
+  return (
+    !!findMissionInBoard(snapshot.board, missionId) ||
+    snapshot.history.some((entry) => entry.mission.id === missionId)
+  );
+}
+
 function selectHistoryMission(
   history: readonly MissionHistorySummary[],
   missionId: string | null | undefined,
 ): string | null {
   if (missionId && history.some((entry) => entry.mission.id === missionId)) return missionId;
   return history[0]?.mission.id ?? null;
+}
+
+function selectDetailTask(
+  detail: MissionDetailView | null,
+  taskId: string | null | undefined,
+): string | null {
+  if (!detail) return taskId ?? null;
+  const tasks = flattenedTasks(detail);
+  if (taskId && tasks.some((task) => task.id === taskId)) return taskId;
+  return tasks[0]?.id ?? null;
+}
+
+function flattenedTasks(detail: MissionDetailView): TaskCardView[] {
+  return MISSION_BOARD_COLUMNS.flatMap((column) => detail.taskBoard.columns[column]);
+}
+
+function isDetailSection(value: unknown): value is MissionDetailSection {
+  return value === "tasks" || value === "timeline" || value === "attempts" || value === "proof";
+}
+
+function detailSectionItems(
+  detail: MissionDetailView | null,
+  section: MissionDetailSection,
+): readonly unknown[] {
+  if (!detail) return [];
+  if (section === "tasks") return flattenedTasks(detail);
+  if (section === "timeline") return detail.timeline;
+  if (section === "attempts") return detail.attempts;
+  return [detail.proofSummary];
+}
+
+function firstProjectedFilePath(proof: MissionProofSummary): string | null {
+  return proof.artifacts.find((artifact) => isPlainRelativePath(artifact.uri))?.uri ?? null;
+}
+
+function safeProjectedPath(
+  rawPath: string | null | undefined,
+  options: {
+    projectRoot: string;
+    resolveProjectPath: (projectRoot: string, path: string | null) => string | null;
+  },
+): string | null {
+  if (!rawPath || !isPlainRelativePath(rawPath)) return null;
+  return options.resolveProjectPath(options.projectRoot, rawPath);
+}
+
+function isPlainRelativePath(value: string): boolean {
+  if (/^[a-z][a-z0-9+.-]*:/iu.test(value)) return false;
+  if (value.startsWith("/") || value.startsWith("\\") || value.startsWith("~")) return false;
+  if (value.includes("\0")) return false;
+  return true;
+}
+
+function moveMissionDetailSelection(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail">,
+  action: "left" | "right" | "up" | "down" | "home" | "end",
+  options: { width?: number; height?: number },
+): MissionWorkspaceModel {
+  let next = cloneModel(model);
+  if (!snapshot.detail) return next;
+  if (action === "left" || action === "right") {
+    return cycleMissionDetailSection(next, snapshot, action === "left" ? -1 : 1, options);
+  }
+  const items = detailSectionItems(snapshot.detail, next.detailSection);
+  if (next.detailSection === "tasks") {
+    const tasks = flattenedTasks(snapshot.detail);
+    const current = Math.max(
+      0,
+      tasks.findIndex((task) => task.id === next.selectedTaskId),
+    );
+    const last = Math.max(0, tasks.length - 1);
+    const index =
+      action === "up"
+        ? Math.max(0, current - 1)
+        : action === "down"
+          ? Math.min(last, current + 1)
+          : action === "home"
+            ? 0
+            : action === "end"
+              ? last
+              : current;
+    next.selectedTaskId = tasks[index]?.id ?? null;
+  } else {
+    const rows = effectiveDetailItemCapacity(
+      options.width,
+      options.height,
+      next.density,
+      items.length,
+    );
+    const max = Math.max(0, items.length - 1);
+    const current = next.detailScroll[next.detailSection];
+    next.detailScroll[next.detailSection] =
+      action === "up"
+        ? Math.max(0, current - 1)
+        : action === "down"
+          ? Math.min(max, current + 1)
+          : action === "home"
+            ? 0
+            : action === "end"
+              ? Math.max(0, items.length - rows)
+              : current;
+  }
+  next = clampMissionWorkspaceModel(next, snapshot, options);
+  return next;
 }
 
 function nearestNonEmptyColumn(
@@ -799,6 +1359,244 @@ function missionHistoryRowHeight(density: MissionWorkspaceDensity): number {
   return 5;
 }
 
+function missionDetailRowHeight(density: MissionWorkspaceDensity): number {
+  if (density === "compact") return 2;
+  if (density === "comfortable") return 4;
+  return 5;
+}
+
+function detailRows(height: number | undefined): number {
+  return Math.max(0, (height ?? 24) - MISSION_HEADER_ROWS - 1 - MISSION_FOOTER_ROWS);
+}
+
+function detailItemCapacity(height: number | undefined, density: MissionWorkspaceDensity): number {
+  return Math.max(0, Math.floor(detailRows(height) / missionDetailRowHeight(density)));
+}
+
+function effectiveDetailItemCapacity(
+  width: number | undefined,
+  height: number | undefined,
+  density: MissionWorkspaceDensity,
+  itemCount: number,
+): number {
+  if ((width ?? 120) >= 72) return detailItemCapacity(height, density);
+  if (itemCount <= 0) return 0;
+  const availableRows = detailRows(height);
+  const rowHeight = missionDetailRowHeight(density);
+  const reservedContextRows = Math.min(2, availableRows, Math.max(0, availableRows - rowHeight));
+  return Math.max(0, Math.floor((availableRows - reservedContextRows) / rowHeight));
+}
+
+function missionDetailLayout(
+  width: number,
+  height: number,
+  model: MissionWorkspaceModel,
+  detail: MissionDetailView | null,
+): MissionDetailLayout {
+  const wide = width >= 72;
+  const contextWidth = wide ? Math.min(34, Math.max(24, Math.floor(width * 0.36))) : 0;
+  const sectionX = wide ? contextWidth + 1 : 0;
+  const sectionWidth = Math.max(1, width - sectionX);
+  const availableRows = detailRows(height);
+  const rawRows = detail
+    ? detailRowsForSection(detail, model.detailSection, model.density, sectionWidth)
+    : [];
+  const itemCapacity = effectiveDetailItemCapacity(width, height, model.density, rawRows.length);
+  const linkLabels = detailLinkLabels(width);
+  const linkWidth =
+    linkLabels.reduce((sum, entry) => sum + terminalDisplayWidth(entry.label), 0) +
+    Math.max(0, linkLabels.length - 1);
+  const linkStart = Math.max(0, width - linkWidth);
+  const sectionLimit = Math.max(0, linkStart - 1);
+  const sectionLabels = MISSION_DETAIL_SECTIONS.map((section, index) =>
+    detailSectionLabel(section, index, model.detailSection, width),
+  );
+  const sectionSpans = boundedSpansForLabels(sectionLabels, 0, 1, sectionLimit);
+  const sections = sectionLabels
+    .map<MissionHeaderChip>((label, index) => ({
+      kind: "section",
+      label,
+      section: MISSION_DETAIL_SECTIONS[index]!,
+      row: 2,
+      start: sectionSpans[index]?.start ?? 0,
+      width: sectionSpans[index]?.width ?? 0,
+    }))
+    .filter((chip) => chip.width > 0 && chip.start + chip.width <= sectionLimit);
+  const linkSpans = boundedSpansForLabels(
+    linkLabels.map((entry) => entry.label),
+    linkStart,
+    1,
+    width,
+  );
+  const links = linkLabels
+    .map<MissionHeaderChip>((entry, index) => ({
+      kind: "deep-link",
+      label: entry.label,
+      link: entry.link,
+      row: 2,
+      start: linkSpans[index]?.start ?? 0,
+      width: linkSpans[index]?.width ?? 0,
+    }))
+    .filter((chip) => chip.width > 0 && chip.start + chip.width <= width);
+
+  if (!detail) {
+    return {
+      wide,
+      contextWidth,
+      sectionX,
+      sectionWidth,
+      availableRows,
+      itemCapacity,
+      sections,
+      links,
+      contextRows: [],
+      rows: [],
+    };
+  }
+
+  const rowHeight = missionDetailRowHeight(model.density);
+  const contextRows = missionDetailContextLines(detail, Math.max(1, contextWidth || width)).map(
+    (line, index) => ({
+      kind: "context" as const,
+      id: `context-${index}`,
+      index,
+      hoverKey: index,
+      x: 0,
+      y: MISSION_HEADER_ROWS + 1 + index,
+      width: Math.max(1, contextWidth || width),
+      height: 1,
+      lines: [line],
+    }),
+  );
+  const start = Math.max(0, model.detailScroll[model.detailSection]);
+  const maxNarrowContextRows =
+    rawRows.length > 0
+      ? itemCapacity > 0
+        ? Math.max(0, availableRows - rowHeight)
+        : availableRows
+      : availableRows;
+  const narrowContextRows = wide
+    ? []
+    : contextRows.slice(0, Math.min(2, availableRows, maxNarrowContextRows));
+  const capacityAfterContext = itemCapacity;
+  const rows = rawRows.slice(start, start + capacityAfterContext).map((row, visibleIndex) => ({
+    ...row,
+    index: start + visibleIndex,
+    hoverKey: detailHoverKey(model.detailSection, start + visibleIndex),
+    x: sectionX,
+    y: MISSION_HEADER_ROWS + 1 + narrowContextRows.length + visibleIndex * rowHeight,
+    width: sectionWidth,
+    height: rowHeight,
+  }));
+  return {
+    wide,
+    contextWidth,
+    sectionX,
+    sectionWidth,
+    availableRows,
+    itemCapacity,
+    sections,
+    links,
+    contextRows: wide ? contextRows.slice(0, availableRows) : [],
+    rows: [...narrowContextRows, ...rows],
+  };
+}
+
+function detailSectionLabel(
+  section: MissionDetailSection,
+  index: number,
+  active: MissionDetailSection,
+  width: number,
+): string {
+  const name =
+    width < 72
+      ? section === "tasks"
+        ? "T"
+        : section === "timeline"
+          ? "L"
+          : section === "attempts"
+            ? "A"
+            : "P"
+      : section;
+  return `${index + 1}${width < 72 ? "" : " "}${section === active ? `[${name}]` : name}`;
+}
+
+function detailLinkLabels(width: number): { link: MissionDeepLinkKind; label: string }[] {
+  if (width < 36)
+    return [
+      { link: "terminal", label: "t" },
+      { link: "files", label: "f" },
+      { link: "diff", label: "d" },
+    ];
+  if (width < 72)
+    return [
+      { link: "terminal", label: "t term" },
+      { link: "files", label: "f file" },
+      { link: "diff", label: "d diff" },
+    ];
+  return [
+    { link: "terminal", label: "t terminal" },
+    { link: "files", label: "f files" },
+    { link: "diff", label: "d diff" },
+  ];
+}
+
+function detailRowsForSection(
+  detail: MissionDetailView,
+  section: MissionDetailSection,
+  density: MissionWorkspaceDensity,
+  width: number,
+): Omit<MissionDetailRowLayout, "index" | "hoverKey" | "x" | "y" | "width" | "height">[] {
+  if (section === "tasks") {
+    return flattenedTasks(detail).map((task) => ({
+      kind: "tasks",
+      id: task.id,
+      lines: missionDetailTaskLines(task, density, width),
+    }));
+  }
+  if (section === "timeline") {
+    return detail.timeline.map((entry) => ({
+      kind: "timeline",
+      id: `${entry.sequence}`,
+      lines: missionDetailTimelineLines(entry, width),
+    }));
+  }
+  if (section === "attempts") {
+    return detail.attempts.map((attempt) => ({
+      kind: "attempts",
+      id: attempt.id,
+      lines: missionDetailAttemptLines(attempt, density, width),
+    }));
+  }
+  return [
+    {
+      kind: "proof",
+      id: "proof",
+      lines: missionDetailProofLines(detail, density, width),
+    },
+  ];
+}
+
+function detailHoverKey(section: MissionDetailSection, index: number): number {
+  return index * MISSION_DETAIL_SECTIONS.length + MISSION_DETAIL_SECTIONS.indexOf(section);
+}
+
+function boundedSpansForLabels(
+  labels: readonly string[],
+  start: number,
+  gap: number,
+  endExclusive: number,
+): { start: number; width: number }[] {
+  let cursor = start;
+  return labels.map((label) => {
+    const width = terminalDisplayWidth(label);
+    if (width <= 0 || cursor + width > endExclusive) return { start: cursor, width: 0 };
+    const span = { start: cursor, width };
+    cursor += width + gap;
+    return span;
+  });
+}
+
 function missionHeaderLayout(
   width: number,
   model: MissionWorkspaceModel,
@@ -870,12 +1668,17 @@ function missionSecondHeaderLabel(
   return `<${fitTerminal(` ${summary} `, Math.max(0, width - 2))}>`;
 }
 
-function missionFooterLabel(width: number, quitHint: string | null | undefined): string {
+function missionFooterLabel(
+  width: number,
+  model: Pick<MissionWorkspaceModel, "mode">,
+  quitHint: string | null | undefined,
+): string {
   const quit = quitHint?.trim() || "^q quit";
-  return fitTerminal(
-    `${quit} · tab mode · arrows move · z density · r refresh · enter details next`,
-    width,
-  );
+  const controls =
+    model.mode === "detail"
+      ? "esc back · tab sections · 1-4 section · arrows move · t/f/d open · r refresh"
+      : "tab mode · arrows move · enter details · z density · r refresh";
+  return fitTerminal(`${quit} · ${controls}`, width);
 }
 
 function fitTerminal(text: string, width: number): string {


### PR DESCRIPTION
## Summary
- add read-only Mission details with Tasks, Timeline, Attempts, and Proof sections
- persist exact mission/task selection and keep narrow/wide layouts deterministic
- add fail-closed Terminal, Files, and Diff deep links with tmux/filesystem preflight
- accept canonical tmux `%pane` refs in durable mission contracts

## Verification
- `pnpm check` (contracts 41, daemon 1784)
- `pnpm build:tui`
- live compiled-TUI smoke at narrow and wide sizes
- real durable mission replay and `%pane` Terminal navigation
- Files/Diff navigation, dead-target fail-closed behavior, Escape/back, and Ctrl+Q exit
