### PR TITLE
M29.1: add semantic OpenTUI theme foundation

### DIFF
--- a/packages/daemon/src/lib/app-config.test.ts
+++ b/packages/daemon/src/lib/app-config.test.ts
@@ -46,10 +46,19 @@ describe("parseAppConfig — deep partial merge", () => {
     expect(cfg.keys.cheatsheet).toBe("M-k");
     expect(cfg.keys.menu).toBe("M-m");
     expect(cfg.keys.panels).toEqual(DEFAULT_APP_CONFIG.keys.panels);
+    expect(cfg.theme.mode).toBe("dark");
     expect(cfg.theme.muted).toBe("colour240");
     expect(cfg.theme.status.working).toBe("colour221");
     expect(cfg.theme.glyphs).toEqual(DEFAULT_APP_CONFIG.theme.glyphs);
     expect(cfg.updater).toEqual(DEFAULT_APP_CONFIG.updater);
+  });
+
+  it("persists valid theme modes and falls back for invalid values", () => {
+    expect(parseAppConfig({ theme: { mode: "light" } }).theme.mode).toBe("light");
+    expect(parseAppConfig({ theme: { mode: "system" } }).theme.mode).toBe("system");
+    expect(parseAppConfig({ theme: { mode: "sepia" } }).theme.mode).toBe(
+      DEFAULT_APP_CONFIG.theme.mode,
+    );
   });
 
   it("defaults the sidebar toggle key to M-b", () => {
@@ -122,8 +131,15 @@ describe("parseAppConfig — mistyped fields fall back to default", () => {
 
   it("theme — non-string colors/glyphs become defaults", () => {
     const cfg = parseAppConfig({
-      theme: { accent: 1, fg: [], status: { done: {}, idle: "colour10" }, glyphs: { active: 7 } },
+      theme: {
+        mode: 1,
+        accent: 1,
+        fg: [],
+        status: { done: {}, idle: "colour10" },
+        glyphs: { active: 7 },
+      },
     });
+    expect(cfg.theme.mode).toBe(DEFAULT_APP_CONFIG.theme.mode);
     expect(cfg.theme.accent).toBe(DEFAULT_APP_CONFIG.theme.accent);
     expect(cfg.theme.fg).toBe(DEFAULT_APP_CONFIG.theme.fg);
     expect(cfg.theme.status.done).toBe(DEFAULT_APP_CONFIG.theme.status.done);

--- a/packages/daemon/src/lib/app-config.ts
+++ b/packages/daemon/src/lib/app-config.ts
@@ -24,6 +24,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { AgentStatus } from "../tui/detect/classify.ts";
+import type { ThemeModeSetting } from "../tui/mirror/theme.ts";
 
 // ---------------------------------------------------------------------------
 // Shape
@@ -76,6 +77,8 @@ export interface AppThemeGlyphs {
  * reads as one system.
  */
 export interface AppTheme {
+  /** Explicit palette mode or terminal-following mode. Default keeps legacy dark visuals. */
+  mode: ThemeModeSetting;
   /** Primary/brand accent (default `colour75`). */
   accent: string;
   /** Muted/secondary foreground for dim text (default `colour240`). */
@@ -251,6 +254,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
     panels: { explorer: "M-e", changes: "M-g", config: "M-," },
   },
   theme: {
+    mode: "dark",
     accent: "colour75",
     muted: "colour240",
     fg: "colour250",
@@ -359,6 +363,7 @@ export function parseAppConfig(input: unknown): AppConfig {
       },
     },
     theme: {
+      mode: pickChoice(theme.mode, ["dark", "light", "system"], D.theme.mode),
       accent: pickString(theme.accent, D.theme.accent),
       muted: pickString(theme.muted, D.theme.muted),
       fg: pickString(theme.fg, D.theme.fg),

--- a/packages/daemon/src/tui/mirror/THEME.md
+++ b/packages/daemon/src/tui/mirror/THEME.md
@@ -1,0 +1,48 @@
+# Semantic theme foundation
+
+`theme.ts` is the app-owned semantic token boundary. It deliberately stays
+small: OpenTUI receives concrete `RGBA` values, but app code should name the
+role it needs instead of hard-coding surface colors.
+
+## Token roles
+
+- `colors.accent` is the user-selected brand/action color. It is preserved
+  exactly, so a saved accent may equal a status color.
+- `colors.focus` and `colors.focusBorder` are focus tokens. They default from
+  accent when safe, but fall back to the base focus family when the selected
+  accent collides with any resolved status color. Keyboard focus must not look
+  like blocked, working, done, idle, or unknown state.
+- `colors.status.*` are state tokens. They must remain visually distinct from
+  focus so blocked, working, done, idle, and unknown states are never confused
+  with navigation focus. They are not guaranteed to be distinct from raw user
+  accent because old saved accents remain valid.
+- `density`, `borders`, and `glyphs` are structural tokens. They describe the
+  app's default spacing, border style, and common terminal symbols; they are not
+  per-surface layout decisions.
+
+## State precedence
+
+Theme state resolves in this order:
+
+1. The persisted app config supplies the selected mode (`dark`, `light`, or
+   `system`) and custom token overrides such as `theme.accent`.
+2. Explicit `dark`/`light` modes choose that palette directly.
+3. `system` follows the renderer `theme_mode` subscription; if the renderer
+   has not reported a mode yet, the dark palette is used as the stable fallback.
+4. Custom accent, foreground, muted, status, and glyph overrides are applied
+   after palette selection. Existing saved custom accents remain valid.
+
+Snapshots are stable immutable containers. The TypeScript contract exposes
+readonly token fields and runtime freezes the containers. `RGBA` itself exposes
+mutable channel setters backed by native storage, so snapshots provide readonly
+RGBA references by contract; consumers must treat them as immutable and never
+mutate color instances in place. Consumers subscribe once, compare snapshot
+identity, and avoid allocating reactive theme objects during render.
+
+## Primitive versus recipe boundary
+
+This module is a primitive-style foundation: it defines semantic tokens, mode
+resolution, and subscriptions. Recipes such as Missions lanes, settings rows,
+dialogs, or terminal chrome decide how those tokens are mapped to their own
+layout and interaction states. tmux-ide does not depend on TUIparts at runtime;
+the reference informed the shape, but the visual layer remains app-owned.

--- a/packages/daemon/src/tui/mirror/settings-model.test.ts
+++ b/packages/daemon/src/tui/mirror/settings-model.test.ts
@@ -42,6 +42,8 @@ import {
   settingsRootItems,
   snapshotEveryPatch,
   themeItems,
+  themeModeItems,
+  themeModePatch,
   themePatch,
   tickMsPatch,
   updatesCheckPatch,
@@ -82,6 +84,16 @@ describe("theme", () => {
     expect(themePatch("colour203")).toEqual({ theme: { accent: "colour203" } });
     expect(presetRgb("colour203")).toEqual([255, 95, 95]);
     expect(presetRgb("colour99")).toBeNull();
+  });
+  it("offers dark/light/system mode rows and persists only theme.mode", () => {
+    expect(themeModeItems(CFG).map((row) => [row.id, row.current, row.detail])).toEqual([
+      ["dark", true, "dark palette"],
+      ["light", false, "light palette"],
+      ["system", false, "follow terminal theme_mode"],
+    ]);
+    const system = parseAppConfig({ theme: { mode: "system" } });
+    expect(themeModeItems(system).find((row) => row.current)?.id).toBe("system");
+    expect(themeModePatch("light")).toEqual({ theme: { mode: "light" } });
   });
 });
 

--- a/packages/daemon/src/tui/mirror/settings-model.ts
+++ b/packages/daemon/src/tui/mirror/settings-model.ts
@@ -12,6 +12,7 @@
  * never left guessing.
  */
 import type { AppConfig, AppConfigPatch, AppKeys } from "../../lib/app-config.ts";
+import type { ThemeModeSetting } from "./theme.ts";
 import { parseHHMM, type NotificationPrefs } from "../chrome/notify-prefs.ts";
 import type { DialogSelectItem } from "./dialog-model.ts";
 
@@ -103,6 +104,25 @@ export function presetRgb(accent: string): [number, number, number] | null {
 /** PURE — the patch persisting a picked accent. */
 export function themePatch(accent: string): AppConfigPatch {
   return { theme: { accent } };
+}
+
+export const THEME_MODE_LABELS: Readonly<Record<ThemeModeSetting, string>> = {
+  dark: "Dark",
+  light: "Light",
+  system: "System",
+};
+
+export function themeModeItems(cfg: AppConfig): DialogSelectItem[] {
+  return (["dark", "light", "system"] as const).map((mode) => ({
+    id: mode,
+    label: THEME_MODE_LABELS[mode],
+    detail: mode === "system" ? "follow terminal theme_mode" : `${mode} palette`,
+    current: cfg.theme.mode === mode,
+  }));
+}
+
+export function themeModePatch(mode: ThemeModeSetting): AppConfigPatch {
+  return { theme: { mode } };
 }
 
 // ── Notifications ────────────────────────────────────────────────────────────

--- a/packages/daemon/src/tui/mirror/theme.test.ts
+++ b/packages/daemon/src/tui/mirror/theme.test.ts
@@ -1,0 +1,217 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  ACCENT,
+  DARK_THEME,
+  DEFAULT_BG,
+  LIGHT_THEME,
+  colorToThemeBytes,
+  createSemanticThemeSnapshot,
+  createSemanticThemeStore,
+  type ResolvedThemeMode,
+  type ThemeModeSource,
+} from "./theme.ts";
+import { THEME_PRESETS } from "./settings-model.ts";
+
+function rgbaKey(color: { r: number; g: number; b: number; a: number }): string {
+  return colorToThemeBytes(color as Parameters<typeof colorToThemeBytes>[0]).join(",");
+}
+
+class FakeThemeModeSource implements ThemeModeSource {
+  themeMode: ResolvedThemeMode | null;
+  readonly listeners = new Set<(mode: ResolvedThemeMode) => void>();
+
+  constructor(mode: ResolvedThemeMode | null) {
+    this.themeMode = mode;
+  }
+
+  on(event: "theme_mode", listener: (mode: ResolvedThemeMode) => void): void {
+    expect(event).toBe("theme_mode");
+    this.listeners.add(listener);
+  }
+
+  off(event: "theme_mode", listener: (mode: ResolvedThemeMode) => void): void {
+    expect(event).toBe("theme_mode");
+    this.listeners.delete(listener);
+  }
+
+  emit(mode: ResolvedThemeMode): void {
+    this.themeMode = mode;
+    for (const listener of this.listeners) listener(mode);
+  }
+}
+
+describe("semantic theme snapshots", () => {
+  it("uses only RGBA.fromInts so docs/tui-web's narrow browser shim remains a drift detector", () => {
+    const source = readFileSync(fileURLToPath(new URL("./theme.ts", import.meta.url)), "utf-8");
+    expect(source).toContain("RGBA.fromInts");
+    expect(source).not.toMatch(/RGBA\.from(?!Ints\b)/u);
+  });
+
+  it("resolves dark, light, and system mode with a stable dark fallback", () => {
+    expect(createSemanticThemeSnapshot({ mode: "dark" }).mode).toBe("dark");
+    expect(createSemanticThemeSnapshot({ mode: "light" }).mode).toBe("light");
+    expect(createSemanticThemeSnapshot({ mode: "system" }, "light").mode).toBe("light");
+    expect(createSemanticThemeSnapshot({ mode: "system" }, null).mode).toBe("dark");
+    expect(createSemanticThemeSnapshot({ mode: "system" }, "light").setting).toBe("system");
+  });
+
+  it("keeps dark compatibility exports mapped to the legacy dark palette", () => {
+    expect(rgbaKey(DEFAULT_BG)).toBe(rgbaKey(DARK_THEME.colors.background));
+    expect(rgbaKey(ACCENT)).toBe(rgbaKey(DARK_THEME.colors.accent));
+  });
+
+  it("normalizes color bytes without confusing real normalized channels and browser-shim bytes", () => {
+    const real = createSemanticThemeSnapshot({ accent: "#010101" }).colors.accent;
+    expect(colorToThemeBytes(real)).toEqual([1, 1, 1, 255]);
+    const shimLikeColor = { r: 1, g: 1, b: 1, a: 255 } as Parameters<typeof colorToThemeBytes>[0];
+    expect(colorToThemeBytes(shimLikeColor)).toEqual([1, 1, 1, 255]);
+  });
+
+  it("derives custom accent tokens without changing semantic status tokens", () => {
+    const snapshot = createSemanticThemeSnapshot({ mode: "dark", accent: "#ff00aa" });
+    expect(rgbaKey(snapshot.colors.accent)).toBe("255,0,170,255");
+    expect(rgbaKey(snapshot.colors.focus)).toBe("255,0,170,255");
+    expect(rgbaKey(snapshot.colors.focusBorder)).not.toBe(rgbaKey(snapshot.colors.focus));
+    expect(rgbaKey(snapshot.colors.status.blocked)).toBe(rgbaKey(DARK_THEME.colors.status.blocked));
+  });
+
+  it("preserves a saved accent that collides with status while deriving collision-safe focus", () => {
+    const snapshot = createSemanticThemeSnapshot({ mode: "dark", accent: "colour203" });
+    expect(rgbaKey(snapshot.colors.accent)).toBe("255,95,95,255");
+    expect(rgbaKey(snapshot.colors.accent)).toBe(rgbaKey(snapshot.colors.status.blocked));
+    expect(rgbaKey(snapshot.colors.focus)).toBe(rgbaKey(DARK_THEME.colors.focus));
+    expect(rgbaKey(snapshot.colors.focus)).not.toBe(rgbaKey(snapshot.colors.status.blocked));
+    expect(rgbaKey(snapshot.colors.focusBorder)).not.toBe(rgbaKey(snapshot.colors.status.blocked));
+  });
+
+  it("keeps focus and focusBorder safe against adversarial custom status overrides", () => {
+    const snapshot = createSemanticThemeSnapshot({
+      mode: "dark",
+      accent: "colour203",
+      status: {
+        blocked: "colour203",
+        working: "#82aaff",
+        done: "#6e91e6",
+        idle: "#99b9ff",
+        unknown: "#a5c2ff",
+      },
+    });
+    const statusColors = Object.values(snapshot.colors.status).map(rgbaKey);
+    expect(rgbaKey(snapshot.colors.accent)).toBe(rgbaKey(snapshot.colors.status.blocked));
+    expect(statusColors).not.toContain(rgbaKey(snapshot.colors.focus));
+    expect(statusColors).not.toContain(rgbaKey(snapshot.colors.focusBorder));
+    expect(rgbaKey(snapshot.colors.focusBorder)).not.toBe(rgbaKey(snapshot.colors.focus));
+  });
+
+  it("moves a derived focus border that collides with a custom status override", () => {
+    const baseline = createSemanticThemeSnapshot({ mode: "dark", accent: "#ff00aa" });
+    const [r, g, b] = colorToThemeBytes(baseline.colors.focusBorder);
+    const collidingStatus = `#${[r, g, b]
+      .map((channel) => channel.toString(16).padStart(2, "0"))
+      .join("")}`;
+    const snapshot = createSemanticThemeSnapshot({
+      mode: "dark",
+      accent: "#ff00aa",
+      status: { blocked: collidingStatus },
+    });
+    expect(rgbaKey(snapshot.colors.focus)).toBe(rgbaKey(snapshot.colors.accent));
+    expect(rgbaKey(snapshot.colors.focusBorder)).not.toBe(rgbaKey(snapshot.colors.status.blocked));
+    expect(rgbaKey(snapshot.colors.focusBorder)).not.toBe(rgbaKey(snapshot.colors.focus));
+  });
+
+  it("accepts tmux colour tokens and preserves saved status/glyph overrides", () => {
+    const snapshot = createSemanticThemeSnapshot({
+      accent: "colour75",
+      status: { idle: "colour10" },
+      glyphs: { active: "◆" },
+    });
+    expect(rgbaKey(snapshot.colors.accent)).toBe("95,175,255,255");
+    expect(rgbaKey(snapshot.colors.status.idle)).toBe("0,255,0,255");
+    expect(snapshot.glyphs.active).toBe("◆");
+    expect(snapshot.glyphs.inactive).toBe(DARK_THEME.glyphs.inactive);
+  });
+
+  it("returns immutable stable containers for identical store state", () => {
+    const store = createSemanticThemeStore({ mode: "dark" });
+    const first = store.getSnapshot();
+    store.setMode("dark");
+    expect(store.getSnapshot()).toBe(first);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first.colors)).toBe(true);
+    expect(Object.isFrozen(first.colors.status)).toBe(true);
+    expect(Object.isFrozen(first.density)).toBe(true);
+    expect(Object.isFrozen(first.borders)).toBe(true);
+    expect(Object.isFrozen(first.glyphs)).toBe(true);
+  });
+
+  it("keeps focus/accent colors distinct from semantic status colors in both palettes", () => {
+    for (const snapshot of [DARK_THEME, LIGHT_THEME]) {
+      const reserved = new Set([rgbaKey(snapshot.colors.accent), rgbaKey(snapshot.colors.focus)]);
+      expect(reserved.has(rgbaKey(snapshot.colors.status.blocked))).toBe(false);
+      expect(reserved.has(rgbaKey(snapshot.colors.status.working))).toBe(false);
+      expect(reserved.has(rgbaKey(snapshot.colors.status.done))).toBe(false);
+      expect(reserved.has(rgbaKey(snapshot.colors.status.idle))).toBe(false);
+      expect(reserved.has(rgbaKey(snapshot.colors.status.unknown))).toBe(false);
+    }
+  });
+
+  it("keeps focus collision-safe for every curated accent against resolved status colors", () => {
+    for (const preset of THEME_PRESETS) {
+      const snapshot = createSemanticThemeSnapshot({ mode: "dark", accent: preset.accent });
+      const statusColors = Object.values(snapshot.colors.status).map(rgbaKey);
+      expect(snapshot.colors.accent).toBeDefined();
+      expect(statusColors).not.toContain(rgbaKey(snapshot.colors.focus));
+      expect(statusColors).not.toContain(rgbaKey(snapshot.colors.focusBorder));
+    }
+  });
+});
+
+describe("semantic theme store", () => {
+  it("follows renderer theme_mode only while setting is system and unsubscribes cleanly", () => {
+    const source = new FakeThemeModeSource("dark");
+    const store = createSemanticThemeStore({ mode: "system" });
+    let notifications = 0;
+    store.subscribe(() => notifications++);
+
+    const unsubscribeRenderer = store.followRendererThemeMode(source);
+    expect(store.getSnapshot().mode).toBe("dark");
+    expect(source.listeners.size).toBe(1);
+
+    source.emit("light");
+    expect(store.getSnapshot().mode).toBe("light");
+    expect(notifications).toBe(1);
+
+    store.setMode("dark");
+    source.emit("light");
+    expect(store.getSnapshot().mode).toBe("dark");
+    expect(notifications).toBe(2);
+
+    store.setMode("system");
+    expect(store.getSnapshot().mode).toBe("light");
+    expect(notifications).toBe(3);
+
+    unsubscribeRenderer();
+    expect(source.listeners.size).toBe(0);
+    source.emit("dark");
+    expect(store.getSnapshot().mode).toBe("light");
+    expect(notifications).toBe(3);
+  });
+
+  it("notifies subscribers once per material accent change", () => {
+    const store = createSemanticThemeStore({ mode: "dark", accent: "colour75" });
+    const snapshots = [store.getSnapshot()];
+    const unsubscribe = store.subscribe(() => snapshots.push(store.getSnapshot()));
+
+    store.setAccent("colour75");
+    store.setAccent("colour203");
+    store.setAccent("colour203");
+    unsubscribe();
+    store.setAccent("colour114");
+
+    expect(snapshots).toHaveLength(2);
+    expect(rgbaKey(snapshots[0]!.colors.accent)).toBe("95,175,255,255");
+    expect(rgbaKey(snapshots[1]!.colors.accent)).toBe("255,95,95,255");
+  });
+});

--- a/packages/daemon/src/tui/mirror/theme.ts
+++ b/packages/daemon/src/tui/mirror/theme.ts
@@ -1,45 +1,531 @@
 /**
- * The unified app's color tokens — PURE data, hoisted out of app.tsx (M26) so
- * the surfaces extracted from it (starting with {@link ./sidebar.tsx}) carry
- * their palette with them instead of reaching back into a 21k-line module.
+ * Semantic theme substrate for the unified app.
  *
- * Companion to {@link ./status-grammar.ts}: that file owns the per-AGENT-STATE
- * glyph + hue (a status signal), this one owns the CHROME (surface, accent,
- * hover, selection). Keep the two families distinct — focus is an accent signal,
- * agent state is a status signal, and they must never collide on a hue.
+ * This module is still the compatibility bridge for the extracted surfaces:
+ * existing named RGBA exports stay stable and map to the default dark snapshot.
+ * New code should consume {@link SemanticThemeSnapshot} / {@link ThemeStore}
+ * instead of inventing per-surface colors.
  *
  * Node-free on purpose: the web host (docs/tui-web) imports this module
- * verbatim, aliasing @opentui/core to a browser shim for RGBA.
+ * verbatim, aliasing @opentui/core to a browser shim that only exposes RGBA.
  */
 import { RGBA } from "@opentui/core";
 
-export const DEFAULT_FG = RGBA.fromInts(212, 212, 216, 255);
-export const DEFAULT_BG = RGBA.fromInts(16, 16, 22, 255);
+export type ResolvedThemeMode = "dark" | "light";
+export type ThemeModeSetting = ResolvedThemeMode | "system";
+
+export interface ThemeModeSource {
+  readonly themeMode: ResolvedThemeMode | null;
+  on(event: "theme_mode", listener: (mode: ResolvedThemeMode) => void): unknown;
+  off(event: "theme_mode", listener: (mode: ResolvedThemeMode) => void): unknown;
+}
+
+export interface SemanticThemeColors {
+  readonly background: RGBA;
+  readonly surface: RGBA;
+  readonly surfaceRaised: RGBA;
+  readonly foreground: RGBA;
+  readonly mutedForeground: RGBA;
+  readonly border: RGBA;
+  readonly accent: RGBA;
+  readonly accentMuted: RGBA;
+  readonly focus: RGBA;
+  readonly focusBorder: RGBA;
+  readonly selection: RGBA;
+  readonly selectionForeground: RGBA;
+  readonly hover: RGBA;
+  readonly buttonHover: RGBA;
+  readonly attention: RGBA;
+  readonly status: {
+    readonly blocked: RGBA;
+    readonly working: RGBA;
+    readonly done: RGBA;
+    readonly idle: RGBA;
+    readonly unknown: RGBA;
+  };
+}
+
+export interface SemanticThemeTokens {
+  readonly colors: SemanticThemeColors;
+  readonly density: {
+    readonly compactGap: number;
+    readonly comfortableGap: number;
+    readonly detailedGap: number;
+    readonly paddingX: number;
+  };
+  readonly borders: {
+    readonly style: "single" | "rounded" | "double" | "bold";
+    readonly focusedStyle: "single" | "rounded" | "double" | "bold";
+  };
+  readonly glyphs: {
+    readonly active: string;
+    readonly inactive: string;
+    readonly focusHorizontal: string;
+    readonly focusVertical: string;
+    readonly check: string;
+    readonly scrollThumb: string;
+    readonly scrollTrack: string;
+  };
+}
+
+export interface SemanticThemeSnapshot extends SemanticThemeTokens {
+  readonly mode: ResolvedThemeMode;
+  readonly setting: ThemeModeSetting;
+}
+
+export interface ThemeConfigInput {
+  mode?: ThemeModeSetting;
+  accent?: string;
+  muted?: string;
+  fg?: string;
+  status?: Partial<Record<keyof SemanticThemeColors["status"], string>>;
+  glyphs?: Partial<Pick<SemanticThemeTokens["glyphs"], "active" | "inactive">>;
+}
+
+export interface ThemeStoreOptions {
+  mode?: ThemeModeSetting;
+  accent?: string;
+  rendererMode?: ResolvedThemeMode | null;
+}
+
+export interface ThemeStore {
+  getSnapshot(): SemanticThemeSnapshot;
+  subscribe(listener: () => void): () => void;
+  setMode(mode: ThemeModeSetting): void;
+  setAccent(accent: string | undefined): void;
+  configure(config: ThemeConfigInput | undefined): void;
+  followRendererThemeMode(source: ThemeModeSource): () => void;
+}
+
+const STANDARD_ANSI: readonly (readonly [number, number, number])[] = [
+  [0, 0, 0],
+  [128, 0, 0],
+  [0, 128, 0],
+  [128, 128, 0],
+  [0, 0, 128],
+  [128, 0, 128],
+  [0, 128, 128],
+  [192, 192, 192],
+  [128, 128, 128],
+  [255, 0, 0],
+  [0, 255, 0],
+  [255, 255, 0],
+  [0, 0, 255],
+  [255, 0, 255],
+  [0, 255, 255],
+  [255, 255, 255],
+];
+
+const ANSI_LEVELS = [0, 95, 135, 175, 215, 255] as const;
+export type RgbaByteTuple = readonly [number, number, number, number];
+type RgbaWithOptionalToInts = RGBA & { toInts?: () => [number, number, number, number] };
+
+function rgba(r: number, g: number, b: number, a = 255): RGBA {
+  return RGBA.fromInts(r, g, b, a);
+}
+
+function byteChannel(channel: number): number {
+  return Math.max(0, Math.min(255, Math.round(channel)));
+}
+
+export function colorToThemeBytes(color: RGBA): RgbaByteTuple {
+  const maybeRealRgba = color as RgbaWithOptionalToInts;
+  if (typeof maybeRealRgba.toInts === "function") {
+    const [r, g, b, a] = maybeRealRgba.toInts();
+    return [byteChannel(r), byteChannel(g), byteChannel(b), byteChannel(a)];
+  }
+  return [byteChannel(color.r), byteChannel(color.g), byteChannel(color.b), byteChannel(color.a)];
+}
+
+function rgbaKey(color: RGBA): string {
+  return colorToThemeBytes(color).join(",");
+}
+
+function parseThemeColor(value: string | undefined, fallback: RGBA): RGBA {
+  if (!value) return fallback;
+  const tmuxMatch = value.match(/^colou?r(\d+)$/u);
+  if (tmuxMatch) {
+    const n = Number(tmuxMatch[1]);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return fallback;
+    if (n < 16) {
+      const [r, g, b] = STANDARD_ANSI[n]!;
+      return rgba(r, g, b);
+    }
+    if (n < 232) {
+      const idx = n - 16;
+      const r = ANSI_LEVELS[Math.floor(idx / 36)]!;
+      const g = ANSI_LEVELS[Math.floor((idx % 36) / 6)]!;
+      const b = ANSI_LEVELS[idx % 6]!;
+      return rgba(r, g, b);
+    }
+    const level = 8 + 10 * (n - 232);
+    return rgba(level, level, level);
+  }
+
+  const hexMatch = value.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/u);
+  if (!hexMatch) return fallback;
+  let hex = hexMatch[1]!;
+  if (hex.length === 3) {
+    const [r, g, b] = hex.split("");
+    hex = `${r}${r}${g}${g}${b}${b}`;
+  }
+  return rgba(
+    Number.parseInt(hex.slice(0, 2), 16),
+    Number.parseInt(hex.slice(2, 4), 16),
+    Number.parseInt(hex.slice(4, 6), 16),
+  );
+}
+
+function mix(base: RGBA, overlay: RGBA, amount: number, alphaByteOverride?: number): RGBA {
+  const [baseR, baseG, baseB, baseA] = colorToThemeBytes(base);
+  const [overlayR, overlayG, overlayB] = colorToThemeBytes(overlay);
+  const alphaByte = alphaByteOverride === undefined ? baseA : byteChannel(alphaByteOverride);
+  const channel = (a: number, b: number) => Math.round(a + (b - a) * amount);
+  return rgba(
+    channel(baseR, overlayR),
+    channel(baseG, overlayG),
+    channel(baseB, overlayB),
+    alphaByte,
+  );
+}
+
+function cloneColor(color: RGBA): RGBA {
+  const [r, g, b, a] = colorToThemeBytes(color);
+  return rgba(r, g, b, a);
+}
+
+function collidesWithAny(color: RGBA, colors: readonly RGBA[]): boolean {
+  const key = rgbaKey(color);
+  return colors.some((candidate) => rgbaKey(candidate) === key);
+}
+
+function safeColorCandidate(candidates: readonly RGBA[], forbidden: readonly RGBA[]): RGBA {
+  for (const candidate of candidates) {
+    if (!collidesWithAny(candidate, forbidden)) return cloneColor(candidate);
+  }
+  for (const r of ANSI_LEVELS) {
+    for (const g of ANSI_LEVELS) {
+      for (const b of ANSI_LEVELS) {
+        const candidate = rgba(r, g, b);
+        if (!collidesWithAny(candidate, forbidden)) return candidate;
+      }
+    }
+  }
+  for (let channel = 0; channel <= 255; channel++) {
+    const candidate = rgba(channel, channel, channel);
+    if (!collidesWithAny(candidate, forbidden)) return candidate;
+  }
+  throw new Error("No collision-safe theme color candidate available");
+}
+
+function safeFocusColor(base: SemanticThemeSnapshot, statusColors: readonly RGBA[]): RGBA {
+  const contrast = base.mode === "dark" ? rgba(255, 255, 255) : rgba(0, 0, 0);
+  return safeColorCandidate(
+    [
+      base.colors.focus,
+      base.colors.focusBorder,
+      ...([0.18, 0.28, 0.38, 0.5, 0.64, 0.78] as const).map((amount) =>
+        mix(base.colors.focus, contrast, amount),
+      ),
+    ],
+    statusColors,
+  );
+}
+
+function safeFocusBorderColor(
+  focus: RGBA,
+  preferred: RGBA,
+  base: SemanticThemeSnapshot,
+  statusColors: readonly RGBA[],
+): RGBA {
+  const contrast = base.mode === "dark" ? rgba(255, 255, 255) : rgba(0, 0, 0);
+  return safeColorCandidate(
+    [
+      preferred,
+      base.colors.focusBorder,
+      mix(focus, contrast, base.mode === "dark" ? 0.18 : 0.14),
+      mix(focus, contrast, base.mode === "dark" ? 0.28 : 0.24),
+      base.colors.focus,
+    ],
+    [...statusColors, focus],
+  );
+}
+
+function freezeSnapshot(snapshot: SemanticThemeSnapshot): SemanticThemeSnapshot {
+  for (const colors of [
+    snapshot.colors,
+    snapshot.colors.status,
+    snapshot.density,
+    snapshot.borders,
+    snapshot.glyphs,
+  ]) {
+    Object.freeze(colors);
+  }
+  return Object.freeze(snapshot);
+}
+
+function darkPalette(): SemanticThemeSnapshot {
+  const accent = rgba(130, 170, 255);
+  return freezeSnapshot({
+    mode: "dark",
+    setting: "dark",
+    colors: {
+      background: rgba(16, 16, 22),
+      surface: rgba(22, 22, 30),
+      surfaceRaised: rgba(30, 30, 40),
+      foreground: rgba(212, 212, 216),
+      mutedForeground: rgba(110, 110, 130),
+      border: rgba(60, 60, 80),
+      accent,
+      accentMuted: rgba(60, 66, 92),
+      focus: rgba(130, 170, 255),
+      focusBorder: rgba(110, 145, 230),
+      selection: rgba(40, 46, 66),
+      selectionForeground: rgba(255, 255, 255),
+      hover: rgba(30, 34, 48),
+      buttonHover: rgba(52, 60, 86),
+      attention: rgba(92, 44, 48),
+      status: {
+        blocked: rgba(255, 95, 95),
+        working: rgba(255, 215, 95),
+        done: rgba(135, 175, 255),
+        idle: rgba(135, 215, 135),
+        unknown: rgba(128, 128, 128),
+      },
+    },
+    density: { compactGap: 0, comfortableGap: 1, detailedGap: 2, paddingX: 1 },
+    borders: { style: "single", focusedStyle: "single" },
+    glyphs: {
+      active: "●",
+      inactive: "○",
+      focusHorizontal: "─",
+      focusVertical: "│",
+      check: "✓",
+      scrollThumb: "█",
+      scrollTrack: "░",
+    },
+  });
+}
+
+function lightPalette(): SemanticThemeSnapshot {
+  const accent = rgba(45, 105, 220);
+  return freezeSnapshot({
+    mode: "light",
+    setting: "light",
+    colors: {
+      background: rgba(248, 248, 250),
+      surface: rgba(238, 240, 246),
+      surfaceRaised: rgba(255, 255, 255),
+      foreground: rgba(28, 32, 42),
+      mutedForeground: rgba(92, 99, 118),
+      border: rgba(188, 196, 214),
+      accent,
+      accentMuted: rgba(212, 224, 255),
+      focus: rgba(45, 105, 220),
+      focusBorder: rgba(20, 80, 190),
+      selection: rgba(218, 228, 252),
+      selectionForeground: rgba(15, 25, 45),
+      hover: rgba(228, 234, 246),
+      buttonHover: rgba(208, 220, 246),
+      attention: rgba(255, 224, 224),
+      status: {
+        blocked: rgba(210, 52, 72),
+        working: rgba(176, 120, 0),
+        done: rgba(66, 92, 210),
+        idle: rgba(38, 135, 82),
+        unknown: rgba(112, 118, 130),
+      },
+    },
+    density: { compactGap: 0, comfortableGap: 1, detailedGap: 2, paddingX: 1 },
+    borders: { style: "single", focusedStyle: "single" },
+    glyphs: {
+      active: "●",
+      inactive: "○",
+      focusHorizontal: "─",
+      focusVertical: "│",
+      check: "✓",
+      scrollThumb: "█",
+      scrollTrack: "░",
+    },
+  });
+}
+
+export const DARK_THEME = darkPalette();
+export const LIGHT_THEME = lightPalette();
+
+function baseFor(mode: ResolvedThemeMode): SemanticThemeSnapshot {
+  return mode === "dark" ? DARK_THEME : LIGHT_THEME;
+}
+
+function resolvedMode(
+  setting: ThemeModeSetting,
+  rendererMode: ResolvedThemeMode | null,
+): ResolvedThemeMode {
+  return setting === "system" ? (rendererMode ?? "dark") : setting;
+}
+
+function withAppThemeConfig(
+  base: SemanticThemeSnapshot,
+  setting: ThemeModeSetting,
+  config: ThemeConfigInput | undefined,
+): SemanticThemeSnapshot {
+  const accent = parseThemeColor(config?.accent, base.colors.accent);
+  const foreground = parseThemeColor(config?.fg, base.colors.foreground);
+  const muted = parseThemeColor(config?.muted, base.colors.mutedForeground);
+  const white = rgba(255, 255, 255);
+  const black = rgba(0, 0, 0);
+  const contrast = base.mode === "dark" ? white : black;
+  const status = {
+    blocked: parseThemeColor(config?.status?.blocked, base.colors.status.blocked),
+    working: parseThemeColor(config?.status?.working, base.colors.status.working),
+    done: parseThemeColor(config?.status?.done, base.colors.status.done),
+    idle: parseThemeColor(config?.status?.idle, base.colors.status.idle),
+    unknown: parseThemeColor(config?.status?.unknown, base.colors.status.unknown),
+  };
+  const statusColors = Object.values(status);
+  const accentCollidesWithStatus = collidesWithAny(accent, statusColors);
+  const focus = accentCollidesWithStatus ? safeFocusColor(base, statusColors) : cloneColor(accent);
+  const preferredFocusBorder = accentCollidesWithStatus
+    ? base.colors.focusBorder
+    : mix(accent, contrast, base.mode === "dark" ? 0.18 : 0.14);
+  const focusBorder = safeFocusBorderColor(focus, preferredFocusBorder, base, statusColors);
+  return freezeSnapshot({
+    mode: base.mode,
+    setting,
+    colors: {
+      background: cloneColor(base.colors.background),
+      surface: cloneColor(base.colors.surface),
+      surfaceRaised: cloneColor(base.colors.surfaceRaised),
+      foreground,
+      mutedForeground: muted,
+      border: cloneColor(base.colors.border),
+      accent,
+      accentMuted: mix(base.colors.surface, accent, base.mode === "dark" ? 0.34 : 0.18),
+      focus,
+      focusBorder,
+      selection: mix(base.colors.background, accent, base.mode === "dark" ? 0.22 : 0.16),
+      selectionForeground: cloneColor(base.colors.selectionForeground),
+      hover: mix(base.colors.background, accent, base.mode === "dark" ? 0.08 : 0.06),
+      buttonHover: mix(base.colors.background, accent, base.mode === "dark" ? 0.24 : 0.16),
+      attention: cloneColor(base.colors.attention),
+      status,
+    },
+    density: { ...base.density },
+    borders: { ...base.borders },
+    glyphs: {
+      ...base.glyphs,
+      active: config?.glyphs?.active ?? base.glyphs.active,
+      inactive: config?.glyphs?.inactive ?? base.glyphs.inactive,
+    },
+  });
+}
+
+export function createSemanticThemeSnapshot(
+  config: ThemeConfigInput | undefined = undefined,
+  rendererMode: ResolvedThemeMode | null = null,
+): SemanticThemeSnapshot {
+  const setting = config?.mode ?? "dark";
+  return withAppThemeConfig(baseFor(resolvedMode(setting, rendererMode)), setting, config);
+}
+
+export function createSemanticThemeStore(
+  config: ThemeConfigInput | undefined = undefined,
+  options: ThemeStoreOptions = {},
+): ThemeStore {
+  let currentConfig: ThemeConfigInput = {
+    ...config,
+    mode: options.mode ?? config?.mode ?? "dark",
+    accent: options.accent ?? config?.accent,
+  };
+  let rendererMode = options.rendererMode ?? null;
+  let snapshot = createSemanticThemeSnapshot(currentConfig, rendererMode);
+  const listeners = new Set<() => void>();
+
+  const refresh = () => {
+    const next = createSemanticThemeSnapshot(currentConfig, rendererMode);
+    if (sameSnapshot(snapshot, next)) return;
+    snapshot = next;
+    for (const listener of listeners) listener();
+  };
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    setMode(mode) {
+      if (currentConfig.mode === mode) return;
+      currentConfig = { ...currentConfig, mode };
+      refresh();
+    },
+    setAccent(accent) {
+      if (currentConfig.accent === accent) return;
+      currentConfig = { ...currentConfig, accent };
+      refresh();
+    },
+    configure(nextConfig) {
+      currentConfig = { ...nextConfig, mode: nextConfig?.mode ?? "dark" };
+      refresh();
+    },
+    followRendererThemeMode(source) {
+      const apply = (mode: ResolvedThemeMode | null) => {
+        if (rendererMode === mode) return;
+        rendererMode = mode;
+        if (currentConfig.mode === "system") refresh();
+      };
+      apply(source.themeMode);
+      const listener = (mode: ResolvedThemeMode) => apply(mode);
+      source.on("theme_mode", listener);
+      return () => {
+        source.off("theme_mode", listener);
+      };
+    },
+  };
+}
+
+function sameSnapshot(a: SemanticThemeSnapshot, b: SemanticThemeSnapshot): boolean {
+  return (
+    a.mode === b.mode &&
+    a.setting === b.setting &&
+    rgbaKey(a.colors.accent) === rgbaKey(b.colors.accent) &&
+    rgbaKey(a.colors.foreground) === rgbaKey(b.colors.foreground) &&
+    rgbaKey(a.colors.mutedForeground) === rgbaKey(b.colors.mutedForeground) &&
+    rgbaKey(a.colors.status.blocked) === rgbaKey(b.colors.status.blocked) &&
+    rgbaKey(a.colors.status.working) === rgbaKey(b.colors.status.working) &&
+    rgbaKey(a.colors.status.done) === rgbaKey(b.colors.status.done) &&
+    rgbaKey(a.colors.status.idle) === rgbaKey(b.colors.status.idle) &&
+    rgbaKey(a.colors.status.unknown) === rgbaKey(b.colors.status.unknown) &&
+    a.glyphs.active === b.glyphs.active &&
+    a.glyphs.inactive === b.glyphs.inactive
+  );
+}
+
+const compatibilityTheme = DARK_THEME;
+
+export const DEFAULT_FG = compatibilityTheme.colors.foreground;
+export const DEFAULT_BG = compatibilityTheme.colors.background;
 
 /** The sidebar's surface — one lift above DEFAULT_BG so the nav column reads as
  *  chrome, not as content. */
-export const SIDEBAR_BG = RGBA.fromInts(22, 22, 30, 255);
-export const ACCENT = RGBA.fromInts(130, 170, 255, 255);
-export const MUTED = RGBA.fromInts(110, 110, 130, 255);
-export const BADGE_BG = RGBA.fromInts(60, 66, 92, 255);
+export const SIDEBAR_BG = compatibilityTheme.colors.surface;
+export const ACCENT = compatibilityTheme.colors.accent;
+export const MUTED = compatibilityTheme.colors.mutedForeground;
+export const BADGE_BG = compatibilityTheme.colors.accentMuted;
 
-/** Focused-pane gutter hairline (M22.7): the ACCENT family, drawn as │/─ glyphs
- *  so the gutter stays visually thin (a filled bar read as extra padding — user
- *  feedback). Doesn't compete with the blocked chip's red — focus is an accent
- *  signal, agent state is a status signal, never the same hue. */
-export const FOCUS_BORDER_FG = RGBA.fromInts(110, 145, 230, 255);
+/** Focused-pane gutter hairline: focus is an accent signal, not agent status. */
+export const FOCUS_BORDER_FG = compatibilityTheme.colors.focusBorder;
 
 /** The selected row/tab. Always wins over HOVER_BG. */
-export const TAB_ACTIVE_BG = RGBA.fromInts(40, 46, 66, 255);
+export const TAB_ACTIVE_BG = compatibilityTheme.colors.selection;
 
-/** A single subtle pointer-hover tint, one lift above both DEFAULT_BG (16,16,22)
- *  and SIDEBAR_BG (22,22,30) and below TAB_ACTIVE_BG — the active/selected state
- *  always wins over hover. Used on every hoverable row/segment. */
-export const HOVER_BG = RGBA.fromInts(30, 34, 48, 255);
+/** A single subtle pointer-hover tint. */
+export const HOVER_BG = compatibilityTheme.colors.hover;
 
 /** A chip/button under the pointer. */
-export const BUTTON_HOVER_BG = RGBA.fromInts(52, 60, 86, 255);
+export const BUTTON_HOVER_BG = compatibilityTheme.colors.buttonHover;
 
-/** The attention flash (M25.1): a just-flipped hidden agent's row pulses this
- *  for a beat — the status-strip note's "look here" twin. */
-export const CHIP_ATTN_BG = RGBA.fromInts(92, 44, 48, 255);
+/** The attention flash: a short-lived "look here" signal, distinct from focus. */
+export const CHIP_ATTN_BG = compatibilityTheme.colors.attention;


### PR DESCRIPTION
## Mission card

`tsk_m29_01_theme_foundation` — Build the semantic theme foundation.

## What changed

- adds typed, readonly semantic tokens for colors, status, focus, density, borders, and glyphs
- adds dark, light, and terminal-following `system` modes with a stable dark fallback
- adds a stable subscribed theme store with renderer `theme_mode` follow/unsubscribe lifecycle
- derives custom tmux/hex accents while keeping focus collision-safe against semantic statuses
- preserves the existing named dark RGBA exports as an app migration bridge
- persists `theme.mode` through the tolerant app config and adds pure settings rows/patches
- keeps the shared theme browser-safe by using only `RGBA.fromInts`
- documents the app-owned primitive/recipe boundary in `THEME.md`

## Review corrections included

- corrected normalized OpenTUI RGBA math
- preserved parity with the byte-based docs browser shim, including `#010101`
- handles the existing Coral preset colliding with blocked red without changing the saved accent
- checks focus and focus-border fallbacks against adversarial custom status overrides

## Validation

- focused theme/config/settings suite: 72 passed
- `pnpm --filter @tmux-ide/daemon typecheck`: passed
- `pnpm lint`: passed
- `pnpm format:check`: passed
- `pnpm test:tui-renderer`: 9 passed, 3 snapshots, 201 assertions
- docs build including the Vite browser-shim bundle: passed
- `pnpm check`: passed before the final focused collision guard; focused tests, daemon typecheck, format, and diff checks passed after it
- `git diff --check`: passed
