### PR TITLE
fix(docs): preserve /docs/agent-teams

### DIFF
--- a/docs/app/docs/agent-teams/page.tsx
+++ b/docs/app/docs/agent-teams/page.tsx
@@ -1,0 +1,9 @@
+import { permanentRedirect } from "next/navigation";
+
+/**
+ * Stable compatibility entry point for links published before the guide moved
+ * to its more descriptive `/docs/multi-agent-teams` slug.
+ */
+export default function AgentTeamsCompatibilityPage() {
+  permanentRedirect("/docs/multi-agent-teams");
+}


### PR DESCRIPTION
## Summary
- preserve the high-traffic `/docs/agent-teams` entry point
- permanently redirect it to the maintained `/docs/multi-agent-teams` guide

## Verification
- `pnpm exec prettier --check docs/app/docs/agent-teams/page.tsx`
- `pnpm docs:build` (route table includes static `/docs/agent-teams`)