### PR TITLE
M29.2: add OpenTUI visual recipes and renderer gallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run typecheck:workspace && pnpm run test:unit && pnpm run test:tui-renderer && pnpm run docs:build && pnpm run pack:check && pnpm run check:native-deps",
     "postinstall": "node scripts/postinstall.js",
     "docs": "turbo run dev --filter=@tmux-ide/docs",
-    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx",
+    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx",
     "test:tui-smoke": "node scripts/smoke-tui-missions.mjs"
   },
   "keywords": [

--- a/packages/daemon/src/tui/mirror/RECIPES.md
+++ b/packages/daemon/src/tui/mirror/RECIPES.md
@@ -1,0 +1,59 @@
+# Visual recipe layer
+
+This directory keeps visual recipes app-owned. The recipe layer consumes
+`SemanticThemeSnapshot` tokens from `theme.ts`; it does not define a second
+palette or own global input.
+
+## Anatomy
+
+- `recipes.ts` is pure state, geometry, text, scrollbar, gallery, and hit-test
+  logic. It is safe to unit-test without OpenTUI rendering.
+- `recipes.tsx` is presentational Solid/OpenTUI composition over ordinary
+  `<box>`, `<text>`, and recipe props.
+- `recipes-gallery.tsx` is a deterministic renderer harness for dark/light
+  snapshots and interaction coverage.
+
+## State precedence
+
+Recipe visual state resolves in this order:
+
+`disabled > pressed > selected > focused > attention > hovered > loading > empty > status > base`
+
+The order is encoded in `RECIPE_STATE_PRECEDENCE` and enforced by
+`resolveRecipeState()`. Status color is semantic state; focus and selection are
+navigation state and must remain visually distinct through the theme layer.
+
+## Interaction ownership
+
+tmux-ide keeps one root keyboard owner and one central pointer router. Recipes
+are presentational: they can display selected/focused/hovered/pressed state, but
+they do not install global `useKeyboard` handlers or route pane/editor/dialog
+events. The gallery uses a root container and pure hit testing to exercise the
+same architecture without implying that recipes own app behavior.
+
+## TUIparts spike decisions
+
+- Button: pattern only for this card. TUIparts Button packages useful press
+  behavior, but tmux-ide already routes activation centrally. Adopting it now
+  would add a second behavior owner before surfaces are migrated.
+- Tabs: pattern only. TUIparts Tabs owns roving focus and selection; tmux-ide
+  hosted/composite views already have an authoritative model and hit-test path.
+- Input: pattern only. tmux-ide editor/search/prompt text is already routed
+  through app-owned buffers and dialog stack. Native OpenTUI Input remains useful
+  later for isolated prompts, but this card provides an `InputShell` recipe.
+- Dialog: defer. TUIparts Dialog is provider/root-keyboard/portal behavior; it
+  conflicts with the current one global dialog stack and overlay geometry unless
+  a later card deliberately replaces that stack.
+- Badge: adopt as an app-owned recipe shape. It has no reusable behavior, so a
+  local `Badge`/`StatusChip` is the correct layer.
+
+No `@tuiparts/solid` dependency is added. The small reusable ideas are the
+primitive-versus-recipe boundary and state render callback shape, not runtime
+code.
+
+## Card 03 migration path
+
+Migrate shell surfaces one strip at a time: tab bar chips, dialog rows, palette
+rows, Files/Diff rows, and Missions chrome. Each migration should preserve the
+existing pure geometry first, then replace repeated JSX with recipes that
+consume those geometry projections.

--- a/packages/daemon/src/tui/mirror/__snapshots__/recipes-gallery-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/__snapshots__/recipes-gallery-renderer.test.tsx.snap
@@ -1,0 +1,141 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`RecipesGallery OpenTUI renderer renders deterministic %sx%s dark gallery frame 1`] = `
+" tmux-ide recipe gallery · dark
+ ready
+┌─────────────────────────────────────┐  Board  History  Detail
+│ ○ Panel                             │  segmented control
+└─────────────────────────────────────┘
+ ○ SectionHeader · detail               │ Search…                              │
+○ consistent spacing               pure  shell only; app owns text
+
+● Blocked selected row keeps s… blocked t toggle theme
+! Attention beats pointer hover   flash enter activate focused recipe
+× Disabled row                   locked
+ › Run action                            ○ Nothing here
+ … Loading                                 empty/loading states stay explicit
+ × Disabled
+ blocked    done    idle                Scroll content                        █
+                                        top follows model                     ░
+                                                                              ░
+
+
+
+
+
+
+ tab/j move · enter/space activate · t theme · mouse selects"
+`;
+
+exports[`RecipesGallery OpenTUI renderer renders deterministic %sx%s light gallery frame 1`] = `
+" tmux-ide recipe gallery · light
+ ready
+┌─────────────────────────────────────┐  Board  History  Detail
+│ ○ Panel                             │  segmented control
+└─────────────────────────────────────┘
+ ○ SectionHeader · detail               │ Search…                              │
+○ consistent spacing               pure  shell only; app owns text
+
+● Blocked selected row keeps s… blocked t toggle theme
+! Attention beats pointer hover   flash enter activate focused recipe
+× Disabled row                   locked
+ › Run action                            ○ Nothing here
+ … Loading                                 empty/loading states stay explicit
+ × Disabled
+ blocked    done    idle                Scroll content                        █
+                                        top follows model                     ░
+                                                                              ░
+
+
+
+
+
+
+ tab/j move · enter/space activate · t theme · mouse selects"
+`;
+
+exports[`RecipesGallery OpenTUI renderer renders deterministic %sx%s dark gallery frame 2`] = `
+" tmux-ide recipe gallery · dark
+ ready
+┌─────────────────────────────────────────────────────────┐   Board  History  Detail
+│ ○ Panel                                                 │   segmented control
+└─────────────────────────────────────────────────────────┘
+ ○ SectionHeader · detail                                    │ Search…                                                 │
+○ consistent spacing                                   pure   shell only; app owns text
+
+● Blocked selected row keeps status marker          blocked  t toggle theme
+! Attention beats pointer hover                       flash  enter activate focused recipe
+× Disabled row                                       locked
+ › Run action                                                 ○ Nothing here
+ … Loading                                                      empty/loading states stay explicit
+ × Disabled
+ blocked    done    idle                                     Scroll content                                           █
+                                                             top follows model                                        ░
+                                                                                                                      ░
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ tab/j move · enter/space activate · t theme · mouse selects"
+`;
+
+exports[`RecipesGallery OpenTUI renderer renders deterministic %sx%s light gallery frame 2`] = `
+" tmux-ide recipe gallery · light
+ ready
+┌─────────────────────────────────────────────────────────┐   Board  History  Detail
+│ ○ Panel                                                 │   segmented control
+└─────────────────────────────────────────────────────────┘
+ ○ SectionHeader · detail                                    │ Search…                                                 │
+○ consistent spacing                                   pure   shell only; app owns text
+
+● Blocked selected row keeps status marker          blocked  t toggle theme
+! Attention beats pointer hover                       flash  enter activate focused recipe
+× Disabled row                                       locked
+ › Run action                                                 ○ Nothing here
+ … Loading                                                      empty/loading states stay explicit
+ × Disabled
+ blocked    done    idle                                     Scroll content                                           █
+                                                             top follows model                                        ░
+                                                                                                                      ░
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ tab/j move · enter/space activate · t theme · mouse selects"
+`;

--- a/packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx
@@ -1,0 +1,194 @@
+/* @jsxImportSource @opentui/solid */
+import { MouseButtons } from "@opentui/core/testing";
+import { testRender } from "@opentui/solid";
+import { afterEach, describe, expect, it } from "bun:test";
+import { RecipesGallery } from "./recipes-gallery.tsx";
+import {
+  createRecipeGalleryModel,
+  recipeGalleryHitTest,
+  recipeGalleryLayout,
+  recipeGalleryTheme,
+  type RecipeGalleryModel,
+} from "./recipes.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import { colorToThemeBytes } from "./theme.ts";
+
+type TestSetup = Awaited<ReturnType<typeof testRender>>;
+
+let setup: TestSetup | null = null;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = null;
+});
+
+function frameLines(frame: string): string[] {
+  const lines = frame.endsWith("\n") ? frame.slice(0, -1).split("\n") : frame.split("\n");
+  return lines.map((line) => line.replace(/\r$/u, ""));
+}
+
+function stableFrame(frame: string): string {
+  return frameLines(frame)
+    .map((line) => line.replace(/\s+$/u, ""))
+    .join("\n");
+}
+
+function expectFrameBounds(frame: string, width: number, height: number): void {
+  const lines = frameLines(frame);
+  expect(lines).toHaveLength(height);
+  for (const line of lines) {
+    expect(terminalDisplayWidth(line)).toBeLessThanOrEqual(width);
+  }
+}
+
+function colorKey(color: Parameters<typeof colorToThemeBytes>[0]): string {
+  return colorToThemeBytes(color).join(",");
+}
+
+function expectFrameShowsEveryRecipe(frame: string): void {
+  const stable = stableFrame(frame);
+  for (const label of [
+    "Panel",
+    "SectionHeader",
+    "Blocked selected row",
+    "Run action",
+    "blocked",
+    "Board  History  Detail",
+    "Search…",
+    "toggle theme",
+    "Nothing here",
+    "Scroll content",
+  ]) {
+    expect(stable).toContain(label);
+  }
+}
+
+function expectSemanticMarkerSpan(mode: "dark" | "light"): void {
+  const theme = recipeGalleryTheme(mode);
+  const spans = setup!.captureSpans();
+  const blockedLine = spans.lines.find((line) =>
+    line.spans.some((span) => span.text.includes("Blocked selected row")),
+  );
+  expect(blockedLine).toBeDefined();
+  const marker = blockedLine!.spans.find((span) => span.text === theme.glyphs.active);
+  expect(marker).toBeDefined();
+  expect(colorKey(marker!.fg)).toBe(colorKey(theme.colors.status.blocked));
+  expect(colorKey(marker!.bg)).toBe(colorKey(theme.colors.selection));
+}
+
+function expectInputPlaceholderSpan(mode: "dark" | "light"): void {
+  const theme = recipeGalleryTheme(mode);
+  const spans = setup!.captureSpans();
+  const inputLine = spans.lines.find((line) =>
+    line.spans.some((span) => span.text.includes("Search…")),
+  );
+  expect(inputLine).toBeDefined();
+  const placeholder = inputLine!.spans.find((span) => span.text.includes("Search…"));
+  expect(placeholder).toBeDefined();
+  expect(colorKey(placeholder!.fg)).toBe(colorKey(theme.colors.mutedForeground));
+}
+
+async function renderGallery(width: number, height: number, initial: RecipeGalleryModel) {
+  let model = initial;
+  setup = await testRender(
+    () => (
+      <RecipesGallery
+        width={width}
+        height={height}
+        initial={initial}
+        onModel={(next) => {
+          model = next;
+        }}
+      />
+    ),
+    { width, height },
+  );
+  await setup.renderOnce();
+  return {
+    model: () => model,
+    frame: () => setup!.captureCharFrame(),
+    clickItem: async (id: string) => {
+      const layout = recipeGalleryLayout(width, height, model.mode);
+      const item = layout.items.find((candidate) => candidate.id === id);
+      if (!item) throw new Error(`No gallery item ${id}`);
+      const x = item.x + Math.floor(item.width / 2);
+      const y = item.y + Math.floor(item.height / 2);
+      expect(recipeGalleryHitTest(layout, x, y)).toBe(id);
+      await setup!.mockMouse.click(x, y, MouseButtons.LEFT);
+      await setup!.renderOnce();
+    },
+  };
+}
+
+describe("RecipesGallery OpenTUI renderer", () => {
+  it.each([
+    [80, 24, "dark"],
+    [80, 24, "light"],
+    [120, 40, "dark"],
+    [120, 40, "light"],
+  ] as const)("renders deterministic %sx%s %s gallery frame", async (width, height, mode) => {
+    const harness = await renderGallery(width, height, createRecipeGalleryModel(mode));
+    const frame = harness.frame();
+    expectFrameBounds(frame, width, height);
+    expect(recipeGalleryLayout(width, height, mode).items.map((item) => item.id)).toEqual([
+      "surface",
+      "section",
+      "row",
+      "button",
+      "badge",
+      "tabs",
+      "input",
+      "keyhint",
+      "empty",
+      "scrollbar",
+    ]);
+    expectFrameShowsEveryRecipe(frame);
+    const input = recipeGalleryLayout(width, height, mode).items.find(
+      (item) => item.id === "input",
+    );
+    const inputShell = stableFrame(frame).match(/│ Search…\s*│/u)?.[0];
+    expect(input).toBeDefined();
+    expect(inputShell).toBeDefined();
+    expect(terminalDisplayWidth(inputShell!)).toBe(input!.width);
+    expectInputPlaceholderSpan(mode);
+    expectSemanticMarkerSpan(mode);
+    expect(stableFrame(frame)).toMatchSnapshot();
+    expect(stableFrame(frame)).toContain(`recipe gallery · ${mode}`);
+  });
+
+  it("updates the gallery through isolated keyboard commands", async () => {
+    const harness = await renderGallery(80, 24, createRecipeGalleryModel("dark"));
+    const initial = stableFrame(harness.frame());
+
+    await setup!.mockInput.pressKey("t");
+    await setup!.renderOnce();
+    expect(harness.model().mode).toBe("light");
+    expect(stableFrame(harness.frame())).toContain("light mode");
+
+    await setup!.mockInput.pressKey("j");
+    await setup!.renderOnce();
+    expect(harness.model().selectedId).toBe("badge");
+
+    setup!.mockInput.pressEnter();
+    await setup!.renderOnce();
+    expect(harness.model().pressedId).toBe("badge");
+    expect(stableFrame(harness.frame())).toContain("activated badge");
+    expect(stableFrame(harness.frame())).not.toBe(initial);
+  });
+
+  it("routes mouse selection through projected gallery hit geometry", async () => {
+    const harness = await renderGallery(120, 40, createRecipeGalleryModel("dark"));
+    await harness.clickItem("input");
+    expect(harness.model().selectedId).toBe("input");
+    expect(harness.model().pressedId).toBe("input");
+    const frame = stableFrame(harness.frame());
+    expect(frame).toContain("selected input");
+    expect(frame).toContain("typed query▏");
+  });
+
+  it("destroys cleanly without a hanging renderer", async () => {
+    await renderGallery(80, 24, createRecipeGalleryModel("dark"));
+    setup!.renderer.destroy();
+    setup = null;
+  });
+});

--- a/packages/daemon/src/tui/mirror/recipes-gallery.tsx
+++ b/packages/daemon/src/tui/mirror/recipes-gallery.tsx
@@ -1,0 +1,256 @@
+/* @jsxImportSource @opentui/solid */
+import { useKeyboard } from "@opentui/solid";
+import { createSignal, For } from "solid-js";
+import {
+  applyRecipeGalleryCommand,
+  createRecipeGalleryModel,
+  recipeGalleryCommandForKey,
+  recipeGalleryHitTest,
+  recipeGalleryLayout,
+  recipeGalleryTheme,
+  type RecipeGalleryLayout,
+  type RecipeGalleryModel,
+} from "./recipes.ts";
+import {
+  Badge,
+  Button,
+  EmptyState,
+  InputShell,
+  KeyHint,
+  Scrollbar,
+  SectionHeader,
+  SegmentedControl,
+  SelectableRow,
+  Surface,
+} from "./recipes.tsx";
+import { clipTerminal } from "./missions-workspace.ts";
+
+export interface RecipesGalleryProps {
+  width: number;
+  height: number;
+  initial?: RecipeGalleryModel;
+  onModel?: (model: RecipeGalleryModel) => void;
+}
+
+function RecipeItem(props: {
+  layout: RecipeGalleryLayout;
+  item: RecipeGalleryLayout["items"][number];
+  model: RecipeGalleryModel;
+}) {
+  const theme = () => recipeGalleryTheme(props.model.mode);
+  const active = () => props.model.selectedId === props.item.id;
+  const pressed = () => props.model.pressedId === props.item.id;
+  const bodyWidth = () => Math.max(0, props.item.width - 2);
+  return (
+    <box
+      x={props.item.x}
+      y={props.item.y}
+      width={props.item.width}
+      height={props.item.height}
+      flexDirection="column"
+      overflow="hidden"
+      position="absolute"
+    >
+      {props.item.kind === "surface" ? (
+        <Surface
+          theme={theme()}
+          title="Panel"
+          width={props.item.width}
+          height={props.item.height}
+          focused={active()}
+        >
+          <text fg={theme().colors.mutedForeground}> app-owned chrome </text>
+        </Surface>
+      ) : props.item.kind === "section" ? (
+        <>
+          <SectionHeader
+            theme={theme()}
+            title="SectionHeader"
+            detail="detail"
+            focused={active()}
+            width={props.item.width}
+          />
+          <SelectableRow
+            theme={theme()}
+            label="consistent spacing"
+            meta="pure"
+            width={props.item.width}
+          />
+        </>
+      ) : props.item.kind === "row" ? (
+        <>
+          <SelectableRow
+            theme={theme()}
+            label="Blocked selected row keeps status marker"
+            meta="blocked"
+            width={props.item.width}
+            selected
+            hovered
+            tone="blocked"
+            status="blocked"
+          />
+          <SelectableRow
+            theme={theme()}
+            label="Attention beats pointer hover"
+            meta="flash"
+            width={props.item.width}
+            attention
+            hovered
+          />
+          <SelectableRow
+            theme={theme()}
+            label="Disabled row"
+            meta="locked"
+            width={props.item.width}
+            disabled
+          />
+        </>
+      ) : props.item.kind === "button" ? (
+        <>
+          <Button
+            theme={theme()}
+            label="Run action"
+            width={Math.min(18, props.item.width)}
+            focused={active()}
+            pressed={pressed()}
+          />
+          <Button theme={theme()} label="Loading" width={Math.min(16, props.item.width)} loading />
+          <Button
+            theme={theme()}
+            label="Disabled"
+            width={Math.min(16, props.item.width)}
+            disabled
+          />
+        </>
+      ) : props.item.kind === "badge" ? (
+        <box flexDirection="row" gap={1} overflow="hidden">
+          <Badge theme={theme()} label="blocked" tone="blocked" width={10} />
+          <Badge theme={theme()} label="done" tone="done" width={7} />
+          <Badge theme={theme()} label="idle" tone="idle" width={7} />
+        </box>
+      ) : props.item.kind === "tabs" ? (
+        <>
+          <SegmentedControl
+            theme={theme()}
+            width={props.item.width}
+            activeId="board"
+            focusedId={active() ? "history" : undefined}
+            items={[
+              { id: "board", label: "Board" },
+              { id: "history", label: "History" },
+              { id: "detail", label: "Detail" },
+            ]}
+          />
+          <text fg={theme().colors.mutedForeground}> segmented control </text>
+        </>
+      ) : props.item.kind === "input" ? (
+        <>
+          <InputShell
+            theme={theme()}
+            value={active() ? "typed query" : ""}
+            placeholder="Search…"
+            width={props.item.width}
+            focused={active()}
+          />
+          <text fg={theme().colors.mutedForeground}> shell only; app owns text </text>
+        </>
+      ) : props.item.kind === "keyhint" ? (
+        <>
+          <KeyHint theme={theme()} keys="t" label="toggle theme" width={props.item.width} />
+          <KeyHint
+            theme={theme()}
+            keys="enter"
+            label="activate focused recipe"
+            width={props.item.width}
+          />
+        </>
+      ) : props.item.kind === "empty" ? (
+        <EmptyState
+          theme={theme()}
+          title="Nothing here"
+          detail="empty/loading states stay explicit"
+          width={props.item.width}
+        />
+      ) : (
+        <box flexDirection="row" overflow="hidden">
+          <box width={Math.max(1, bodyWidth())} flexDirection="column">
+            <text fg={theme().colors.foreground}>
+              {clipTerminal("Scroll content", bodyWidth())}
+            </text>
+            <text fg={theme().colors.mutedForeground}>
+              {clipTerminal("top follows model", bodyWidth())}
+            </text>
+          </box>
+          <Scrollbar
+            theme={theme()}
+            contentRows={24}
+            viewportRows={6}
+            top={active() ? 9 : 3}
+            height={props.item.height}
+          />
+        </box>
+      )}
+    </box>
+  );
+}
+
+export function RecipesGallery(props: RecipesGalleryProps) {
+  const [model, setModel] = createSignal(props.initial ?? createRecipeGalleryModel());
+  const updateModel = (next: RecipeGalleryModel) => {
+    setModel(next);
+    props.onModel?.(next);
+  };
+  const layout = () => recipeGalleryLayout(props.width, props.height, model().mode);
+  const theme = () => recipeGalleryTheme(model().mode);
+  useKeyboard((event) => {
+    const command = recipeGalleryCommandForKey(event.name, event.ctrl, event.meta);
+    if (command !== "none") updateModel(applyRecipeGalleryCommand(model(), command));
+  });
+  return (
+    <box
+      width={props.width}
+      height={props.height}
+      overflow="hidden"
+      backgroundColor={theme().colors.background}
+      onMouseDown={(event) => {
+        const hit = recipeGalleryHitTest(layout(), event.x, event.y);
+        if (hit) updateModel(applyRecipeGalleryCommand(model(), "none", hit));
+      }}
+    >
+      <box
+        x={0}
+        y={0}
+        width={props.width}
+        height={2}
+        position="absolute"
+        flexDirection="column"
+        overflow="hidden"
+      >
+        <text fg={theme().colors.accent}>
+          {clipTerminal(` tmux-ide recipe gallery · ${model().mode}`, props.width)}
+        </text>
+        <text fg={theme().colors.mutedForeground}>
+          {clipTerminal(` ${model().message}`, props.width)}
+        </text>
+      </box>
+      <For each={layout().items}>
+        {(item) => <RecipeItem layout={layout()} item={item} model={model()} />}
+      </For>
+      <box
+        x={0}
+        y={Math.max(0, props.height - 1)}
+        width={props.width}
+        height={1}
+        position="absolute"
+        overflow="hidden"
+      >
+        <text fg={theme().colors.mutedForeground}>
+          {clipTerminal(
+            " tab/j move · enter/space activate · t theme · mouse selects",
+            props.width,
+          )}
+        </text>
+      </box>
+    </box>
+  );
+}

--- a/packages/daemon/src/tui/mirror/recipes.test.ts
+++ b/packages/daemon/src/tui/mirror/recipes.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyRecipeGalleryCommand,
+  createRecipeGalleryModel,
+  recipeGalleryCommandForKey,
+  recipeGalleryHitTest,
+  recipeGalleryLayout,
+  recipeGalleryTheme,
+  recipePalette,
+  resolveRecipeState,
+  rowText,
+  scrollbarGlyphs,
+} from "./recipes.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import { colorToThemeBytes, createSemanticThemeSnapshot } from "./theme.ts";
+
+function colorKey(color: Parameters<typeof colorToThemeBytes>[0]): string {
+  return colorToThemeBytes(color).join(",");
+}
+
+describe("visual recipes", () => {
+  it("resolves recipe state precedence explicitly", () => {
+    expect(
+      resolveRecipeState({
+        disabled: true,
+        pressed: true,
+        selected: true,
+        focused: true,
+        hovered: true,
+        attention: true,
+        loading: true,
+        empty: true,
+        status: "working",
+      }),
+    ).toBe("disabled");
+    expect(resolveRecipeState({ pressed: true, selected: true })).toBe("pressed");
+    expect(resolveRecipeState({ selected: true, focused: true })).toBe("selected");
+    expect(resolveRecipeState({ focused: true, hovered: true, attention: true })).toBe("focused");
+    expect(resolveRecipeState({ hovered: true, attention: true })).toBe("attention");
+    expect(resolveRecipeState({ hovered: true, status: "blocked" })).toBe("hovered");
+    expect(resolveRecipeState({ status: "done" })).toBe("status");
+  });
+
+  it("keeps semantic status color orthogonal to selected interaction state", () => {
+    const theme = createSemanticThemeSnapshot({ mode: "dark" });
+    const blockedSelected = recipePalette(theme, {
+      selected: true,
+      hovered: true,
+      status: "blocked",
+    });
+    expect(blockedSelected.state).toBe("selected");
+    expect(colorKey(blockedSelected.background)).toBe(colorKey(theme.colors.selection));
+    expect(colorKey(blockedSelected.border)).toBe(colorKey(theme.colors.focusBorder));
+    expect(colorKey(blockedSelected.accent)).toBe(colorKey(theme.colors.status.blocked));
+  });
+
+  it("derives palettes from the semantic theme without a second hard-coded palette", () => {
+    const theme = createSemanticThemeSnapshot({ mode: "dark", accent: "#123456" });
+    const selected = recipePalette(theme, { selected: true });
+    const focused = recipePalette(theme, { focused: true });
+    const blocked = recipePalette(theme, { status: "blocked" });
+
+    expect(colorKey(selected.background)).toBe(colorKey(theme.colors.selection));
+    expect(colorKey(selected.border)).toBe(colorKey(theme.colors.focusBorder));
+    expect(colorKey(focused.accent)).toBe(colorKey(theme.colors.focus));
+    expect(colorKey(blocked.accent)).toBe(colorKey(theme.colors.status.blocked));
+  });
+
+  it("pins row metadata within the requested terminal width", () => {
+    const text = rowText(
+      "▶",
+      "A very long mission title that must not eat metadata",
+      "running · codex",
+      30,
+    );
+    expect(terminalDisplayWidth(text)).toBeLessThanOrEqual(30);
+    expect(text).toContain("running · codex");
+
+    const narrow = rowText("▶", "title", "running · codex", 8);
+    expect(terminalDisplayWidth(narrow)).toBeLessThanOrEqual(8);
+    expect(narrow).toContain("run");
+  });
+
+  it("projects scrollbar glyphs deterministically", () => {
+    expect(scrollbarGlyphs(5, 10, 0, 3)).toEqual(["░", "░", "░"]);
+    expect(scrollbarGlyphs(100, 10, 50, 5)).toEqual(["░", "░", "█", "░", "░"]);
+    expect(scrollbarGlyphs(0, 0, 0, 0)).toEqual([]);
+  });
+});
+
+describe("recipe gallery projection", () => {
+  it.each([
+    [80, 24, 2],
+    [120, 40, 2],
+  ] as const)("keeps %sx%s gallery geometry in bounds", (width, height, expectedColumns) => {
+    const layout = recipeGalleryLayout(width, height, "dark");
+    expect(layout.columns).toHaveLength(expectedColumns);
+    expect(layout.items.map((item) => item.id)).toEqual([
+      "surface",
+      "section",
+      "row",
+      "button",
+      "badge",
+      "tabs",
+      "input",
+      "keyhint",
+      "empty",
+      "scrollbar",
+    ]);
+    for (const rect of [layout.header, layout.footer, ...layout.columns, ...layout.items]) {
+      expect(rect.x).toBeGreaterThanOrEqual(0);
+      expect(rect.y).toBeGreaterThanOrEqual(0);
+      expect(rect.width).toBeGreaterThanOrEqual(0);
+      expect(rect.height).toBeGreaterThanOrEqual(0);
+      expect(rect.x + rect.width).toBeLessThanOrEqual(width);
+      expect(rect.y + rect.height).toBeLessThanOrEqual(height);
+    }
+  });
+
+  it("hit-tests recipe item rectangles from the same layout projection", () => {
+    const layout = recipeGalleryLayout(120, 40, "light");
+    const button = layout.items.find((item) => item.id === "button");
+    expect(button).toBeDefined();
+    expect(recipeGalleryHitTest(layout, button!.x, button!.y)).toBe("button");
+    expect(
+      recipeGalleryHitTest(
+        layout,
+        button!.x + Math.max(0, button!.width - 1),
+        button!.y + Math.max(0, button!.height - 1),
+      ),
+    ).toBe("button");
+    expect(recipeGalleryHitTest(layout, 119, 39)).toBeNull();
+  });
+
+  it("applies gallery commands without owning global routing", () => {
+    const model = createRecipeGalleryModel("dark");
+    expect(recipeGalleryCommandForKey("tab")).toBe("move-next");
+    expect(recipeGalleryCommandForKey("t")).toBe("toggle-mode");
+    expect(recipeGalleryCommandForKey("t", true)).toBe("none");
+
+    const next = applyRecipeGalleryCommand(model, "move-next");
+    expect(next.selectedId).not.toBe(model.selectedId);
+    const toggled = applyRecipeGalleryCommand(next, "toggle-mode");
+    expect(toggled.mode).toBe("light");
+    const clicked = applyRecipeGalleryCommand(toggled, "none", "input");
+    expect(clicked.selectedId).toBe("input");
+    expect(clicked.pressedId).toBe("input");
+  });
+
+  it("uses stable immutable dark/light gallery theme snapshots", () => {
+    const darkA = recipeGalleryTheme("dark");
+    const darkB = recipeGalleryTheme("dark");
+    const light = recipeGalleryTheme("light");
+    expect(darkA).toBe(darkB);
+    expect(darkA).not.toBe(light);
+    expect(Object.isFrozen(darkA.colors)).toBe(true);
+  });
+});

--- a/packages/daemon/src/tui/mirror/recipes.ts
+++ b/packages/daemon/src/tui/mirror/recipes.ts
@@ -1,0 +1,430 @@
+import type { RGBA } from "@opentui/core";
+import {
+  createSemanticThemeSnapshot,
+  type ResolvedThemeMode,
+  type SemanticThemeSnapshot,
+} from "./theme.ts";
+import { clipTerminal } from "./missions-workspace.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+
+export type RecipeTone = "neutral" | "accent" | "blocked" | "working" | "done" | "idle" | "unknown";
+
+export interface RecipeInteractionState {
+  selected?: boolean;
+  focused?: boolean;
+  hovered?: boolean;
+  pressed?: boolean;
+  disabled?: boolean;
+  attention?: boolean;
+  loading?: boolean;
+  empty?: boolean;
+  status?: Exclude<RecipeTone, "neutral" | "accent">;
+}
+
+export type RecipeResolvedState =
+  | "disabled"
+  | "pressed"
+  | "selected"
+  | "focused"
+  | "hovered"
+  | "attention"
+  | "loading"
+  | "empty"
+  | "status"
+  | "base";
+
+export interface RecipePalette {
+  state: RecipeResolvedState;
+  foreground: RGBA;
+  background: RGBA;
+  border: RGBA;
+  accent: RGBA;
+  marker: string;
+}
+
+export interface RecipeRowParts {
+  marker: string;
+  body: string;
+}
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface RecipeGalleryItem extends Rect {
+  id: string;
+  kind:
+    | "surface"
+    | "section"
+    | "row"
+    | "button"
+    | "badge"
+    | "tabs"
+    | "input"
+    | "keyhint"
+    | "empty"
+    | "scrollbar";
+  label: string;
+}
+
+export interface RecipeGalleryLayout {
+  width: number;
+  height: number;
+  mode: ResolvedThemeMode;
+  header: Rect;
+  footer: Rect;
+  columns: readonly Rect[];
+  items: readonly RecipeGalleryItem[];
+}
+
+export type RecipeGalleryCommand = "toggle-mode" | "move-next" | "move-prev" | "activate" | "none";
+
+export interface RecipeGalleryModel {
+  mode: ResolvedThemeMode;
+  selectedId: string;
+  pressedId: string | null;
+  message: string;
+}
+
+const STATE_ORDER: readonly RecipeResolvedState[] = [
+  "disabled",
+  "pressed",
+  "selected",
+  "focused",
+  "attention",
+  "hovered",
+  "loading",
+  "empty",
+  "status",
+  "base",
+];
+
+export const RECIPE_STATE_PRECEDENCE = STATE_ORDER;
+
+function statusColor(theme: SemanticThemeSnapshot, tone: RecipeTone | undefined): RGBA {
+  if (tone === "blocked") return theme.colors.status.blocked;
+  if (tone === "working") return theme.colors.status.working;
+  if (tone === "done") return theme.colors.status.done;
+  if (tone === "idle") return theme.colors.status.idle;
+  if (tone === "unknown") return theme.colors.status.unknown;
+  return theme.colors.mutedForeground;
+}
+
+export function resolveRecipeState(state: RecipeInteractionState): RecipeResolvedState {
+  if (state.disabled) return "disabled";
+  if (state.pressed) return "pressed";
+  if (state.selected) return "selected";
+  if (state.focused) return "focused";
+  if (state.attention) return "attention";
+  if (state.hovered) return "hovered";
+  if (state.loading) return "loading";
+  if (state.empty) return "empty";
+  if (state.status) return "status";
+  return "base";
+}
+
+function stateAccent(
+  theme: SemanticThemeSnapshot,
+  state: RecipeInteractionState,
+  fallback: RGBA,
+): RGBA {
+  return state.status ? statusColor(theme, state.status) : fallback;
+}
+
+export function recipePalette(
+  theme: SemanticThemeSnapshot,
+  state: RecipeInteractionState = {},
+  tone: RecipeTone = state.status ?? "neutral",
+): RecipePalette {
+  const resolved = resolveRecipeState(state);
+  if (resolved === "disabled") {
+    return {
+      state: resolved,
+      foreground: theme.colors.mutedForeground,
+      background: theme.colors.surface,
+      border: theme.colors.border,
+      accent: theme.colors.mutedForeground,
+      marker: "×",
+    };
+  }
+  if (resolved === "pressed") {
+    return {
+      state: resolved,
+      foreground: theme.colors.selectionForeground,
+      background: theme.colors.buttonHover,
+      border: theme.colors.focusBorder,
+      accent: theme.colors.focus,
+      marker: "◆",
+    };
+  }
+  if (resolved === "selected") {
+    return {
+      state: resolved,
+      foreground: theme.colors.selectionForeground,
+      background: theme.colors.selection,
+      border: theme.colors.focusBorder,
+      accent: stateAccent(theme, state, theme.colors.focus),
+      marker: theme.glyphs.active,
+    };
+  }
+  if (resolved === "focused") {
+    return {
+      state: resolved,
+      foreground: theme.colors.foreground,
+      background: theme.colors.surfaceRaised,
+      border: theme.colors.focusBorder,
+      accent: stateAccent(theme, state, theme.colors.focus),
+      marker: "›",
+    };
+  }
+  if (resolved === "hovered") {
+    return {
+      state: resolved,
+      foreground: theme.colors.foreground,
+      background: theme.colors.hover,
+      border: theme.colors.border,
+      accent: stateAccent(theme, state, theme.colors.accent),
+      marker: "·",
+    };
+  }
+  if (resolved === "attention") {
+    return {
+      state: resolved,
+      foreground: theme.colors.foreground,
+      background: theme.colors.attention,
+      border: theme.colors.focusBorder,
+      accent: stateAccent(theme, state, theme.colors.focus),
+      marker: "!",
+    };
+  }
+  if (resolved === "loading") {
+    return {
+      state: resolved,
+      foreground: theme.colors.mutedForeground,
+      background: theme.colors.surface,
+      border: theme.colors.border,
+      accent: theme.colors.status.working,
+      marker: "…",
+    };
+  }
+  if (resolved === "empty") {
+    return {
+      state: resolved,
+      foreground: theme.colors.mutedForeground,
+      background: theme.colors.background,
+      border: theme.colors.border,
+      accent: theme.colors.mutedForeground,
+      marker: "○",
+    };
+  }
+  if (resolved === "status") {
+    const accent = statusColor(theme, state.status);
+    return {
+      state: resolved,
+      foreground: theme.colors.foreground,
+      background: theme.colors.surface,
+      border: accent,
+      accent,
+      marker: theme.glyphs.active,
+    };
+  }
+  const accent = tone === "accent" ? theme.colors.accent : statusColor(theme, tone);
+  return {
+    state: resolved,
+    foreground: theme.colors.foreground,
+    background: theme.colors.surface,
+    border: theme.colors.border,
+    accent,
+    marker: theme.glyphs.inactive,
+  };
+}
+
+export function rowText(marker: string, label: string, meta: string, width: number): string {
+  const parts = rowParts(marker, label, meta, width);
+  return `${parts.marker}${parts.body}`;
+}
+
+export function rowParts(
+  marker: string,
+  label: string,
+  meta: string,
+  width: number,
+): RecipeRowParts {
+  if (width <= 0) return { marker: "", body: "" };
+  const markerPart = clipTerminal(marker, width);
+  const markerWidth = terminalDisplayWidth(markerPart);
+  const bodyWidth = Math.max(0, width - markerWidth);
+  if (bodyWidth <= 0) return { marker: markerPart, body: "" };
+  const prefix = " ";
+  const textWidth = Math.max(0, bodyWidth - 1);
+  if (!meta) return { marker: markerPart, body: `${prefix}${clipTerminal(label, textWidth)}` };
+  const metaWidth = terminalDisplayWidth(meta);
+  if (metaWidth + 1 >= textWidth) {
+    return { marker: markerPart, body: `${prefix}${clipTerminal(meta, textWidth)}` };
+  }
+  const titleWidth = Math.max(0, textWidth - metaWidth - 1);
+  const title = clipTerminal(label, titleWidth);
+  const gap = " ".repeat(Math.max(1, textWidth - terminalDisplayWidth(title) - metaWidth));
+  return { marker: markerPart, body: `${prefix}${title}${gap}${meta}` };
+}
+
+export function scrollbarGlyphs(
+  contentRows: number,
+  viewportRows: number,
+  top: number,
+  height: number,
+): readonly string[] {
+  if (height <= 0) return [];
+  if (contentRows <= viewportRows || contentRows <= 0)
+    return Array.from({ length: height }, () => "░");
+  const thumbHeight = Math.max(1, Math.floor((viewportRows / contentRows) * height));
+  const maxTop = Math.max(1, contentRows - viewportRows);
+  const thumbTop = Math.min(
+    height - thumbHeight,
+    Math.floor((top / maxTop) * (height - thumbHeight)),
+  );
+  return Array.from({ length: height }, (_, index) =>
+    index >= thumbTop && index < thumbTop + thumbHeight ? "█" : "░",
+  );
+}
+
+const GALLERY_ITEMS: readonly Omit<RecipeGalleryItem, keyof Rect>[] = [
+  { id: "surface", kind: "surface", label: "Surface / Panel" },
+  { id: "section", kind: "section", label: "SectionHeader" },
+  { id: "row", kind: "row", label: "SelectableRow" },
+  { id: "button", kind: "button", label: "Button / ActionChip" },
+  { id: "badge", kind: "badge", label: "Badge / StatusChip" },
+  { id: "tabs", kind: "tabs", label: "Tabs / SegmentedControl" },
+  { id: "input", kind: "input", label: "InputShell" },
+  { id: "keyhint", kind: "keyhint", label: "KeyHint" },
+  { id: "empty", kind: "empty", label: "EmptyState" },
+  { id: "scrollbar", kind: "scrollbar", label: "Scrollbar" },
+];
+
+export function createRecipeGalleryModel(mode: ResolvedThemeMode = "dark"): RecipeGalleryModel {
+  return { mode, selectedId: "button", pressedId: null, message: "ready" };
+}
+
+const GALLERY_THEME_DARK = createSemanticThemeSnapshot({ mode: "dark" });
+const GALLERY_THEME_LIGHT = createSemanticThemeSnapshot({ mode: "light" });
+
+export function recipeGalleryTheme(mode: ResolvedThemeMode): SemanticThemeSnapshot {
+  return mode === "light" ? GALLERY_THEME_LIGHT : GALLERY_THEME_DARK;
+}
+
+export function recipeGalleryLayout(
+  width: number,
+  height: number,
+  mode: ResolvedThemeMode,
+): RecipeGalleryLayout {
+  const safeWidth = Math.max(0, width);
+  const safeHeight = Math.max(0, height);
+  const header = { x: 0, y: 0, width: safeWidth, height: Math.min(2, safeHeight) };
+  const footerHeight = safeHeight > 0 ? 1 : 0;
+  const footer = {
+    x: 0,
+    y: Math.max(0, safeHeight - footerHeight),
+    width: safeWidth,
+    height: footerHeight,
+  };
+  const bodyY = header.height;
+  const bodyHeight = Math.max(0, safeHeight - header.height - footer.height);
+  const gap = safeWidth >= 96 ? 2 : 1;
+  const columnCount = safeWidth >= 80 && bodyHeight >= 15 ? 2 : 1;
+  const columnWidth = columnCount === 2 ? Math.floor((safeWidth - gap) / 2) : safeWidth;
+  const columns: Rect[] =
+    columnCount === 2
+      ? [
+          { x: 0, y: bodyY, width: columnWidth, height: bodyHeight },
+          {
+            x: columnWidth + gap,
+            y: bodyY,
+            width: safeWidth - columnWidth - gap,
+            height: bodyHeight,
+          },
+        ]
+      : [{ x: 0, y: bodyY, width: safeWidth, height: bodyHeight }];
+  const rowsPerColumn = Math.max(1, Math.ceil(GALLERY_ITEMS.length / columnCount));
+  const items: RecipeGalleryItem[] = [];
+  for (const [index, item] of GALLERY_ITEMS.entries()) {
+    const columnIndex = Math.min(columns.length - 1, Math.floor(index / rowsPerColumn));
+    const row = index % rowsPerColumn;
+    const column = columns[columnIndex];
+    if (!column) continue;
+    const y = column.y + row * 3;
+    if (y >= column.y + column.height) continue;
+    items.push({
+      ...item,
+      x: column.x,
+      y,
+      width: column.width,
+      height: Math.min(3, column.y + column.height - y),
+    });
+  }
+  return Object.freeze({
+    width: safeWidth,
+    height: safeHeight,
+    mode,
+    header,
+    footer,
+    columns: Object.freeze(columns),
+    items: Object.freeze(items),
+  });
+}
+
+export function recipeGalleryHitTest(
+  layout: RecipeGalleryLayout,
+  x: number,
+  y: number,
+): string | null {
+  for (const item of layout.items) {
+    if (x >= item.x && x < item.x + item.width && y >= item.y && y < item.y + item.height) {
+      return item.id;
+    }
+  }
+  return null;
+}
+
+export function recipeGalleryCommandForKey(
+  name: string,
+  ctrl = false,
+  meta = false,
+): RecipeGalleryCommand {
+  if (ctrl || meta) return "none";
+  if (name === "tab" || name === "down" || name === "right" || name === "j") return "move-next";
+  if (name === "up" || name === "left" || name === "k") return "move-prev";
+  if (name === "space" || name === "return" || name === "enter") return "activate";
+  if (name === "t") return "toggle-mode";
+  return "none";
+}
+
+export function applyRecipeGalleryCommand(
+  model: RecipeGalleryModel,
+  command: RecipeGalleryCommand,
+  itemId?: string | null,
+): RecipeGalleryModel {
+  const ids = GALLERY_ITEMS.map((item) => item.id);
+  const current = Math.max(0, ids.indexOf(model.selectedId));
+  if (itemId && ids.includes(itemId)) {
+    return { ...model, selectedId: itemId, pressedId: itemId, message: `selected ${itemId}` };
+  }
+  if (command === "toggle-mode") {
+    const mode = model.mode === "dark" ? "light" : "dark";
+    return { ...model, mode, message: `${mode} mode` };
+  }
+  if (command === "move-next") {
+    const selectedId = ids[(current + 1) % ids.length]!;
+    return { ...model, selectedId, pressedId: null, message: `focus ${selectedId}` };
+  }
+  if (command === "move-prev") {
+    const selectedId = ids[(current - 1 + ids.length) % ids.length]!;
+    return { ...model, selectedId, pressedId: null, message: `focus ${selectedId}` };
+  }
+  if (command === "activate") {
+    return { ...model, pressedId: model.selectedId, message: `activated ${model.selectedId}` };
+  }
+  return model;
+}

--- a/packages/daemon/src/tui/mirror/recipes.tsx
+++ b/packages/daemon/src/tui/mirror/recipes.tsx
@@ -1,0 +1,275 @@
+/* @jsxImportSource @opentui/solid */
+import type { JSX } from "@opentui/solid";
+import { For, Show } from "solid-js";
+import {
+  recipePalette,
+  rowParts,
+  scrollbarGlyphs,
+  type RecipeInteractionState,
+  type RecipeTone,
+} from "./recipes.ts";
+import type { SemanticThemeSnapshot } from "./theme.ts";
+import { clipTerminal } from "./missions-workspace.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+
+interface ThemeProps {
+  theme: SemanticThemeSnapshot;
+}
+
+export interface SurfaceProps extends ThemeProps {
+  title?: string;
+  height?: number;
+  width?: number;
+  focused?: boolean;
+  attention?: boolean;
+  children?: JSX.Element;
+}
+
+export function Surface(props: SurfaceProps) {
+  const palette = () =>
+    recipePalette(props.theme, { focused: props.focused, attention: props.attention });
+  return (
+    <box
+      width={props.width}
+      height={props.height}
+      border
+      borderColor={palette().border}
+      borderStyle={props.focused ? props.theme.borders.focusedStyle : props.theme.borders.style}
+      backgroundColor={props.theme.colors.background}
+      flexDirection="column"
+      overflow="hidden"
+    >
+      <Show when={props.title}>
+        {(title) => <SectionHeader theme={props.theme} title={title()} focused={props.focused} />}
+      </Show>
+      {props.children}
+    </box>
+  );
+}
+
+export interface SectionHeaderProps extends ThemeProps {
+  title: string;
+  detail?: string;
+  focused?: boolean;
+  width?: number;
+}
+
+export function SectionHeader(props: SectionHeaderProps) {
+  const palette = () => recipePalette(props.theme, { focused: props.focused });
+  const body = () => {
+    const detail = props.detail ? ` · ${props.detail}` : "";
+    return clipTerminal(` ${props.title}${detail}`, Math.max(0, (props.width ?? 200) - 3));
+  };
+  return (
+    <box height={1} backgroundColor={palette().background} overflow="hidden" flexDirection="row">
+      <text fg={palette().accent}>{` ${palette().marker}`}</text>
+      <text fg={palette().foreground}>{body()}</text>
+    </box>
+  );
+}
+
+export interface SelectableRowProps extends ThemeProps, RecipeInteractionState {
+  label: string;
+  meta?: string;
+  width: number;
+  tone?: RecipeTone;
+}
+
+export function SelectableRow(props: SelectableRowProps) {
+  const palette = () => recipePalette(props.theme, props, props.tone);
+  const parts = () => rowParts(palette().marker, props.label, props.meta ?? "", props.width);
+  return (
+    <box height={1} backgroundColor={palette().background} overflow="hidden" flexDirection="row">
+      <text fg={palette().accent}>{parts().marker}</text>
+      <text fg={palette().foreground}>{parts().body}</text>
+    </box>
+  );
+}
+
+export interface ButtonProps extends ThemeProps, RecipeInteractionState {
+  label: string;
+  tone?: RecipeTone;
+  width?: number;
+}
+
+export function Button(props: ButtonProps) {
+  const palette = () => recipePalette(props.theme, props, props.tone ?? "accent");
+  const marker = () => (props.loading ? "…" : palette().marker);
+  const body = () => {
+    const width = props.width ?? props.label.length + 4;
+    return `${clipTerminal(` ${props.label}`, Math.max(0, width - 3))} `;
+  };
+  return (
+    <box
+      height={1}
+      width={props.width}
+      backgroundColor={palette().background}
+      overflow="hidden"
+      flexDirection="row"
+    >
+      <text fg={palette().accent}>{` ${marker()}`}</text>
+      <text fg={palette().foreground}>{body()}</text>
+    </box>
+  );
+}
+
+export const ActionChip = Button;
+
+export interface BadgeProps extends ThemeProps {
+  label: string;
+  tone?: RecipeTone;
+  width?: number;
+  state?: RecipeInteractionState;
+}
+
+export function Badge(props: BadgeProps) {
+  const state = (): RecipeInteractionState => {
+    if (props.state) return props.state;
+    if (props.tone && props.tone !== "neutral" && props.tone !== "accent") {
+      return { status: props.tone };
+    }
+    return {};
+  };
+  const palette = () => recipePalette(props.theme, state(), props.tone);
+  const label = () =>
+    ` ${clipTerminal(props.label, Math.max(0, (props.width ?? props.label.length + 2) - 2))} `;
+  return (
+    <box height={1} width={props.width} backgroundColor={palette().accent} overflow="hidden">
+      <text fg={props.theme.colors.selectionForeground}>{label()}</text>
+    </box>
+  );
+}
+
+export const StatusChip = Badge;
+
+export interface TabItem {
+  id: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface SegmentedControlProps extends ThemeProps {
+  items: readonly TabItem[];
+  activeId: string;
+  focusedId?: string;
+  width: number;
+}
+
+export function SegmentedControl(props: SegmentedControlProps) {
+  return (
+    <box height={1} width={props.width} flexDirection="row" overflow="hidden">
+      <For each={props.items}>
+        {(item) => {
+          const palette = () =>
+            recipePalette(props.theme, {
+              selected: item.id === props.activeId,
+              focused: item.id === props.focusedId,
+              disabled: item.disabled,
+            });
+          const label = () => ` ${clipTerminal(item.label, 10)} `;
+          return (
+            <box height={1} backgroundColor={palette().background}>
+              <text fg={palette().foreground}>{label()}</text>
+            </box>
+          );
+        }}
+      </For>
+    </box>
+  );
+}
+
+export const Tabs = SegmentedControl;
+
+export interface InputShellProps extends ThemeProps {
+  value: string;
+  placeholder?: string;
+  focused?: boolean;
+  disabled?: boolean;
+  width: number;
+}
+
+export function InputShell(props: InputShellProps) {
+  const palette = () =>
+    recipePalette(props.theme, { focused: props.focused, disabled: props.disabled });
+  const value = () => props.value || props.placeholder || "";
+  const content = () => {
+    const cursor = props.focused && !props.disabled ? "▏" : "";
+    const width = Math.max(0, props.width - 4);
+    const clipped = clipTerminal(`${value()}${cursor}`, width);
+    return `${clipped}${" ".repeat(Math.max(0, width - terminalDisplayWidth(clipped)))}`;
+  };
+  return (
+    <box
+      height={1}
+      width={props.width}
+      backgroundColor={palette().background}
+      overflow="hidden"
+      flexDirection="row"
+    >
+      <text fg={palette().border}>│</text>
+      <text fg={props.value ? palette().foreground : props.theme.colors.mutedForeground}>
+        {` ${content()} `}
+      </text>
+      <text fg={palette().border}>│</text>
+    </box>
+  );
+}
+
+export interface KeyHintProps extends ThemeProps {
+  keys: string;
+  label: string;
+  width?: number;
+}
+
+export function KeyHint(props: KeyHintProps) {
+  return (
+    <box height={1} width={props.width} overflow="hidden" flexDirection="row">
+      <text fg={props.theme.colors.accent}>{props.keys}</text>
+      <text fg={props.theme.colors.mutedForeground}> {clipTerminal(props.label, 40)}</text>
+    </box>
+  );
+}
+
+export interface EmptyStateProps extends ThemeProps {
+  title: string;
+  detail?: string;
+  width: number;
+}
+
+export function EmptyState(props: EmptyStateProps) {
+  const palette = () => recipePalette(props.theme, { empty: true });
+  return (
+    <box width={props.width} height={2} flexDirection="column" overflow="hidden">
+      <box height={1} flexDirection="row" overflow="hidden">
+        <text fg={palette().accent}>{` ${palette().marker}`}</text>
+        <text fg={palette().foreground}>
+          {clipTerminal(` ${props.title}`, Math.max(0, props.width - 2))}
+        </text>
+      </box>
+      <text fg={props.theme.colors.mutedForeground}>
+        {clipTerminal(`   ${props.detail ?? ""}`, props.width)}
+      </text>
+    </box>
+  );
+}
+
+export interface ScrollbarProps extends ThemeProps {
+  contentRows: number;
+  viewportRows: number;
+  top: number;
+  height: number;
+}
+
+export function Scrollbar(props: ScrollbarProps) {
+  return (
+    <box width={1} height={props.height} flexDirection="column" overflow="hidden">
+      <For each={scrollbarGlyphs(props.contentRows, props.viewportRows, props.top, props.height)}>
+        {(glyph) => (
+          <text fg={glyph === "█" ? props.theme.colors.accent : props.theme.colors.border}>
+            {glyph}
+          </text>
+        )}
+      </For>
+    </box>
+  );
+}


### PR DESCRIPTION
## Summary
- add app-owned OpenTUI/Solid visual recipes derived from semantic theme tokens
- add a responsive 80x24/120x40 recipe gallery with isolated keyboard and mouse interaction
- document TUIparts adoption decisions and the Card 03 migration path
- add pure state/geometry tests plus dark/light native renderer snapshots and semantic span assertions

## Verification
- `pnpm check`
- 1,924 unit tests passed
- 16 OpenTUI renderer tests passed with 7 snapshots
- docs build, package dry-run, and native dependency check passed

Mission: M29, Card 02 (`tsk_m29_02_recipes_gallery`)
Commit: `c3bebce`