### PR TITLE
docs: preview Missions workspace on homepage

### DIFF
--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -161,6 +161,11 @@ const features = [
       "wait agent-status and wait output --match block until a session hits a status or a pane matches a regex. Scriptable synchronization.",
   },
   {
+    title: "Missions workspace preview",
+    description:
+      "A durable project-scoped Missions board, history, and details surface for reviewing mission progress inside the current app.",
+  },
+  {
     title: "Crash-proof restore",
     description:
       "Continuous snapshots; tmux-ide restore rebuilds sessions, windows, layouts, cwds, and titles after a tmux server death.",


### PR DESCRIPTION
## Summary

- add one small `Missions workspace preview` capability card to the website landing page
- describe only the shipped project-scoped board, history, and details surface
- deliberately avoid claims about mission creation, automatic dispatch, or harness orchestration

## Demo mission

- Mission: `mis_demo_site_missions_20260719`
- Task: `tsk_demo_site_missions_card`
- Attempt: `att_demo_site_missions` (`codex`, pane `%2`)

## Validation

- `pnpm exec prettier --check docs/app/(home)/page.tsx`
- `pnpm docs:build`
- `git diff --check`