### PR TITLE
feat(tui): add dense framed mission board

### DIFF
--- a/packages/daemon/src/tui/mirror/missions-surface.tsx
+++ b/packages/daemon/src/tui/mirror/missions-surface.tsx
@@ -133,9 +133,17 @@ export function MissionsSurface(props: MissionSurfaceProps) {
           <box flexDirection="row" flexGrow={1} gap={1}>
             <For each={props.layout.board.columns}>
               {(column) => (
-                <box flexDirection="column" width={column.width}>
-                  <text fg={ACCENT}>
-                    {clipTerminal(`${column.label} (${column.count})`, column.width)}
+                <box
+                  flexDirection="column"
+                  width={column.width}
+                  height={column.height}
+                  border={column.width >= 2 && column.height >= 2}
+                  borderColor={column.active ? ACCENT : MUTED}
+                  backgroundColor={DEFAULT_BG}
+                  overflow="hidden"
+                >
+                  <text fg={column.active ? ACCENT : MUTED}>
+                    {clipTerminal(column.title, column.bodyWidth)}
                   </text>
                   <For each={column.cards}>
                     {(cardLayout) => {
@@ -154,7 +162,15 @@ export function MissionsSurface(props: MissionSurfaceProps) {
                         >
                           <For each={cardLayout.lines}>
                             {(line, lineIndex) => (
-                              <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>
+                              <text
+                                fg={
+                                  selected && lineIndex() === 0
+                                    ? ACCENT
+                                    : lineIndex() === 0
+                                      ? DEFAULT_FG
+                                      : MUTED
+                                }
+                              >
                                 {clipTerminal(line, cardLayout.width)}
                               </text>
                             )}

--- a/packages/daemon/src/tui/mirror/missions-workspace.test.ts
+++ b/packages/daemon/src/tui/mirror/missions-workspace.test.ts
@@ -37,6 +37,7 @@ import {
   missionTmuxPreflightCommands,
   missionWorkspaceHitTest,
   missionWorkspaceLayout,
+  pinnedPrimaryLine,
   moveMissionSelection,
   openMissionDetail,
   readMissionWorkspace,
@@ -511,6 +512,125 @@ describe("missions workspace loader/model", () => {
     ).toBe(true);
   });
 
+  it("projects framed board lanes with active state, title counts, and bounded bodies", () => {
+    const view = snapshot(
+      board({
+        planned: [card("mis_a", "planned"), card("mis_b", "planned")],
+        running: [card("mis_c", "running")],
+      }),
+    );
+    const model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_c"), view, {
+      width: 56,
+      height: 12,
+    });
+    const layout = missionWorkspaceLayout(56, 12, model, view);
+    expect(
+      layout.board.columns.map((column) => [column.column, column.title, column.active]),
+    ).toEqual([
+      ["planned", "Planned · 2", false],
+      ["running", "Running · 1", true],
+    ]);
+    for (const column of layout.board.columns) {
+      expect(column.y).toBe(MISSION_HEADER_ROWS);
+      expect(column.height).toBe(layout.height - MISSION_HEADER_ROWS - MISSION_FOOTER_ROWS);
+      expect(column.x + column.width).toBeLessThanOrEqual(layout.width);
+      expect(column.bodyX).toBeGreaterThanOrEqual(column.x);
+      expect(column.bodyY).toBeGreaterThan(column.y);
+      expect(column.bodyX + column.bodyWidth).toBeLessThanOrEqual(column.x + column.width);
+      expect(column.bodyY + column.bodyHeight).toBeLessThanOrEqual(column.y + column.height);
+      for (const item of column.cards) {
+        expect(item.x).toBe(column.bodyX);
+        expect(item.width).toBe(column.bodyWidth);
+        expect(item.y).toBeGreaterThanOrEqual(column.bodyY);
+        expect(item.y + item.height).toBeLessThanOrEqual(layout.height - MISSION_FOOTER_ROWS);
+      }
+    }
+  });
+
+  it("formats dense mission rows by density with pinned status, progress, and agent", () => {
+    const latestAttempt = {
+      id: "att_a",
+      taskId: "tsk_a",
+      status: "running",
+      outcome: null,
+      agent: "worker",
+      harness: "codex",
+      model: "gpt-5",
+      terminal: "%7",
+      session: "proj",
+      worktree: "apps/api",
+      startedAt: "2026-01-01T00:01:00.000Z",
+      updatedAt: "2026-01-01T00:02:00.000Z",
+      finishedAt: null,
+      durationMs: null,
+      proofIds: [],
+    };
+    const mission = card("mis_a", "running", "Dense mission", { latestAttempt });
+    const compact = missionCardLines(mission, "compact", 80)[0]!;
+    expect(compact.startsWith("Dense mission")).toBe(true);
+    expect(compact.endsWith("started 2/4 @worker")).toBe(true);
+    expect(terminalWidth(compact)).toBe(80);
+    const comfortable = missionCardLines(mission, "comfortable", 80);
+    expect(comfortable).toHaveLength(3);
+    expect(comfortable[1]).toBe("summary mis_a");
+    expect(comfortable[2]).toBe("attempt worker/codex");
+    expect(
+      missionCardLines(mission, "detailed", 12).every((line) => terminalWidth(line) <= 12),
+    ).toBe(true);
+  });
+
+  it("pins mission and task primary metadata at realistic and narrow widths", () => {
+    const longTitle =
+      "Implement the extremely long and descriptive mission board responsive surface";
+    const latestAttempt = {
+      id: "att_a",
+      taskId: "tsk_a",
+      status: "running",
+      outcome: null,
+      agent: "coordinator",
+      harness: "codex",
+      model: "gpt-5",
+      terminal: "%7",
+      session: "proj",
+      worktree: "apps/api",
+      startedAt: "2026-01-01T00:01:00.000Z",
+      updatedAt: "2026-01-01T00:02:00.000Z",
+      finishedAt: null,
+      durationMs: null,
+      proofIds: [],
+    };
+    const mission = card("mis_a", "running", longTitle, { latestAttempt });
+    for (const width of [24, 28, 32]) {
+      const line = missionCardLines(mission, "compact", width)[0]!;
+      expect(terminalWidth(line)).toBeLessThanOrEqual(width);
+      expect(line).toMatch(/started 2\/4 @coordinator$/);
+    }
+    expect(missionCardLines(mission, "compact", 12)[0]).toBe("started 2/4");
+    expect(missionCardLines(mission, "compact", 8)[0]).toBe("started…");
+    const comfortable = missionCardLines(
+      card("mis_blocked", "running", longTitle, {
+        latestAttempt,
+        blockedBy: ["tsk_a", "tsk_b", "tsk_c", "tsk_d"],
+      }),
+      "comfortable",
+      32,
+    );
+    expect(comfortable[0]).toMatch(/started 2\/4 @coordinator$/);
+    expect(comfortable[1]).toBe("summary mis_blocked");
+    expect(comfortable[2]).toBe("blocked by 4");
+    expect(comfortable.join("\n")).not.toContain("agent coordinator");
+
+    const longTask = task("tsk_long", "running", {
+      title: "Implement a very long selected task row with stable right metadata",
+      latestAttempt,
+    });
+    const taskLine = missionDetailTaskLines(longTask, "compact", 28)[0]!;
+    expect(terminalWidth(taskLine)).toBeLessThanOrEqual(28);
+    expect(taskLine).toMatch(/started p1 @coordinator$/);
+    expect(missionDetailTaskLines(longTask, "compact", 10)[0]).toBe("started p1");
+    expect(pinnedPrimaryLine(longTitle, 0, "started 2/4", "coordinator")).toBe("");
+  });
+
   it("uses density-aware item capacity and never overflows into the footer", () => {
     const many = Array.from({ length: 8 }, (_, index) => card(`mis_${index}`, "planned"));
     const view = snapshot(
@@ -553,8 +673,16 @@ describe("missions workspace loader/model", () => {
       const layout = missionWorkspaceLayout(width, 10, model, view);
       expect(layout.board.visibleColumns.length).toBe(1);
       for (const column of layout.board.columns) {
+        expect(column.width).toBeGreaterThanOrEqual(0);
+        expect(column.height).toBeGreaterThanOrEqual(0);
+        expect(column.bodyWidth).toBeGreaterThanOrEqual(0);
+        expect(column.bodyHeight).toBeGreaterThanOrEqual(0);
         expect(column.width).toBeLessThanOrEqual(layout.width);
         expect(column.x + column.width).toBeLessThanOrEqual(layout.width);
+        expect(column.bodyX + column.bodyWidth).toBeLessThanOrEqual(layout.width);
+        expect(column.bodyY + column.bodyHeight).toBeLessThanOrEqual(
+          layout.height - MISSION_FOOTER_ROWS,
+        );
         for (const item of column.cards)
           expect(item.x + item.width).toBeLessThanOrEqual(layout.width);
       }
@@ -621,7 +749,13 @@ describe("missions workspace loader/model", () => {
       kind: "horizontal",
       direction: 1,
     });
-    expect(missionWorkspaceHitTest(layout, 1, 3)).toEqual({
+    const planned = layout.board.columns.find((column) => column.column === "planned")!;
+    expect(missionWorkspaceHitTest(layout, planned.x, planned.y)).toEqual({
+      kind: "column",
+      column: "planned",
+    });
+    const firstCard = planned.cards[0]!;
+    expect(missionWorkspaceHitTest(layout, firstCard.x, firstCard.y)).toEqual({
       kind: "card",
       missionId: "mis_a",
       column: "planned",

--- a/packages/daemon/src/tui/mirror/missions-workspace.ts
+++ b/packages/daemon/src/tui/mirror/missions-workspace.ts
@@ -139,10 +139,18 @@ export interface MissionHeaderChip {
 export interface MissionColumnLayout {
   column: MissionBoardColumn;
   label: string;
+  title: string;
   x: number;
+  y: number;
   width: number;
+  height: number;
+  bodyX: number;
+  bodyY: number;
+  bodyWidth: number;
+  bodyHeight: number;
   count: number;
   scroll: number;
+  active: boolean;
   cards: MissionCardLayout[];
 }
 
@@ -685,23 +693,33 @@ export function missionWorkspaceLayout(
     const cards = snapshot?.board.columns[column] ?? [];
     const start = Math.max(0, model.columnScroll[column]);
     const visibleCards = cards.slice(start, start + boardCapacity);
+    const lane = missionLaneRect(x, columnWidth, safeHeight);
+    const count = snapshot?.board.counts[column] ?? 0;
     columns.push({
       column,
       label: MISSION_COLUMN_LABELS[column],
+      title: `${MISSION_COLUMN_LABELS[column]} · ${count}`,
       x,
+      y: lane.y,
       width: columnWidth,
-      count: snapshot?.board.counts[column] ?? 0,
+      height: lane.height,
+      bodyX: lane.bodyX,
+      bodyY: lane.bodyY,
+      bodyWidth: lane.bodyWidth,
+      bodyHeight: lane.bodyHeight,
+      count,
       scroll: start,
+      active: model.selectedColumn === column,
       cards: visibleCards.map((card, visibleIndex) => ({
         missionId: card.id,
         column,
         index: start + visibleIndex,
         hoverKey: missionCardHoverKey(column, start + visibleIndex),
-        x,
-        y: MISSION_HEADER_ROWS + 1 + visibleIndex * cardHeight,
-        width: columnWidth,
+        x: lane.bodyX,
+        y: lane.bodyY + visibleIndex * cardHeight,
+        width: lane.bodyWidth,
         height: cardHeight,
-        lines: missionCardLines(card, model.density, columnWidth),
+        lines: missionCardLines(card, model.density, lane.bodyWidth),
       })),
     });
     x += columnWidth + MISSION_COLUMN_GAP;
@@ -756,7 +774,7 @@ export function missionWorkspaceHitTest(
   }
   if (layout.mode === "board") {
     for (const column of layout.board.columns) {
-      if (y === MISSION_HEADER_ROWS && x >= column.x && x < column.x + column.width)
+      if (x >= column.x && x < column.x + column.width && y >= column.y && y < column.bodyY)
         return { kind: "column", column: column.column };
       for (const card of column.cards) {
         if (x >= card.x && x < card.x + card.width && y >= card.y && y < card.y + card.height) {
@@ -818,8 +836,10 @@ export function missionCardLines(
 ): string[] {
   const progress =
     card.progress.total > 0 ? `${card.progress.done}/${card.progress.total}` : "no tasks";
-  const lines = [card.title, `${card.status} · ${progress}`];
+  const agent = card.latestAttempt?.agent ?? "";
+  const lines = [pinnedPrimaryLine(card.title, width, `${card.status} ${progress}`, agent)];
   if (density !== "compact") {
+    lines.push(card.summary);
     if (card.blockedBy.length > 0) lines.push(`blocked by ${card.blockedBy.length}`);
     if (card.latestAttempt)
       lines.push(`attempt ${card.latestAttempt.agent}/${card.latestAttempt.harness}`);
@@ -874,11 +894,13 @@ export function missionDetailTaskLines(
   density: MissionWorkspaceDensity,
   width: number,
 ): string[] {
+  const agent = task.latestAttempt?.agent ?? task.assignee ?? "";
   const lines = [
-    `${task.title}`,
-    `${task.column} · ${task.status} · p${task.priority}${task.assignee ? ` · ${task.assignee}` : ""}`,
+    pinnedPrimaryLine(task.title, width, `${task.status} p${task.priority}`, agent),
+    task.summary,
   ];
   if (density !== "compact") {
+    lines.push(`${task.column}${task.assignee ? ` · ${task.assignee}` : ""}`);
     if (task.dependencies.length > 0) lines.push(`depends ${task.dependencies.join(", ")}`);
     if (task.blockedBy.length > 0) lines.push(`blocked by ${task.blockedBy.join(", ")}`);
     if (task.latestAttempt)
@@ -890,7 +912,29 @@ export function missionDetailTaskLines(
   }
   if (density === "detailed")
     lines.push(`task ${task.id} · duration ${formatDuration(task.durationMs)}`);
-  return lines.slice(0, missionDetailRowHeight(density)).map((line) => clipTerminal(line, width));
+  const limit = density === "compact" ? 1 : missionDetailRowHeight(density);
+  return lines.slice(0, limit).map((line) => clipTerminal(line, width));
+}
+
+export function pinnedPrimaryLine(
+  title: string,
+  width: number,
+  requiredMeta: string,
+  agent: string | null | undefined = null,
+): string {
+  if (width <= 0) return "";
+  const compactAgent = agent ? `@${agent}` : "";
+  const required = requiredMeta.trim();
+  const fullMeta = [required, compactAgent].filter(Boolean).join(" ");
+  const meta = terminalDisplayWidth(fullMeta) <= width || !required ? fullMeta : required;
+  if (terminalDisplayWidth(meta) >= width) return clipTerminal(meta, width);
+  const metaWidth = terminalDisplayWidth(meta);
+  const minGap = meta.length > 0 ? 1 : 0;
+  const titleWidth = Math.max(0, width - metaWidth - minGap);
+  const clippedTitle = clipTerminal(title, titleWidth);
+  if (!clippedTitle) return meta;
+  const gap = " ".repeat(Math.max(minGap, width - terminalDisplayWidth(clippedTitle) - metaWidth));
+  return clipTerminal(`${clippedTitle}${gap}${meta}`, width);
 }
 
 export function missionDetailTimelineLines(entry: MissionTimelineEntry, width: number): string[] {
@@ -1307,6 +1351,35 @@ function missionCardHoverKey(column: MissionBoardColumn, index: number): number 
   return index * MISSION_BOARD_COLUMNS.length + columnIndex(column);
 }
 
+function missionLaneRect(x: number, width: number, height: number) {
+  return missionLaneViewport(
+    x,
+    MISSION_HEADER_ROWS,
+    width,
+    Math.max(0, height - MISSION_HEADER_ROWS - MISSION_FOOTER_ROWS),
+  );
+}
+
+function missionLaneViewport(x: number, y: number, width: number, height: number) {
+  const safeWidth = Math.max(0, width);
+  const safeHeight = Math.max(0, height);
+  const bordered = safeWidth >= 2 && safeHeight >= 2;
+  const inset = bordered ? 1 : 0;
+  const innerWidth = Math.max(0, safeWidth - inset * 2);
+  const innerHeight = Math.max(0, safeHeight - inset * 2);
+  const titleRows = innerHeight > 0 ? 1 : 0;
+  return {
+    x,
+    y,
+    width: safeWidth,
+    height: safeHeight,
+    bodyX: x + inset,
+    bodyY: y + inset + titleRows,
+    bodyWidth: innerWidth,
+    bodyHeight: Math.max(0, innerHeight - titleRows),
+  };
+}
+
 function visibleColumnCount(width: number | undefined): number {
   const safeWidth = Math.max(1, width ?? 120);
   const max = Math.floor(
@@ -1322,7 +1395,8 @@ function followColumnOffset(index: number, offset: number, count: number): numbe
 }
 
 function boardRows(height: number | undefined): number {
-  return Math.max(0, (height ?? 24) - MISSION_HEADER_ROWS - 1 - MISSION_FOOTER_ROWS);
+  const laneHeight = Math.max(0, (height ?? 24) - MISSION_HEADER_ROWS - MISSION_FOOTER_ROWS);
+  return Math.max(0, laneHeight - 3);
 }
 
 function historyRows(height: number | undefined): number {
@@ -1348,9 +1422,9 @@ function scrollToIndex(index: number, top: number, rows: number): number {
 }
 
 function missionCardHeight(density: MissionWorkspaceDensity): number {
-  if (density === "compact") return 2;
-  if (density === "comfortable") return 4;
-  return 6;
+  if (density === "compact") return 1;
+  if (density === "comfortable") return 3;
+  return 5;
 }
 
 function missionHistoryRowHeight(density: MissionWorkspaceDensity): number {


### PR DESCRIPTION
## Summary
- render Missions columns as native bordered lanes with active focus treatment and shared geometry
- make compact mission rows single-line and pin status/progress/agent metadata by terminal width
- keep comfortable/detailed rows dense and non-duplicative
- extend geometry, density, hit-test, and narrow-width regressions

## Validation
- `pnpm vitest run packages/daemon/src/tui/mirror/missions-workspace.test.ts packages/daemon/src/tui/mirror/missions-surface.test.ts` (34 passed)
- `pnpm --filter @tmux-ide/daemon typecheck`
- `pnpm build:tui`
- `pnpm check`
- `git diff --check`
- isolated compiled 120x40 tmux smoke

Mission: `mis_m28_missions_ui_polish`
Task: `tsk_m28_02_dense_board`