### PR TITLE
feat(tui): add composite workspace views

### DIFF
--- a/packages/contracts/src/__tests__/workspace-config.test.ts
+++ b/packages/contracts/src/__tests__/workspace-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { WorkspaceConfigV1SchemaZ } from "../workspace-config.ts";
+import type { WorkspaceAppLayoutNode } from "../workspace-config.ts";
 
 describe("WorkspaceConfigV1SchemaZ", () => {
   it("accepts a minimal versioned workspace", () => {
@@ -128,5 +129,149 @@ describe("WorkspaceConfigV1SchemaZ", () => {
     expect(result.success).toBe(false);
     if (result.success) return;
     expect(result.error.issues[0]?.message).toContain("Duplicate view id");
+  });
+
+  it("accepts composite split/tab application views while preserving shorthand views", () => {
+    const result = WorkspaceConfigV1SchemaZ.parse({
+      version: 1,
+      app: {
+        views: [
+          { id: "home", panel: "home" },
+          {
+            id: "ide",
+            title: "IDE",
+            layout: {
+              type: "split",
+              id: "ide-root",
+              direction: "horizontal",
+              weights: [72, 28],
+              children: [
+                { type: "panel", id: "terminal-main", panel: "terminals", min_size: 40 },
+                {
+                  type: "tabs",
+                  id: "inspection-dock",
+                  active: "files-tab",
+                  children: [
+                    { type: "panel", id: "files-tab", panel: "files", min_size: 24 },
+                    { type: "panel", id: "diff-tab", panel: "diff", min_size: 24 },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result.app?.views[0]).toEqual({ id: "home", panel: "home" });
+    expect(result.app?.views[1]).toMatchObject({ id: "ide", title: "IDE" });
+  });
+
+  it("rejects invalid composite layout trees with precise paths", () => {
+    const cases = [
+      {
+        value: {
+          version: 1,
+          app: {
+            views: [
+              {
+                id: "bad",
+                layout: {
+                  type: "split",
+                  id: "root",
+                  direction: "horizontal",
+                  weights: [1],
+                  children: [
+                    { type: "panel", id: "a", panel: "files" },
+                    { type: "panel", id: "b", panel: "diff" },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        path: "app.views.0.layout.weights",
+      },
+      {
+        value: {
+          version: 1,
+          app: {
+            views: [
+              {
+                id: "bad",
+                layout: {
+                  type: "tabs",
+                  id: "tabs",
+                  active: "missing",
+                  children: [{ type: "panel", id: "a", panel: "files" }],
+                },
+              },
+            ],
+          },
+        },
+        path: "app.views.0.layout.active",
+      },
+      {
+        value: {
+          version: 1,
+          app: {
+            views: [
+              {
+                id: "bad",
+                layout: {
+                  type: "split",
+                  id: "root",
+                  direction: "vertical",
+                  children: [
+                    { type: "panel", id: "dup", panel: "files" },
+                    { type: "panel", id: "dup", panel: "diff" },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        path: "app.views.0.layout.children.1.id",
+      },
+    ];
+
+    for (const item of cases) {
+      const result = WorkspaceConfigV1SchemaZ.safeParse(item.value);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.map((issue) => issue.path.join("."))).toContain(item.path);
+      }
+    }
+  });
+
+  it("rejects composite layouts beyond the depth and node-count bounds", () => {
+    let deep: WorkspaceAppLayoutNode = { type: "panel", id: "deep-leaf", panel: "files" };
+    for (let index = 0; index < 8; index += 1) {
+      deep = { type: "tabs", id: `deep-${index}`, children: [deep] };
+    }
+
+    let nextId = 0;
+    const broad = (depth: number): WorkspaceAppLayoutNode => {
+      const id = `node-${nextId++}`;
+      if (depth === 0) return { type: "panel", id, panel: "files" };
+      return {
+        type: "split",
+        id,
+        direction: "horizontal",
+        children: Array.from({ length: 4 }, () => broad(depth - 1)),
+      };
+    };
+
+    const issuesFor = (layout: WorkspaceAppLayoutNode) => {
+      const result = WorkspaceConfigV1SchemaZ.safeParse({
+        version: 1,
+        app: { views: [{ id: "bounded", layout }] },
+      });
+      expect(result.success).toBe(false);
+      return result.success ? [] : result.error.issues.map((issue) => issue.message);
+    };
+
+    expect(issuesFor(deep)).toContain("Composite view layout must not be deeper than 8 nodes");
+    expect(issuesFor(broad(3))).toContain("Composite view layout must not exceed 64 nodes");
   });
 });

--- a/packages/contracts/src/workspace-config.ts
+++ b/packages/contracts/src/workspace-config.ts
@@ -46,15 +46,72 @@ export const WorkspaceTerminalConfigSchemaZ = z.strictObject({
 
 export const WorkspacePanelKindSchemaZ = z.enum(["home", "terminals", "files", "diff", "missions"]);
 
-/** V1 views are deliberately full-panel; split/tab layout trees belong to C07. */
+const WorkspaceLayoutIdSchemaZ = NonEmptyStringSchema.max(128);
+
+type WorkspaceAppLayoutNodeInput =
+  | {
+      type: "panel";
+      id: string;
+      panel: z.infer<typeof WorkspacePanelKindSchemaZ>;
+      min_size?: number;
+    }
+  | {
+      type: "split";
+      id: string;
+      direction: "horizontal" | "vertical";
+      children: WorkspaceAppLayoutNodeInput[];
+      weights?: number[];
+    }
+  | {
+      type: "tabs";
+      id: string;
+      children: WorkspaceAppLayoutNodeInput[];
+      active?: string;
+    };
+
+export const WorkspaceAppLayoutNodeSchemaZ: z.ZodType<WorkspaceAppLayoutNodeInput> = z.lazy(() =>
+  z.discriminatedUnion("type", [
+    z.strictObject({
+      type: z.literal("panel"),
+      id: WorkspaceLayoutIdSchemaZ,
+      panel: WorkspacePanelKindSchemaZ,
+      min_size: z.number().int().positive().optional(),
+    }),
+    z.strictObject({
+      type: z.literal("split"),
+      id: WorkspaceLayoutIdSchemaZ,
+      direction: z.enum(["horizontal", "vertical"]),
+      children: z.array(WorkspaceAppLayoutNodeSchemaZ).min(2).max(4),
+      weights: z.array(z.number().positive()).optional(),
+    }),
+    z.strictObject({
+      type: z.literal("tabs"),
+      id: WorkspaceLayoutIdSchemaZ,
+      children: z.array(WorkspaceAppLayoutNodeSchemaZ).min(1).max(8),
+      active: WorkspaceLayoutIdSchemaZ.optional(),
+    }),
+  ]),
+);
+
 export const WorkspaceFullPanelViewSchemaZ = z.strictObject({
   id: NonEmptyStringSchema,
   title: NonEmptyStringSchema.optional(),
   panel: WorkspacePanelKindSchemaZ,
 });
 
+export const WorkspaceCompositeViewSchemaZ = z.strictObject({
+  id: NonEmptyStringSchema,
+  title: NonEmptyStringSchema.optional(),
+  layout: WorkspaceAppLayoutNodeSchemaZ,
+});
+
+export const WorkspaceAppViewSchemaZ = z.union([
+  WorkspaceFullPanelViewSchemaZ,
+  WorkspaceCompositeViewSchemaZ,
+]);
+
 export const WorkspaceAppConfigSchemaZ = z.strictObject({
-  views: z.array(WorkspaceFullPanelViewSchemaZ).min(1),
+  views: z.array(WorkspaceAppViewSchemaZ).min(1),
 });
 
 export const WorkspaceHarnessProfileSchemaZ = z.strictObject({
@@ -140,16 +197,88 @@ export const WorkspaceConfigV1SchemaZ = WorkspaceConfigV1ObjectSchemaZ.superRefi
         });
       }
       viewIds.add(view.id);
+      if ("layout" in view) {
+        validateWorkspaceLayoutTree(view.layout, ["app", "views", index, "layout"], context);
+      }
     }
   },
 );
+
+function validateWorkspaceLayoutTree(
+  root: WorkspaceAppLayoutNodeInput,
+  path: (string | number)[],
+  context: z.RefinementCtx,
+): void {
+  const seen = new Map<string, (string | number)[]>();
+  let count = 0;
+  const walk = (
+    node: WorkspaceAppLayoutNodeInput,
+    nodePath: (string | number)[],
+    depth: number,
+  ) => {
+    count += 1;
+    if (count > 64) {
+      context.addIssue({
+        code: "custom",
+        path,
+        message: "Composite view layout must not exceed 64 nodes",
+      });
+      return;
+    }
+    if (depth > 8) {
+      context.addIssue({
+        code: "custom",
+        path: nodePath,
+        message: "Composite view layout must not be deeper than 8 nodes",
+      });
+    }
+    const existing = seen.get(node.id);
+    if (existing) {
+      context.addIssue({
+        code: "custom",
+        path: [...nodePath, "id"],
+        message: `Duplicate layout node id "${node.id}"`,
+      });
+    } else {
+      seen.set(node.id, [...nodePath, "id"]);
+    }
+
+    if (node.type === "split") {
+      if (node.weights !== undefined && node.weights.length !== node.children.length) {
+        context.addIssue({
+          code: "custom",
+          path: [...nodePath, "weights"],
+          message: "Split weights length must match children length",
+        });
+      }
+      node.children.forEach((child, childIndex) =>
+        walk(child, [...nodePath, "children", childIndex], depth + 1),
+      );
+    } else if (node.type === "tabs") {
+      if (node.active && !node.children.some((child) => child.id === node.active)) {
+        context.addIssue({
+          code: "custom",
+          path: [...nodePath, "active"],
+          message: `Unknown active tab child "${node.active}"`,
+        });
+      }
+      node.children.forEach((child, childIndex) =>
+        walk(child, [...nodePath, "children", childIndex], depth + 1),
+      );
+    }
+  };
+  walk(root, path, 1);
+}
 
 export type WorkspaceCommand = z.infer<typeof WorkspaceCommandSchemaZ>;
 export type WorkspaceTerminalPane = z.infer<typeof WorkspaceTerminalPaneSchemaZ>;
 export type WorkspaceTerminalRow = z.infer<typeof WorkspaceTerminalRowSchemaZ>;
 export type WorkspaceTerminalConfig = z.infer<typeof WorkspaceTerminalConfigSchemaZ>;
 export type WorkspacePanelKind = z.infer<typeof WorkspacePanelKindSchemaZ>;
+export type WorkspaceAppLayoutNode = z.infer<typeof WorkspaceAppLayoutNodeSchemaZ>;
 export type WorkspaceFullPanelView = z.infer<typeof WorkspaceFullPanelViewSchemaZ>;
+export type WorkspaceCompositeView = z.infer<typeof WorkspaceCompositeViewSchemaZ>;
+export type WorkspaceAppView = z.infer<typeof WorkspaceAppViewSchemaZ>;
 export type WorkspaceAppConfig = z.infer<typeof WorkspaceAppConfigSchemaZ>;
 export type WorkspaceHarnessProfile = z.infer<typeof WorkspaceHarnessProfileSchemaZ>;
 export type WorkspaceAgentRole = z.infer<typeof WorkspaceAgentRoleSchemaZ>;

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -320,6 +320,19 @@ import {
   type TmuxBuffer,
 } from "./palette.ts";
 import {
+  compositeHitTest,
+  compositeLeafViewport,
+  cycleCompositeFocus,
+  reconcileCompositeLayoutState,
+  resizeCompositeSeparator,
+  resolveCompositeLayout,
+  revealCompositePanel,
+  setCompositeActiveTab,
+  type CompositePanelLeaf,
+  type CompositeLayoutState,
+  type CompositeResolvedLayout,
+} from "./composite-layout.ts";
+import {
   PanelHostLoadGeneration,
   findFirstHostedViewForPanel,
   findHostedViewById,
@@ -374,9 +387,11 @@ import {
   absoluteProjectPath,
   chooseInitialWorkspaceView,
   defaultWorkspaceUiState,
+  layoutStateForView,
   loadWorkspaceUiState,
   relativeProjectPath,
   serializeWorkspaceUiState,
+  setWorkspaceViewLayoutState,
   shouldHydrateWorkspaceView,
   viewStateFor,
   type WorkspaceUiStateV1,
@@ -988,7 +1003,37 @@ try {
     const activeView = createMemo(
       () => findHostedViewById(hostedViews(), activeViewId()) ?? hostedViews()[0]!,
     );
-    const activePanel = (): HostedPanelKind => activeView().panel;
+    const mainRect = () => ({
+      x: 0,
+      y: 0,
+      width: canvasCols(),
+      height: canvasRows(),
+    });
+    const compositeStateForActiveView = (): CompositeLayoutState | null => {
+      const view = activeView();
+      if (!view.layout) return null;
+      return reconcileCompositeLayoutState(
+        view.layout,
+        layoutStateForView(workspaceUiState(), view.id),
+      );
+    };
+    const activeCompositeLayout = createMemo<CompositeResolvedLayout | null>(() => {
+      const view = activeView();
+      if (!view.layout) return null;
+      return resolveCompositeLayout(
+        view.id,
+        view.layout,
+        mainRect(),
+        layoutStateForView(workspaceUiState(), view.id),
+      );
+    });
+    const focusedCompositeLeaf = () =>
+      activeCompositeLayout()?.leaves.find(
+        (leaf) => leaf.nodeId === activeCompositeLayout()?.focusedLeafId,
+      ) ??
+      activeCompositeLayout()?.leaves[0] ??
+      null;
+    const activePanel = (): HostedPanelKind => focusedCompositeLeaf()?.panel ?? activeView().panel;
     const tab = (): Tab => legacyTabFromPanelKind(activePanel());
     const mode = (): "home" | "mirror" | "editor" | "diff" | "missions" => panelMode(activePanel());
     const surfaceSpans = createMemo(() => panelSpans(hostedViews()));
@@ -1099,13 +1144,89 @@ try {
         else if (effect === "enter-diff") prepareDiff(workspaceDir());
       }
     };
+    const activationState = () => ({
+      filesLoaded: fileNodes().length > 0,
+      diffLoaded: diffEntries().length > 0,
+    });
+    const runPanelActivation = (panel: HostedPanelKind) => {
+      runActivationEffects(hostedActivationEffects(panel, activationState()));
+      if (panel === "missions") ensureMissionsLoaded();
+    };
+    const persistCompositeLayoutState = (layout: CompositeLayoutState) => {
+      const view = activeView();
+      if (!view.layout) return;
+      touchedWorkspaceViewIds.add(view.id);
+      setWorkspaceUiState((state) => setWorkspaceViewLayoutState(state, view, layout));
+    };
+    const focusCompositeLeaf = (leafId: string) => {
+      const view = activeView();
+      if (!view.layout) return false;
+      const next = reconcileCompositeLayoutState(view.layout, {
+        ...compositeStateForActiveView(),
+        focusedLeafId: leafId,
+      });
+      persistCompositeLayoutState(next);
+      const leaf = resolveCompositeLayout(view.id, view.layout, mainRect(), next).leaves.find(
+        (item) => item.nodeId === leafId,
+      );
+      if (leaf) runPanelActivation(leaf.panel);
+      return Boolean(leaf);
+    };
+    const activateCompositeTab = (tabsNodeId: string, childId: string) => {
+      const view = activeView();
+      if (!view.layout) return false;
+      const next = setCompositeActiveTab(
+        view.layout,
+        compositeStateForActiveView(),
+        tabsNodeId,
+        childId,
+      );
+      persistCompositeLayoutState(next);
+      const leaf = resolveCompositeLayout(view.id, view.layout, mainRect(), next).leaves.find(
+        (item) => item.nodeId === next.focusedLeafId,
+      );
+      if (leaf) runPanelActivation(leaf.panel);
+      return true;
+    };
+    const cycleCompositeLeafFocus = () => {
+      const view = activeView();
+      if (!view.layout) return false;
+      const next = cycleCompositeFocus(view.layout, compositeStateForActiveView());
+      persistCompositeLayoutState(next);
+      const leaf = resolveCompositeLayout(view.id, view.layout, mainRect(), next).leaves.find(
+        (item) => item.nodeId === next.focusedLeafId,
+      );
+      if (leaf) runPanelActivation(leaf.panel);
+      return true;
+    };
+    const focusPanelInActiveComposite = (panel: HostedPanelKind): boolean => {
+      const view = activeView();
+      if (!view.layout) return false;
+      const next = revealCompositePanel(
+        view.layout,
+        compositeStateForActiveView(),
+        panel,
+        focusedCompositeLeaf()?.panel === panel ? focusedCompositeLeaf()?.nodeId : null,
+      );
+      if (!next) return false;
+      persistCompositeLayoutState(next);
+      const leaf = resolveCompositeLayout(view.id, view.layout, mainRect(), next).leaves.find(
+        (item) => item.nodeId === next.focusedLeafId,
+      );
+      if (leaf) runPanelActivation(leaf.panel);
+      return true;
+    };
+    const selectViewForPanel = (viewId: string, panel: HostedPanelKind) => {
+      if (focusPanelInActiveComposite(panel)) return;
+      if (selectView(viewId)) focusPanelInActiveComposite(panel);
+    };
     const missionLayoutSize = () => ({
       width: canvasCols(),
       height: Math.max(4, dims().height - TABBAR_H),
     });
     const persistMissionSelection = (missionId: string | null, taskId: string | null = null) => {
       const view = activeView();
-      if (view.panel !== "missions") return;
+      if (activePanel() !== "missions") return;
       touchedWorkspaceViewIds.add(view.id);
       setWorkspaceUiState((state) =>
         workspaceStateWithMissionSelection(state, view.id, missionId, taskId),
@@ -1193,14 +1314,16 @@ try {
       }
       clearSelection();
       snapshotActiveWorkspaceView();
-      if (activePanel() === "missions" && plan.view.panel !== "missions") {
+      const previousPanel = activePanel();
+      if (previousPanel === "missions" && plan.view.panel !== "missions") {
         missionWorkspaceLoader.cancel();
         currentMissionsLoadIdentity = null;
       }
       runActivationEffects(plan.effects);
       setActiveViewId(plan.activeViewId);
       hydrateActiveWorkspaceView();
-      if (plan.view.panel === "missions") ensureMissionsLoaded();
+      if (plan.view.layout) runPanelActivation(activePanel());
+      else if (plan.view.panel === "missions") ensureMissionsLoaded();
       refreshFocusRecord();
       return true;
     };
@@ -1421,6 +1544,18 @@ try {
     type DragState =
       | { kind: "sidebar" }
       | { kind: "border"; sep: Separator; originCx: number; originCy: number; lastSize: number }
+      | {
+          kind: "composite";
+          viewId: string;
+          splitNodeId: string;
+          separatorIndex: number;
+          direction: "horizontal" | "vertical";
+          axisSize: number;
+          originX: number;
+          originY: number;
+          originState: CompositeLayoutState | null;
+          lastDelta: number;
+        }
       | {
           kind: "scrollbar";
           grabOffset: number;
@@ -2486,32 +2621,37 @@ try {
 
     const workspaceUiProjectRoot = (): string =>
       workspaceUiController.snapshot().repository?.metadata.projectRoot ?? workspaceDir();
+    const currentLayoutPointer = () => layoutStateForView(workspaceUiState(), activeView().id);
+    const withCurrentLayout = <T extends WorkspaceViewState>(entry: T): T => {
+      const layout = currentLayoutPointer();
+      return layout ? ({ ...entry, layout } as T) : entry;
+    };
     const currentWorkspaceViewState = (): WorkspaceViewState => {
       const panel = activePanel();
       const root = workspaceUiProjectRoot();
       if (panel === "files") {
-        return {
+        return withCurrentLayout({
           panel,
           openPath: relativeProjectPath(root, editorPath()),
           selectedPath: relativeProjectPath(root, visibleFiles()[fileSel()]?.node.path ?? null),
-        };
+        });
       }
       if (panel === "diff") {
-        return {
+        return withCurrentLayout({
           panel,
           selectedPath: diffVisibleFiles()[diffSel()]?.path ?? null,
-        };
+        });
       }
       if (panel === "missions") {
         const existing = missionSelectionFromWorkspaceState(workspaceUiState(), activeView().id);
-        return {
+        return withCurrentLayout({
           panel,
           selectedMissionId:
             missionWorkspaceModel().selectedMissionId ?? existing.selectedMissionId,
           selectedTaskId: missionWorkspaceModel().selectedTaskId ?? existing.selectedTaskId,
-        };
+        });
       }
-      return { panel };
+      return withCurrentLayout({ panel });
     };
     const stateWithCurrentWorkspaceView = (): WorkspaceUiStateV1 => {
       const view = activeView();
@@ -2532,13 +2672,15 @@ try {
     };
     hydrateActiveWorkspaceView = ({ firstProjectLoad = false } = {}) => {
       const view = activeView();
-      const entry = viewStateFor(workspaceUiState(), view);
+      const entry = view.layout
+        ? (workspaceUiState().views[view.id] ?? null)
+        : viewStateFor(workspaceUiState(), view);
       if (!entry) return;
       if (
         !shouldHydrateWorkspaceView({
           firstProjectLoad,
           explicitEditPath: values.edit ?? null,
-          view,
+          view: view.layout ? { panel: entry.panel } : view,
           entry,
         })
       ) {
@@ -2620,7 +2762,7 @@ try {
           .then(() => {
             snapshotActiveWorkspaceView();
             setCurTarget(intent.session);
-            selectView(intent.viewId);
+            selectViewForPanel(intent.viewId, "terminals");
             attach(intent.session);
             if (intent.paneId) {
               execFile("tmux", ["select-pane", "-t", intent.paneId], (error) => {
@@ -2641,7 +2783,7 @@ try {
         void stat(intent.path)
           .then((info) => {
             snapshotActiveWorkspaceView();
-            selectView(intent.viewId);
+            selectViewForPanel(intent.viewId, "files");
             if (info.isFile() && intent.mode === "open") openEditor(intent.path);
             else void revealPath(intent.path);
           })
@@ -2651,7 +2793,7 @@ try {
       void stat(intent.path)
         .then((info) => {
           snapshotActiveWorkspaceView();
-          selectView(intent.viewId);
+          selectViewForPanel(intent.viewId, "diff");
           prepareDiff(info.isDirectory() ? intent.path : dirname(intent.path));
         })
         .catch(() => setStatusNote(`diff target unavailable: ${intent.path}`));
@@ -5271,6 +5413,7 @@ try {
         searchKey(evt);
         return;
       }
+      if (evt.ctrl && evt.name === "tab" && cycleCompositeLeafFocus()) return;
       // F5 (and ^p when it arrives) open the command palette; ⌘K is the kitty
       // fast path handled above.
       if (evt.name === "f5" || (evt.ctrl && evt.name === "p")) {
@@ -6140,6 +6283,144 @@ try {
         if (!paletteContains(g, x, y)) setPaletteOpen(false);
         return;
       }
+      const compositeLayout = activeCompositeLayout();
+      if (!dragging && compositeLayout && x >= sidebarW() && y >= TABBAR_H) {
+        const localX = x - sidebarW();
+        const localY = y - TABBAR_H;
+        const hit = compositeHitTest(compositeLayout, localX, localY);
+        if (type === "down" && hit?.kind === "tab") {
+          activateCompositeTab(hit.tabsNodeId, hit.childId);
+          return;
+        }
+        if (hit?.kind === "leaf") {
+          const leaf = compositeLayout.leaves.find((item) => item.nodeId === hit.leafId);
+          const alreadyFocused = hit.leafId === compositeLayout.focusedLeafId;
+          if (type === "down") {
+            focusCompositeLeaf(hit.leafId);
+            if (!alreadyFocused) return;
+          }
+          if (leaf?.panel === "terminals") {
+            const viewport = compositeLeafViewport(leaf.rect, 2);
+            const bodyX = localX - leaf.rect.x - viewport.bodyLeft;
+            const bodyY = localY - leaf.rect.y - viewport.bodyTop;
+            const bodyW = viewport.bodyWidth;
+            const bodyH = viewport.bodyHeight;
+            if (bodyW <= 0 || bodyH <= 0) return;
+            const pane = panes().find((candidate) => {
+              const rect = scaledPaneRect(candidate, bodyW, bodyH);
+              return (
+                bodyX >= rect.left &&
+                bodyX < rect.left + rect.width &&
+                bodyY >= rect.top &&
+                bodyY < rect.top + rect.height
+              );
+            });
+            if (!pane) return;
+            const rect = scaledPaneRect(pane, bodyW, bodyH);
+            const col = Math.max(
+              0,
+              Math.min(
+                pane.width - 1,
+                Math.floor(((bodyX - rect.left) * pane.width) / Math.max(1, rect.width)),
+              ),
+            );
+            const row = Math.max(
+              0,
+              Math.min(
+                pane.height - 1,
+                Math.floor(((bodyY - rect.top) * pane.height) / Math.max(1, rect.height)),
+              ),
+            );
+            if (type === "down") {
+              mirror?.focus(pane.id);
+              return;
+            }
+            if (type === "scroll") {
+              const dir = e.scroll?.direction;
+              if (dir === "up" || dir === "down") wheel(pane, dir, col, row);
+              return;
+            }
+          }
+          if (leaf?.panel === "files") {
+            const viewport = compositeLeafViewport(leaf.rect, 3);
+            const bodyX = localX - leaf.rect.x - viewport.bodyLeft;
+            const bodyY = localY - leaf.rect.y - viewport.bodyTop;
+            const bodyW = viewport.bodyWidth;
+            const bodyH = viewport.bodyHeight;
+            if (bodyW <= 0 || bodyH <= 0) return;
+            const listW = Math.min(bodyW, Math.max(1, Math.min(24, Math.floor(bodyW * 0.38))));
+            const overList = bodyX < listW;
+            if (type === "scroll") {
+              const dir = e.scroll?.direction;
+              if (dir !== "up" && dir !== "down") return;
+              const step = dir === "up" ? -SCROLL_STEP : SCROLL_STEP;
+              if (overList) {
+                setFileTop((top) => clampTop(top + step, visibleFiles().length, bodyH));
+              } else {
+                setEditorTop((top) => clampTop(top + step, editorLines().length, bodyH));
+              }
+              return;
+            }
+            if (type === "down" && bodyY >= 0 && bodyY < bodyH && overList) {
+              const top = clampTop(fileTop(), visibleFiles().length, bodyH);
+              const idx = top + bodyY;
+              if (idx >= 0 && idx < visibleFiles().length) {
+                clearSelection();
+                setFilesFocus("list");
+                activateFile(idx);
+              }
+              return;
+            }
+          }
+          if (leaf?.panel === "diff") {
+            const viewport = compositeLeafViewport(leaf.rect, 3);
+            const bodyX = localX - leaf.rect.x - viewport.bodyLeft;
+            const bodyY = localY - leaf.rect.y - viewport.bodyTop;
+            const bodyW = viewport.bodyWidth;
+            const bodyH = viewport.bodyHeight;
+            if (bodyW <= 0 || bodyH <= 0) return;
+            const listW = Math.min(bodyW, Math.max(1, Math.min(24, Math.floor(bodyW * 0.36))));
+            const overList = bodyX < listW;
+            if (type === "scroll") {
+              const dir = e.scroll?.direction;
+              if (dir !== "up" && dir !== "down") return;
+              const step = dir === "up" ? -SCROLL_STEP : SCROLL_STEP;
+              if (overList) {
+                setDiffFileTop((top) => clampTop(top + step, diffRows().length, bodyH));
+              } else {
+                setDiffTop((top) => clampTop(top + step, diffLines().length, bodyH));
+              }
+              return;
+            }
+            if (type === "down" && bodyY >= 0 && bodyY < bodyH && overList) {
+              const top = clampTop(diffFileTop(), diffRows().length, bodyH);
+              const row = diffRows()[top + bodyY];
+              if (row?.kind === "file") selectDiffFile(row.fileIndex);
+              return;
+            }
+          }
+          return;
+        }
+        if (type === "down" && hit?.kind === "separator") {
+          dragging = {
+            kind: "composite",
+            viewId: compositeLayout.viewId,
+            splitNodeId: hit.nodeId,
+            separatorIndex: hit.index,
+            direction: hit.direction,
+            axisSize:
+              compositeLayout.separators.find(
+                (separator) => separator.nodeId === hit.nodeId && separator.index === hit.index,
+              )?.axisSize ?? 0,
+            originX: x,
+            originY: y,
+            originState: layoutStateForView(workspaceUiState(), activeView().id),
+            lastDelta: 0,
+          };
+          setStatusNote("resizing split…");
+          return;
+        }
+      }
       if (isHostedPanelInert(activePanel())) {
         if (type === "out") {
           setHoverIf(null);
@@ -6298,7 +6579,7 @@ try {
       // sticks even when intermediate drags were dropped.
       if (dragging) {
         const isDrag = type === "drag";
-        const isEnd = type === "up" || type === "drag-end" || type === "drop";
+        const isEnd = type === "up" || type === "drag-end" || type === "drop" || type === "out";
         if (isDrag || isEnd) {
           if (dragging.kind === "sidebar") {
             setSidebarW(clampSidebarWidth(x));
@@ -6308,6 +6589,23 @@ try {
             const row = y - dragging.top0;
             const top = dragTop(row, dragging.grabOffset, dragging.contentLen, dragging.viewH);
             applyScrollTop(dragging.surface, top);
+          } else if (dragging.kind === "composite") {
+            const view = activeView();
+            if (view.id === dragging.viewId && view.layout) {
+              const delta =
+                dragging.direction === "horizontal" ? x - dragging.originX : y - dragging.originY;
+              if (delta !== dragging.lastDelta) {
+                dragging.lastDelta = delta;
+                persistCompositeLayoutState(
+                  resizeCompositeSeparator(view.layout, dragging.originState, {
+                    splitNodeId: dragging.splitNodeId,
+                    separatorIndex: dragging.separatorIndex,
+                    delta,
+                    axisSize: dragging.axisSize,
+                  }),
+                );
+              }
+            }
           } else {
             const cx = x - sidebarW();
             const cy = y - TABBAR_H - HEADER_ROWS;
@@ -6780,6 +7078,349 @@ try {
       </>
     );
 
+    const scaledPaneRect = (pane: LivePane, width: number, height: number) => {
+      if (width <= 0 || height <= 0) {
+        return { left: 0, top: 0, width: 0, height: 0 };
+      }
+      const sourceW = Math.max(1, canvasCols());
+      const sourceH = Math.max(1, canvasRows());
+      const left = Math.max(0, Math.min(width - 1, Math.floor((pane.left * width) / sourceW)));
+      const top = Math.max(0, Math.min(height - 1, Math.floor((pane.top * height) / sourceH)));
+      const right = Math.max(
+        left + 1,
+        Math.min(width, Math.ceil(((pane.left + pane.width) * width) / sourceW)),
+      );
+      const bottom = Math.max(
+        top + 1,
+        Math.min(height, Math.ceil(((pane.top + pane.height) * height) / sourceH)),
+      );
+      return { left, top, width: right - left, height: bottom - top };
+    };
+
+    const compositeMiniSplitWidth = (width: number, ratio: number) =>
+      width <= 0 ? 0 : Math.min(width, Math.max(1, Math.min(24, Math.floor(width * ratio))));
+
+    const compositeLeafChrome = (leaf: CompositePanelLeaf) => {
+      const viewport = compositeLeafViewport(leaf.rect, 0);
+      return (
+        <box
+          height={1}
+          flexDirection="row"
+          backgroundColor={leaf.focused ? TAB_ACTIVE_BG : GUTTER_BG}
+        >
+          <text fg={leaf.focused ? ACCENT : MUTED}>
+            {clipTerminal(
+              `${leaf.focused ? "●" : "○"} ${leaf.title} · ${leaf.panel}`,
+              viewport.innerWidth,
+            )}
+          </text>
+        </box>
+      );
+    };
+
+    const compositeTerminalLeaf = (leaf: CompositePanelLeaf) => {
+      const viewport = compositeLeafViewport(leaf.rect, 2);
+      const bodyW = viewport.bodyWidth;
+      const bodyH = viewport.bodyHeight;
+      return (
+        <>
+          {compositeLeafChrome(leaf)}
+          <box height={1} flexDirection="row" gap={1}>
+            <text fg={DEFAULT_FG} attributes={1}>
+              {clipTerminal(curTarget(), Math.max(0, bodyW - 10))}
+            </text>
+            <text fg={MUTED}>{clipTerminal(status(), Math.max(0, bodyW - 2))}</text>
+          </box>
+          <box position="relative" flexGrow={1} backgroundColor={DEFAULT_BG} overflow="hidden">
+            <Show
+              when={FB_PANES && mirror}
+              fallback={
+                <For each={panes()}>
+                  {(pane) => {
+                    const rect = () => scaledPaneRect(pane, bodyW, bodyH);
+                    return (
+                      <Show when={rect().width > 0 && rect().height > 0}>
+                        <box
+                          position="absolute"
+                          left={rect().left}
+                          top={rect().top}
+                          width={rect().width}
+                          height={rect().height}
+                          flexDirection="column"
+                          backgroundColor={DEFAULT_BG}
+                          overflow="hidden"
+                        >
+                          <For each={paneSelRows(pane).slice(0, rect().height)}>
+                            {(runs) => (
+                              <box flexDirection="row" height={1}>
+                                <For each={runs}>
+                                  {(run) => (
+                                    <text
+                                      fg={packedToRgba(run.fg, DEFAULT_FG)}
+                                      bg={packedToRgba(run.bg, DEFAULT_BG)}
+                                      attributes={run.attributes}
+                                    >
+                                      {run.text}
+                                    </text>
+                                  )}
+                                </For>
+                              </box>
+                            )}
+                          </For>
+                        </box>
+                      </Show>
+                    );
+                  }}
+                </For>
+              }
+            >
+              <For each={paneIds()}>
+                {(id) => {
+                  const pane = () => panesById().get(id);
+                  const rect = () => (pane() ? scaledPaneRect(pane()!, bodyW, bodyH) : null);
+                  return (
+                    <Show when={pane() && rect() && rect()!.width > 0 && rect()!.height > 0}>
+                      <box
+                        position="absolute"
+                        left={rect()!.left}
+                        top={rect()!.top}
+                        width={rect()!.width}
+                        height={rect()!.height}
+                        backgroundColor={DEFAULT_BG}
+                        overflow="hidden"
+                      >
+                        <pane_surface
+                          width={rect()!.width}
+                          height={rect()!.height}
+                          mirror={mirror!}
+                          paneId={id}
+                          defaultFg={DEFAULT_FG_PACKED}
+                          defaultBg={DEFAULT_BG_PACKED}
+                          searchHl={SEARCH_HL}
+                          searchCur={SEARCH_CUR}
+                          scrollOffset={pane()!.snapshot.scrollOffset}
+                          paneFocused={leaf.focused && pane()!.active}
+                          contentVersion={pane()!.version}
+                          selRange={leaf.focused ? mirrorSelForPane(id) : null}
+                          search={leaf.focused ? mirrorSearchForPane(pane()!) : null}
+                        />
+                      </box>
+                    </Show>
+                  );
+                }}
+              </For>
+            </Show>
+          </box>
+        </>
+      );
+    };
+
+    const compositeFilesLeaf = (leaf: CompositePanelLeaf) => {
+      const viewport = compositeLeafViewport(leaf.rect, 3);
+      const bodyW = viewport.bodyWidth;
+      const bodyH = viewport.bodyHeight;
+      const listW = compositeMiniSplitWidth(bodyW, 0.38);
+      const editorW = Math.max(0, bodyW - listW);
+      return (
+        <>
+          {compositeLeafChrome(leaf)}
+          <box height={1} flexDirection="row" gap={1}>
+            <text fg={ACCENT} attributes={1}>
+              {clipTerminal(editorPath() ? basename(editorPath()!) : "files", listW)}
+            </text>
+            <text fg={MUTED}>{clipTerminal(editorMsg(), Math.max(0, editorW - 1))}</text>
+          </box>
+          <text fg={MUTED}>{clipTerminal("─".repeat(bodyW), bodyW)}</text>
+          <box flexDirection="row" flexGrow={1} overflow="hidden">
+            <box width={listW} flexDirection="column" backgroundColor={GUTTER_BG}>
+              <For each={fileListVisible().slice(0, bodyH)}>
+                {(row) => {
+                  const n = row.node;
+                  const selected = () => row.index === fileSel();
+                  const prefix =
+                    "  ".repeat(n.depth) + (n.isDir ? (n.expanded ? "▾ " : "▸ ") : "  ");
+                  return (
+                    <box
+                      height={1}
+                      paddingLeft={1}
+                      backgroundColor={selected() ? TAB_ACTIVE_BG : GUTTER_BG}
+                    >
+                      <text fg={n.isDir ? DIR_FG : selected() ? DEFAULT_FG : MUTED}>
+                        {clipTerminal(prefix + n.name, Math.max(0, listW - 1))}
+                      </text>
+                    </box>
+                  );
+                }}
+              </For>
+            </box>
+            <box width={editorW} flexDirection="column" overflow="hidden">
+              <For each={editorVisible().slice(0, bodyH)}>
+                {(ln) => (
+                  <box height={1} flexDirection="row">
+                    <text bg={GUTTER_BG} fg={GUTTER_FG}>
+                      {formatGutter(ln.num, Math.min(4, gutterWidth(editorLines().length)))}
+                    </text>
+                    <text fg={DEFAULT_FG}>
+                      {clipTerminal(ln.text || " ", Math.max(0, editorW - 4))}
+                    </text>
+                  </box>
+                )}
+              </For>
+            </box>
+          </box>
+        </>
+      );
+    };
+
+    const compositeDiffLeaf = (leaf: CompositePanelLeaf) => {
+      const viewport = compositeLeafViewport(leaf.rect, 3);
+      const bodyW = viewport.bodyWidth;
+      const bodyH = viewport.bodyHeight;
+      const listW = compositeMiniSplitWidth(bodyW, 0.36);
+      const diffW = Math.max(0, bodyW - listW);
+      return (
+        <>
+          {compositeLeafChrome(leaf)}
+          <box height={1} flexDirection="row" gap={1}>
+            <text fg={ACCENT} attributes={1}>
+              {clipTerminal(basename(diffDir()) || "diff", listW)}
+            </text>
+            <text fg={MUTED}>
+              {clipTerminal(`${diffVisibleFiles().length} files`, Math.max(0, diffW - 1))}
+            </text>
+          </box>
+          <text fg={MUTED}>{clipTerminal("─".repeat(bodyW), bodyW)}</text>
+          <box flexDirection="row" flexGrow={1} overflow="hidden">
+            <box width={listW} flexDirection="column" backgroundColor={GUTTER_BG}>
+              <For each={fileVisible().slice(0, bodyH)}>
+                {({ row }) =>
+                  row.kind === "header" ? (
+                    <box height={1} paddingLeft={1}>
+                      <text fg={ACCENT}>{clipTerminal(row.label, Math.max(0, listW - 1))}</text>
+                    </box>
+                  ) : (
+                    <box
+                      height={1}
+                      paddingLeft={1}
+                      backgroundColor={row.fileIndex === diffSel() ? TAB_ACTIVE_BG : GUTTER_BG}
+                    >
+                      <text fg={row.fileIndex === diffSel() ? DEFAULT_FG : MUTED}>
+                        {clipTerminal(
+                          `${row.entry.status} ${row.entry.path}`,
+                          Math.max(0, listW - 1),
+                        )}
+                      </text>
+                    </box>
+                  )
+                }
+              </For>
+            </box>
+            <box width={diffW} flexDirection="column" paddingLeft={1} overflow="hidden">
+              <For each={diffVisible().slice(0, bodyH)}>
+                {(ln) => (
+                  <box height={1} backgroundColor={DIFF_LINE_BG[ln.kind] ?? DEFAULT_BG}>
+                    <text fg={DIFF_FG[ln.kind]}>
+                      {clipTerminal(ln.text || " ", Math.max(0, diffW - 1))}
+                    </text>
+                  </box>
+                )}
+              </For>
+            </box>
+          </box>
+        </>
+      );
+    };
+
+    const compositeHomeLeaf = (leaf: CompositePanelLeaf) => {
+      const viewport = compositeLeafViewport(leaf.rect, 2);
+      return (
+        <>
+          {compositeLeafChrome(leaf)}
+          <box height={1} flexDirection="row" gap={1}>
+            <text fg={ACCENT} attributes={1}>
+              tmux-ide
+            </text>
+            <text fg={MUTED}>
+              {clipTerminal(`${rollup().sessions} sessions`, Math.max(0, viewport.innerWidth - 10))}
+            </text>
+          </box>
+          <box flexDirection="column" flexGrow={1} overflow="hidden">
+            <For each={homeItems().slice(0, viewport.bodyHeight)}>
+              {(it, i) => (
+                <box
+                  height={1}
+                  paddingLeft={1}
+                  backgroundColor={i() === clampedSel() ? TAB_ACTIVE_BG : DEFAULT_BG}
+                >
+                  <text fg={it.kind === "header" ? ACCENT : MUTED}>
+                    {clipTerminal(
+                      it.kind === "session"
+                        ? `${STATUS_GLYPH[it.status]} ${it.session}`
+                        : it.kind === "project"
+                          ? `▸ ${it.name}`
+                          : it.kind === "recent"
+                            ? `↺ ${it.name}`
+                            : `· ${it.label}`,
+                      Math.max(0, viewport.bodyWidth - 1),
+                    )}
+                  </text>
+                </box>
+              )}
+            </For>
+          </box>
+        </>
+      );
+    };
+
+    const compositeMissionsLeaf = (leaf: CompositePanelLeaf) => {
+      const viewport = compositeLeafViewport(leaf.rect, 2);
+      return (
+        <>
+          {compositeLeafChrome(leaf)}
+          <box height={1} flexDirection="row" gap={1}>
+            <text fg={ACCENT} attributes={1}>
+              missions
+            </text>
+            <text fg={MUTED}>
+              {clipTerminal(
+                missionsLayout().header.labels[1] ?? "",
+                Math.max(0, viewport.innerWidth - 10),
+              )}
+            </text>
+          </box>
+          <box flexDirection="column" flexGrow={1} overflow="hidden">
+            <Show
+              when={missionWorkspaceSnapshot()}
+              fallback={<text fg={MUTED}>No mission data loaded.</text>}
+            >
+              <For each={missionsLayout().board.columns.slice(0, Math.min(3, viewport.bodyHeight))}>
+                {(column) => (
+                  <box height={1} flexDirection="row" gap={1}>
+                    <text fg={ACCENT}>{clipTerminal(column.label, 10)}</text>
+                    <text fg={MUTED}>{clipTerminal(`${column.count}`, 4)}</text>
+                    <text fg={DEFAULT_FG}>
+                      {clipTerminal(
+                        column.cards[0]?.lines[0] ?? "—",
+                        Math.max(0, viewport.bodyWidth - 18),
+                      )}
+                    </text>
+                  </box>
+                )}
+              </For>
+            </Show>
+          </box>
+        </>
+      );
+    };
+
+    const compositeLeafBody = (leaf: CompositePanelLeaf) => {
+      if (leaf.panel === "terminals") return compositeTerminalLeaf(leaf);
+      if (leaf.panel === "files") return compositeFilesLeaf(leaf);
+      if (leaf.panel === "diff") return compositeDiffLeaf(leaf);
+      if (leaf.panel === "missions") return compositeMissionsLeaf(leaf);
+      return compositeHomeLeaf(leaf);
+    };
+
     return (
       <box
         flexDirection="column"
@@ -6853,12 +7494,84 @@ try {
             onMouse={(e) => route(e as RouteEvent)}
           />
           <box
+            position="relative"
             flexDirection="column"
             flexGrow={1}
             overflow="hidden"
             onMouse={(e: RouteEvent) => route(e)}
           >
-            <Show when={mode() === "home"}>
+            <Show when={activeCompositeLayout()}>
+              {(layout) => (
+                <>
+                  <For each={layout().leaves}>
+                    {(leaf) => (
+                      <box
+                        position="absolute"
+                        left={leaf.rect.x}
+                        top={leaf.rect.y}
+                        width={leaf.rect.width}
+                        height={leaf.rect.height}
+                        flexDirection="column"
+                        backgroundColor={DEFAULT_BG}
+                        overflow="hidden"
+                        border={compositeLeafViewport(leaf.rect, 0).bordered}
+                        borderColor={leaf.focused ? ACCENT : MUTED}
+                      >
+                        {compositeLeafBody(leaf)}
+                      </box>
+                    )}
+                  </For>
+                  <For each={layout().separators}>
+                    {(separator) => (
+                      <box
+                        position="absolute"
+                        left={separator.rect.x}
+                        top={separator.rect.y}
+                        width={separator.rect.width}
+                        height={separator.rect.height}
+                      >
+                        <text fg={ACCENT}>
+                          {separator.direction === "horizontal"
+                            ? Array(separator.rect.height).fill("│").join("\n")
+                            : "─".repeat(separator.rect.width)}
+                        </text>
+                      </box>
+                    )}
+                  </For>
+                  <For each={layout().tabs}>
+                    {(tab) => (
+                      <box
+                        position="absolute"
+                        left={tab.rect.x}
+                        top={tab.rect.y}
+                        width={tab.rect.width}
+                        height={1}
+                      >
+                        <text
+                          fg={tab.active ? DEFAULT_BG : DEFAULT_FG}
+                          bg={tab.active ? ACCENT : BUTTON_BG}
+                        >
+                          {clipTerminal(tab.label, tab.rect.width)}
+                        </text>
+                      </box>
+                    )}
+                  </For>
+                  <Show when={layout().note}>
+                    <box
+                      position="absolute"
+                      left={1}
+                      top={Math.max(0, canvasRows() - 2)}
+                      height={1}
+                    >
+                      <text fg={BANNER_FG}>
+                        {clipTerminal(layout().note!, Math.max(4, canvasCols() - 2))}
+                      </text>
+                    </box>
+                  </Show>
+                </>
+              )}
+            </Show>
+            <Show when={!activeCompositeLayout() && mode() === "home"}>
               {/* HOME header (y=0) + rule (y=1); rows below start at y=2 — the
               coordinate `route` reverses for a home-row click. */}
               <box paddingLeft={1} flexDirection="row" gap={1}>
@@ -7002,7 +7715,7 @@ try {
                 {buttonRow(homeButtons)}
               </box>
             </Show>
-            <Show when={mode() === "mirror"}>
+            <Show when={!activeCompositeLayout() && mode() === "mirror"}>
               <box paddingLeft={1} flexDirection="row" gap={1}>
                 <text fg={DEFAULT_FG} attributes={1}>
                   {curTarget()}
@@ -7230,7 +7943,7 @@ try {
                 </box>
               </Show>
             </Show>
-            <Show when={mode() === "editor"}>
+            <Show when={!activeCompositeLayout() && mode() === "editor"}>
               {/* FILES tab: header (gy=0) · rule/banner (gy=1) · two-column body
               (gy=2+): the file LIST on the left, the editor on the right. `route`
               reverses this geometry for wheel + click. NO onMouse on the rows —
@@ -7360,7 +8073,7 @@ try {
                 </text>
               </box>
             </Show>
-            <Show when={mode() === "diff"}>
+            <Show when={!activeCompositeLayout() && mode() === "diff"}>
               {/* header (y=0) · rule (y=1) · two-column body (y=2+) · footer
               verbs (last row). `route` reverses this geometry: left column =
               grouped file list (headers + rows from the SAME buildDiffRows the
@@ -7473,7 +8186,7 @@ try {
                 </text>
               </box>
             </Show>
-            <Show when={mode() === "missions"}>
+            <Show when={!activeCompositeLayout() && mode() === "missions"}>
               <box width={canvasCols()} flexDirection="row" gap={1}>
                 <For each={missionsLayout().header.rows[0] ?? []}>
                   {(chip) => (

--- a/packages/daemon/src/tui/mirror/composite-layout.test.ts
+++ b/packages/daemon/src/tui/mirror/composite-layout.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceAppLayoutNode } from "@tmux-ide/contracts";
+import {
+  compositeHitTest,
+  compositeLeafViewport,
+  cycleCompositeFocus,
+  defaultCompositeLayoutState,
+  findCompositePanelLeaf,
+  firstCompositePanelKind,
+  reconcileCompositeLayoutState,
+  resizeCompositeSeparator,
+  resolveCompositeLayout,
+  revealCompositePanel,
+  setCompositeActiveTab,
+} from "./composite-layout.ts";
+
+const ideLayout: WorkspaceAppLayoutNode = {
+  type: "split",
+  id: "ide-root",
+  direction: "horizontal",
+  weights: [72, 28],
+  children: [
+    { type: "panel", id: "terminal-main", panel: "terminals", min_size: 40 },
+    {
+      type: "tabs",
+      id: "dock",
+      active: "files-tab",
+      children: [
+        { type: "panel", id: "files-tab", panel: "files", min_size: 24 },
+        { type: "panel", id: "diff-tab", panel: "diff", min_size: 24 },
+      ],
+    },
+  ],
+};
+
+describe("composite layout", () => {
+  it("resolves split/tabs geometry with deterministic rounding and exact hits", () => {
+    const layout = resolveCompositeLayout(
+      "ide",
+      ideLayout,
+      { x: 0, y: 0, width: 101, height: 30 },
+      null,
+    );
+
+    expect(firstCompositePanelKind(ideLayout)).toBe("terminals");
+    expect(findCompositePanelLeaf(ideLayout, "diff")).toBe("diff-tab");
+    expect(layout.leaves.map((leaf) => [leaf.nodeId, leaf.panel, leaf.rect])).toEqual([
+      ["terminal-main", "terminals", { x: 0, y: 0, width: 66, height: 30 }],
+      ["files-tab", "files", { x: 67, y: 1, width: 34, height: 29 }],
+    ]);
+    expect(layout.separators[0]).toMatchObject({
+      nodeId: "ide-root",
+      direction: "horizontal",
+      rect: { x: 66, y: 0, width: 1, height: 30 },
+    });
+    expect(layout.tabs.map((tab) => [tab.childId, tab.active, tab.rect.y])).toEqual([
+      ["files-tab", true, 0],
+      ["diff-tab", false, 0],
+    ]);
+    expect(compositeHitTest(layout, 1, 1)).toEqual({
+      kind: "leaf",
+      leafId: "terminal-main",
+      panel: "terminals",
+    });
+    expect(compositeHitTest(layout, 66, 10)).toEqual({
+      kind: "separator",
+      nodeId: "ide-root",
+      index: 0,
+      direction: "horizontal",
+    });
+    expect(compositeHitTest(layout, 74, 0)).toEqual({
+      kind: "tab",
+      tabsNodeId: "dock",
+      childId: "files-tab",
+    });
+  });
+
+  it("reconciles active tabs/focus and cycles only visible leaves", () => {
+    expect(reconcileCompositeLayoutState(ideLayout, null).splitWeights).toEqual({});
+
+    const state = reconcileCompositeLayoutState(ideLayout, {
+      focusedLeafId: "gone",
+      activeTabs: { dock: "diff-tab", stale: "x" },
+      splitWeights: { "ide-root": [1, 3], stale: [1, 1] },
+    });
+    expect(state.activeTabs.dock).toBe("diff-tab");
+    expect(state.focusedLeafId).toBe("terminal-main");
+    const diff = resolveCompositeLayout(
+      "ide",
+      ideLayout,
+      { x: 0, y: 0, width: 80, height: 20 },
+      state,
+    );
+    expect(diff.leaves.map((leaf) => leaf.nodeId)).toEqual(["terminal-main", "diff-tab"]);
+
+    const cycled = cycleCompositeFocus(ideLayout, state);
+    expect(cycled.focusedLeafId).toBe("diff-tab");
+    const files = setCompositeActiveTab(ideLayout, cycled, "dock", "files-tab");
+    expect(files.activeTabs.dock).toBe("files-tab");
+    expect(files.focusedLeafId).toBe("files-tab");
+  });
+
+  it("does not persist config/default split weights on focus, tab, or reveal changes", () => {
+    const initial = resolveCompositeLayout(
+      "ide",
+      ideLayout,
+      { x: 0, y: 0, width: 101, height: 30 },
+      null,
+    );
+    expect(initial.leaves.map((leaf) => [leaf.nodeId, leaf.rect.width])).toEqual([
+      ["terminal-main", 66],
+      ["files-tab", 34],
+    ]);
+
+    const cycled = cycleCompositeFocus(ideLayout, null);
+    expect(cycled.focusedLeafId).toBe("files-tab");
+    expect(cycled.splitWeights).toEqual({});
+    expect(
+      resolveCompositeLayout(
+        "ide",
+        ideLayout,
+        { x: 0, y: 0, width: 101, height: 30 },
+        cycled,
+      ).leaves.map((leaf) => [leaf.nodeId, leaf.rect.width]),
+    ).toEqual([
+      ["terminal-main", 66],
+      ["files-tab", 34],
+    ]);
+
+    const diffTab = setCompositeActiveTab(ideLayout, null, "dock", "diff-tab");
+    expect(diffTab.splitWeights).toEqual({});
+    expect(
+      resolveCompositeLayout(
+        "ide",
+        ideLayout,
+        { x: 0, y: 0, width: 101, height: 30 },
+        diffTab,
+      ).leaves.map((leaf) => [leaf.nodeId, leaf.rect.width]),
+    ).toEqual([
+      ["terminal-main", 66],
+      ["diff-tab", 34],
+    ]);
+
+    const revealed = revealCompositePanel(ideLayout, null, "diff");
+    expect(revealed?.splitWeights).toEqual({});
+    expect(
+      resolveCompositeLayout(
+        "ide",
+        ideLayout,
+        { x: 0, y: 0, width: 101, height: 30 },
+        revealed,
+      ).leaves.map((leaf) => [leaf.nodeId, leaf.rect.width]),
+    ).toEqual([
+      ["terminal-main", 66],
+      ["diff-tab", 34],
+    ]);
+  });
+
+  it("exposes only visible leaf bodies for concurrent compiled rendering", () => {
+    const filesVisible = resolveCompositeLayout(
+      "ide",
+      ideLayout,
+      { x: 0, y: 0, width: 80, height: 24 },
+      { focusedLeafId: "terminal-main", activeTabs: { dock: "files-tab" }, splitWeights: {} },
+    );
+    expect(filesVisible.leaves.map((leaf) => [leaf.nodeId, leaf.panel])).toEqual([
+      ["terminal-main", "terminals"],
+      ["files-tab", "files"],
+    ]);
+    expect(filesVisible.leaves.some((leaf) => leaf.panel === "diff")).toBe(false);
+
+    const diffVisible = resolveCompositeLayout(
+      "ide",
+      ideLayout,
+      { x: 0, y: 0, width: 80, height: 24 },
+      setCompositeActiveTab(ideLayout, defaultCompositeLayoutState(), "dock", "diff-tab"),
+    );
+    expect(diffVisible.leaves.map((leaf) => [leaf.nodeId, leaf.panel])).toEqual([
+      ["terminal-main", "terminals"],
+      ["diff-tab", "diff"],
+    ]);
+    expect(diffVisible.leaves.some((leaf) => leaf.panel === "files")).toBe(false);
+  });
+
+  it("fails soft under impossible minimums without negative or out-of-bounds rectangles", () => {
+    for (const rect of [
+      { x: 0, y: 0, width: 0, height: 0 },
+      { x: 0, y: 0, width: 1, height: 1 },
+      { x: 0, y: 0, width: 2, height: 2 },
+      { x: 0, y: 0, width: 20, height: 4 },
+    ]) {
+      const layout = resolveCompositeLayout("ide", ideLayout, rect, {
+        focusedLeafId: "diff-tab",
+        activeTabs: { dock: "diff-tab" },
+        splitWeights: {},
+      });
+      if (rect.width > 0 && rect.height > 0) expect(layout.note).toContain("below minimum");
+      if (rect.width > 0 && rect.height > 0) {
+        expect(layout.leaves.length).toBeGreaterThan(0);
+        expect(layout.focusedLeafId).toBe(layout.leaves.find((leaf) => leaf.focused)?.nodeId);
+      }
+      for (const item of [...layout.leaves, ...layout.separators, ...layout.tabs]) {
+        expect(item.rect.x).toBeGreaterThanOrEqual(0);
+        expect(item.rect.y).toBeGreaterThanOrEqual(0);
+        expect(item.rect.width).toBeGreaterThanOrEqual(0);
+        expect(item.rect.height).toBeGreaterThanOrEqual(0);
+        expect(item.rect.x + item.rect.width).toBeLessThanOrEqual(rect.width);
+        expect(item.rect.y + item.rect.height).toBeLessThanOrEqual(rect.height);
+      }
+    }
+  });
+
+  it("preserves the semantically focused subtree when split minima cannot fit", () => {
+    const layout = resolveCompositeLayout(
+      "ide",
+      ideLayout,
+      { x: 0, y: 0, width: 20, height: 4 },
+      {
+        focusedLeafId: "diff-tab",
+        activeTabs: { dock: "diff-tab" },
+        splitWeights: {},
+      },
+    );
+
+    expect(layout.note).toContain("below minimum");
+    expect(layout.focusedLeafId).toBe("diff-tab");
+    expect(layout.leaves.map((leaf) => [leaf.nodeId, leaf.panel, leaf.focused])).toEqual([
+      ["diff-tab", "diff", true],
+    ]);
+    expect(layout.separators).toEqual([]);
+    for (const item of [...layout.leaves, ...layout.tabs]) {
+      expect(item.rect.x + item.rect.width).toBeLessThanOrEqual(20);
+      expect(item.rect.y + item.rect.height).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it("derives bounded leaf viewports for border, chrome, render, and pointer math", () => {
+    expect(compositeLeafViewport({ x: 0, y: 0, width: 0, height: 0 }, 2)).toMatchObject({
+      bordered: false,
+      innerWidth: 0,
+      innerHeight: 0,
+      bodyLeft: 0,
+      bodyTop: 2,
+      bodyWidth: 0,
+      bodyHeight: 0,
+    });
+    expect(compositeLeafViewport({ x: 0, y: 0, width: 1, height: 1 }, 2)).toMatchObject({
+      bordered: false,
+      innerWidth: 1,
+      innerHeight: 1,
+      bodyLeft: 0,
+      bodyTop: 2,
+      bodyWidth: 1,
+      bodyHeight: 0,
+    });
+    expect(compositeLeafViewport({ x: 0, y: 0, width: 2, height: 2 }, 2)).toMatchObject({
+      bordered: false,
+      leftInset: 0,
+      topInset: 0,
+      innerWidth: 2,
+      innerHeight: 2,
+      bodyLeft: 0,
+      bodyTop: 2,
+      bodyWidth: 2,
+      bodyHeight: 0,
+    });
+    expect(compositeLeafViewport({ x: 0, y: 0, width: 20, height: 10 }, 2)).toMatchObject({
+      bordered: true,
+      leftInset: 1,
+      topInset: 1,
+      innerWidth: 18,
+      innerHeight: 8,
+      bodyLeft: 1,
+      bodyTop: 3,
+      bodyWidth: 18,
+      bodyHeight: 6,
+    });
+    expect(compositeLeafViewport({ x: 4, y: 5, width: 20, height: 10 }, 3)).toMatchObject({
+      innerWidth: 18,
+      innerHeight: 8,
+      bodyLeft: 1,
+      bodyTop: 4,
+      bodyWidth: 18,
+      bodyHeight: 5,
+    });
+  });
+
+  it("resizes horizontal and vertical separators with min clamping and stable weights", () => {
+    const horizontal = resizeCompositeSeparator(ideLayout, null, {
+      splitNodeId: "ide-root",
+      separatorIndex: 0,
+      delta: -100,
+      axisSize: 101,
+    });
+    expect(horizontal.splitWeights["ide-root"]).toEqual([40, 60]);
+    expect(reconcileCompositeLayoutState(ideLayout, horizontal).splitWeights).toEqual({
+      "ide-root": [40, 60],
+    });
+    const horizontalLayout = resolveCompositeLayout(
+      "ide",
+      ideLayout,
+      { x: 0, y: 0, width: 101, height: 30 },
+      horizontal,
+    );
+    expect(horizontalLayout.leaves[0]?.rect.width).toBe(40);
+    expect(horizontalLayout.leaves.every((leaf) => leaf.rect.width >= 0)).toBe(true);
+
+    const verticalLayout: WorkspaceAppLayoutNode = {
+      type: "split",
+      id: "root",
+      direction: "vertical",
+      children: [
+        { type: "panel", id: "top", panel: "terminals", min_size: 5 },
+        { type: "panel", id: "bottom", panel: "files", min_size: 4 },
+      ],
+    };
+    const vertical = resizeCompositeSeparator(verticalLayout, null, {
+      splitNodeId: "root",
+      separatorIndex: 0,
+      delta: 100,
+      axisSize: 20,
+    });
+    expect(vertical.splitWeights.root).toEqual([15, 4]);
+    expect(
+      resolveCompositeLayout(
+        "v",
+        verticalLayout,
+        { x: 0, y: 0, width: 40, height: 20 },
+        vertical,
+      ).leaves.map((leaf) => leaf.rect.height),
+    ).toEqual([15, 4]);
+  });
+
+  it("keeps multi-event separator drags origin-relative instead of compounding", () => {
+    const rawOrigin = null;
+
+    const firstTick = resizeCompositeSeparator(ideLayout, rawOrigin, {
+      splitNodeId: "ide-root",
+      separatorIndex: 0,
+      delta: 1,
+      axisSize: 101,
+    });
+    expect(firstTick.splitWeights["ide-root"]).toEqual([67, 33]);
+
+    const secondTickFromOrigin = resizeCompositeSeparator(ideLayout, rawOrigin, {
+      splitNodeId: "ide-root",
+      separatorIndex: 0,
+      delta: 2,
+      axisSize: 101,
+    });
+    expect(secondTickFromOrigin.splitWeights["ide-root"]).toEqual([68, 32]);
+
+    const compoundedIfUsingMutatedState = resizeCompositeSeparator(ideLayout, firstTick, {
+      splitNodeId: "ide-root",
+      separatorIndex: 0,
+      delta: 2,
+      axisSize: 101,
+    });
+    expect(compoundedIfUsingMutatedState.splitWeights["ide-root"]).toEqual([69, 31]);
+    expect(secondTickFromOrigin.splitWeights["ide-root"]).not.toEqual(
+      compoundedIfUsingMutatedState.splitWeights["ide-root"],
+    );
+  });
+
+  it("reveals hidden nested tabs for a requested panel occurrence", () => {
+    const nested: WorkspaceAppLayoutNode = {
+      type: "tabs",
+      id: "outer",
+      active: "term",
+      children: [
+        { type: "panel", id: "term", panel: "terminals" },
+        {
+          type: "tabs",
+          id: "inner",
+          active: "files-a",
+          children: [
+            { type: "panel", id: "files-a", panel: "files" },
+            { type: "panel", id: "diff-a", panel: "diff" },
+            { type: "panel", id: "files-b", panel: "files" },
+          ],
+        },
+      ],
+    };
+    const revealedDiff = revealCompositePanel(nested, null, "diff");
+    expect(revealedDiff?.activeTabs).toMatchObject({ outer: "inner", inner: "diff-a" });
+    expect(revealedDiff?.focusedLeafId).toBe("diff-a");
+
+    const revealedSecondFiles = revealCompositePanel(nested, null, "files", "files-b");
+    expect(revealedSecondFiles?.activeTabs).toMatchObject({ outer: "inner", inner: "files-b" });
+    expect(revealedSecondFiles?.focusedLeafId).toBe("files-b");
+  });
+
+  it("handles vertical nesting and Unicode tab labels without overlap", () => {
+    const layoutNode: WorkspaceAppLayoutNode = {
+      type: "tabs",
+      id: "tabs",
+      children: [
+        { type: "panel", id: "Pair 👨‍💻", panel: "files" },
+        { type: "panel", id: "分析", panel: "diff" },
+      ],
+    };
+    const layout = resolveCompositeLayout(
+      "unicode",
+      layoutNode,
+      { x: 0, y: 0, width: 24, height: 8 },
+      null,
+    );
+    for (const [index, tab] of layout.tabs.entries()) {
+      const previous = layout.tabs[index - 1];
+      if (previous)
+        expect(tab.rect.x).toBeGreaterThanOrEqual(previous.rect.x + previous.rect.width);
+      expect(tab.rect.x + tab.rect.width).toBeLessThanOrEqual(24);
+    }
+  });
+});

--- a/packages/daemon/src/tui/mirror/composite-layout.ts
+++ b/packages/daemon/src/tui/mirror/composite-layout.ts
@@ -1,0 +1,710 @@
+import type { WorkspaceAppLayoutNode, WorkspacePanelKind } from "@tmux-ide/contracts";
+import stringWidth from "string-width";
+
+export interface CompositeRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface CompositeLayoutState {
+  focusedLeafId: string | null;
+  activeTabs: Record<string, string>;
+  splitWeights: Record<string, number[]>;
+}
+
+export interface CompositePanelLeaf {
+  nodeId: string;
+  panel: WorkspacePanelKind;
+  rect: CompositeRect;
+  focused: boolean;
+  title: string;
+}
+
+export interface CompositeLeafViewport {
+  bordered: boolean;
+  leftInset: number;
+  rightInset: number;
+  topInset: number;
+  bottomInset: number;
+  innerWidth: number;
+  innerHeight: number;
+  bodyLeft: number;
+  bodyTop: number;
+  bodyWidth: number;
+  bodyHeight: number;
+}
+
+export interface CompositeSeparator {
+  nodeId: string;
+  direction: "horizontal" | "vertical";
+  childBefore: string;
+  childAfter: string;
+  rect: CompositeRect;
+  index: number;
+  axisSize: number;
+}
+
+export interface CompositeTabChip {
+  tabsNodeId: string;
+  childId: string;
+  label: string;
+  rect: CompositeRect;
+  active: boolean;
+}
+
+export interface CompositeResolvedLayout {
+  viewId: string;
+  rect: CompositeRect;
+  leaves: CompositePanelLeaf[];
+  separators: CompositeSeparator[];
+  tabs: CompositeTabChip[];
+  focusedLeafId: string | null;
+  note: string | null;
+}
+
+export type CompositeHit =
+  | { kind: "leaf"; leafId: string; panel: WorkspacePanelKind }
+  | { kind: "separator"; nodeId: string; index: number; direction: "horizontal" | "vertical" }
+  | { kind: "tab"; tabsNodeId: string; childId: string }
+  | null;
+
+export interface CompositeSeparatorResizeInput {
+  splitNodeId: string;
+  separatorIndex: number;
+  delta: number;
+  axisSize: number;
+}
+
+const PANEL_LABELS: Readonly<Record<WorkspacePanelKind, string>> = {
+  home: "Home",
+  terminals: "Terminals",
+  files: "Files",
+  diff: "Diff",
+  missions: "Missions",
+};
+
+export function defaultCompositeLayoutState(): CompositeLayoutState {
+  return { focusedLeafId: null, activeTabs: {}, splitWeights: {} };
+}
+
+export function compositeLeafViewport(
+  rect: CompositeRect,
+  chromeRows: number,
+): CompositeLeafViewport {
+  const normalized = normalizeRect(rect);
+  // A border needs one cell on every side *and* at least one interior cell.
+  // Below that, keep the scarce cells available for the panel fallback.
+  const bordered = normalized.width >= 3 && normalized.height >= 3;
+  const leftInset = bordered ? 1 : 0;
+  const rightInset = bordered ? 1 : 0;
+  const topInset = bordered ? 1 : 0;
+  const bottomInset = bordered ? 1 : 0;
+  const innerWidth = Math.max(0, normalized.width - leftInset - rightInset);
+  const innerHeight = Math.max(0, normalized.height - topInset - bottomInset);
+  const safeChromeRows = Math.max(0, Math.floor(chromeRows));
+  return {
+    bordered,
+    leftInset,
+    rightInset,
+    topInset,
+    bottomInset,
+    innerWidth,
+    innerHeight,
+    bodyLeft: leftInset,
+    bodyTop: topInset + safeChromeRows,
+    bodyWidth: innerWidth,
+    bodyHeight: Math.max(0, innerHeight - safeChromeRows),
+  };
+}
+
+export function compositePanelIds(node: WorkspaceAppLayoutNode): string[] {
+  if (node.type === "panel") return [node.id];
+  return node.children.flatMap(compositePanelIds);
+}
+
+export function compositeContainsPanel(
+  node: WorkspaceAppLayoutNode,
+  panel: WorkspacePanelKind,
+): boolean {
+  if (node.type === "panel") return node.panel === panel;
+  return node.children.some((child) => compositeContainsPanel(child, panel));
+}
+
+export function firstCompositePanelKind(node: WorkspaceAppLayoutNode): WorkspacePanelKind {
+  if (node.type === "panel") return node.panel;
+  return firstCompositePanelKind(node.children[0]!);
+}
+
+export function findCompositePanelLeaf(
+  node: WorkspaceAppLayoutNode,
+  panel: WorkspacePanelKind,
+): string | null {
+  if (node.type === "panel") return node.panel === panel ? node.id : null;
+  for (const child of node.children) {
+    const found = findCompositePanelLeaf(child, panel);
+    if (found) return found;
+  }
+  return null;
+}
+
+export function reconcileCompositeLayoutState(
+  node: WorkspaceAppLayoutNode,
+  state: Partial<CompositeLayoutState> | null | undefined,
+): CompositeLayoutState {
+  const leafIds = new Set(compositePanelIds(node));
+  const activeTabs: Record<string, string> = {};
+  const splitWeights: Record<string, number[]> = {};
+  const visit = (current: WorkspaceAppLayoutNode) => {
+    if (current.type === "tabs") {
+      const childIds = new Set(current.children.map((child) => child.id));
+      const requested = state?.activeTabs?.[current.id] ?? current.active ?? null;
+      activeTabs[current.id] =
+        requested && childIds.has(requested) ? requested : current.children[0]!.id;
+      current.children.forEach(visit);
+    } else if (current.type === "split") {
+      const saved = state?.splitWeights?.[current.id];
+      if (
+        saved &&
+        saved.length === current.children.length &&
+        saved.every((value) => Number.isFinite(value) && value > 0)
+      ) {
+        splitWeights[current.id] = [...saved];
+      }
+      current.children.forEach(visit);
+    }
+  };
+  visit(node);
+  return {
+    focusedLeafId:
+      state?.focusedLeafId && leafIds.has(state.focusedLeafId)
+        ? state.focusedLeafId
+        : (firstVisibleLeaf(node, activeTabs)?.id ?? null),
+    activeTabs,
+    splitWeights,
+  };
+}
+
+export function resolveCompositeLayout(
+  viewId: string,
+  node: WorkspaceAppLayoutNode,
+  rect: CompositeRect,
+  state: Partial<CompositeLayoutState> | null | undefined,
+): CompositeResolvedLayout {
+  const reconciled = reconcileCompositeLayoutState(node, state);
+  const leaves: CompositePanelLeaf[] = [];
+  const separators: CompositeSeparator[] = [];
+  const tabs: CompositeTabChip[] = [];
+  const noteParts: string[] = [];
+  const rootRect = normalizeRect(rect);
+  const focusedLeafId = visibleLeafIds(node, reconciled.activeTabs).includes(
+    reconciled.focusedLeafId ?? "",
+  )
+    ? reconciled.focusedLeafId
+    : (firstVisibleLeaf(node, reconciled.activeTabs)?.id ?? null);
+
+  const emit = (current: WorkspaceAppLayoutNode, area: CompositeRect): void => {
+    area = clampRect(area, rootRect);
+    if (area.width <= 0 || area.height <= 0) {
+      noteParts.push("Composite layout has no visible cells");
+      return;
+    }
+    if (current.type === "panel") {
+      leaves.push({
+        nodeId: current.id,
+        panel: current.panel,
+        rect: area,
+        focused: current.id === focusedLeafId,
+        title: PANEL_LABELS[current.panel],
+      });
+      return;
+    }
+    if (current.type === "tabs") {
+      if (area.height < 2) {
+        noteParts.push(`Composite tabs "${current.id}" are below minimum size`);
+        const leaf = firstVisibleLeaf(current, reconciled.activeTabs) ?? firstPanelLeaf(current);
+        if (leaf) {
+          leaves.push({
+            nodeId: leaf.id,
+            panel: leaf.panel,
+            rect: area,
+            focused: leaf.id === focusedLeafId,
+            title: PANEL_LABELS[leaf.panel],
+          });
+        }
+        return;
+      }
+      const active = reconciled.activeTabs[current.id] ?? current.children[0]!.id;
+      let cursor = area.x;
+      for (const child of current.children) {
+        const label = ` ${child.id === active ? "[" : ""}${tabLabel(child)}${
+          child.id === active ? "]" : ""
+        } `;
+        const width = Math.min(
+          Math.max(1, stringWidth(label)),
+          Math.max(0, area.x + area.width - cursor),
+        );
+        if (width > 0) {
+          tabs.push({
+            tabsNodeId: current.id,
+            childId: child.id,
+            label,
+            rect: { x: cursor, y: area.y, width, height: 1 },
+            active: child.id === active,
+          });
+          cursor += width;
+        }
+      }
+      const child =
+        current.children.find((candidate) => candidate.id === active) ?? current.children[0]!;
+      emit(child, {
+        x: area.x,
+        y: area.y + 1,
+        width: area.width,
+        height: Math.max(0, area.height - 1),
+      });
+      return;
+    }
+
+    const axisSize = current.direction === "horizontal" ? area.width : area.height;
+    const separatorCells = current.children.length - 1;
+    const contentSize = Math.max(0, axisSize - separatorCells);
+    const minSizes = current.children.map((child) => subtreeMinSize(child, current.direction));
+    const minTotal = minSizes.reduce((sum, value) => sum + value, 0);
+    if (axisSize < current.children.length + separatorCells || minTotal > contentSize) {
+      noteParts.push(`Composite split "${current.id}" is below minimum size`);
+      const preferred =
+        childContainingLeaf(current, focusedLeafId) ??
+        current.children.find((child) =>
+          visibleLeafIds(child, reconciled.activeTabs).includes(focusedLeafId ?? ""),
+        ) ??
+        current.children[0]!;
+      emit(preferred, area);
+      return;
+    }
+    const override = reconciled.splitWeights[current.id];
+    const weights = override ?? current.weights ?? current.children.map(() => 1);
+    const sizes = override
+      ? allocatePersistedSizes(contentSize, minSizes, weights)
+      : allocateSizes(contentSize, minSizes, weights);
+    if (
+      sizes.reduce((sum, value) => sum + value, 0) < minSizes.reduce((sum, value) => sum + value, 0)
+    ) {
+      noteParts.push(`Composite split "${current.id}" is below minimum size`);
+    }
+    let cursor = current.direction === "horizontal" ? area.x : area.y;
+    current.children.forEach((child, index) => {
+      const size = sizes[index] ?? 0;
+      if (size <= 0) return;
+      const childRect =
+        current.direction === "horizontal"
+          ? { x: cursor, y: area.y, width: size, height: area.height }
+          : { x: area.x, y: cursor, width: area.width, height: size };
+      emit(child, childRect);
+      cursor += size;
+      if (index < current.children.length - 1) {
+        if (
+          cursor < (current.direction === "horizontal" ? area.x + area.width : area.y + area.height)
+        ) {
+          const separatorRect =
+            current.direction === "horizontal"
+              ? { x: cursor, y: area.y, width: 1, height: area.height }
+              : { x: area.x, y: cursor, width: area.width, height: 1 };
+          separators.push({
+            nodeId: current.id,
+            direction: current.direction,
+            childBefore: child.id,
+            childAfter: current.children[index + 1]!.id,
+            rect: clampRect(separatorRect, rootRect),
+            index,
+            axisSize,
+          });
+        }
+        cursor += 1;
+      }
+    });
+  };
+
+  emit(node, rootRect);
+  if (leaves.length === 0) {
+    const fallback =
+      leafById(node, focusedLeafId) ??
+      firstVisibleLeaf(node, reconciled.activeTabs) ??
+      firstPanelLeaf(node);
+    if (fallback && rootRect.width > 0 && rootRect.height > 0) {
+      leaves.push({
+        nodeId: fallback.id,
+        panel: fallback.panel,
+        rect: rootRect,
+        focused: true,
+        title: PANEL_LABELS[fallback.panel],
+      });
+    }
+  }
+  const effectiveFocusedLeafId =
+    leaves.find((leaf) => leaf.nodeId === focusedLeafId)?.nodeId ?? leaves[0]?.nodeId ?? null;
+  for (const leaf of leaves) leaf.focused = leaf.nodeId === effectiveFocusedLeafId;
+  return {
+    viewId,
+    rect: rootRect,
+    leaves,
+    separators: separators.filter(
+      (separator) => separator.rect.width > 0 && separator.rect.height > 0,
+    ),
+    tabs: tabs.filter((tab) => tab.rect.width > 0 && tab.rect.height > 0),
+    focusedLeafId: effectiveFocusedLeafId,
+    note: noteParts[0] ?? null,
+  };
+}
+
+export function compositeHitTest(
+  layout: CompositeResolvedLayout,
+  x: number,
+  y: number,
+): CompositeHit {
+  for (const tab of layout.tabs) {
+    if (inside(tab.rect, x, y))
+      return { kind: "tab", tabsNodeId: tab.tabsNodeId, childId: tab.childId };
+  }
+  for (const separator of layout.separators) {
+    if (inside(separator.rect, x, y)) {
+      return {
+        kind: "separator",
+        nodeId: separator.nodeId,
+        index: separator.index,
+        direction: separator.direction,
+      };
+    }
+  }
+  for (const leaf of layout.leaves) {
+    if (inside(leaf.rect, x, y)) return { kind: "leaf", leafId: leaf.nodeId, panel: leaf.panel };
+  }
+  return null;
+}
+
+export function cycleCompositeFocus(
+  node: WorkspaceAppLayoutNode,
+  state: Partial<CompositeLayoutState> | null | undefined,
+  direction = 1,
+): CompositeLayoutState {
+  const reconciled = reconcileCompositeLayoutState(node, state);
+  const ids = visibleLeafIds(node, reconciled.activeTabs);
+  if (ids.length === 0) return reconciled;
+  const current = Math.max(0, ids.indexOf(reconciled.focusedLeafId ?? ids[0]!));
+  return { ...reconciled, focusedLeafId: ids[(current + direction + ids.length) % ids.length]! };
+}
+
+export function setCompositeActiveTab(
+  node: WorkspaceAppLayoutNode,
+  state: Partial<CompositeLayoutState> | null | undefined,
+  tabsNodeId: string,
+  childId: string,
+): CompositeLayoutState {
+  const reconciled = reconcileCompositeLayoutState(node, state);
+  const tab = findNode(node, tabsNodeId);
+  if (!tab || tab.type !== "tabs" || !tab.children.some((child) => child.id === childId)) {
+    return reconciled;
+  }
+  const activeTabs = { ...reconciled.activeTabs, [tabsNodeId]: childId };
+  const focusedLeafId = firstVisibleLeaf(
+    tab.children.find((child) => child.id === childId)!,
+    activeTabs,
+  )?.id;
+  return reconcileCompositeLayoutState(node, {
+    ...reconciled,
+    activeTabs,
+    focusedLeafId: focusedLeafId ?? reconciled.focusedLeafId,
+  });
+}
+
+export function revealCompositePanel(
+  node: WorkspaceAppLayoutNode,
+  state: Partial<CompositeLayoutState> | null | undefined,
+  panel: WorkspacePanelKind,
+  preferredLeafId?: string | null,
+): CompositeLayoutState | null {
+  const reconciled = reconcileCompositeLayoutState(node, state);
+  const match =
+    findPanelOccurrence(node, panel, preferredLeafId ?? null) ??
+    findPanelOccurrence(node, panel, null);
+  if (!match) return null;
+  return reconcileCompositeLayoutState(node, {
+    ...reconciled,
+    activeTabs: { ...reconciled.activeTabs, ...match.activeTabs },
+    focusedLeafId: match.leafId,
+  });
+}
+
+export function resizeCompositeSeparator(
+  node: WorkspaceAppLayoutNode,
+  state: Partial<CompositeLayoutState> | null | undefined,
+  input: CompositeSeparatorResizeInput,
+): CompositeLayoutState {
+  const reconciled = reconcileCompositeLayoutState(node, state);
+  const split = findNode(node, input.splitNodeId);
+  if (!split || split.type !== "split") return reconciled;
+  const beforeIndex = input.separatorIndex;
+  const afterIndex = beforeIndex + 1;
+  if (beforeIndex < 0 || afterIndex >= split.children.length) return reconciled;
+  const separatorCells = split.children.length - 1;
+  const contentSize = Math.max(0, input.axisSize - separatorCells);
+  const minimums = split.children.map((child) => subtreeMinSize(child, split.direction));
+  const override = reconciled.splitWeights[split.id];
+  const currentWeights = override ?? split.weights ?? split.children.map(() => 1);
+  const currentSizes = override
+    ? allocatePersistedSizes(contentSize, minimums, currentWeights)
+    : allocateSizes(contentSize, minimums, currentWeights);
+  const resized = resizeAdjacentSizes(currentSizes, minimums, beforeIndex, input.delta);
+  const splitWeights = {
+    ...reconciled.splitWeights,
+    [split.id]: sizesToWeights(resized),
+  };
+  return reconcileCompositeLayoutState(node, { ...reconciled, splitWeights });
+}
+
+export function compositeSubtreeMinSize(
+  node: WorkspaceAppLayoutNode,
+  axis: "horizontal" | "vertical",
+): number {
+  return subtreeMinSize(node, axis);
+}
+
+function inside(rect: CompositeRect, x: number, y: number): boolean {
+  return x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height;
+}
+
+function normalizeRect(rect: CompositeRect): CompositeRect {
+  return {
+    x: Math.max(0, Math.trunc(rect.x)),
+    y: Math.max(0, Math.trunc(rect.y)),
+    width: Math.max(0, Math.trunc(rect.width)),
+    height: Math.max(0, Math.trunc(rect.height)),
+  };
+}
+
+function clampRect(rect: CompositeRect, bounds: CompositeRect): CompositeRect {
+  const x = Math.max(bounds.x, Math.min(rect.x, bounds.x + bounds.width));
+  const y = Math.max(bounds.y, Math.min(rect.y, bounds.y + bounds.height));
+  const right = Math.max(x, Math.min(rect.x + rect.width, bounds.x + bounds.width));
+  const bottom = Math.max(y, Math.min(rect.y + rect.height, bounds.y + bounds.height));
+  return { x, y, width: right - x, height: bottom - y };
+}
+
+function tabLabel(node: WorkspaceAppLayoutNode): string {
+  if (node.type === "panel") return PANEL_LABELS[node.panel];
+  return node.id;
+}
+
+function subtreeMinSize(node: WorkspaceAppLayoutNode, axis: "horizontal" | "vertical"): number {
+  if (node.type === "panel") return node.min_size ?? 1;
+  if (node.type === "tabs")
+    return axis === "vertical"
+      ? 1 + Math.max(1, ...node.children.map((child) => subtreeMinSize(child, axis)))
+      : Math.max(1, ...node.children.map((child) => subtreeMinSize(child, axis)));
+  const childMins = node.children.map((child) => subtreeMinSize(child, axis));
+  return node.direction === axis
+    ? childMins.reduce((sum, value) => sum + value, 0) + node.children.length - 1
+    : Math.max(...childMins);
+}
+
+function allocateSizes(total: number, minimums: number[], weights: number[]): number[] {
+  if (minimums.length === 0) return [];
+  if (total <= 0) return minimums.map(() => 0);
+  const minTotal = minimums.reduce((sum, value) => sum + value, 0);
+  if (minTotal >= total) {
+    const out = minimums.map(() => 0);
+    let remaining = total;
+    for (const [index, min] of minimums.entries()) {
+      const size = Math.min(min, remaining);
+      out[index] = size;
+      remaining -= size;
+    }
+    return out;
+  }
+  const extra = total - minTotal;
+  const weightTotal = weights.reduce((sum, value) => sum + value, 0) || weights.length;
+  const exact = weights.map((weight) => (extra * weight) / weightTotal);
+  const floors = exact.map(Math.floor);
+  let remainder = extra - floors.reduce((sum, value) => sum + value, 0);
+  const order = exact
+    .map((value, index) => ({ index, fraction: value - Math.floor(value) }))
+    .sort((a, b) => b.fraction - a.fraction || a.index - b.index);
+  for (const item of order) {
+    if (remainder <= 0) break;
+    floors[item.index]! += 1;
+    remainder -= 1;
+  }
+  return minimums.map((min, index) => min + (floors[index] ?? 0));
+}
+
+function allocatePersistedSizes(total: number, minimums: number[], weights: number[]): number[] {
+  if (minimums.length === 0) return [];
+  if (total <= 0) return minimums.map(() => 0);
+  const weightTotal = weights.reduce((sum, value) => sum + value, 0) || weights.length;
+  const exact = weights.map((weight) => (total * weight) / weightTotal);
+  const sizes = exact.map(Math.floor);
+  let remainder = total - sizes.reduce((sum, value) => sum + value, 0);
+  const order = exact
+    .map((value, index) => ({ index, fraction: value - Math.floor(value) }))
+    .sort((a, b) => b.fraction - a.fraction || a.index - b.index);
+  for (const item of order) {
+    if (remainder <= 0) break;
+    sizes[item.index]! += 1;
+    remainder -= 1;
+  }
+  return clampSizesToMinimums(sizes, minimums, total);
+}
+
+function clampSizesToMinimums(sizes: number[], minimums: number[], total: number): number[] {
+  const out = sizes.map((size) => Math.max(0, size));
+  for (const [index, min] of minimums.entries()) {
+    const deficit = min - (out[index] ?? 0);
+    if (deficit <= 0) continue;
+    out[index] = min;
+    let remaining = deficit;
+    for (const donor of out.keys()) {
+      if (donor === index) continue;
+      const available = Math.max(0, (out[donor] ?? 0) - (minimums[donor] ?? 1));
+      const take = Math.min(available, remaining);
+      out[donor]! -= take;
+      remaining -= take;
+      if (remaining <= 0) break;
+    }
+  }
+  const diff = total - out.reduce((sum, value) => sum + value, 0);
+  if (diff !== 0 && out.length > 0) out[out.length - 1]! += diff;
+  return out.map((size) => Math.max(0, size));
+}
+
+function firstPanelLeaf(
+  node: WorkspaceAppLayoutNode,
+): Extract<WorkspaceAppLayoutNode, { type: "panel" }> | null {
+  if (node.type === "panel") return node;
+  for (const child of node.children) {
+    const found = firstPanelLeaf(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+function leafById(
+  node: WorkspaceAppLayoutNode,
+  id: string | null | undefined,
+): Extract<WorkspaceAppLayoutNode, { type: "panel" }> | null {
+  if (!id) return null;
+  if (node.type === "panel") return node.id === id ? node : null;
+  for (const child of node.children) {
+    const found = leafById(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function childContainingLeaf(
+  node: Extract<WorkspaceAppLayoutNode, { type: "split" }>,
+  leafId: string | null | undefined,
+): WorkspaceAppLayoutNode | null {
+  if (!leafId) return null;
+  return node.children.find((child) => leafById(child, leafId)) ?? null;
+}
+
+function firstVisibleLeaf(
+  node: WorkspaceAppLayoutNode,
+  activeTabs: Record<string, string>,
+): Extract<WorkspaceAppLayoutNode, { type: "panel" }> | null {
+  if (node.type === "panel") return node;
+  if (node.type === "tabs") {
+    const active = activeTabs[node.id] ?? node.active ?? node.children[0]!.id;
+    return firstVisibleLeaf(
+      node.children.find((child) => child.id === active) ?? node.children[0]!,
+      activeTabs,
+    );
+  }
+  for (const child of node.children) {
+    const found = firstVisibleLeaf(child, activeTabs);
+    if (found) return found;
+  }
+  return null;
+}
+
+function visibleLeafIds(
+  node: WorkspaceAppLayoutNode,
+  activeTabs: Record<string, string>,
+): string[] {
+  if (node.type === "panel") return [node.id];
+  if (node.type === "tabs") {
+    const active = activeTabs[node.id] ?? node.active ?? node.children[0]!.id;
+    return visibleLeafIds(
+      node.children.find((child) => child.id === active) ?? node.children[0]!,
+      activeTabs,
+    );
+  }
+  return node.children.flatMap((child) => visibleLeafIds(child, activeTabs));
+}
+
+function findNode(node: WorkspaceAppLayoutNode, id: string): WorkspaceAppLayoutNode | null {
+  if (node.id === id) return node;
+  if (node.type === "panel") return null;
+  for (const child of node.children) {
+    const found = findNode(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function resizeAdjacentSizes(
+  sizes: number[],
+  minimums: number[],
+  beforeIndex: number,
+  delta: number,
+): number[] {
+  const out = [...sizes];
+  const afterIndex = beforeIndex + 1;
+  const before = out[beforeIndex] ?? 0;
+  const after = out[afterIndex] ?? 0;
+  const beforeMin = minimums[beforeIndex] ?? 1;
+  const afterMin = minimums[afterIndex] ?? 1;
+  const clampedDelta = Math.max(beforeMin - before, Math.min(delta, after - afterMin));
+  out[beforeIndex] = before + clampedDelta;
+  out[afterIndex] = after - clampedDelta;
+  return out.map((size, index) => Math.max(minimums[index] ?? 1, size));
+}
+
+function sizesToWeights(sizes: number[]): number[] {
+  return sizes.map((size) => Math.max(1, Math.trunc(size)));
+}
+
+function findPanelOccurrence(
+  node: WorkspaceAppLayoutNode,
+  panel: WorkspacePanelKind,
+  preferredLeafId: string | null,
+  activeTabs: Record<string, string> = {},
+): { leafId: string; activeTabs: Record<string, string> } | null {
+  if (node.type === "panel") {
+    if (node.panel !== panel) return null;
+    if (preferredLeafId && node.id !== preferredLeafId) return null;
+    return { leafId: node.id, activeTabs };
+  }
+  if (node.type === "tabs") {
+    const preferredChild = preferredLeafId
+      ? node.children.find((child) => leafById(child, preferredLeafId))
+      : null;
+    const ordered = preferredChild
+      ? [preferredChild, ...node.children.filter((child) => child.id !== preferredChild.id)]
+      : node.children;
+    for (const child of ordered) {
+      const found = findPanelOccurrence(child, panel, preferredLeafId, {
+        ...activeTabs,
+        [node.id]: child.id,
+      });
+      if (found) return found;
+    }
+    return null;
+  }
+  for (const child of node.children) {
+    const found = findPanelOccurrence(child, panel, preferredLeafId, activeTabs);
+    if (found) return found;
+  }
+  return null;
+}

--- a/packages/daemon/src/tui/mirror/panel-host.test.ts
+++ b/packages/daemon/src/tui/mirror/panel-host.test.ts
@@ -186,6 +186,42 @@ describe("panel-host", () => {
     ]);
   });
 
+  it("builds composite hosted views and resolves panel lookups through leaves", () => {
+    const views = buildHostedPanelViews([
+      {
+        id: "ide",
+        title: "IDE",
+        layout: {
+          type: "split",
+          id: "root",
+          direction: "horizontal",
+          children: [
+            { type: "panel", id: "term", panel: "terminals" },
+            {
+              type: "tabs",
+              id: "dock",
+              children: [
+                { type: "panel", id: "files", panel: "files" },
+                { type: "panel", id: "diff", panel: "diff" },
+              ],
+            },
+          ],
+        },
+      },
+      { id: "missions", panel: "missions" },
+    ]);
+
+    expect(views[0]).toMatchObject({
+      id: "ide",
+      title: "IDE",
+      panel: "terminals",
+      glyph: "◫",
+    });
+    expect(findFirstHostedViewForPanel(views, "files")?.id).toBe("ide");
+    expect(findFirstHostedViewForPanel(views, "diff")?.id).toBe("ide");
+    expect(findFirstHostedViewForPanel(views, "missions")?.id).toBe("missions");
+  });
+
   it("keeps stale async config generations from winning", () => {
     const generations = new PanelHostLoadGeneration();
     const slow = generations.next();

--- a/packages/daemon/src/tui/mirror/panel-host.ts
+++ b/packages/daemon/src/tui/mirror/panel-host.ts
@@ -1,4 +1,7 @@
 import type {
+  WorkspaceAppLayoutNode,
+  WorkspaceAppView,
+  WorkspaceCompositeView,
   WorkspaceConfigV1,
   WorkspaceFullPanelView,
   WorkspacePanelKind,
@@ -6,6 +9,11 @@ import type {
 import stringWidth from "string-width";
 import type { ResolvedConfig } from "../../lib/resolved-config.ts";
 import type { Tab } from "./app-state.ts";
+import {
+  compositeContainsPanel,
+  findCompositePanelLeaf,
+  firstCompositePanelKind,
+} from "./composite-layout.ts";
 import type { Span } from "./spans.ts";
 
 export type HostedPanelKind = WorkspacePanelKind;
@@ -19,6 +27,7 @@ export interface HostedPanelView {
   id: string;
   title: string;
   panel: HostedPanelKind;
+  layout: WorkspaceAppLayoutNode | null;
   glyph: string;
   order: number;
   shortcut: HostedPanelShortcut | null;
@@ -109,18 +118,44 @@ export function panelSpans(views: readonly HostedPanelView[]): Span[] {
 }
 
 export function buildHostedPanelViews(
-  configuredViews: readonly WorkspaceFullPanelView[] | null | undefined,
+  configuredViews:
+    | readonly WorkspaceAppView[]
+    | readonly WorkspaceFullPanelView[]
+    | null
+    | undefined,
 ): HostedPanelView[] {
   const source =
     configuredViews && configuredViews.length > 0 ? configuredViews : CANONICAL_PANEL_VIEWS;
-  return source.map((view, index) => ({
-    id: view.id,
-    title: view.title ?? PANEL_TITLES[view.panel],
-    panel: view.panel,
-    glyph: PANEL_GLYPHS[view.panel],
-    order: index,
-    shortcut: shortcutForHostedViewIndex(index),
-  }));
+  return source.map((view, index) => {
+    if (isCompositeView(view)) {
+      const panel = firstCompositePanelKind(view.layout);
+      return {
+        id: view.id,
+        title: view.title ?? "Workspace",
+        panel,
+        layout: view.layout,
+        glyph: "◫",
+        order: index,
+        shortcut: shortcutForHostedViewIndex(index),
+      };
+    }
+    const panel = view.panel;
+    return {
+      id: view.id,
+      title: view.title ?? PANEL_TITLES[panel],
+      panel,
+      layout: null,
+      glyph: PANEL_GLYPHS[panel],
+      order: index,
+      shortcut: shortcutForHostedViewIndex(index),
+    };
+  });
+}
+
+function isCompositeView(
+  view: WorkspaceAppView | WorkspaceFullPanelView,
+): view is WorkspaceCompositeView {
+  return "layout" in view;
 }
 
 export function shortcutForHostedViewIndex(index: number): HostedPanelShortcut | null {
@@ -154,7 +189,22 @@ export function findFirstHostedViewForPanel(
   panel: HostedPanelKind | null | undefined,
 ): HostedPanelView | null {
   if (!panel) return null;
-  return views.find((view) => view.panel === panel) ?? null;
+  return (
+    views.find((view) =>
+      view.layout ? compositeContainsPanel(view.layout, panel) : view.panel === panel,
+    ) ?? null
+  );
+}
+
+export function preferredLeafForPanel(
+  view: HostedPanelView,
+  panel: HostedPanelKind,
+): string | null {
+  return view.layout
+    ? findCompositePanelLeaf(view.layout, panel)
+    : view.panel === panel
+      ? view.id
+      : null;
 }
 
 export function reconcileHostedSelection(

--- a/packages/daemon/src/tui/mirror/workspace-ui-state.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace-ui-state.test.ts
@@ -19,8 +19,10 @@ import {
   relativeProjectPath,
   serializeWorkspaceUiState,
   setMissionsSelection,
+  setWorkspaceViewLayoutState,
   shouldHydrateWorkspaceView,
   viewStateFor,
+  layoutStateForView,
   writeWorkspaceUiStateWithRetry,
   type WorkspaceUiStateV1,
 } from "./workspace-ui-state.ts";
@@ -54,11 +56,51 @@ function resolution(
 
 function views(): HostedPanelView[] {
   return [
-    { id: "home", title: "Home", panel: "home", glyph: "⌂", order: 0, shortcut: null },
-    { id: "files-a", title: "Files A", panel: "files", glyph: "▤", order: 1, shortcut: null },
-    { id: "diff-a", title: "Diff A", panel: "diff", glyph: "±", order: 2, shortcut: null },
-    { id: "files-b", title: "Files B", panel: "files", glyph: "▤", order: 3, shortcut: null },
-    { id: "missions", title: "Missions", panel: "missions", glyph: "◆", order: 4, shortcut: null },
+    {
+      id: "home",
+      title: "Home",
+      panel: "home",
+      layout: null,
+      glyph: "⌂",
+      order: 0,
+      shortcut: null,
+    },
+    {
+      id: "files-a",
+      title: "Files A",
+      panel: "files",
+      layout: null,
+      glyph: "▤",
+      order: 1,
+      shortcut: null,
+    },
+    {
+      id: "diff-a",
+      title: "Diff A",
+      panel: "diff",
+      layout: null,
+      glyph: "±",
+      order: 2,
+      shortcut: null,
+    },
+    {
+      id: "files-b",
+      title: "Files B",
+      panel: "files",
+      layout: null,
+      glyph: "▤",
+      order: 3,
+      shortcut: null,
+    },
+    {
+      id: "missions",
+      title: "Missions",
+      panel: "missions",
+      layout: null,
+      glyph: "◆",
+      order: 4,
+      shortcut: null,
+    },
   ];
 }
 
@@ -174,6 +216,39 @@ describe("workspace UI-state contract", () => {
     expect(missionsSelection(state, "other")).toEqual({
       selectedMissionId: null,
       selectedTaskId: null,
+    });
+  });
+
+  it("round-trips bounded composite layout pointers without YAML/runtime state", () => {
+    const state = setWorkspaceViewLayoutState(defaultWorkspaceUiState(), views()[1]!, {
+      focusedLeafId: "files-tab",
+      activeTabs: { dock: "diff-tab" },
+      splitWeights: { root: [70, 30] },
+    });
+
+    expect(layoutStateForView(state, "files-a")).toEqual({
+      focusedLeafId: "files-tab",
+      activeTabs: { dock: "diff-tab" },
+      splitWeights: { root: [70, 30] },
+    });
+    const parsed = parseWorkspaceUiStateJson(serializeWorkspaceUiState(state));
+    expect(parsed.state.views["files-a"]).toEqual({
+      panel: "files",
+      openPath: null,
+      selectedPath: null,
+      layout: {
+        focusedLeafId: "files-tab",
+        activeTabs: { dock: "diff-tab" },
+        splitWeights: { root: [70, 30] },
+      },
+    });
+    const bad = parseWorkspaceUiStateJson(
+      '{"version":1,"active":null,"views":{"ide":{"panel":"files","layout":{"focusedLeafId":"bad\\u0000","activeTabs":{"dock":"files"},"splitWeights":{"root":[1,-1]}}}}}',
+    );
+    expect(layoutStateForView(bad.state, "ide")).toEqual({
+      focusedLeafId: null,
+      activeTabs: { dock: "files" },
+      splitWeights: {},
     });
   });
 

--- a/packages/daemon/src/tui/mirror/workspace-ui-state.ts
+++ b/packages/daemon/src/tui/mirror/workspace-ui-state.ts
@@ -10,6 +10,7 @@ import type { HostedPanelKind, HostedPanelView } from "./panel-host.ts";
 import { findFirstHostedViewForPanel, findHostedViewById } from "./panel-host.ts";
 import type { Tab } from "./app-state.ts";
 import { panelKindFromLegacyTab } from "./panel-host.ts";
+import type { CompositeLayoutState } from "./composite-layout.ts";
 
 export const WORKSPACE_UI_STATE_PATH = "ui/workspace.json";
 export const WORKSPACE_UI_STATE_VERSION = 1;
@@ -43,22 +44,28 @@ export interface WorkspaceFilesViewState {
   panel: "files";
   openPath: string | null;
   selectedPath: string | null;
+  layout?: WorkspaceCompositeLayoutViewState;
 }
 
 export interface WorkspaceDiffViewState {
   panel: "diff";
   selectedPath: string | null;
+  layout?: WorkspaceCompositeLayoutViewState;
 }
 
 export interface WorkspaceMissionsViewState {
   panel: "missions";
   selectedMissionId: string | null;
   selectedTaskId: string | null;
+  layout?: WorkspaceCompositeLayoutViewState;
 }
 
 export interface WorkspaceEmptyViewState {
   panel: "home" | "terminals";
+  layout?: WorkspaceCompositeLayoutViewState;
 }
+
+export type WorkspaceCompositeLayoutViewState = CompositeLayoutState;
 
 export type WorkspaceViewState =
   | WorkspaceFilesViewState
@@ -193,17 +200,20 @@ function cleanViewState(
     diagnostics.push(diagnostic("INVALID_FIELD", `$.views.${key}.panel`, "panel is unsupported"));
     return null;
   }
+  const layout = cleanLayoutState(value.layout, `$.views.${key}.layout`, diagnostics);
   if (panel === "files") {
     return {
       panel,
       openPath: cleanPath(value.openPath),
       selectedPath: cleanPath(value.selectedPath),
+      ...(layout ? { layout } : {}),
     };
   }
   if (panel === "diff") {
     return {
       panel,
       selectedPath: cleanPath(value.selectedPath),
+      ...(layout ? { layout } : {}),
     };
   }
   if (panel === "missions") {
@@ -211,9 +221,61 @@ function cleanViewState(
       panel,
       selectedMissionId: cleanId(value.selectedMissionId),
       selectedTaskId: cleanId(value.selectedTaskId),
+      ...(layout ? { layout } : {}),
     };
   }
-  return { panel };
+  return { panel, ...(layout ? { layout } : {}) };
+}
+
+function cleanLayoutState(
+  value: unknown,
+  path: string,
+  diagnostics: WorkspaceUiStateDiagnostic[],
+): WorkspaceCompositeLayoutViewState | null {
+  if (value === undefined || value === null) return null;
+  if (!isRecord(value)) {
+    diagnostics.push(diagnostic("INVALID_FIELD", path, "layout state must be an object"));
+    return null;
+  }
+  const focusedLeafId = cleanId(value.focusedLeafId);
+  const activeTabs: Record<string, string> = {};
+  if (isRecord(value.activeTabs)) {
+    for (const [key, raw] of Object.entries(value.activeTabs).slice(0, 64)) {
+      const id = cleanId(key);
+      const childId = cleanId(raw);
+      if (id && childId) activeTabs[id] = childId;
+    }
+  } else if (value.activeTabs !== undefined) {
+    diagnostics.push(
+      diagnostic("INVALID_FIELD", `${path}.activeTabs`, "activeTabs must be an object"),
+    );
+  }
+  const splitWeights: Record<string, number[]> = {};
+  if (isRecord(value.splitWeights)) {
+    for (const [key, raw] of Object.entries(value.splitWeights).slice(0, 64)) {
+      const id = cleanId(key);
+      if (
+        id &&
+        Array.isArray(raw) &&
+        raw.length >= 2 &&
+        raw.length <= 4 &&
+        raw.every((item) => typeof item === "number" && Number.isFinite(item) && item > 0)
+      ) {
+        splitWeights[id] = raw.map((item) => item as number);
+      }
+    }
+  } else if (value.splitWeights !== undefined) {
+    diagnostics.push(
+      diagnostic("INVALID_FIELD", `${path}.splitWeights`, "splitWeights must be an object"),
+    );
+  }
+  if (
+    !focusedLeafId &&
+    Object.keys(activeTabs).length === 0 &&
+    Object.keys(splitWeights).length === 0
+  )
+    return null;
+  return { focusedLeafId, activeTabs, splitWeights };
 }
 
 function cloneState(state: WorkspaceUiStateV1): WorkspaceUiStateV1 {
@@ -302,17 +364,26 @@ export function serializeWorkspaceUiState(state: WorkspaceUiStateV1): string {
         panel: "files",
         openPath: view.openPath,
         selectedPath: view.selectedPath,
+        ...(view.layout ? { layout: orderedLayoutState(view.layout) } : {}),
       };
     } else if (view.panel === "diff") {
-      orderedViews[id] = { panel: "diff", selectedPath: view.selectedPath };
+      orderedViews[id] = {
+        panel: "diff",
+        selectedPath: view.selectedPath,
+        ...(view.layout ? { layout: orderedLayoutState(view.layout) } : {}),
+      };
     } else if (view.panel === "missions") {
       orderedViews[id] = {
         panel: "missions",
         selectedMissionId: view.selectedMissionId,
         selectedTaskId: view.selectedTaskId,
+        ...(view.layout ? { layout: orderedLayoutState(view.layout) } : {}),
       };
     } else {
-      orderedViews[id] = { panel: view.panel };
+      orderedViews[id] = {
+        panel: view.panel,
+        ...(view.layout ? { layout: orderedLayoutState(view.layout) } : {}),
+      };
     }
   }
   const clean: WorkspaceUiStateV1 = {
@@ -321,6 +392,22 @@ export function serializeWorkspaceUiState(state: WorkspaceUiStateV1): string {
     views: orderedViews,
   };
   return `${JSON.stringify(clean, null, 2)}\n`;
+}
+
+function orderedLayoutState(
+  layout: WorkspaceCompositeLayoutViewState,
+): WorkspaceCompositeLayoutViewState {
+  const activeTabs: Record<string, string> = {};
+  for (const key of Object.keys(layout.activeTabs).sort())
+    activeTabs[key] = layout.activeTabs[key]!;
+  const splitWeights: Record<string, number[]> = {};
+  for (const key of Object.keys(layout.splitWeights).sort())
+    splitWeights[key] = [...layout.splitWeights[key]!];
+  return {
+    focusedLeafId: cleanId(layout.focusedLeafId),
+    activeTabs,
+    splitWeights,
+  };
 }
 
 export function workspaceUiStateToJsonValue(state: WorkspaceUiStateV1): JsonValue {
@@ -472,12 +559,74 @@ export function setMissionsSelection(
     views: {
       ...state.views,
       [id]: {
+        ...(state.views[id]?.layout ? { layout: state.views[id].layout } : {}),
         panel: "missions",
         selectedMissionId: cleanId(missionId),
         selectedTaskId: cleanId(taskId),
       },
     },
   };
+}
+
+export function layoutStateForView(
+  state: WorkspaceUiStateV1,
+  viewId: string,
+): WorkspaceCompositeLayoutViewState | null {
+  return state.views[viewId]?.layout ?? null;
+}
+
+function workspaceViewStateWithLayout(
+  entry: WorkspaceViewState,
+  layout: WorkspaceCompositeLayoutViewState,
+): WorkspaceViewState {
+  const cleanLayout = orderedLayoutState(layout);
+  if (entry.panel === "files") {
+    return {
+      panel: "files",
+      openPath: entry.openPath,
+      selectedPath: entry.selectedPath,
+      layout: cleanLayout,
+    };
+  }
+  if (entry.panel === "diff") {
+    return { panel: "diff", selectedPath: entry.selectedPath, layout: cleanLayout };
+  }
+  if (entry.panel === "missions") {
+    return {
+      panel: "missions",
+      selectedMissionId: entry.selectedMissionId,
+      selectedTaskId: entry.selectedTaskId,
+      layout: cleanLayout,
+    };
+  }
+  return { panel: entry.panel, layout: cleanLayout };
+}
+
+export function setWorkspaceViewLayoutState(
+  state: WorkspaceUiStateV1,
+  view: Pick<HostedPanelView, "id" | "panel">,
+  layout: WorkspaceCompositeLayoutViewState,
+): WorkspaceUiStateV1 {
+  const id = cleanId(view.id);
+  if (!id) return cloneState(state);
+  const existing = state.views[id] ?? workspaceViewStateForPanel(view.panel);
+  return {
+    version: WORKSPACE_UI_STATE_VERSION,
+    active: state.active ? { ...state.active } : null,
+    views: {
+      ...state.views,
+      [id]: workspaceViewStateWithLayout(existing, layout),
+    },
+  };
+}
+
+function workspaceViewStateForPanel(panel: HostedPanelKind): WorkspaceViewState {
+  if (panel === "files") return { panel: "files", openPath: null, selectedPath: null };
+  if (panel === "diff") return { panel: "diff", selectedPath: null };
+  if (panel === "missions") {
+    return { panel: "missions", selectedMissionId: null, selectedTaskId: null };
+  }
+  return { panel };
 }
 
 export function missionsSelection(


### PR DESCRIPTION
## Summary

- extend workspace app views with validated recursive panel, split, and tab layouts while preserving full-panel configs
- add deterministic composite geometry, focus, local-tab reveal, deep-link routing, separator resize, and impossible-size fallback behavior
- render concurrent live Terminal, Files, Diff, Home, and Missions leaves with focused input routing and terminal keep-alive
- persist exact per-view focus, active local tabs, split weights, and mission selection with stale-state reconciliation

## Validation

- `pnpm check`
- `pnpm build:tui`
- `git diff --check`
- compiled TUI smoke: concurrent Terminal + Files, local Diff/Missions tabs, Ctrl+Tab focus, persisted separator drag, 30x10 fallback, Ctrl+Q exit, and target tmux session/terminal survival after TUI exit

## Scope

Completes C07: composite split/tab application views, focus, sizing, persistence, deep links, and keep-alive.