### PR TITLE
feat(tui): add responsive shell chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run typecheck:workspace && pnpm run test:unit && pnpm run test:tui-renderer && pnpm run docs:build && pnpm run pack:check && pnpm run check:native-deps",
     "postinstall": "node scripts/postinstall.js",
     "docs": "turbo run dev --filter=@tmux-ide/docs",
-    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx",
+    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx",
     "test:tui-smoke": "node scripts/smoke-tui-missions.mjs"
   },
   "keywords": [

--- a/packages/daemon/src/tui/mirror/SHELL_CHROME.md
+++ b/packages/daemon/src/tui/mirror/SHELL_CHROME.md
@@ -1,0 +1,39 @@
+# Responsive shell chrome
+
+The shell chrome boundary is split from app behavior:
+
+- `shell-chrome.ts` owns responsive geometry, tab labels/spans, overlay widths,
+  status/help text, and visual state precedence.
+- `shell-chrome.tsx` renders presentational Solid/OpenTUI pieces over the app's
+  existing root router. It does not install keyboard handlers in production.
+- `app.tsx` keeps the authoritative input owner, pointer routing, tmux pane
+  forwarding, lifecycle, and PaneSurface framebuffer path.
+
+## Responsive rules
+
+- `wide` starts at `160x45` and is verified at `200x60`.
+- `standard` starts at `96x30` and is verified at `120x40`.
+- `compact` covers smaller terminals and is verified at `80x24`.
+
+The sidebar stores a user-preferred width, but the rendered width is projected
+per terminal size. Compact mode caps the sidebar at 20 cells so the main surface
+keeps usable width; the preferred width is not overwritten by compact rendering.
+
+Palette and dialog widths are projected from the same shell layout. Their render
+placement and hit-test geometry consume the same values.
+
+## Visual semantics
+
+Navigation state and semantic state remain distinct:
+
+- active view: selection background;
+- keyboard focus: focus border/attributes;
+- pointer hover: hover background;
+- workspace context: accent foreground over raised surface, not alert styling;
+- agent attention: attention background and blocked-status border when otherwise
+  neutral; when combined with selection/hover/focus it keeps a distinct alert
+  marker/border so navigation state does not erase the semantic cue;
+- terminal focus: dedicated focus fill/marker.
+
+This mirrors the recipe layer: visual recipes can show state, but behavior stays
+with the central app router.

--- a/packages/daemon/src/tui/mirror/__snapshots__/shell-chrome-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/__snapshots__/shell-chrome-renderer.test.tsx.snap
@@ -1,0 +1,134 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`ShellChrome OpenTUI renderer renders deterministic %sx%s compact shell chrome 1`] = `
+" ⌂  !  ▤  ±  ◆                                 ready ⧉ web  !blocked F5 palette
+  tmux              ┌──────────────────────────────────────────────────────────┐
+ ● web              │ › compact workspace                                      │
+ ○ api              │● Active view and keyboard focus are selected     terminal│
+ ○ docs             │! Agent attention keeps blocked status             blocked│
+                    │· Pointer hover is a separate surface                hover│
+                    │▣ Terminal · terminals                                    │
+                    ││ Palette query…▏                  │                      │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    └──────────────────────────────────────────────────────────┘
+  F5 · ^q quit       terminal · ready · F5 palette"
+`;
+
+exports[`ShellChrome OpenTUI renderer renders deterministic %sx%s standard shell chrome 1`] = `
+" ⌂ Home  ! Terminal  ▤ Files  ± Diff  ◆ Missions                                       ready ⧉ web  !blocked F5 palette
+  tmux-ide                  ┌──────────────────────────────────────────────────────────────────────────────────────────┐
+ ● web                      │ › standard workspace                                                                     │
+ ○ api                      │● Active view and keyboard focus are selected                                     terminal│
+ ○ docs                     │! Agent attention keeps blocked status                                             blocked│
+                            │· Pointer hover is a separate surface                                                hover│
+                            │▣ Terminal · terminals                                                                    │
+                            ││ Palette query…▏                  │                                                      │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            └──────────────────────────────────────────────────────────────────────────────────────────┘
+  F5 palette · ^q quit       tmux-ide · terminal · ready · F5 palette · arrows move · ^q quit"
+`;
+
+exports[`ShellChrome OpenTUI renderer renders deterministic %sx%s wide shell chrome 1`] = `
+" F1 ⌂ Home  F2 ! Terminal  F3 ▤ Files  F4 ± Diff  F6 ◆ Missions                                                                                                        ready ⧉ web  !blocked F5 palette
+  tmux-ide                  ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+ ● web                      │ › wide workspace                                                                                                                                                         │
+ ○ api                      │● Active view and keyboard focus are selected                                                                                                                     terminal│
+ ○ docs                     │! Agent attention keeps blocked status                                                                                                                             blocked│
+                            │· Pointer hover is a separate surface                                                                                                                                hover│
+                            │▣ Terminal · terminals                                                                                                                                                    │
+                            ││ Palette query…▏                  │                                                                                                                                      │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+  F5 palette · ^q quit       tmux-ide · terminal · ready · F5 palette · arrows move · ^q quit"
+`;

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -226,6 +226,7 @@ import {
   MUTED,
   SIDEBAR_BG,
   TAB_ACTIVE_BG,
+  createSemanticThemeStore,
 } from "./theme.ts";
 import { rollupChips, homeFooterHints, type FleetRollup } from "../team/home.ts";
 import {
@@ -341,10 +342,8 @@ import {
   isHostedPanelInert,
   legacyTabFromPanelKind,
   navigateHostedPanel,
-  panelCell,
   panelKindFromLegacyTab,
   panelMode,
-  panelSpans,
   planHostedInitialActivation,
   planHostedReconciledActivation,
   planHostedViewActivation,
@@ -353,6 +352,8 @@ import {
   type HostedPanelKind,
   type HostedPanelView,
 } from "./panel-host.ts";
+import { ShellCompositeLeafChrome, ShellTabBar } from "./shell-chrome.tsx";
+import { shellChromeLayout, shellSidebarHint, shellSurfaceTabSpans } from "./shell-chrome.ts";
 import {
   MissionWorkspaceLoader,
   clipTerminal,
@@ -408,7 +409,6 @@ import {
   type WorkspaceViewState,
 } from "./workspace-ui-state.ts";
 import {
-  DIALOG_W,
   DIALOG_ROWS,
   dialogPos,
   dialogHeaderRows,
@@ -804,7 +804,6 @@ const HEADER_ROWS = 2;
 // sidebar + main region). Its height offsets every region's global y, so the
 // router subtracts it once (`gy = y - TABBAR_H`) before the per-mode math.
 const TABBAR_H = 1;
-const PALETTE_W = 60;
 const PALETTE_ROWS = 10;
 // ── M21.9 clickable-chip labels ─────────────────────────────────────────────
 // Fixed strings so the x-span math is constant (every glyph single-width). The
@@ -849,12 +848,6 @@ const WELCOME_ACTION_ROW = 3; // 0-based within the welcome block
 // quit" hint reads "detach" so the keycap tells the truth.
 const HOSTED = process.env.TMUX_IDE_HOSTED === "1";
 const QUIT_HINT = HOSTED ? "^q detach" : "^q quit";
-// The sidebar footer hint, split so its "F5 palette" segment is a chip: the
-// span starts after paddingLeft (1) + the pre text.
-const SIDEBAR_HINT_PRE = "F1-4/F6-13 views · ";
-const SIDEBAR_HINT_BTN = "F5 palette";
-const SIDEBAR_HINT_POST = ` · ${QUIT_HINT}`;
-const SIDEBAR_HINT_SPAN = { start: 1 + SIDEBAR_HINT_PRE.length, width: SIDEBAR_HINT_BTN.length };
 // Scrollback-search highlight backgrounds (M20.3), packed 0xRRGGBB to sit in a
 // run's `bg` (search paints a bg, distinct from selection's inverse video, so
 // the two coexist). Every visible match gets the dim accent; the CURRENT match
@@ -928,6 +921,24 @@ try {
     // a bare side-effect import of the module gets DCE'd by the transpiler.
     if (FB_PANES) registerPaneSurface();
     const dims = useTerminalDimensions();
+    const semanticThemeStore = createSemanticThemeStore(loadAppConfig().theme, {
+      rendererMode: appRenderer.themeMode,
+    });
+    const [semanticTheme, setSemanticTheme] = createSignal(semanticThemeStore.getSnapshot());
+    const disposeSemanticThemeStore = semanticThemeStore.subscribe(() =>
+      setSemanticTheme(semanticThemeStore.getSnapshot()),
+    );
+    const disposeRendererThemeMode = semanticThemeStore.followRendererThemeMode(appRenderer);
+    onCleanup(() => {
+      disposeRendererThemeMode();
+      disposeSemanticThemeStore();
+    });
+    const shellLayout = () => shellChromeLayout(dims().width, dims().height, preferredSidebarW());
+    const sidebarW = () => shellLayout().sidebar.width;
+    const sidebarHint = () => shellSidebarHint(shellLayout().variant, QUIT_HINT, sidebarW());
+    const paletteW = () => shellLayout().paletteWidth;
+    const dialogW = () => shellLayout().dialogWidth;
+    const dialogInnerWidth = () => dialogInnerW(dialogW());
     const canvasCols = () => Math.max(20, dims().width - sidebarW());
     const canvasRows = () => Math.max(4, dims().height - HEADER_ROWS - TABBAR_H);
 
@@ -958,7 +969,9 @@ try {
     // window-strip spans, the router's region math, the render widths) reads
     // `sidebarW()` so a boundary drag reflows the whole app. Restored from
     // app-state (clamped), re-clamped defensively, re-persisted on release.
-    const [sidebarW, setSidebarW] = createSignal(clampSidebarWidth(persisted.sidebarW));
+    const [preferredSidebarW, setPreferredSidebarW] = createSignal(
+      clampSidebarWidth(persisted.sidebarW),
+    );
     // Recently-opened folders (M22.5) — restored from app-state, prepended-to on
     // every folder open, persisted with the rest of the app state. Home renders
     // them under a "recent" header (deduped against sessions + the registry).
@@ -1048,7 +1061,9 @@ try {
     const activePanel = (): HostedPanelKind => focusedCompositeLeaf()?.panel ?? activeView().panel;
     const tab = (): Tab => legacyTabFromPanelKind(activePanel());
     const mode = (): "home" | "mirror" | "editor" | "diff" | "missions" => panelMode(activePanel());
-    const surfaceSpans = createMemo(() => panelSpans(hostedViews()));
+    const surfaceSpans = createMemo(() =>
+      shellSurfaceTabSpans(hostedViews(), shellLayout().variant),
+    );
     const [missionWorkspaceLoad, setMissionWorkspaceLoad] = createSignal<MissionWorkspaceLoadState>(
       {
         status: "loading",
@@ -3642,11 +3657,11 @@ try {
     const paletteCount = () => paletteBuffers()?.length ?? paletteRowList().length;
     /** The palette box geometry as placed by the render, for the router. */
     const paletteGeom = (): PaletteGeom => {
-      const { left, top } = palettePos(dims().width, dims().height, PALETTE_W);
+      const { left, top } = palettePos(dims().width, dims().height, paletteW());
       return {
         left,
         top,
-        width: PALETTE_W,
+        width: paletteW(),
         visibleRows: Math.min(PALETTE_ROWS, Math.max(0, paletteCount() - paletteTop())),
       };
     };
@@ -3917,7 +3932,7 @@ try {
     const dlgSelectSpec = () => dlgSelect()!.spec as DialogSelectSpec;
     const dlgPromptSpec = () => dlgPrompt()!.spec as DialogPromptSpec;
     const dlgConfirmSpec = () => dlgConfirm()!.spec as DialogConfirmSpec;
-    const DLG_INNER_W = dialogInnerW(DIALOG_W);
+
     /** The visible window of the top select's filtered rows (render + router). */
     const dlgVisibleItems = () => {
       dialogRev();
@@ -3929,7 +3944,7 @@ try {
      *  hit-tests the router (the palette's law). */
     const dialogGeomNow = (): DialogGeom => {
       const e = dialogStack.top()!;
-      const { left, top } = dialogPos(dims().width, dims().height, DIALOG_W);
+      const { left, top } = dialogPos(dims().width, dims().height, dialogW());
       const visibleRows =
         e.spec.kind === "select"
           ? Math.min(DIALOG_ROWS, Math.max(0, dialogStack.filtered().length - e.state.top))
@@ -3939,8 +3954,8 @@ try {
       return {
         left,
         top,
-        width: DIALOG_W,
-        headerRows: dialogHeaderRows(e.spec),
+        width: dialogW(),
+        headerRows: dialogHeaderRows(e.spec, dialogW()),
         visibleRows,
         footerRows: 1,
       };
@@ -4203,7 +4218,7 @@ try {
         contextSession: contextSession() || null,
         openFile: editorPath(),
         diffFile: diffVisibleFiles()[diffSel()]?.path ?? null,
-        sidebarW: sidebarW(),
+        sidebarW: preferredSidebarW(),
         recentFolders: recentFolders(),
         lastSpawns: lastSpawns(),
         customCommands: customCommands(),
@@ -5920,7 +5935,7 @@ try {
         // The sidebar footer's "F5 palette" segment is a chip (last screen row).
         if (y === dims().height - 1) {
           setHoverIf(
-            spanHit([SIDEBAR_HINT_SPAN], x) === 0 ? { region: "sidebtn", index: 0 } : null,
+            spanHit([sidebarHint().buttonSpan], x) === 0 ? { region: "sidebtn", index: 0 } : null,
           );
           return;
         }
@@ -6438,7 +6453,7 @@ try {
         const gy = y - TABBAR_H;
         if (x < sidebarW()) {
           if (y === dims().height - 1) {
-            if (spanHit([SIDEBAR_HINT_SPAN], x) === 0) openPalette();
+            if (spanHit([sidebarHint().buttonSpan], x) === 0) openPalette();
             return;
           }
           const hit = sidebarHit(gy, fleet().length, fleetAgents().length);
@@ -6551,7 +6566,7 @@ try {
         const isEnd = type === "up" || type === "drag-end" || type === "drop" || type === "out";
         if (isDrag || isEnd) {
           if (dragging.kind === "sidebar") {
-            setSidebarW(clampSidebarWidth(x));
+            setPreferredSidebarW(clampSidebarWidth(x));
           } else if (dragging.kind === "scrollbar") {
             // Absolute scroll: the pointer's row within the track maps to a top,
             // honoring the grab offset so the thumb tracks the cursor 1:1.
@@ -6713,7 +6728,7 @@ try {
         if (type !== "down") return;
         // The footer hint's "F5 palette" segment is a chip (last screen row).
         if (y === dims().height - 1) {
-          if (spanHit([SIDEBAR_HINT_SPAN], x) === 0) openPalette();
+          if (spanHit([sidebarHint().buttonSpan], x) === 0) openPalette();
           return;
         }
         // Session rows switch the workspace; agent rows JUMP to their exact pane
@@ -7072,18 +7087,14 @@ try {
     const compositeLeafChrome = (leaf: CompositePanelLeaf) => {
       const viewport = compositeLeafViewport(leaf.rect, 0);
       return (
-        <box
-          height={1}
-          flexDirection="row"
-          backgroundColor={leaf.focused ? TAB_ACTIVE_BG : GUTTER_BG}
-        >
-          <text fg={leaf.focused ? ACCENT : MUTED}>
-            {clipTerminal(
-              `${leaf.focused ? "●" : "○"} ${leaf.title} · ${leaf.panel}`,
-              viewport.innerWidth,
-            )}
-          </text>
-        </box>
+        <ShellCompositeLeafChrome
+          theme={semanticTheme()}
+          title={leaf.title}
+          panel={leaf.panel}
+          width={viewport.innerWidth}
+          focused={leaf.focused}
+          terminalFocused={leaf.panel === "terminals" && leaf.focused}
+        />
       );
     };
 
@@ -7407,44 +7418,21 @@ try {
           backgroundColor={TABBAR_BG}
           onMouse={(e: RouteEvent) => route(e)}
         >
-          <For each={hostedViews()}>
-            {(view, i) => (
-              <box
-                backgroundColor={
-                  activeViewId() === view.id
-                    ? ACCENT
-                    : isHovered("surfacetab", i())
-                      ? HOVER_BG
-                      : TABBAR_BG
-                }
-              >
-                <text
-                  fg={activeViewId() === view.id ? DEFAULT_BG : MUTED}
-                  attributes={activeViewId() === view.id ? 1 : 0}
-                >
-                  {panelCell(view)}
-                </text>
-              </box>
-            )}
-          </For>
-          <box flexGrow={1} />
-          <Show when={note()}>
-            <text fg={ACCENT} attributes={1}>{`${note()} `}</text>
-          </Show>
-          {/* Right-aligned CHIPS (M21.9): the workspace-context chip (click →
-            its Terminal) and the palette hint (click → open the palette). The
-            router hit-tests `tabbarButtons().spans` — the same defs walked
-            here, right-anchored, so the cells match exactly. */}
-          <For each={tabbarButtons().defs}>
-            {(b, i) => (
-              <text
-                fg={b.id === "tab-context" ? ACCENT : MUTED}
-                bg={isHovered("tabbtn", i()) ? BUTTON_HOVER_BG : TABBAR_BG}
-              >
-                {b.label}
-              </text>
-            )}
-          </For>
+          <ShellTabBar
+            theme={semanticTheme()}
+            width={dims().width}
+            variant={shellLayout().variant}
+            views={hostedViews()}
+            activeViewId={activeViewId()}
+            hoveredIndex={hover()?.region === "surfacetab" ? hover()!.index : null}
+            note={note()}
+            rightChips={tabbarButtons().defs.map((button, index) => ({
+              id: button.id,
+              label: button.label,
+              hovered: isHovered("tabbtn", index),
+              context: button.id === "tab-context",
+            }))}
+          />
         </box>
         <box flexDirection="row" flexGrow={1} backgroundColor={DEFAULT_BG} overflow="hidden">
           <Sidebar
@@ -7455,11 +7443,8 @@ try {
             nowSec={Math.floor(Date.now() / 1000)}
             isHovered={isHovered}
             flashed={(paneId: string) => attnFlash().has(paneId)}
-            hint={{
-              pre: SIDEBAR_HINT_PRE,
-              btn: SIDEBAR_HINT_BTN,
-              post: SIDEBAR_HINT_POST,
-            }}
+            variant={shellLayout().variant}
+            hint={sidebarHint()}
             onMouse={(e) => route(e as RouteEvent)}
           />
           <box
@@ -8185,9 +8170,9 @@ try {
         <Show when={paletteOpen()}>
           <box
             position="absolute"
-            left={palettePos(dims().width, dims().height, PALETTE_W).left}
-            top={palettePos(dims().width, dims().height, PALETTE_W).top}
-            width={PALETTE_W}
+            left={palettePos(dims().width, dims().height, paletteW()).left}
+            top={palettePos(dims().width, dims().height, paletteW()).top}
+            width={paletteW()}
             flexDirection="column"
             backgroundColor={PALETTE_BG}
             border
@@ -8208,7 +8193,7 @@ try {
                     </text>
                     <text fg={DEFAULT_FG}>{`${paletteQuery()}▏`}</text>
                   </box>
-                  <text fg={MUTED}>{"─".repeat(PALETTE_W - 4)}</text>
+                  <text fg={MUTED}>{"─".repeat(paletteW() - 4)}</text>
                   {/* Rows (M24.4): group headers render as inert muted lines;
                     action rows carry the selection prefix + a right-aligned
                     keycap (paletteRowText keeps the keycap inside the width
@@ -8235,7 +8220,7 @@ try {
                               paletteRowText(
                                 r.type === "action" ? r.action.label : "",
                                 r.type === "action" ? r.shortcut : null,
-                                PALETTE_W - 6,
+                                paletteW() - 6,
                               )}
                           </text>
                         </Show>
@@ -8255,7 +8240,7 @@ try {
                 <box flexGrow={1} />
                 <text fg={MUTED}>{"esc back"}</text>
               </box>
-              <text fg={MUTED}>{"─".repeat(PALETTE_W - 4)}</text>
+              <text fg={MUTED}>{"─".repeat(paletteW() - 4)}</text>
               <For each={paletteBuffers()!.slice(paletteTop(), paletteTop() + PALETTE_ROWS)}>
                 {(b, i) => (
                   <box
@@ -8390,9 +8375,9 @@ try {
         <Show when={dlgSelect()}>
           <box
             position="absolute"
-            left={dialogPos(dims().width, dims().height, DIALOG_W).left}
-            top={dialogPos(dims().width, dims().height, DIALOG_W).top}
-            width={DIALOG_W}
+            left={dialogPos(dims().width, dims().height, dialogW()).left}
+            top={dialogPos(dims().width, dims().height, dialogW()).top}
+            width={dialogW()}
             flexDirection="column"
             backgroundColor={PALETTE_BG}
             border
@@ -8401,7 +8386,7 @@ try {
             paddingRight={1}
           >
             <text fg={dlgAccent()} attributes={1}>
-              {dlgSelectSpec().title.slice(0, DLG_INNER_W).padEnd(DLG_INNER_W)}
+              {dlgSelectSpec().title.slice(0, dialogInnerWidth()).padEnd(dialogInnerWidth())}
             </text>
             <Show when={dlgSelectSpec().filterable !== false}>
               <box flexDirection="row">
@@ -8411,7 +8396,7 @@ try {
                 <text fg={DEFAULT_FG}>{`${dlgSelect()!.state.query}▏`}</text>
               </box>
             </Show>
-            <text fg={MUTED}>{"─".repeat(DLG_INNER_W)}</text>
+            <text fg={MUTED}>{"─".repeat(dialogInnerWidth())}</text>
             <For each={dlgVisibleItems()}>
               {(item, i) => {
                 const abs = () => dlgSelect()!.state.top + i();
@@ -8424,7 +8409,7 @@ try {
                   dialogRowText(item, {
                     selected: selected(),
                     armed: armed(),
-                    innerW: item.swatch ? DLG_INNER_W - 2 : DLG_INNER_W,
+                    innerW: item.swatch ? dialogInnerWidth() - 2 : dialogInnerWidth(),
                   }).slice(2);
                 const markerFg = () =>
                   item.current ? dlgAccent() : selected() ? DEFAULT_FG : MUTED;
@@ -8451,15 +8436,15 @@ try {
             <Show when={dlgVisibleItems().length === 0}>
               <text fg={MUTED}>{"  no matches"}</text>
             </Show>
-            <text fg={MUTED}>{selectFooter(dlgSelectSpec()).slice(0, DLG_INNER_W)}</text>
+            <text fg={MUTED}>{selectFooter(dlgSelectSpec()).slice(0, dialogInnerWidth())}</text>
           </box>
         </Show>
         <Show when={dlgPrompt()}>
           <box
             position="absolute"
-            left={dialogPos(dims().width, dims().height, DIALOG_W).left}
-            top={dialogPos(dims().width, dims().height, DIALOG_W).top}
-            width={DIALOG_W}
+            left={dialogPos(dims().width, dims().height, dialogW()).left}
+            top={dialogPos(dims().width, dims().height, dialogW()).top}
+            width={dialogW()}
             flexDirection="column"
             backgroundColor={PALETTE_BG}
             border
@@ -8468,9 +8453,9 @@ try {
             paddingRight={1}
           >
             <text fg={ACCENT} attributes={1}>
-              {dlgPromptSpec().title.slice(0, DLG_INNER_W).padEnd(DLG_INNER_W)}
+              {dlgPromptSpec().title.slice(0, dialogInnerWidth()).padEnd(dialogInnerWidth())}
             </text>
-            <text fg={MUTED}>{"─".repeat(DLG_INNER_W)}</text>
+            <text fg={MUTED}>{"─".repeat(dialogInnerWidth())}</text>
             <box flexDirection="row">
               <text fg={ACCENT} attributes={1}>
                 {"▸ "}
@@ -8486,16 +8471,16 @@ try {
             <text
               fg={promptFooter(dlgPromptSpec(), dlgPrompt()!.state).error ? DIFF_DEL_FG : MUTED}
             >
-              {promptFooter(dlgPromptSpec(), dlgPrompt()!.state).text.slice(0, DLG_INNER_W)}
+              {promptFooter(dlgPromptSpec(), dlgPrompt()!.state).text.slice(0, dialogInnerWidth())}
             </text>
           </box>
         </Show>
         <Show when={dlgConfirm()}>
           <box
             position="absolute"
-            left={dialogPos(dims().width, dims().height, DIALOG_W).left}
-            top={dialogPos(dims().width, dims().height, DIALOG_W).top}
-            width={DIALOG_W}
+            left={dialogPos(dims().width, dims().height, dialogW()).left}
+            top={dialogPos(dims().width, dims().height, dialogW()).top}
+            width={dialogW()}
             flexDirection="column"
             backgroundColor={PALETTE_BG}
             border
@@ -8504,10 +8489,14 @@ try {
             paddingRight={1}
           >
             <text fg={ACCENT} attributes={1}>
-              {dlgConfirmSpec().title.slice(0, DLG_INNER_W).padEnd(DLG_INNER_W)}
+              {dlgConfirmSpec().title.slice(0, dialogInnerWidth()).padEnd(dialogInnerWidth())}
             </text>
-            <text fg={MUTED}>{"─".repeat(DLG_INNER_W)}</text>
-            <For each={dlgConfirmSpec().body ? wrapText(dlgConfirmSpec().body!, DLG_INNER_W) : []}>
+            <text fg={MUTED}>{"─".repeat(dialogInnerWidth())}</text>
+            <For
+              each={
+                dlgConfirmSpec().body ? wrapText(dlgConfirmSpec().body!, dialogInnerWidth()) : []
+              }
+            >
               {(line) => <text fg={MUTED}>{line || " "}</text>}
             </For>
             <For each={confirmOptions(dlgConfirmSpec())}>
@@ -8516,7 +8505,7 @@ try {
                 return (
                   <box height={1} backgroundColor={selected() ? TAB_ACTIVE_BG : PALETTE_BG}>
                     <text fg={selected() ? DEFAULT_FG : MUTED}>
-                      {`${selected() ? "› " : "  "}${label}`.slice(0, DLG_INNER_W)}
+                      {`${selected() ? "› " : "  "}${label}`.slice(0, dialogInnerWidth())}
                     </text>
                   </box>
                 );

--- a/packages/daemon/src/tui/mirror/dialog-model.ts
+++ b/packages/daemon/src/tui/mirror/dialog-model.ts
@@ -214,11 +214,11 @@ export function dialogInnerW(width: number): number {
 }
 
 /** PURE — chrome rows above the first hit-testable row, per kind. */
-export function dialogHeaderRows(spec: DialogSpec): number {
+export function dialogHeaderRows(spec: DialogSpec, width = DIALOG_W): number {
   // top border + title + rule = 3 …
   if (spec.kind === "select") return spec.filterable === false ? 3 : 4; // … + filter input
   if (spec.kind === "prompt") return 3;
-  return 3 + (spec.body ? wrapText(spec.body, dialogInnerW(DIALOG_W)).length : 0);
+  return 3 + (spec.body ? wrapText(spec.body, dialogInnerW(width)).length : 0);
 }
 
 /** PURE — total box height for a geometry (empty lists still show one

--- a/packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx
@@ -1,0 +1,352 @@
+/* @jsxImportSource @opentui/solid */
+import { MouseButtons } from "@opentui/core/testing";
+import { testRender, useKeyboard } from "@opentui/solid";
+import { createSignal, onCleanup } from "solid-js";
+import { afterEach, describe, expect, it } from "bun:test";
+import { buildHostedPanelViews } from "./panel-host.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import {
+  ShellCompositeLeafChrome,
+  ShellMiniSidebar,
+  ShellStatusStrip,
+  ShellTabBar,
+} from "./shell-chrome.tsx";
+import {
+  shellChromeLayout,
+  shellSidebarHint,
+  shellSurfaceTabs,
+  shellVisualPalette,
+} from "./shell-chrome.ts";
+import {
+  createSemanticThemeSnapshot,
+  createSemanticThemeStore,
+  type ResolvedThemeMode,
+  type ThemeModeSource,
+} from "./theme.ts";
+import { Surface, SelectableRow, InputShell } from "./recipes.tsx";
+import { colorToThemeBytes } from "./theme.ts";
+
+type TestSetup = Awaited<ReturnType<typeof testRender>>;
+
+let setup: TestSetup | null = null;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = null;
+});
+
+const views = buildHostedPanelViews([
+  { id: "home", title: "Home", panel: "home" },
+  { id: "terminal", title: "Terminal", panel: "terminals" },
+  { id: "files", title: "Files", panel: "files" },
+  { id: "diff", title: "Diff", panel: "diff" },
+  { id: "missions", title: "Missions", panel: "missions" },
+]);
+
+function frameLines(frame: string): string[] {
+  const lines = frame.endsWith("\n") ? frame.slice(0, -1).split("\n") : frame.split("\n");
+  return lines.map((line) => line.replace(/\r$/u, ""));
+}
+
+function stableFrame(frame: string): string {
+  return frameLines(frame)
+    .map((line) => line.replace(/\s+$/u, ""))
+    .join("\n");
+}
+
+function expectFrameBounds(frame: string, width: number, height: number): void {
+  const lines = frameLines(frame);
+  expect(lines).toHaveLength(height);
+  for (const line of lines) expect(terminalDisplayWidth(line)).toBeLessThanOrEqual(width);
+}
+
+function colorKey(color: Parameters<typeof colorToThemeBytes>[0]): string {
+  return colorToThemeBytes(color).join(",");
+}
+
+class ThemeModeHarnessSource implements ThemeModeSource {
+  themeMode: ResolvedThemeMode | null = "dark";
+  listeners = new Set<(mode: ResolvedThemeMode) => void>();
+  on(_event: "theme_mode", listener: (mode: ResolvedThemeMode) => void): void {
+    this.listeners.add(listener);
+  }
+  off(_event: "theme_mode", listener: (mode: ResolvedThemeMode) => void): void {
+    this.listeners.delete(listener);
+  }
+  emit(mode: ResolvedThemeMode): void {
+    this.themeMode = mode;
+    for (const listener of this.listeners) listener(mode);
+  }
+}
+
+function expectSidebarHintCells(frame: string, width: number, height: number): void {
+  const layout = shellChromeLayout(width, height, 28);
+  const hint = shellSidebarHint(layout.variant, "^q quit", layout.sidebar.width);
+  const lines = frameLines(frame);
+  const footer = lines[height - 1] ?? "";
+  const sidebarCells = footer.slice(0, layout.sidebar.width);
+  expect(sidebarCells).toContain(hint.label);
+  expect(sidebarCells.indexOf(hint.label)).toBe(sidebarCells.lastIndexOf(hint.label));
+  expect(sidebarCells.slice(hint.inset, hint.inset + hint.label.length)).toBe(hint.label);
+  expect(
+    sidebarCells.slice(hint.buttonSpan.start, hint.buttonSpan.start + hint.buttonSpan.width),
+  ).toBe("F5");
+}
+
+function expectRenderedTabBoundaries(frame: string, width: number, height: number): void {
+  const layout = shellChromeLayout(width, height, 28);
+  const tabs = shellSurfaceTabs(views, "terminal", layout.variant, null, new Set(["terminal"]));
+  const top = frameLines(frame)[0] ?? "";
+  for (const tab of tabs) {
+    expect(top.slice(tab.span.start, tab.span.start + tab.span.width)).toBe(tab.label);
+  }
+}
+
+function ShellChromeHarness(props: { width: number; height: number }) {
+  const theme = createSemanticThemeSnapshot({ mode: "dark" });
+  const [active, setActive] = createSignal("terminal");
+  const [hovered, setHovered] = createSignal<number | null>(null);
+  const [message, setMessage] = createSignal("ready");
+  const layout = () => shellChromeLayout(props.width, props.height, 28);
+  const tabs = () => shellSurfaceTabs(views, active(), layout().variant, hovered());
+  const selectTab = (index: number) => {
+    const tab = tabs()[index];
+    if (!tab) return;
+    setActive(tab.id);
+    setMessage(`selected ${tab.id}`);
+  };
+  useKeyboard((event) => {
+    if (event.name === "right")
+      selectTab(Math.min(views.length - 1, tabs().findIndex((tab) => tab.id === active()) + 1));
+    else if (event.name === "left")
+      selectTab(Math.max(0, tabs().findIndex((tab) => tab.id === active()) - 1));
+    else if (event.name === "f5") setMessage("palette");
+  });
+  return (
+    <box
+      width={props.width}
+      height={props.height}
+      flexDirection="column"
+      overflow="hidden"
+      onMouseMove={(event) => {
+        const hit = tabs().findIndex(
+          (tab) =>
+            event.x >= tab.span.start && event.x < tab.span.start + tab.span.width && event.y === 0,
+        );
+        setHovered(hit >= 0 ? hit : null);
+      }}
+      onMouseDown={(event) => {
+        const hit = tabs().findIndex(
+          (tab) =>
+            event.x >= tab.span.start && event.x < tab.span.start + tab.span.width && event.y === 0,
+        );
+        if (hit >= 0) selectTab(hit);
+      }}
+    >
+      <ShellTabBar
+        theme={theme}
+        width={props.width}
+        variant={layout().variant}
+        views={views}
+        activeViewId={active()}
+        hoveredIndex={hovered()}
+        note={message()}
+        attentionViewIds={new Set(["terminal"])}
+        rightChips={[
+          { id: "context", label: "⧉ web ", context: true },
+          { id: "alert", label: "!blocked ", attention: true },
+          { id: "palette", label: "F5 palette ", hovered: message() === "palette" },
+        ]}
+      />
+      <box flexDirection="row" flexGrow={1} overflow="hidden">
+        <ShellMiniSidebar
+          theme={theme}
+          width={layout().sidebar.width}
+          variant={layout().variant}
+          active="web"
+          hint={shellSidebarHint(layout().variant, "^q quit", layout().sidebar.width)}
+          sessions={[
+            { name: "web", status: "working" },
+            { name: "api", status: "blocked" },
+            { name: "docs", status: "idle" },
+          ]}
+        />
+        <box flexDirection="column" flexGrow={1} overflow="hidden">
+          <Surface
+            theme={theme}
+            title={`${layout().variant} workspace`}
+            focused
+            width={layout().main.width}
+            height={Math.max(4, layout().main.height - 1)}
+          >
+            <SelectableRow
+              theme={theme}
+              label="Active view and keyboard focus are selected"
+              meta={active()}
+              width={Math.max(1, layout().main.width - 2)}
+              selected
+            />
+            <SelectableRow
+              theme={theme}
+              label="Agent attention keeps blocked status"
+              meta="blocked"
+              width={Math.max(1, layout().main.width - 2)}
+              attention
+              status="blocked"
+              tone="blocked"
+            />
+            <SelectableRow
+              theme={theme}
+              label="Pointer hover is a separate surface"
+              meta="hover"
+              width={Math.max(1, layout().main.width - 2)}
+              hovered
+            />
+            <ShellCompositeLeafChrome
+              theme={theme}
+              title="Terminal"
+              panel="terminals"
+              width={Math.max(1, layout().main.width - 2)}
+              focused
+              terminalFocused
+            />
+            <InputShell
+              theme={theme}
+              value=""
+              placeholder="Palette query…"
+              width={Math.min(36, layout().main.width - 2)}
+              focused
+            />
+          </Surface>
+          <ShellStatusStrip
+            theme={theme}
+            layout={layout()}
+            project="tmux-ide"
+            mode={active()}
+            notification={message()}
+            help="F5 palette · arrows move · ^q quit"
+          />
+        </box>
+      </box>
+    </box>
+  );
+}
+
+async function renderShell(width: number, height: number) {
+  setup = await testRender(() => <ShellChromeHarness width={width} height={height} />, {
+    width,
+    height,
+  });
+  await setup.renderOnce();
+  return {
+    frame: () => setup!.captureCharFrame(),
+  };
+}
+
+describe("ShellChrome OpenTUI renderer", () => {
+  it.each([
+    [80, 24, "compact"],
+    [120, 40, "standard"],
+    [200, 60, "wide"],
+  ] as const)("renders deterministic %sx%s %s shell chrome", async (width, height, variant) => {
+    const harness = await renderShell(width, height);
+    const frame = harness.frame();
+    expectFrameBounds(frame, width, height);
+    expect(stableFrame(frame)).toMatchSnapshot();
+    expect(stableFrame(frame)).toContain(`${variant} workspace`);
+    expect(stableFrame(frame)).toContain("F5");
+    expect(stableFrame(frame)).toContain("^q quit");
+    expectSidebarHintCells(frame, width, height);
+    expectRenderedTabBoundaries(frame, width, height);
+  });
+
+  it("drives keyboard navigation through the shell harness", async () => {
+    const harness = await renderShell(120, 40);
+    setup!.mockInput.pressArrow("right");
+    await setup!.renderOnce();
+    expect(stableFrame(harness.frame())).toContain("selected files");
+    await setup!.mockInput.pressKey("f5");
+    await setup!.renderOnce();
+    expect(stableFrame(harness.frame())).toContain("palette");
+  });
+
+  it("routes mouse hover/click from the same projected tab spans", async () => {
+    const harness = await renderShell(120, 40);
+    const layout = shellChromeLayout(120, 40, 28);
+    const tabs = shellSurfaceTabs(views, "terminal", layout.variant, null);
+    const frameTop = frameLines(harness.frame())[0]!;
+    const visualFilesStart = frameTop.indexOf(tabs.find((tab) => tab.id === "files")!.label);
+    expect(visualFilesStart).toBe(tabs.find((tab) => tab.id === "files")!.span.start);
+    const visualFilesCenter =
+      visualFilesStart + Math.floor(tabs.find((tab) => tab.id === "files")!.span.width / 2);
+    await setup!.mockMouse.moveTo(visualFilesCenter, 0);
+    await setup!.renderOnce();
+    await setup!.mockMouse.click(visualFilesCenter, 0, MouseButtons.LEFT);
+    await setup!.renderOnce();
+    expect(stableFrame(harness.frame())).toContain("selected files");
+  });
+
+  it("captures distinct semantic chrome spans", async () => {
+    await renderShell(120, 40);
+    const theme = createSemanticThemeSnapshot({ mode: "dark" });
+    const attentionPalette = shellVisualPalette(theme, { attention: true });
+    const contextPalette = shellVisualPalette(theme, { context: true });
+    const selectedAttention = shellVisualPalette(theme, { selected: true, attention: true });
+    const spans = setup!.captureSpans();
+    const contextChip = spans.lines
+      .flatMap((line) => line.spans)
+      .find((span) => span.text.includes("⧉ web"));
+    expect(contextChip).toBeDefined();
+    expect(colorKey(contextChip!.bg)).toBe(colorKey(contextPalette.bg));
+    expect(colorKey(contextChip!.bg)).not.toBe(colorKey(theme.colors.attention));
+
+    const tabAttentionMarker = spans.lines[0]!.spans.find((span) => span.text === "!");
+    expect(tabAttentionMarker).toBeDefined();
+    expect(colorKey(tabAttentionMarker!.fg)).toBe(colorKey(theme.colors.status.blocked));
+    expect(colorKey(tabAttentionMarker!.bg)).toBe(colorKey(selectedAttention.bg));
+
+    const attentionLine = spans.lines.find((line) =>
+      line.spans.some((span) => span.text.includes("Agent attention")),
+    );
+    expect(attentionLine).toBeDefined();
+    const marker = attentionLine!.spans.find((span) => span.text === "!")!;
+    expect(marker).toBeDefined();
+    expect(colorKey(marker.bg)).toBe(colorKey(attentionPalette.bg));
+  });
+
+  it("updates shell colors from renderer theme_mode without rebuilding an input owner", async () => {
+    const source = new ThemeModeHarnessSource();
+    function ThemeModeShell() {
+      const store = createSemanticThemeStore({ mode: "system" });
+      const [theme, setTheme] = createSignal(store.getSnapshot());
+      const unsubscribe = store.subscribe(() => setTheme(store.getSnapshot()));
+      const unfollow = store.followRendererThemeMode(source);
+      onCleanup(() => {
+        unfollow();
+        unsubscribe();
+      });
+      return (
+        <ShellTabBar
+          theme={theme()}
+          width={80}
+          variant="compact"
+          views={views}
+          activeViewId="terminal"
+          hoveredIndex={null}
+        />
+      );
+    }
+
+    setup = await testRender(() => <ThemeModeShell />, { width: 80, height: 4 });
+    await setup.renderOnce();
+    const darkBg = setup
+      .captureSpans()
+      .lines[0]!.spans.find((span) => span.text.includes(" ❯ "))!.bg;
+    source.emit("light");
+    await setup.renderOnce();
+    const lightBg = setup
+      .captureSpans()
+      .lines[0]!.spans.find((span) => span.text.includes(" ❯ "))!.bg;
+    expect(colorKey(lightBg)).not.toBe(colorKey(darkBg));
+  });
+});

--- a/packages/daemon/src/tui/mirror/shell-chrome.test.ts
+++ b/packages/daemon/src/tui/mirror/shell-chrome.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  shellChromeLayout,
+  shellChromeVariant,
+  shellOverlayWidth,
+  shellSidebarHint,
+  shellStatusLine,
+  shellSurfaceTabs,
+  shellVisualPalette,
+} from "./shell-chrome.ts";
+import { buildHostedPanelViews } from "./panel-host.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import {
+  colorToThemeBytes,
+  createSemanticThemeSnapshot,
+  createSemanticThemeStore,
+  type ResolvedThemeMode,
+  type ThemeModeSource,
+} from "./theme.ts";
+
+function key(color: Parameters<typeof colorToThemeBytes>[0]): string {
+  return colorToThemeBytes(color).join(",");
+}
+
+const views = buildHostedPanelViews([
+  { id: "home", title: "Home", panel: "home" },
+  { id: "terminal", title: "Terminal", panel: "terminals" },
+  { id: "files", title: "Files", panel: "files" },
+  { id: "diff", title: "Diff", panel: "diff" },
+  { id: "missions", title: "Missions", panel: "missions" },
+]);
+
+describe("shell chrome responsive projection", () => {
+  it.each([
+    [80, 24, "compact", 20],
+    [120, 40, "standard", 28],
+    [200, 60, "wide", 28],
+  ] as const)("projects %sx%s as %s", (width, height, variant, sidebarWidth) => {
+    const layout = shellChromeLayout(width, height, 28);
+    expect(layout.variant).toBe(variant);
+    expect(layout.sidebar.width).toBe(sidebarWidth);
+    expect(layout.main.x).toBe(layout.sidebar.width);
+    expect(layout.main.width + layout.sidebar.width).toBe(width);
+    expect(layout.paletteWidth).toBe(shellOverlayWidth(width, variant, "palette"));
+    expect(layout.dialogWidth).toBe(shellOverlayWidth(width, variant, "dialog"));
+  });
+
+  it("keeps surface tab labels and spans deterministic by variant", () => {
+    const compact = shellSurfaceTabs(views, "files", "compact", 1);
+    expect(compact.map((tab) => tab.label)).toEqual([" ⌂ ", " ❯ ", " ▤ ", " ± ", " ◆ "]);
+    expect(compact[1]!.hovered).toBe(true);
+    expect(compact[2]!.selected).toBe(true);
+    expect(compact.map((tab) => tab.span.start)).toEqual([0, 3, 6, 9, 12]);
+
+    const wide = shellSurfaceTabs(views, "missions", "wide", null);
+    expect(wide[0]!.label).toContain("F1");
+    expect(wide[4]!.label).toContain("F6");
+    expect(wide[4]!.selected).toBe(true);
+  });
+
+  it("keeps attention inside fixed-width tab labels and spans", () => {
+    const alerted = shellSurfaceTabs(views, "terminal", "standard", null, new Set(["terminal"]));
+    const normal = shellSurfaceTabs(views, "terminal", "standard", null);
+    expect(alerted[1]!.label).toBe(" ! Terminal ");
+    expect(alerted[1]!.span).toEqual(normal[1]!.span);
+    expect(alerted[2]!.span).toEqual(normal[2]!.span);
+    expect(alerted.map((tab) => tab.span.start)).toEqual(normal.map((tab) => tab.span.start));
+  });
+
+  it.each([
+    ["compact", 16, "^q quit"],
+    ["compact", 20, "^q detach"],
+    ["standard", 28, "^q quit"],
+    ["wide", 28, "^q detach"],
+  ] as const)("projects width-aware %s sidebar hint spans", (variant, width, quitHint) => {
+    const hint = shellSidebarHint(variant, quitHint, width);
+    expect(terminalDisplayWidth(hint.label)).toBeLessThanOrEqual(width);
+    expect(hint.label).toContain("F5");
+    expect(hint.label).toContain(quitHint.includes("detach") ? "^q detach" : "^q quit");
+    expect(hint.pre + hint.btn + hint.post).toBe(hint.label);
+    expect(hint.inset).toBe(2);
+    expect(hint.buttonSpan.width).toBe(2);
+    expect(
+      `${" ".repeat(hint.inset)}${hint.label}`.slice(
+        hint.buttonSpan.start,
+        hint.buttonSpan.start + 2,
+      ),
+    ).toBe("F5");
+    expect(hint.buttonSpan.start + hint.buttonSpan.width).toBeLessThanOrEqual(width);
+  });
+
+  it("keeps active view, keyboard focus, hover, attention, and terminal focus visually distinct", () => {
+    const theme = createSemanticThemeSnapshot({ mode: "dark" });
+    const selected = shellVisualPalette(theme, { selected: true, focused: true });
+    const hovered = shellVisualPalette(theme, { hovered: true });
+    const context = shellVisualPalette(theme, { context: true });
+    const attention = shellVisualPalette(theme, { attention: true });
+    const selectedAttention = shellVisualPalette(theme, {
+      selected: true,
+      focused: true,
+      attention: true,
+    });
+    const terminal = shellVisualPalette(theme, { terminalFocus: true });
+
+    expect(key(selected.bg)).toBe(key(theme.colors.selection));
+    expect(key(hovered.bg)).toBe(key(theme.colors.hover));
+    expect(key(context.bg)).not.toBe(key(theme.colors.attention));
+    expect(key(context.fg)).toBe(key(theme.colors.accent));
+    expect(key(attention.bg)).toBe(key(theme.colors.attention));
+    expect(key(attention.border)).toBe(key(theme.colors.status.blocked));
+    expect(key(selectedAttention.bg)).toBe(key(theme.colors.selection));
+    expect(selectedAttention.marker).toBe("!");
+    expect(key(selectedAttention.border)).toBe(key(theme.colors.status.blocked));
+    expect(key(terminal.bg)).toBe(key(theme.colors.focus));
+    expect(
+      new Set([selected.marker, hovered.marker, context.marker, attention.marker, terminal.marker])
+        .size,
+    ).toBe(5);
+  });
+
+  it("follows renderer theme_mode through the semantic theme store subscription", () => {
+    class Source implements ThemeModeSource {
+      themeMode: ResolvedThemeMode | null = "dark";
+      listeners = new Set<(mode: ResolvedThemeMode) => void>();
+      on(_event: "theme_mode", listener: (mode: ResolvedThemeMode) => void): void {
+        this.listeners.add(listener);
+      }
+      off(_event: "theme_mode", listener: (mode: ResolvedThemeMode) => void): void {
+        this.listeners.delete(listener);
+      }
+      emit(mode: ResolvedThemeMode): void {
+        this.themeMode = mode;
+        for (const listener of this.listeners) listener(mode);
+      }
+    }
+
+    const source = new Source();
+    const store = createSemanticThemeStore({ mode: "system" });
+    let current = store.getSnapshot();
+    const unsubscribe = store.subscribe(() => {
+      current = store.getSnapshot();
+    });
+    const unfollow = store.followRendererThemeMode(source);
+
+    expect(current.mode).toBe("dark");
+    source.emit("light");
+    expect(current.mode).toBe("light");
+    store.setMode("dark");
+    source.emit("dark");
+    expect(current.mode).toBe("dark");
+    store.setMode("system");
+    source.emit("light");
+    expect(current.mode).toBe("light");
+
+    unfollow();
+    unsubscribe();
+    source.emit("dark");
+    expect(current.mode).toBe("light");
+  });
+
+  it("clips status/help strip by responsive variant", () => {
+    expect(shellChromeVariant(200, 60)).toBe("wide");
+    const compact = shellStatusLine(
+      "compact",
+      {
+        project: "project",
+        mode: "Missions",
+        notification: "blocked agent",
+        help: "F5 palette · ^q quit",
+      },
+      24,
+    );
+    expect(compact).toContain("Missions");
+    expect(compact.length).toBeLessThanOrEqual(24);
+  });
+});

--- a/packages/daemon/src/tui/mirror/shell-chrome.ts
+++ b/packages/daemon/src/tui/mirror/shell-chrome.ts
@@ -1,0 +1,307 @@
+import type { RGBA } from "@opentui/core";
+import type { HostedPanelView } from "./panel-host.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import type { Rect } from "./recipes.ts";
+import type { SemanticThemeSnapshot } from "./theme.ts";
+import type { Span } from "./spans.ts";
+
+export type ShellChromeVariant = "compact" | "standard" | "wide";
+
+export interface ShellChromeLayout {
+  width: number;
+  height: number;
+  variant: ShellChromeVariant;
+  tabbar: Rect;
+  sidebar: Rect;
+  main: Rect;
+  status: Rect;
+  paletteWidth: number;
+  dialogWidth: number;
+}
+
+export interface ShellTabPresentation {
+  id: string;
+  label: string;
+  span: Span;
+  selected: boolean;
+  focused: boolean;
+  hovered: boolean;
+  attention: boolean;
+}
+
+export interface ShellSidebarHint {
+  pre: string;
+  btn: string;
+  post: string;
+  buttonSpan: Span;
+  label: string;
+  inset: number;
+}
+
+export interface ShellVisualState {
+  selected?: boolean;
+  focused?: boolean;
+  hovered?: boolean;
+  context?: boolean;
+  attention?: boolean;
+  terminalFocus?: boolean;
+}
+
+export interface ShellVisualPalette {
+  fg: RGBA;
+  bg: RGBA;
+  border: RGBA;
+  marker: string;
+  attributes: number;
+}
+
+export const SHELL_TABBAR_ROWS = 1;
+export const SHELL_STATUS_ROWS = 1;
+
+export function shellChromeVariant(width: number, height: number): ShellChromeVariant {
+  if (width >= 160 && height >= 45) return "wide";
+  if (width >= 96 && height >= 30) return "standard";
+  return "compact";
+}
+
+export function shellOverlayWidth(
+  terminalWidth: number,
+  variant: ShellChromeVariant,
+  kind: "palette" | "dialog",
+): number {
+  const safe = Math.max(20, Math.floor(terminalWidth));
+  const margin = variant === "compact" ? 2 : 4;
+  const preferred =
+    kind === "palette" ? (variant === "wide" ? 72 : 60) : variant === "wide" ? 72 : 60;
+  return Math.max(32, Math.min(preferred, safe - margin));
+}
+
+export function shellSidebarWidth(
+  terminalWidth: number,
+  preferredWidth: number,
+  variant = shellChromeVariant(terminalWidth, 24),
+): number {
+  const safe = Math.max(20, Math.floor(terminalWidth));
+  const preferred = Math.max(16, Math.min(48, Math.floor(preferredWidth)));
+  if (variant === "compact") return Math.min(preferred, Math.max(16, Math.min(20, safe - 48)));
+  if (variant === "standard") return Math.min(preferred, 32);
+  return preferred;
+}
+
+export function shellChromeLayout(
+  width: number,
+  height: number,
+  preferredSidebarWidth: number,
+): ShellChromeLayout {
+  const safeWidth = Math.max(0, Math.floor(width));
+  const safeHeight = Math.max(0, Math.floor(height));
+  const variant = shellChromeVariant(safeWidth, safeHeight);
+  const sidebarWidth =
+    safeHeight > SHELL_TABBAR_ROWS
+      ? shellSidebarWidth(safeWidth, preferredSidebarWidth, variant)
+      : 0;
+  const statusHeight = safeHeight >= 8 ? SHELL_STATUS_ROWS : 0;
+  const bodyY = Math.min(SHELL_TABBAR_ROWS, safeHeight);
+  const bodyHeight = Math.max(0, safeHeight - bodyY);
+  return {
+    width: safeWidth,
+    height: safeHeight,
+    variant,
+    tabbar: { x: 0, y: 0, width: safeWidth, height: Math.min(SHELL_TABBAR_ROWS, safeHeight) },
+    sidebar: { x: 0, y: bodyY, width: sidebarWidth, height: bodyHeight },
+    main: {
+      x: sidebarWidth,
+      y: bodyY,
+      width: Math.max(0, safeWidth - sidebarWidth),
+      height: bodyHeight,
+    },
+    status: {
+      x: sidebarWidth,
+      y: Math.max(bodyY, safeHeight - statusHeight),
+      width: Math.max(0, safeWidth - sidebarWidth),
+      height: statusHeight,
+    },
+    paletteWidth: shellOverlayWidth(safeWidth, variant, "palette"),
+    dialogWidth: shellOverlayWidth(safeWidth, variant, "dialog"),
+  };
+}
+
+export function shellPanelCell(
+  view: Pick<HostedPanelView, "glyph" | "title" | "shortcut">,
+  variant: ShellChromeVariant,
+  attention = false,
+): string {
+  const glyph = attention ? "!" : view.glyph;
+  if (variant === "compact") return ` ${glyph} `;
+  const shortcut = view.shortcut ? `${view.shortcut.label} ` : "";
+  if (variant === "standard") return ` ${glyph} ${view.title} `;
+  return ` ${shortcut}${glyph} ${view.title} `;
+}
+
+export function shellSurfaceTabs(
+  views: readonly HostedPanelView[],
+  activeViewId: string,
+  variant: ShellChromeVariant,
+  hoveredIndex: number | null,
+  attentionViewIds: ReadonlySet<string> = new Set(),
+): readonly ShellTabPresentation[] {
+  let x = 0;
+  return views.map((view, index) => {
+    const attention = attentionViewIds.has(view.id);
+    const label = shellPanelCell(view, variant, attention);
+    const width = terminalDisplayWidth(label);
+    const item: ShellTabPresentation = {
+      id: view.id,
+      label,
+      span: { start: x, width },
+      selected: view.id === activeViewId,
+      focused: view.id === activeViewId,
+      hovered: hoveredIndex === index,
+      attention,
+    };
+    x += width;
+    return item;
+  });
+}
+
+export function shellSurfaceTabSpans(
+  views: readonly HostedPanelView[],
+  variant: ShellChromeVariant,
+): Span[] {
+  return shellSurfaceTabs(views, "", variant, null).map((tab) => tab.span);
+}
+
+export function shellSidebarHint(
+  variant: ShellChromeVariant,
+  quitHint: string,
+  width = variant === "compact" ? 20 : 28,
+  inset = 2,
+): ShellSidebarHint {
+  const safeWidth = Math.max(0, Math.floor(width));
+  const safeInset = Math.max(0, Math.min(safeWidth, Math.floor(inset)));
+  const contentWidth = Math.max(0, safeWidth - safeInset);
+  const quit = quitHint.includes("detach") ? "^q detach" : "^q quit";
+  const btn = "F5";
+  const candidates =
+    variant === "compact"
+      ? [`${btn} · ${quit}`, `${btn}/${quit}`]
+      : [`${btn} palette · ${quit}`, `${btn} pal · ${quit}`, `${btn}/${quit}`];
+  const label =
+    candidates.find((candidate) => terminalDisplayWidth(candidate) <= contentWidth) ??
+    clipToWidth(`${btn}/${quit}`, contentWidth);
+  const btnStart = Math.max(0, label.indexOf(btn));
+  const btnEnd = btnStart >= 0 ? btnStart + btn.length : 0;
+  return {
+    pre: label.slice(0, btnStart),
+    btn,
+    post: label.slice(btnEnd),
+    buttonSpan: {
+      start: safeInset + terminalDisplayWidth(label.slice(0, btnStart)),
+      width: btn.length,
+    },
+    label,
+    inset: safeInset,
+  };
+}
+
+function clipToWidth(value: string, width: number): string {
+  if (width <= 0) return "";
+  if (terminalDisplayWidth(value) <= width) return value;
+  let out = "";
+  for (const char of value) {
+    if (terminalDisplayWidth(out + char) > width) break;
+    out += char;
+  }
+  return out;
+}
+
+export function shellVisualPalette(
+  theme: SemanticThemeSnapshot,
+  state: ShellVisualState,
+): ShellVisualPalette {
+  const attention = Boolean(state.attention);
+  if (state.terminalFocus) {
+    return {
+      fg: theme.colors.background,
+      bg: theme.colors.focus,
+      border: attention ? theme.colors.status.blocked : theme.colors.focusBorder,
+      marker: attention ? "!" : "▣",
+      attributes: 1,
+    };
+  }
+  if (state.selected) {
+    return {
+      fg: theme.colors.selectionForeground,
+      bg: theme.colors.selection,
+      border: attention ? theme.colors.status.blocked : theme.colors.focusBorder,
+      marker: attention ? "!" : theme.glyphs.active,
+      attributes: state.focused ? 1 : 0,
+    };
+  }
+  if (attention) {
+    return {
+      fg: theme.colors.foreground,
+      bg: theme.colors.attention,
+      border: theme.colors.status.blocked,
+      marker: "!",
+      attributes: 1,
+    };
+  }
+  if (state.context) {
+    return {
+      fg: theme.colors.accent,
+      bg: theme.colors.surfaceRaised,
+      border: theme.colors.accentMuted,
+      marker: "⧉",
+      attributes: 0,
+    };
+  }
+  if (state.hovered) {
+    return {
+      fg: theme.colors.foreground,
+      bg: theme.colors.hover,
+      border: theme.colors.border,
+      marker: "·",
+      attributes: 0,
+    };
+  }
+  if (state.focused) {
+    return {
+      fg: theme.colors.foreground,
+      bg: theme.colors.surfaceRaised,
+      border: theme.colors.focusBorder,
+      marker: "›",
+      attributes: 0,
+    };
+  }
+  return {
+    fg: theme.colors.mutedForeground,
+    bg: theme.colors.surface,
+    border: theme.colors.border,
+    marker: theme.glyphs.inactive,
+    attributes: 0,
+  };
+}
+
+export function shellStatusLine(
+  variant: ShellChromeVariant,
+  input: {
+    project: string;
+    mode: string;
+    notification: string | null;
+    help: string;
+  },
+  width: number,
+): string {
+  const context = variant === "compact" ? `${input.mode}` : `${input.project} · ${input.mode}`;
+  const note = input.notification ? ` · ${input.notification}` : "";
+  const help = variant === "compact" ? input.help.split(" · ")[0] : input.help;
+  const text = ` ${context}${note} · ${help}`;
+  if (terminalDisplayWidth(text) <= width) return text;
+  let out = "";
+  for (const char of text) {
+    if (terminalDisplayWidth(`${out}${char}…`) > width) break;
+    out += char;
+  }
+  return `${out}…`;
+}

--- a/packages/daemon/src/tui/mirror/shell-chrome.tsx
+++ b/packages/daemon/src/tui/mirror/shell-chrome.tsx
@@ -1,0 +1,251 @@
+/* @jsxImportSource @opentui/solid */
+import { For, Show } from "solid-js";
+import type { HostedPanelView } from "./panel-host.ts";
+import {
+  shellStatusLine,
+  shellSurfaceTabs,
+  shellVisualPalette,
+  type ShellChromeLayout,
+  type ShellChromeVariant,
+  type ShellSidebarHint,
+} from "./shell-chrome.ts";
+import type { SemanticThemeSnapshot } from "./theme.ts";
+import { clipTerminal } from "./missions-workspace.ts";
+
+export interface ShellTabBarProps {
+  theme: SemanticThemeSnapshot;
+  width: number;
+  variant: ShellChromeVariant;
+  views: readonly HostedPanelView[];
+  activeViewId: string;
+  hoveredIndex: number | null;
+  attentionViewIds?: ReadonlySet<string>;
+  note?: string | null;
+  rightChips?: readonly {
+    id: string;
+    label: string;
+    hovered?: boolean;
+    context?: boolean;
+    attention?: boolean;
+  }[];
+}
+
+export function ShellTabBar(props: ShellTabBarProps) {
+  const tabs = () =>
+    shellSurfaceTabs(
+      props.views,
+      props.activeViewId,
+      props.variant,
+      props.hoveredIndex,
+      props.attentionViewIds,
+    );
+  return (
+    <box
+      height={1}
+      width={props.width}
+      flexDirection="row"
+      backgroundColor={props.theme.colors.surface}
+      overflow="hidden"
+    >
+      <For each={tabs()}>
+        {(tab) => {
+          const palette = () =>
+            shellVisualPalette(props.theme, {
+              selected: tab.selected,
+              focused: tab.focused,
+              hovered: tab.hovered,
+              attention: tab.attention,
+            });
+          return (
+            <box height={1} backgroundColor={palette().bg} flexDirection="row">
+              <Show
+                when={tab.attention && tab.label.includes("!")}
+                fallback={
+                  <text fg={palette().fg} attributes={palette().attributes}>
+                    {tab.label}
+                  </text>
+                }
+              >
+                {(() => {
+                  const markerIndex = tab.label.indexOf("!");
+                  const before = tab.label.slice(0, markerIndex);
+                  const after = tab.label.slice(markerIndex + 1);
+                  return (
+                    <>
+                      <text fg={palette().fg} attributes={palette().attributes}>
+                        {before}
+                      </text>
+                      <text fg={props.theme.colors.status.blocked} attributes={1}>
+                        !
+                      </text>
+                      <text fg={palette().fg} attributes={palette().attributes}>
+                        {after}
+                      </text>
+                    </>
+                  );
+                })()}
+              </Show>
+            </box>
+          );
+        }}
+      </For>
+      <box flexGrow={1} />
+      <Show when={props.note}>
+        <text fg={props.theme.colors.focus} attributes={1}>
+          {clipTerminal(`${props.note} `, Math.max(0, Math.floor(props.width / 3)))}
+        </text>
+      </Show>
+      <For each={props.rightChips ?? []}>
+        {(chip) => {
+          const palette = () =>
+            shellVisualPalette(props.theme, {
+              hovered: chip.hovered,
+              context: chip.context,
+              attention: chip.attention,
+            });
+          return (
+            <>
+              <Show
+                when={chip.attention && chip.label.includes("!")}
+                fallback={
+                  <text fg={palette().fg} bg={palette().bg} attributes={palette().attributes}>
+                    {chip.label}
+                  </text>
+                }
+              >
+                {(() => {
+                  const markerIndex = chip.label.indexOf("!");
+                  const before = chip.label.slice(0, markerIndex);
+                  const after = chip.label.slice(markerIndex + 1);
+                  return (
+                    <>
+                      <text fg={palette().fg} bg={palette().bg} attributes={palette().attributes}>
+                        {before}
+                      </text>
+                      <text fg={props.theme.colors.status.blocked} bg={palette().bg} attributes={1}>
+                        !
+                      </text>
+                      <text fg={palette().fg} bg={palette().bg} attributes={palette().attributes}>
+                        {after}
+                      </text>
+                    </>
+                  );
+                })()}
+              </Show>
+            </>
+          );
+        }}
+      </For>
+    </box>
+  );
+}
+
+export interface ShellStatusStripProps {
+  theme: SemanticThemeSnapshot;
+  layout: ShellChromeLayout;
+  project: string;
+  mode: string;
+  notification: string | null;
+  help: string;
+}
+
+export function ShellStatusStrip(props: ShellStatusStripProps) {
+  return (
+    <box
+      height={props.layout.status.height}
+      width={props.layout.status.width}
+      backgroundColor={props.theme.colors.surface}
+      overflow="hidden"
+    >
+      <text fg={props.theme.colors.mutedForeground}>
+        {shellStatusLine(
+          props.layout.variant,
+          {
+            project: props.project,
+            mode: props.mode,
+            notification: props.notification,
+            help: props.help,
+          },
+          props.layout.status.width,
+        )}
+      </text>
+    </box>
+  );
+}
+
+export interface ShellCompositeLeafChromeProps {
+  theme: SemanticThemeSnapshot;
+  title: string;
+  panel: string;
+  width: number;
+  focused: boolean;
+  terminalFocused?: boolean;
+  attention?: boolean;
+}
+
+export function ShellCompositeLeafChrome(props: ShellCompositeLeafChromeProps) {
+  const palette = () =>
+    shellVisualPalette(props.theme, {
+      focused: props.focused,
+      terminalFocus: props.terminalFocused,
+      attention: props.attention,
+    });
+  return (
+    <box height={1} flexDirection="row" backgroundColor={palette().bg} overflow="hidden">
+      <text fg={palette().border}>{palette().marker}</text>
+      <text fg={palette().fg} attributes={palette().attributes}>
+        {clipTerminal(` ${props.title} · ${props.panel}`, Math.max(0, props.width - 1))}
+      </text>
+    </box>
+  );
+}
+
+export interface ShellMiniSidebarProps {
+  theme: SemanticThemeSnapshot;
+  width: number;
+  variant: ShellChromeVariant;
+  sessions: readonly {
+    name: string;
+    status: "idle" | "working" | "blocked" | "done" | "unknown";
+  }[];
+  active: string;
+  hint: ShellSidebarHint;
+}
+
+export function ShellMiniSidebar(props: ShellMiniSidebarProps) {
+  return (
+    <box
+      width={props.width}
+      flexDirection="column"
+      backgroundColor={props.theme.colors.surface}
+      paddingLeft={1}
+      overflow="hidden"
+    >
+      <text fg={props.theme.colors.focus} attributes={1}>
+        {props.variant === "compact" ? " tmux" : " tmux-ide"}
+      </text>
+      <For each={props.sessions}>
+        {(session) => {
+          const selected = () => session.name === props.active;
+          const palette = () => shellVisualPalette(props.theme, { selected: selected() });
+          return (
+            <box height={1} flexDirection="row" backgroundColor={palette().bg}>
+              <text fg={props.theme.colors.status[session.status]}>{selected() ? "●" : "○"}</text>
+              <text fg={palette().fg}>
+                {clipTerminal(` ${session.name}`, Math.max(0, props.width - 1))}
+              </text>
+            </box>
+          );
+        }}
+      </For>
+      <box flexGrow={1} />
+      <box height={1} width={props.width} flexDirection="row" overflow="hidden">
+        <text fg={props.theme.colors.mutedForeground}>{props.hint.pre}</text>
+        <text fg={props.theme.colors.foreground} bg={props.theme.colors.hover}>
+          {props.hint.btn}
+        </text>
+        <text fg={props.theme.colors.mutedForeground}>{props.hint.post}</text>
+      </box>
+    </box>
+  );
+}

--- a/packages/daemon/src/tui/mirror/sidebar.tsx
+++ b/packages/daemon/src/tui/mirror/sidebar.tsx
@@ -44,6 +44,7 @@ import {
   TAB_ACTIVE_BG,
 } from "./theme.ts";
 import type { AgentStatus } from "../detect/classify.ts";
+import type { ShellChromeVariant } from "./shell-chrome.ts";
 
 /** A session row: the fleet's name + its rolled-up status. */
 export interface SidebarSession {
@@ -71,6 +72,7 @@ export interface SidebarMouseEvent {
 export interface SidebarProps {
   /** Column width in cells. */
   width: number;
+  variant?: ShellChromeVariant;
   sessions: SidebarSession[];
   /** Pre-sorted, attention-first (see the note above). */
   agents: AgentRowInput[];
@@ -100,7 +102,7 @@ export function Sidebar(props: SidebarProps) {
       onMouse={(e: SidebarMouseEvent) => props.onMouse?.(e)}
     >
       <text fg={ACCENT} attributes={1}>
-        tmux-ide
+        {props.variant === "compact" ? "tmux" : "tmux-ide"}
       </text>
       <text fg={MUTED}>{"─".repeat(props.width - 2)}</text>
       <box flexDirection="column">
@@ -119,7 +121,7 @@ export function Sidebar(props: SidebarProps) {
             >
               <text fg={STATUS_COLOR[s.status]}>{STATUS_GLYPH[s.status]}</text>
               <text fg={s.name === props.current ? DEFAULT_FG : MUTED}>
-                {s.name.slice(0, props.width - 5)}
+                {s.name.slice(0, Math.max(1, props.width - (props.variant === "compact" ? 3 : 5)))}
               </text>
             </box>
           )}
@@ -206,7 +208,7 @@ export function Sidebar(props: SidebarProps) {
       {/* Footer hint — its middle segment is a CHIP (M21.9): the router
         hit-tests SIDEBAR_HINT_SPAN on the last screen row, and these three runs
         render the exact same cells. */}
-      <box flexDirection="row">
+      <box width={props.width} flexDirection="row" overflow="hidden">
         <text fg={MUTED}>{props.hint.pre}</text>
         <text fg={MUTED} bg={props.isHovered("sidebtn", 0) ? BUTTON_HOVER_BG : SIDEBAR_BG}>
           {props.hint.btn}


### PR DESCRIPTION
## Summary
- introduce responsive compact, standard, and wide shell chrome projections
- centralize tab, sidebar, palette, and dialog geometry so rendering and hit-testing agree
- add semantic focus, hover, selection, context, and attention treatments
- add OpenTUI renderer coverage at 80x24, 120x40, and 200x60

## Validation
- pnpm check
- pnpm test:tui-renderer
- pnpm --filter @tmux-ide/daemon typecheck
- pnpm lint
- pnpm format:check
- git diff --check