### PR TITLE
refactor(tui): extract missions surface boundary

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -355,26 +355,16 @@ import {
 } from "./panel-host.ts";
 import {
   MissionWorkspaceLoader,
-  applyMissionWorkspaceHit,
-  closeMissionDetail,
   clipTerminal,
-  cycleMissionDensity,
-  cycleMissionDetailSection,
   defaultMissionWorkspaceModel,
   invalidatedMissionWorkspaceLoadState,
   missionSelectionFromWorkspaceState,
   missionTmuxPanePreflightMatches,
   missionTmuxPreflightCommands,
   missionWorkspaceHitTest,
-  missionWorkspaceLayout,
-  moveMissionSelection,
-  openMissionDetail,
   readMissionWorkspace,
   reconcileMissionWorkspaceModel,
   resolveMissionDeepLink,
-  scrollMissionWorkspace,
-  setMissionDetailSection,
-  setMissionWorkspaceMode,
   workspaceStateWithMissionSelection,
   type MissionDeepLinkKind,
   type MissionDeepLinkResolution,
@@ -382,6 +372,12 @@ import {
   type MissionWorkspaceModel,
   type MissionWorkspaceSnapshot,
 } from "./missions-workspace.ts";
+import { MissionsSurface, missionSurfaceLayout } from "./missions-surface.tsx";
+import {
+  handleMissionSurfaceKey,
+  handleMissionSurfacePointerDown,
+  handleMissionSurfaceScroll,
+} from "./missions-surface-controller.ts";
 import {
   WorkspaceUiStateController,
   absoluteProjectPath,
@@ -2804,108 +2800,22 @@ try {
       meta: boolean;
       shift: boolean;
     }): boolean => {
-      const snapshot = missionSnapshotForModel();
-      if (evt.name === "r") {
-        loadMissionsWorkspace("refresh");
-        return true;
-      }
-      if (evt.name === "t" || evt.name === "f" || evt.name === "d") {
-        followMissionDeepLink(evt.name === "t" ? "terminal" : evt.name === "f" ? "files" : "diff");
-        return true;
-      }
-      if (evt.name === "z") {
-        updateMissionModel((model) => cycleMissionDensity(model, snapshot, missionLayoutSize()));
-        return true;
-      }
-      if (!snapshot) return true;
-      if (missionWorkspaceModel().mode === "detail") {
-        if (evt.name === "escape" || evt.name === "backspace") {
-          updateMissionModel(closeMissionDetail);
-          return true;
-        }
-        if (evt.name === "tab") {
-          updateMissionModel((model) =>
-            cycleMissionDetailSection(model, snapshot, evt.shift ? -1 : 1, missionLayoutSize()),
-          );
-          return true;
-        }
-        const sectionKey =
-          evt.name === "1"
-            ? "tasks"
-            : evt.name === "2"
-              ? "timeline"
-              : evt.name === "3"
-                ? "attempts"
-                : evt.name === "4"
-                  ? "proof"
-                  : null;
-        if (sectionKey) {
-          updateMissionModel((model) =>
-            setMissionDetailSection(model, snapshot, sectionKey, missionLayoutSize()),
-          );
-          return true;
-        }
-      }
-      if (evt.name === "tab") {
-        updateMissionModel((model) =>
-          setMissionWorkspaceMode(
-            model,
-            snapshot,
-            model.mode === "board" ? "history" : "board",
-            missionLayoutSize(),
-          ),
-        );
-        return true;
-      }
-      if (evt.name === "b" || evt.name === "y") {
-        updateMissionModel((model) =>
-          setMissionWorkspaceMode(
-            model,
-            snapshot,
-            evt.name === "b" ? "board" : "history",
-            missionLayoutSize(),
-          ),
-        );
-        return true;
-      }
-      const movement =
-        evt.name === "left" || evt.name === "h"
-          ? "left"
-          : evt.name === "right" || evt.name === "l"
-            ? "right"
-            : evt.name === "up" || evt.name === "k"
-              ? "up"
-              : evt.name === "down" || evt.name === "j"
-                ? "down"
-                : evt.name === "home"
-                  ? "home"
-                  : evt.name === "end"
-                    ? "end"
-                    : null;
-      if (movement) {
-        updateMissionModel((model) =>
-          moveMissionSelection(model, snapshot, movement, missionLayoutSize()),
-        );
-        return true;
-      }
-      if (evt.name === "return") {
-        const selected = missionWorkspaceModel().selectedMissionId;
-        if (selected) {
-          persistMissionSelection(selected, missionWorkspaceModel().selectedTaskId);
-          updateMissionModel((model) =>
-            openMissionDetail(model, snapshot, {
-              persistedTaskId: missionSelectionFromWorkspaceState(
-                workspaceUiState(),
-                activeViewId(),
-              ).selectedTaskId,
-              ...missionLayoutSize(),
-            }),
-          );
-          if (snapshot.detail?.mission.id !== selected) loadMissionsWorkspace("refresh");
-        }
-        return true;
-      }
-      return true;
+      return handleMissionSurfaceKey(
+        evt,
+        {
+          model: missionWorkspaceModel(),
+          snapshot: missionSnapshotForModel(),
+          layoutSize: missionLayoutSize(),
+          persistedTaskId: missionSelectionFromWorkspaceState(workspaceUiState(), activeViewId())
+            .selectedTaskId,
+        },
+        {
+          updateModel: updateMissionModel,
+          refresh: () => loadMissionsWorkspace("refresh"),
+          followDeepLink: followMissionDeepLink,
+          persistSelection: persistMissionSelection,
+        },
+      );
     };
     const missionLoadErrorMessage = (): string => {
       const state = missionWorkspaceLoad();
@@ -2920,7 +2830,7 @@ try {
       quitHint: QUIT_HINT,
     });
     const missionsLayout = createMemo(() =>
-      missionWorkspaceLayout(
+      missionSurfaceLayout(
         canvasCols(),
         Math.max(4, dims().height - TABBAR_H),
         missionWorkspaceModel(),
@@ -6431,24 +6341,23 @@ try {
           return;
         }
         if (mode() === "missions" && type === "scroll") {
-          const snapshot = missionWorkspaceSnapshot();
-          if (!snapshot) return;
           const hit = missionHitAt(x, y);
           const direction = e.scroll?.direction;
           if (direction !== "up" && direction !== "down") return;
-          const delta = direction === "up" ? -SCROLL_STEP : SCROLL_STEP;
-          const target =
-            hit?.kind === "detail-row"
-              ? hit.section
-              : missionWorkspaceModel().mode === "detail"
-                ? missionWorkspaceModel().detailSection
-                : hit?.kind === "card" || hit?.kind === "column"
-                  ? hit.column
-                  : missionWorkspaceModel().mode === "history"
-                    ? "history"
-                    : missionWorkspaceModel().selectedColumn;
-          updateMissionModel((model) =>
-            scrollMissionWorkspace(model, snapshot, target, delta, missionLayoutSize()),
+          handleMissionSurfaceScroll(
+            hit,
+            direction,
+            {
+              model: missionWorkspaceModel(),
+              snapshot: missionWorkspaceSnapshot(),
+              layoutSize: missionLayoutSize(),
+              persistedTaskId: missionSelectionFromWorkspaceState(
+                workspaceUiState(),
+                activeViewId(),
+              ).selectedTaskId,
+            },
+            { updateModel: updateMissionModel },
+            SCROLL_STEP,
           );
           return;
         }
@@ -6486,27 +6395,25 @@ try {
           return;
         }
         if (mode() === "missions") {
-          const snapshot = missionWorkspaceSnapshot();
           const hit = missionHitAt(x, y);
-          if (hit?.kind === "refresh") {
-            loadMissionsWorkspace("refresh");
-          } else if (hit?.kind === "deep-link") {
-            followMissionDeepLink(hit.link);
-          } else if (hit?.kind === "detail-section" && snapshot) {
-            updateMissionModel((model) =>
-              setMissionDetailSection(model, snapshot, hit.section, missionLayoutSize()),
-            );
-          } else if (hit && snapshot) {
-            updateMissionModel((model) =>
-              applyMissionWorkspaceHit(model, snapshot, hit, missionLayoutSize()),
-            );
-            if (hit.kind === "card" || hit.kind === "history") {
-              updateMissionModel((model) =>
-                openMissionDetail(model, snapshot, missionLayoutSize()),
-              );
-              loadMissionsWorkspace("refresh");
-            }
-          }
+          handleMissionSurfacePointerDown(
+            hit,
+            {
+              model: missionWorkspaceModel(),
+              snapshot: missionWorkspaceSnapshot(),
+              layoutSize: missionLayoutSize(),
+              persistedTaskId: missionSelectionFromWorkspaceState(
+                workspaceUiState(),
+                activeViewId(),
+              ).selectedTaskId,
+            },
+            {
+              updateModel: updateMissionModel,
+              refresh: () => loadMissionsWorkspace("refresh"),
+              followDeepLink: followMissionDeepLink,
+              persistSelection: persistMissionSelection,
+            },
+          );
         }
         return;
       }
@@ -8187,257 +8094,22 @@ try {
               </box>
             </Show>
             <Show when={!activeCompositeLayout() && mode() === "missions"}>
-              <box width={canvasCols()} flexDirection="row" gap={1}>
-                <For each={missionsLayout().header.rows[0] ?? []}>
-                  {(chip) => (
-                    <text
-                      fg={DEFAULT_FG}
-                      bg={
-                        chip.kind === "mode" && chip.mode === missionWorkspaceModel().mode
-                          ? BUTTON_ACTIVE_BG
-                          : chip.kind === "mode" &&
-                              isHovered("missionmode", chip.mode === "board" ? 0 : 1)
-                            ? BUTTON_HOVER_BG
-                            : chip.kind === "refresh" && isHovered("missionbutton", 0)
-                              ? BUTTON_HOVER_BG
-                              : chip.kind === "density" && isHovered("missionbutton", 1)
-                                ? BUTTON_HOVER_BG
-                                : BUTTON_BG
-                      }
-                    >
-                      {chip.label}
-                    </text>
-                  )}
-                </For>
-              </box>
-              <box width={canvasCols()} flexDirection="row">
-                <text
-                  fg={BUTTON_FG}
-                  bg={isHovered("missionbutton", 2) ? BUTTON_HOVER_BG : BUTTON_BG}
-                >
-                  {"<"}
-                </text>
-                <text fg={MUTED}>
-                  {clipTerminal(
-                    missionsLayout().header.labels[1].slice(1, -1),
-                    Math.max(0, canvasCols() - 2),
-                  )}
-                </text>
-                <Show when={canvasCols() > 1}>
-                  <text
-                    fg={BUTTON_FG}
-                    bg={isHovered("missionbutton", 3) ? BUTTON_HOVER_BG : BUTTON_BG}
-                  >
-                    {">"}
-                  </text>
-                </Show>
-              </box>
-              <Show when={missionWorkspaceLoad().status === "loading"}>
-                <box flexDirection="column" flexGrow={1}>
-                  <box height={1} />
-                  <text fg={DEFAULT_FG}>Loading missions…</text>
-                  <text fg={MUTED}>Mission history is read from the active project runtime.</text>
-                </box>
-              </Show>
-              <Show when={missionWorkspaceLoad().status === "error" && !missionWorkspaceSnapshot()}>
-                <box flexDirection="column" flexGrow={1}>
-                  <box height={1} />
-                  <text fg={BANNER_FG}>Mission data could not be loaded.</text>
-                  <text fg={MUTED}>{missionLoadErrorMessage()}</text>
-                  <text fg={MUTED}>Press r to retry. Other workspace views remain available.</text>
-                </box>
-              </Show>
-              <Show when={missionWorkspaceLoad().status === "empty"}>
-                <box flexDirection="column" flexGrow={1}>
-                  <box height={1} />
-                  <text fg={DEFAULT_FG}>No missions yet.</text>
-                  <text fg={MUTED}>
-                    This read-only board will populate from durable mission history.
-                  </text>
-                </box>
-              </Show>
-              <Show
-                when={
-                  missionWorkspaceSnapshot() &&
-                  missionWorkspaceLoad().status !== "loading" &&
-                  !(missionWorkspaceLoad().status === "error" && !missionWorkspaceSnapshot()) &&
-                  missionWorkspaceLoad().status !== "empty"
-                }
-              >
-                <Show when={missionWorkspaceModel().mode === "board"}>
-                  <box flexDirection="row" flexGrow={1} gap={1}>
-                    <For each={missionsLayout().board.columns}>
-                      {(column) => (
-                        <box flexDirection="column" width={column.width}>
-                          <text fg={ACCENT}>
-                            {clipTerminal(`${column.label} (${column.count})`, column.width)}
-                          </text>
-                          <For each={column.cards}>
-                            {(cardLayout) => {
-                              const selected =
-                                missionWorkspaceModel().selectedMissionId === cardLayout.missionId;
-                              return (
-                                <box
-                                  flexDirection="column"
-                                  height={cardLayout.height}
-                                  backgroundColor={
-                                    selected
-                                      ? BADGE_BG
-                                      : isHovered("missioncard", cardLayout.hoverKey)
-                                        ? HOVER_BG
-                                        : DEFAULT_BG
-                                  }
-                                >
-                                  <For each={cardLayout.lines}>
-                                    {(line, lineIndex) => (
-                                      <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>
-                                        {clipTerminal(line, cardLayout.width)}
-                                      </text>
-                                    )}
-                                  </For>
-                                </box>
-                              );
-                            }}
-                          </For>
-                        </box>
-                      )}
-                    </For>
-                  </box>
-                </Show>
-                <Show when={missionWorkspaceModel().mode === "history"}>
-                  <box flexDirection="column" flexGrow={1}>
-                    <For each={missionsLayout().history.rows}>
-                      {(row) => {
-                        const selected =
-                          missionWorkspaceModel().selectedMissionId === row.missionId;
-                        return (
-                          <box
-                            flexDirection="column"
-                            height={row.height}
-                            backgroundColor={
-                              selected
-                                ? BADGE_BG
-                                : isHovered("missionhistory", row.hoverKey)
-                                  ? HOVER_BG
-                                  : DEFAULT_BG
-                            }
-                          >
-                            <For each={row.lines}>
-                              {(line, lineIndex) => (
-                                <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>
-                                  {clipTerminal(line, row.width)}
-                                </text>
-                              )}
-                            </For>
-                          </box>
-                        );
-                      }}
-                    </For>
-                  </box>
-                </Show>
-                <Show when={missionWorkspaceModel().mode === "detail"}>
-                  <box flexDirection="column" flexGrow={1}>
-                    <box width={canvasCols()} flexDirection="row" gap={1}>
-                      <For each={missionsLayout().detail.sections}>
-                        {(chip) => (
-                          <text
-                            fg={DEFAULT_FG}
-                            bg={
-                              chip.section === missionWorkspaceModel().detailSection ||
-                              isHovered(
-                                "missionbutton",
-                                10 + missionsLayout().detail.sections.indexOf(chip),
-                              )
-                                ? BUTTON_ACTIVE_BG
-                                : BUTTON_BG
-                            }
-                          >
-                            {chip.label}
-                          </text>
-                        )}
-                      </For>
-                      <box flexGrow={1} />
-                      <For each={missionsLayout().detail.links}>
-                        {(chip) => {
-                          const resolved = chip.link ? missionDeepLink(chip.link) : null;
-                          return (
-                            <text
-                              fg={resolved?.available ? BUTTON_FG : MUTED}
-                              bg={
-                                chip.link &&
-                                isHovered(
-                                  "missionbutton",
-                                  20 + missionsLayout().detail.links.indexOf(chip),
-                                )
-                                  ? BUTTON_HOVER_BG
-                                  : BUTTON_BG
-                              }
-                            >
-                              {chip.label}
-                            </text>
-                          );
-                        }}
-                      </For>
-                    </box>
-                    <Show
-                      when={missionWorkspaceSnapshot()?.detail}
-                      fallback={
-                        <box flexDirection="column" flexGrow={1}>
-                          <text fg={DEFAULT_FG}>Loading mission detail…</text>
-                          <text fg={MUTED}>Press r to refresh if this does not resolve.</text>
-                        </box>
-                      }
-                    >
-                      <box flexDirection="row" flexGrow={1} gap={1}>
-                        <Show when={missionsLayout().detail.wide}>
-                          <box flexDirection="column" width={missionsLayout().detail.contextWidth}>
-                            <For each={missionsLayout().detail.contextRows}>
-                              {(row) => (
-                                <For each={row.lines}>
-                                  {(line, lineIndex) => (
-                                    <text fg={lineIndex() === 0 ? ACCENT : MUTED}>{line}</text>
-                                  )}
-                                </For>
-                              )}
-                            </For>
-                          </box>
-                        </Show>
-                        <box flexDirection="column" width={missionsLayout().detail.sectionWidth}>
-                          <For each={missionsLayout().detail.rows}>
-                            {(row) => {
-                              const selected =
-                                row.kind === "tasks" &&
-                                missionWorkspaceModel().selectedTaskId === row.id;
-                              return (
-                                <box
-                                  flexDirection="column"
-                                  height={row.height}
-                                  backgroundColor={
-                                    selected
-                                      ? BADGE_BG
-                                      : isHovered("missionhistory", row.hoverKey)
-                                        ? HOVER_BG
-                                        : DEFAULT_BG
-                                  }
-                                >
-                                  <For each={row.lines}>
-                                    {(line, lineIndex) => (
-                                      <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>
-                                        {line}
-                                      </text>
-                                    )}
-                                  </For>
-                                </box>
-                              );
-                            }}
-                          </For>
-                        </box>
-                      </box>
-                    </Show>
-                  </box>
-                </Show>
-              </Show>
-              <text fg={MUTED}>{missionsLayout().footer.label}</text>
+              <MissionsSurface
+                width={canvasCols()}
+                layout={missionsLayout()}
+                model={missionWorkspaceModel()}
+                snapshot={missionWorkspaceSnapshot()}
+                loadState={missionWorkspaceLoad()}
+                errorMessage={missionLoadErrorMessage()}
+                resolveDeepLink={missionDeepLink}
+                isHovered={isHovered}
+                theme={{
+                  bannerFg: BANNER_FG,
+                  buttonFg: BUTTON_FG,
+                  buttonBg: BUTTON_BG,
+                  buttonActiveBg: BUTTON_ACTIVE_BG,
+                }}
+              />
             </Show>
           </box>
         </box>

--- a/packages/daemon/src/tui/mirror/missions-surface-controller.ts
+++ b/packages/daemon/src/tui/mirror/missions-surface-controller.ts
@@ -1,0 +1,202 @@
+import {
+  applyMissionWorkspaceHit,
+  closeMissionDetail,
+  cycleMissionDensity,
+  cycleMissionDetailSection,
+  moveMissionSelection,
+  openMissionDetail,
+  scrollMissionWorkspace,
+  setMissionDetailSection,
+  setMissionWorkspaceMode,
+  type MissionDeepLinkKind,
+  type MissionWorkspaceHit,
+  type MissionWorkspaceModel,
+  type MissionWorkspaceSnapshot,
+} from "./missions-workspace.ts";
+
+export interface MissionSurfaceKeyEvent {
+  name: string;
+  ctrl: boolean;
+  meta: boolean;
+  shift: boolean;
+}
+
+export interface MissionSurfaceLayoutSize {
+  width: number;
+  height: number;
+}
+
+export interface MissionSurfaceControllerState {
+  model: MissionWorkspaceModel;
+  snapshot: MissionWorkspaceSnapshot | null;
+  layoutSize: MissionSurfaceLayoutSize;
+  persistedTaskId: string | null;
+}
+
+export interface MissionSurfaceControllerActions {
+  updateModel: (updater: (model: MissionWorkspaceModel) => MissionWorkspaceModel) => void;
+  refresh: () => void;
+  followDeepLink: (kind: MissionDeepLinkKind) => void;
+  persistSelection: (missionId: string | null, taskId: string | null) => void;
+}
+
+export function handleMissionSurfaceKey(
+  event: MissionSurfaceKeyEvent,
+  state: MissionSurfaceControllerState,
+  actions: MissionSurfaceControllerActions,
+): boolean {
+  const { snapshot, layoutSize } = state;
+  if (event.name === "r") {
+    actions.refresh();
+    return true;
+  }
+  if (event.name === "t" || event.name === "f" || event.name === "d") {
+    actions.followDeepLink(event.name === "t" ? "terminal" : event.name === "f" ? "files" : "diff");
+    return true;
+  }
+  if (event.name === "z") {
+    actions.updateModel((model) => cycleMissionDensity(model, snapshot, layoutSize));
+    return true;
+  }
+  if (!snapshot) return true;
+  if (state.model.mode === "detail") {
+    if (event.name === "escape" || event.name === "backspace") {
+      actions.updateModel(closeMissionDetail);
+      return true;
+    }
+    if (event.name === "tab") {
+      actions.updateModel((model) =>
+        cycleMissionDetailSection(model, snapshot, event.shift ? -1 : 1, layoutSize),
+      );
+      return true;
+    }
+    const sectionKey =
+      event.name === "1"
+        ? "tasks"
+        : event.name === "2"
+          ? "timeline"
+          : event.name === "3"
+            ? "attempts"
+            : event.name === "4"
+              ? "proof"
+              : null;
+    if (sectionKey) {
+      actions.updateModel((model) =>
+        setMissionDetailSection(model, snapshot, sectionKey, layoutSize),
+      );
+      return true;
+    }
+  }
+  if (event.name === "tab") {
+    actions.updateModel((model) =>
+      setMissionWorkspaceMode(
+        model,
+        snapshot,
+        model.mode === "board" ? "history" : "board",
+        layoutSize,
+      ),
+    );
+    return true;
+  }
+  if (event.name === "b" || event.name === "y") {
+    actions.updateModel((model) =>
+      setMissionWorkspaceMode(
+        model,
+        snapshot,
+        event.name === "b" ? "board" : "history",
+        layoutSize,
+      ),
+    );
+    return true;
+  }
+  const movement =
+    event.name === "left" || event.name === "h"
+      ? "left"
+      : event.name === "right" || event.name === "l"
+        ? "right"
+        : event.name === "up" || event.name === "k"
+          ? "up"
+          : event.name === "down" || event.name === "j"
+            ? "down"
+            : event.name === "home"
+              ? "home"
+              : event.name === "end"
+                ? "end"
+                : null;
+  if (movement) {
+    actions.updateModel((model) => moveMissionSelection(model, snapshot, movement, layoutSize));
+    return true;
+  }
+  if (event.name === "return") {
+    const selected = state.model.selectedMissionId;
+    if (selected) {
+      actions.persistSelection(selected, state.model.selectedTaskId);
+      actions.updateModel((model) =>
+        openMissionDetail(model, snapshot, {
+          persistedTaskId: state.persistedTaskId,
+          ...layoutSize,
+        }),
+      );
+      if (snapshot.detail?.mission.id !== selected) actions.refresh();
+    }
+    return true;
+  }
+  return true;
+}
+
+export function handleMissionSurfaceScroll(
+  hit: MissionWorkspaceHit,
+  direction: "up" | "down",
+  state: MissionSurfaceControllerState,
+  actions: Pick<MissionSurfaceControllerActions, "updateModel">,
+  step: number,
+): boolean {
+  const { snapshot, model, layoutSize } = state;
+  if (!snapshot) return true;
+  const delta = direction === "up" ? -step : step;
+  const target =
+    hit?.kind === "detail-row"
+      ? hit.section
+      : model.mode === "detail"
+        ? model.detailSection
+        : hit?.kind === "card" || hit?.kind === "column"
+          ? hit.column
+          : model.mode === "history"
+            ? "history"
+            : model.selectedColumn;
+  actions.updateModel((current) =>
+    scrollMissionWorkspace(current, snapshot, target, delta, layoutSize),
+  );
+  return true;
+}
+
+export function handleMissionSurfacePointerDown(
+  hit: MissionWorkspaceHit,
+  state: MissionSurfaceControllerState,
+  actions: MissionSurfaceControllerActions,
+): boolean {
+  const { snapshot, layoutSize } = state;
+  if (hit?.kind === "refresh") {
+    actions.refresh();
+    return true;
+  }
+  if (hit?.kind === "deep-link") {
+    actions.followDeepLink(hit.link);
+    return true;
+  }
+  if (hit?.kind === "detail-section" && snapshot) {
+    actions.updateModel((model) =>
+      setMissionDetailSection(model, snapshot, hit.section, layoutSize),
+    );
+    return true;
+  }
+  if (hit && snapshot) {
+    actions.updateModel((model) => applyMissionWorkspaceHit(model, snapshot, hit, layoutSize));
+    if (hit.kind === "card" || hit.kind === "history") {
+      actions.updateModel((model) => openMissionDetail(model, snapshot, layoutSize));
+      actions.refresh();
+    }
+    return true;
+  }
+  return false;
+}

--- a/packages/daemon/src/tui/mirror/missions-surface.test.ts
+++ b/packages/daemon/src/tui/mirror/missions-surface.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultMissionWorkspaceModel,
+  type MissionWorkspaceSnapshot,
+} from "./missions-workspace.ts";
+import {
+  handleMissionSurfaceKey,
+  handleMissionSurfacePointerDown,
+  handleMissionSurfaceScroll,
+  type MissionSurfaceControllerActions,
+} from "./missions-surface-controller.ts";
+
+const layoutSize = { width: 80, height: 24 };
+
+function snapshot(): MissionWorkspaceSnapshot {
+  const mission = {
+    id: "mis_demo",
+    column: "planned",
+  };
+  return {
+    board: {
+      columns: {
+        planned: [mission],
+        running: [],
+        blocked: [],
+        review: [],
+        done: [],
+      },
+      counts: { planned: 1, running: 0, blocked: 0, review: 0, done: 0, total: 1 },
+    },
+    history: [],
+    detail: null,
+    project: { identityKey: "project", projectRoot: "/project" },
+    loadedAt: "2026-07-19T00:00:00.000Z",
+  } as MissionWorkspaceSnapshot;
+}
+
+function actionsFor(modelRef: { model: ReturnType<typeof defaultMissionWorkspaceModel> }) {
+  const calls: string[] = [];
+  const actions: MissionSurfaceControllerActions = {
+    updateModel: (updater) => {
+      calls.push("update");
+      modelRef.model = updater(modelRef.model);
+    },
+    refresh: () => calls.push("refresh"),
+    followDeepLink: (kind) => calls.push(`link:${kind}`),
+    persistSelection: (missionId, taskId) =>
+      calls.push(`persist:${missionId ?? ""}:${taskId ?? ""}`),
+  };
+  return { actions, calls };
+}
+
+describe("missions surface boundary", () => {
+  it("maps keys to explicit navigation and action dependencies", () => {
+    const state = {
+      model: defaultMissionWorkspaceModel("mis_demo"),
+      snapshot: null,
+      layoutSize,
+      persistedTaskId: null,
+    };
+    const { actions, calls } = actionsFor({ model: state.model });
+
+    expect(
+      handleMissionSurfaceKey(
+        { name: "r", ctrl: false, meta: false, shift: false },
+        state,
+        actions,
+      ),
+    ).toBe(true);
+    expect(
+      handleMissionSurfaceKey(
+        { name: "t", ctrl: false, meta: false, shift: false },
+        state,
+        actions,
+      ),
+    ).toBe(true);
+    expect(
+      handleMissionSurfaceKey(
+        { name: "z", ctrl: false, meta: false, shift: false },
+        state,
+        actions,
+      ),
+    ).toBe(true);
+
+    expect(calls).toEqual(["refresh", "link:terminal", "update"]);
+  });
+
+  it("keeps enter persistence/detail behavior outside JSX and refreshes missing detail", () => {
+    const modelRef = { model: defaultMissionWorkspaceModel("mis_demo", "tsk_demo") };
+    const { actions, calls } = actionsFor(modelRef);
+
+    handleMissionSurfaceKey(
+      { name: "return", ctrl: false, meta: false, shift: false },
+      { model: modelRef.model, snapshot: snapshot(), layoutSize, persistedTaskId: "tsk_saved" },
+      actions,
+    );
+
+    expect(calls).toEqual(["persist:mis_demo:tsk_demo", "update", "refresh"]);
+    expect(modelRef.model.mode).toBe("detail");
+    expect(modelRef.model.selectedMissionId).toBe("mis_demo");
+  });
+
+  it("routes pointer hits through explicit action callbacks", () => {
+    const modelRef = { model: defaultMissionWorkspaceModel() };
+    const { actions, calls } = actionsFor(modelRef);
+
+    expect(
+      handleMissionSurfacePointerDown(
+        { kind: "refresh" },
+        { model: modelRef.model, snapshot: snapshot(), layoutSize, persistedTaskId: null },
+        actions,
+      ),
+    ).toBe(true);
+    expect(
+      handleMissionSurfacePointerDown(
+        { kind: "deep-link", link: "files" },
+        { model: modelRef.model, snapshot: snapshot(), layoutSize, persistedTaskId: null },
+        actions,
+      ),
+    ).toBe(true);
+    expect(
+      handleMissionSurfacePointerDown(
+        { kind: "card", missionId: "mis_demo", column: "planned", index: 0, hoverKey: 0 },
+        { model: modelRef.model, snapshot: snapshot(), layoutSize, persistedTaskId: null },
+        actions,
+      ),
+    ).toBe(true);
+
+    expect(calls).toEqual(["refresh", "link:files", "update", "update", "refresh"]);
+    expect(modelRef.model.mode).toBe("detail");
+    expect(modelRef.model.selectedMissionId).toBe("mis_demo");
+  });
+
+  it("routes scroll without requiring app-level mission model knowledge", () => {
+    const modelRef = { model: defaultMissionWorkspaceModel("mis_demo") };
+    const { actions, calls } = actionsFor(modelRef);
+
+    expect(
+      handleMissionSurfaceScroll(
+        { kind: "column", column: "planned" },
+        "down",
+        { model: modelRef.model, snapshot: snapshot(), layoutSize, persistedTaskId: null },
+        actions,
+        3,
+      ),
+    ).toBe(true);
+
+    expect(calls).toEqual(["update"]);
+    expect(modelRef.model.columnScroll.planned).toBe(0);
+  });
+});

--- a/packages/daemon/src/tui/mirror/missions-surface.tsx
+++ b/packages/daemon/src/tui/mirror/missions-surface.tsx
@@ -1,0 +1,303 @@
+import type { RGBA } from "@opentui/core";
+import { For, Show } from "solid-js";
+import {
+  ACCENT,
+  BADGE_BG,
+  BUTTON_HOVER_BG,
+  DEFAULT_BG,
+  DEFAULT_FG,
+  HOVER_BG,
+  MUTED,
+} from "./theme.ts";
+import {
+  clipTerminal,
+  missionWorkspaceLayout,
+  type MissionDeepLinkKind,
+  type MissionDeepLinkResolution,
+  type MissionWorkspaceLayout,
+  type MissionWorkspaceLoadState,
+  type MissionWorkspaceModel,
+  type MissionWorkspaceSnapshot,
+} from "./missions-workspace.ts";
+
+export type MissionSurfaceHoverRegion =
+  | "missionmode"
+  | "missionbutton"
+  | "missioncard"
+  | "missionhistory";
+
+export interface MissionSurfaceTheme {
+  bannerFg: RGBA;
+  buttonFg: RGBA;
+  buttonBg: RGBA;
+  buttonActiveBg: RGBA;
+}
+
+export interface MissionSurfaceProps {
+  width: number;
+  layout: MissionWorkspaceLayout;
+  model: MissionWorkspaceModel;
+  snapshot: MissionWorkspaceSnapshot | null;
+  loadState: MissionWorkspaceLoadState;
+  errorMessage: string;
+  resolveDeepLink: (kind: MissionDeepLinkKind) => MissionDeepLinkResolution;
+  isHovered: (region: MissionSurfaceHoverRegion, index: number) => boolean;
+  theme: MissionSurfaceTheme;
+}
+
+export function missionSurfaceLayout(
+  width: number,
+  height: number,
+  model: MissionWorkspaceModel,
+  snapshot: MissionWorkspaceSnapshot | null,
+  options: Parameters<typeof missionWorkspaceLayout>[4],
+): MissionWorkspaceLayout {
+  return missionWorkspaceLayout(width, height, model, snapshot, options);
+}
+
+export function MissionsSurface(props: MissionSurfaceProps) {
+  const ready = () =>
+    props.snapshot &&
+    props.loadState.status !== "loading" &&
+    !(props.loadState.status === "error" && !props.snapshot) &&
+    props.loadState.status !== "empty";
+
+  return (
+    <>
+      <box width={props.width} flexDirection="row" gap={1}>
+        <For each={props.layout.header.rows[0] ?? []}>
+          {(chip) => (
+            <text
+              fg={DEFAULT_FG}
+              bg={
+                chip.kind === "mode" && chip.mode === props.model.mode
+                  ? props.theme.buttonActiveBg
+                  : chip.kind === "mode" &&
+                      props.isHovered("missionmode", chip.mode === "board" ? 0 : 1)
+                    ? BUTTON_HOVER_BG
+                    : chip.kind === "refresh" && props.isHovered("missionbutton", 0)
+                      ? BUTTON_HOVER_BG
+                      : chip.kind === "density" && props.isHovered("missionbutton", 1)
+                        ? BUTTON_HOVER_BG
+                        : props.theme.buttonBg
+              }
+            >
+              {chip.label}
+            </text>
+          )}
+        </For>
+      </box>
+      <box width={props.width} flexDirection="row">
+        <text
+          fg={props.theme.buttonFg}
+          bg={props.isHovered("missionbutton", 2) ? BUTTON_HOVER_BG : props.theme.buttonBg}
+        >
+          {"<"}
+        </text>
+        <text fg={MUTED}>
+          {clipTerminal(props.layout.header.labels[1].slice(1, -1), Math.max(0, props.width - 2))}
+        </text>
+        <Show when={props.width > 1}>
+          <text
+            fg={props.theme.buttonFg}
+            bg={props.isHovered("missionbutton", 3) ? BUTTON_HOVER_BG : props.theme.buttonBg}
+          >
+            {">"}
+          </text>
+        </Show>
+      </box>
+      <Show when={props.loadState.status === "loading"}>
+        <box flexDirection="column" flexGrow={1}>
+          <box height={1} />
+          <text fg={DEFAULT_FG}>Loading missions…</text>
+          <text fg={MUTED}>Mission history is read from the active project runtime.</text>
+        </box>
+      </Show>
+      <Show when={props.loadState.status === "error" && !props.snapshot}>
+        <box flexDirection="column" flexGrow={1}>
+          <box height={1} />
+          <text fg={props.theme.bannerFg}>Mission data could not be loaded.</text>
+          <text fg={MUTED}>{props.errorMessage}</text>
+          <text fg={MUTED}>Press r to retry. Other workspace views remain available.</text>
+        </box>
+      </Show>
+      <Show when={props.loadState.status === "empty"}>
+        <box flexDirection="column" flexGrow={1}>
+          <box height={1} />
+          <text fg={DEFAULT_FG}>No missions yet.</text>
+          <text fg={MUTED}>This read-only board will populate from durable mission history.</text>
+        </box>
+      </Show>
+      <Show when={ready()}>
+        <Show when={props.model.mode === "board"}>
+          <box flexDirection="row" flexGrow={1} gap={1}>
+            <For each={props.layout.board.columns}>
+              {(column) => (
+                <box flexDirection="column" width={column.width}>
+                  <text fg={ACCENT}>
+                    {clipTerminal(`${column.label} (${column.count})`, column.width)}
+                  </text>
+                  <For each={column.cards}>
+                    {(cardLayout) => {
+                      const selected = props.model.selectedMissionId === cardLayout.missionId;
+                      return (
+                        <box
+                          flexDirection="column"
+                          height={cardLayout.height}
+                          backgroundColor={
+                            selected
+                              ? BADGE_BG
+                              : props.isHovered("missioncard", cardLayout.hoverKey)
+                                ? HOVER_BG
+                                : DEFAULT_BG
+                          }
+                        >
+                          <For each={cardLayout.lines}>
+                            {(line, lineIndex) => (
+                              <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>
+                                {clipTerminal(line, cardLayout.width)}
+                              </text>
+                            )}
+                          </For>
+                        </box>
+                      );
+                    }}
+                  </For>
+                </box>
+              )}
+            </For>
+          </box>
+        </Show>
+        <Show when={props.model.mode === "history"}>
+          <box flexDirection="column" flexGrow={1}>
+            <For each={props.layout.history.rows}>
+              {(row) => {
+                const selected = props.model.selectedMissionId === row.missionId;
+                return (
+                  <box
+                    flexDirection="column"
+                    height={row.height}
+                    backgroundColor={
+                      selected
+                        ? BADGE_BG
+                        : props.isHovered("missionhistory", row.hoverKey)
+                          ? HOVER_BG
+                          : DEFAULT_BG
+                    }
+                  >
+                    <For each={row.lines}>
+                      {(line, lineIndex) => (
+                        <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>
+                          {clipTerminal(line, row.width)}
+                        </text>
+                      )}
+                    </For>
+                  </box>
+                );
+              }}
+            </For>
+          </box>
+        </Show>
+        <Show when={props.model.mode === "detail"}>
+          <box flexDirection="column" flexGrow={1}>
+            <box width={props.width} flexDirection="row" gap={1}>
+              <For each={props.layout.detail.sections}>
+                {(chip) => (
+                  <text
+                    fg={DEFAULT_FG}
+                    bg={
+                      chip.section === props.model.detailSection ||
+                      props.isHovered(
+                        "missionbutton",
+                        10 + props.layout.detail.sections.indexOf(chip),
+                      )
+                        ? props.theme.buttonActiveBg
+                        : props.theme.buttonBg
+                    }
+                  >
+                    {chip.label}
+                  </text>
+                )}
+              </For>
+              <box flexGrow={1} />
+              <For each={props.layout.detail.links}>
+                {(chip) => {
+                  const resolved = chip.link ? props.resolveDeepLink(chip.link) : null;
+                  return (
+                    <text
+                      fg={resolved?.available ? props.theme.buttonFg : MUTED}
+                      bg={
+                        chip.link &&
+                        props.isHovered(
+                          "missionbutton",
+                          20 + props.layout.detail.links.indexOf(chip),
+                        )
+                          ? BUTTON_HOVER_BG
+                          : props.theme.buttonBg
+                      }
+                    >
+                      {chip.label}
+                    </text>
+                  );
+                }}
+              </For>
+            </box>
+            <Show
+              when={props.snapshot?.detail}
+              fallback={
+                <box flexDirection="column" flexGrow={1}>
+                  <text fg={DEFAULT_FG}>Loading mission detail…</text>
+                  <text fg={MUTED}>Press r to refresh if this does not resolve.</text>
+                </box>
+              }
+            >
+              <box flexDirection="row" flexGrow={1} gap={1}>
+                <Show when={props.layout.detail.wide}>
+                  <box flexDirection="column" width={props.layout.detail.contextWidth}>
+                    <For each={props.layout.detail.contextRows}>
+                      {(row) => (
+                        <For each={row.lines}>
+                          {(line, lineIndex) => (
+                            <text fg={lineIndex() === 0 ? ACCENT : MUTED}>{line}</text>
+                          )}
+                        </For>
+                      )}
+                    </For>
+                  </box>
+                </Show>
+                <box flexDirection="column" width={props.layout.detail.sectionWidth}>
+                  <For each={props.layout.detail.rows}>
+                    {(row) => {
+                      const selected =
+                        row.kind === "tasks" && props.model.selectedTaskId === row.id;
+                      return (
+                        <box
+                          flexDirection="column"
+                          height={row.height}
+                          backgroundColor={
+                            selected
+                              ? BADGE_BG
+                              : props.isHovered("missionhistory", row.hoverKey)
+                                ? HOVER_BG
+                                : DEFAULT_BG
+                          }
+                        >
+                          <For each={row.lines}>
+                            {(line, lineIndex) => (
+                              <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>{line}</text>
+                            )}
+                          </For>
+                        </box>
+                      );
+                    }}
+                  </For>
+                </box>
+              </box>
+            </Show>
+          </box>
+        </Show>
+      </Show>
+      <text fg={MUTED}>{props.layout.footer.label}</text>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- extract the full Missions Solid/OpenTUI renderer from the monolithic mirror app
- add an explicit pure controller boundary for keyboard, pointer, and scroll dispatch
- preserve repository loading, persistence, deep links, composite embedding, terminal routing, and renderer lifecycle in the host

## Validation
- `pnpm vitest run packages/daemon/src/tui/mirror/missions-surface.test.ts packages/daemon/src/tui/mirror/missions-workspace.test.ts` (31 passed)
- `pnpm --filter @tmux-ide/daemon typecheck`
- `pnpm build:tui`
- `pnpm check`
- `git diff --check`

Mission: `mis_m28_missions_ui_polish`
Task: `tsk_m28_01_surface_boundary`