### PR TITLE
feat(tui): polish terminal and changes surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run typecheck:workspace && pnpm run test:unit && pnpm run test:tui-renderer && pnpm run docs:build && pnpm run pack:check && pnpm run check:native-deps",
     "postinstall": "node scripts/postinstall.js",
     "docs": "turbo run dev --filter=@tmux-ide/docs",
-    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx",
+    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx",
     "test:tui-smoke": "node scripts/smoke-tui-missions.mjs"
   },
   "keywords": [

--- a/packages/daemon/src/tui/mirror/__snapshots__/changes-terminal-surface-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/__snapshots__/changes-terminal-surface-renderer.test.tsx.snap
@@ -1,0 +1,267 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`Changes and terminal surfaces OpenTUI renderer renders Changes %sx%s with projected chip parity 1`] = `
+" Changes 3 files · +18 -3 │ app▏                     │                    ○ [r]
+ ready
+  ○ Staged (1)                   diff --git a/src/app.ts b/src/app.ts
+M○  README.md +2                 @@ -1 +1 @@
+  ○ Unstaged (1)                 -old
+M●  src/app.… +12 -3 · [s stage] +new
+  ○ Untracked (1)                 context
+?○  notes/todo.md +4
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ ]/[ hunk · / filter · ^e e ○ [s stage]   ○ [u unstage]   ○ [S all]   ○ [U all]"
+`;
+
+exports[`Changes and terminal surfaces OpenTUI renderer renders Changes %sx%s with projected chip parity 2`] = `
+" Changes 3 files · +18 -3 │ app▏                     │                                                    ○ [r refresh]
+ ready
+  ○ Staged (1)                          diff --git a/src/app.ts b/src/app.ts
+M○  README.md +2                        @@ -1 +1 @@
+  ○ Unstaged (1)                        -old
+M●  src/app.ts +12 -3       · [s stage] +new
+  ○ Untracked (1)                        context
+?○  notes/todo.md +4
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ ]/[ hunk · ^e edit · / filter · r refresh · ^g home · ^q quit      ○ [s stage]   ○ [u unstage]   ○ [S all]   ○ [U all]"
+`;
+
+exports[`Changes and terminal surfaces OpenTUI renderer renders Changes %sx%s with projected chip parity 3`] = `
+" Changes 3 files · +18 -3 │ app▏                     │                                                                                                                                    ○ [r refresh]
+ ready
+  ○ Staged (1)                                      diff --git a/src/app.ts b/src/app.ts
+M○  README.md +2                                    @@ -1 +1 @@
+  ○ Unstaged (1)                                    -old
+M●  src/app.ts +12 -3                   · [s stage] +new
+  ○ Untracked (1)                                    context
+?○  notes/todo.md +4
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ ]/[ hunk · ^e edit · / filter · r refresh · ^g home · ^q quit                                                                                      ○ [s stage]   ○ [u unstage]   ○ [S all]   ○ [U all]"
+`;
+
+exports[`Changes and terminal surfaces OpenTUI renderer renders terminal chrome %sx%s without expanding body cells 1`] = `
+" api server                  ● [⛶ zoom]   ○ [+ split]   ● [/ search]   ● [SYNC]
+framebuffer body stays opaque
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ focused · attention · zoomed · ↑12/120 · workspace %7"
+`;
+
+exports[`Changes and terminal surfaces OpenTUI renderer renders terminal chrome %sx%s without expanding body cells 2`] = `
+" api server                                                          ● [⛶ zoom]   ○ [+ split]   ● [/ search]   ● [SYNC]
+framebuffer body stays opaque
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ focused · attention · zoomed · ↑12/120 · workspace %7"
+`;
+
+exports[`Changes and terminal surfaces OpenTUI renderer renders terminal chrome %sx%s without expanding body cells 3`] = `
+" api server                                                                                                                                          ● [⛶ zoom]   ○ [+ split]   ● [/ search]   ● [SYNC]
+framebuffer body stays opaque
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ focused · attention · zoomed · ↑12/120 · workspace %7"
+`;

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -388,6 +388,14 @@ import {
 } from "./home-surface.ts";
 import { FilesSurface } from "./files-surface.tsx";
 import { filesHitTest, filesListWidth, projectFilesSurface } from "./files-surface.ts";
+import { ChangesSurface } from "./changes-surface.tsx";
+import {
+  changesBodyRows,
+  changesHitTest,
+  changesListWidth,
+  projectChangesSurface,
+  type ChangesActionId,
+} from "./changes-surface.ts";
 import type { FilesActionId } from "./files-surface.ts";
 import {
   handleMissionSurfaceKey,
@@ -712,8 +720,7 @@ type HoverRegion =
   | "windowtab"
   | "files"
   | "diff"
-  // M24.5: the diff footer's clickable [s stage]/[u unstage]/[S all]/[U all]
-  // verb chips (index into DIFF_VERBS).
+  // Changes view file/action rows.
   | "diffverb"
   | "button"
   | "tabbtn"
@@ -792,20 +799,6 @@ const STATUS_LETTER_FG: Record<string, RGBA> = {
 const DIFF_ADD_BG = RGBA.fromInts(20, 60, 30, 255);
 const DIFF_DEL_BG = RGBA.fromInts(60, 20, 20, 255);
 const DIFF_LINE_BG: Partial<Record<DiffLineKind, RGBA>> = { add: DIFF_ADD_BG, del: DIFF_DEL_BG };
-// The diff footer's clickable stage/unstage verbs (M24.5) — fixed labels so
-// the x-span math is constant. Laid out from the main column's first content
-// cell (sidebarW()+paddingLeft 1) with the render's gap={1}; the spans memo and
-// the footer render walk this SAME list, so a click lands where it's drawn.
-const DIFF_VERBS: { id: "stage" | "unstage" | "stage-all" | "unstage-all"; label: string }[] = [
-  { id: "stage", label: "[s stage]" },
-  { id: "unstage", label: "[u unstage]" },
-  { id: "stage-all", label: "[S all]" },
-  { id: "unstage-all", label: "[U all]" },
-];
-// A diff file row's right-anchored stage/unstage chip (shown on the selected
-// and hovered rows) — trailing space = a 1-cell inset from the list edge.
-const DIFF_ROW_CHIP_STAGE = "[s stage] ";
-const DIFF_ROW_CHIP_UNSTAGE = "[u unstage] ";
 const HEADER_ROWS = 2;
 // The persistent surface-tab row is one screen row at the very top (above the
 // sidebar + main region). Its height offsets every region's global y, so the
@@ -2042,8 +2035,8 @@ try {
 
     // Body rows below header (1) + rule (1), above the footer (1) — shared by both
     // columns. The left column width is a capped fraction of the canvas.
-    const diffBodyRows = () => Math.max(1, dims().height - 3 - TABBAR_H);
-    const diffListW = () => Math.max(20, Math.min(48, Math.floor(canvasCols() * 0.34)));
+    const diffBodyRows = () => Math.max(1, changesBodyRows(dims().height - TABBAR_H));
+    const diffListW = () => changesListWidth(canvasCols());
     const diffLines = createMemo(() => classifyDiff(diffText()));
     // Grouped rows (section headers + files) and the flat selectable-file order,
     // both from ONE buildDiffRows pass over the filtered entries: the render,
@@ -2067,6 +2060,30 @@ try {
       const top = clampTop(diffFileTop(), rows.length, view);
       return rows.slice(top, top + view).map((row, i) => ({ row, rowIndex: top + i }));
     });
+    const changesSurfaceProjection = createMemo(() =>
+      projectChangesSurface({
+        width: canvasCols(),
+        height: dims().height - TABBAR_H,
+        dir: diffDir(),
+        fileCount: diffVisibleFiles().length,
+        totals: diffTotals(),
+        filterQuery: diffFilter(),
+        message: diffMsg(),
+        listRows: fileVisible(),
+        selectedFileIndex: diffSel(),
+        diffLines: diffVisible(),
+        hovered:
+          hover()?.region === "diff" ||
+          hover()?.region === "diffverb" ||
+          hover()?.region === "button"
+            ? (hover() as
+                | { region: "diff"; index: number }
+                | { region: "diffverb"; index: number }
+                | { region: "button"; index: number })
+            : null,
+        footerHint: `]/[ hunk · ^e edit · / filter · r refresh · ^g home · ${QUIT_HINT}`,
+      }),
+    );
 
     const runGit = (args: string[], cb: (out: string) => void) => {
       execFile(
@@ -2292,42 +2309,17 @@ try {
       setTab("diff");
     };
 
-    /** The diff footer's clickable verb chips — laid out from the main column's
-     *  first content cell, exactly matching the rendered `paddingLeft={1}
-     *  gap={1}` row (shared render↔router). */
-    const diffVerbSpans = createMemo(() =>
-      spans(
-        DIFF_VERBS.map((v) => v.label),
-        sidebarW() + 1,
-        1,
-      ),
-    );
-    const runDiffVerb = (id: (typeof DIFF_VERBS)[number]["id"]) => {
-      const cur = diffVisibleFiles()[diffSel()];
-      if (id === "stage-all") stageAll();
+    const runChangesAction = (id: ChangesActionId, fileIndex = diffSel()) => {
+      if (id === "refresh") refreshStatus();
+      else if (id === "stage-all") stageAll();
       else if (id === "unstage-all") unstageAll();
-      else if (cur && id === "stage") stageEntry(cur);
-      else if (cur && id === "unstage") unstageEntry(cur);
+      else {
+        const entry = diffVisibleFiles()[fileIndex];
+        if (!entry) return;
+        if (id === "stage" || id === "row-stage") stageEntry(entry);
+        else if (id === "unstage" || id === "row-unstage") unstageEntry(entry);
+      }
     };
-    /** A diff file row's right-anchored [s stage]/[u unstage] chip: label by
-     *  group, span pinned to the list column's right edge — the same
-     *  spansFromRight math the render's flexGrow spacer produces. */
-    const diffRowChipLabel = (e: DiffEntry) =>
-      e.group === "staged" ? DIFF_ROW_CHIP_UNSTAGE : DIFF_ROW_CHIP_STAGE;
-    const diffRowChipSpan = (e: DiffEntry): Span =>
-      spansFromRight([diffRowChipLabel(e)], sidebarW() + diffListW(), 0)[0]!;
-    /** Truncate a diff row's path (keeping the tail — the filename is the
-     *  signal) so status + ± counts + the chip (when shown) fit the column. */
-    const diffRowPath = (e: DiffEntry, chip: boolean): string => {
-      const addW = (e.additions ?? 0) > 0 ? `+${e.additions}`.length + 1 : 0;
-      const delW = (e.deletions ?? 0) > 0 ? `-${e.deletions}`.length + 1 : 0;
-      const budget = Math.max(
-        4,
-        diffListW() - 4 - addW - delW - (chip ? diffRowChipLabel(e).length + 1 : 0),
-      );
-      return e.path.length > budget ? "…" + e.path.slice(-(budget - 1)) : e.path;
-    };
-
     let mirror: SessionMirror | null = null;
     // ── EVENT-DRIVEN RE-PIN (M23.5) ──────────────────────────────────────────
     // The 200ms canvas size poll is gone: a createEffect on the renderer dims
@@ -6008,29 +6000,14 @@ try {
         return;
       }
       if (m === "diff") {
-        if (gy === 0) {
-          const i = spanHit(headerButtons().spans, x);
-          setHoverIf(i >= 0 ? { region: "button", index: i } : null);
-          return;
-        }
-        // The footer's stage/unstage verb chips (last screen row).
-        if (y === dims().height - 1) {
-          const i = spanHit(diffVerbSpans(), x);
-          setHoverIf(i >= 0 ? { region: "diffverb", index: i } : null);
-          return;
-        }
-        const contentY = gy - HEADER_ROWS;
-        const overList = x < sidebarW() + diffListW();
-        if (!overList || contentY < 0) {
-          setHoverIf(null);
-          return;
-        }
-        // Only FILE rows are hoverable (section headers are inert); the hover
-        // index is the ROW index, matching the render's slice.
-        const rows = diffRows();
-        const top = clampTop(diffFileTop(), rows.length, diffBodyRows());
-        const idx = top + contentY;
-        setHoverIf(rows[idx]?.kind === "file" ? { region: "diff", index: idx } : null);
+        const hit = changesHitTest(changesSurfaceProjection(), x - sidebarW(), gy);
+        if (hit?.area === "header" && hit.actionIndex !== undefined)
+          setHoverIf({ region: "button", index: hit.actionIndex });
+        else if (hit?.area === "footer" && hit.actionIndex !== undefined)
+          setHoverIf({ region: "diffverb", index: hit.actionIndex });
+        else if (hit?.area === "list" && hit.fileIndex !== undefined && hit.rowIndex !== undefined)
+          setHoverIf({ region: "diff", index: hit.rowIndex });
+        else setHoverIf(null);
         return;
       }
       if (m === "missions") {
@@ -6846,12 +6823,12 @@ try {
       // left-column click selects that file ROW (headers are inert), and the
       // row's right-anchored [s stage]/[u unstage] chip wins over selection.
       if (mode() === "diff") {
-        const overList = x < sidebarW() + diffListW();
+        const hit = changesHitTest(changesSurfaceProjection(), x - sidebarW(), gy);
         if (type === "scroll") {
           const dir = e.scroll?.direction;
           if (dir !== "up" && dir !== "down") return;
           const step = dir === "up" ? -SCROLL_STEP : SCROLL_STEP;
-          if (overList) {
+          if (hit?.area === "list") {
             setDiffFileTop((t) => clampTop(t + step, diffRows().length, diffBodyRows()));
           } else {
             setDiffTop((t) => clampTop(t + step, diffLines().length, diffBodyRows()));
@@ -6859,31 +6836,16 @@ try {
           return;
         }
         if (type !== "down") return;
-        // The header row (gy=0) carries the right-aligned refresh button.
-        if (gy === 0) {
-          const hb = headerButtons();
-          const i = spanHit(hb.spans, x);
-          if (i >= 0) runButton(hb.defs[i]!.id);
+        if ((hit?.area === "header" || hit?.area === "footer") && hit.actionId) {
+          runChangesAction(hit.actionId);
           return;
         }
-        // The footer's stage/unstage verb chips (same spans the render draws).
-        if (y === dims().height - 1) {
-          const i = spanHit(diffVerbSpans(), x);
-          if (i >= 0) runDiffVerb(DIFF_VERBS[i]!.id);
+        if (hit?.area !== "list" || hit.fileIndex === undefined) return;
+        if (hit.actionId) {
+          runChangesAction(hit.actionId, hit.fileIndex);
           return;
         }
-        const contentY = gy - HEADER_ROWS;
-        if (contentY < 0 || !overList) return;
-        const rows = diffRows();
-        const top = clampTop(diffFileTop(), rows.length, diffBodyRows());
-        const row = rows[top + contentY];
-        if (!row || row.kind !== "file") return;
-        const chip = diffRowChipSpan(row.entry);
-        if (x >= chip.start && x < chip.start + chip.width) {
-          toggleStageEntry(row.entry);
-          return;
-        }
-        selectDiffFile(row.fileIndex);
+        selectDiffFile(hit.fileIndex);
         return;
       }
       // The per-window strip (gy=1) — resolved by the SAME x-span math the render
@@ -7772,117 +7734,17 @@ try {
               />
             </Show>
             <Show when={!activeCompositeLayout() && mode() === "diff"}>
-              {/* header (y=0) · rule (y=1) · two-column body (y=2+) · footer
-              verbs (last row). `route` reverses this geometry: left column =
-              grouped file list (headers + rows from the SAME buildDiffRows the
-              router walks), right = diff. NO onMouse on the rows — the main
-              column container routes everything. */}
-              <box paddingLeft={1} flexDirection="row" gap={1}>
-                <text fg={ACCENT} attributes={1}>
-                  {basename(diffDir()) || "diff"}
-                </text>
-                <text fg={MUTED}>{`${diffVisibleFiles().length} files`}</text>
-                <Show when={diffTotals().additions > 0}>
-                  <text fg={DIFF_ADD_FG}>{`+${diffTotals().additions}`}</text>
-                </Show>
-                <Show when={diffTotals().deletions > 0}>
-                  <text fg={DIFF_DEL_FG}>{`-${diffTotals().deletions}`}</text>
-                </Show>
-                <Show when={diffFilter() !== null}>
-                  <text fg={ACCENT}>{`/${diffFilter()}▏`}</text>
-                </Show>
-                <Show when={diffMsg()}>
-                  <text fg={MUTED}>{`· ${diffMsg()}`}</text>
-                </Show>
-                {buttonRow(headerButtons)}
-              </box>
-              <text fg={MUTED}>{"─".repeat(Math.max(4, canvasCols() - 2))}</text>
-              <box flexDirection="row" flexGrow={1}>
-                {/* Left: the grouped changed-file list (Staged / Unstaged /
-                  Untracked). Section headers are inert; file rows show ±
-                  counts and, when selected or hovered, a right-anchored
-                  stage/unstage chip the router hit-tests with the SAME
-                  spansFromRight math. */}
-                <box width={diffListW()} flexDirection="column" backgroundColor={GUTTER_BG}>
-                  <For each={fileVisible()}>
-                    {({ row, rowIndex }) =>
-                      row.kind === "header" ? (
-                        <box height={1} paddingLeft={1} backgroundColor={GUTTER_BG}>
-                          <text fg={ACCENT} attributes={1}>
-                            {row.label}
-                          </text>
-                        </box>
-                      ) : (
-                        <box
-                          height={1}
-                          flexDirection="row"
-                          gap={1}
-                          paddingLeft={1}
-                          backgroundColor={
-                            row.fileIndex === diffSel()
-                              ? TAB_ACTIVE_BG
-                              : isHovered("diff", rowIndex)
-                                ? HOVER_BG
-                                : GUTTER_BG
-                          }
-                        >
-                          <text fg={STATUS_LETTER_FG[row.entry.status] ?? DEFAULT_FG}>
-                            {row.entry.status}
-                          </text>
-                          <text fg={row.fileIndex === diffSel() ? DEFAULT_FG : MUTED}>
-                            {diffRowPath(
-                              row.entry,
-                              row.fileIndex === diffSel() || isHovered("diff", rowIndex),
-                            )}
-                          </text>
-                          <Show when={(row.entry.additions ?? 0) > 0}>
-                            <text fg={DIFF_ADD_FG}>{`+${row.entry.additions}`}</text>
-                          </Show>
-                          <Show when={(row.entry.deletions ?? 0) > 0}>
-                            <text fg={DIFF_DEL_FG}>{`-${row.entry.deletions}`}</text>
-                          </Show>
-                          <Show when={row.fileIndex === diffSel() || isHovered("diff", rowIndex)}>
-                            <box flexGrow={1} />
-                            <text fg={BUTTON_FG} bg={BUTTON_BG}>
-                              {diffRowChipLabel(row.entry)}
-                            </text>
-                          </Show>
-                        </box>
-                      )
-                    }
-                  </For>
-                </box>
-                {/* Right: unified diff of the selected file — add/del rows carry
-                  the widget-derived background fills under the fg classes — with
-                  a right-edge scrollbar overlaid on the last column. */}
-                <box position="relative" flexGrow={1} flexDirection="column" paddingLeft={1}>
-                  {scrollbarOverlay(diffScrollGeom)}
-                  <For each={diffVisible()}>
-                    {(ln) => (
-                      <box height={1} backgroundColor={DIFF_LINE_BG[ln.kind] ?? DEFAULT_BG}>
-                        <text fg={DIFF_FG[ln.kind]}>{ln.text || " "}</text>
-                      </box>
-                    )}
-                  </For>
-                </box>
-              </box>
-              {/* Footer: clickable stage/unstage verbs (the spans the router
-                hit-tests) followed by plain keyboard hints. */}
-              <box paddingLeft={1} flexDirection="row" gap={1}>
-                <For each={DIFF_VERBS}>
-                  {(v, i) => (
-                    <text
-                      fg={BUTTON_FG}
-                      bg={isHovered("diffverb", i()) ? BUTTON_HOVER_BG : BUTTON_BG}
-                    >
-                      {v.label}
-                    </text>
-                  )}
-                </For>
-                <text fg={MUTED}>
-                  {`]/[ hunk · ^e edit · / filter · r refresh · ^g home · ${QUIT_HINT}`}
-                </text>
-              </box>
+              <ChangesSurface
+                theme={semanticTheme()}
+                projection={changesSurfaceProjection()}
+                colors={{
+                  gutterBg: GUTTER_BG,
+                  gutterFg: GUTTER_FG,
+                  statusLetterFg: STATUS_LETTER_FG,
+                  diffFg: DIFF_FG,
+                  diffLineBg: DIFF_LINE_BG,
+                }}
+              />
             </Show>
             <Show when={!activeCompositeLayout() && mode() === "missions"}>
               <MissionsSurface

--- a/packages/daemon/src/tui/mirror/changes-surface.ts
+++ b/packages/daemon/src/tui/mirror/changes-surface.ts
@@ -1,0 +1,338 @@
+import type { RGBA } from "@opentui/core";
+import type { DiffEntry, DiffGroup, DiffLine, DiffLineKind, DiffRow } from "./diff-model.ts";
+import { clipTerminal } from "./missions-workspace.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import { actionChipSpansFromRight, actionChipWidth, type Rect } from "./recipes.ts";
+
+export type ChangesVariant = "compact" | "standard" | "wide";
+export type ChangesActionId =
+  | "refresh"
+  | "stage"
+  | "unstage"
+  | "stage-all"
+  | "unstage-all"
+  | "row-stage"
+  | "row-unstage";
+
+export interface ChangesAction {
+  id: ChangesActionId;
+  label: string;
+  description: string;
+  disabled?: boolean;
+  hovered?: boolean;
+}
+
+export interface ChangesActionSpan extends ChangesAction {
+  start: number;
+  width: number;
+}
+
+export interface ChangesProjectedFileRow extends Rect {
+  id: string;
+  kind: "file";
+  rowIndex: number;
+  fileIndex: number;
+  entry: DiffEntry;
+  status: string;
+  path: string;
+  countText: string;
+  selected: boolean;
+  hovered: boolean;
+  action: ChangesActionSpan | null;
+}
+
+export interface ChangesProjectedHeaderRow extends Rect {
+  id: string;
+  kind: "header";
+  rowIndex: number;
+  label: string;
+  group: DiffGroup;
+}
+
+export type ChangesProjectedListRow = ChangesProjectedHeaderRow | ChangesProjectedFileRow;
+
+export interface ChangesProjectedDiffLine extends Rect {
+  id: string;
+  kind: DiffLineKind;
+  text: string;
+}
+
+export interface ChangesSurfaceProjection {
+  width: number;
+  height: number;
+  variant: ChangesVariant;
+  header: Rect;
+  banner: Rect;
+  body: Rect;
+  footer: Rect;
+  list: Rect;
+  diff: Rect;
+  title: string;
+  pathContext: string;
+  totals: string;
+  filter: { active: boolean; query: string };
+  state: "ready" | "empty" | "loading" | "error";
+  message: string;
+  headerActions: readonly ChangesActionSpan[];
+  listRows: readonly ChangesProjectedListRow[];
+  diffLines: readonly ChangesProjectedDiffLine[];
+  footerHint: string;
+  footerActions: readonly ChangesActionSpan[];
+}
+
+export interface ChangesSurfaceInput {
+  width: number;
+  height: number;
+  dir: string;
+  fileCount: number;
+  totals: { additions: number; deletions: number };
+  filterQuery: string | null;
+  message: string;
+  listRows: readonly { row: DiffRow; rowIndex: number }[];
+  selectedFileIndex: number;
+  diffLines: readonly DiffLine[];
+  hovered:
+    | { region: "diff"; index: number }
+    | { region: "diffverb"; index: number }
+    | { region: "button"; index: number }
+    | null;
+  footerHint: string;
+}
+
+export function changesVariant(width: number, height: number): ChangesVariant {
+  if (width >= 160 && height >= 45) return "wide";
+  if (width >= 96 && height >= 30) return "standard";
+  return "compact";
+}
+
+export function changesListWidth(width: number): number {
+  const safe = Math.max(0, Math.floor(width));
+  if (safe < 58) return safe;
+  if (safe < 96) return Math.max(22, Math.min(34, Math.floor(safe * 0.42)));
+  return Math.max(28, Math.min(52, Math.floor(safe * 0.34)));
+}
+
+export function changesBodyRows(height: number): number {
+  return Math.max(0, Math.floor(height) - 3);
+}
+
+export function projectChangesSurface(input: ChangesSurfaceInput): ChangesSurfaceProjection {
+  const width = Math.max(0, Math.floor(input.width));
+  const height = Math.max(0, Math.floor(input.height));
+  const variant = changesVariant(width, height);
+  const headerHeight = Math.min(1, height);
+  const bannerHeight = height >= 4 ? 1 : 0;
+  const footerHeight = height >= 6 ? 1 : 0;
+  const bodyY = headerHeight + bannerHeight;
+  const bodyHeight = Math.max(0, height - bodyY - footerHeight);
+  const listWidth = Math.min(width, changesListWidth(width));
+  const diffVisible = width - listWidth >= 24 && bodyHeight > 0;
+  const list: Rect = { x: 0, y: bodyY, width: diffVisible ? listWidth : width, height: bodyHeight };
+  const diff: Rect = {
+    x: diffVisible ? list.width : 0,
+    y: bodyY,
+    width: diffVisible ? Math.max(0, width - list.width) : 0,
+    height: bodyHeight,
+  };
+  const headerActions = actionChipSpansFromRight(
+    [
+      {
+        id: "refresh" as const,
+        label: variant === "compact" ? "[r]" : "[r refresh]",
+        description: "Refresh git status",
+        hovered: input.hovered?.region === "button" && input.hovered.index === 0,
+      },
+    ],
+    width,
+    1,
+  );
+  const listRows = input.listRows.slice(0, bodyHeight).map((row, offset) =>
+    row.row.kind === "header"
+      ? projectListHeader(row.row, row.rowIndex, list, offset)
+      : projectListFile({
+          row: row.row,
+          rowIndex: row.rowIndex,
+          y: list.y + offset,
+          width: list.width,
+          selectedFileIndex: input.selectedFileIndex,
+          hovered: input.hovered,
+        }),
+  );
+  const diffLines = diffVisible
+    ? input.diffLines.slice(0, bodyHeight).map((line, offset) => ({
+        id: `diff:${offset}`,
+        kind: line.kind,
+        text: clipTerminal(line.text || " ", Math.max(0, diff.width - 1)),
+        x: diff.x,
+        y: diff.y + offset,
+        width: diff.width,
+        height: 1,
+      }))
+    : [];
+  const footerActions = actionChipSpansFromRight(footerActionDefs(input.hovered), width, 1);
+  const state =
+    input.message && input.fileCount === 0
+      ? input.message.includes("clean")
+        ? "empty"
+        : "error"
+      : input.fileCount === 0
+        ? "empty"
+        : "ready";
+  return {
+    width,
+    height,
+    variant,
+    header: { x: 0, y: 0, width, height: headerHeight },
+    banner: { x: 0, y: headerHeight, width, height: bannerHeight },
+    body: { x: 0, y: bodyY, width, height: bodyHeight },
+    footer: { x: 0, y: height - footerHeight, width, height: footerHeight },
+    list,
+    diff,
+    title: "Changes",
+    pathContext: clipTerminal(input.dir, width),
+    totals: `${input.fileCount} files · +${input.totals.additions} -${input.totals.deletions}`,
+    filter: { active: input.filterQuery !== null, query: input.filterQuery ?? "" },
+    state,
+    message: input.message || (input.fileCount === 0 ? "working tree clean" : input.dir),
+    headerActions,
+    listRows,
+    diffLines,
+    footerHint:
+      variant === "compact"
+        ? "]/[ hunk · / filter · ^e edit"
+        : clipTerminal(input.footerHint, width),
+    footerActions,
+  };
+}
+
+function projectListHeader(
+  row: Extract<DiffRow, { kind: "header" }>,
+  rowIndex: number,
+  list: Rect,
+  offset: number,
+): ChangesProjectedHeaderRow {
+  return {
+    id: `header:${row.group}:${rowIndex}`,
+    kind: "header",
+    rowIndex,
+    group: row.group,
+    label: clipTerminal(row.label, Math.max(0, list.width - 1)),
+    x: list.x,
+    y: list.y + offset,
+    width: list.width,
+    height: 1,
+  };
+}
+
+function projectListFile(input: {
+  row: Extract<DiffRow, { kind: "file" }>;
+  rowIndex: number;
+  y: number;
+  width: number;
+  selectedFileIndex: number;
+  hovered: ChangesSurfaceInput["hovered"];
+}): ChangesProjectedFileRow {
+  const selected = input.row.fileIndex === input.selectedFileIndex;
+  const hovered = input.hovered?.region === "diff" && input.hovered.index === input.rowIndex;
+  const entry = input.row.entry;
+  const chip = rowAction(entry, hovered || selected);
+  const actionWidth = hovered || selected ? actionChipWidth(chip.label) : 0;
+  const countText = countLabel(entry);
+  const countWidth = countText ? terminalDisplayWidth(countText) + 1 : 0;
+  const pathWidth = Math.max(4, input.width - 4 - countWidth - actionWidth);
+  const base: ChangesProjectedFileRow = {
+    id: `file:${entry.group}:${entry.path}`,
+    kind: "file",
+    rowIndex: input.rowIndex,
+    fileIndex: input.row.fileIndex,
+    entry,
+    status: entry.status,
+    path: clipTerminal(entry.path, pathWidth),
+    countText,
+    selected,
+    hovered,
+    action: null,
+    x: 0,
+    y: input.y,
+    width: input.width,
+    height: 1,
+  };
+  if (!selected && !hovered) return base;
+  const span = actionChipSpansFromRight([chip], input.width, 0)[0]!;
+  return { ...base, action: span };
+}
+
+function rowAction(entry: DiffEntry, hovered: boolean): ChangesAction {
+  return {
+    id: entry.group === "staged" ? "row-unstage" : "row-stage",
+    label: entry.group === "staged" ? "[u unstage]" : "[s stage]",
+    description: entry.group === "staged" ? "Unstage file" : "Stage file",
+    hovered,
+  };
+}
+
+function footerActionDefs(hovered: ChangesSurfaceInput["hovered"]): ChangesAction[] {
+  const defs: ChangesAction[] = [
+    { id: "stage", label: "[s stage]", description: "Stage selected file" },
+    { id: "unstage", label: "[u unstage]", description: "Unstage selected file" },
+    { id: "stage-all", label: "[S all]", description: "Stage all files" },
+    { id: "unstage-all", label: "[U all]", description: "Unstage all files" },
+  ];
+  return defs.map((action, index) => ({
+    ...action,
+    hovered: hovered?.region === "diffverb" && hovered.index === index,
+  }));
+}
+
+function countLabel(entry: DiffEntry): string {
+  const add = entry.additions && entry.additions > 0 ? `+${entry.additions}` : "";
+  const del = entry.deletions && entry.deletions > 0 ? `-${entry.deletions}` : "";
+  return [add, del].filter(Boolean).join(" ");
+}
+
+export function changesHitTest(
+  projection: ChangesSurfaceProjection,
+  x: number,
+  y: number,
+):
+  | { area: "header"; actionId?: ChangesActionId; actionIndex?: number }
+  | { area: "list"; rowIndex?: number; fileIndex?: number; actionId?: ChangesActionId }
+  | { area: "diff" | "footer"; actionId?: ChangesActionId; actionIndex?: number }
+  | null {
+  if (x < 0 || y < 0 || x >= projection.width || y >= projection.height) return null;
+  if (y < projection.header.height) {
+    const i = projection.headerActions.findIndex((span) => containsX(span, x));
+    return i >= 0
+      ? { area: "header", actionId: projection.headerActions[i]!.id, actionIndex: i }
+      : { area: "header" };
+  }
+  if (y >= projection.footer.y) {
+    const i = projection.footerActions.findIndex((span) => containsX(span, x));
+    return i >= 0
+      ? { area: "footer", actionId: projection.footerActions[i]!.id, actionIndex: i }
+      : { area: "footer" };
+  }
+  if (y < projection.body.y) return null;
+  if (x < projection.list.width) {
+    const row = projection.listRows.find((candidate) => candidate.y === y);
+    if (!row) return { area: "list" };
+    if (row.kind === "header") return { area: "list", rowIndex: row.rowIndex };
+    if (row.action && containsX(row.action, x))
+      return {
+        area: "list",
+        rowIndex: row.rowIndex,
+        fileIndex: row.fileIndex,
+        actionId: row.action.id,
+      };
+    return { area: "list", rowIndex: row.rowIndex, fileIndex: row.fileIndex };
+  }
+  return { area: "diff" };
+}
+
+function containsX(span: { start: number; width: number }, x: number): boolean {
+  return x >= span.start && x < span.start + span.width;
+}
+
+export function colorForDiffKind(kind: DiffLineKind, colors: Record<DiffLineKind, RGBA>): RGBA {
+  return colors[kind];
+}

--- a/packages/daemon/src/tui/mirror/changes-surface.tsx
+++ b/packages/daemon/src/tui/mirror/changes-surface.tsx
@@ -1,0 +1,257 @@
+/* @jsxImportSource @opentui/solid */
+import { For, Show } from "solid-js";
+import type { RGBA } from "@opentui/core";
+import type { SemanticThemeSnapshot } from "./theme.ts";
+import { ActionChip, EmptyState, InputShell, SectionHeader, SelectableRow } from "./recipes.tsx";
+import { recipePalette } from "./recipes.ts";
+import type { ChangesProjectedFileRow, ChangesSurfaceProjection } from "./changes-surface.ts";
+import { changesHitTest } from "./changes-surface.ts";
+import type { DiffLineKind } from "./diff-model.ts";
+
+export interface ChangesSurfaceColors {
+  gutterBg: RGBA;
+  gutterFg: RGBA;
+  statusLetterFg: Record<string, RGBA>;
+  diffFg: Record<DiffLineKind, RGBA>;
+  diffLineBg: Partial<Record<DiffLineKind, RGBA>>;
+}
+
+export interface ChangesSurfaceProps {
+  theme: SemanticThemeSnapshot;
+  projection: ChangesSurfaceProjection;
+  colors: ChangesSurfaceColors;
+}
+
+export function ChangesSurface(props: ChangesSurfaceProps) {
+  return (
+    <box
+      width={props.projection.width}
+      height={props.projection.height}
+      position="relative"
+      backgroundColor={props.theme.colors.background}
+      overflow="hidden"
+    >
+      <ChangesHeader theme={props.theme} projection={props.projection} />
+      <box
+        position="absolute"
+        left={0}
+        top={props.projection.banner.y}
+        width={props.projection.banner.width}
+        height={props.projection.banner.height}
+        paddingLeft={1}
+        overflow="hidden"
+      >
+        <text
+          fg={
+            props.projection.state === "error"
+              ? props.theme.colors.status.blocked
+              : props.theme.colors.mutedForeground
+          }
+        >
+          {props.projection.message}
+        </text>
+      </box>
+      <box
+        position="absolute"
+        left={props.projection.list.x}
+        top={props.projection.list.y}
+        width={props.projection.list.width}
+        height={props.projection.list.height}
+        flexDirection="column"
+        backgroundColor={props.colors.gutterBg}
+        overflow="hidden"
+      >
+        <Show
+          when={props.projection.listRows.length > 0}
+          fallback={
+            <EmptyState
+              theme={props.theme}
+              title={props.projection.state === "empty" ? "No changes" : "Loading changes"}
+              detail={props.projection.message}
+              width={props.projection.list.width}
+            />
+          }
+        >
+          <For each={props.projection.listRows}>
+            {(row) =>
+              row.kind === "header" ? (
+                <box height={1} paddingLeft={1} overflow="hidden">
+                  <SectionHeader theme={props.theme} title={row.label} width={row.width} />
+                </box>
+              ) : (
+                <ChangesFileRow theme={props.theme} colors={props.colors} row={row} />
+              )
+            }
+          </For>
+        </Show>
+      </box>
+      <Show when={props.projection.diff.width > 0}>
+        <box
+          position="absolute"
+          left={props.projection.diff.x}
+          top={props.projection.diff.y}
+          width={props.projection.diff.width}
+          height={props.projection.diff.height}
+          flexDirection="column"
+          overflow="hidden"
+        >
+          <Show
+            when={props.projection.diffLines.length > 0}
+            fallback={
+              <EmptyState
+                theme={props.theme}
+                title="No diff"
+                detail={props.projection.message}
+                width={props.projection.diff.width}
+              />
+            }
+          >
+            <For each={props.projection.diffLines}>
+              {(line) => (
+                <box
+                  height={1}
+                  backgroundColor={
+                    props.colors.diffLineBg[line.kind] ?? props.theme.colors.background
+                  }
+                  overflow="hidden"
+                >
+                  <text fg={props.colors.diffFg[line.kind]}>{line.text}</text>
+                </box>
+              )}
+            </For>
+          </Show>
+        </box>
+      </Show>
+      <box
+        position="absolute"
+        left={0}
+        top={props.projection.footer.y}
+        width={props.projection.footer.width}
+        height={props.projection.footer.height}
+        overflow="hidden"
+      >
+        <text fg={props.theme.colors.mutedForeground}>{` ${props.projection.footerHint}`}</text>
+        <For each={props.projection.footerActions}>
+          {(action) => (
+            <box position="absolute" left={action.start} top={0} width={action.width} height={1}>
+              <ActionChip
+                theme={props.theme}
+                label={action.label}
+                width={action.width}
+                hovered={action.hovered}
+                disabled={action.disabled}
+              />
+            </box>
+          )}
+        </For>
+      </box>
+    </box>
+  );
+}
+
+function ChangesHeader(props: {
+  theme: SemanticThemeSnapshot;
+  projection: ChangesSurfaceProjection;
+}) {
+  const leftWidth = () =>
+    Math.max(0, props.projection.headerActions[0]?.start ?? props.projection.width);
+  return (
+    <box
+      position="absolute"
+      left={props.projection.header.x}
+      top={props.projection.header.y}
+      width={props.projection.header.width}
+      height={props.projection.header.height}
+      overflow="hidden"
+    >
+      <box
+        height={1}
+        width={leftWidth()}
+        paddingLeft={1}
+        flexDirection="row"
+        gap={1}
+        overflow="hidden"
+      >
+        <text fg={props.theme.colors.accent} attributes={1}>
+          {props.projection.title}
+        </text>
+        <text fg={props.theme.colors.mutedForeground}>{props.projection.totals}</text>
+        <Show when={props.projection.filter.active}>
+          <InputShell
+            theme={props.theme}
+            value={props.projection.filter.query}
+            placeholder="filter changes"
+            width={Math.min(28, Math.max(12, leftWidth() - 32))}
+            focused
+          />
+        </Show>
+      </box>
+      <For each={props.projection.headerActions}>
+        {(action) => (
+          <box position="absolute" left={action.start} top={0} width={action.width} height={1}>
+            <ActionChip
+              theme={props.theme}
+              label={action.label}
+              width={action.width}
+              hovered={action.hovered}
+              disabled={action.disabled}
+            />
+          </box>
+        )}
+      </For>
+    </box>
+  );
+}
+
+function ChangesFileRow(props: {
+  theme: SemanticThemeSnapshot;
+  colors: ChangesSurfaceColors;
+  row: ChangesProjectedFileRow;
+}) {
+  const palette = () =>
+    recipePalette(props.theme, {
+      selected: props.row.selected,
+      hovered: props.row.hovered,
+      status:
+        props.row.entry.group === "staged"
+          ? "done"
+          : props.row.entry.group === "unstaged"
+            ? "working"
+            : "unknown",
+    });
+  const countWidth = () => (props.row.countText ? props.row.countText.length + 1 : 0);
+  const rowWidth = () =>
+    Math.max(1, props.row.width - countWidth() - (props.row.action?.width ?? 0));
+  return (
+    <box height={1} flexDirection="row" backgroundColor={palette().background} overflow="hidden">
+      <text fg={props.colors.statusLetterFg[props.row.status] ?? props.theme.colors.foreground}>
+        {props.row.status}
+      </text>
+      <SelectableRow
+        theme={props.theme}
+        label={` ${props.row.path}`}
+        width={rowWidth()}
+        selected={props.row.selected}
+        hovered={props.row.hovered}
+        tone="neutral"
+      />
+      <Show when={props.row.countText}>
+        {(count) => <text fg={props.theme.colors.mutedForeground}>{` ${count()}`}</text>}
+      </Show>
+      <Show when={props.row.action}>
+        {(action) => (
+          <box position="absolute" left={action().start} top={0} width={action().width} height={1}>
+            <ActionChip
+              theme={props.theme}
+              label={action().label}
+              width={action().width}
+              hovered={action().hovered}
+            />
+          </box>
+        )}
+      </Show>
+    </box>
+  );
+}
+
+export { changesHitTest };

--- a/packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx
@@ -1,0 +1,282 @@
+/* @jsxImportSource @opentui/solid */
+import { MouseButtons } from "@opentui/core/testing";
+import { testRender, useKeyboard } from "@opentui/solid";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it } from "bun:test";
+import { RGBA } from "@opentui/core";
+import { buildDiffRows, classifyDiff, type DiffEntry } from "./diff-model.ts";
+import { ChangesSurface } from "./changes-surface.tsx";
+import { changesHitTest, projectChangesSurface } from "./changes-surface.ts";
+import { TerminalPaneChrome } from "./terminal-surface.tsx";
+import { projectTerminalPaneChrome, terminalChromeHitTest } from "./terminal-surface.ts";
+import { createSemanticThemeSnapshot } from "./theme.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import { actionChipWidth } from "./recipes.ts";
+
+type TestSetup = Awaited<ReturnType<typeof testRender>>;
+
+let setup: TestSetup | null = null;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = null;
+});
+
+const THEME = createSemanticThemeSnapshot({ mode: "dark" });
+const COLORS = {
+  gutterBg: RGBA.fromInts(24, 26, 34, 255),
+  gutterFg: RGBA.fromInts(120, 124, 140, 255),
+  statusLetterFg: {
+    M: RGBA.fromInts(235, 200, 100, 255),
+    "?": RGBA.fromInts(150, 150, 170, 255),
+  },
+  diffFg: {
+    add: RGBA.fromInts(120, 200, 140, 255),
+    del: RGBA.fromInts(240, 120, 120, 255),
+    hunk: RGBA.fromInts(120, 170, 255, 255),
+    meta: RGBA.fromInts(120, 120, 140, 255),
+    context: RGBA.fromInts(170, 170, 185, 255),
+  },
+  diffLineBg: {
+    add: RGBA.fromInts(20, 60, 30, 255),
+    del: RGBA.fromInts(60, 20, 20, 255),
+  },
+};
+
+function frameLines(frame: string): string[] {
+  const lines = frame.endsWith("\n") ? frame.slice(0, -1).split("\n") : frame.split("\n");
+  return lines.map((line) => line.replace(/\r$/u, ""));
+}
+
+function stableFrame(frame: string): string {
+  return frameLines(frame)
+    .map((line) => line.replace(/\s+$/u, ""))
+    .join("\n");
+}
+
+function expectFrameBounds(frame: string, width: number, height: number): void {
+  const lines = frameLines(frame);
+  expect(lines).toHaveLength(height);
+  for (const line of lines) expect(terminalDisplayWidth(line)).toBeLessThanOrEqual(width);
+}
+
+function expectPaintedChip(
+  frame: string,
+  x: number,
+  y: number,
+  width: number,
+  label: string,
+): void {
+  const text = (frameLines(frame)[y] ?? "").slice(x, x + width);
+  expect(terminalDisplayWidth(text)).toBe(width);
+  expect(text).toContain(label);
+  expect(width).toBe(actionChipWidth(label));
+}
+
+const entry = (over: Partial<DiffEntry>): DiffEntry => ({
+  group: "unstaged",
+  status: "M",
+  path: "src/app.ts",
+  additions: 12,
+  deletions: 3,
+  ...over,
+});
+
+function fixtureRows() {
+  return buildDiffRows([
+    entry({ group: "staged", path: "README.md", additions: 2, deletions: 0 }),
+    entry({ group: "unstaged", path: "src/app.ts", additions: 12, deletions: 3 }),
+    entry({ group: "untracked", path: "notes/todo.md", status: "?", additions: 4, deletions: 0 }),
+  ]);
+}
+
+function changesProjection(
+  width: number,
+  height: number,
+  selected: number,
+  hovered: number | null,
+) {
+  const rows = fixtureRows();
+  return projectChangesSurface({
+    width,
+    height,
+    dir: "/repo/workspace",
+    fileCount: rows.files.length,
+    totals: { additions: 18, deletions: 3 },
+    filterQuery: "app",
+    message: "ready",
+    listRows: rows.rows.map((row, rowIndex) => ({ row, rowIndex })),
+    selectedFileIndex: selected,
+    diffLines: classifyDiff(
+      "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n context",
+    ),
+    hovered: hovered === null ? null : { region: "diff", index: hovered },
+    footerHint: "]/[ hunk · ^e edit · / filter · r refresh · ^g home · ^q quit",
+  });
+}
+
+async function renderChanges(width: number, height: number) {
+  const calls: string[] = [];
+  let latest = "";
+  function Harness() {
+    const [selected, setSelected] = createSignal(1);
+    const projection = () => changesProjection(width, height, selected(), null);
+    useKeyboard((event) => {
+      if (event.name === "down") setSelected(Math.min(2, selected() + 1));
+      if (event.name === "r") calls.push("keyboard:refresh");
+    });
+    return (
+      <box
+        width={width}
+        height={height}
+        overflow="hidden"
+        onMouseDown={(event) => {
+          const hit = changesHitTest(projection(), event.x, event.y);
+          if ((hit?.area === "header" || hit?.area === "footer") && hit.actionId)
+            calls.push(`mouse:${hit.actionId}`);
+          else if (hit?.area === "list" && hit.actionId) calls.push(`mouse:${hit.actionId}`);
+          else if (hit?.area === "list" && hit.fileIndex !== undefined) {
+            setSelected(hit.fileIndex);
+            calls.push(`mouse:select:${hit.fileIndex}`);
+          }
+        }}
+      >
+        <ChangesSurface theme={THEME} projection={projection()} colors={COLORS} />
+      </box>
+    );
+  }
+  setup = await testRender(() => <Harness />, { width, height });
+  await setup.renderOnce();
+  latest = setup.captureCharFrame();
+  return {
+    calls,
+    projection: () => changesProjection(width, height, 1, null),
+    frame: () => {
+      latest = setup!.captureCharFrame();
+      return latest;
+    },
+  };
+}
+
+async function renderTerminal(width: number, height: number) {
+  const calls: string[] = [];
+  function Harness() {
+    const projection = () =>
+      projectTerminalPaneChrome({
+        width,
+        height,
+        title: "api server",
+        paneId: "%7",
+        session: "workspace",
+        focused: true,
+        attention: true,
+        scrollOffset: 12,
+        scrollbackDepth: 120,
+        selected: false,
+        zoomed: true,
+        sync: true,
+        search: "error",
+      });
+    return (
+      <box
+        width={width}
+        height={height}
+        overflow="hidden"
+        onMouseDown={(event) => {
+          const hit = terminalChromeHitTest(projection(), event.x, event.y);
+          if (hit?.area === "header" && hit.actionId) calls.push(`mouse:${hit.actionId}`);
+        }}
+      >
+        <TerminalPaneChrome theme={THEME} projection={projection()}>
+          <text fg={THEME.colors.foreground}>framebuffer body stays opaque</text>
+        </TerminalPaneChrome>
+      </box>
+    );
+  }
+  setup = await testRender(() => <Harness />, { width, height });
+  await setup.renderOnce();
+  return {
+    calls,
+    projection: () =>
+      projectTerminalPaneChrome({
+        width,
+        height,
+        title: "api server",
+        paneId: "%7",
+        session: "workspace",
+        focused: true,
+        attention: true,
+        scrollOffset: 12,
+        scrollbackDepth: 120,
+        selected: false,
+        zoomed: true,
+        sync: true,
+        search: "error",
+      }),
+    frame: () => setup!.captureCharFrame(),
+  };
+}
+
+describe("Changes and terminal surfaces OpenTUI renderer", () => {
+  it.each([
+    [80, 24],
+    [120, 40],
+    [200, 60],
+  ] as const)("renders Changes %sx%s with projected chip parity", async (width, height) => {
+    const harness = await renderChanges(width, height);
+    const frame = harness.frame();
+    const projection = harness.projection();
+    expectFrameBounds(frame, width, height);
+    expect(stableFrame(frame)).toMatchSnapshot();
+    expect(stableFrame(frame)).toContain("Changes");
+    for (const action of projection.headerActions)
+      expectPaintedChip(frame, action.start, 0, action.width, action.label);
+    for (const action of projection.footerActions)
+      expectPaintedChip(frame, action.start, projection.footer.y, action.width, action.label);
+    const selected = projection.listRows.find((row) => row.kind === "file" && row.selected);
+    if (selected?.kind === "file" && selected.action) {
+      expectPaintedChip(
+        frame,
+        selected.action.start,
+        selected.y,
+        selected.action.width,
+        selected.action.label,
+      );
+    }
+  });
+
+  it("routes Changes mouse and keyboard through one action boundary", async () => {
+    const harness = await renderChanges(120, 40);
+    const projection = harness.projection();
+    const refresh = projection.headerActions[0]!;
+    await setup!.mockMouse.click(refresh.start + 1, 0, MouseButtons.LEFT);
+    await setup!.mockInput.pressKey("r");
+    const selected = projection.listRows.find((row) => row.kind === "file" && row.selected);
+    if (selected?.kind === "file" && selected.action) {
+      await setup!.mockMouse.click(selected.action.start + 1, selected.y, MouseButtons.LEFT);
+    }
+    expect(harness.calls).toEqual(["mouse:refresh", "keyboard:refresh", "mouse:row-stage"]);
+  });
+
+  it.each([
+    [80, 24],
+    [120, 40],
+    [200, 60],
+  ] as const)(
+    "renders terminal chrome %sx%s without expanding body cells",
+    async (width, height) => {
+      const harness = await renderTerminal(width, height);
+      const frame = harness.frame();
+      const projection = harness.projection();
+      expectFrameBounds(frame, width, height);
+      expect(stableFrame(frame)).toMatchSnapshot();
+      expect(stableFrame(frame)).toContain("api server");
+      expect(stableFrame(frame)).toContain("framebuffer body");
+      expect(projection.body.y).toBe(1);
+      const zoom = projection.actions[0]!;
+      expectPaintedChip(frame, zoom.start, 0, zoom.width, zoom.label);
+      await setup!.mockMouse.click(zoom.start + 1, 0, MouseButtons.LEFT);
+      expect(harness.calls).toEqual(["mouse:zoom"]);
+    },
+  );
+});

--- a/packages/daemon/src/tui/mirror/changes-terminal-surface.test.ts
+++ b/packages/daemon/src/tui/mirror/changes-terminal-surface.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { buildDiffRows, classifyDiff, type DiffEntry } from "./diff-model.ts";
+import { changesHitTest, projectChangesSurface } from "./changes-surface.ts";
+import { projectTerminalPaneChrome, terminalChromeHitTest } from "./terminal-surface.ts";
+import { actionChipWidth } from "./recipes.ts";
+
+const entry = (over: Partial<DiffEntry>): DiffEntry => ({
+  group: "unstaged",
+  status: "M",
+  path: "src/app.ts",
+  additions: 12,
+  deletions: 3,
+  ...over,
+});
+
+function changes(width: number, height: number) {
+  const data = buildDiffRows([
+    entry({ group: "staged", path: "README.md", status: "M", additions: 2, deletions: 0 }),
+    entry({ group: "unstaged", path: "src/app.ts", status: "M", additions: 12, deletions: 3 }),
+    entry({
+      group: "untracked",
+      path: "notes/new file.md",
+      status: "?",
+      additions: 4,
+      deletions: 0,
+    }),
+  ]);
+  return projectChangesSurface({
+    width,
+    height,
+    dir: "/repo/workspace",
+    fileCount: data.files.length,
+    totals: { additions: 18, deletions: 3 },
+    filterQuery: "app",
+    message: "ready",
+    listRows: data.rows.map((row, rowIndex) => ({ row, rowIndex })),
+    selectedFileIndex: 1,
+    diffLines: classifyDiff(
+      "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n context",
+    ),
+    hovered: { region: "diff", index: 3 },
+    footerHint: "]/[ hunk · ^e edit · / filter · r refresh · ^g home · ^q quit",
+  });
+}
+
+describe("Changes surface projection", () => {
+  it.each([
+    [80, 24, "compact"],
+    [120, 40, "standard"],
+    [200, 60, "wide"],
+  ] as const)("keeps %sx%s %s geometry and action cells bounded", (width, height, variant) => {
+    const projection = changes(width, height);
+    expect(projection.variant).toBe(variant);
+    expect(projection.list.x + projection.list.width).toBeLessThanOrEqual(width);
+    expect(projection.diff.x + projection.diff.width).toBeLessThanOrEqual(width);
+    for (const action of [...projection.headerActions, ...projection.footerActions]) {
+      expect(action.width).toBe(actionChipWidth(action.label));
+      expect(action.start).toBeGreaterThanOrEqual(0);
+      expect(action.start + action.width).toBeLessThanOrEqual(width);
+    }
+    const selected = projection.listRows.find((row) => row.kind === "file" && row.selected);
+    expect(selected?.kind).toBe("file");
+    if (selected?.kind === "file" && selected.action) {
+      expect(changesHitTest(projection, selected.action.start + 1, selected.y)).toMatchObject({
+        area: "list",
+        fileIndex: selected.fileIndex,
+        actionId: "row-stage",
+      });
+    }
+    const refresh = projection.headerActions[0]!;
+    expect(changesHitTest(projection, refresh.start + 1, 0)).toMatchObject({
+      area: "header",
+      actionId: "refresh",
+    });
+  });
+
+  it("reports empty state honestly without negative geometry", () => {
+    const projection = projectChangesSurface({
+      width: 20,
+      height: 8,
+      dir: "/repo",
+      fileCount: 0,
+      totals: { additions: 0, deletions: 0 },
+      filterQuery: null,
+      message: "working tree clean",
+      listRows: [],
+      selectedFileIndex: 0,
+      diffLines: [],
+      hovered: null,
+      footerHint: "^q quit",
+    });
+    expect(projection.state).toBe("empty");
+    expect(projection.list.width).toBeGreaterThanOrEqual(0);
+    expect(projection.body.height).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("Terminal pane chrome projection", () => {
+  it.each([
+    [40, 10, "compact"],
+    [80, 24, "standard"],
+    [140, 40, "wide"],
+  ] as const)(
+    "projects %sx%s %s terminal chrome without touching body cells",
+    (width, height, variant) => {
+      const projection = projectTerminalPaneChrome({
+        width,
+        height,
+        title: "api server",
+        paneId: "%7",
+        session: "workspace",
+        focused: true,
+        attention: true,
+        scrollOffset: 12,
+        scrollbackDepth: 120,
+        selected: false,
+        zoomed: true,
+        sync: true,
+        search: "error",
+      });
+      expect(projection.variant).toBe(variant);
+      expect(projection.body.y).toBe(projection.header.height);
+      expect(projection.body.height).toBe(
+        height - projection.header.height - projection.footer.height,
+      );
+      for (const action of projection.actions) {
+        expect(action.start + action.width).toBeLessThanOrEqual(width);
+      }
+      const first = projection.actions[0]!;
+      expect(terminalChromeHitTest(projection, first.start + 1, 0)).toMatchObject({
+        area: "header",
+        actionId: first.id,
+      });
+      expect(terminalChromeHitTest(projection, 1, projection.body.y)).toMatchObject({
+        area: "body",
+      });
+    },
+  );
+});

--- a/packages/daemon/src/tui/mirror/terminal-surface.ts
+++ b/packages/daemon/src/tui/mirror/terminal-surface.ts
@@ -1,0 +1,157 @@
+import { clipTerminal } from "./missions-workspace.ts";
+import { terminalDisplayWidth } from "./panel-host.ts";
+import { actionChipSpansFromRight, type Rect } from "./recipes.ts";
+
+export type TerminalChromeVariant = "compact" | "standard" | "wide";
+export type TerminalChromeActionId = "zoom" | "split" | "search" | "sync";
+
+export interface TerminalChromeAction {
+  id: TerminalChromeActionId;
+  label: string;
+  description: string;
+  active?: boolean;
+  disabled?: boolean;
+  hovered?: boolean;
+}
+
+export interface TerminalChromeActionSpan extends TerminalChromeAction {
+  start: number;
+  width: number;
+}
+
+export interface TerminalPaneChromeInput {
+  width: number;
+  height: number;
+  title: string;
+  paneId: string;
+  session: string;
+  focused: boolean;
+  attention?: boolean;
+  scrollOffset?: number;
+  scrollbackDepth?: number;
+  selected?: boolean;
+  zoomed?: boolean;
+  sync?: boolean;
+  search?: string | null;
+  hoveredActionIndex?: number | null;
+}
+
+export interface TerminalPaneChromeProjection {
+  width: number;
+  height: number;
+  variant: TerminalChromeVariant;
+  header: Rect;
+  body: Rect;
+  footer: Rect;
+  title: string;
+  status: string;
+  focused: boolean;
+  attention: boolean;
+  bodyRows: number;
+  actions: readonly TerminalChromeActionSpan[];
+}
+
+export function terminalChromeVariant(width: number, height: number): TerminalChromeVariant {
+  if (width >= 120 && height >= 32) return "wide";
+  if (width >= 72 && height >= 18) return "standard";
+  return "compact";
+}
+
+export function projectTerminalPaneChrome(
+  input: TerminalPaneChromeInput,
+): TerminalPaneChromeProjection {
+  const width = Math.max(0, Math.floor(input.width));
+  const height = Math.max(0, Math.floor(input.height));
+  const variant = terminalChromeVariant(width, height);
+  const headerHeight = Math.min(1, height);
+  const footerHeight = height >= 8 ? 1 : 0;
+  const bodyY = headerHeight;
+  const bodyHeight = Math.max(0, height - headerHeight - footerHeight);
+  const actions = terminalActions(input, variant).map((action, index) => ({
+    ...action,
+    hovered: input.hoveredActionIndex === index,
+  }));
+  const actionSpans = actionChipSpansFromRight(actions, width, 1);
+  const titleBudget = Math.max(4, (actionSpans[0]?.start ?? width) - 1);
+  return {
+    width,
+    height,
+    variant,
+    header: { x: 0, y: 0, width, height: headerHeight },
+    body: { x: 0, y: bodyY, width, height: bodyHeight },
+    footer: { x: 0, y: height - footerHeight, width, height: footerHeight },
+    title: clipTerminal(input.title || input.session, titleBudget),
+    status: clipTerminal(statusText(input, variant), width),
+    focused: input.focused,
+    attention: input.attention === true,
+    bodyRows: bodyHeight,
+    actions: actionSpans,
+  };
+}
+
+function terminalActions(
+  input: TerminalPaneChromeInput,
+  variant: TerminalChromeVariant,
+): TerminalChromeAction[] {
+  const zoomLabel = variant === "compact" ? "[Z]" : "[⛶ zoom]";
+  const splitLabel = variant === "compact" ? "[+]" : "[+ split]";
+  const out: TerminalChromeAction[] = [
+    { id: "zoom", label: zoomLabel, description: "Toggle pane zoom", active: input.zoomed },
+    { id: "split", label: splitLabel, description: "Split focused pane" },
+  ];
+  if (variant !== "compact") {
+    out.push({
+      id: "search",
+      label: input.search ? "[/ search]" : "[/]",
+      description: "Search scrollback",
+      active: input.search !== null && input.search !== undefined,
+    });
+  }
+  if (input.sync)
+    out.push({ id: "sync", label: "[SYNC]", description: "Synchronize panes", active: true });
+  return out;
+}
+
+function statusText(input: TerminalPaneChromeInput, variant: TerminalChromeVariant): string {
+  const parts = [
+    input.focused ? "focused" : "idle",
+    input.attention ? "attention" : "",
+    input.selected ? "select" : "",
+    input.zoomed ? "zoomed" : "",
+    input.scrollOffset && input.scrollOffset > 0
+      ? `↑${input.scrollOffset}/${input.scrollbackDepth ?? "?"}`
+      : "",
+    variant === "compact" ? input.paneId : `${input.session} ${input.paneId}`,
+  ].filter(Boolean);
+  return parts.join(" · ");
+}
+
+export function terminalChromeHitTest(
+  projection: TerminalPaneChromeProjection,
+  x: number,
+  y: number,
+):
+  | { area: "header"; actionId?: TerminalChromeActionId; actionIndex?: number }
+  | { area: "body" | "footer" }
+  | null {
+  if (x < 0 || y < 0 || x >= projection.width || y >= projection.height) return null;
+  if (y < projection.header.height) {
+    const actionIndex = projection.actions.findIndex(
+      (span) => x >= span.start && x < span.start + span.width,
+    );
+    if (actionIndex >= 0) {
+      return {
+        area: "header",
+        actionId: projection.actions[actionIndex]!.id,
+        actionIndex,
+      };
+    }
+    return { area: "header" };
+  }
+  if (projection.footer.height > 0 && y >= projection.footer.y) return { area: "footer" };
+  return { area: "body" };
+}
+
+export function cells(text: string): number {
+  return terminalDisplayWidth(text);
+}

--- a/packages/daemon/src/tui/mirror/terminal-surface.tsx
+++ b/packages/daemon/src/tui/mirror/terminal-surface.tsx
@@ -1,0 +1,84 @@
+/* @jsxImportSource @opentui/solid */
+import { For, Show } from "solid-js";
+import type { SemanticThemeSnapshot } from "./theme.ts";
+import { ActionChip } from "./recipes.tsx";
+import { recipePalette } from "./recipes.ts";
+import { terminalChromeHitTest, type TerminalPaneChromeProjection } from "./terminal-surface.ts";
+
+export interface TerminalPaneChromeProps {
+  theme: SemanticThemeSnapshot;
+  projection: TerminalPaneChromeProjection;
+  children?: unknown;
+}
+
+export function TerminalPaneChrome(props: TerminalPaneChromeProps) {
+  const palette = () =>
+    recipePalette(props.theme, {
+      focused: props.projection.focused,
+      attention: props.projection.attention,
+    });
+  return (
+    <box
+      width={props.projection.width}
+      height={props.projection.height}
+      position="relative"
+      overflow="hidden"
+      backgroundColor={props.theme.colors.background}
+    >
+      <box
+        position="absolute"
+        left={0}
+        top={props.projection.header.y}
+        width={props.projection.header.width}
+        height={props.projection.header.height}
+        backgroundColor={palette().background}
+        overflow="hidden"
+      >
+        <text fg={palette().accent}>{` ${props.projection.title}`}</text>
+        <For each={props.projection.actions}>
+          {(action) => (
+            <box position="absolute" left={action.start} top={0} width={action.width} height={1}>
+              <ActionChip
+                theme={props.theme}
+                label={action.label}
+                width={action.width}
+                hovered={action.hovered}
+                selected={action.active}
+                disabled={action.disabled}
+              />
+            </box>
+          )}
+        </For>
+      </box>
+      <box
+        position="absolute"
+        left={props.projection.body.x}
+        top={props.projection.body.y}
+        width={props.projection.body.width}
+        height={props.projection.body.height}
+        overflow="hidden"
+      >
+        <Show
+          when={props.children}
+          fallback={<text fg={props.theme.colors.mutedForeground}>terminal framebuffer</text>}
+        >
+          {props.children as never}
+        </Show>
+      </box>
+      <Show when={props.projection.footer.height > 0}>
+        <box
+          position="absolute"
+          left={0}
+          top={props.projection.footer.y}
+          width={props.projection.footer.width}
+          height={props.projection.footer.height}
+          overflow="hidden"
+        >
+          <text fg={props.theme.colors.mutedForeground}>{` ${props.projection.status}`}</text>
+        </box>
+      </Show>
+    </box>
+  );
+}
+
+export { terminalChromeHitTest };


### PR DESCRIPTION
## Summary
- extract shared terminal surface chrome without changing mirrored body geometry
- add a responsive Changes surface projection and renderer
- route Changes keyboard and mouse actions through the same command boundary
- extend the headless OpenTUI renderer gate

## Verification
- 7 projection tests
- 7 dedicated renderer tests / 6 snapshots
- full renderer suite: 39 passed
- daemon typecheck and formatting
- full pnpm check: 1,954 unit tests, docs, pack and native deps
- compiled TUI smoke at 80x24, 120x40 and 200x60
- Ctrl-C remained forwarded; Ctrl-Q exited cleanly