### PR TITLE
feat(tui): add mission board navigation state

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -358,6 +358,7 @@ import {
   clipTerminal,
   defaultMissionWorkspaceModel,
   invalidatedMissionWorkspaceLoadState,
+  missionModelFromWorkspaceState,
   missionSelectionFromWorkspaceState,
   missionTmuxPanePreflightMatches,
   missionTmuxPreflightCommands,
@@ -365,6 +366,7 @@ import {
   readMissionWorkspace,
   reconcileMissionWorkspaceModel,
   resolveMissionDeepLink,
+  workspaceStateWithMissionModel,
   workspaceStateWithMissionSelection,
   type MissionDeepLinkKind,
   type MissionDeepLinkResolution,
@@ -1228,6 +1230,12 @@ try {
         workspaceStateWithMissionSelection(state, view.id, missionId, taskId),
       );
     };
+    const persistMissionModel = (model: MissionWorkspaceModel) => {
+      const view = activeView();
+      if (activePanel() !== "missions") return;
+      touchedWorkspaceViewIds.add(view.id);
+      setWorkspaceUiState((state) => workspaceStateWithMissionModel(state, view.id, model));
+    };
     const updateMissionModel = (
       updater: (model: MissionWorkspaceModel) => MissionWorkspaceModel,
     ) => {
@@ -1237,11 +1245,7 @@ try {
           updated.mode !== "detail" && updated.selectedMissionId !== current.selectedMissionId
             ? { ...updated, selectedTaskId: null }
             : updated;
-        if (
-          next.selectedMissionId !== current.selectedMissionId ||
-          next.selectedTaskId !== current.selectedTaskId
-        )
-          persistMissionSelection(next.selectedMissionId, next.selectedTaskId);
+        if (next !== current) persistMissionModel(next);
         return next;
       });
     };
@@ -1273,11 +1277,15 @@ try {
           if (!accepted) return;
           setMissionWorkspaceSnapshot(snapshot);
           updateMissionModel((current) =>
-            reconcileMissionWorkspaceModel(current, snapshot, {
-              persistedMissionId: persistedSelection.selectedMissionId,
-              persistedTaskId: persistedSelection.selectedTaskId,
-              ...missionLayoutSize(),
-            }),
+            reconcileMissionWorkspaceModel(
+              missionModelFromWorkspaceState(workspaceUiState(), activeView(), current),
+              snapshot,
+              {
+                persistedMissionId: persistedSelection.selectedMissionId,
+                persistedTaskId: persistedSelection.selectedTaskId,
+                ...missionLayoutSize(),
+              },
+            ),
           );
           setMissionWorkspaceLoad(accepted);
           if (reason === "refresh") setStatusNote("missions refreshed");
@@ -2639,13 +2647,11 @@ try {
         });
       }
       if (panel === "missions") {
-        const existing = missionSelectionFromWorkspaceState(workspaceUiState(), activeView().id);
-        return withCurrentLayout({
-          panel,
-          selectedMissionId:
-            missionWorkspaceModel().selectedMissionId ?? existing.selectedMissionId,
-          selectedTaskId: missionWorkspaceModel().selectedTaskId ?? existing.selectedTaskId,
-        });
+        const model = missionWorkspaceModel();
+        const state = workspaceStateWithMissionModel(workspaceUiState(), activeView().id, model);
+        const entry = state.views[activeView().id];
+        if (entry?.panel === "missions") return withCurrentLayout(entry);
+        return withCurrentLayout({ panel, selectedMissionId: null, selectedTaskId: null });
       }
       return withCurrentLayout({ panel });
     };
@@ -2706,11 +2712,7 @@ try {
       } else if (entry.panel === "missions") {
         setMissionWorkspaceModel((current) =>
           reconcileMissionWorkspaceModel(
-            {
-              ...current,
-              selectedMissionId: entry.selectedMissionId,
-              selectedTaskId: entry.selectedTaskId,
-            },
+            missionModelFromWorkspaceState(workspaceUiState(), view, current),
             missionWorkspaceSnapshot(),
             missionLayoutSize(),
           ),
@@ -5968,12 +5970,24 @@ try {
         } else if (
           hit?.kind === "refresh" ||
           hit?.kind === "density" ||
-          hit?.kind === "horizontal"
+          hit?.kind === "horizontal" ||
+          hit?.kind === "collapse" ||
+          hit?.kind === "zoom"
         ) {
           setHoverIf({
             region: "missionbutton",
             index:
-              hit.kind === "refresh" ? 0 : hit.kind === "density" ? 1 : hit.direction < 0 ? 2 : 3,
+              hit.kind === "refresh"
+                ? 0
+                : hit.kind === "density"
+                  ? 1
+                  : hit.kind === "horizontal"
+                    ? hit.direction < 0
+                      ? 2
+                      : 3
+                    : hit.kind === "collapse"
+                      ? 4
+                      : 5,
           });
         } else if (hit?.kind === "card") {
           setHoverIf({ region: "missioncard", index: hit.hoverKey });

--- a/packages/daemon/src/tui/mirror/missions-surface-controller.ts
+++ b/packages/daemon/src/tui/mirror/missions-surface-controller.ts
@@ -8,6 +8,8 @@ import {
   scrollMissionWorkspace,
   setMissionDetailSection,
   setMissionWorkspaceMode,
+  toggleMissionColumnCollapse,
+  toggleMissionColumnZoom,
   type MissionDeepLinkKind,
   type MissionWorkspaceHit,
   type MissionWorkspaceModel,
@@ -56,6 +58,14 @@ export function handleMissionSurfaceKey(
   }
   if (event.name === "z") {
     actions.updateModel((model) => cycleMissionDensity(model, snapshot, layoutSize));
+    return true;
+  }
+  if (event.name === "c") {
+    actions.updateModel((model) => toggleMissionColumnCollapse(model, snapshot, layoutSize));
+    return true;
+  }
+  if (event.name === "x") {
+    actions.updateModel((model) => toggleMissionColumnZoom(model, snapshot, layoutSize));
     return true;
   }
   if (!snapshot) return true;

--- a/packages/daemon/src/tui/mirror/missions-surface.test.ts
+++ b/packages/daemon/src/tui/mirror/missions-surface.test.ts
@@ -81,8 +81,22 @@ describe("missions surface boundary", () => {
         actions,
       ),
     ).toBe(true);
+    expect(
+      handleMissionSurfaceKey(
+        { name: "c", ctrl: false, meta: false, shift: false },
+        state,
+        actions,
+      ),
+    ).toBe(true);
+    expect(
+      handleMissionSurfaceKey(
+        { name: "x", ctrl: false, meta: false, shift: false },
+        state,
+        actions,
+      ),
+    ).toBe(true);
 
-    expect(calls).toEqual(["refresh", "link:terminal", "update"]);
+    expect(calls).toEqual(["refresh", "link:terminal", "update", "update", "update"]);
   });
 
   it("keeps enter persistence/detail behavior outside JSX and refreshes missing detail", () => {

--- a/packages/daemon/src/tui/mirror/missions-surface.tsx
+++ b/packages/daemon/src/tui/mirror/missions-surface.tsx
@@ -79,7 +79,11 @@ export function MissionsSurface(props: MissionSurfaceProps) {
                       ? BUTTON_HOVER_BG
                       : chip.kind === "density" && props.isHovered("missionbutton", 1)
                         ? BUTTON_HOVER_BG
-                        : props.theme.buttonBg
+                        : chip.kind === "collapse" && props.isHovered("missionbutton", 4)
+                          ? BUTTON_HOVER_BG
+                          : chip.kind === "zoom" && props.isHovered("missionbutton", 5)
+                            ? BUTTON_HOVER_BG
+                            : props.theme.buttonBg
               }
             >
               {chip.label}
@@ -142,9 +146,11 @@ export function MissionsSurface(props: MissionSurfaceProps) {
                   backgroundColor={DEFAULT_BG}
                   overflow="hidden"
                 >
-                  <text fg={column.active ? ACCENT : MUTED}>
-                    {clipTerminal(column.title, column.bodyWidth)}
-                  </text>
+                  <Show when={column.showTitle}>
+                    <text fg={column.active ? ACCENT : MUTED}>
+                      {clipTerminal(column.title, column.bodyWidth)}
+                    </text>
+                  </Show>
                   <For each={column.cards}>
                     {(cardLayout) => {
                       const selected = props.model.selectedMissionId === cardLayout.missionId;

--- a/packages/daemon/src/tui/mirror/missions-workspace.test.ts
+++ b/packages/daemon/src/tui/mirror/missions-workspace.test.ts
@@ -35,6 +35,7 @@ import {
   missionSelectionFromWorkspaceState,
   missionTmuxPanePreflightMatches,
   missionTmuxPreflightCommands,
+  missionModelFromWorkspaceState,
   missionWorkspaceHitTest,
   missionWorkspaceLayout,
   pinnedPrimaryLine,
@@ -46,6 +47,9 @@ import {
   scrollMissionWorkspace,
   setMissionDetailSection,
   setMissionWorkspaceMode,
+  toggleMissionColumnCollapse,
+  toggleMissionColumnZoom,
+  workspaceStateWithMissionModel,
   workspaceStateWithMissionSelection,
 } from "./missions-workspace.ts";
 import {
@@ -717,6 +721,55 @@ describe("missions workspace loader/model", () => {
     expect(clamped.historyScroll).toBe(0);
   });
 
+  it("keeps keyboard selection visible in long columns across movement, density, and resize", () => {
+    const many = Array.from({ length: 20 }, (_, index) => card(`mis_${index}`, "planned"));
+    const view = snapshot(board({ planned: many }));
+    let model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_0"), view, {
+      width: 80,
+      height: 10,
+    });
+    for (let index = 0; index < 19; index++) {
+      model = moveMissionSelection(model, view, "down", { width: 80, height: 10 });
+    }
+    expect(model.selectedMissionId).toBe("mis_19");
+    let layout = missionWorkspaceLayout(80, 10, model, view);
+    expect(layout.board.columns[0]!.cards.map((item) => item.missionId)).toContain("mis_19");
+    model = cycleMissionDensity(model, view, { width: 80, height: 10 });
+    layout = missionWorkspaceLayout(80, 10, model, view);
+    expect(layout.board.columns[0]!.cards.map((item) => item.missionId)).toContain("mis_19");
+    model = reconcileMissionWorkspaceModel(model, view, { width: 80, height: 6 });
+    layout = missionWorkspaceLayout(80, 6, model, view);
+    expect(layout.board.columns[0]!.cards.map((item) => item.missionId)).toContain("mis_19");
+    model = moveMissionSelection(model, view, "home", { width: 80, height: 6 });
+    expect(model.selectedMissionId).toBe("mis_0");
+    expect(model.columnScroll.planned).toBe(0);
+  });
+
+  it("keeps detail task selection visible with projected scroll geometry", () => {
+    const tasks = Array.from({ length: 9 }, (_, index) => task(`tsk_${index}`, "planned"));
+    const view = snapshot(
+      board({ running: [card("mis_detail", "running")] }),
+      [],
+      detail({
+        taskBoard: {
+          columns: { planned: tasks, running: [], blocked: [], review: [], done: [] },
+          counts: { planned: 9, running: 0, blocked: 0, review: 0, done: 0, total: 9 },
+        },
+      }),
+    );
+    let model = openMissionDetail(defaultMissionWorkspaceModel("mis_detail"), view, {
+      width: 56,
+      height: 12,
+    });
+    model = moveMissionSelection(model, view, "end", { width: 56, height: 12 });
+    const layout = missionWorkspaceLayout(56, 12, model, view);
+    expect(model.selectedTaskId).toBe("tsk_8");
+    expect(layout.detail.rows.map((row) => row.id)).toContain("tsk_8");
+    for (const row of layout.detail.rows) {
+      expect(row.y + row.height).toBeLessThanOrEqual(layout.height - MISSION_FOOTER_ROWS);
+    }
+  });
+
   it("formats history projected outcome/duration/task/attempt/proof/diff/test/pr/last event fields", () => {
     const lines = missionHistoryLines(history("mis_done", "failed"), "detailed", 120).join("\n");
     expect(lines).toContain("failed");
@@ -821,6 +874,149 @@ describe("missions workspace loader/model", () => {
     expect(model.selectedMissionId).toBe("mis_c");
   });
 
+  it("projects horizontal overflow hints and header hit parity for density collapse zoom and arrows", () => {
+    const view = snapshot(board({ done: [card("mis_done", "done")] }));
+    let model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_done"), view, {
+      width: 56,
+      height: 10,
+    });
+    let layout = missionWorkspaceLayout(56, 10, model, view);
+    expect(layout.header.labels[1]).toContain("more ◀");
+    for (const kind of ["density", "collapse", "zoom", "refresh"] as const) {
+      const chip = layout.header.rows[0]!.find((item) => item.kind === kind)!;
+      expect(missionWorkspaceHitTest(layout, chip.start, chip.row)).toEqual({ kind });
+    }
+    const left = layout.header.rows[1]!.find((item) => item.direction === -1)!;
+    model = applyMissionWorkspaceHit(
+      model,
+      view,
+      { kind: "horizontal", direction: -1 },
+      {
+        width: 56,
+        height: 10,
+      },
+    );
+    expect(model.horizontalOffset).toBe(3);
+    model = { ...model, horizontalOffset: 2 };
+    layout = missionWorkspaceLayout(56, 10, model, view);
+    expect(missionWorkspaceHitTest(layout, left.start, left.row)).toEqual({
+      kind: "horizontal",
+      direction: -1,
+    });
+    expect(layout.header.labels[1]).toContain("more ◀▶");
+  });
+
+  it("collapses and expands focused lanes without discarding mission data or bounds", () => {
+    const view = snapshot(
+      board({
+        planned: [card("mis_a", "planned")],
+        running: [card("mis_b", "running"), card("mis_c", "running")],
+      }),
+    );
+    let model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_b"), view, {
+      width: 56,
+      height: 12,
+    });
+    model = toggleMissionColumnCollapse(model, view, { width: 56, height: 12 });
+    expect(model.collapsedColumns.running).toBe(true);
+    let layout = missionWorkspaceLayout(56, 12, model, view);
+    const running = layout.board.columns.find((column) => column.column === "running")!;
+    expect(running.collapsed).toBe(true);
+    expect(running.title).toBe("Ru 2");
+    expect(running.cards).toEqual([]);
+    expect(view.board.columns.running).toHaveLength(2);
+    expect(running.x + running.width).toBeLessThanOrEqual(layout.width);
+    model = toggleMissionColumnCollapse(model, view, { width: 56, height: 12 });
+    layout = missionWorkspaceLayout(56, 12, model, view);
+    expect(layout.board.columns.find((column) => column.column === "running")!.cards).toHaveLength(
+      2,
+    );
+  });
+
+  it("packs variable-width board windows so collapsed rails reveal additional lanes", () => {
+    const view = snapshot(
+      board({
+        planned: [card("mis_a", "planned")],
+        running: [card("mis_b", "running")],
+        blocked: [card("mis_c", "blocked")],
+        review: [card("mis_d", "review")],
+      }),
+    );
+    let model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_a"), view, {
+      width: 56,
+      height: 12,
+    });
+    let layout = missionWorkspaceLayout(56, 12, model, view);
+    expect(layout.board.visibleColumns).toEqual(["planned", "running"]);
+    model = toggleMissionColumnCollapse(model, view, { width: 56, height: 12 });
+    layout = missionWorkspaceLayout(56, 12, model, view);
+    expect(layout.board.visibleColumns).toEqual(["planned", "running", "blocked"]);
+    expect(layout.board.columns[0]!.collapsed).toBe(true);
+    for (const column of layout.board.columns) {
+      expect(column.x + column.width).toBeLessThanOrEqual(layout.width);
+      expect(column.bodyX + column.bodyWidth).toBeLessThanOrEqual(layout.width);
+    }
+    model = toggleMissionColumnCollapse(model, view, { width: 56, height: 12 });
+    layout = missionWorkspaceLayout(56, 12, model, view);
+    expect(layout.board.visibleColumns).toEqual(["planned", "running"]);
+    expect(layout.header.labels[1]).toContain("more ▶");
+  });
+
+  it("projects compact collapsed lane titles that preserve identity and count inside body width", () => {
+    const view = snapshot(
+      board({ running: Array.from({ length: 12 }, (_, i) => card(`mis_${i}`, "running")) }),
+    );
+    let model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_0"), view, {
+      width: 56,
+      height: 12,
+    });
+    model = toggleMissionColumnCollapse(model, view, { width: 56, height: 12 });
+    const layout = missionWorkspaceLayout(56, 12, model, view);
+    const running = layout.board.columns.find((column) => column.column === "running")!;
+    expect(running.collapsed).toBe(true);
+    expect(running.bodyWidth).toBe(6);
+    expect(running.title).toBe("Ru 12");
+    expect(terminalWidth(running.title)).toBeLessThanOrEqual(running.bodyWidth);
+  });
+
+  it("keeps shortest lane title visibility and card geometry in sync with projection", () => {
+    const view = snapshot(board({ planned: [card("mis_a", "planned")] }));
+    const model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_a"), view, {
+      width: 56,
+      height: 4,
+    });
+    const layout = missionWorkspaceLayout(56, 4, model, view);
+    const planned = layout.board.columns[0]!;
+    expect(planned.titleRows).toBe(0);
+    expect(planned.showTitle).toBe(false);
+    expect(planned.cards).toHaveLength(1);
+    expect(planned.cards[0]!.height).toBe(1);
+    expect(planned.cards[0]!.y + planned.cards[0]!.height).toBeLessThanOrEqual(
+      layout.height - MISSION_FOOTER_ROWS,
+    );
+  });
+
+  it("zooms the focused column and restores the prior board window deterministically", () => {
+    const view = snapshot(board({ done: [card("mis_done", "done")] }));
+    let model = reconcileMissionWorkspaceModel(defaultMissionWorkspaceModel("mis_done"), view, {
+      width: 20,
+      height: 10,
+    });
+    expect(model.horizontalOffset).toBe(4);
+    model.horizontalOffset = 3;
+    model = toggleMissionColumnZoom(model, view, { width: 20, height: 10 });
+    expect(model.zoomColumn).toBe("done");
+    expect(model.zoomRestoreHorizontalOffset).toBe(3);
+    let layout = missionWorkspaceLayout(20, 10, model, view);
+    expect(layout.board.visibleColumns).toEqual(["done"]);
+    expect(layout.board.columns[0]!.width).toBe(20);
+    model = toggleMissionColumnZoom(model, view, { width: 20, height: 10 });
+    expect(model.zoomColumn).toBeNull();
+    expect(model.horizontalOffset).toBe(3);
+    layout = missionWorkspaceLayout(20, 10, model, view);
+    expect(layout.board.visibleColumns).toEqual(["review"]);
+  });
+
   it("keeps header chip spans non-overlapping at narrow, medium, and wide widths", () => {
     for (const width of [20, 56, 72, 120, 180]) {
       const layout = missionWorkspaceLayout(width, 10, defaultMissionWorkspaceModel(), snapshot());
@@ -833,6 +1029,8 @@ describe("missions workspace loader/model", () => {
           "mode",
           "mode",
           "density",
+          "collapse",
+          "zoom",
           "refresh",
         ]);
       }
@@ -1397,6 +1595,70 @@ describe("missions workspace loader/model", () => {
     expect(json).not.toContain("columns");
     expect(json).not.toContain("history");
     expect(json).not.toContain("projection");
+  });
+
+  it("persists exact-view missions navigation without projection blobs and hydrates legacy selection", () => {
+    const viewA = {
+      id: "mission-a",
+      title: "Missions A",
+      panel: "missions",
+      layout: null,
+      glyph: "◆",
+      order: 0,
+      shortcut: null,
+    } as const;
+    const viewB = { ...viewA, id: "mission-b", title: "Missions B" };
+    let model = {
+      ...defaultMissionWorkspaceModel("mis_one", "tsk_one"),
+      mode: "board" as const,
+      density: "detailed" as const,
+      selectedColumn: "done" as const,
+      preferredRow: 7,
+      columnScroll: { planned: 0, running: 2, blocked: 0, review: 0, done: 5 },
+      horizontalOffset: 3,
+      collapsedColumns: {
+        planned: false,
+        running: true,
+        blocked: false,
+        review: true,
+        done: false,
+      },
+      zoomColumn: "done" as const,
+      zoomRestoreHorizontalOffset: 2,
+    };
+    const state = workspaceStateWithMissionModel(defaultWorkspaceUiState(), viewA.id, model);
+    const isolated = workspaceStateWithMissionModel(
+      state,
+      viewB.id,
+      defaultMissionWorkspaceModel("mis_two"),
+    );
+    expect(missionModelFromWorkspaceState(isolated, viewA).selectedMissionId).toBe("mis_one");
+    expect(missionModelFromWorkspaceState(isolated, viewA).columnScroll.done).toBe(5);
+    expect(missionModelFromWorkspaceState(isolated, viewA).collapsedColumns.running).toBe(true);
+    expect(missionModelFromWorkspaceState(isolated, viewA).zoomColumn).toBe("done");
+    expect(missionModelFromWorkspaceState(isolated, viewB).selectedMissionId).toBe("mis_two");
+    const json = serializeWorkspaceUiState(isolated);
+    expect(json).toContain('"navigation"');
+    expect(json).not.toContain("columns");
+    expect(json).not.toContain("projection");
+
+    const legacy = workspaceStateWithMissionSelection(
+      defaultWorkspaceUiState(),
+      viewA.id,
+      "mis_legacy",
+      "tsk_legacy",
+    );
+    model = missionModelFromWorkspaceState(legacy, viewA, defaultMissionWorkspaceModel());
+    expect(model.selectedMissionId).toBe("mis_legacy");
+    expect(model.selectedTaskId).toBe("tsk_legacy");
+    expect(model.density).toBe("comfortable");
+    expect(model.collapsedColumns).toEqual({
+      planned: false,
+      running: false,
+      blocked: false,
+      review: false,
+      done: false,
+    });
   });
 });
 

--- a/packages/daemon/src/tui/mirror/missions-workspace.ts
+++ b/packages/daemon/src/tui/mirror/missions-workspace.ts
@@ -20,8 +20,13 @@ import { MissionRepository, MissionRepositoryError } from "../../lib/mission-rep
 import type { ProjectRuntimeRepository } from "../../lib/project-runtime-repository.ts";
 import type { HostedPanelView } from "./panel-host.ts";
 import { findFirstHostedViewForPanel, terminalDisplayWidth } from "./panel-host.ts";
-import type { WorkspaceUiStateV1 } from "./workspace-ui-state.ts";
-import { missionsSelection, setMissionsSelection } from "./workspace-ui-state.ts";
+import type { WorkspaceMissionsNavigationState, WorkspaceUiStateV1 } from "./workspace-ui-state.ts";
+import {
+  missionsSelection,
+  setMissionsNavigation,
+  setMissionsSelection,
+  viewStateFor,
+} from "./workspace-ui-state.ts";
 
 export const MISSION_BOARD_COLUMNS = ["planned", "running", "blocked", "review", "done"] as const;
 export const MISSION_COLUMN_LABELS: Readonly<Record<MissionBoardColumn, string>> = {
@@ -31,9 +36,17 @@ export const MISSION_COLUMN_LABELS: Readonly<Record<MissionBoardColumn, string>>
   review: "Review",
   done: "Done",
 };
+export const MISSION_COLUMN_SHORT_LABELS: Readonly<Record<MissionBoardColumn, string>> = {
+  planned: "Pl",
+  running: "Ru",
+  blocked: "Bl",
+  review: "Re",
+  done: "Do",
+};
 export const MISSION_DENSITIES = ["compact", "comfortable", "detailed"] as const;
 export const MISSION_MIN_COLUMN_WIDTH = 22;
 export const MISSION_MAX_COLUMN_WIDTH = 34;
+export const MISSION_COLLAPSED_COLUMN_WIDTH = 8;
 export const MISSION_COLUMN_GAP = 1;
 export const MISSION_HEADER_ROWS = 2;
 export const MISSION_FOOTER_ROWS = 1;
@@ -86,6 +99,9 @@ export interface MissionWorkspaceModel {
   selectedTaskId: string | null;
   detailSection: MissionDetailSection;
   detailScroll: Record<MissionDetailSection, number>;
+  collapsedColumns: Record<MissionBoardColumn, boolean>;
+  zoomColumn: MissionBoardColumn | null;
+  zoomRestoreHorizontalOffset: number | null;
 }
 
 export interface MissionWorkspaceLayout {
@@ -125,7 +141,15 @@ export interface MissionHeaderLayout {
 }
 
 export interface MissionHeaderChip {
-  kind: "mode" | "density" | "refresh" | "horizontal" | "section" | "deep-link";
+  kind:
+    | "mode"
+    | "density"
+    | "refresh"
+    | "horizontal"
+    | "collapse"
+    | "zoom"
+    | "section"
+    | "deep-link";
   label: string;
   row: number;
   start: number;
@@ -148,10 +172,28 @@ export interface MissionColumnLayout {
   bodyY: number;
   bodyWidth: number;
   bodyHeight: number;
+  titleRows: number;
+  showTitle: boolean;
   count: number;
   scroll: number;
   active: boolean;
+  collapsed: boolean;
+  zoomed: boolean;
   cards: MissionCardLayout[];
+}
+
+interface MissionBoardPackedColumn {
+  column: MissionBoardColumn;
+  width: number;
+  collapsed: boolean;
+}
+
+interface MissionBoardWindow {
+  offset: number;
+  columns: MissionBoardPackedColumn[];
+  hasLeft: boolean;
+  hasRight: boolean;
+  maxOffset: number;
 }
 
 export interface MissionCardLayout {
@@ -221,6 +263,8 @@ export type MissionWorkspaceHit =
   | { kind: "mode"; mode: MissionWorkspaceMode }
   | { kind: "density" }
   | { kind: "refresh" }
+  | { kind: "collapse" }
+  | { kind: "zoom" }
   | { kind: "horizontal"; direction: -1 | 1 }
   | { kind: "column"; column: MissionBoardColumn }
   | { kind: "card"; missionId: string; column: MissionBoardColumn; index: number; hoverKey: number }
@@ -330,6 +374,9 @@ export function defaultMissionWorkspaceModel(
     selectedTaskId,
     detailSection: "tasks",
     detailScroll: emptyDetailScrolls(),
+    collapsedColumns: emptyCollapsedColumns(),
+    zoomColumn: null,
+    zoomRestoreHorizontalOffset: null,
   };
 }
 
@@ -403,6 +450,7 @@ export function clampMissionWorkspaceModel(
   if (selected) {
     next.selectedColumn = selected.column;
     next.preferredRow = selected.index;
+    if (next.zoomColumn) next.zoomColumn = selected.column;
     next.columnScroll[selected.column] = scrollToIndex(
       selected.index,
       next.columnScroll[selected.column],
@@ -411,7 +459,8 @@ export function clampMissionWorkspaceModel(
     next.horizontalOffset = followColumnOffset(
       columnIndex(selected.column),
       next.horizontalOffset,
-      visibleColumnCount(options.width),
+      options.width,
+      next,
     );
   } else if (next.mode === "board") {
     const fallback = firstBoardMission(snapshot.board);
@@ -422,7 +471,8 @@ export function clampMissionWorkspaceModel(
       next.horizontalOffset = followColumnOffset(
         columnIndex(fallback.column),
         next.horizontalOffset,
-        visibleColumnCount(options.width),
+        options.width,
+        next,
       );
     }
   }
@@ -467,7 +517,7 @@ export function clampMissionWorkspaceModel(
   }
   next.horizontalOffset = Math.min(
     Math.max(0, next.horizontalOffset),
-    Math.max(0, MISSION_BOARD_COLUMNS.length - visibleColumnCount(options.width)),
+    missionBoardWindow(options.width ?? 120, next).maxOffset,
   );
   return next;
 }
@@ -552,6 +602,47 @@ export function cycleMissionDensity(
   return snapshot ? clampMissionWorkspaceModel(next, snapshot, options) : next;
 }
 
+export function toggleMissionColumnCollapse(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail"> | null,
+  options: { width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  const next = cloneModel(model);
+  const column = next.selectedColumn;
+  next.collapsedColumns[column] = !next.collapsedColumns[column];
+  if (next.collapsedColumns[column] && next.zoomColumn === column) {
+    next.zoomColumn = null;
+    next.horizontalOffset = next.zoomRestoreHorizontalOffset ?? next.horizontalOffset;
+    next.zoomRestoreHorizontalOffset = null;
+  }
+  return snapshot ? clampMissionWorkspaceModel(next, snapshot, options) : next;
+}
+
+export function toggleMissionColumnZoom(
+  model: MissionWorkspaceModel,
+  snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail"> | null,
+  options: { width?: number; height?: number } = {},
+): MissionWorkspaceModel {
+  const next = cloneModel(model);
+  if (next.mode !== "board") return next;
+  if (next.zoomColumn) {
+    const restore = next.zoomRestoreHorizontalOffset ?? next.horizontalOffset;
+    next.zoomColumn = null;
+    next.zoomRestoreHorizontalOffset = null;
+    const clamped = snapshot ? clampMissionWorkspaceModel(next, snapshot, options) : next;
+    clamped.horizontalOffset = Math.min(
+      Math.max(0, restore),
+      missionBoardWindow(options.width ?? 120, clamped).maxOffset,
+    );
+    return clamped;
+  } else {
+    next.zoomColumn = next.selectedColumn;
+    next.zoomRestoreHorizontalOffset = next.horizontalOffset;
+    next.collapsedColumns[next.selectedColumn] = false;
+  }
+  return snapshot ? clampMissionWorkspaceModel(next, snapshot, options) : next;
+}
+
 export function scrollMissionWorkspace(
   model: MissionWorkspaceModel,
   snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history" | "detail">,
@@ -574,6 +665,8 @@ export function applyMissionWorkspaceHit(
 ): MissionWorkspaceModel {
   if (hit.kind === "mode") return setMissionWorkspaceMode(model, snapshot, hit.mode, options);
   if (hit.kind === "density") return cycleMissionDensity(model, snapshot, options);
+  if (hit.kind === "collapse") return toggleMissionColumnCollapse(model, snapshot, options);
+  if (hit.kind === "zoom") return toggleMissionColumnZoom(model, snapshot, options);
   if (hit.kind === "detail-section")
     return clampMissionWorkspaceModel(
       { ...cloneModel(model), detailSection: hit.section },
@@ -670,59 +763,62 @@ export function missionWorkspaceLayout(
 ): MissionWorkspaceLayout {
   const safeWidth = Math.max(1, width);
   const safeHeight = Math.max(1, height);
-  const visibleCount = visibleColumnCount(safeWidth);
-  const horizontalOffset = Math.min(
-    Math.max(0, model.horizontalOffset),
-    Math.max(0, MISSION_BOARD_COLUMNS.length - visibleCount),
-  );
-  const visibleColumns = MISSION_BOARD_COLUMNS.slice(
-    horizontalOffset,
-    horizontalOffset + visibleCount,
-  );
-  const gapTotal = Math.max(0, visibleColumns.length - 1) * MISSION_COLUMN_GAP;
-  const columnWidth = Math.min(
-    MISSION_MAX_COLUMN_WIDTH,
-    Math.max(1, Math.floor((safeWidth - gapTotal) / Math.max(1, visibleColumns.length))),
-  );
+  const zoomColumn = model.mode === "board" ? model.zoomColumn : null;
+  const packedWindow = missionBoardWindow(safeWidth, model);
+  const visibleColumns = packedWindow.columns.map((column) => column.column);
+  const columnWidth = Math.max(1, Math.max(...packedWindow.columns.map((column) => column.width)));
   const cardHeight = missionCardHeight(model.density);
   const availableRows = boardRows(safeHeight);
   const boardCapacity = boardItemCapacity(safeHeight, model.density);
   const columns: MissionColumnLayout[] = [];
   let x = 0;
-  for (const column of visibleColumns) {
+  for (const packed of packedWindow.columns) {
+    const column = packed.column;
     const cards = snapshot?.board.columns[column] ?? [];
     const start = Math.max(0, model.columnScroll[column]);
-    const visibleCards = cards.slice(start, start + boardCapacity);
-    const lane = missionLaneRect(x, columnWidth, safeHeight);
+    const collapsed = packed.collapsed && column !== zoomColumn;
+    const widthForColumn = Math.max(1, Math.min(packed.width, safeWidth - x));
+    const visibleCards = collapsed ? [] : cards.slice(start, start + boardCapacity);
+    const lane = missionLaneRect(x, widthForColumn, safeHeight);
     const count = snapshot?.board.counts[column] ?? 0;
     columns.push({
       column,
       label: MISSION_COLUMN_LABELS[column],
-      title: `${MISSION_COLUMN_LABELS[column]} · ${count}`,
+      title: missionColumnTitle(column, count, collapsed, lane.bodyWidth),
       x,
       y: lane.y,
-      width: columnWidth,
+      width: widthForColumn,
       height: lane.height,
       bodyX: lane.bodyX,
       bodyY: lane.bodyY,
       bodyWidth: lane.bodyWidth,
       bodyHeight: lane.bodyHeight,
+      titleRows: lane.titleRows,
+      showTitle: lane.titleRows > 0,
       count,
       scroll: start,
       active: model.selectedColumn === column,
-      cards: visibleCards.map((card, visibleIndex) => ({
-        missionId: card.id,
-        column,
-        index: start + visibleIndex,
-        hoverKey: missionCardHoverKey(column, start + visibleIndex),
-        x: lane.bodyX,
-        y: lane.bodyY + visibleIndex * cardHeight,
-        width: lane.bodyWidth,
-        height: cardHeight,
-        lines: missionCardLines(card, model.density, lane.bodyWidth),
-      })),
+      collapsed,
+      zoomed: zoomColumn === column,
+      cards: visibleCards
+        .map((card, visibleIndex) => {
+          const y = lane.bodyY + visibleIndex * cardHeight;
+          const height = Math.max(0, Math.min(cardHeight, lane.bodyY + lane.bodyHeight - y));
+          return {
+            missionId: card.id,
+            column,
+            index: start + visibleIndex,
+            hoverKey: missionCardHoverKey(column, start + visibleIndex),
+            x: lane.bodyX,
+            y,
+            width: lane.bodyWidth,
+            height,
+            lines: missionCardLines(card, model.density, lane.bodyWidth).slice(0, height),
+          };
+        })
+        .filter((card) => card.height > 0),
     });
-    x += columnWidth + MISSION_COLUMN_GAP;
+    x += widthForColumn + MISSION_COLUMN_GAP;
   }
   const historyAvailableRows = historyRows(safeHeight);
   const historyStart = Math.max(0, model.historyScroll);
@@ -1127,6 +1223,71 @@ export function workspaceStateWithMissionSelection(
   return setMissionsSelection(state, viewId, missionId, taskId);
 }
 
+export function missionModelFromWorkspaceState(
+  state: WorkspaceUiStateV1,
+  view: HostedPanelView,
+  fallback: MissionWorkspaceModel = defaultMissionWorkspaceModel(),
+): MissionWorkspaceModel {
+  const entry = viewStateFor(state, view);
+  if (entry?.panel !== "missions" || !entry.navigation) {
+    const selection = missionsSelection(state, view.id);
+    return {
+      ...cloneModel(fallback),
+      selectedMissionId: selection.selectedMissionId ?? fallback.selectedMissionId,
+      selectedTaskId: selection.selectedTaskId ?? fallback.selectedTaskId,
+    };
+  }
+  return {
+    ...cloneModel(fallback),
+    mode: entry.navigation.mode,
+    density: entry.navigation.density,
+    selectedMissionId: entry.selectedMissionId,
+    selectedColumn: entry.navigation.selectedColumn,
+    preferredRow: entry.navigation.preferredRow,
+    columnScroll: { ...entry.navigation.columnScroll },
+    historyScroll: entry.navigation.historyScroll,
+    horizontalOffset: entry.navigation.horizontalOffset,
+    detailReturnMode: entry.navigation.detailReturnMode,
+    selectedTaskId: entry.selectedTaskId,
+    detailSection: entry.navigation.detailSection,
+    detailScroll: { ...entry.navigation.detailScroll },
+    collapsedColumns: { ...entry.navigation.collapsedColumns },
+    zoomColumn: entry.navigation.zoomColumn,
+    zoomRestoreHorizontalOffset: entry.navigation.zoomRestoreHorizontalOffset,
+  };
+}
+
+export function workspaceStateWithMissionModel(
+  state: WorkspaceUiStateV1,
+  viewId: string,
+  model: MissionWorkspaceModel,
+): WorkspaceUiStateV1 {
+  return setMissionsNavigation(
+    state,
+    viewId,
+    { selectedMissionId: model.selectedMissionId, selectedTaskId: model.selectedTaskId },
+    missionModelToNavigation(model),
+  );
+}
+
+function missionModelToNavigation(model: MissionWorkspaceModel): WorkspaceMissionsNavigationState {
+  return {
+    mode: model.mode,
+    density: model.density,
+    selectedColumn: model.selectedColumn,
+    preferredRow: model.preferredRow,
+    columnScroll: { ...model.columnScroll },
+    historyScroll: model.historyScroll,
+    horizontalOffset: model.horizontalOffset,
+    detailReturnMode: model.detailReturnMode,
+    detailSection: model.detailSection,
+    detailScroll: { ...model.detailScroll },
+    collapsedColumns: { ...model.collapsedColumns },
+    zoomColumn: model.zoomColumn,
+    zoomRestoreHorizontalOffset: model.zoomRestoreHorizontalOffset,
+  };
+}
+
 export function clipTerminal(text: string, width: number): string {
   if (width <= 0) return "";
   if (terminalDisplayWidth(text) <= width) return text;
@@ -1178,11 +1339,16 @@ function emptyDetailScrolls(): Record<MissionDetailSection, number> {
   return { tasks: 0, timeline: 0, attempts: 0, proof: 0 };
 }
 
+function emptyCollapsedColumns(): Record<MissionBoardColumn, boolean> {
+  return { planned: false, running: false, blocked: false, review: false, done: false };
+}
+
 function cloneModel(model: MissionWorkspaceModel): MissionWorkspaceModel {
   return {
     ...model,
     columnScroll: { ...model.columnScroll },
     detailScroll: { ...model.detailScroll },
+    collapsedColumns: { ...model.collapsedColumns },
   };
 }
 
@@ -1351,6 +1517,16 @@ function missionCardHoverKey(column: MissionBoardColumn, index: number): number 
   return index * MISSION_BOARD_COLUMNS.length + columnIndex(column);
 }
 
+function missionColumnTitle(
+  column: MissionBoardColumn,
+  count: number,
+  collapsed: boolean,
+  width: number,
+): string {
+  if (collapsed) return clipTerminal(`${MISSION_COLUMN_SHORT_LABELS[column]} ${count}`, width);
+  return `${MISSION_COLUMN_LABELS[column]} · ${count}`;
+}
+
 function missionLaneRect(x: number, width: number, height: number) {
   return missionLaneViewport(
     x,
@@ -1367,7 +1543,7 @@ function missionLaneViewport(x: number, y: number, width: number, height: number
   const inset = bordered ? 1 : 0;
   const innerWidth = Math.max(0, safeWidth - inset * 2);
   const innerHeight = Math.max(0, safeHeight - inset * 2);
-  const titleRows = innerHeight > 0 ? 1 : 0;
+  const titleRows = innerHeight >= 2 ? 1 : 0;
   return {
     x,
     y,
@@ -1377,26 +1553,115 @@ function missionLaneViewport(x: number, y: number, width: number, height: number
     bodyY: y + inset + titleRows,
     bodyWidth: innerWidth,
     bodyHeight: Math.max(0, innerHeight - titleRows),
+    titleRows,
   };
 }
 
-function visibleColumnCount(width: number | undefined): number {
+function missionBoardWindow(
+  width: number | undefined,
+  model: MissionWorkspaceModel,
+): MissionBoardWindow {
   const safeWidth = Math.max(1, width ?? 120);
-  const max = Math.floor(
-    (safeWidth + MISSION_COLUMN_GAP) / (MISSION_MIN_COLUMN_WIDTH + MISSION_COLUMN_GAP),
-  );
-  return Math.max(1, Math.min(MISSION_BOARD_COLUMNS.length, max));
+  if (model.mode === "board" && model.zoomColumn) {
+    return {
+      offset: columnIndex(model.zoomColumn),
+      columns: [{ column: model.zoomColumn, width: safeWidth, collapsed: false }],
+      hasLeft: false,
+      hasRight: false,
+      maxOffset: columnIndex(model.zoomColumn),
+    };
+  }
+  const maxOffset = missionBoardMaxOffset(safeWidth, model);
+  const offset = Math.min(Math.max(0, model.horizontalOffset), maxOffset);
+  const packed = packMissionBoardColumns(safeWidth, offset, model);
+  const last = packed.at(-1);
+  return {
+    offset,
+    columns: packed,
+    hasLeft: offset > 0,
+    hasRight: last ? columnIndex(last.column) < MISSION_BOARD_COLUMNS.length - 1 : false,
+    maxOffset,
+  };
 }
 
-function followColumnOffset(index: number, offset: number, count: number): number {
-  if (index < offset) return index;
-  if (index >= offset + count) return index - count + 1;
-  return offset;
+function missionBoardMaxOffset(width: number, model: MissionWorkspaceModel): number {
+  for (let offset = 0; offset < MISSION_BOARD_COLUMNS.length; offset++) {
+    const packed = packMissionBoardColumns(width, offset, model);
+    if (packed.some((column) => column.column === "done")) return offset;
+  }
+  return Math.max(0, MISSION_BOARD_COLUMNS.length - 1);
+}
+
+function packMissionBoardColumns(
+  width: number,
+  offset: number,
+  model: MissionWorkspaceModel,
+): MissionBoardPackedColumn[] {
+  const safeWidth = Math.max(1, width);
+  const columns: MissionBoardPackedColumn[] = [];
+  let used = 0;
+  for (
+    let index = Math.min(Math.max(0, offset), MISSION_BOARD_COLUMNS.length - 1);
+    index < MISSION_BOARD_COLUMNS.length;
+    index++
+  ) {
+    const column = MISSION_BOARD_COLUMNS[index]!;
+    const collapsed = model.collapsedColumns[column] === true;
+    const baseWidth = collapsed ? MISSION_COLLAPSED_COLUMN_WIDTH : MISSION_MIN_COLUMN_WIDTH;
+    const gap = columns.length > 0 ? MISSION_COLUMN_GAP : 0;
+    if (columns.length > 0 && used + gap + baseWidth > safeWidth) break;
+    const widthForColumn = columns.length === 0 ? Math.min(baseWidth, safeWidth) : baseWidth;
+    columns.push({ column, width: widthForColumn, collapsed });
+    used += gap + widthForColumn;
+  }
+  const expanded = columns.filter((column) => !column.collapsed);
+  let remaining = Math.max(0, safeWidth - used);
+  while (remaining > 0 && expanded.some((column) => column.width < MISSION_MAX_COLUMN_WIDTH)) {
+    for (const column of expanded) {
+      if (remaining <= 0) break;
+      if (column.width >= MISSION_MAX_COLUMN_WIDTH) continue;
+      column.width += 1;
+      remaining -= 1;
+    }
+  }
+  return columns.length > 0
+    ? columns
+    : [{ column: MISSION_BOARD_COLUMNS[0]!, width: safeWidth, collapsed: false }];
+}
+
+function followColumnOffset(
+  index: number,
+  offset: number,
+  width: number | undefined,
+  model: MissionWorkspaceModel,
+): number {
+  const maxOffset = missionBoardWindow(width ?? 120, model).maxOffset;
+  let next = Math.min(Math.max(0, offset), maxOffset);
+  if (
+    packMissionBoardColumns(width ?? 120, next, model).some(
+      (column) => columnIndex(column.column) === index,
+    )
+  )
+    return next;
+  if (index < next) return Math.min(index, maxOffset);
+  while (next < maxOffset) {
+    next += 1;
+    if (
+      packMissionBoardColumns(width ?? 120, next, model).some(
+        (column) => columnIndex(column.column) === index,
+      )
+    )
+      return next;
+  }
+  return maxOffset;
 }
 
 function boardRows(height: number | undefined): number {
   const laneHeight = Math.max(0, (height ?? 24) - MISSION_HEADER_ROWS - MISSION_FOOTER_ROWS);
-  return Math.max(0, laneHeight - 3);
+  if (laneHeight < 2) return laneHeight;
+  const innerHeight = Math.max(0, laneHeight - 2);
+  const titleRows = innerHeight >= 2 ? 1 : 0;
+  return Math.max(0, innerHeight - titleRows);
 }
 
 function historyRows(height: number | undefined): number {
@@ -1404,7 +1669,9 @@ function historyRows(height: number | undefined): number {
 }
 
 function boardItemCapacity(height: number | undefined, density: MissionWorkspaceDensity): number {
-  return Math.max(0, Math.floor(boardRows(height) / missionCardHeight(density)));
+  const rows = boardRows(height);
+  if (rows <= 0) return 0;
+  return Math.max(1, Math.floor(rows / missionCardHeight(density)));
 }
 
 function historyItemCapacity(height: number | undefined, density: MissionWorkspaceDensity): number {
@@ -1703,6 +1970,8 @@ function missionHeaderLayout(
     label: missionModeLabel("history", model.mode === "history"),
   });
   addFirst({ kind: "density", label: densityLabel(model.density) });
+  addFirst({ kind: "collapse", label: collapseLabel(model) });
+  addFirst({ kind: "zoom", label: zoomLabel(model) });
   addFirst({ kind: "refresh", label: "r refresh" });
 
   const secondRow: MissionHeaderChip[] = [];
@@ -1721,12 +1990,13 @@ function missionHeaderLayout(
       width: 1,
     });
   }
-  const secondLabel = missionSecondHeaderLabel(width, snapshot, presentation);
+  const secondLabel = missionSecondHeaderLabel(width, model, snapshot, presentation);
   return { rows: [firstRow, secondRow], labels: [clipTerminal(firstLabel, width), secondLabel] };
 }
 
 function missionSecondHeaderLabel(
   width: number,
+  model: MissionWorkspaceModel,
   snapshot: Pick<MissionWorkspaceSnapshot, "board" | "history"> | null,
   presentation: MissionWorkspacePresentationOptions,
 ): string {
@@ -1739,20 +2009,39 @@ function missionSecondHeaderLabel(
   const summary = snapshot
     ? `${status}${project} · ${snapshot.board.counts.total} total · ${snapshot.history.length} finished`
     : `${status}${project}`;
-  return `<${fitTerminal(` ${summary} `, Math.max(0, width - 2))}>`;
+  const overflow = boardOverflowHint(model, width);
+  if (overflow && width < 30) return `<${fitTerminal(` ${status} · ${overflow} `, width - 2)}>`;
+  return `<${fitTerminal(` ${summary}${overflow ? ` · ${overflow}` : ""} `, Math.max(0, width - 2))}>`;
 }
 
 function missionFooterLabel(
   width: number,
-  model: Pick<MissionWorkspaceModel, "mode">,
+  model: Pick<MissionWorkspaceModel, "mode" | "zoomColumn">,
   quitHint: string | null | undefined,
 ): string {
   const quit = quitHint?.trim() || "^q quit";
   const controls =
     model.mode === "detail"
       ? "esc back · tab sections · 1-4 section · arrows move · t/f/d open · r refresh"
-      : "tab mode · arrows move · enter details · z density · r refresh";
+      : `tab mode · arrows move · enter details · z density · c collapse · x ${model.zoomColumn ? "unzoom" : "zoom"} · r refresh`;
   return fitTerminal(`${quit} · ${controls}`, width);
+}
+
+function collapseLabel(model: MissionWorkspaceModel): string {
+  return model.collapsedColumns[model.selectedColumn] ? "c expand" : "c collapse";
+}
+
+function zoomLabel(model: MissionWorkspaceModel): string {
+  return model.zoomColumn ? "x unzoom" : "x zoom";
+}
+
+function boardOverflowHint(model: MissionWorkspaceModel, width: number): string {
+  if (model.mode !== "board" || model.zoomColumn) return "";
+  const window = missionBoardWindow(width, model);
+  if (window.hasLeft && window.hasRight) return "more ◀▶";
+  if (window.hasLeft) return "more ◀";
+  if (window.hasRight) return "more ▶";
+  return "";
 }
 
 function fitTerminal(text: string, width: number): string {
@@ -1782,6 +2071,8 @@ function missionHeaderHit(header: MissionHeaderLayout, x: number, y: number): Mi
     if (x < chip.start || x >= chip.start + chip.width) continue;
     if (chip.kind === "mode" && chip.mode) return { kind: "mode", mode: chip.mode };
     if (chip.kind === "density") return { kind: "density" };
+    if (chip.kind === "collapse") return { kind: "collapse" };
+    if (chip.kind === "zoom") return { kind: "zoom" };
     if (chip.kind === "refresh") return { kind: "refresh" };
     if (chip.kind === "horizontal" && chip.direction) {
       return { kind: "horizontal", direction: chip.direction };

--- a/packages/daemon/src/tui/mirror/workspace-ui-state.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace-ui-state.test.ts
@@ -19,6 +19,7 @@ import {
   relativeProjectPath,
   serializeWorkspaceUiState,
   setMissionsSelection,
+  setMissionsNavigation,
   setWorkspaceViewLayoutState,
   shouldHydrateWorkspaceView,
   viewStateFor,
@@ -215,6 +216,57 @@ describe("workspace UI-state contract", () => {
     });
     expect(missionsSelection(state, "other")).toEqual({
       selectedMissionId: null,
+      selectedTaskId: null,
+    });
+  });
+
+  it("round-trips bounded missions navigation and tolerates legacy selection-only state", () => {
+    const state = setMissionsNavigation(
+      defaultWorkspaceUiState(),
+      "missions",
+      { selectedMissionId: "mission-1", selectedTaskId: "task-1" },
+      {
+        mode: "board",
+        density: "detailed",
+        selectedColumn: "running",
+        preferredRow: 9,
+        columnScroll: { planned: 0, running: 7, blocked: 0, review: 0, done: 0 },
+        historyScroll: 3,
+        horizontalOffset: 1,
+        detailReturnMode: "history",
+        detailSection: "timeline",
+        detailScroll: { tasks: 2, timeline: 4, attempts: 0, proof: 0 },
+        collapsedColumns: {
+          planned: false,
+          running: false,
+          blocked: true,
+          review: false,
+          done: true,
+        },
+        zoomColumn: "running",
+        zoomRestoreHorizontalOffset: 0,
+      },
+    );
+    const parsed = parseWorkspaceUiStateJson(serializeWorkspaceUiState(state));
+    expect(parsed.state.views.missions).toMatchObject({
+      panel: "missions",
+      selectedMissionId: "mission-1",
+      selectedTaskId: "task-1",
+      navigation: {
+        density: "detailed",
+        selectedColumn: "running",
+        columnScroll: { running: 7 },
+        collapsedColumns: { blocked: true, done: true },
+        zoomColumn: "running",
+      },
+    });
+
+    const legacy = parseWorkspaceUiStateJson(
+      '{"version":1,"active":null,"views":{"missions":{"panel":"missions","selectedMissionId":"mission-legacy","selectedTaskId":null}}}',
+    );
+    expect(legacy.state.views.missions).toEqual({
+      panel: "missions",
+      selectedMissionId: "mission-legacy",
       selectedTaskId: null,
     });
   });

--- a/packages/daemon/src/tui/mirror/workspace-ui-state.ts
+++ b/packages/daemon/src/tui/mirror/workspace-ui-state.ts
@@ -57,7 +57,24 @@ export interface WorkspaceMissionsViewState {
   panel: "missions";
   selectedMissionId: string | null;
   selectedTaskId: string | null;
+  navigation?: WorkspaceMissionsNavigationState;
   layout?: WorkspaceCompositeLayoutViewState;
+}
+
+export interface WorkspaceMissionsNavigationState {
+  mode: "board" | "history" | "detail";
+  density: "compact" | "comfortable" | "detailed";
+  selectedColumn: "planned" | "running" | "blocked" | "review" | "done";
+  preferredRow: number;
+  columnScroll: Record<"planned" | "running" | "blocked" | "review" | "done", number>;
+  historyScroll: number;
+  horizontalOffset: number;
+  detailReturnMode: "board" | "history";
+  detailSection: "tasks" | "timeline" | "attempts" | "proof";
+  detailScroll: Record<"tasks" | "timeline" | "attempts" | "proof", number>;
+  collapsedColumns: Record<"planned" | "running" | "blocked" | "review" | "done", boolean>;
+  zoomColumn: "planned" | "running" | "blocked" | "review" | "done" | null;
+  zoomRestoreHorizontalOffset: number | null;
 }
 
 export interface WorkspaceEmptyViewState {
@@ -123,6 +140,10 @@ export interface WorkspaceUiControllerSaveResult {
 
 const PANELS: readonly HostedPanelKind[] = ["home", "terminals", "files", "diff", "missions"];
 const RESERVED_OBJECT_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+const MISSION_COLUMNS = ["planned", "running", "blocked", "review", "done"] as const;
+const MISSION_MODES = ["board", "history", "detail"] as const;
+const MISSION_DENSITIES = ["compact", "comfortable", "detailed"] as const;
+const MISSION_DETAIL_SECTIONS = ["tasks", "timeline", "attempts", "proof"] as const;
 
 export const DEFAULT_WORKSPACE_UI_STATE: WorkspaceUiStateV1 = Object.freeze({
   version: WORKSPACE_UI_STATE_VERSION,
@@ -164,6 +185,73 @@ function cleanPath(value: unknown): string | null {
   if (value.length === 0 || value.length > WORKSPACE_UI_STATE_MAX_PATH_LENGTH) return null;
   if (value.includes("\0")) return null;
   return value;
+}
+
+function oneOf<T extends readonly string[]>(value: unknown, allowed: T): T[number] | null {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value)
+    ? (value as T[number])
+    : null;
+}
+
+function cleanNonnegativeInt(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function cleanNumberRecord<const Keys extends readonly string[]>(
+  value: unknown,
+  keys: Keys,
+): Record<Keys[number], number> {
+  const out = Object.fromEntries(keys.map((key) => [key, 0])) as Record<Keys[number], number>;
+  if (!isRecord(value)) return out;
+  for (const key of keys as readonly Keys[number][]) {
+    const clean = cleanNonnegativeInt(value[key]);
+    if (clean !== null) out[key] = clean;
+  }
+  return out;
+}
+
+function cleanBooleanRecord<const Keys extends readonly string[]>(
+  value: unknown,
+  keys: Keys,
+): Record<Keys[number], boolean> {
+  const out = Object.fromEntries(keys.map((key) => [key, false])) as Record<Keys[number], boolean>;
+  if (!isRecord(value)) return out;
+  for (const key of keys as readonly Keys[number][]) out[key] = value[key] === true;
+  return out;
+}
+
+function cleanMissionsNavigation(
+  value: unknown,
+  path: string,
+  diagnostics: WorkspaceUiStateDiagnostic[],
+): WorkspaceMissionsNavigationState | null {
+  if (value === undefined || value === null) return null;
+  if (!isRecord(value)) {
+    diagnostics.push(diagnostic("INVALID_FIELD", path, "missions navigation must be an object"));
+    return null;
+  }
+  const mode = oneOf(value.mode, MISSION_MODES) ?? "board";
+  const density = oneOf(value.density, MISSION_DENSITIES) ?? "comfortable";
+  const selectedColumn = oneOf(value.selectedColumn, MISSION_COLUMNS) ?? "planned";
+  const detailReturnMode = oneOf(value.detailReturnMode, ["board", "history"] as const) ?? "board";
+  const detailSection = oneOf(value.detailSection, MISSION_DETAIL_SECTIONS) ?? "tasks";
+  const zoomColumn = oneOf(value.zoomColumn, MISSION_COLUMNS);
+  const zoomRestoreHorizontalOffset = cleanNonnegativeInt(value.zoomRestoreHorizontalOffset);
+  return {
+    mode,
+    density,
+    selectedColumn,
+    preferredRow: cleanNonnegativeInt(value.preferredRow) ?? 0,
+    columnScroll: cleanNumberRecord(value.columnScroll, MISSION_COLUMNS),
+    historyScroll: cleanNonnegativeInt(value.historyScroll) ?? 0,
+    horizontalOffset: cleanNonnegativeInt(value.horizontalOffset) ?? 0,
+    detailReturnMode,
+    detailSection,
+    detailScroll: cleanNumberRecord(value.detailScroll, MISSION_DETAIL_SECTIONS),
+    collapsedColumns: cleanBooleanRecord(value.collapsedColumns, MISSION_COLUMNS),
+    zoomColumn,
+    zoomRestoreHorizontalOffset,
+  };
 }
 
 function cleanActive(
@@ -217,10 +305,16 @@ function cleanViewState(
     };
   }
   if (panel === "missions") {
+    const navigation = cleanMissionsNavigation(
+      value.navigation,
+      `$.views.${key}.navigation`,
+      diagnostics,
+    );
     return {
       panel,
       selectedMissionId: cleanId(value.selectedMissionId),
       selectedTaskId: cleanId(value.selectedTaskId),
+      ...(navigation ? { navigation } : {}),
       ...(layout ? { layout } : {}),
     };
   }
@@ -377,6 +471,7 @@ export function serializeWorkspaceUiState(state: WorkspaceUiStateV1): string {
         panel: "missions",
         selectedMissionId: view.selectedMissionId,
         selectedTaskId: view.selectedTaskId,
+        ...(view.navigation ? { navigation: orderedMissionsNavigation(view.navigation) } : {}),
         ...(view.layout ? { layout: orderedLayoutState(view.layout) } : {}),
       };
     } else {
@@ -408,6 +503,44 @@ function orderedLayoutState(
     activeTabs,
     splitWeights,
   };
+}
+
+function orderedMissionsNavigation(
+  navigation: WorkspaceMissionsNavigationState,
+): WorkspaceMissionsNavigationState {
+  return {
+    mode: navigation.mode,
+    density: navigation.density,
+    selectedColumn: navigation.selectedColumn,
+    preferredRow: navigation.preferredRow,
+    columnScroll: orderedNumberRecord(navigation.columnScroll, MISSION_COLUMNS),
+    historyScroll: navigation.historyScroll,
+    horizontalOffset: navigation.horizontalOffset,
+    detailReturnMode: navigation.detailReturnMode,
+    detailSection: navigation.detailSection,
+    detailScroll: orderedNumberRecord(navigation.detailScroll, MISSION_DETAIL_SECTIONS),
+    collapsedColumns: orderedBooleanRecord(navigation.collapsedColumns, MISSION_COLUMNS),
+    zoomColumn: navigation.zoomColumn,
+    zoomRestoreHorizontalOffset: navigation.zoomRestoreHorizontalOffset,
+  };
+}
+
+function orderedNumberRecord<const Keys extends readonly string[]>(
+  record: Record<Keys[number], number>,
+  keys: Keys,
+): Record<Keys[number], number> {
+  return Object.fromEntries(
+    (keys as readonly Keys[number][]).map((key) => [key, record[key] ?? 0]),
+  ) as Record<Keys[number], number>;
+}
+
+function orderedBooleanRecord<const Keys extends readonly string[]>(
+  record: Record<Keys[number], boolean>,
+  keys: Keys,
+): Record<Keys[number], boolean> {
+  return Object.fromEntries(
+    (keys as readonly Keys[number][]).map((key) => [key, record[key] === true]),
+  ) as Record<Keys[number], boolean>;
 }
 
 export function workspaceUiStateToJsonValue(state: WorkspaceUiStateV1): JsonValue {
@@ -563,6 +696,34 @@ export function setMissionsSelection(
         panel: "missions",
         selectedMissionId: cleanId(missionId),
         selectedTaskId: cleanId(taskId),
+        ...(state.views[id]?.panel === "missions" && state.views[id].navigation
+          ? { navigation: state.views[id].navigation }
+          : {}),
+      },
+    },
+  };
+}
+
+export function setMissionsNavigation(
+  state: WorkspaceUiStateV1,
+  viewId: string,
+  selection: Pick<WorkspaceMissionsViewState, "selectedMissionId" | "selectedTaskId">,
+  navigation: WorkspaceMissionsNavigationState,
+): WorkspaceUiStateV1 {
+  const id = cleanId(viewId);
+  if (!id) return cloneState(state);
+  const existing = state.views[id];
+  return {
+    version: WORKSPACE_UI_STATE_VERSION,
+    active: state.active ? { ...state.active } : null,
+    views: {
+      ...state.views,
+      [id]: {
+        ...(existing?.layout ? { layout: existing.layout } : {}),
+        panel: "missions",
+        selectedMissionId: cleanId(selection.selectedMissionId),
+        selectedTaskId: cleanId(selection.selectedTaskId),
+        navigation: orderedMissionsNavigation(navigation),
       },
     },
   };
@@ -596,6 +757,7 @@ function workspaceViewStateWithLayout(
       panel: "missions",
       selectedMissionId: entry.selectedMissionId,
       selectedTaskId: entry.selectedTaskId,
+      ...(entry.navigation ? { navigation: orderedMissionsNavigation(entry.navigation) } : {}),
       layout: cleanLayout,
     };
   }


### PR DESCRIPTION
## Summary

- add persistent per-view Missions navigation state for mode, density, scroll, collapse, and zoom
- add authoritative variable-width lane packing so collapsed lanes reclaim viewport space
- keep render, hit testing, keyboard/mouse navigation, and tiny-height behavior on the same geometry model

## Validation

- `pnpm vitest run packages/daemon/src/tui/mirror/missions-workspace.test.ts packages/daemon/src/tui/mirror/missions-surface.test.ts packages/daemon/src/tui/mirror/workspace-ui-state.test.ts` (58 passed)
- `pnpm --filter @tmux-ide/contracts typecheck`
- `pnpm --filter @tmux-ide/daemon typecheck`
- `pnpm build:tui`
- `pnpm check`
- `git diff --check`