### PR TITLE
feat(tui): add responsive missions dashboard

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -362,7 +362,6 @@ import {
   missionSelectionFromWorkspaceState,
   missionTmuxPanePreflightMatches,
   missionTmuxPreflightCommands,
-  missionWorkspaceHitTest,
   readMissionWorkspace,
   reconcileMissionWorkspaceModel,
   resolveMissionDeepLink,
@@ -374,6 +373,11 @@ import {
   type MissionWorkspaceModel,
   type MissionWorkspaceSnapshot,
 } from "./missions-workspace.ts";
+import {
+  missionDashboardHitTest,
+  missionDashboardMainSize,
+  missionDashboardProjection,
+} from "./missions-dashboard.ts";
 import { MissionsSurface, missionSurfaceLayout } from "./missions-surface.tsx";
 import {
   handleMissionSurfaceKey,
@@ -1218,10 +1222,10 @@ try {
       if (focusPanelInActiveComposite(panel)) return;
       if (selectView(viewId)) focusPanelInActiveComposite(panel);
     };
-    const missionLayoutSize = () => ({
-      width: canvasCols(),
-      height: Math.max(4, dims().height - TABBAR_H),
-    });
+    const missionLayoutSize = () => {
+      const size = missionDashboardMainSize(canvasCols(), Math.max(4, dims().height - TABBAR_H));
+      return { width: size.mainWidth, height: size.height };
+    };
     const persistMissionSelection = (missionId: string | null, taskId: string | null = null) => {
       const view = activeView();
       if (activePanel() !== "missions") return;
@@ -2840,9 +2844,21 @@ try {
         missionLayoutPresentation(),
       ),
     );
+    const missionsDashboard = createMemo(() =>
+      missionDashboardProjection(
+        canvasCols(),
+        Math.max(4, dims().height - TABBAR_H),
+        missionWorkspaceModel(),
+        missionWorkspaceSnapshot(),
+        {
+          ...missionLayoutPresentation(),
+          agents: fleetAgents(),
+        },
+      ),
+    );
     const missionHitAt = (x: number, y: number) => {
       const gy = y - TABBAR_H;
-      return missionWorkspaceHitTest(missionsLayout(), x - sidebarW(), gy);
+      return missionDashboardHitTest(missionsDashboard(), x - sidebarW(), gy);
     };
 
     // ── WATCHER PUSH REFRESH (M24.6) ─────────────────────────────────────────
@@ -8110,7 +8126,7 @@ try {
             <Show when={!activeCompositeLayout() && mode() === "missions"}>
               <MissionsSurface
                 width={canvasCols()}
-                layout={missionsLayout()}
+                dashboard={missionsDashboard()}
                 model={missionWorkspaceModel()}
                 snapshot={missionWorkspaceSnapshot()}
                 loadState={missionWorkspaceLoad()}

--- a/packages/daemon/src/tui/mirror/missions-dashboard.test.ts
+++ b/packages/daemon/src/tui/mirror/missions-dashboard.test.ts
@@ -1,0 +1,474 @@
+import { describe, expect, it } from "vitest";
+import type {
+  MissionBoardColumn,
+  MissionBoardView,
+  MissionCardView,
+  MissionDetailView,
+  MissionProgressSummary,
+  MissionProofSummary,
+  TaskCardView,
+} from "@tmux-ide/contracts";
+import type { AgentRowInput } from "./agent-rows.ts";
+import {
+  MISSION_BOARD_COLUMNS,
+  defaultMissionWorkspaceModel,
+  missionWorkspaceHitTest,
+  reconcileMissionWorkspaceModel,
+} from "./missions-workspace.ts";
+import {
+  missionDashboardHitTest,
+  missionDashboardInspectorGeometry,
+  missionDashboardMainSize,
+  missionDashboardProjection,
+  type MissionDashboardProjection,
+} from "./missions-dashboard.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+
+function progress(overrides: Partial<MissionProgressSummary> = {}): MissionProgressSummary {
+  return {
+    total: 6,
+    planned: 1,
+    running: 2,
+    blocked: 1,
+    review: 1,
+    completed: 1,
+    failed: 0,
+    cancelled: 0,
+    done: 1,
+    ...overrides,
+  };
+}
+
+function proof(overrides: Partial<MissionProofSummary> = {}): MissionProofSummary {
+  return {
+    proofIds: [],
+    hasProof: false,
+    noProofReasons: [],
+    notesCount: 0,
+    tests: { suites: 0, passed: 0, failed: 0, skipped: 0, total: 0 },
+    commits: [],
+    diff: { summaries: [], urls: [], filesChanged: 0, insertions: 0, deletions: 0 },
+    prs: [],
+    artifacts: [],
+    ...overrides,
+  };
+}
+
+function card(
+  id: string,
+  column: MissionBoardColumn,
+  overrides: Partial<MissionCardView> = {},
+): MissionCardView {
+  return {
+    version: 1,
+    id,
+    title: `Mission ${id}`,
+    summary: `summary ${id}`,
+    status:
+      column === "planned"
+        ? "planned"
+        : column === "running"
+          ? "started"
+          : column === "blocked"
+            ? "blocked"
+            : column === "review"
+              ? "review"
+              : "completed",
+    column,
+    labels: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    durationMs: null,
+    progress: progress(),
+    blockedBy: [],
+    latestAttempt: null,
+    proofSummary: proof(),
+    refs: { missionId: id, taskIds: [], attemptIds: [], proofIds: [] },
+    ...overrides,
+  };
+}
+
+function task(id: string, overrides: Partial<TaskCardView> = {}): TaskCardView {
+  return {
+    version: 1,
+    id,
+    missionId: "mis_running",
+    title: `Task ${id}`,
+    summary: `summary ${id}`,
+    status: "started",
+    column: "running",
+    priority: 2,
+    dependencies: [],
+    blockedBy: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    durationMs: null,
+    latestAttempt: null,
+    proofSummary: proof(),
+    refs: { missionId: "mis_running", taskId: id, attemptIds: [], proofIds: [] },
+    ...overrides,
+  };
+}
+
+function board(): MissionBoardView {
+  const columns = Object.fromEntries(
+    MISSION_BOARD_COLUMNS.map((column) => [
+      column,
+      [card(`mis_${column}`, column, column === "running" ? { id: "mis_running" } : {})],
+    ]),
+  ) as MissionBoardView["columns"];
+  return {
+    version: 1,
+    columns,
+    counts: {
+      planned: 1,
+      running: 1,
+      blocked: 1,
+      review: 1,
+      done: 1,
+      total: 5,
+    },
+  };
+}
+
+function snapshot(): Parameters<typeof missionDashboardProjection>[3] {
+  const attempt = {
+    id: "att_running",
+    taskId: "tsk_running",
+    status: "running" as const,
+    agent: "codex",
+    harness: "harness",
+    model: "gpt-5",
+    terminal: "%7",
+    session: "demo-session",
+    startedAt: "2026-01-01T00:00:02.000Z",
+    updatedAt: "2026-01-01T00:00:03.000Z",
+    durationMs: null,
+    proofIds: [],
+  };
+  const runningMission = card("mis_running", "running", {
+    latestAttempt: attempt,
+    refs: {
+      missionId: "mis_running",
+      taskIds: ["tsk_running"],
+      attemptIds: ["att_running"],
+      proofIds: [],
+    },
+  });
+  const taskOne = task("tsk_running", {
+    latestAttempt: attempt,
+    refs: {
+      missionId: "mis_running",
+      taskId: "tsk_running",
+      attemptIds: ["att_running"],
+      proofIds: [],
+      terminal: "%7",
+      session: "demo-session",
+    },
+  });
+  const b = board();
+  b.columns.running = [runningMission];
+  return {
+    board: b,
+    history: [
+      {
+        version: 1,
+        mission: card("mis_done", "done"),
+        outcome: "completed",
+        finishedAt: "2026-01-01T00:10:00.000Z",
+        durationMs: 600_000,
+        taskTotals: progress({ total: 1, done: 1, completed: 1, planned: 0, running: 0 }),
+        attemptTotals: {
+          total: 1,
+          submitted: 1,
+          approved: 0,
+          rejected: 0,
+          failed: 0,
+          interrupted: 0,
+          running: 0,
+        },
+        proofSummary: proof(),
+        lastEvent: null,
+      },
+    ],
+    detail: {
+      version: 1,
+      mission: runningMission,
+      taskBoard: {
+        columns: {
+          planned: [],
+          running: [taskOne],
+          blocked: [],
+          review: [],
+          done: [],
+        },
+        counts: { planned: 0, running: 1, blocked: 0, review: 0, done: 0, total: 1 },
+      },
+      attempts: [attempt],
+      proofSummary: proof(),
+      progress: progress(),
+      timeline: [
+        {
+          version: 1,
+          sequence: 3,
+          timestamp: "2026-01-01T00:00:03.000Z",
+          missionId: "mis_running",
+          taskId: "tsk_running",
+          attemptId: "att_running",
+          type: "attempt.started",
+          label: "Attempt started",
+          actor: { type: "user", id: "pm" },
+          refs: {
+            missionId: "mis_running",
+            taskId: "tsk_running",
+            attemptId: "att_running",
+            terminal: "%7",
+            session: "demo-session",
+          },
+        },
+      ],
+    } satisfies MissionDetailView,
+    project: { identityKey: "project", projectRoot: "/repo/demo" },
+    loadedAt: "2026-07-19T00:00:00.000Z",
+  };
+}
+
+function agents(): AgentRowInput[] {
+  return [
+    {
+      paneId: "%8",
+      windowIndex: 0,
+      session: "other-session",
+      kind: "codex",
+      state: "blocked",
+      since: 1,
+      displayName: "unrelated-codex",
+    },
+    {
+      paneId: "%7",
+      windowIndex: 1,
+      session: "demo-session",
+      kind: "codex",
+      state: "working",
+      since: 2,
+      displayName: "runner",
+    },
+    {
+      paneId: "%9",
+      windowIndex: 2,
+      session: "demo-session",
+      kind: "claude",
+      state: "idle",
+      since: 3,
+    },
+  ];
+}
+
+function assertProjectionBounds(projection: MissionDashboardProjection) {
+  expect(projection.main.x).toBe(0);
+  expect(projection.main.y).toBe(0);
+  expect(projection.main.width).toBeGreaterThan(0);
+  expect(projection.main.height).toBe(projection.height);
+  if (projection.inspector) {
+    expect(projection.inspector.x).toBe(projection.main.width + 1);
+    expect(projection.main.width + 1 + projection.inspector.width).toBe(projection.width);
+    expect(projection.inspector.height).toBe(projection.height);
+    const bodyWidth = Math.max(1, projection.inspector.width - 2);
+    expect(projection.inspector.rows.length).toBeLessThanOrEqual(projection.inspector.bodyRows);
+    expect(
+      projection.inspector.borderRows +
+        projection.inspector.titleRows +
+        projection.inspector.rows.length,
+    ).toBeLessThanOrEqual(projection.inspector.height);
+    for (const row of projection.inspector.rows) {
+      expect(terminalDisplayWidth(`${row.label}: ${row.value}`)).toBeLessThanOrEqual(bodyWidth);
+    }
+  } else {
+    expect(projection.main.width).toBe(projection.width);
+  }
+  for (const column of projection.main.layout.board.columns) {
+    expect(column.x).toBeGreaterThanOrEqual(0);
+    expect(column.x + column.width).toBeLessThanOrEqual(projection.main.width);
+    expect(column.height).toBeGreaterThanOrEqual(1);
+  }
+}
+
+describe("missions dashboard projection", () => {
+  it("projects narrow, medium, and wide regions with bounded main plus inspector widths", () => {
+    const model = defaultMissionWorkspaceModel("mis_running", "tsk_running");
+    const snap = snapshot();
+    const narrow = missionDashboardProjection(80, 24, model, snap);
+    const medium = missionDashboardProjection(120, 40, model, snap);
+    const wide = missionDashboardProjection(200, 60, model, snap);
+
+    expect(narrow.variant).toBe("narrow");
+    expect(narrow.inspector).toBeNull();
+    expect(medium.variant).toBe("medium");
+    expect(medium.inspector?.variant).toBe("medium");
+    expect(wide.variant).toBe("wide");
+    expect(wide.inspector?.variant).toBe("wide");
+    expect(missionDashboardMainSize(120, 40).mainWidth).toBe(medium.main.width);
+    expect(missionDashboardMainSize(200, 60).mainWidth).toBe(wide.main.width);
+    assertProjectionBounds(narrow);
+    assertProjectionBounds(medium);
+    assertProjectionBounds(wide);
+  });
+
+  it("projects exact bordered inspector title and body rows at short heights", () => {
+    expect(missionDashboardInspectorGeometry(24, 1)).toEqual({
+      borderRows: 0,
+      titleRows: 1,
+      bodyRows: 0,
+    });
+    expect(missionDashboardInspectorGeometry(24, 2)).toEqual({
+      borderRows: 2,
+      titleRows: 0,
+      bodyRows: 0,
+    });
+    expect(missionDashboardInspectorGeometry(24, 3)).toEqual({
+      borderRows: 2,
+      titleRows: 1,
+      bodyRows: 0,
+    });
+    expect(missionDashboardInspectorGeometry(24, 4)).toEqual({
+      borderRows: 2,
+      titleRows: 1,
+      bodyRows: 1,
+    });
+
+    for (const height of [1, 2, 3, 4, 24]) {
+      const projection = missionDashboardProjection(
+        120,
+        height,
+        defaultMissionWorkspaceModel("mis_running", "tsk_running"),
+        snapshot(),
+      );
+      const inspector = projection.inspector!;
+      expect(inspector.rows.length).toBeLessThanOrEqual(inspector.bodyRows);
+      expect(
+        inspector.borderRows + inspector.titleRows + inspector.rows.length,
+      ).toBeLessThanOrEqual(inspector.height);
+      expect(inspector.bodyRows).toBeGreaterThanOrEqual(0);
+      expect(inspector.titleRows).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("shows selected mission task facts and prioritizes pane/session matched agents", () => {
+    const model = defaultMissionWorkspaceModel("mis_running", "tsk_running");
+    const projection = missionDashboardProjection(200, 60, model, snapshot(), {
+      agents: agents(),
+    });
+
+    expect(projection.inspector?.rows.map((row) => `${row.label}:${row.value}`)).toContain(
+      "task:tsk_running · started · p2",
+    );
+    expect(projection.inspector?.agents.map((agent) => [agent.display, agent.rank])).toEqual([
+      ["runner", "pane"],
+      ["claude", "session"],
+    ]);
+  });
+
+  it("uses kind/display fallback only when exact pane and session matches are absent", () => {
+    const snap = snapshot();
+    snap.detail!.attempts[0] = {
+      ...snap.detail!.attempts[0]!,
+      terminal: "%404",
+      session: "missing-session",
+    };
+    snap.detail!.mission = {
+      ...snap.detail!.mission,
+      latestAttempt: snap.detail!.attempts[0]!,
+    };
+    snap.detail!.taskBoard.columns.running[0] = {
+      ...snap.detail!.taskBoard.columns.running[0]!,
+      latestAttempt: snap.detail!.attempts[0]!,
+    };
+    const projection = missionDashboardProjection(
+      200,
+      60,
+      defaultMissionWorkspaceModel("mis_running", "tsk_running"),
+      snap,
+      { agents: agents() },
+    );
+
+    expect(projection.inspector?.agents.map((agent) => [agent.display, agent.rank])).toEqual([
+      ["unrelated-codex", "kind"],
+      ["runner", "kind"],
+    ]);
+  });
+
+  it("does not invent task context when persisted selectedTaskId is null or stale", () => {
+    const noTask = missionDashboardProjection(
+      200,
+      60,
+      defaultMissionWorkspaceModel("mis_running", null),
+      snapshot(),
+    );
+    const staleTask = missionDashboardProjection(
+      200,
+      60,
+      defaultMissionWorkspaceModel("mis_running", "tsk_missing"),
+      snapshot(),
+    );
+
+    expect(noTask.inspector?.rows.find((row) => row.key === "task")?.value).toBe(
+      "no task selected",
+    );
+    expect(staleTask.inspector?.rows.find((row) => row.key === "task")?.value).toBe(
+      "no task selected",
+    );
+  });
+
+  it("degrades explicitly at medium and narrow widths without duplicate selection state", () => {
+    const model = defaultMissionWorkspaceModel("mis_running", "tsk_running");
+    const medium = missionDashboardProjection(120, 24, model, snapshot());
+    const narrow = missionDashboardProjection(80, 24, model, snapshot());
+
+    expect(medium.inspector?.rows.some((row) => row.key === "mission")).toBe(true);
+    expect(medium.inspector?.rows.some((row) => row.key === "task")).toBe(true);
+    expect(narrow.inspector).toBeNull();
+    assertProjectionBounds(medium);
+    assertProjectionBounds(narrow);
+  });
+
+  it("routes mission hit tests through main-region coordinates and leaves inspector inert", () => {
+    const model = defaultMissionWorkspaceModel("mis_running");
+    const projection = missionDashboardProjection(200, 40, model, snapshot());
+    const firstCard = projection.main.layout.board.columns[1]!.cards[0]!;
+
+    expect(
+      missionDashboardHitTest(projection, firstCard.x + projection.main.x, firstCard.y),
+    ).toEqual(missionWorkspaceHitTest(projection.main.layout, firstCard.x, firstCard.y));
+    expect(
+      missionDashboardHitTest(projection, projection.inspector!.x + 2, projection.inspector!.y + 2),
+    ).toBeNull();
+  });
+
+  it("reconciles selected board columns against the dashboard main width at medium sizes", () => {
+    const snap = snapshot();
+    const fullCanvasModel = reconcileMissionWorkspaceModel(
+      {
+        ...defaultMissionWorkspaceModel("mis_done"),
+        selectedColumn: "done",
+      },
+      snap,
+      { width: 120, height: 24 },
+    );
+    const dashboardSize = missionDashboardMainSize(120, 24);
+    const dashboardModel = reconcileMissionWorkspaceModel(
+      {
+        ...defaultMissionWorkspaceModel("mis_done"),
+        selectedColumn: "done",
+      },
+      snap,
+      { width: dashboardSize.mainWidth, height: dashboardSize.height },
+    );
+
+    expect(dashboardSize.mainWidth).toBe(95);
+    expect(
+      missionDashboardProjection(120, 24, dashboardModel, snap).main.layout.board.visibleColumns,
+    ).toContain("done");
+    expect(fullCanvasModel.horizontalOffset).toBe(0);
+    expect(dashboardModel.horizontalOffset).toBeGreaterThan(0);
+  });
+});

--- a/packages/daemon/src/tui/mirror/missions-dashboard.ts
+++ b/packages/daemon/src/tui/mirror/missions-dashboard.ts
@@ -1,0 +1,451 @@
+import type {
+  MissionAttemptSummary,
+  MissionCardView,
+  MissionDetailView,
+  MissionHistorySummary,
+  TaskCardView,
+} from "@tmux-ide/contracts";
+
+import type { AgentRowInput } from "./agent-rows.ts";
+import { agentDisplayKind } from "./agent-rows.ts";
+import {
+  MISSION_BOARD_COLUMNS,
+  MISSION_COLUMN_GAP,
+  MISSION_MIN_COLUMN_WIDTH,
+  clipTerminal,
+  missionWorkspaceHitTest,
+  missionWorkspaceLayout,
+  type MissionWorkspaceHit,
+  type MissionWorkspaceLayout,
+  type MissionWorkspaceModel,
+  type MissionWorkspacePresentationOptions,
+  type MissionWorkspaceSnapshot,
+} from "./missions-workspace.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+
+export const MISSION_DASHBOARD_INSPECTOR_GAP = 1;
+export const MISSION_DASHBOARD_COMPACT_INSPECTOR_WIDTH = 24;
+export const MISSION_DASHBOARD_WIDE_INSPECTOR_MIN_WIDTH = 34;
+export const MISSION_DASHBOARD_WIDE_INSPECTOR_MAX_WIDTH = 46;
+export const MISSION_DASHBOARD_MEDIUM_MIN_WIDTH =
+  MISSION_MIN_COLUMN_WIDTH * 3 +
+  MISSION_COLUMN_GAP * 2 +
+  MISSION_DASHBOARD_INSPECTOR_GAP +
+  MISSION_DASHBOARD_COMPACT_INSPECTOR_WIDTH;
+export const MISSION_DASHBOARD_WIDE_MIN_WIDTH =
+  MISSION_MIN_COLUMN_WIDTH * MISSION_BOARD_COLUMNS.length +
+  MISSION_COLUMN_GAP * (MISSION_BOARD_COLUMNS.length - 1) +
+  MISSION_DASHBOARD_INSPECTOR_GAP +
+  MISSION_DASHBOARD_WIDE_INSPECTOR_MIN_WIDTH;
+
+export type MissionDashboardVariant = "narrow" | "medium" | "wide";
+
+export interface MissionDashboardProjection {
+  width: number;
+  height: number;
+  variant: MissionDashboardVariant;
+  main: MissionDashboardRegion;
+  inspector: MissionDashboardInspector | null;
+}
+
+export interface MissionDashboardRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  layout: MissionWorkspaceLayout;
+}
+
+export interface MissionDashboardInspector {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  variant: Exclude<MissionDashboardVariant, "narrow">;
+  borderRows: number;
+  titleRows: number;
+  bodyRows: number;
+  title: string;
+  rows: MissionDashboardInspectorRow[];
+  agents: MissionDashboardAgentContext[];
+}
+
+export interface MissionDashboardInspectorRow {
+  key: string;
+  label: string;
+  value: string;
+  emphasis?: boolean;
+}
+
+export interface MissionDashboardAgentContext {
+  key: string;
+  rank: "pane" | "session" | "kind";
+  display: string;
+  state: string;
+  context: string;
+}
+
+export interface MissionDashboardProjectionOptions extends MissionWorkspacePresentationOptions {
+  agents?: readonly AgentRowInput[];
+}
+
+export function missionDashboardProjection(
+  width: number,
+  height: number,
+  model: MissionWorkspaceModel,
+  snapshot: MissionWorkspaceSnapshot | null,
+  options: MissionDashboardProjectionOptions = {},
+): MissionDashboardProjection {
+  const {
+    width: safeWidth,
+    height: safeHeight,
+    mainWidth,
+    inspectorWidth,
+    variant,
+  } = missionDashboardMainSize(width, height);
+  const mainLayout = missionWorkspaceLayout(mainWidth, safeHeight, model, snapshot, options);
+  const main: MissionDashboardRegion = {
+    x: 0,
+    y: 0,
+    width: mainWidth,
+    height: safeHeight,
+    layout: mainLayout,
+  };
+  const inspector =
+    inspectorWidth > 0
+      ? missionDashboardInspector(
+          mainWidth + MISSION_DASHBOARD_INSPECTOR_GAP,
+          0,
+          inspectorWidth,
+          safeHeight,
+          variant === "wide" ? "wide" : "medium",
+          model,
+          snapshot,
+          options.agents ?? [],
+        )
+      : null;
+  return { width: safeWidth, height: safeHeight, variant, main, inspector };
+}
+
+export function missionDashboardMainSize(
+  width: number,
+  height: number,
+): {
+  width: number;
+  height: number;
+  mainWidth: number;
+  inspectorWidth: number;
+  variant: MissionDashboardVariant;
+} {
+  const safeWidth = Math.max(1, width);
+  const safeHeight = Math.max(1, height);
+  const variant = missionDashboardVariant(safeWidth);
+  const inspectorWidth = missionDashboardInspectorWidth(safeWidth, variant);
+  const mainWidth =
+    inspectorWidth > 0
+      ? Math.max(1, safeWidth - MISSION_DASHBOARD_INSPECTOR_GAP - inspectorWidth)
+      : safeWidth;
+  return { width: safeWidth, height: safeHeight, mainWidth, inspectorWidth, variant };
+}
+
+export function missionDashboardHitTest(
+  projection: MissionDashboardProjection,
+  x: number,
+  y: number,
+): MissionWorkspaceHit {
+  if (
+    x < projection.main.x ||
+    x >= projection.main.x + projection.main.width ||
+    y < projection.main.y ||
+    y >= projection.main.y + projection.main.height
+  ) {
+    return null;
+  }
+  return missionWorkspaceHitTest(
+    projection.main.layout,
+    x - projection.main.x,
+    y - projection.main.y,
+  );
+}
+
+export function missionDashboardVariant(width: number): MissionDashboardVariant {
+  if (width >= MISSION_DASHBOARD_WIDE_MIN_WIDTH) return "wide";
+  if (width >= MISSION_DASHBOARD_MEDIUM_MIN_WIDTH) return "medium";
+  return "narrow";
+}
+
+export function missionDashboardInspectorWidth(
+  width: number,
+  variant: MissionDashboardVariant,
+): number {
+  if (variant === "narrow") return 0;
+  if (variant === "medium") return Math.min(MISSION_DASHBOARD_COMPACT_INSPECTOR_WIDTH, width - 1);
+  return Math.max(
+    MISSION_DASHBOARD_WIDE_INSPECTOR_MIN_WIDTH,
+    Math.min(MISSION_DASHBOARD_WIDE_INSPECTOR_MAX_WIDTH, Math.floor(width * 0.24)),
+  );
+}
+
+function missionDashboardInspector(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  variant: Exclude<MissionDashboardVariant, "narrow">,
+  model: MissionWorkspaceModel,
+  snapshot: MissionWorkspaceSnapshot | null,
+  agents: readonly AgentRowInput[],
+): MissionDashboardInspector {
+  const selected = selectedMissionContext(model, snapshot);
+  const task = selected.detail ? selectedTaskContext(model, selected.detail) : null;
+  const attempts = selectedAttempts(selected.mission, selected.detail, task);
+  const matchedAgents = relevantMissionAgents(attempts, agents, width - 2);
+  const bodyWidth = Math.max(1, width - 2);
+  const geometry = missionDashboardInspectorGeometry(width, height);
+  const rows = inspectorRows(selected, task, matchedAgents, bodyWidth, variant).slice(
+    0,
+    geometry.bodyRows,
+  );
+  const title = selected.mission
+    ? selected.mission.title
+    : snapshot
+      ? "No mission selected"
+      : "Missions";
+  return {
+    x,
+    y,
+    width: Math.max(1, width),
+    height: Math.max(1, height),
+    variant,
+    ...geometry,
+    title: clipTerminal(title, bodyWidth),
+    rows,
+    agents: matchedAgents,
+  };
+}
+
+export function missionDashboardInspectorGeometry(
+  width: number,
+  height: number,
+): { borderRows: number; titleRows: number; bodyRows: number } {
+  const safeWidth = Math.max(1, width);
+  const safeHeight = Math.max(1, height);
+  const borderRows = safeWidth >= 2 && safeHeight >= 2 ? 2 : 0;
+  const titleRows = safeHeight > borderRows ? 1 : 0;
+  return {
+    borderRows,
+    titleRows,
+    bodyRows: Math.max(0, safeHeight - borderRows - titleRows),
+  };
+}
+
+function inspectorRows(
+  selected: SelectedMissionContext,
+  task: TaskCardView | null,
+  agents: readonly MissionDashboardAgentContext[],
+  width: number,
+  variant: Exclude<MissionDashboardVariant, "narrow">,
+): MissionDashboardInspectorRow[] {
+  const rows: MissionDashboardInspectorRow[] = [];
+  if (!selected.mission) {
+    rows.push(row("state", "state", "select a mission", width, true));
+    rows.push(row("hint", "hint", "board/history selection drives this panel", width));
+    return rows;
+  }
+  const mission = selected.mission;
+  rows.push(row("mission", variant === "wide" ? "mission" : "mis", mission.id, width, true));
+  rows.push(row("status", "status", `${mission.status} · ${progressText(mission)}`, width));
+  if (task) {
+    rows.push(row("task", "task", `${task.id} · ${task.status} · p${task.priority}`, width, true));
+  } else if (selected.detail && selected.detail.taskBoard.counts.total === 0) {
+    rows.push(row("task", "task", "no tasks", width));
+  } else if (selected.detail) {
+    rows.push(row("task", "task", "no task selected", width));
+  }
+  const latest = task?.latestAttempt ?? mission.latestAttempt;
+  if (latest) {
+    rows.push(
+      row(
+        "attempt",
+        "attempt",
+        `${latest.status}${latest.agent ? ` · ${latest.agent}` : ""}${latest.model ? ` · ${latest.model}` : ""}`,
+        width,
+      ),
+    );
+    if (latest.session || latest.terminal)
+      rows.push(
+        row("terminal", "term", [latest.session, latest.terminal].filter(Boolean).join(" "), width),
+      );
+  }
+  if (agents.length > 0) {
+    rows.push(row("agents", "agents", `${agents.length} relevant`, width, true));
+    for (const agent of agents.slice(0, variant === "wide" ? 4 : 2)) {
+      rows.push(
+        row(`agent-${agent.key}`, agent.state, `${agent.display} · ${agent.context}`, width),
+      );
+    }
+  } else {
+    rows.push(row("agents", "agents", "no matching live agent", width));
+  }
+  if (variant === "wide") {
+    if (mission.summary) rows.push(row("summary", "summary", mission.summary, width));
+    if (mission.blockedBy.length > 0)
+      rows.push(row("blocked", "blocked", mission.blockedBy.join(", "), width));
+    if (mission.proofSummary.hasProof)
+      rows.push(row("proof", "proof", `${mission.proofSummary.proofIds.length} item(s)`, width));
+    if (selected.detail && selected.detail.timeline.length > 0) {
+      const last = selected.detail.timeline[selected.detail.timeline.length - 1]!;
+      rows.push(row("event", "event", `#${last.sequence} ${last.label}`, width));
+    }
+  }
+  return rows;
+}
+
+function row(
+  key: string,
+  label: string,
+  value: string,
+  width: number,
+  emphasis = false,
+): MissionDashboardInspectorRow {
+  const prefix = `${label}: `;
+  const valueWidth = Math.max(0, width - terminalDisplayWidth(prefix));
+  return {
+    key,
+    label,
+    value: clipTerminal(value, valueWidth),
+    emphasis,
+  };
+}
+
+interface SelectedMissionContext {
+  mission: MissionCardView | null;
+  detail: MissionDetailView | null;
+  history: MissionHistorySummary | null;
+}
+
+function selectedMissionContext(
+  model: MissionWorkspaceModel,
+  snapshot: MissionWorkspaceSnapshot | null,
+): SelectedMissionContext {
+  if (!snapshot) return { mission: null, detail: null, history: null };
+  const selectedId = model.selectedMissionId;
+  const detail =
+    snapshot.detail && (!selectedId || snapshot.detail.mission.id === selectedId)
+      ? snapshot.detail
+      : null;
+  const boardMission = selectedId ? findMissionCard(snapshot, selectedId) : null;
+  const history = selectedId
+    ? (snapshot.history.find((entry) => entry.mission.id === selectedId) ?? null)
+    : null;
+  return {
+    mission: detail?.mission ?? boardMission ?? history?.mission ?? null,
+    detail,
+    history,
+  };
+}
+
+function selectedTaskContext(
+  model: Pick<MissionWorkspaceModel, "selectedTaskId">,
+  detail: MissionDetailView,
+): TaskCardView | null {
+  if (!model.selectedTaskId) return null;
+  return (
+    MISSION_BOARD_COLUMNS.flatMap((column) => detail.taskBoard.columns[column]).find(
+      (task) => task.id === model.selectedTaskId,
+    ) ?? null
+  );
+}
+
+function selectedAttempts(
+  mission: MissionCardView | null,
+  detail: MissionDetailView | null,
+  task: TaskCardView | null,
+): MissionAttemptSummary[] {
+  const attempts = new Map<string, MissionAttemptSummary>();
+  if (task?.latestAttempt) attempts.set(task.latestAttempt.id, task.latestAttempt);
+  if (detail) {
+    for (const attempt of detail.attempts) {
+      if (!task || attempt.taskId === task.id) attempts.set(attempt.id, attempt);
+    }
+  }
+  if (attempts.size === 0 && mission?.latestAttempt) {
+    attempts.set(mission.latestAttempt.id, mission.latestAttempt);
+  }
+  return [...attempts.values()];
+}
+
+function relevantMissionAgents(
+  attempts: readonly MissionAttemptSummary[],
+  agents: readonly AgentRowInput[],
+  width: number,
+): MissionDashboardAgentContext[] {
+  const ranked = new Map<string, MissionDashboardAgentContext>();
+  for (const attempt of attempts) {
+    if (attempt.terminal) {
+      for (const agent of agents.filter((item) => item.paneId === attempt.terminal)) {
+        ranked.set(agentKey(agent), agentContext(agent, "pane", width));
+      }
+    }
+  }
+  for (const attempt of attempts) {
+    if (attempt.session) {
+      for (const agent of agents.filter((item) => item.session === attempt.session)) {
+        const key = agentKey(agent);
+        if (!ranked.has(key)) ranked.set(key, agentContext(agent, "session", width));
+      }
+    }
+  }
+  if (ranked.size > 0) return [...ranked.values()];
+  for (const attempt of attempts) {
+    const fallbackKind = attempt.agent;
+    if (!fallbackKind) continue;
+    for (const agent of agents.filter((item) => {
+      const display = agentDisplayKind(item);
+      return item.kind === fallbackKind || display === fallbackKind;
+    })) {
+      const key = agentKey(agent);
+      if (!ranked.has(key)) ranked.set(key, agentContext(agent, "kind", width));
+    }
+  }
+  return [...ranked.values()];
+}
+
+function agentContext(
+  agent: AgentRowInput,
+  rank: MissionDashboardAgentContext["rank"],
+  width: number,
+): MissionDashboardAgentContext {
+  const display = agentDisplayKind(agent);
+  const context =
+    rank === "pane"
+      ? `${agent.session} ${agent.paneId}`
+      : rank === "session"
+        ? `${agent.session} ${agent.paneId}`
+        : `${agent.kind} ${agent.session}`;
+  return {
+    key: agentKey(agent),
+    rank,
+    display: clipTerminal(display, width),
+    state: agent.state,
+    context: clipTerminal(context, width),
+  };
+}
+
+function agentKey(agent: AgentRowInput): string {
+  return `${agent.session}:${agent.paneId}`;
+}
+
+function findMissionCard(snapshot: MissionWorkspaceSnapshot, id: string): MissionCardView | null {
+  for (const column of MISSION_BOARD_COLUMNS) {
+    const found = snapshot.board.columns[column].find((mission) => mission.id === id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function progressText(mission: Pick<MissionCardView, "progress">): string {
+  return mission.progress.total > 0
+    ? `${mission.progress.done}/${mission.progress.total}`
+    : "no tasks";
+}

--- a/packages/daemon/src/tui/mirror/missions-surface.tsx
+++ b/packages/daemon/src/tui/mirror/missions-surface.tsx
@@ -1,5 +1,6 @@
 import type { RGBA } from "@opentui/core";
 import { For, Show } from "solid-js";
+import type { MissionDashboardProjection } from "./missions-dashboard.ts";
 import {
   ACCENT,
   BADGE_BG,
@@ -35,6 +36,18 @@ export interface MissionSurfaceTheme {
 
 export interface MissionSurfaceProps {
   width: number;
+  dashboard: MissionDashboardProjection;
+  model: MissionWorkspaceModel;
+  snapshot: MissionWorkspaceSnapshot | null;
+  loadState: MissionWorkspaceLoadState;
+  errorMessage: string;
+  resolveDeepLink: (kind: MissionDeepLinkKind) => MissionDeepLinkResolution;
+  isHovered: (region: MissionSurfaceHoverRegion, index: number) => boolean;
+  theme: MissionSurfaceTheme;
+}
+
+interface MissionMainSurfaceProps {
+  width: number;
   layout: MissionWorkspaceLayout;
   model: MissionWorkspaceModel;
   snapshot: MissionWorkspaceSnapshot | null;
@@ -56,6 +69,59 @@ export function missionSurfaceLayout(
 }
 
 export function MissionsSurface(props: MissionSurfaceProps) {
+  return (
+    <box width={props.width} height={props.dashboard.height} flexDirection="row" gap={1}>
+      <box
+        width={props.dashboard.main.width}
+        height={props.dashboard.main.height}
+        flexDirection="column"
+        overflow="hidden"
+      >
+        <MissionMainSurface
+          width={props.dashboard.main.width}
+          layout={props.dashboard.main.layout}
+          model={props.model}
+          snapshot={props.snapshot}
+          loadState={props.loadState}
+          errorMessage={props.errorMessage}
+          resolveDeepLink={props.resolveDeepLink}
+          isHovered={props.isHovered}
+          theme={props.theme}
+        />
+      </box>
+      <Show when={props.dashboard.inspector}>
+        {(inspector) => (
+          <box
+            width={inspector().width}
+            height={inspector().height}
+            flexDirection="column"
+            border={inspector().width >= 2 && inspector().height >= 2}
+            borderColor={MUTED}
+            overflow="hidden"
+            backgroundColor={DEFAULT_BG}
+          >
+            <Show when={inspector().titleRows > 0}>
+              <text fg={ACCENT}>
+                {clipTerminal(inspector().title, Math.max(0, inspector().width - 2))}
+              </text>
+            </Show>
+            <For each={inspector().rows.slice(0, inspector().bodyRows)}>
+              {(row) => (
+                <box height={1} flexDirection="row" overflow="hidden">
+                  <text fg={row.emphasis ? ACCENT : MUTED}>{row.label}</text>
+                  <text fg={MUTED}>{": "}</text>
+                  <text fg={row.emphasis ? DEFAULT_FG : MUTED}>{row.value}</text>
+                </box>
+              )}
+            </For>
+          </box>
+        )}
+      </Show>
+    </box>
+  );
+}
+
+function MissionMainSurface(props: MissionMainSurfaceProps) {
   const ready = () =>
     props.snapshot &&
     props.loadState.status !== "loading" &&


### PR DESCRIPTION
## Summary

- add a pure responsive Missions dashboard projection with narrow, medium, and wide layouts
- show selected mission/task facts and authoritative live-agent context in a bounded inspector
- share main-region geometry across rendering, hit testing, keyboard navigation, scrolling, and resize reconciliation
- preserve the compact composite Missions leaf and existing per-view state

## Validation

- focused Missions Vitest suite (66 passed)
- `pnpm --filter @tmux-ide/contracts typecheck`
- `pnpm --filter @tmux-ide/daemon typecheck`
- `pnpm build:tui`
- `pnpm check`
- `git diff --check`