### PR TITLE
feat(tui): redesign Home and Files surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run typecheck:workspace && pnpm run test:unit && pnpm run test:tui-renderer && pnpm run docs:build && pnpm run pack:check && pnpm run check:native-deps",
     "postinstall": "node scripts/postinstall.js",
     "docs": "turbo run dev --filter=@tmux-ide/docs",
-    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx",
+    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx",
     "test:tui-smoke": "node scripts/smoke-tui-missions.mjs"
   },
   "keywords": [

--- a/packages/daemon/src/tui/mirror/__snapshots__/home-files-surface-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/__snapshots__/home-files-surface-renderer.test.tsx.snap
@@ -1,0 +1,267 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`Home and Files surfaces OpenTUI renderer renders deterministic %sx%s home first-run frame 1`] = `
+" Home · undefined sessions · undefined projects ● 0 ● 0 ● 0 ○ 0
+────────────────────────────────────────────────────────────────────────────────
+
+                              Welcome to tmux-ide
+
+                          ○ ▸ open a folder — press f
+
+                                press f to open
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ open a folder to start
+ j/k enter ○ [f folder] ^ ○ [n session]   ○ [a agent]   ○ [o open]   ○ [d diff]"
+`;
+
+exports[`Home and Files surfaces OpenTUI renderer renders deterministic %sx%s home populated frame 1`] = `
+" tmux-ide Home · Sessions, registered projects, and recent folders ● 0 ● 1 ● 0 ○ 0
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+● workspace                                                                      2w · working ○ [+ agent]   ○ [± diff]
+○ docs                                                                           /repo/docs ○ [+ agent]   ○ [▸ launch]
+○ playground                                                                                /tmp/playground ○ [▸ open]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ workspace · 2 windows
+ enter open · n new session · ^q quit ○ [f open folder]   ○ [n new session]   ○ [a new agent]   ○ [o open]   ○ [d diff]"
+`;
+
+exports[`Home and Files surfaces OpenTUI renderer renders deterministic %sx%s home populated frame 2`] = `
+" tmux-ide Home · Sessions, registered projects, and recent folders ● 0 ● 1 ● 0 ○ 0
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+● workspace                                                                                                                                                      2w · working ○ [+ agent]   ○ [± diff]
+○ docs                                                                                                                                                           /repo/docs ○ [+ agent]   ○ [▸ launch]
+○ playground                                                                                                                                                                /tmp/playground ○ [▸ open]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ workspace · 2 windows
+ enter open · n new session · ^q quit                                                                                 ○ [f open folder]   ○ [n new session]   ○ [a new agent]   ○ [o open]   ○ [d diff]"
+`;
+
+exports[`Home and Files surfaces OpenTUI renderer renders deterministic %sx%s files filtered frame 1`] = `
+" Files 1:8 2L ready │ app▏         │             ○ save   ○ reload   ○ / filter
+ /repo/workspace/src/app.ts
+● ▾ src                            1 export const app = true;
+○     app.ts M                     2 console.log(app);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ enter open · / filter · esc list"
+`;
+
+exports[`Home and Files surfaces OpenTUI renderer renders deterministic %sx%s files empty frame 1`] = `
+" Files 1:8 0L ready                                                ○ / filter   ○ H dot:off   ○ I ign:off   ○ r refresh
+ no files visible — try H or I
+ ○ No files                              ○ No file open
+   no files visible — try H or I           Select a file from the list.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ enter open · / filter · ^q quit"
+`;
+
+exports[`Home and Files surfaces OpenTUI renderer renders deterministic %sx%s files error frame 1`] = `
+" Files 1:8 2L read failed                                                                                                               ○ reload   ○ / filter   ○ H dot:off   ○ I ign:off   ○ r refresh
+ outside workspace
+● ▾ src                                       1 export const app = true;
+○     app.ts M                                2 console.log(app);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ enter open · / filter · ^q quit"
+`;

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -228,7 +228,7 @@ import {
   TAB_ACTIVE_BG,
   createSemanticThemeStore,
 } from "./theme.ts";
-import { rollupChips, homeFooterHints, type FleetRollup } from "../team/home.ts";
+import { homeFooterHints, type FleetRollup } from "../team/home.ts";
 import {
   isBinary,
   classifyFile,
@@ -380,6 +380,15 @@ import {
   missionDashboardProjection,
 } from "./missions-dashboard.ts";
 import { MissionsSurface, missionSurfaceLayout } from "./missions-surface.tsx";
+import { HomeSurface, homeActionAtProjection } from "./home-surface.tsx";
+import {
+  homeItemIndexAtProjection,
+  projectHomeSurface,
+  type HomeActionId,
+} from "./home-surface.ts";
+import { FilesSurface } from "./files-surface.tsx";
+import { filesHitTest, filesListWidth, projectFilesSurface } from "./files-surface.ts";
+import type { FilesActionId } from "./files-surface.ts";
 import {
   handleMissionSurfaceKey,
   handleMissionSurfacePointerDown,
@@ -484,10 +493,8 @@ import {
 } from "./attention.ts";
 import {
   buildHomeItems,
-  centerPad,
   clampSelectable,
   firstRunTip,
-  isFirstRun,
   stepSelectable,
   sessionNameFor,
   isValidSessionName,
@@ -805,17 +812,6 @@ const HEADER_ROWS = 2;
 // router subtracts it once (`gy = y - TABBAR_H`) before the per-mode math.
 const TABBAR_H = 1;
 const PALETTE_ROWS = 10;
-// ── M21.9 clickable-chip labels ─────────────────────────────────────────────
-// Fixed strings so the x-span math is constant (every glyph single-width). The
-// home chips sit flush right on their row (trailing space = a 1-cell inset);
-// the tab-bar labels are the EXACT strings the bar renders, so `spansFromRight`
-// lands cell-for-cell on what's drawn.
-const HOME_CHIP_SESSION = "[± diff] ";
-const HOME_CHIP_PROJECT = "[▸ launch] ";
-const HOME_CHIP_RECENT = "[▸ open] ";
-// The spawn verb's home entry (M23.1): session/project rows carry a second
-// chip left of the primary one; `a` is its keyboard twin.
-const HOME_CHIP_AGENT = "[+ agent] ";
 // ── M24.4 kitty keyboard protocol ───────────────────────────────────────────
 // One config read at boot (the dragSelect discipline): when on, the renderer
 // requests kitty's disambiguated key encoding from the host terminal, which is
@@ -835,13 +831,10 @@ const PALETTE_ROW_KEYCAPS: Readonly<Record<string, string>> = Object.fromEntries
 );
 // ── M22.5 first-run welcome ─────────────────────────────────────────────────
 // A centered greeting shown only on a truly empty fleet (no sessions, no
-// registered projects). WELCOME_ROWS rows in the content area (gy 2…); the
-// clickable "open a folder" action sits at WELCOME_ACTION_ROW. The render
-// centers each line with the same centerPad the router hit-tests with.
+// registered projects). Geometry now lives in the Home surface projection so
+// render and pointer routing consume the same model.
 const WELCOME_LINE = "Welcome to tmux-ide — a cockpit for the tmux sessions you already have.";
 const WELCOME_ACTION_LABEL = "▸ open a folder — press f";
-const WELCOME_ROWS = 6;
-const WELCOME_ACTION_ROW = 3; // 0-based within the welcome block
 // HOSTED mode (M23.2): the detachable-cockpit launcher stamps this marker on
 // the app's pane command inside `_tmux-ide-app`. ^q then detaches the tmux
 // client instead of exiting (the cockpit survives the terminal); every "^q
@@ -1777,28 +1770,16 @@ try {
       );
     };
     const homeItems = createMemo<HomeItem[]>(() => buildHomeItems(projectsData(), recentFolders()));
-    // First-run (M22.5): a truly empty fleet gets a centered welcome. It reserves
-    // WELCOME_ROWS at the top of the content area, so the home row math shifts by
-    // that offset while it shows (shared by render, hover and click routing).
-    const firstRun = () => isFirstRun(projectsData());
-    const welcomeOffset = () => (firstRun() ? WELCOME_ROWS : 0);
-    /** The centered x-span [start, end) of the welcome's clickable action — the
-     *  render draws the label after the same centerPad, so a click lands on it. */
-    const welcomeActionSpan = (): [number, number] => {
-      const start = sidebarW() + centerPad(canvasCols(), WELCOME_ACTION_LABEL.length);
-      return [start, start + WELCOME_ACTION_LABEL.length];
-    };
     /** Whether (gy, x) hits the welcome action row (only while first-run). */
     const welcomeActionHit = (gy: number, x: number): boolean => {
-      if (!firstRun() || gy - 2 !== WELCOME_ACTION_ROW) return false;
-      const [x0, x1] = welcomeActionSpan();
-      return x >= x0 && x < x1;
+      return (
+        homeActionAtProjection(homeSurfaceProjection(), x, gy, sidebarW(), 0)?.source === "welcome"
+      );
     };
     /** The home item index under content-row gy (accounting for the welcome
      *  offset), or -1 when gy is above the first row / on the welcome block. */
     const homeItemIndexAt = (gy: number): number => {
-      const idx = gy - 2 - welcomeOffset();
-      return idx >= 0 ? idx : -1;
+      return homeItemIndexAtProjection(homeSurfaceProjection(), sidebarW(), gy, sidebarW(), 0);
     };
     const rollup = (): FleetRollup => {
       const r: FleetRollup = {
@@ -1839,6 +1820,39 @@ try {
       homeFooterHints()
         .map((h) => `${h.keys} ${h.label}`)
         .join("   ");
+    // A path-input line on HOME (`o` to open). null = not prompting.
+    const [pathPrompt, setPathPrompt] = createSignal<string | null>(null);
+    // A session-name input line on HOME (`n` / the [n new session] chip).
+    const [sessionPrompt, setSessionPrompt] = createSignal<string | null>(null);
+    const homeSurfaceProjection = createMemo(() =>
+      projectHomeSurface({
+        width: canvasCols(),
+        height: dims().height - TABBAR_H,
+        projects: projectsData(),
+        items: homeItems(),
+        selectedIndex: clampedSel(),
+        hovered:
+          hover()?.region === "home" ||
+          hover()?.region === "homechip" ||
+          hover()?.region === "homeagentchip" ||
+          hover()?.region === "welcomeopen" ||
+          hover()?.region === "button"
+            ? (hover() as {
+                region: "home" | "homechip" | "homeagentchip" | "welcomeopen" | "button";
+                index: number;
+              })
+            : null,
+        rollup: rollup(),
+        detail: detailLine(),
+        footerHint: homeFooter(),
+        sessionPrompt: sessionPrompt(),
+        pathPrompt: pathPrompt(),
+        quitHint: QUIT_HINT,
+        welcomeLine: WELCOME_LINE,
+        welcomeActionLabel: WELCOME_ACTION_LABEL,
+        welcomeTip,
+      }),
+    );
     const scrollOffsets = new Map<string, number>();
     let dirty = false;
     const markDirty = () => {
@@ -1856,10 +1870,6 @@ try {
     const [editorModified, setEditorModified] = createSignal(false);
     const [editorReadOnly, setEditorReadOnly] = createSignal<ReadOnlyReason>(null);
     const [editorMsg, setEditorMsg] = createSignal("");
-    // A path-input line on HOME (`o` to open). null = not prompting.
-    const [pathPrompt, setPathPrompt] = createSignal<string | null>(null);
-    // A session-name input line on HOME (`n` / the [n new session] chip).
-    const [sessionPrompt, setSessionPrompt] = createSignal<string | null>(null);
 
     // Visible text rows = full height minus tab bar (1) + header (1) + rule/banner
     // (1) + footer (1).
@@ -2425,7 +2435,7 @@ try {
     // the EDITOR (typing). Opening a file hands focus to the editor; esc hands it
     // back to the list.
     const [filesFocus, setFilesFocus] = createSignal<"list" | "editor">("list");
-    const filesListW = () => Math.max(20, Math.min(44, Math.floor(canvasCols() * 0.34)));
+    const filesListW = () => filesListWidth(canvasCols());
     /** The workspace directory driving both the file list and the diff panel. */
     const workspaceDir = () => contextDir() || invokeCwd;
     const fileStatusMap = createMemo(() => statusMapFromEntries(fileStatusEntries()));
@@ -2448,6 +2458,39 @@ try {
       const rel = relPath(top, n.path);
       return rel ? (fileStatusMap().get(rel) ?? null) : null;
     };
+    const filesSurfaceProjection = createMemo(() =>
+      projectFilesSurface({
+        width: canvasCols(),
+        height: dims().height - TABBAR_H,
+        workspaceDir: workspaceDir(),
+        editorPath: editorPath(),
+        editorModified: editorModified(),
+        editorCursor: editorCursor(),
+        editorLineCount: editorLines().length,
+        editorMessage: editorMsg(),
+        readOnly: editorReadOnly(),
+        filterQuery: filesQuery(),
+        focus: filesFocus(),
+        showHidden: showHiddenFiles(),
+        showIgnored: showIgnoredFiles(),
+        visibleRows: fileListVisible(),
+        totalRows: visibleFiles().length,
+        fileSelection: fileSel(),
+        fileTop: fileTop(),
+        editorVisible: editorVisible(),
+        editorTop: editorTop(),
+        editorTotalLines: editorLines().length,
+        hovered:
+          hover()?.region === "files" || hover()?.region === "button"
+            ? (hover() as { region: "files" | "button"; index: number })
+            : null,
+        statusFor: fileStatusFor,
+        readOnlyBanner: readOnlyBanner(editorReadOnly()),
+        footerBase: `j/k · enter open · [/] change · / filter · H dot:${
+          showHiddenFiles() ? "on" : "off"
+        } · I ign:${showIgnoredFiles() ? "on" : "off"} · ^s save · esc list · ^g home · ${QUIT_HINT}`,
+      }),
+    );
 
     // The gitignore matcher for the CURRENT workspace root (reloaded when the
     // root changes or the tree refreshes — cheap: one small file read).
@@ -5560,35 +5603,30 @@ try {
           return;
         }
         if (evt.name === "o") {
-          setPathPrompt("");
+          runHomeAction("open-file");
           return;
         }
         // `f` — open a folder (M22.5): the [f open folder] chip / welcome action /
         // palette command's keyboard twin. Launches the filesystem picker.
         if (evt.name === "f") {
-          void openFolderFlow();
+          runHomeAction("open-folder");
           return;
         }
         // `n` — the [n new session] chip's keyboard twin.
         if (evt.name === "n") {
-          setSessionPrompt("");
+          runHomeAction("new-session");
           return;
         }
         // `a` — the row [+ agent] chip's keyboard twin (M23.1): spawn an agent
         // for the selected row (or a fresh session when nothing is selected).
         if (evt.name === "a") {
-          newAgentFromHome(selectedHomeItem());
+          runHomeAction("new-agent");
           return;
         }
         // `d` — open the diff panel for the selected row's project dir (the
         // home item carries it via the team payload), adopting it as context.
         if (evt.name === "d") {
-          const r = selectedHomeItem();
-          if (r && r.kind === "session") {
-            setContextSession(r.session);
-            setContextDir(r.dir ?? invokeCwd);
-          }
-          enterDiff(selectedHomeDir() ?? invokeCwd);
+          runHomeAction("open-diff");
           return;
         }
         if (evt.name === "j" || evt.name === "down") {
@@ -5737,31 +5775,6 @@ try {
         ),
       };
     });
-    /** Buttons on the home footer (the last screen row): the app-handled home
-     *  keys (`n` new session, `o` open-file, `d` diff) as clickable chips. The
-     *  other footer hints advertise tmux-chrome binds this app's keyboard
-     *  doesn't own, so they stay plain text rather than dead buttons.
-     *  Right-aligned to the fixed edge. */
-    const homeButtons = createMemo<{ defs: HeaderButton[]; spans: Span[] }>(() => {
-      const defs: HeaderButton[] =
-        mode() === "home"
-          ? [
-              { id: "home-openfolder", label: "[f open folder]" },
-              { id: "home-new", label: "[n new session]" },
-              { id: "home-agent", label: "[a new agent]" },
-              { id: "home-open", label: "[o open]" },
-              { id: "home-diff", label: "[d diff]" },
-            ]
-          : [];
-      return {
-        defs,
-        spans: spansFromRight(
-          defs.map((d) => d.label),
-          buttonRightEdge(),
-          1,
-        ),
-      };
-    });
     // The focused pane and its window's zoom state, derived from the live geometry
     // (window_zoomed_flag is a window property, so every pane of the active window
     // reports the same value; reading the focused pane keeps the intent clear).
@@ -5787,6 +5800,38 @@ try {
         ),
       };
     });
+    const runHomeAction = (id: HomeActionId, itemIndex = clampedSel()) => {
+      if (id === "open-folder") void openFolderFlow();
+      else if (id === "new-agent") newAgentFromHome(homeItems()[itemIndex] ?? selectedHomeItem());
+      else if (id === "open-file") setPathPrompt("");
+      else if (id === "new-session") setSessionPrompt("");
+      else if (id === "primary") runHomeChip(itemIndex);
+      else if (id === "open-diff") {
+        const r = homeItems()[itemIndex] ?? selectedHomeItem();
+        const dir = r && r.kind !== "header" ? (r.dir ?? invokeCwd) : invokeCwd;
+        if (r && r.kind === "session") {
+          setContextSession(r.session);
+          setContextDir(dir);
+        }
+        enterDiff(dir);
+      }
+    };
+
+    const runFilesAction = (id: FilesActionId) => {
+      if (id === "save") saveEditor();
+      else if (id === "reload") {
+        const p = editorPath();
+        if (p) openEditor(p);
+      } else if (id === "filter") {
+        filesPreFilterPath = visibleFiles()[fileSel()]?.node.path ?? null;
+        setFilesQuery("");
+        setFileSel(0);
+        setFileTop(0);
+      } else if (id === "toggle-hidden") toggleHiddenFiles();
+      else if (id === "toggle-ignored") toggleIgnoredFiles();
+      else if (id === "refresh") refreshTree();
+    };
+
     /** Run a header/strip button by id. Reload re-reads the open file from disk
      *  (discarding unsaved edits — the ● dot warns first); split forks the focused
      *  pane via the control client, same command the context menu issues. */
@@ -5802,19 +5847,6 @@ try {
       } else if (id === "zoom") {
         const pid = mirror?.focusedPane();
         if (pid) void mirror?.command(`resize-pane -Z -t ${pid}`).catch(() => {});
-      } else if (id === "home-openfolder") void openFolderFlow();
-      else if (id === "home-agent") newAgentFromHome(selectedHomeItem());
-      else if (id === "home-open") setPathPrompt("");
-      else if (id === "home-new") setSessionPrompt("");
-      else if (id === "home-diff") {
-        // Mirror the home `d` key: adopt the selected session's dir as context and
-        // open its diff.
-        const r = selectedHomeItem();
-        if (r && r.kind === "session") {
-          setContextSession(r.session);
-          setContextDir(r.dir ?? invokeCwd);
-        }
-        enterDiff(selectedHomeDir() ?? invokeCwd);
       }
     };
 
@@ -5860,60 +5892,27 @@ try {
       if (id === "tab-palette") openPalette();
       else if (id === "tab-context" && contextSession()) switchTarget(contextSession());
     };
-    /** A home row's right-aligned verb chip span (sessions/projects only). The
-     *  row box runs flush to the terminal's right edge, so the span anchors
-     *  there — same for every row of a kind. */
-    const homeChipLabel = (it: HomeItem | undefined): string =>
-      it?.kind === "session"
-        ? HOME_CHIP_SESSION
-        : it?.kind === "project"
-          ? HOME_CHIP_PROJECT
-          : it?.kind === "recent"
-            ? HOME_CHIP_RECENT
-            : "";
-    /** A home row's chip list, left to right: session/project rows lead with
-     *  the [+ agent] spawn chip (M23.1), then every row's PRIMARY verb chip.
-     *  The render walks these defs and the hit-test lays the SAME labels out
-     *  from the right edge, so clicks land exactly on what's drawn. */
-    const homeRowChips = (
-      it: HomeItem | undefined,
-    ): { id: "agent" | "primary"; label: string }[] => {
-      const defs: { id: "agent" | "primary"; label: string }[] = [];
-      if (it?.kind === "session" || it?.kind === "project") {
-        defs.push({ id: "agent", label: HOME_CHIP_AGENT });
-      }
-      const primary = homeChipLabel(it);
-      if (primary) defs.push({ id: "primary", label: primary });
-      return defs;
-    };
     /** Which chip (if any) column `x` hits on the row for `it`. */
-    const homeChipAt = (it: HomeItem | undefined, x: number): "agent" | "primary" | null => {
-      const defs = homeRowChips(it);
-      if (defs.length === 0) return null;
-      const i = spanHit(
-        spansFromRight(
-          defs.map((d) => d.label),
-          buttonRightEdge(),
-          0,
-        ),
-        x,
+    const homeChipAt = (
+      it: HomeItem | undefined,
+      x: number,
+      itemIndex: number,
+    ): "agent" | "primary" | null => {
+      if (!it) return null;
+      const localX = x - sidebarW();
+      const row = homeSurfaceProjection().rows.find(
+        (candidate) => candidate.itemIndex === itemIndex,
       );
-      return i >= 0 ? defs[i]!.id : null;
+      const action = row?.actionSpans.find(
+        (span) => localX >= span.start && localX < span.start + span.width,
+      );
+      if (!action) return null;
+      return action.id === "new-agent" ? "agent" : action.id === "primary" ? "primary" : null;
     };
     /** The `[+ agent]` chip's x-span on the sidebar's AGENTS header row and the
      *  empty-state row (M24.1) — right-anchored flush to the sidebar's edge; the
      *  render (label · flexGrow spacer · chip) lays out the same cells. */
     const agentsChipSpans = createMemo(() => spansFromRight([AGENTS_ADD_CHIP], sidebarW(), 0));
-    /** A home row's muted meta text — sessions keep the exact `3w · project`
-     *  string the panel always showed; projects show their dir + origin. */
-    const homeRowMeta = (it: HomeItem): string =>
-      it.kind === "session"
-        ? `${it.windows}w${it.project === it.session ? "" : ` · ${it.project}`}`
-        : it.kind === "project"
-          ? `${it.dir ?? ""} · registered`
-          : it.kind === "recent"
-            ? `${dirname(it.dir)} · recent`
-            : "";
 
     /** Resolve the hovered {region, index} from pointer coords with the SAME
      *  geometry the click router uses, then update `hover` (no-op unless changed).
@@ -5959,9 +5958,13 @@ try {
       }
       const m = mode();
       if (m === "home") {
-        if (y === dims().height - 1) {
-          const i = spanHit(homeButtons().spans, x);
-          setHoverIf(i >= 0 ? { region: "button", index: i } : null);
+        const action = homeActionAtProjection(homeSurfaceProjection(), x, gy, sidebarW(), 0);
+        if (action?.source === "footer") {
+          setHoverIf(
+            action.actionIndex !== undefined
+              ? { region: "button", index: action.actionIndex }
+              : null,
+          );
           return;
         }
         if (welcomeActionHit(gy, x)) {
@@ -5974,7 +5977,7 @@ try {
           setHoverIf(null);
           return;
         }
-        const chip = homeChipAt(it, x);
+        const chip = homeChipAt(it, x, idx);
         setHoverIf({
           region: chip === "agent" ? "homeagentchip" : chip === "primary" ? "homechip" : "home",
           index: idx,
@@ -5983,8 +5986,12 @@ try {
       }
       if (m === "editor") {
         if (gy === 0) {
-          const i = spanHit(headerButtons().spans, x);
-          setHoverIf(i >= 0 ? { region: "button", index: i } : null);
+          const hit = filesHitTest(filesSurfaceProjection(), x - sidebarW(), gy);
+          setHoverIf(
+            hit?.area === "header" && hit.actionIndex !== undefined
+              ? { region: "button", index: hit.actionIndex }
+              : null,
+          );
           return;
         }
         const contentY = gy - HEADER_ROWS;
@@ -6754,17 +6761,9 @@ try {
       // (gy=0) + rule (gy=1), so a click at row gy hits home item `gy - 2`.
       if (mode() === "home") {
         if (type !== "down") return;
-        // The footer occupies the last screen row; its right-aligned chips
-        // ([n new session] / [o open] / [d diff]) are hit-tested there first.
-        if (y === dims().height - 1) {
-          const hb = homeButtons();
-          const i = spanHit(hb.spans, x);
-          if (i >= 0) runButton(hb.defs[i]!.id);
-          return;
-        }
-        // The first-run welcome's "open a folder" action (M22.5).
-        if (welcomeActionHit(gy, x)) {
-          void openFolderFlow();
+        const action = homeActionAtProjection(homeSurfaceProjection(), x, gy, sidebarW(), 0);
+        if (action?.source === "footer" || action?.source === "welcome") {
+          runHomeAction(action.id, action.itemIndex);
           return;
         }
         // A row click: the right-aligned verb chips win over the row body
@@ -6773,12 +6772,12 @@ try {
         const idx = homeItemIndexAt(gy);
         const it = homeItems()[idx];
         if (!it || it.kind === "header") return;
-        const chip = homeChipAt(it, x);
-        if (chip === "agent") {
+        if (action?.source === "row") {
           setSel(idx);
-          newAgentFromHome(it);
-        } else if (chip === "primary") runHomeChip(idx);
-        else activateHomeItem(idx);
+          runHomeAction(action.id, idx);
+          return;
+        }
+        activateHomeItem(idx);
         return;
       }
       // FILES (editor) mode: header (gy=0) + rule/banner (gy=1), then a two-column
@@ -6797,11 +6796,10 @@ try {
           return;
         }
         if (type !== "down") return;
-        // The header row (gy=0) carries the right-aligned save/reload buttons.
+        // The header row (gy=0) carries the projected Files actions.
         if (gy === 0) {
-          const hb = headerButtons();
-          const i = spanHit(hb.spans, x);
-          if (i >= 0) runButton(hb.defs[i]!.id);
+          const hit = filesHitTest(filesSurfaceProjection(), x - sidebarW(), gy);
+          if (hit?.area === "header" && hit.actionId) runFilesAction(hit.actionId);
           return;
         }
         const contentY = gy - HEADER_ROWS;
@@ -7526,148 +7524,11 @@ try {
               )}
             </Show>
             <Show when={!activeCompositeLayout() && mode() === "home"}>
-              {/* HOME header (y=0) + rule (y=1); rows below start at y=2 — the
-              coordinate `route` reverses for a home-row click. */}
-              <box paddingLeft={1} flexDirection="row" gap={1}>
-                <text fg={ACCENT} attributes={1}>
-                  tmux-ide
-                </text>
-                <text fg={MUTED}>{`· ${rollup().sessions} sessions ·`}</text>
-                <For each={rollupChips(rollup())}>
-                  {(c) => (
-                    <text
-                      fg={STATUS_COLOR[c.status]}
-                    >{`${STATUS_GLYPH[c.status]} ${c.count}`}</text>
-                  )}
-                </For>
-              </box>
-              <text fg={MUTED}>{"─".repeat(Math.max(4, canvasCols() - 2))}</text>
-              {/* FIRST-RUN welcome (M22.5): exactly WELCOME_ROWS rows so the home
-                row math below simply shifts by welcomeOffset(). Each line is
-                centered with the SAME centerPad the click router hit-tests, so
-                the "open a folder" action lands where it's drawn. */}
-              <Show when={firstRun()}>
-                <box flexDirection="column">
-                  <box height={1} />
-                  <box flexDirection="row">
-                    <text>{" ".repeat(centerPad(canvasCols(), WELCOME_LINE.length))}</text>
-                    <text fg={DEFAULT_FG}>{WELCOME_LINE}</text>
-                  </box>
-                  <box height={1} />
-                  <box flexDirection="row">
-                    <text>{" ".repeat(centerPad(canvasCols(), WELCOME_ACTION_LABEL.length))}</text>
-                    <text
-                      fg={BUTTON_FG}
-                      bg={isHovered("welcomeopen", 0) ? BUTTON_HOVER_BG : BUTTON_BG}
-                    >
-                      {WELCOME_ACTION_LABEL}
-                    </text>
-                  </box>
-                  <box height={1} />
-                  <box flexDirection="row">
-                    <text>{" ".repeat(centerPad(canvasCols(), welcomeTip.length))}</text>
-                    <text fg={MUTED}>{welcomeTip}</text>
-                  </box>
-                </box>
-              </Show>
-              {/* HOME items (M21.9): live-session rows, then the registry
-                section (header + launchable project rows), then (M22.5) the
-                recently-opened folders. One uniform selectable-row layout —
-                status glyph / title / meta — plus a right-aligned verb CHIP the
-                router hit-tests by the same right-anchored span math
-                (homeChipHit). Headers are inert. */}
-              <box flexDirection="column">
-                <For each={homeItems()}>
-                  {(it, i) => (
-                    <Show
-                      when={it.kind !== "header"}
-                      fallback={
-                        <box height={1} paddingLeft={1}>
-                          <text fg={MUTED}>{it.kind === "header" ? `· ${it.label}` : ""}</text>
-                        </box>
-                      }
-                    >
-                      <box
-                        flexDirection="row"
-                        gap={1}
-                        paddingLeft={1}
-                        height={1}
-                        backgroundColor={
-                          i() === clampedSel()
-                            ? TAB_ACTIVE_BG
-                            : isHovered("home", i())
-                              ? HOVER_BG
-                              : DEFAULT_BG
-                        }
-                      >
-                        <text fg={it.kind === "session" ? STATUS_COLOR[it.status] : DIR_FG}>
-                          {it.kind === "session"
-                            ? STATUS_GLYPH[it.status]
-                            : it.kind === "recent"
-                              ? "↺"
-                              : "▸"}
-                        </text>
-                        <text fg={i() === clampedSel() ? DEFAULT_FG : MUTED} attributes={1}>
-                          {it.kind === "session"
-                            ? it.session
-                            : it.kind === "project"
-                              ? it.name
-                              : it.kind === "recent"
-                                ? it.name
-                                : ""}
-                        </text>
-                        <text fg={MUTED}>{homeRowMeta(it)}</text>
-                        <box flexGrow={1} />
-                        {/* The row's chips (M23.1: [+ agent] before the primary
-                          verb) — the SAME defs homeChipAt lays out from the
-                          right edge, so hover/click match cell-for-cell. */}
-                        <For each={homeRowChips(it)}>
-                          {(c) => (
-                            <text
-                              fg={BUTTON_FG}
-                              bg={
-                                isHovered(c.id === "agent" ? "homeagentchip" : "homechip", i())
-                                  ? BUTTON_HOVER_BG
-                                  : BUTTON_BG
-                              }
-                            >
-                              {c.label}
-                            </text>
-                          )}
-                        </For>
-                      </box>
-                    </Show>
-                  )}
-                </For>
-              </box>
-              <box flexGrow={1} />
-              <Show
-                when={sessionPrompt() !== null}
-                fallback={
-                  <Show
-                    when={pathPrompt() !== null}
-                    fallback={
-                      <box paddingLeft={1}>
-                        <text fg={ACCENT}>{detailLine()}</text>
-                      </box>
-                    }
-                  >
-                    <box paddingLeft={1} flexDirection="row">
-                      <text fg={ACCENT}>{"open file: "}</text>
-                      <text fg={DEFAULT_FG}>{`${pathPrompt() ?? ""}▏`}</text>
-                    </box>
-                  </Show>
-                }
-              >
-                <box paddingLeft={1} flexDirection="row">
-                  <text fg={ACCENT}>{"new session: "}</text>
-                  <text fg={DEFAULT_FG}>{`${sessionPrompt() ?? ""}▏`}</text>
-                </box>
-              </Show>
-              <box paddingLeft={1} flexDirection="row" gap={1}>
-                <text fg={MUTED}>{homeFooter()}</text>
-                {buttonRow(homeButtons)}
-              </box>
+              <HomeSurface
+                theme={semanticTheme()}
+                projection={homeSurfaceProjection()}
+                rollup={rollup()}
+              />
             </Show>
             <Show when={!activeCompositeLayout() && mode() === "mirror"}>
               <box paddingLeft={1} flexDirection="row" gap={1}>
@@ -7898,134 +7759,17 @@ try {
               </Show>
             </Show>
             <Show when={!activeCompositeLayout() && mode() === "editor"}>
-              {/* FILES tab: header (gy=0) · rule/banner (gy=1) · two-column body
-              (gy=2+): the file LIST on the left, the editor on the right. `route`
-              reverses this geometry for wheel + click. NO onMouse on the rows —
-              the main column container routes everything. */}
-              <box paddingLeft={1} flexDirection="row" gap={1}>
-                <text fg={ACCENT} attributes={1}>
-                  {editorPath() ? basename(editorPath()!) : "files"}
-                </text>
-                <Show when={editorModified()}>
-                  <text fg={MODIFIED_FG}>●</text>
-                </Show>
-                <text fg={MUTED}>{`${editorCursor().row + 1}:${editorCursor().col + 1}`}</text>
-                <text fg={MUTED}>{`${editorLines().length}L`}</text>
-                <text fg={MUTED}>{editorMsg()}</text>
-                <Show when={filesQuery() !== null}>
-                  <text fg={ACCENT}>{`/${filesQuery()}▏`}</text>
-                </Show>
-                {buttonRow(headerButtons)}
-              </box>
-              <Show
-                when={readOnlyBanner(editorReadOnly())}
-                fallback={<text fg={MUTED}>{"─".repeat(Math.max(4, canvasCols() - 2))}</text>}
-              >
-                <box paddingLeft={1}>
-                  <text fg={BANNER_FG}>{readOnlyBanner(editorReadOnly())}</text>
-                </box>
-              </Show>
-              <box flexDirection="row" flexGrow={1}>
-                {/* Left: the workspace file list (one-level expandable). */}
-                <box width={filesListW()} flexDirection="column" backgroundColor={GUTTER_BG}>
-                  <For each={fileListVisible()}>
-                    {(row) => {
-                      const n = row.node;
-                      const selected = () => row.index === fileSel() && filesFocus() === "list";
-                      // Reactive: the status map refreshes on the watcher/poll.
-                      const letter = () => fileStatusFor(n);
-                      const prefix =
-                        "  ".repeat(n.depth) + (n.isDir ? (n.expanded ? "▾ " : "▸ ") : "  ");
-                      const label = (prefix + n.name).slice(0, filesListW() - 4);
-                      return (
-                        <box
-                          paddingLeft={1}
-                          height={1}
-                          flexDirection="row"
-                          backgroundColor={
-                            selected()
-                              ? TAB_ACTIVE_BG
-                              : isHovered("files", row.index)
-                                ? HOVER_BG
-                                : GUTTER_BG
-                          }
-                        >
-                          <text
-                            flexGrow={1}
-                            fg={
-                              n.ignored
-                                ? DIFF_META_FG // gitignored: dimmed when shown
-                                : n.isDir
-                                  ? DIR_FG
-                                  : selected()
-                                    ? DEFAULT_FG
-                                    : MUTED
-                            }
-                          >
-                            {label}
-                          </text>
-                          <Show when={letter()}>
-                            <text fg={STATUS_LETTER_FG[letter()!] ?? DEFAULT_FG}>
-                              {` ${letter()!}`}
-                            </text>
-                          </Show>
-                        </box>
-                      );
-                    }}
-                  </For>
-                </box>
-                {/* Right: the editor viewport (gutter + text runs + cursor) with a
-                  right-edge scrollbar overlaid on the last column. */}
-                <box position="relative" flexGrow={1} flexDirection="column">
-                  {scrollbarOverlay(editorScrollGeom)}
-                  <For each={editorVisible()}>
-                    {(ln) => {
-                      const gw = gutterWidth(editorLines().length);
-                      // An active selection on this line inverse-tints its span
-                      // (and wins over the cursor cell, which sits at the drag head
-                      // on the selection boundary anyway).
-                      const selR = editorSelRange(ln.num - 1, ln.text.length);
-                      return (
-                        <box flexDirection="row" height={1}>
-                          <text bg={GUTTER_BG} fg={GUTTER_FG}>
-                            {formatGutter(ln.num, gw)}
-                          </text>
-                          <Show
-                            when={selR}
-                            fallback={
-                              <Show
-                                when={ln.cursorCol !== null}
-                                fallback={<text fg={DEFAULT_FG}>{ln.text}</text>}
-                              >
-                                <text fg={DEFAULT_FG}>{ln.text.slice(0, ln.cursorCol!)}</text>
-                                <text fg={DEFAULT_BG} bg={CURSOR_BG}>
-                                  {ln.text[ln.cursorCol!] ?? " "}
-                                </text>
-                                <text fg={DEFAULT_FG}>{ln.text.slice(ln.cursorCol! + 1)}</text>
-                              </Show>
-                            }
-                          >
-                            <text fg={DEFAULT_FG}>{ln.text.slice(0, selR!.from)}</text>
-                            <text fg={DEFAULT_FG} attributes={ATTR_INVERSE}>
-                              {ln.text.slice(selR!.from, selR!.to + 1) || " "}
-                            </text>
-                            <text fg={DEFAULT_FG}>{ln.text.slice(selR!.to + 1)}</text>
-                          </Show>
-                        </box>
-                      );
-                    }}
-                  </For>
-                </box>
-              </box>
-              <box paddingLeft={1}>
-                <text fg={MUTED}>
-                  {`j/k · enter open · [/] change · / filter · H dot:${
-                    showHiddenFiles() ? "on" : "off"
-                  } · I ign:${
-                    showIgnoredFiles() ? "on" : "off"
-                  } · ^s save · esc list · ^g home · ${QUIT_HINT}`}
-                </text>
-              </box>
+              <FilesSurface
+                theme={semanticTheme()}
+                projection={filesSurfaceProjection()}
+                colors={{
+                  gutterBg: GUTTER_BG,
+                  gutterFg: GUTTER_FG,
+                  cursorBg: CURSOR_BG,
+                  modifiedFg: MODIFIED_FG,
+                  statusLetterFg: STATUS_LETTER_FG,
+                }}
+              />
             </Show>
             <Show when={!activeCompositeLayout() && mode() === "diff"}>
               {/* header (y=0) · rule (y=1) · two-column body (y=2+) · footer

--- a/packages/daemon/src/tui/mirror/files-surface.ts
+++ b/packages/daemon/src/tui/mirror/files-surface.ts
@@ -1,0 +1,371 @@
+import type { RGBA } from "@opentui/core";
+import { clampTop, gutterWidth, type ReadOnlyReason } from "./editor-buffer.ts";
+import { type FileNode, type FilteredRow } from "./file-tree.ts";
+import { clipTerminal } from "./missions-workspace.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import { actionChipSpansFromRight, type Rect } from "./recipes.ts";
+
+export type FilesSurfaceVariant = "compact" | "standard" | "wide";
+export type FilesFocusArea = "list" | "editor";
+export type FilesActionId =
+  | "open"
+  | "toggle-directory"
+  | "filter"
+  | "toggle-hidden"
+  | "toggle-ignored"
+  | "refresh"
+  | "save"
+  | "reload"
+  | "focus-list"
+  | "focus-editor";
+
+export interface FilesActionDescriptor {
+  id: FilesActionId;
+  label: string;
+  disabled?: boolean;
+  hovered?: boolean;
+  description: string;
+}
+
+export type FilesActionSpan = FilesActionDescriptor & { start: number; width: number };
+
+export interface FilesProjectedRow extends Rect {
+  id: string;
+  role: "directory" | "file";
+  sourceIndex: number;
+  visibleIndex: number;
+  label: string;
+  depth: number;
+  selected: boolean;
+  hovered: boolean;
+  disabled: boolean;
+  ignored: boolean;
+  status: string | null;
+  actions: readonly FilesActionDescriptor[];
+}
+
+export interface FilesProjectedEditorLine extends Rect {
+  id: string;
+  lineNumber: number;
+  gutter: string;
+  text: string;
+  cursorCol: number | null;
+}
+
+export interface FilesSurfaceProjection {
+  width: number;
+  height: number;
+  variant: FilesSurfaceVariant;
+  header: Rect;
+  banner: Rect;
+  body: Rect;
+  footer: Rect;
+  list: Rect;
+  editor: Rect;
+  previewVisible: boolean;
+  title: string;
+  pathContext: string;
+  headerMeta: readonly string[];
+  filter: { active: boolean; query: string };
+  state: "loading" | "empty" | "error" | "ready" | "success";
+  stateMessage: string;
+  rows: readonly FilesProjectedRow[];
+  editorLines: readonly FilesProjectedEditorLine[];
+  footerHint: string;
+  actions: readonly FilesActionSpan[];
+}
+
+export interface FilesSurfaceInput {
+  width: number;
+  height: number;
+  workspaceDir: string;
+  editorPath: string | null;
+  editorModified: boolean;
+  editorCursor: { row: number; col: number };
+  editorLineCount: number;
+  editorMessage: string;
+  readOnly: ReadOnlyReason;
+  filterQuery: string | null;
+  focus: FilesFocusArea;
+  showHidden: boolean;
+  showIgnored: boolean;
+  visibleRows: readonly { node: FileNode; index: number }[];
+  totalRows: number;
+  fileSelection: number;
+  fileTop: number;
+  editorVisible: readonly { num: number; text: string; cursorCol: number | null }[];
+  editorTop: number;
+  editorTotalLines: number;
+  hovered: { region: "files" | "button"; index: number } | null;
+  statusFor(node: FileNode): string | null;
+  readOnlyBanner: string | null;
+  footerBase: string;
+}
+
+export function filesSurfaceVariant(width: number, height: number): FilesSurfaceVariant {
+  if (width >= 160 && height >= 45) return "wide";
+  if (width >= 96 && height >= 30) return "standard";
+  return "compact";
+}
+
+export function filesListWidth(width: number): number {
+  const safe = Math.max(0, Math.floor(width));
+  if (safe < 58) return safe;
+  if (safe < 96) return Math.max(20, Math.min(34, Math.floor(safe * 0.42)));
+  return Math.max(24, Math.min(44, Math.floor(safe * 0.34)));
+}
+
+export function filesBodyRows(height: number): number {
+  return Math.max(0, Math.floor(height) - 3);
+}
+
+export function filesHitTest(
+  projection: FilesSurfaceProjection,
+  x: number,
+  y: number,
+):
+  | { area: "header"; actionId?: FilesActionId; actionIndex?: number }
+  | { area: "list"; rowIndex?: number }
+  | { area: "editor" | "footer" }
+  | null {
+  if (x < 0 || y < 0 || x >= projection.width || y >= projection.height) return null;
+  if (y < projection.header.height) {
+    const actionIndex = projection.actions.findIndex(
+      (action) => x >= action.start && x < action.start + action.width,
+    );
+    if (actionIndex >= 0) {
+      return {
+        area: "header",
+        actionId: projection.actions[actionIndex]!.id,
+        actionIndex,
+      };
+    }
+    return { area: "header" };
+  }
+  if (y >= projection.footer.y) return { area: "footer" };
+  if (y < projection.body.y) return null;
+  if (x < projection.list.width) {
+    const row = projection.rows.find((candidate) => y === candidate.y);
+    return row ? { area: "list", rowIndex: row.visibleIndex } : { area: "list" };
+  }
+  return { area: "editor" };
+}
+
+export function projectFilesSurface(input: FilesSurfaceInput): FilesSurfaceProjection {
+  const width = Math.max(0, Math.floor(input.width));
+  const height = Math.max(0, Math.floor(input.height));
+  const variant = filesSurfaceVariant(width, height);
+  const headerHeight = Math.min(1, height);
+  const bannerHeight = height >= 4 ? 1 : 0;
+  const footerHeight = height >= 6 ? 1 : 0;
+  const bodyY = headerHeight + bannerHeight;
+  const bodyHeight = Math.max(0, height - bodyY - footerHeight);
+  const body: Rect = { x: 0, y: bodyY, width, height: bodyHeight };
+  const listWidth = Math.min(width, filesListWidth(width));
+  const previewVisible = width - listWidth >= 24 && bodyHeight > 0;
+  const list: Rect = {
+    x: 0,
+    y: bodyY,
+    width: previewVisible ? listWidth : width,
+    height: bodyHeight,
+  };
+  const editor: Rect = {
+    x: previewVisible ? listWidth : 0,
+    y: bodyY,
+    width: previewVisible ? Math.max(0, width - listWidth) : 0,
+    height: bodyHeight,
+  };
+  const title = "Files";
+  const rows = input.visibleRows.slice(0, bodyHeight).map((row, i) =>
+    projectFileRow({
+      row,
+      y: bodyY + i,
+      width: list.width,
+      selection: input.fileSelection,
+      focus: input.focus,
+      hovered: input.hovered,
+      status: input.statusFor(row.node),
+    }),
+  );
+  const editorLines = previewVisible
+    ? input.editorVisible.slice(0, bodyHeight).map((line, i) =>
+        projectEditorLine({
+          line,
+          y: bodyY + i,
+          x: editor.x,
+          width: editor.width,
+          totalLines: input.editorTotalLines,
+        }),
+      )
+    : [];
+  const state = filesState(input, rows.length, editorLines.length);
+  const actions: FilesActionDescriptor[] = [
+    { id: "filter", label: "/ filter", description: "Filter file names" },
+    {
+      id: "toggle-hidden",
+      label: `H dot:${input.showHidden ? "on" : "off"}`,
+      description: "Toggle dotfiles",
+    },
+    {
+      id: "toggle-ignored",
+      label: `I ign:${input.showIgnored ? "on" : "off"}`,
+      description: "Toggle gitignored files",
+    },
+    { id: "refresh", label: "r refresh", description: "Refresh file tree" },
+  ];
+  if (input.editorPath) {
+    actions.unshift({
+      id: "reload",
+      label: "reload",
+      description: "Reload open file",
+    });
+    if (input.editorModified && !input.readOnly) {
+      actions.unshift({ id: "save", label: "save", description: "Save open file" });
+    }
+  }
+  const actionLimit = variant === "compact" ? 3 : variant === "standard" ? 5 : actions.length;
+  const visibleActions = actions.slice(0, actionLimit).map((action, index) => ({
+    ...action,
+    hovered: input.hovered?.region === "button" && input.hovered.index === index,
+  }));
+  const actionSpans = actionChipSpansFromRight(visibleActions, width, 1);
+  return {
+    width,
+    height,
+    variant,
+    header: { x: 0, y: 0, width, height: headerHeight },
+    banner: { x: 0, y: headerHeight, width, height: bannerHeight },
+    body,
+    footer: { x: 0, y: height - footerHeight, width, height: footerHeight },
+    list,
+    editor,
+    previewVisible,
+    title,
+    pathContext: clipTerminal(input.editorPath ?? input.workspaceDir, width),
+    headerMeta: [
+      `${input.editorCursor.row + 1}:${input.editorCursor.col + 1}`,
+      `${input.editorLineCount}L`,
+      input.editorMessage,
+    ].filter(Boolean),
+    filter: { active: input.filterQuery !== null, query: input.filterQuery ?? "" },
+    state,
+    stateMessage: filesStateMessage(input, state),
+    rows,
+    editorLines,
+    footerHint:
+      variant === "compact"
+        ? "enter open · / filter · esc list"
+        : clipTerminal(input.footerBase, width),
+    actions: actionSpans,
+  };
+}
+
+function filesState(
+  input: FilesSurfaceInput,
+  visibleCount: number,
+  editorVisibleCount: number,
+): FilesSurfaceProjection["state"] {
+  if (input.readOnlyBanner) return "error";
+  if (input.totalRows === 0 && input.visibleRows.length === 0) return "empty";
+  if (input.editorMessage.toLowerCase().includes("saved")) return "success";
+  if (input.visibleRows.length === 0 && input.filterQuery !== null) return "empty";
+  if (visibleCount === 0 && editorVisibleCount === 0) return "loading";
+  return "ready";
+}
+
+function filesStateMessage(
+  input: FilesSurfaceInput,
+  state: FilesSurfaceProjection["state"],
+): string {
+  if (state === "error") return input.readOnlyBanner ?? "file unavailable";
+  if (state === "empty" && input.filterQuery !== null)
+    return `no files match /${input.filterQuery}`;
+  if (state === "empty") return "no files visible — try H or I";
+  if (state === "success") return input.editorMessage;
+  if (state === "loading") return "loading files…";
+  return input.editorPath ? input.editorPath : input.workspaceDir;
+}
+
+function projectFileRow(input: {
+  row: FilteredRow;
+  y: number;
+  width: number;
+  selection: number;
+  focus: FilesFocusArea;
+  hovered: { region: "files" | "button"; index: number } | null;
+  status: string | null;
+}): FilesProjectedRow {
+  const n = input.row.node;
+  const prefix = "  ".repeat(n.depth) + (n.isDir ? (n.expanded ? "▾ " : "▸ ") : "  ");
+  const selected = input.row.index === input.selection && input.focus === "list";
+  const statusReserve = input.status ? 2 : 0;
+  const label = clipTerminal(prefix + n.name, Math.max(1, input.width - statusReserve - 1));
+  return {
+    id: `file:${n.path}`,
+    role: n.isDir ? "directory" : "file",
+    sourceIndex: input.row.index,
+    visibleIndex: input.row.index,
+    x: 0,
+    y: input.y,
+    width: input.width,
+    height: 1,
+    label,
+    depth: n.depth,
+    selected,
+    hovered: input.hovered?.region === "files" && input.hovered.index === input.row.index,
+    disabled: false,
+    ignored: n.ignored,
+    status: input.status,
+    actions: [
+      {
+        id: n.isDir ? "toggle-directory" : "open",
+        label: n.isDir ? "toggle" : "open",
+        description: n.isDir ? "Expand or collapse directory" : "Open file in editor",
+      },
+    ],
+  };
+}
+
+function projectEditorLine(input: {
+  line: { num: number; text: string; cursorCol: number | null };
+  x: number;
+  y: number;
+  width: number;
+  totalLines: number;
+}): FilesProjectedEditorLine {
+  const gw = gutterWidth(input.totalLines);
+  const contentWidth = Math.max(0, input.width - gw);
+  return {
+    id: `line:${input.line.num}`,
+    x: input.x,
+    y: input.y,
+    width: input.width,
+    height: 1,
+    lineNumber: input.line.num,
+    gutter: formatGutterText(input.line.num, gw),
+    text: clipTerminal(input.line.text, contentWidth),
+    cursorCol: input.line.cursorCol,
+  };
+}
+
+function formatGutterText(num: number, width: number): string {
+  const s = String(num);
+  return `${" ".repeat(Math.max(0, width - s.length - 1))}${s} `;
+}
+
+export function filesVisibleTop(fileTop: number, totalRows: number, height: number): number {
+  return clampTop(fileTop, totalRows, filesBodyRows(height));
+}
+
+export function clippedStatusLetter(
+  status: string | null,
+  colorMap: Record<string, RGBA>,
+): { letter: string; color: RGBA } | null {
+  if (!status) return null;
+  const color = colorMap[status];
+  return color ? { letter: status, color } : null;
+}
+
+export function fitsWidth(text: string, width: number): boolean {
+  return terminalDisplayWidth(text) <= width;
+}

--- a/packages/daemon/src/tui/mirror/files-surface.tsx
+++ b/packages/daemon/src/tui/mirror/files-surface.tsx
@@ -1,0 +1,242 @@
+/* @jsxImportSource @opentui/solid */
+import { For, Show } from "solid-js";
+import type { RGBA } from "@opentui/core";
+import type { SemanticThemeSnapshot } from "./theme.ts";
+import { ActionChip, EmptyState, InputShell, SelectableRow } from "./recipes.tsx";
+import { recipePalette } from "./recipes.ts";
+import {
+  filesHitTest,
+  type FilesProjectedRow,
+  type FilesSurfaceProjection,
+} from "./files-surface.ts";
+import { clipTerminal } from "./missions-workspace.ts";
+
+export interface FilesSurfaceTheme {
+  gutterBg: RGBA;
+  gutterFg: RGBA;
+  cursorBg: RGBA;
+  modifiedFg: RGBA;
+  statusLetterFg: Record<string, RGBA>;
+}
+
+export interface FilesSurfaceProps {
+  theme: SemanticThemeSnapshot;
+  colors: FilesSurfaceTheme;
+  projection: FilesSurfaceProjection;
+}
+
+export function FilesSurface(props: FilesSurfaceProps) {
+  return (
+    <box
+      width={props.projection.width}
+      height={props.projection.height}
+      position="relative"
+      backgroundColor={props.theme.colors.background}
+      overflow="hidden"
+    >
+      <FilesHeader theme={props.theme} projection={props.projection} />
+      <box
+        position="absolute"
+        left={0}
+        top={props.projection.banner.y}
+        width={props.projection.banner.width}
+        height={props.projection.banner.height}
+        paddingLeft={1}
+      >
+        <text
+          fg={
+            props.projection.state === "error"
+              ? props.theme.colors.status.blocked
+              : props.projection.state === "success"
+                ? props.theme.colors.status.done
+                : props.theme.colors.mutedForeground
+          }
+        >
+          {props.projection.stateMessage}
+        </text>
+      </box>
+      <box
+        position="absolute"
+        left={props.projection.list.x}
+        top={props.projection.list.y}
+        width={props.projection.list.width}
+        height={props.projection.list.height}
+        flexDirection="column"
+        backgroundColor={props.colors.gutterBg}
+        overflow="hidden"
+      >
+        <Show
+          when={props.projection.rows.length > 0}
+          fallback={
+            <EmptyState
+              theme={props.theme}
+              title={props.projection.state === "loading" ? "Loading files" : "No files"}
+              detail={props.projection.stateMessage}
+              width={props.projection.list.width}
+            />
+          }
+        >
+          <For each={props.projection.rows}>
+            {(row) => (
+              <FileRow
+                theme={props.theme}
+                colors={props.colors}
+                row={row}
+                width={props.projection.list.width}
+              />
+            )}
+          </For>
+        </Show>
+      </box>
+      <Show when={props.projection.previewVisible}>
+        <box
+          position="absolute"
+          left={props.projection.editor.x}
+          top={props.projection.editor.y}
+          width={props.projection.editor.width}
+          height={props.projection.editor.height}
+          flexDirection="column"
+          overflow="hidden"
+        >
+          <Show
+            when={props.projection.editorLines.length > 0}
+            fallback={
+              <EmptyState
+                theme={props.theme}
+                title="No file open"
+                detail="Select a file from the list."
+                width={props.projection.editor.width}
+              />
+            }
+          >
+            <For each={props.projection.editorLines}>
+              {(line) => (
+                <box height={1} flexDirection="row" overflow="hidden">
+                  <text bg={props.colors.gutterBg} fg={props.colors.gutterFg}>
+                    {line.gutter}
+                  </text>
+                  <Show
+                    when={line.cursorCol !== null}
+                    fallback={<text fg={props.theme.colors.foreground}>{line.text}</text>}
+                  >
+                    <text fg={props.theme.colors.foreground}>
+                      {line.text.slice(0, line.cursorCol!)}
+                    </text>
+                    <text fg={props.theme.colors.background} bg={props.colors.cursorBg}>
+                      {line.text[line.cursorCol!] ?? " "}
+                    </text>
+                    <text fg={props.theme.colors.foreground}>
+                      {line.text.slice(line.cursorCol! + 1)}
+                    </text>
+                  </Show>
+                </box>
+              )}
+            </For>
+          </Show>
+        </box>
+      </Show>
+      <box
+        position="absolute"
+        left={0}
+        top={props.projection.footer.y}
+        width={props.projection.footer.width}
+        height={props.projection.footer.height}
+        paddingLeft={1}
+        overflow="hidden"
+      >
+        <text fg={props.theme.colors.mutedForeground}>{props.projection.footerHint}</text>
+      </box>
+    </box>
+  );
+}
+
+function FilesHeader(props: { theme: SemanticThemeSnapshot; projection: FilesSurfaceProjection }) {
+  const leftWidth = () => Math.max(0, props.projection.actions[0]?.start ?? props.projection.width);
+  return (
+    <box
+      position="absolute"
+      left={0}
+      top={props.projection.header.y}
+      width={props.projection.header.width}
+      height={props.projection.header.height}
+      overflow="hidden"
+    >
+      <box
+        height={1}
+        width={leftWidth()}
+        paddingLeft={1}
+        flexDirection="row"
+        gap={1}
+        overflow="hidden"
+      >
+        <text fg={props.theme.colors.accent} attributes={1}>
+          {props.projection.title}
+        </text>
+        <For each={props.projection.headerMeta}>
+          {(meta) => <text fg={props.theme.colors.mutedForeground}>{meta}</text>}
+        </For>
+        <Show when={props.projection.filter.active}>
+          <InputShell
+            theme={props.theme}
+            value={props.projection.filter.query}
+            placeholder="filter files"
+            width={Math.min(30, Math.max(12, leftWidth() - 32))}
+            focused
+          />
+        </Show>
+      </box>
+      <For each={props.projection.actions}>
+        {(action) => (
+          <box position="absolute" left={action.start} top={0} width={action.width} height={1}>
+            <ActionChip
+              theme={props.theme}
+              label={action.label}
+              width={action.width}
+              disabled={action.disabled}
+              hovered={action.hovered}
+            />
+          </box>
+        )}
+      </For>
+    </box>
+  );
+}
+
+function FileRow(props: {
+  theme: SemanticThemeSnapshot;
+  colors: FilesSurfaceTheme;
+  row: FilesProjectedRow;
+  width: number;
+}) {
+  const palette = () =>
+    recipePalette(props.theme, {
+      selected: props.row.selected,
+      hovered: props.row.hovered,
+      disabled: props.row.disabled,
+      status: props.row.status ? "working" : undefined,
+    });
+  const tone = () => (props.row.role === "directory" ? "accent" : "neutral");
+  return (
+    <box height={1} backgroundColor={palette().background} flexDirection="row" overflow="hidden">
+      <SelectableRow
+        theme={props.theme}
+        label={props.row.label}
+        meta=""
+        width={Math.max(1, props.width - (props.row.status ? 2 : 0))}
+        selected={props.row.selected}
+        hovered={props.row.hovered}
+        disabled={props.row.disabled}
+        tone={tone()}
+      />
+      <Show when={props.row.status}>
+        {(status) => (
+          <text fg={props.colors.statusLetterFg[status()] ?? props.theme.colors.foreground}>
+            {` ${status()}`}
+          </text>
+        )}
+      </Show>
+    </box>
+  );
+}
+
+export { filesHitTest };

--- a/packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx
@@ -1,0 +1,611 @@
+/* @jsxImportSource @opentui/solid */
+import { MouseButtons } from "@opentui/core/testing";
+import { testRender, useKeyboard } from "@opentui/solid";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it } from "bun:test";
+import { RGBA } from "@opentui/core";
+import { HomeSurface, homeActionAtProjection } from "./home-surface.tsx";
+import { projectHomeSurface } from "./home-surface.ts";
+import { FilesSurface } from "./files-surface.tsx";
+import { filesHitTest, projectFilesSurface } from "./files-surface.ts";
+import { createSemanticThemeSnapshot } from "./theme.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import type { HomeFleetProject, HomeItem } from "./home-model.ts";
+import type { FileNode } from "./file-tree.ts";
+import { actionChipWidth } from "./recipes.ts";
+
+type TestSetup = Awaited<ReturnType<typeof testRender>>;
+
+let setup: TestSetup | null = null;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = null;
+});
+
+const THEME = createSemanticThemeSnapshot({ mode: "dark" });
+const COLORS = {
+  gutterBg: RGBA.fromInts(24, 26, 34, 255),
+  gutterFg: RGBA.fromInts(120, 124, 140, 255),
+  cursorBg: RGBA.fromInts(120, 170, 255, 255),
+  modifiedFg: RGBA.fromInts(255, 210, 110, 255),
+  statusLetterFg: {
+    M: RGBA.fromInts(255, 190, 100, 255),
+    A: RGBA.fromInts(120, 220, 150, 255),
+  },
+};
+
+function frameLines(frame: string): string[] {
+  const lines = frame.endsWith("\n") ? frame.slice(0, -1).split("\n") : frame.split("\n");
+  return lines.map((line) => line.replace(/\r$/u, ""));
+}
+
+function stableFrame(frame: string): string {
+  return frameLines(frame)
+    .map((line) => line.replace(/\s+$/u, ""))
+    .join("\n");
+}
+
+function expectFrameBounds(frame: string, width: number, height: number): void {
+  const lines = frameLines(frame);
+  expect(lines).toHaveLength(height);
+  for (const line of lines) expect(terminalDisplayWidth(line)).toBeLessThanOrEqual(width);
+}
+
+function expectPaintedChip(
+  frame: string,
+  x: number,
+  y: number,
+  width: number,
+  label: string,
+): void {
+  const line = frameLines(frame)[y] ?? "";
+  const painted = line.slice(x, x + width);
+  expect(terminalDisplayWidth(painted)).toBe(width);
+  expect(painted).toContain(label);
+  expect(width).toBe(actionChipWidth(label));
+}
+
+const fleetProject = (over: Partial<HomeFleetProject>): HomeFleetProject => ({
+  name: "workspace",
+  dir: "/repo/workspace",
+  registered: true,
+  running: true,
+  sessions: [],
+  ...over,
+});
+
+const homeItems: HomeItem[] = [
+  {
+    kind: "session",
+    session: "workspace",
+    project: "workspace",
+    status: "working",
+    windows: 2,
+    dir: "/repo/workspace",
+  },
+  { kind: "project", name: "docs", dir: "/repo/docs" },
+  { kind: "recent", name: "playground", dir: "/tmp/playground" },
+];
+
+const fileNode = (over: Partial<FileNode>): FileNode => ({
+  name: "app.ts",
+  path: "/repo/workspace/app.ts",
+  isDir: false,
+  depth: 0,
+  expanded: false,
+  ignored: false,
+  ...over,
+});
+
+async function renderHomeHarness(
+  width: number,
+  height: number,
+  variant: "first-run" | "populated",
+  options: { items?: HomeItem[]; selectedIndex?: number } = {},
+) {
+  const calls: string[] = [];
+  let latestFrame = "";
+
+  function Harness() {
+    const [selected, setSelected] = createSignal(options.selectedIndex ?? 0);
+    const projects =
+      variant === "first-run"
+        ? []
+        : [
+            fleetProject({
+              sessions: [{ name: "workspace", status: "working", windows: [{}, {}] }],
+            }),
+          ];
+    const items = variant === "first-run" ? [] : (options.items ?? homeItems);
+    const projection = () =>
+      projectHomeSurface({
+        width,
+        height,
+        projects,
+        items,
+        selectedIndex: selected(),
+        hovered: null,
+        rollup: {
+          blocked: 0,
+          working: variant === "first-run" ? 0 : 1,
+          done: 0,
+          idle: 0,
+          unknown: 0,
+          totalAgents: variant === "first-run" ? 0 : 1,
+        },
+        detail: variant === "first-run" ? "open a folder to start" : "workspace · 2 windows",
+        footerHint: "enter open · n new session · ^q quit",
+        pathPrompt: null,
+        sessionPrompt: null,
+        quitHint: "^q quit",
+        welcomeLine: "Welcome to tmux-ide",
+        welcomeActionLabel: "▸ open a folder — press f",
+        welcomeTip: "press f to open",
+      });
+    const run = (id: string) => calls.push(id);
+    useKeyboard((event) => {
+      if (event.name === "down") setSelected(Math.min(items.length - 1, selected() + 1));
+      else if (event.name === "enter") run(`keyboard:${items[selected()]?.kind ?? "none"}`);
+    });
+    return (
+      <box
+        width={width}
+        height={height}
+        overflow="hidden"
+        onMouseDown={(event) => {
+          const action = homeActionAtProjection(projection(), event.x, event.y);
+          if (action) run(`mouse:${action.source}:${action.id}`);
+        }}
+      >
+        <HomeSurface
+          theme={THEME}
+          projection={projection()}
+          rollup={{
+            blocked: 0,
+            working: variant === "first-run" ? 0 : 1,
+            done: 0,
+            idle: 0,
+            unknown: 0,
+            totalAgents: variant === "first-run" ? 0 : 1,
+          }}
+        />
+      </box>
+    );
+  }
+
+  setup = await testRender(() => <Harness />, { width, height });
+  await setup.renderOnce();
+  latestFrame = setup.captureCharFrame();
+  return {
+    calls,
+    frame: () => {
+      latestFrame = setup!.captureCharFrame();
+      return latestFrame;
+    },
+    clickWelcome: async () => {
+      const projection = projectHomeSurface({
+        width,
+        height,
+        projects: [],
+        items: [],
+        selectedIndex: 0,
+        hovered: null,
+        rollup: { blocked: 0, working: 0, done: 0, idle: 0, unknown: 0, totalAgents: 0 },
+        detail: "open a folder to start",
+        footerHint: "enter open · n new session · ^q quit",
+        pathPrompt: null,
+        sessionPrompt: null,
+        quitHint: "^q quit",
+        welcomeLine: "Welcome to tmux-ide",
+        welcomeActionLabel: "▸ open a folder — press f",
+        welcomeTip: "press f to open",
+      });
+      const action = projection.welcome!.action;
+      await setup!.mockMouse.click(action.x + 1, action.y, MouseButtons.LEFT);
+    },
+    projection: () =>
+      projectHomeSurface({
+        width,
+        height,
+        projects:
+          variant === "first-run"
+            ? []
+            : [
+                fleetProject({
+                  sessions: [{ name: "workspace", status: "working", windows: [{}, {}] }],
+                }),
+              ],
+        items: variant === "first-run" ? [] : (options.items ?? homeItems),
+        selectedIndex: options.selectedIndex ?? 0,
+        hovered: null,
+        rollup: {
+          blocked: 0,
+          working: variant === "first-run" ? 0 : 1,
+          done: 0,
+          idle: 0,
+          unknown: 0,
+          totalAgents: variant === "first-run" ? 0 : 1,
+        },
+        detail: variant === "first-run" ? "open a folder to start" : "workspace · 2 windows",
+        footerHint: "enter open · n new session · ^q quit",
+        pathPrompt: null,
+        sessionPrompt: null,
+        quitHint: "^q quit",
+        welcomeLine: "Welcome to tmux-ide",
+        welcomeActionLabel: "▸ open a folder — press f",
+        welcomeTip: "press f to open",
+      }),
+  };
+}
+
+async function renderFilesHarness(
+  width: number,
+  height: number,
+  variant: "filtered" | "empty" | "error",
+) {
+  const calls: string[] = [];
+  let latestFrame = "";
+
+  function Harness() {
+    const [selected, setSelected] = createSignal(0);
+    const rows =
+      variant === "empty"
+        ? []
+        : [
+            {
+              node: fileNode({
+                name: "src",
+                path: "/repo/workspace/src",
+                isDir: true,
+                expanded: true,
+              }),
+              index: 0,
+            },
+            {
+              node: fileNode({ name: "app.ts", path: "/repo/workspace/src/app.ts", depth: 1 }),
+              index: 1,
+            },
+          ];
+    const projection = () =>
+      projectFilesSurface({
+        width,
+        height,
+        workspaceDir: "/repo/workspace",
+        editorPath: variant === "empty" ? null : "/repo/workspace/src/app.ts",
+        editorModified: variant === "filtered",
+        editorCursor: { row: 0, col: 7 },
+        editorLineCount: variant === "empty" ? 0 : 2,
+        editorMessage: variant === "error" ? "read failed" : "ready",
+        readOnly: variant === "error" ? { kind: "outside-workspace", path: "/tmp/outside" } : null,
+        filterQuery: variant === "filtered" ? "app" : null,
+        focus: "list",
+        showHidden: false,
+        showIgnored: false,
+        visibleRows: rows,
+        totalRows: rows.length,
+        fileSelection: selected(),
+        fileTop: 0,
+        editorVisible:
+          variant === "empty"
+            ? []
+            : [
+                {
+                  num: 1,
+                  text: "export const app = true;",
+                  cursorCol: variant === "filtered" ? 7 : null,
+                },
+                { num: 2, text: "console.log(app);", cursorCol: null },
+              ],
+        editorTop: 0,
+        editorTotalLines: variant === "empty" ? 0 : 2,
+        hovered: null,
+        statusFor: (node) => (node.name === "app.ts" ? "M" : null),
+        readOnlyBanner: variant === "error" ? "outside workspace" : null,
+        footerBase: "enter open · / filter · ^q quit",
+      });
+    useKeyboard((event) => {
+      if (event.name === "down") setSelected(Math.min(rows.length - 1, selected() + 1));
+      else if (event.name === "enter")
+        calls.push(`keyboard:${rows[selected()]?.node.name ?? "none"}`);
+      else if (event.name === "/") calls.push("keyboard:filter");
+    });
+    return (
+      <box
+        width={width}
+        height={height}
+        overflow="hidden"
+        onMouseDown={(event) => {
+          const hit = filesHitTest(projection(), event.x, event.y);
+          if (hit?.area === "list" && hit.rowIndex !== undefined)
+            calls.push(`mouse:open:${hit.rowIndex}`);
+          else if (hit?.area === "header" && hit.actionId) calls.push(`mouse:${hit.actionId}`);
+          else calls.push(`mouse:${hit?.area ?? "none"}`);
+        }}
+      >
+        <FilesSurface theme={THEME} projection={projection()} colors={COLORS} />
+      </box>
+    );
+  }
+
+  setup = await testRender(() => <Harness />, { width, height });
+  await setup.renderOnce();
+  latestFrame = setup.captureCharFrame();
+  return {
+    calls,
+    frame: () => {
+      latestFrame = setup!.captureCharFrame();
+      return latestFrame;
+    },
+    clickSelectedRow: async () => {
+      const projection = projectFilesSurface({
+        width,
+        height,
+        workspaceDir: "/repo/workspace",
+        editorPath: "/repo/workspace/src/app.ts",
+        editorModified: true,
+        editorCursor: { row: 0, col: 7 },
+        editorLineCount: 2,
+        editorMessage: "ready",
+        readOnly: null,
+        filterQuery: "app",
+        focus: "list",
+        showHidden: false,
+        showIgnored: false,
+        visibleRows: [
+          {
+            node: fileNode({
+              name: "src",
+              path: "/repo/workspace/src",
+              isDir: true,
+              expanded: true,
+            }),
+            index: 0,
+          },
+          {
+            node: fileNode({ name: "app.ts", path: "/repo/workspace/src/app.ts", depth: 1 }),
+            index: 1,
+          },
+        ],
+        totalRows: 2,
+        fileSelection: 0,
+        fileTop: 0,
+        editorVisible: [
+          { num: 1, text: "export const app = true;", cursorCol: 7 },
+          { num: 2, text: "console.log(app);", cursorCol: null },
+        ],
+        editorTop: 0,
+        editorTotalLines: 2,
+        hovered: null,
+        statusFor: (node) => (node.name === "app.ts" ? "M" : null),
+        readOnlyBanner: null,
+        footerBase: "enter open · / filter · ^q quit",
+      });
+      const row = projection.rows[0]!;
+      await setup!.mockMouse.click(1, row.y, MouseButtons.LEFT);
+    },
+    clickHeaderAction: async (id: "save" | "reload" | "filter") => {
+      const projection = projectFilesSurface({
+        width,
+        height,
+        workspaceDir: "/repo/workspace",
+        editorPath: "/repo/workspace/src/app.ts",
+        editorModified: true,
+        editorCursor: { row: 0, col: 7 },
+        editorLineCount: 2,
+        editorMessage: "ready",
+        readOnly: null,
+        filterQuery: "app",
+        focus: "list",
+        showHidden: false,
+        showIgnored: false,
+        visibleRows: [
+          {
+            node: fileNode({
+              name: "src",
+              path: "/repo/workspace/src",
+              isDir: true,
+              expanded: true,
+            }),
+            index: 0,
+          },
+          {
+            node: fileNode({ name: "app.ts", path: "/repo/workspace/src/app.ts", depth: 1 }),
+            index: 1,
+          },
+        ],
+        totalRows: 2,
+        fileSelection: 0,
+        fileTop: 0,
+        editorVisible: [
+          { num: 1, text: "export const app = true;", cursorCol: 7 },
+          { num: 2, text: "console.log(app);", cursorCol: null },
+        ],
+        editorTop: 0,
+        editorTotalLines: 2,
+        hovered: null,
+        statusFor: (node) => (node.name === "app.ts" ? "M" : null),
+        readOnlyBanner: null,
+        footerBase: "enter open · / filter · ^q quit",
+      });
+      const action = projection.actions.find((candidate) => candidate.id === id);
+      if (!action) throw new Error(`missing header action ${id}`);
+      await setup!.mockMouse.click(
+        action.start + Math.floor(action.width / 2),
+        0,
+        MouseButtons.LEFT,
+      );
+    },
+    projection: () =>
+      projectFilesSurface({
+        width,
+        height,
+        workspaceDir: "/repo/workspace",
+        editorPath: variant === "empty" ? null : "/repo/workspace/src/app.ts",
+        editorModified: variant === "filtered",
+        editorCursor: { row: 0, col: 7 },
+        editorLineCount: variant === "empty" ? 0 : 2,
+        editorMessage: variant === "error" ? "read failed" : "ready",
+        readOnly: variant === "error" ? { kind: "outside-workspace", path: "/tmp/outside" } : null,
+        filterQuery: variant === "filtered" ? "app" : null,
+        focus: "list",
+        showHidden: false,
+        showIgnored: false,
+        visibleRows:
+          variant === "empty"
+            ? []
+            : [
+                {
+                  node: fileNode({
+                    name: "src",
+                    path: "/repo/workspace/src",
+                    isDir: true,
+                    expanded: true,
+                  }),
+                  index: 0,
+                },
+                {
+                  node: fileNode({ name: "app.ts", path: "/repo/workspace/src/app.ts", depth: 1 }),
+                  index: 1,
+                },
+              ],
+        totalRows: variant === "empty" ? 0 : 2,
+        fileSelection: 0,
+        fileTop: 0,
+        editorVisible:
+          variant === "empty"
+            ? []
+            : [
+                {
+                  num: 1,
+                  text: "export const app = true;",
+                  cursorCol: variant === "filtered" ? 7 : null,
+                },
+                { num: 2, text: "console.log(app);", cursorCol: null },
+              ],
+        editorTop: 0,
+        editorTotalLines: variant === "empty" ? 0 : 2,
+        hovered: null,
+        statusFor: (node) => (node.name === "app.ts" ? "M" : null),
+        readOnlyBanner: variant === "error" ? "outside workspace" : null,
+        footerBase: "enter open · / filter · ^q quit",
+      }),
+  };
+}
+
+describe("Home and Files surfaces OpenTUI renderer", () => {
+  it.each([
+    [80, 24, "first-run"],
+    [120, 40, "populated"],
+    [200, 60, "populated"],
+  ] as const)("renders deterministic %sx%s home %s frame", async (width, height, variant) => {
+    const harness = await renderHomeHarness(width, height, variant);
+    const frame = harness.frame();
+    expectFrameBounds(frame, width, height);
+    expect(stableFrame(frame)).toMatchSnapshot();
+    expect(stableFrame(frame)).toContain("Home");
+    if (variant === "first-run") {
+      expect(stableFrame(frame)).toContain("open a folder");
+      const action = harness.projection().welcome!.action;
+      expectPaintedChip(frame, action.x, action.y, action.width, action.label);
+    } else {
+      expect(stableFrame(frame)).toContain("workspace");
+      expect(stableFrame(frame)).toContain("working");
+      const projection = harness.projection();
+      const rowAction = projection.rows[0]!.actionSpans.at(-1)!;
+      expectPaintedChip(
+        frame,
+        rowAction.start,
+        projection.rows[0]!.y,
+        rowAction.width,
+        rowAction.label,
+      );
+      for (const action of projection.footerActionSpans) {
+        expectPaintedChip(
+          frame,
+          action.start,
+          projection.footerActionY,
+          action.width,
+          action.label,
+        );
+      }
+    }
+  });
+
+  it.each([
+    [80, 24, "filtered"],
+    [120, 40, "empty"],
+    [200, 60, "error"],
+  ] as const)("renders deterministic %sx%s files %s frame", async (width, height, variant) => {
+    const harness = await renderFilesHarness(width, height, variant);
+    const frame = harness.frame();
+    expectFrameBounds(frame, width, height);
+    expect(stableFrame(frame)).toMatchSnapshot();
+    expect(stableFrame(frame)).toContain("Files");
+    const projection = harness.projection();
+    for (const action of projection.actions) {
+      expectPaintedChip(frame, action.start, 0, action.width, action.label);
+    }
+    if (projection.previewVisible) {
+      expect(filesHitTest(projection, projection.list.width - 1, projection.body.y)).toMatchObject({
+        area: "list",
+      });
+      expect(filesHitTest(projection, projection.editor.x, projection.body.y)).toMatchObject({
+        area: "editor",
+      });
+    }
+    if (variant === "filtered") expect(stableFrame(frame)).toContain("/app");
+    if (variant === "empty") expect(stableFrame(frame)).toContain("No files");
+    if (variant === "error") expect(stableFrame(frame)).toContain("outside workspace");
+  });
+
+  it("renders compact Home focus-following selected row inside the frame", async () => {
+    const many = Array.from(
+      { length: 30 },
+      (_, index): HomeItem => ({
+        kind: "session",
+        session: `session-${index}`,
+        project: "workspace",
+        status: "idle",
+        windows: 1,
+        dir: "/repo/workspace",
+      }),
+    );
+    const harness = await renderHomeHarness(80, 24, "populated", {
+      items: many,
+      selectedIndex: 29,
+    });
+    const frame = harness.frame();
+    const projection = harness.projection();
+    const selected = projection.rows.find((row) => row.selected)!;
+    expect(selected.itemIndex).toBe(29);
+    expect(stableFrame(frame)).toContain("session-29");
+    const action = selected.actionSpans.at(-1)!;
+    expectPaintedChip(frame, action.start, selected.y, action.width, action.label);
+  });
+
+  it("routes Home keyboard and mouse through the same local action boundary", async () => {
+    const harness = await renderHomeHarness(80, 24, "first-run");
+    await harness.clickWelcome();
+    await setup!.renderOnce();
+    expect(harness.calls).toEqual(["mouse:welcome:open-folder"]);
+  });
+
+  it("routes Files keyboard and mouse through the same local action boundary", async () => {
+    const harness = await renderFilesHarness(80, 24, "filtered");
+    await setup!.mockInput.pressKey("/");
+    await setup!.renderOnce();
+    await harness.clickHeaderAction("save");
+    await setup!.renderOnce();
+    await harness.clickHeaderAction("reload");
+    await setup!.renderOnce();
+    await harness.clickSelectedRow();
+    await setup!.renderOnce();
+    expect(harness.calls).toEqual([
+      "keyboard:filter",
+      "mouse:save",
+      "mouse:reload",
+      "mouse:open:0",
+    ]);
+  });
+});

--- a/packages/daemon/src/tui/mirror/home-files-surface.test.ts
+++ b/packages/daemon/src/tui/mirror/home-files-surface.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest";
+import type { HomeFleetProject, HomeItem } from "./home-model.ts";
+import {
+  homeActionAtProjection,
+  homeItemIndexAtProjection,
+  projectHomeSurface,
+} from "./home-surface.ts";
+import { filesHitTest, projectFilesSurface } from "./files-surface.ts";
+import type { FileNode } from "./file-tree.ts";
+import { actionChipWidth } from "./recipes.ts";
+
+const project = (over: Partial<HomeFleetProject>): HomeFleetProject => ({
+  name: "workspace",
+  dir: "/repo/workspace",
+  registered: false,
+  running: true,
+  sessions: [],
+  ...over,
+});
+
+const homeItems: HomeItem[] = [
+  {
+    kind: "session",
+    session: "app",
+    project: "workspace",
+    status: "working",
+    windows: 2,
+    dir: "/repo/workspace",
+  },
+  { kind: "project", name: "docs", dir: "/repo/docs" },
+  { kind: "recent", name: "scratch", dir: "/tmp/scratch" },
+];
+
+const node = (over: Partial<FileNode>): FileNode => ({
+  name: "file.ts",
+  path: "/repo/file.ts",
+  isDir: false,
+  depth: 0,
+  expanded: false,
+  ignored: false,
+  ...over,
+});
+
+describe("Home surface projection", () => {
+  it.each([
+    [80, 24, "compact"],
+    [120, 40, "standard"],
+    [200, 60, "wide"],
+  ] as const)(
+    "projects bounded %sx%s %s layout and stable row actions",
+    (width, height, variant) => {
+      const projection = projectHomeSurface({
+        width,
+        height,
+        projects: [project({ sessions: [{ name: "app", status: "working", windows: [{}] }] })],
+        items: homeItems,
+        selectedIndex: 0,
+        hovered: null,
+        rollup: { blocked: 0, working: 1, done: 0, idle: 0, unknown: 0, totalAgents: 1 },
+        detail: "session app · 2 windows",
+        footerHint: "enter open · ^q quit",
+        pathPrompt: null,
+        sessionPrompt: null,
+        quitHint: "^q quit",
+        welcomeLine: "Welcome to tmux-ide",
+        welcomeActionLabel: "▸ open a folder — press f",
+        welcomeTip: "press f to open",
+      });
+
+      expect(projection.variant).toBe(variant);
+      expect(projection.width).toBe(width);
+      expect(projection.height).toBe(height);
+      expect(projection.rows.length).toBeGreaterThan(0);
+      for (const row of projection.rows) {
+        expect(row.y).toBeGreaterThanOrEqual(2);
+        expect(row.y).toBeLessThan(projection.footer.y);
+        expect(row.width).toBeLessThanOrEqual(width);
+        for (const span of row.actionSpans) {
+          expect(span.start).toBeGreaterThanOrEqual(0);
+          expect(span.start + span.width).toBeLessThanOrEqual(width);
+        }
+      }
+
+      const selected = projection.rows[0]!;
+      const primary = selected.actionSpans.find((span) => span.id === "primary")!;
+      expect(primary.width).toBe(actionChipWidth(primary.label));
+      const hit = homeActionAtProjection(
+        projection,
+        primary.start + Math.floor(primary.width / 2),
+        selected.y,
+      );
+      expect(hit).toMatchObject({ source: "row", itemIndex: 0, id: "primary" });
+      expect(homeItemIndexAtProjection(projection, 1, selected.y)).toBe(0);
+      expect(projection.footerActions.map((action) => action.id)).toEqual([
+        "open-folder",
+        "new-session",
+        "new-agent",
+        "open-file",
+        "open-diff",
+      ]);
+      for (const span of projection.footerActionSpans) {
+        expect(span.width).toBe(actionChipWidth(span.label));
+        expect(span.start + span.width).toBeLessThanOrEqual(width);
+      }
+    },
+  );
+
+  it("keeps selected Home row visible in compact focus-following window", () => {
+    const many = Array.from(
+      { length: 30 },
+      (_, index): HomeItem => ({
+        kind: "session",
+        session: `session-${index}`,
+        project: "workspace",
+        status: "idle",
+        windows: 1,
+        dir: "/repo/workspace",
+      }),
+    );
+    const projection = projectHomeSurface({
+      width: 80,
+      height: 24,
+      projects: [
+        project({
+          sessions: many.map((item) => ({ name: item.session, status: "idle", windows: [{}] })),
+        }),
+      ],
+      items: many,
+      selectedIndex: 29,
+      hovered: null,
+      rollup: { blocked: 0, working: 0, done: 0, idle: 30, unknown: 0, totalAgents: 0 },
+      detail: "session-29",
+      footerHint: "enter open · ^q quit",
+      pathPrompt: null,
+      sessionPrompt: null,
+      quitHint: "^q quit",
+      welcomeLine: "Welcome to tmux-ide",
+      welcomeActionLabel: "▸ open a folder — press f",
+      welcomeTip: "press f to open",
+    });
+
+    const selected = projection.rows.find((row) => row.selected);
+    expect(selected?.itemIndex).toBe(29);
+    expect(selected?.label).toContain("session-29");
+    expect(projection.rows[0]!.itemIndex).toBeGreaterThan(0);
+    expect(homeItemIndexAtProjection(projection, 1, selected!.y)).toBe(29);
+  });
+
+  it("keeps first-run welcome action and rows in one projection", () => {
+    const projection = projectHomeSurface({
+      width: 80,
+      height: 24,
+      projects: [],
+      items: [],
+      selectedIndex: 0,
+      hovered: { region: "welcomeopen", index: 0 },
+      rollup: { blocked: 0, working: 0, done: 0, idle: 0, unknown: 0, totalAgents: 0 },
+      detail: "no sessions yet",
+      footerHint: "f open folder · ^q quit",
+      pathPrompt: null,
+      sessionPrompt: null,
+      quitHint: "^q quit",
+      welcomeLine: "Welcome to tmux-ide",
+      welcomeActionLabel: "▸ open a folder — press f",
+      welcomeTip: "press f to open",
+    });
+
+    expect(projection.welcome).not.toBeNull();
+    expect(projection.rows).toEqual([]);
+    const action = projection.welcome!.action;
+    expect(homeActionAtProjection(projection, action.x + 1, action.y)).toMatchObject({
+      source: "welcome",
+      id: "open-folder",
+    });
+  });
+});
+
+describe("Files surface projection", () => {
+  it.each([
+    [80, 24, "compact"],
+    [120, 40, "standard"],
+    [200, 60, "wide"],
+  ] as const)("projects bounded %sx%s %s files geometry", (width, height, variant) => {
+    const projection = projectFilesSurface({
+      width,
+      height,
+      workspaceDir: "/repo/workspace",
+      editorPath: "/repo/workspace/src/app.ts",
+      editorModified: true,
+      editorCursor: { row: 4, col: 2 },
+      editorLineCount: 9,
+      editorMessage: "saved",
+      readOnly: null,
+      filterQuery: "app",
+      focus: "list",
+      showHidden: false,
+      showIgnored: true,
+      visibleRows: [
+        {
+          node: node({ name: "src", path: "/repo/workspace/src", isDir: true, expanded: true }),
+          index: 0,
+        },
+        { node: node({ name: "app.ts", path: "/repo/workspace/src/app.ts", depth: 1 }), index: 1 },
+      ],
+      totalRows: 2,
+      fileSelection: 1,
+      fileTop: 0,
+      editorVisible: [
+        { num: 1, text: "export const app = true;", cursorCol: null },
+        { num: 2, text: "console.log(app);", cursorCol: 7 },
+      ],
+      editorTop: 0,
+      editorTotalLines: 2,
+      hovered: { region: "files", index: 1 },
+      statusFor: (file) => (file.name === "app.ts" ? "M" : null),
+      readOnlyBanner: null,
+      footerBase: "enter open · / filter · ^q quit",
+    });
+
+    expect(projection.variant).toBe(variant);
+    expect(projection.list.x + projection.list.width).toBeLessThanOrEqual(width);
+    expect(projection.editor.x + projection.editor.width).toBeLessThanOrEqual(width);
+    expect(projection.body.y + projection.body.height).toBeLessThanOrEqual(projection.footer.y);
+    for (const row of projection.rows) {
+      expect(row.y).toBeGreaterThanOrEqual(projection.body.y);
+      expect(row.y).toBeLessThan(projection.footer.y);
+      expect(row.actions[0]?.id).toBe(row.role === "directory" ? "toggle-directory" : "open");
+      expect(row.id).toMatch(/^file:/u);
+    }
+
+    const selected = projection.rows.find((row) => row.selected)!;
+    for (const action of projection.actions) {
+      expect(action.width).toBe(actionChipWidth(action.label));
+      expect(action.start + action.width).toBeLessThanOrEqual(width);
+    }
+    const save = projection.actions.find((action) => action.id === "save");
+    expect(save).toBeDefined();
+    expect(filesHitTest(projection, save!.start + 1, 0)).toMatchObject({
+      area: "header",
+      actionId: "save",
+    });
+    expect(filesHitTest(projection, 1, selected.y)).toMatchObject({
+      area: "list",
+      rowIndex: 1,
+    });
+    expect(filesHitTest(projection, projection.editor.x + 2, projection.body.y)).toMatchObject({
+      area: "editor",
+    });
+  });
+
+  it("uses explicit empty and error state metadata", () => {
+    const projection = projectFilesSurface({
+      width: 80,
+      height: 24,
+      workspaceDir: "/repo/workspace",
+      editorPath: null,
+      editorModified: false,
+      editorCursor: { row: 0, col: 0 },
+      editorLineCount: 0,
+      editorMessage: "read failed",
+      readOnly: { kind: "outside-workspace", path: "/tmp/escape" },
+      filterQuery: null,
+      focus: "list",
+      showHidden: false,
+      showIgnored: false,
+      visibleRows: [],
+      totalRows: 0,
+      fileSelection: 0,
+      fileTop: 0,
+      editorVisible: [],
+      editorTop: 0,
+      editorTotalLines: 0,
+      hovered: null,
+      statusFor: () => null,
+      readOnlyBanner: "outside workspace",
+      footerBase: "^g home · ^q quit",
+    });
+
+    expect(projection.state).toBe("error");
+    expect(projection.stateMessage).toBe("outside workspace");
+    expect(projection.rows).toEqual([]);
+    expect(filesHitTest(projection, 1, projection.body.y)).toMatchObject({ area: "list" });
+  });
+});

--- a/packages/daemon/src/tui/mirror/home-surface.ts
+++ b/packages/daemon/src/tui/mirror/home-surface.ts
@@ -1,0 +1,439 @@
+import type { AgentStatus } from "../detect/classify.ts";
+import type { FleetRollup } from "../team/home.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import { clipTerminal } from "./missions-workspace.ts";
+import { centerPad, isFirstRun, type HomeFleetProject, type HomeItem } from "./home-model.ts";
+import { actionChipSpansFromRight, actionChipWidth, type Rect } from "./recipes.ts";
+
+export type HomeSurfaceVariant = "compact" | "standard" | "wide";
+
+export type HomeRowRole = "section" | "session" | "project" | "recent";
+export type HomeActionId =
+  | "open-folder"
+  | "new-session"
+  | "open-file"
+  | "open-diff"
+  | "new-agent"
+  | "primary";
+
+export interface HomeActionDescriptor {
+  id: HomeActionId;
+  label: string;
+  disabled?: boolean;
+  hovered?: boolean;
+  description: string;
+}
+
+export interface HomeProjectedRow extends Rect {
+  id: string;
+  role: HomeRowRole;
+  itemIndex: number;
+  label: string;
+  meta: string;
+  status?: AgentStatus;
+  selected: boolean;
+  hovered: boolean;
+  disabled: boolean;
+  attention: boolean;
+  overflowBefore: number;
+  overflowAfter: number;
+  actions: readonly HomeActionDescriptor[];
+  actionSpans: readonly (HomeActionDescriptor & { start: number; width: number })[];
+}
+
+export interface HomeWelcomeProjection {
+  rows: readonly { y: number; text: string; x: number; role: "title" | "action" | "hint" }[];
+  action: Rect & { id: "open-folder"; label: string; hovered: boolean };
+}
+
+export interface HomeSurfaceProjection {
+  width: number;
+  height: number;
+  variant: HomeSurfaceVariant;
+  header: Rect;
+  body: Rect;
+  footer: Rect;
+  firstRun: boolean;
+  title: string;
+  subtitle: string;
+  stats: readonly { id: AgentStatus | "sessions" | "projects"; label: string; count: number }[];
+  welcome: HomeWelcomeProjection | null;
+  rows: readonly HomeProjectedRow[];
+  detail: string;
+  prompt:
+    | { kind: "session"; label: string; value: string }
+    | { kind: "path"; label: string; value: string }
+    | null;
+  footerHint: string;
+  footerActions: readonly HomeActionDescriptor[];
+  footerActionY: number;
+  footerActionSpans: readonly (HomeActionDescriptor & { start: number; width: number })[];
+}
+
+export interface HomeSurfaceInput {
+  width: number;
+  height: number;
+  projects: readonly HomeFleetProject[];
+  items: readonly HomeItem[];
+  selectedIndex: number;
+  hovered: {
+    region: "home" | "homechip" | "homeagentchip" | "welcomeopen" | "button";
+    index: number;
+  } | null;
+  rollup: FleetRollup;
+  detail: string;
+  footerHint: string;
+  sessionPrompt: string | null;
+  pathPrompt: string | null;
+  quitHint: string;
+  welcomeLine: string;
+  welcomeActionLabel: string;
+  welcomeTip: string;
+}
+
+const HEADER_ROWS = 2;
+const FOOTER_ROWS = 2;
+const WELCOME_ROWS = 6;
+const WELCOME_ACTION_ROW = 3;
+const HOME_CHIP_AGENT = "[+ agent] ";
+const HOME_CHIP_SESSION = "[± diff] ";
+const HOME_CHIP_PROJECT = "[▸ launch] ";
+const HOME_CHIP_RECENT = "[▸ open] ";
+
+export function homeSurfaceVariant(width: number, height: number): HomeSurfaceVariant {
+  if (width >= 160 && height >= 45) return "wide";
+  if (width >= 96 && height >= 30) return "standard";
+  return "compact";
+}
+
+export function homeContentRows(projection: Pick<HomeSurfaceProjection, "rows">): number {
+  return projection.rows.length;
+}
+
+export function homeWelcomeOffset(projects: readonly HomeFleetProject[]): number {
+  return isFirstRun(projects) ? WELCOME_ROWS : 0;
+}
+
+export function homeItemIndexAtProjection(
+  projection: HomeSurfaceProjection,
+  globalX: number,
+  globalY: number,
+  originX = 0,
+  originY = 0,
+): number {
+  const x = globalX - originX;
+  const y = globalY - originY;
+  if (x < 0 || x >= projection.width || y < projection.body.y || y >= projection.footer.y) {
+    return -1;
+  }
+  const row = projection.rows.find((candidate) => y >= candidate.y && y < candidate.y + 1);
+  return row?.itemIndex ?? -1;
+}
+
+export function homeActionAtProjection(
+  projection: HomeSurfaceProjection,
+  globalX: number,
+  globalY: number,
+  originX = 0,
+  originY = 0,
+): {
+  source: "welcome" | "footer" | "row";
+  id: HomeActionId;
+  itemIndex?: number;
+  actionIndex?: number;
+} | null {
+  const x = globalX - originX;
+  const y = globalY - originY;
+  if (projection.welcome && y === projection.welcome.action.y) {
+    const a = projection.welcome.action;
+    if (x >= a.x && x < a.x + a.width) return { source: "welcome", id: "open-folder" };
+  }
+  if (y === projection.footerActionY) {
+    const actionIndex = projection.footerActionSpans.findIndex(
+      (span) => x >= span.start && x < span.start + span.width,
+    );
+    const hit = actionIndex >= 0 ? projection.footerActionSpans[actionIndex] : undefined;
+    return hit ? { source: "footer", id: hit.id, actionIndex } : null;
+  }
+  const row = projection.rows.find((candidate) => y === candidate.y);
+  if (!row) return null;
+  const actionIndex = row.actionSpans.findIndex(
+    (span) => x >= span.start && x < span.start + span.width,
+  );
+  const action = actionIndex >= 0 ? row.actionSpans[actionIndex] : undefined;
+  return action ? { source: "row", id: action.id, itemIndex: row.itemIndex, actionIndex } : null;
+}
+
+export function projectHomeSurface(input: HomeSurfaceInput): HomeSurfaceProjection {
+  const width = Math.max(0, Math.floor(input.width));
+  const height = Math.max(0, Math.floor(input.height));
+  const variant = homeSurfaceVariant(width, height);
+  const firstRun = isFirstRun(input.projects);
+  const footerHeight = height >= 8 ? FOOTER_ROWS : 1;
+  const headerHeight = Math.min(HEADER_ROWS, height);
+  const footerY = Math.max(headerHeight, height - footerHeight);
+  const body: Rect = {
+    x: 0,
+    y: headerHeight,
+    width,
+    height: Math.max(0, footerY - headerHeight),
+  };
+  const title = variant === "compact" ? "Home" : "tmux-ide Home";
+  const subtitle =
+    variant === "compact"
+      ? `${input.rollup.sessions} sessions · ${input.rollup.projects} projects`
+      : "Sessions, registered projects, and recent folders";
+  const stats = [
+    { id: "sessions" as const, label: "sessions", count: input.rollup.sessions },
+    { id: "blocked" as const, label: "blocked", count: input.rollup.blocked },
+    { id: "working" as const, label: "working", count: input.rollup.working },
+    { id: "done" as const, label: "done", count: input.rollup.done },
+    { id: "projects" as const, label: "projects", count: input.rollup.projects },
+  ].filter((stat) => variant !== "compact" || stat.count > 0 || stat.id === "sessions");
+  const welcome = firstRun ? projectWelcome(input, width, body) : null;
+  const rowsStartY = body.y + (welcome ? WELCOME_ROWS : 0);
+  const maxRows = Math.max(0, footerY - rowsStartY);
+  const windowStart = homeWindowStart(input.items, input.selectedIndex, maxRows);
+  const visibleItems = input.items.slice(windowStart, windowStart + maxRows);
+  const rows = visibleItems.map((item, offset) =>
+    projectHomeRow({
+      item,
+      itemIndex: windowStart + offset,
+      y: rowsStartY + offset,
+      width,
+      variant,
+      selected: windowStart + offset === input.selectedIndex,
+      hovered: input.hovered,
+      overflowBefore: windowStart,
+      overflowAfter: Math.max(0, input.items.length - (windowStart + visibleItems.length)),
+    }),
+  );
+  const footerActionDefs: HomeActionDescriptor[] = [
+    {
+      id: "open-folder",
+      label: variant === "compact" ? "[f folder]" : "[f open folder]",
+      description: "Open a folder",
+    },
+    {
+      id: "new-session",
+      label: variant === "compact" ? "[n session]" : "[n new session]",
+      description: "Create a session here",
+    },
+    {
+      id: "new-agent",
+      label: variant === "compact" ? "[a agent]" : "[a new agent]",
+      description: "Start an agent here",
+    },
+    { id: "open-file", label: "[o open]", description: "Open a file by path" },
+    { id: "open-diff", label: "[d diff]", description: "Open selected project diff" },
+  ];
+  const footerActions: HomeActionDescriptor[] = footerActionDefs.map((action, index) => ({
+    ...action,
+    hovered: input.hovered?.region === "button" && input.hovered.index === index,
+  }));
+  const footerActionY = footerHeight > 1 ? footerY + 1 : footerY;
+  const footerActionSpans = actionChipSpansFromRight(footerActions, width, 1);
+  const prompt =
+    input.sessionPrompt !== null
+      ? ({ kind: "session", label: "new session", value: input.sessionPrompt } as const)
+      : input.pathPrompt !== null
+        ? ({ kind: "path", label: "open file", value: input.pathPrompt } as const)
+        : null;
+  const footerHint =
+    variant === "compact"
+      ? compactFooter(input.footerHint, input.quitHint, width)
+      : clipTerminal(input.footerHint, width);
+  return {
+    width,
+    height,
+    variant,
+    header: { x: 0, y: 0, width, height: headerHeight },
+    body,
+    footer: { x: 0, y: footerY, width, height: footerHeight },
+    firstRun,
+    title,
+    subtitle,
+    stats,
+    welcome,
+    rows,
+    detail: clipTerminal(input.detail, width),
+    prompt,
+    footerHint,
+    footerActions,
+    footerActionY,
+    footerActionSpans,
+  };
+}
+
+function homeWindowStart(
+  items: readonly HomeItem[],
+  selectedIndex: number,
+  capacity: number,
+): number {
+  if (capacity <= 0 || items.length <= capacity) return 0;
+  const selected = Math.max(0, Math.min(items.length - 1, selectedIndex));
+  if (selected < capacity) return 0;
+  const maxStart = Math.max(0, items.length - capacity);
+  return Math.min(maxStart, selected - capacity + 1);
+}
+
+function projectWelcome(input: HomeSurfaceInput, width: number, body: Rect): HomeWelcomeProjection {
+  const line = clipTerminal(input.welcomeLine, width);
+  const action = clipTerminal(input.welcomeActionLabel, width);
+  const actionWidth = actionChipWidth(action);
+  const actionX = centerPad(width, actionWidth);
+  const hint = clipTerminal(input.welcomeTip, width);
+  return {
+    rows: [
+      { y: body.y + 1, text: line, x: centerPad(width, terminalDisplayWidth(line)), role: "title" },
+      {
+        y: body.y + WELCOME_ACTION_ROW,
+        text: action,
+        x: actionX,
+        role: "action",
+      },
+      {
+        y: body.y + 5,
+        text: hint,
+        x: centerPad(width, terminalDisplayWidth(hint)),
+        role: "hint",
+      },
+    ],
+    action: {
+      id: "open-folder",
+      label: action,
+      x: actionX,
+      y: body.y + WELCOME_ACTION_ROW,
+      width: actionWidth,
+      height: 1,
+      hovered: input.hovered?.region === "welcomeopen",
+    },
+  };
+}
+
+function projectHomeRow(input: {
+  item: HomeItem;
+  itemIndex: number;
+  y: number;
+  width: number;
+  variant: HomeSurfaceVariant;
+  selected: boolean;
+  hovered: {
+    region: "home" | "homechip" | "homeagentchip" | "welcomeopen" | "button";
+    index: number;
+  } | null;
+  overflowBefore: number;
+  overflowAfter: number;
+}): HomeProjectedRow {
+  const { item, itemIndex, width, variant } = input;
+  if (item.kind === "header") {
+    return {
+      id: `section:${item.label}`,
+      role: "section",
+      itemIndex,
+      x: 0,
+      y: input.y,
+      width,
+      height: 1,
+      label: item.label,
+      meta: "",
+      selected: false,
+      hovered: false,
+      disabled: true,
+      attention: false,
+      overflowBefore: input.overflowBefore,
+      overflowAfter: input.overflowAfter,
+      actions: [],
+      actionSpans: [],
+    };
+  }
+  const actions = homeRowActions(item);
+  const hoveredActionId =
+    input.hovered?.index === itemIndex
+      ? input.hovered.region === "homeagentchip"
+        ? "new-agent"
+        : input.hovered.region === "homechip"
+          ? "primary"
+          : null
+      : null;
+  const actionsWithHover = actions.map((action) => ({
+    ...action,
+    hovered: action.id === hoveredActionId,
+  }));
+  const actionSpans = actionChipSpansFromRight(actionsWithHover, width, 0);
+  const role = item.kind;
+  const label =
+    item.kind === "session" ? item.session : item.kind === "project" ? item.name : item.name;
+  return {
+    id:
+      item.kind === "session"
+        ? `session:${item.session}`
+        : item.kind === "project"
+          ? `project:${item.name}`
+          : `recent:${item.dir}`,
+    role,
+    itemIndex,
+    x: 0,
+    y: input.y,
+    width,
+    height: 1,
+    label: clipTerminal(label, labelBudget(width, actions, variant)),
+    meta: homeRowMeta(item, variant),
+    status: item.kind === "session" ? item.status : undefined,
+    selected: input.selected,
+    hovered:
+      input.hovered?.index === itemIndex &&
+      (input.hovered.region === "home" ||
+        input.hovered.region === "homechip" ||
+        input.hovered.region === "homeagentchip"),
+    disabled: false,
+    attention: item.kind === "session" && item.status === "blocked",
+    overflowBefore: input.overflowBefore,
+    overflowAfter: input.overflowAfter,
+    actions: actionsWithHover,
+    actionSpans,
+  };
+}
+
+function homeRowActions(item: HomeItem): HomeActionDescriptor[] {
+  if (item.kind === "header") return [];
+  const out: HomeActionDescriptor[] = [];
+  if (item.kind === "session" || item.kind === "project") {
+    out.push({ id: "new-agent", label: HOME_CHIP_AGENT, description: "Start an agent here" });
+  }
+  if (item.kind === "session") {
+    out.push({ id: "primary", label: HOME_CHIP_SESSION, description: "Open project diff" });
+  } else if (item.kind === "project") {
+    out.push({ id: "primary", label: HOME_CHIP_PROJECT, description: "Launch project" });
+  } else if (item.kind === "recent") {
+    out.push({ id: "primary", label: HOME_CHIP_RECENT, description: "Open recent folder" });
+  }
+  return out;
+}
+
+function labelBudget(
+  width: number,
+  actions: readonly HomeActionDescriptor[],
+  variant: HomeSurfaceVariant,
+): number {
+  const actionWidth = actions.reduce((sum, action) => sum + actionChipWidth(action.label), 0);
+  const metaReserve = variant === "compact" ? 8 : 20;
+  return Math.max(4, width - actionWidth - metaReserve - 6);
+}
+
+function homeRowMeta(item: Exclude<HomeItem, { kind: "header" }>, variant: HomeSurfaceVariant) {
+  if (item.kind === "session") {
+    const windows = `${item.windows}w`;
+    return variant === "compact"
+      ? `${windows} · ${item.status}`
+      : `${windows}${item.project === item.session ? "" : ` · ${item.project}`} · ${item.status}`;
+  }
+  if (item.kind === "project") return variant === "compact" ? "registered" : `${item.dir ?? ""}`;
+  return variant === "compact" ? "recent" : item.dir;
+}
+
+function compactFooter(footerHint: string, quitHint: string, width: number): string {
+  const base = `j/k enter · f folder · ${quitHint}`;
+  if (terminalDisplayWidth(base) <= width) return base;
+  return clipTerminal(footerHint, width);
+}

--- a/packages/daemon/src/tui/mirror/home-surface.tsx
+++ b/packages/daemon/src/tui/mirror/home-surface.tsx
@@ -1,0 +1,254 @@
+/* @jsxImportSource @opentui/solid */
+import { For, Show } from "solid-js";
+import { rollupChips, type FleetRollup } from "../team/home.ts";
+import { STATUS_GLYPH } from "./status-grammar.ts";
+import type { SemanticThemeSnapshot } from "./theme.ts";
+import { ActionChip, EmptyState, SectionHeader, SelectableRow } from "./recipes.tsx";
+import {
+  homeActionAtProjection,
+  type HomeActionId,
+  type HomeSurfaceProjection,
+} from "./home-surface.ts";
+import { actionChipWidth, recipePalette } from "./recipes.ts";
+import { clipTerminal } from "./missions-workspace.ts";
+
+export interface HomeSurfaceProps {
+  theme: SemanticThemeSnapshot;
+  projection: HomeSurfaceProjection;
+  rollup: FleetRollup;
+}
+
+export function HomeSurface(props: HomeSurfaceProps) {
+  return (
+    <box
+      width={props.projection.width}
+      height={props.projection.height}
+      position="relative"
+      backgroundColor={props.theme.colors.background}
+      overflow="hidden"
+    >
+      <HomeHeader theme={props.theme} projection={props.projection} rollup={props.rollup} />
+      <HomeWelcome theme={props.theme} projection={props.projection} />
+      <For each={props.projection.rows}>
+        {(row) => (
+          <box position="absolute" left={0} top={row.y} width={row.width} height={1}>
+            <Show
+              when={row.role !== "section"}
+              fallback={<SectionHeader theme={props.theme} title={row.label} width={row.width} />}
+            >
+              <HomeRow theme={props.theme} row={row} />
+            </Show>
+          </box>
+        )}
+      </For>
+      <box
+        position="absolute"
+        left={0}
+        top={props.projection.footer.y}
+        width={props.projection.width}
+        height={1}
+        paddingLeft={1}
+      >
+        <Show
+          when={props.projection.prompt}
+          fallback={
+            <Show
+              when={props.projection.rows.length > 0 || props.projection.firstRun}
+              fallback={
+                <EmptyState
+                  theme={props.theme}
+                  title="No projects yet"
+                  detail="Open a folder to start."
+                  width={props.projection.width}
+                />
+              }
+            >
+              <text fg={props.theme.colors.accent}>{props.projection.detail}</text>
+            </Show>
+          }
+        >
+          {(prompt) => (
+            <box flexDirection="row" overflow="hidden">
+              <text fg={props.theme.colors.accent}>{`${prompt().label}: `}</text>
+              <text fg={props.theme.colors.foreground}>{`${prompt().value}▏`}</text>
+            </box>
+          )}
+        </Show>
+      </box>
+      <box
+        position="absolute"
+        left={0}
+        top={props.projection.footerActionY}
+        width={props.projection.width}
+        height={1}
+        overflow="hidden"
+      >
+        <text fg={props.theme.colors.mutedForeground}>
+          {clipTerminal(` ${props.projection.footerHint}`, props.projection.width)}
+        </text>
+        <For each={props.projection.footerActionSpans}>
+          {(action) => (
+            <box position="absolute" left={action.start} top={0} width={action.width} height={1}>
+              <ActionChip
+                theme={props.theme}
+                label={action.label}
+                width={action.width}
+                disabled={action.disabled}
+                hovered={action.hovered}
+              />
+            </box>
+          )}
+        </For>
+      </box>
+    </box>
+  );
+}
+
+function HomeHeader(props: {
+  theme: SemanticThemeSnapshot;
+  projection: HomeSurfaceProjection;
+  rollup: FleetRollup;
+}) {
+  return (
+    <>
+      <box
+        position="absolute"
+        left={0}
+        top={0}
+        width={props.projection.width}
+        height={1}
+        paddingLeft={1}
+        flexDirection="row"
+        gap={1}
+        overflow="hidden"
+      >
+        <text fg={props.theme.colors.accent} attributes={1}>
+          {props.projection.title}
+        </text>
+        <text fg={props.theme.colors.mutedForeground}>{`· ${props.projection.subtitle}`}</text>
+        <For each={rollupChips(props.rollup)}>
+          {(chip) => (
+            <text fg={props.theme.colors.status[chip.status]}>
+              {`${STATUS_GLYPH[chip.status]} ${chip.count}`}
+            </text>
+          )}
+        </For>
+      </box>
+      <box
+        position="absolute"
+        left={0}
+        top={1}
+        width={props.projection.width}
+        height={1}
+        overflow="hidden"
+      >
+        <text fg={props.theme.colors.mutedForeground}>
+          {"─".repeat(Math.max(0, props.projection.width))}
+        </text>
+      </box>
+    </>
+  );
+}
+
+function HomeWelcome(props: { theme: SemanticThemeSnapshot; projection: HomeSurfaceProjection }) {
+  return (
+    <Show when={props.projection.welcome}>
+      {(welcome) => (
+        <For each={welcome().rows}>
+          {(row) => (
+            <box position="absolute" left={row.x} top={row.y} height={1}>
+              <Show
+                when={row.role === "action"}
+                fallback={
+                  <text
+                    fg={
+                      row.role === "hint"
+                        ? props.theme.colors.mutedForeground
+                        : props.theme.colors.foreground
+                    }
+                  >
+                    {row.text}
+                  </text>
+                }
+              >
+                <ActionChip
+                  theme={props.theme}
+                  label={row.text}
+                  width={welcome().action.width}
+                  hovered={welcome().action.hovered}
+                />
+              </Show>
+            </box>
+          )}
+        </For>
+      )}
+    </Show>
+  );
+}
+
+function HomeRow(props: {
+  theme: SemanticThemeSnapshot;
+  row: HomeSurfaceProjection["rows"][number];
+}) {
+  const tone = () =>
+    props.row.status === "blocked"
+      ? "blocked"
+      : props.row.status === "working"
+        ? "working"
+        : props.row.status === "done"
+          ? "done"
+          : props.row.status === "idle"
+            ? "idle"
+            : props.row.status === "unknown"
+              ? "unknown"
+              : props.row.role === "session"
+                ? "accent"
+                : "neutral";
+  const palette = () =>
+    recipePalette(
+      props.theme,
+      {
+        selected: props.row.selected,
+        hovered: props.row.hovered,
+        attention: props.row.attention,
+        status: props.row.status,
+      },
+      tone(),
+    );
+  const labelWidth = () => Math.max(1, props.row.width - actionWidth(props.row));
+  return (
+    <box height={1} flexDirection="row" backgroundColor={palette().background} overflow="hidden">
+      <SelectableRow
+        theme={props.theme}
+        label={props.row.label}
+        meta={props.row.meta}
+        width={labelWidth()}
+        selected={props.row.selected}
+        hovered={props.row.hovered}
+        attention={props.row.attention}
+        status={props.row.status}
+        tone={tone()}
+      />
+      <For each={props.row.actionSpans}>
+        {(action) => (
+          <box position="absolute" left={action.start} top={0} width={action.width} height={1}>
+            <ActionChip
+              theme={props.theme}
+              label={action.label}
+              width={action.width}
+              disabled={action.disabled}
+              hovered={action.hovered}
+            />
+          </box>
+        )}
+      </For>
+    </box>
+  );
+}
+
+function actionWidth(row: HomeSurfaceProjection["rows"][number]): number {
+  return row.actionSpans.reduce((sum, action) => sum + actionChipWidth(action.label), 0);
+}
+
+export { homeActionAtProjection };
+export type { HomeActionId };

--- a/packages/daemon/src/tui/mirror/recipes.ts
+++ b/packages/daemon/src/tui/mirror/recipes.ts
@@ -54,6 +54,51 @@ export interface Rect {
   height: number;
 }
 
+export interface ActionChipGeometry {
+  label: string;
+  width: number;
+  markerWidth: number;
+  bodyWidth: number;
+}
+
+export function actionChipWidth(label: string, width?: number): number {
+  return Math.max(0, Math.floor(width ?? terminalDisplayWidth(label) + 4));
+}
+
+export function actionChipGeometry(label: string, width?: number): ActionChipGeometry {
+  const resolved = actionChipWidth(label, width);
+  const markerWidth = Math.min(2, resolved);
+  return {
+    label,
+    width: resolved,
+    markerWidth,
+    bodyWidth: Math.max(0, resolved - markerWidth),
+  };
+}
+
+export function actionChipText(label: string, width?: number): string {
+  const geometry = actionChipGeometry(label, width);
+  if (geometry.bodyWidth <= 0) return "";
+  return clipTerminal(` ${label}`, Math.max(0, geometry.bodyWidth - 1)) + " ";
+}
+
+export function actionChipSpansFromRight<T extends { label: string }>(
+  actions: readonly T[],
+  rightEdge: number,
+  gap: number,
+): (T & { start: number; width: number })[] {
+  const widths = actions.map((action) => actionChipWidth(action.label));
+  const total =
+    widths.reduce((sum, width) => sum + width, 0) + gap * Math.max(0, widths.length - 1);
+  let x = Math.max(0, rightEdge - total);
+  return actions.map((action, index) => {
+    const width = widths[index] ?? 0;
+    const out = { ...action, start: x, width };
+    x += width + gap;
+    return out;
+  });
+}
+
 export interface RecipeGalleryItem extends Rect {
   id: string;
   kind:

--- a/packages/daemon/src/tui/mirror/recipes.tsx
+++ b/packages/daemon/src/tui/mirror/recipes.tsx
@@ -2,6 +2,8 @@
 import type { JSX } from "@opentui/solid";
 import { For, Show } from "solid-js";
 import {
+  actionChipGeometry,
+  actionChipText,
   recipePalette,
   rowParts,
   scrollbarGlyphs,
@@ -11,6 +13,9 @@ import {
 import type { SemanticThemeSnapshot } from "./theme.ts";
 import { clipTerminal } from "./missions-workspace.ts";
 import { terminalDisplayWidth } from "./panel-host.ts";
+
+const openTuiBorderStyle = (style: SemanticThemeSnapshot["borders"]["style"]) =>
+  style === "bold" ? "heavy" : style;
 
 interface ThemeProps {
   theme: SemanticThemeSnapshot;
@@ -34,7 +39,9 @@ export function Surface(props: SurfaceProps) {
       height={props.height}
       border
       borderColor={palette().border}
-      borderStyle={props.focused ? props.theme.borders.focusedStyle : props.theme.borders.style}
+      borderStyle={openTuiBorderStyle(
+        props.focused ? props.theme.borders.focusedStyle : props.theme.borders.style,
+      )}
       backgroundColor={props.theme.colors.background}
       flexDirection="column"
       overflow="hidden"
@@ -95,14 +102,12 @@ export interface ButtonProps extends ThemeProps, RecipeInteractionState {
 export function Button(props: ButtonProps) {
   const palette = () => recipePalette(props.theme, props, props.tone ?? "accent");
   const marker = () => (props.loading ? "…" : palette().marker);
-  const body = () => {
-    const width = props.width ?? props.label.length + 4;
-    return `${clipTerminal(` ${props.label}`, Math.max(0, width - 3))} `;
-  };
+  const geometry = () => actionChipGeometry(props.label, props.width);
+  const body = () => actionChipText(props.label, props.width);
   return (
     <box
       height={1}
-      width={props.width}
+      width={geometry().width}
       backgroundColor={palette().background}
       overflow="hidden"
       flexDirection="row"


### PR DESCRIPTION
## Summary
- replace the legacy Home and Files rendering blocks with responsive projected Solid/OpenTUI surfaces
- centralize action-chip terminal-cell geometry so paint, hover, and click routing agree
- add compact/standard/wide states, focus-following Home rows, explicit Files empty/error/success states, and routed header/footer actions
- add pure projection tests plus real OpenTUI renderer snapshots and mouse/keyboard interaction coverage

## Verification
- `pnpm check` (agent run): 44 contracts, 1901 daemon unit tests, 32 renderer tests, docs build, pack check, native deps
- `pnpm test:tui-renderer`: 32 passed, 16 snapshots
- `bun test ./packages/daemon/src/tui/mirror/home-files-surface.test.ts`: 9 passed
- `pnpm --filter @tmux-ide/daemon typecheck`
- `git diff --check`