### PR TITLE
refactor(tui): make input lifecycle explicit

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -385,6 +385,14 @@ import {
   handleMissionSurfaceScroll,
 } from "./missions-surface-controller.ts";
 import {
+  TuiCleanupRegistry,
+  createTuiLifecycleExecutor,
+  executeCtrlCCommand,
+  resolveCtrlCCommand,
+  resolveInputLayer,
+  resolveQuitLifecycleCommand,
+} from "./input-lifecycle.ts";
+import {
   WorkspaceUiStateController,
   absoluteProjectPath,
   chooseInitialWorkspaceView,
@@ -914,6 +922,8 @@ hostAutowrap = installHostAutowrapGuard((sequence) => writeSync(process.stdout.f
 
 try {
   await render(() => {
+    const cleanupRegistry = new TuiCleanupRegistry();
+    onCleanup(() => cleanupRegistry.runAll());
     // Register <pane_surface> before any is created (M21.3). An explicit call —
     // a bare side-effect import of the module gets DCE'd by the transpiler.
     if (FB_PANES) registerPaneSurface();
@@ -1437,7 +1447,7 @@ try {
     missionsRefreshTimer = setInterval(() => {
       if (mode() === "missions") loadMissionsWorkspace("cadence");
     }, 10_000);
-    onCleanup(() => {
+    cleanupRegistry.set("missions-refresh-timer", () => {
       if (missionsRefreshTimer) clearInterval(missionsRefreshTimer);
     });
 
@@ -2897,7 +2907,7 @@ try {
           // `r` / toggles / mutations refresh on demand.
         });
     };
-    onCleanup(() => void stopFilesWatch?.().catch(() => {}));
+    cleanupRegistry.set("files-watch", () => void stopFilesWatch?.().catch(() => {}));
     /** A tab switch back onto a stale Files surface catches up in one shot. */
     const catchUpFilesIfStale = () => {
       if (!filesStale) return;
@@ -2910,7 +2920,7 @@ try {
     const filesStatusPoll = setInterval(() => {
       if (mode() === "editor" && fileNodes().length > 0) refreshFileStatus();
     }, 3000);
-    onCleanup(() => clearInterval(filesStatusPoll));
+    cleanupRegistry.set("files-status-poll", () => clearInterval(filesStatusPoll));
 
     /** The project dir the fleet payload records for `session` (null if unknown). */
     const dirForSession = (name: string): string | null => {
@@ -3651,6 +3661,18 @@ try {
       loadRepoFiles(); // refresh the "Go to file:" source (async, M24.6)
       setPaletteOpen(true);
     };
+    const lifecycleExecutor = createTuiLifecycleExecutor({
+      // Renderer destruction disposes the Solid root first, so the shared
+      // onCleanup path owns mirrors/buffers and the host-mode guard restores
+      // DECAWM after OpenTUI's native terminal teardown.
+      destroyRenderer: () => appRenderer.destroy(),
+      // HOSTED (M23.2): put the cockpit away and keep running. A client that
+      // came here via switch-client bounces BACK to its last session; a plain
+      // terminal attach has no last session, so switch-client -l fails and the
+      // fallback detaches.
+      switchClientBack: (callback) => execFile("tmux", ["switch-client", "-l"], callback),
+      detachClient: () => execFile("tmux", ["detach-client"], () => {}),
+    });
     const runPaletteAction = (a: PaletteAction) => {
       // Usage history (M24.4): every dispatched action bumps its stable key —
       // count + lastUsed feed the "recent" group and the ranking tie-break.
@@ -3807,10 +3829,7 @@ try {
           void runSettingsCommand(a.id);
           break;
         case "quit":
-          // Renderer destruction disposes the Solid root first, so the shared
-          // onCleanup path owns mirrors/buffers and the host-mode guard restores
-          // DECAWM after OpenTUI's native terminal teardown.
-          appRenderer.destroy();
+          lifecycleExecutor.run(resolveQuitLifecycleCommand({ hosted: HOSTED }, "palette"));
           break;
       }
     };
@@ -4349,13 +4368,15 @@ try {
       const diffTimer = setInterval(() => {
         if (mode() === "diff") refreshStatus();
       }, 3000);
-      onCleanup(() => {
+      cleanupRegistry.set("state-and-fleet-timers", () => {
         clearInterval(t);
         clearInterval(fleetTimer);
         clearInterval(diffTimer);
         if (saveTimer) clearTimeout(saveTimer);
         if (workspaceUiSaveTimer) clearTimeout(workspaceUiSaveTimer);
         if (noteTimer) clearTimeout(noteTimer);
+      });
+      cleanupRegistry.set("terminal-and-editor", () => {
         mirror?.dispose();
         editBuffer?.destroy();
       });
@@ -5280,112 +5301,106 @@ try {
     };
 
     useKeyboard((evt) => {
-      if (evt.ctrl && evt.name === "q") {
-        // HOSTED (M23.2): put the cockpit away and keep running — the palette's
-        // "Quit" verb is the real exit. A client that came here via
-        // switch-client (launched inside tmux) bounces BACK to its last
-        // session; a client that attached from a plain terminal has no last
-        // session, so `switch-client -l` fails and it detaches instead. No -t:
-        // tmux resolves "current client" from the pane's $TMUX to the most
-        // recently active client on our session — the presser.
-        if (HOSTED) {
-          execFile("tmux", ["switch-client", "-l"], (err) => {
-            if (err) execFile("tmux", ["detach-client"], () => {});
-          });
-          return;
-        }
-        appRenderer.destroy();
+      const layer = resolveInputLayer(
+        {
+          dialogOpen: dialogStack.depth() > 0,
+          menuOpen: Boolean(menu()),
+          paletteOpen: paletteOpen(),
+          searchOpen: Boolean(search()),
+          mode: mode() === "mirror" ? "mirror" : mode(),
+          activePanelInert: isHostedPanelInert(activePanel()),
+          missionMode: missionWorkspaceModel().mode,
+          editorFocus: filesFocus(),
+          editorFilterOpen: filesQuery() !== null,
+          diffFilterOpen: diffFilter() !== null,
+          homePromptOpen: pathPrompt() !== null || sessionPrompt() !== null,
+          configuredShortcutKeys: hostedViews().flatMap((view) =>
+            view.shortcut ? [view.shortcut.key] : [],
+          ),
+          compositeCycleAvailable: Boolean(
+            activeView().layout && (activeCompositeLayout()?.leaves.length ?? 0) > 1,
+          ),
+        },
+        evt,
+        { hosted: HOSTED },
+      );
+      if (layer.kind === "lifecycle") {
+        lifecycleExecutor.run(layer.command);
         return;
       }
-      // SUPER-modified keys arrive only under the kitty keyboard protocol
-      // (M24.4). ⌘K opens the palette — suppressed while any overlay owns the
-      // keyboard (dialog/menu/palette/search), mirroring F5. Every OTHER super
-      // combo is consumed here: it must never type into a prompt/editor/query
-      // and never reach a pane (forwarding modifier-rich keys into panes is a
-      // separate card — #83).
-      if (evt.super) {
-        if (
-          evt.name === "k" &&
-          !evt.ctrl &&
-          dialogStack.depth() === 0 &&
-          !menu() &&
-          !paletteOpen() &&
-          !search()
-        ) {
-          openPalette();
-        }
-        return;
-      }
-      // A DIALOG owns the keyboard while open (M22.4) — topmost overlay, so it
-      // is checked before the menu and the palette. EVERY key is consumed here
-      // (escape pops one stack level inside dialogKey): nothing may leak to the
-      // pane/editor beneath while a settings flow is on screen.
-      if (dialogStack.depth() > 0) {
-        dialogKey(dialogStack, evt);
-        return;
-      }
-      // The context menu owns the keyboard while open (before the palette).
-      if (menu()) {
-        menuKey(evt);
-        return;
-      }
-      // The palette owns the keyboard while open (keyboard-only overlay); esc/enter
-      // inside close it.
-      if (paletteOpen()) {
-        paletteKey(evt);
-        return;
-      }
-      // The scrollback-search session owns the keyboard while open (the bottom input
-      // line + n/N navigation), so no key leaks to the pane; ^q above still works.
-      if (search()) {
-        searchKey(evt);
-        return;
-      }
-      if (evt.ctrl && evt.name === "tab" && cycleCompositeLeafFocus()) return;
-      // F5 (and ^p when it arrives) open the command palette; ⌘K is the kitty
-      // fast path handled above.
-      if (evt.name === "f5" || (evt.ctrl && evt.name === "p")) {
+      if (layer.kind === "kitty-super-palette") {
         openPalette();
         return;
       }
-      // F1..F4 then F6..F13 switch configured hosted views by position. F5 is
-      // reserved for the palette; later views remain reachable by mouse/palette.
-      const fView = hostedViews().find((view) => view.shortcut?.key === evt.name);
-      if (fView) {
-        selectView(fView.id);
+      if (layer.kind === "kitty-super-suppressed") return;
+      if (layer.kind === "dialog") {
+        dialogKey(dialogStack, evt);
         return;
       }
-      // ^g, not ^h: legacy encoding makes ctrl+h indistinguishable from
-      // backspace (0x08), which must keep flowing to the pane. Works from every
-      // hosted view, including inert Missions.
-      if (evt.ctrl && (evt.name === "g" || evt.name === "h")) {
-        if (mode() !== "home") goHome();
+      if (layer.kind === "menu") {
+        menuKey(evt);
         return;
       }
-      if (mode() === "missions") {
+      if (layer.kind === "palette") {
+        paletteKey(evt);
+        return;
+      }
+      if (layer.kind === "search") {
+        searchKey(evt);
+        return;
+      }
+      if (layer.kind === "global") {
+        switch (layer.command.kind) {
+          case "cycle-composite-focus":
+            cycleCompositeLeafFocus();
+            break;
+          case "open-palette":
+            openPalette();
+            break;
+          case "select-hosted-view": {
+            const shortcutKey = layer.command.key;
+            const fView = hostedViews().find((view) => view.shortcut?.key === shortcutKey);
+            if (fView) selectView(fView.id);
+            break;
+          }
+          case "go-home":
+            if (mode() !== "home") goHome();
+            break;
+          case "toggle-editor":
+            if (mode() === "diff") openSelectedInEditor();
+            else toggleEditor();
+            break;
+        }
+        return;
+      }
+      if (layer.kind === "missions-detail" || layer.kind === "missions-board-history") {
         handleMissionsKey(evt);
         return;
       }
-      if (isHostedPanelInert(activePanel())) return;
-      // ^e — from the diff panel, open the SELECTED file in the editor at the
-      // first changed line of the top-visible hunk (M24.5); elsewhere toggle the
-      // editor against the previous mode (no-op until a file is opened via
-      // `o`/`--edit`).
-      if (evt.ctrl && evt.name === "e") {
-        if (mode() === "diff") openSelectedInEditor();
-        else toggleEditor();
-        return;
-      }
-      if (mode() === "editor") {
+      if (layer.kind === "inert") return;
+      if (
+        layer.kind === "editor-filter" ||
+        layer.kind === "editor-list" ||
+        layer.kind === "editor-input"
+      ) {
         // ^c with an active selection copies the buffer range (exact text — no
         // trailing trim); without a selection it falls through (no pane to reach
         // from the editor). Save / undo / redo work regardless of focused half.
         if (evt.ctrl && evt.name === "c") {
           const s = selection();
-          if (s && s.surface === "editor") {
-            const { start, end } = orderCells(s.anchor, s.head);
-            copyText(extractSelection(editorLines(), start, end, false));
-          }
+          const command = resolveCtrlCCommand({
+            layer: "editor",
+            hasEditorSelection: Boolean(s && s.surface === "editor"),
+          });
+          executeCtrlCCommand(command, {
+            copyEditorSelection: () => {
+              if (!s || s.surface !== "editor") return;
+              const { start, end } = orderCells(s.anchor, s.head);
+              copyText(extractSelection(editorLines(), start, end, false));
+            },
+            copyTerminalSelection: () => {},
+            forwardTerminalCtrlC: () => {},
+          });
           return;
         }
         if (evt.ctrl && evt.name === "s") {
@@ -5409,9 +5424,9 @@ try {
         // changed files, H / I toggle hidden / gitignored visibility (M24.6).
         // Otherwise the EDITOR has focus and types; esc hands focus back to the
         // list.
-        if (filesFocus() === "list") {
+        if (layer.kind === "editor-filter" || layer.kind === "editor-list") {
           const q = filesQuery();
-          if (q !== null) {
+          if (layer.kind === "editor-filter" && q !== null) {
             // Filter input active: printable chars narrow live; arrows move in
             // the FILTERED rows; enter activates the row (exiting the filter);
             // escape restores the full list and the pre-filter selection.
@@ -5469,11 +5484,11 @@ try {
         editorKey(evt);
         return;
       }
-      if (mode() === "diff") {
+      if (layer.kind === "diff-filter" || layer.kind === "diff") {
         // The `/` filter owns the keyboard while active (M24.5): printable keys
         // narrow the grouped list live, escape/return clear + exit (widget
         // semantics), arrows still move the (filtered) selection.
-        if (diffFilter() !== null) {
+        if (layer.kind === "diff-filter") {
           if (evt.name === "escape" || evt.name === "return") {
             setDiffFilter(null);
             diffFilterReselect();
@@ -5507,9 +5522,9 @@ try {
         else if (evt.name === "r") refreshStatus();
         return;
       }
-      if (mode() === "home") {
+      if (layer.kind === "home-prompt" || layer.kind === "home") {
         // Path-input line (`o` to open); while prompting, every key feeds it.
-        if (pathPrompt() !== null) {
+        if (layer.kind === "home-prompt" && pathPrompt() !== null) {
           if (evt.name === "escape") setPathPrompt(null);
           else if (evt.name === "return") {
             const p = pathPrompt()!.trim();
@@ -5521,7 +5536,7 @@ try {
           return;
         }
         // Session-name input line (`n` / the [n new session] chip) — same shape.
-        if (sessionPrompt() !== null) {
+        if (layer.kind === "home-prompt" && sessionPrompt() !== null) {
           if (evt.name === "escape") setSessionPrompt(null);
           else if (evt.name === "return") submitSessionPrompt();
           else if (evt.name === "backspace") setSessionPrompt((s) => (s ?? "").slice(0, -1));
@@ -5613,10 +5628,27 @@ try {
       // to the pane (interrupt) exactly as before.
       if (evt.ctrl && evt.name === "c") {
         const s = selection();
-        if (s && s.surface === "mirror") {
-          commitMirrorCopy(s.paneId, s.anchor, s.head);
-          return;
-        }
+        const command = resolveCtrlCCommand({
+          layer: "terminal",
+          mirrorAvailable: Boolean(mirror),
+          hasTerminalSelection: Boolean(s && s.surface === "mirror"),
+        });
+        executeCtrlCCommand(command, {
+          copyEditorSelection: () => {},
+          copyTerminalSelection: () => {
+            if (!s || s.surface !== "mirror") return;
+            commitMirrorCopy(s.paneId, s.anchor, s.head);
+          },
+          forwardTerminalCtrlC: () => {
+            const pane = mirror?.focusedPane();
+            if (!pane || !mirror) return;
+            clearSelection();
+            snapLive(pane);
+            tapInputSent(pane); // t0: keystroke dispatched to the pane
+            mirror.sendKey("C-c");
+          },
+        });
+        return;
       }
       // Any key that reaches the pane retires a stale selection highlight.
       clearSelection();

--- a/packages/daemon/src/tui/mirror/input-lifecycle.test.ts
+++ b/packages/daemon/src/tui/mirror/input-lifecycle.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vitest";
+import {
+  OPENTUI_KEYMAP_DECISION,
+  TuiCleanupRegistry,
+  createTuiLifecycleExecutor,
+  executeCtrlCCommand,
+  resolveCtrlCCommand,
+  resolveInputLayer,
+  resolveQuitLifecycleCommand,
+  type TuiInputContext,
+  type TuiKeyEvent,
+} from "./input-lifecycle.ts";
+
+const key = (overrides: Partial<TuiKeyEvent> = {}): TuiKeyEvent => ({
+  name: "x",
+  ctrl: false,
+  meta: false,
+  shift: false,
+  ...overrides,
+});
+
+const context = (overrides: Partial<TuiInputContext> = {}): TuiInputContext => ({
+  dialogOpen: false,
+  menuOpen: false,
+  paletteOpen: false,
+  searchOpen: false,
+  mode: "mirror",
+  activePanelInert: false,
+  missionMode: "board",
+  editorFocus: "list",
+  editorFilterOpen: false,
+  diffFilterOpen: false,
+  homePromptOpen: false,
+  configuredShortcutKeys: ["f1", "f2"],
+  compositeCycleAvailable: true,
+  ...overrides,
+});
+
+describe("input lifecycle boundary", () => {
+  it("records why @opentui/keymap is not adopted for this root listener", () => {
+    expect(OPENTUI_KEYMAP_DECISION).toMatchObject({
+      package: "@opentui/keymap",
+      evaluatedVersion: "0.4.3",
+      adopted: false,
+    });
+    expect(OPENTUI_KEYMAP_DECISION.reason).toContain("arbitrary editor/query/pane text");
+  });
+
+  it.each([
+    [
+      "ctrl-q beats dialog",
+      context({ dialogOpen: true }),
+      key({ name: "q", ctrl: true }),
+      "lifecycle",
+    ],
+    ["dialog beats menu", context({ dialogOpen: true, menuOpen: true }), key(), "dialog"],
+    ["menu beats palette", context({ menuOpen: true, paletteOpen: true }), key(), "menu"],
+    ["palette beats search", context({ paletteOpen: true, searchOpen: true }), key(), "palette"],
+    ["search beats surface", context({ searchOpen: true, mode: "editor" }), key(), "search"],
+    [
+      "ctrl-tab is global when composite can cycle",
+      context(),
+      key({ name: "tab", ctrl: true }),
+      "global",
+    ],
+    ["f5 is global palette", context(), key({ name: "f5" }), "global"],
+    ["ctrl-p is global palette", context(), key({ name: "p", ctrl: true }), "global"],
+    ["configured hosted shortcut is global", context(), key({ name: "f2" }), "global"],
+    [
+      "ctrl-g is global home",
+      context({ activePanelInert: true }),
+      key({ name: "g", ctrl: true }),
+      "global",
+    ],
+    [
+      "missions detail owns missions detail",
+      context({ mode: "missions", missionMode: "detail" }),
+      key(),
+      "missions-detail",
+    ],
+    [
+      "missions board/history owns missions list modes",
+      context({ mode: "missions", missionMode: "history" }),
+      key(),
+      "missions-board-history",
+    ],
+    [
+      "inert beats underlying editor",
+      context({ activePanelInert: true, mode: "editor" }),
+      key(),
+      "inert",
+    ],
+    [
+      "editor filter owns list query",
+      context({ mode: "editor", editorFocus: "list", editorFilterOpen: true }),
+      key(),
+      "editor-filter",
+    ],
+    [
+      "editor list owns file list",
+      context({ mode: "editor", editorFocus: "list" }),
+      key(),
+      "editor-list",
+    ],
+    [
+      "editor input owns editable buffer",
+      context({ mode: "editor", editorFocus: "editor" }),
+      key(),
+      "editor-input",
+    ],
+    [
+      "diff filter owns diff query",
+      context({ mode: "diff", diffFilterOpen: true }),
+      key(),
+      "diff-filter",
+    ],
+    ["diff owns diff mode", context({ mode: "diff" }), key(), "diff"],
+    [
+      "home prompt owns home input",
+      context({ mode: "home", homePromptOpen: true }),
+      key(),
+      "home-prompt",
+    ],
+    ["home owns home mode", context({ mode: "home" }), key(), "home"],
+    ["terminal is final fallback", context(), key(), "terminal"],
+  ])("%s", (_name, ctx, evt, expected) => {
+    expect(resolveInputLayer(ctx, evt, { hosted: false }).kind).toBe(expected);
+  });
+
+  it("does not consume unconfigured function keys or impossible ctrl-tab globally", () => {
+    expect(
+      resolveInputLayer(context({ configuredShortcutKeys: ["f1"] }), key({ name: "f2" }), {
+        hosted: false,
+      }).kind,
+    ).toBe("terminal");
+    expect(
+      resolveInputLayer(
+        context({ compositeCycleAvailable: false }),
+        key({ name: "tab", ctrl: true }),
+        {
+          hosted: false,
+        },
+      ).kind,
+    ).toBe("terminal");
+  });
+
+  it("resolves concrete global commands", () => {
+    expect(
+      resolveInputLayer(context(), key({ name: "tab", ctrl: true }), { hosted: false }),
+    ).toEqual({
+      kind: "global",
+      command: { kind: "cycle-composite-focus" },
+    });
+    expect(resolveInputLayer(context(), key({ name: "f5" }), { hosted: false })).toEqual({
+      kind: "global",
+      command: { kind: "open-palette" },
+    });
+    expect(resolveInputLayer(context(), key({ name: "f2" }), { hosted: false })).toEqual({
+      kind: "global",
+      command: { kind: "select-hosted-view", key: "f2" },
+    });
+    expect(resolveInputLayer(context(), key({ name: "g", ctrl: true }), { hosted: false })).toEqual(
+      {
+        kind: "global",
+        command: { kind: "go-home" },
+      },
+    );
+    expect(
+      resolveInputLayer(context({ mode: "diff" }), key({ name: "e", ctrl: true }), {
+        hosted: false,
+      }),
+    ).toEqual({
+      kind: "global",
+      command: { kind: "toggle-editor" },
+    });
+  });
+
+  it("suppresses super-modified keys except command-palette open when overlays are absent", () => {
+    expect(
+      resolveInputLayer(context(), key({ name: "k", super: true }), { hosted: false }),
+    ).toEqual({ kind: "kitty-super-palette" });
+    expect(
+      resolveInputLayer(context({ paletteOpen: true }), key({ name: "k", super: true }), {
+        hosted: false,
+      }),
+    ).toEqual({ kind: "kitty-super-suppressed" });
+    expect(
+      resolveInputLayer(context(), key({ name: "x", super: true }), { hosted: false }),
+    ).toEqual({ kind: "kitty-super-suppressed" });
+  });
+
+  it("makes ctrl-c terminal copy-vs-forward explicit and never a quit command", () => {
+    expect(
+      resolveCtrlCCommand({ layer: "terminal", mirrorAvailable: true, hasTerminalSelection: true }),
+    ).toEqual({ kind: "copy-terminal-selection" });
+    expect(
+      resolveCtrlCCommand({
+        layer: "terminal",
+        mirrorAvailable: true,
+        hasTerminalSelection: false,
+      }),
+    ).toEqual({ kind: "forward-terminal-ctrl-c" });
+    expect(resolveCtrlCCommand({ layer: "editor", hasEditorSelection: true })).toEqual({
+      kind: "copy-editor-selection",
+    });
+    expect(resolveCtrlCCommand({ layer: "editor", hasEditorSelection: false })).toEqual({
+      kind: "consume",
+    });
+    expect(resolveCtrlCCommand({ layer: "overlay" })).toEqual({ kind: "consume" });
+  });
+
+  it("executes ctrl-c copy/forward through the injected boundary", () => {
+    const calls: string[] = [];
+    const executor = {
+      copyEditorSelection: () => calls.push("copy-editor"),
+      copyTerminalSelection: () => calls.push("copy-terminal"),
+      forwardTerminalCtrlC: () => calls.push("send:C-c"),
+    };
+
+    executeCtrlCCommand({ kind: "copy-terminal-selection" }, executor);
+    executeCtrlCCommand({ kind: "forward-terminal-ctrl-c" }, executor);
+    executeCtrlCCommand({ kind: "consume" }, executor);
+
+    expect(calls).toEqual(["copy-terminal", "send:C-c"]);
+  });
+
+  it("resolves ctrl-q and palette quit lifecycle semantics without direct process exit", () => {
+    expect(resolveQuitLifecycleCommand({ hosted: false }, "keyboard")).toEqual({
+      kind: "destroy-renderer",
+      source: "keyboard",
+    });
+    expect(resolveQuitLifecycleCommand({ hosted: true }, "keyboard")).toEqual({
+      kind: "hosted-detach",
+      source: "keyboard",
+    });
+    expect(resolveQuitLifecycleCommand({ hosted: true }, "palette")).toEqual({
+      kind: "destroy-renderer",
+      source: "palette",
+    });
+  });
+
+  it("runs lifecycle cleanup once, continues after throws, and reports failures deterministically", () => {
+    const calls: string[] = [];
+    const registry = new TuiCleanupRegistry();
+    const failure = new Error("timer cleanup failed");
+    registry.set("watcher", () => calls.push("watcher"));
+    registry.set("timers", () => {
+      calls.push("timers");
+      throw failure;
+    });
+    registry.set("mirror", () => calls.push("mirror"));
+    registry.set("editor-buffer", () => calls.push("editor-buffer"));
+
+    const result = registry.runAll();
+
+    expect(result.names).toEqual(["watcher", "timers", "mirror", "editor-buffer"]);
+    expect(result.failures).toEqual([{ name: "timers", error: failure }]);
+    expect(registry.runAll()).toEqual({ names: [], failures: [] });
+    expect(calls).toEqual(["watcher", "timers", "mirror", "editor-buffer"]);
+  });
+
+  it("executes non-hosted renderer destroy only once", () => {
+    const calls: string[] = [];
+    const executor = createTuiLifecycleExecutor({
+      destroyRenderer: () => calls.push("destroy"),
+      switchClientBack: () => calls.push("switch"),
+      detachClient: () => calls.push("detach"),
+    });
+
+    executor.run({ kind: "destroy-renderer", source: "keyboard" });
+    executor.run({ kind: "destroy-renderer", source: "keyboard" });
+
+    expect(calls).toEqual(["destroy"]);
+  });
+
+  it("executes hosted detach once and falls back to one detach on switch failure", () => {
+    const calls: string[] = [];
+    const executor = createTuiLifecycleExecutor({
+      destroyRenderer: () => calls.push("destroy"),
+      switchClientBack: (callback) => {
+        calls.push("switch");
+        callback(new Error("no last client"));
+      },
+      detachClient: () => calls.push("detach"),
+    });
+
+    executor.run({ kind: "hosted-detach", source: "keyboard" });
+    executor.run({ kind: "hosted-detach", source: "keyboard" });
+
+    expect(calls).toEqual(["switch", "detach"]);
+  });
+
+  it("executes hosted palette quit as destroy once", () => {
+    const calls: string[] = [];
+    const executor = createTuiLifecycleExecutor({
+      destroyRenderer: () => calls.push("destroy"),
+      switchClientBack: () => calls.push("switch"),
+      detachClient: () => calls.push("detach"),
+    });
+
+    executor.run(resolveQuitLifecycleCommand({ hosted: true }, "palette"));
+    executor.run(resolveQuitLifecycleCommand({ hosted: true }, "palette"));
+
+    expect(calls).toEqual(["destroy"]);
+  });
+});

--- a/packages/daemon/src/tui/mirror/input-lifecycle.ts
+++ b/packages/daemon/src/tui/mirror/input-lifecycle.ts
@@ -1,0 +1,243 @@
+export const OPENTUI_KEYMAP_DECISION = {
+  package: "@opentui/keymap",
+  evaluatedVersion: "0.4.3",
+  adopted: false,
+  reason:
+    "The app already has one Solid useKeyboard owner and must forward arbitrary editor/query/pane text; adding keymap here would duplicate rather than replace that root listener.",
+} as const;
+
+export type TuiInputMode = "home" | "editor" | "diff" | "missions" | "mirror";
+export type TuiMissionMode = "board" | "history" | "detail";
+export type TuiEditorFocus = "list" | "editor";
+
+export interface TuiKeyEvent {
+  name: string;
+  ctrl: boolean;
+  meta: boolean;
+  shift: boolean;
+  super?: boolean;
+}
+
+export interface TuiInputContext {
+  dialogOpen: boolean;
+  menuOpen: boolean;
+  paletteOpen: boolean;
+  searchOpen: boolean;
+  mode: TuiInputMode;
+  activePanelInert: boolean;
+  missionMode: TuiMissionMode;
+  editorFocus: TuiEditorFocus;
+  editorFilterOpen: boolean;
+  diffFilterOpen: boolean;
+  homePromptOpen: boolean;
+  configuredShortcutKeys: readonly string[];
+  compositeCycleAvailable: boolean;
+}
+
+export type TuiGlobalCommand =
+  | { kind: "cycle-composite-focus" }
+  | { kind: "open-palette" }
+  | { kind: "select-hosted-view"; key: string }
+  | { kind: "go-home" }
+  | { kind: "toggle-editor" };
+
+export type TuiInputLayer =
+  | { kind: "lifecycle"; command: TuiLifecycleCommand }
+  | { kind: "kitty-super-palette" }
+  | { kind: "kitty-super-suppressed" }
+  | { kind: "dialog" }
+  | { kind: "menu" }
+  | { kind: "palette" }
+  | { kind: "search" }
+  | { kind: "global"; command: TuiGlobalCommand }
+  | { kind: "missions-detail" }
+  | { kind: "missions-board-history" }
+  | { kind: "inert" }
+  | { kind: "editor-filter" }
+  | { kind: "editor-list" }
+  | { kind: "editor-input" }
+  | { kind: "diff-filter" }
+  | { kind: "diff" }
+  | { kind: "home-prompt" }
+  | { kind: "home" }
+  | { kind: "terminal" };
+
+export type TuiLifecycleCommand =
+  | { kind: "destroy-renderer"; source: "keyboard" | "palette" | "error" }
+  | { kind: "hosted-detach"; source: "keyboard" };
+
+export function resolveInputLayer(
+  context: TuiInputContext,
+  event: TuiKeyEvent,
+  options: { hosted: boolean },
+): TuiInputLayer {
+  if (event.ctrl && event.name === "q") {
+    return { kind: "lifecycle", command: resolveQuitLifecycleCommand(options, "keyboard") };
+  }
+  if (event.super) {
+    if (
+      event.name === "k" &&
+      !event.ctrl &&
+      !context.dialogOpen &&
+      !context.menuOpen &&
+      !context.paletteOpen &&
+      !context.searchOpen
+    ) {
+      return { kind: "kitty-super-palette" };
+    }
+    return { kind: "kitty-super-suppressed" };
+  }
+  if (context.dialogOpen) return { kind: "dialog" };
+  if (context.menuOpen) return { kind: "menu" };
+  if (context.paletteOpen) return { kind: "palette" };
+  if (context.searchOpen) return { kind: "search" };
+  const global = resolveGlobalCommand(context, event);
+  if (global) return { kind: "global", command: global };
+  if (context.mode === "missions") {
+    return context.missionMode === "detail"
+      ? { kind: "missions-detail" }
+      : { kind: "missions-board-history" };
+  }
+  if (context.activePanelInert) return { kind: "inert" };
+  if (event.ctrl && event.name === "e")
+    return { kind: "global", command: { kind: "toggle-editor" } };
+  if (context.mode === "editor") {
+    if (context.editorFocus === "list") {
+      return context.editorFilterOpen ? { kind: "editor-filter" } : { kind: "editor-list" };
+    }
+    return { kind: "editor-input" };
+  }
+  if (context.mode === "diff") {
+    return context.diffFilterOpen ? { kind: "diff-filter" } : { kind: "diff" };
+  }
+  if (context.mode === "home") {
+    return context.homePromptOpen ? { kind: "home-prompt" } : { kind: "home" };
+  }
+  return { kind: "terminal" };
+}
+
+export function resolveGlobalCommand(
+  context: TuiInputContext,
+  event: TuiKeyEvent,
+): TuiGlobalCommand | null {
+  if (event.ctrl && event.name === "tab" && context.compositeCycleAvailable) {
+    return { kind: "cycle-composite-focus" };
+  }
+  if (event.name === "f5" || (event.ctrl && event.name === "p")) {
+    return { kind: "open-palette" };
+  }
+  if (context.configuredShortcutKeys.includes(event.name)) {
+    return { kind: "select-hosted-view", key: event.name };
+  }
+  if (event.ctrl && (event.name === "g" || event.name === "h")) {
+    return { kind: "go-home" };
+  }
+  return null;
+}
+
+export function resolveQuitLifecycleCommand(
+  options: { hosted: boolean },
+  source: "keyboard" | "palette" | "error",
+): TuiLifecycleCommand {
+  if (source === "keyboard" && options.hosted) return { kind: "hosted-detach", source };
+  return { kind: "destroy-renderer", source };
+}
+
+export type CtrlCCommand =
+  | { kind: "copy-editor-selection" }
+  | { kind: "copy-terminal-selection" }
+  | { kind: "forward-terminal-ctrl-c" }
+  | { kind: "consume" };
+
+export function resolveCtrlCCommand(context: {
+  layer: "editor" | "terminal" | "inert" | "overlay";
+  hasEditorSelection?: boolean;
+  hasTerminalSelection?: boolean;
+  mirrorAvailable?: boolean;
+}): CtrlCCommand {
+  if (context.layer === "editor") {
+    return context.hasEditorSelection ? { kind: "copy-editor-selection" } : { kind: "consume" };
+  }
+  if (context.layer === "terminal") {
+    if (!context.mirrorAvailable) return { kind: "consume" };
+    return context.hasTerminalSelection
+      ? { kind: "copy-terminal-selection" }
+      : { kind: "forward-terminal-ctrl-c" };
+  }
+  return { kind: "consume" };
+}
+
+export interface CtrlCExecutor {
+  copyEditorSelection: () => void;
+  copyTerminalSelection: () => void;
+  forwardTerminalCtrlC: () => void;
+}
+
+export function executeCtrlCCommand(command: CtrlCCommand, executor: CtrlCExecutor): void {
+  if (command.kind === "copy-editor-selection") executor.copyEditorSelection();
+  else if (command.kind === "copy-terminal-selection") executor.copyTerminalSelection();
+  else if (command.kind === "forward-terminal-ctrl-c") executor.forwardTerminalCtrlC();
+}
+
+export interface TuiCleanupResult {
+  names: string[];
+  failures: { name: string; error: unknown }[];
+}
+
+export class TuiCleanupRegistry {
+  private callbacks = new Map<string, () => void>();
+  private cleaned = false;
+
+  set(name: string, callback: () => void): void {
+    if (this.cleaned) return;
+    this.callbacks.set(name, callback);
+  }
+
+  runAll(): TuiCleanupResult {
+    if (this.cleaned) return { names: [], failures: [] };
+    this.cleaned = true;
+    const names = [...this.callbacks.keys()];
+    const failures: TuiCleanupResult["failures"] = [];
+    for (const [name, callback] of this.callbacks) {
+      try {
+        callback();
+      } catch (error) {
+        failures.push({ name, error });
+      }
+    }
+    this.callbacks.clear();
+    return { names, failures };
+  }
+}
+
+export interface TuiLifecycleExecutor {
+  run(command: TuiLifecycleCommand): void;
+}
+
+export function createTuiLifecycleExecutor(deps: {
+  destroyRenderer: () => void;
+  switchClientBack: (callback: (error: unknown) => void) => void;
+  detachClient: () => void;
+}): TuiLifecycleExecutor {
+  let destroyRequested = false;
+  let hostedDetachRequested = false;
+  let fallbackDetachRequested = false;
+
+  return {
+    run(command) {
+      if (command.kind === "destroy-renderer") {
+        if (destroyRequested) return;
+        destroyRequested = true;
+        deps.destroyRenderer();
+        return;
+      }
+      if (hostedDetachRequested) return;
+      hostedDetachRequested = true;
+      deps.switchClientBack((error) => {
+        if (!error || fallbackDetachRequested) return;
+        fallbackDetachRequested = true;
+        deps.detachClient();
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- make the single root keyboard owner delegate to explicit, fine-grained input layers
- keep Ctrl-C terminal-owned: copy selection or send exactly one `C-c`
- route Ctrl-Q and palette Quit through an injected idempotent lifecycle executor
- centralize cleanup in a throw-tolerant, idempotent registry registered at root creation
- document why `@opentui/keymap@0.4.3` is not adopted beside arbitrary text forwarding

## Validation

- focused input/Missions/host-terminal Vitest suite (102 passed)
- `pnpm --filter @tmux-ide/contracts typecheck`
- `pnpm --filter @tmux-ide/daemon typecheck`
- `pnpm build:tui`
- `pnpm check`
- `git diff --check`
- touched-path audit: no direct `process.exit()`