### PR TITLE
feat(tui): add mission surface command descriptors

### DIFF
--- a/packages/daemon/src/tui/mirror/missions-surface-controller.ts
+++ b/packages/daemon/src/tui/mirror/missions-surface-controller.ts
@@ -11,6 +11,8 @@ import {
   toggleMissionColumnCollapse,
   toggleMissionColumnZoom,
   type MissionDeepLinkKind,
+  type MissionDetailSection,
+  type MissionWorkspaceMode,
   type MissionWorkspaceHit,
   type MissionWorkspaceModel,
   type MissionWorkspaceSnapshot,
@@ -42,45 +44,178 @@ export interface MissionSurfaceControllerActions {
   persistSelection: (missionId: string | null, taskId: string | null) => void;
 }
 
+export type MissionSurfaceCommandRole =
+  | "refresh"
+  | "layout"
+  | "navigate"
+  | "open"
+  | "close"
+  | "link";
+
+export type MissionSurfaceCommandPayload =
+  | { type: "refresh" }
+  | { type: "follow-deep-link"; kind: MissionDeepLinkKind }
+  | { type: "cycle-density" }
+  | { type: "toggle-collapse" }
+  | { type: "toggle-zoom" }
+  | { type: "close-detail" }
+  | { type: "cycle-detail-section"; direction: -1 | 1 }
+  | { type: "set-detail-section"; section: MissionDetailSection }
+  | { type: "set-mode"; mode: MissionWorkspaceMode }
+  | { type: "move-selection"; movement: "left" | "right" | "up" | "down" | "home" | "end" }
+  | {
+      type: "open-detail";
+      persist: boolean;
+      selectedMissionId: string | null;
+      selectedTaskId: string | null;
+    }
+  | { type: "select-hit"; hit: Exclude<MissionWorkspaceHit, { kind: "refresh" } | null> }
+  | { type: "scroll"; hit: MissionWorkspaceHit; direction: "up" | "down"; step: number };
+
+export interface MissionSurfaceCommandDescriptor {
+  id: string;
+  label: string;
+  role: MissionSurfaceCommandRole;
+  disabled: boolean;
+  disabledReason?: string;
+  payload: MissionSurfaceCommandPayload;
+  metadata: {
+    source: "keyboard" | "mouse" | "wheel" | "program";
+    target?: string;
+  };
+}
+
 export function handleMissionSurfaceKey(
   event: MissionSurfaceKeyEvent,
   state: MissionSurfaceControllerState,
   actions: MissionSurfaceControllerActions,
 ): boolean {
-  const { snapshot, layoutSize } = state;
-  if (event.name === "r") {
-    actions.refresh();
-    return true;
-  }
-  if (event.name === "t" || event.name === "f" || event.name === "d") {
-    actions.followDeepLink(event.name === "t" ? "terminal" : event.name === "f" ? "files" : "diff");
-    return true;
-  }
-  if (event.name === "z") {
-    actions.updateModel((model) => cycleMissionDensity(model, snapshot, layoutSize));
-    return true;
-  }
-  if (event.name === "c") {
-    actions.updateModel((model) => toggleMissionColumnCollapse(model, snapshot, layoutSize));
-    return true;
-  }
-  if (event.name === "x") {
-    actions.updateModel((model) => toggleMissionColumnZoom(model, snapshot, layoutSize));
-    return true;
-  }
-  if (!snapshot) return true;
+  return executeMissionSurfaceCommands(missionSurfaceCommandsForKey(event, state), state, actions);
+}
+
+export function handleMissionSurfaceScroll(
+  hit: MissionWorkspaceHit,
+  direction: "up" | "down",
+  state: MissionSurfaceControllerState,
+  actions: Pick<MissionSurfaceControllerActions, "updateModel">,
+  step: number,
+): boolean {
+  return executeMissionSurfaceCommand(
+    missionSurfaceCommand(
+      "mission.scroll",
+      "Scroll missions",
+      "navigate",
+      state,
+      {
+        type: "scroll",
+        hit,
+        direction,
+        step,
+      },
+      "wheel",
+    ),
+    state,
+    {
+      updateModel: actions.updateModel,
+      refresh: () => {},
+      followDeepLink: () => {},
+      persistSelection: () => {},
+    },
+  );
+}
+
+export function handleMissionSurfacePointerDown(
+  hit: MissionWorkspaceHit,
+  state: MissionSurfaceControllerState,
+  actions: MissionSurfaceControllerActions,
+): boolean {
+  const commands = missionSurfaceCommandsForHit(hit, state);
+  if (commands.length === 0) return false;
+  return executeMissionSurfaceCommands(commands, state, actions);
+}
+
+export function missionSurfaceCommandsForKey(
+  event: MissionSurfaceKeyEvent,
+  state: MissionSurfaceControllerState,
+): MissionSurfaceCommandDescriptor[] {
+  if (event.name === "r")
+    return [
+      missionSurfaceCommand("mission.refresh", "Refresh missions", "refresh", state, {
+        type: "refresh",
+      }),
+    ];
+  const link =
+    event.name === "t"
+      ? "terminal"
+      : event.name === "f"
+        ? "files"
+        : event.name === "d"
+          ? "diff"
+          : null;
+  if (link)
+    return [
+      missionSurfaceCommand(`mission.link.${link}`, `Open ${link}`, "link", state, {
+        type: "follow-deep-link",
+        kind: link,
+      }),
+    ];
+  if (event.name === "z")
+    return [
+      missionSurfaceCommand(
+        "mission.layout.density.cycle",
+        "Cycle mission density",
+        "layout",
+        state,
+        {
+          type: "cycle-density",
+        },
+      ),
+    ];
+  if (event.name === "c")
+    return [
+      missionSurfaceCommand(
+        "mission.layout.column.collapse.toggle",
+        "Toggle lane collapse",
+        "layout",
+        state,
+        {
+          type: "toggle-collapse",
+        },
+      ),
+    ];
+  if (event.name === "x")
+    return [
+      missionSurfaceCommand(
+        "mission.layout.column.zoom.toggle",
+        "Toggle lane zoom",
+        "layout",
+        state,
+        {
+          type: "toggle-zoom",
+        },
+      ),
+    ];
   if (state.model.mode === "detail") {
-    if (event.name === "escape" || event.name === "backspace") {
-      actions.updateModel(closeMissionDetail);
-      return true;
-    }
-    if (event.name === "tab") {
-      actions.updateModel((model) =>
-        cycleMissionDetailSection(model, snapshot, event.shift ? -1 : 1, layoutSize),
-      );
-      return true;
-    }
-    const sectionKey =
+    if (event.name === "escape" || event.name === "backspace")
+      return [
+        missionSurfaceCommand("mission.detail.close", "Close mission detail", "close", state, {
+          type: "close-detail",
+        }),
+      ];
+    if (event.name === "tab")
+      return [
+        missionSurfaceCommand(
+          "mission.detail.section.cycle",
+          "Cycle detail section",
+          "navigate",
+          state,
+          {
+            type: "cycle-detail-section",
+            direction: event.shift ? -1 : 1,
+          },
+        ),
+      ];
+    const section =
       event.name === "1"
         ? "tasks"
         : event.name === "2"
@@ -90,34 +225,37 @@ export function handleMissionSurfaceKey(
             : event.name === "4"
               ? "proof"
               : null;
-    if (sectionKey) {
-      actions.updateModel((model) =>
-        setMissionDetailSection(model, snapshot, sectionKey, layoutSize),
-      );
-      return true;
-    }
+    if (section)
+      return [
+        missionSurfaceCommand(
+          `mission.detail.section.${section}`,
+          `Show ${section}`,
+          "navigate",
+          state,
+          {
+            type: "set-detail-section",
+            section,
+          },
+        ),
+      ];
   }
   if (event.name === "tab") {
-    actions.updateModel((model) =>
-      setMissionWorkspaceMode(
-        model,
-        snapshot,
-        model.mode === "board" ? "history" : "board",
-        layoutSize,
-      ),
-    );
-    return true;
+    const mode = state.model.mode === "board" ? "history" : "board";
+    return [
+      missionSurfaceCommand(`mission.mode.${mode}`, `Show ${mode}`, "navigate", state, {
+        type: "set-mode",
+        mode,
+      }),
+    ];
   }
   if (event.name === "b" || event.name === "y") {
-    actions.updateModel((model) =>
-      setMissionWorkspaceMode(
-        model,
-        snapshot,
-        event.name === "b" ? "board" : "history",
-        layoutSize,
-      ),
-    );
-    return true;
+    const mode = event.name === "b" ? "board" : "history";
+    return [
+      missionSurfaceCommand(`mission.mode.${mode}`, `Show ${mode}`, "navigate", state, {
+        type: "set-mode",
+        mode,
+      }),
+    ];
   }
   const movement =
     event.name === "left" || event.name === "h"
@@ -133,80 +271,260 @@ export function handleMissionSurfaceKey(
               : event.name === "end"
                 ? "end"
                 : null;
-  if (movement) {
-    actions.updateModel((model) => moveMissionSelection(model, snapshot, movement, layoutSize));
-    return true;
+  if (movement)
+    return [
+      missionSurfaceCommand(
+        `mission.selection.${movement}`,
+        `Move ${movement}`,
+        "navigate",
+        state,
+        {
+          type: "move-selection",
+          movement,
+        },
+      ),
+    ];
+  if (event.name === "return")
+    return [
+      missionSurfaceCommand("mission.detail.open", "Open mission detail", "open", state, {
+        type: "open-detail",
+        persist: true,
+        selectedMissionId: state.model.selectedMissionId,
+        selectedTaskId: state.model.selectedTaskId,
+      }),
+    ];
+  return [];
+}
+
+export function missionSurfaceCommandsForHit(
+  hit: MissionWorkspaceHit,
+  state: MissionSurfaceControllerState,
+): MissionSurfaceCommandDescriptor[] {
+  if (!hit) return [];
+  if (hit.kind === "refresh")
+    return [
+      missionSurfaceCommand(
+        "mission.refresh",
+        "Refresh missions",
+        "refresh",
+        state,
+        {
+          type: "refresh",
+        },
+        "mouse",
+      ),
+    ];
+  if (hit.kind === "deep-link")
+    return [
+      missionSurfaceCommand(
+        `mission.link.${hit.link}`,
+        `Open ${hit.link}`,
+        "link",
+        state,
+        {
+          type: "follow-deep-link",
+          kind: hit.link,
+        },
+        "mouse",
+      ),
+    ];
+  if (hit.kind === "detail-section")
+    return [
+      missionSurfaceCommand(
+        `mission.detail.section.${hit.section}`,
+        `Show ${hit.section}`,
+        "navigate",
+        state,
+        {
+          type: "set-detail-section",
+          section: hit.section,
+        },
+        "mouse",
+      ),
+    ];
+  const commands = [
+    missionSurfaceCommand(
+      `mission.select.${hit.kind}`,
+      "Select mission target",
+      "navigate",
+      state,
+      {
+        type: "select-hit",
+        hit,
+      },
+      "mouse",
+    ),
+  ];
+  if (hit.kind === "card" || hit.kind === "history") {
+    commands.push(
+      missionSurfaceCommand(
+        "mission.detail.open",
+        "Open mission detail",
+        "open",
+        state,
+        {
+          type: "open-detail",
+          persist: false,
+          selectedMissionId: hit.missionId,
+          selectedTaskId: state.model.selectedTaskId,
+        },
+        "mouse",
+      ),
+    );
   }
-  if (event.name === "return") {
-    const selected = state.model.selectedMissionId;
-    if (selected) {
-      actions.persistSelection(selected, state.model.selectedTaskId);
+  return commands;
+}
+
+export function executeMissionSurfaceCommands(
+  commands: readonly MissionSurfaceCommandDescriptor[],
+  state: MissionSurfaceControllerState,
+  actions: MissionSurfaceControllerActions,
+): boolean {
+  for (const command of commands) executeMissionSurfaceCommand(command, state, actions);
+  return true;
+}
+
+export function executeMissionSurfaceCommand(
+  command: MissionSurfaceCommandDescriptor,
+  state: MissionSurfaceControllerState,
+  actions: MissionSurfaceControllerActions,
+): boolean {
+  const { snapshot, layoutSize } = state;
+  if (command.disabled) return true;
+  const payload = command.payload;
+  switch (payload.type) {
+    case "refresh":
+      actions.refresh();
+      return true;
+    case "follow-deep-link":
+      actions.followDeepLink(payload.kind);
+      return true;
+    case "cycle-density":
+      actions.updateModel((model) => cycleMissionDensity(model, snapshot, layoutSize));
+      return true;
+    case "toggle-collapse":
+      actions.updateModel((model) => toggleMissionColumnCollapse(model, snapshot, layoutSize));
+      return true;
+    case "toggle-zoom":
+      actions.updateModel((model) => toggleMissionColumnZoom(model, snapshot, layoutSize));
+      return true;
+    case "close-detail":
+      actions.updateModel(closeMissionDetail);
+      return true;
+    case "cycle-detail-section":
+      if (!snapshot) return true;
+      actions.updateModel((model) =>
+        cycleMissionDetailSection(model, snapshot, payload.direction, layoutSize),
+      );
+      return true;
+    case "set-detail-section":
+      if (!snapshot) return true;
+      actions.updateModel((model) =>
+        setMissionDetailSection(model, snapshot, payload.section, layoutSize),
+      );
+      return true;
+    case "set-mode":
+      if (!snapshot) return true;
+      actions.updateModel((model) =>
+        setMissionWorkspaceMode(model, snapshot, payload.mode, layoutSize),
+      );
+      return true;
+    case "move-selection":
+      if (!snapshot) return true;
+      actions.updateModel((model) =>
+        moveMissionSelection(model, snapshot, payload.movement, layoutSize),
+      );
+      return true;
+    case "open-detail": {
+      if (!snapshot) return true;
+      const selected = payload.selectedMissionId;
+      if (payload.persist) {
+        actions.persistSelection(selected, payload.selectedTaskId);
+      }
       actions.updateModel((model) =>
         openMissionDetail(model, snapshot, {
           persistedTaskId: state.persistedTaskId,
           ...layoutSize,
         }),
       );
-      if (snapshot.detail?.mission.id !== selected) actions.refresh();
+      if (selected && snapshot.detail?.mission.id !== selected) actions.refresh();
+      return true;
     }
-    return true;
+    case "select-hit":
+      if (!snapshot) return true;
+      actions.updateModel((model) =>
+        applyMissionWorkspaceHit(model, snapshot, payload.hit, layoutSize),
+      );
+      return true;
+    case "scroll": {
+      if (!snapshot) return true;
+      const delta = payload.direction === "up" ? -payload.step : payload.step;
+      const hit = payload.hit;
+      const target =
+        hit?.kind === "detail-row"
+          ? hit.section
+          : state.model.mode === "detail"
+            ? state.model.detailSection
+            : hit?.kind === "card" || hit?.kind === "column"
+              ? hit.column
+              : state.model.mode === "history"
+                ? "history"
+                : state.model.selectedColumn;
+      actions.updateModel((current) =>
+        scrollMissionWorkspace(current, snapshot, target, delta, layoutSize),
+      );
+      return true;
+    }
   }
-  return true;
 }
 
-export function handleMissionSurfaceScroll(
-  hit: MissionWorkspaceHit,
-  direction: "up" | "down",
+function missionSurfaceCommand(
+  id: string,
+  label: string,
+  role: MissionSurfaceCommandRole,
   state: MissionSurfaceControllerState,
-  actions: Pick<MissionSurfaceControllerActions, "updateModel">,
-  step: number,
-): boolean {
-  const { snapshot, model, layoutSize } = state;
-  if (!snapshot) return true;
-  const delta = direction === "up" ? -step : step;
-  const target =
-    hit?.kind === "detail-row"
-      ? hit.section
-      : model.mode === "detail"
-        ? model.detailSection
-        : hit?.kind === "card" || hit?.kind === "column"
-          ? hit.column
-          : model.mode === "history"
-            ? "history"
-            : model.selectedColumn;
-  actions.updateModel((current) =>
-    scrollMissionWorkspace(current, snapshot, target, delta, layoutSize),
-  );
-  return true;
+  payload: MissionSurfaceCommandPayload,
+  source: MissionSurfaceCommandDescriptor["metadata"]["source"] = "keyboard",
+): MissionSurfaceCommandDescriptor {
+  const disabledReason = missionSurfaceCommandDisabledReason(payload, state);
+  return {
+    id,
+    label,
+    role,
+    disabled: Boolean(disabledReason),
+    disabledReason,
+    payload,
+    metadata: { source, target: missionSurfaceCommandTarget(payload) },
+  };
 }
 
-export function handleMissionSurfacePointerDown(
-  hit: MissionWorkspaceHit,
+function missionSurfaceCommandDisabledReason(
+  payload: MissionSurfaceCommandPayload,
   state: MissionSurfaceControllerState,
-  actions: MissionSurfaceControllerActions,
-): boolean {
-  const { snapshot, layoutSize } = state;
-  if (hit?.kind === "refresh") {
-    actions.refresh();
-    return true;
+): string | undefined {
+  if (
+    payload.type === "cycle-detail-section" ||
+    payload.type === "set-detail-section" ||
+    payload.type === "set-mode" ||
+    payload.type === "move-selection" ||
+    payload.type === "select-hit" ||
+    payload.type === "scroll"
+  ) {
+    if (!state.snapshot) return "mission snapshot is not loaded";
   }
-  if (hit?.kind === "deep-link") {
-    actions.followDeepLink(hit.link);
-    return true;
+  if (payload.type === "open-detail") {
+    if (!state.snapshot) return "mission snapshot is not loaded";
+    if (!payload.selectedMissionId && !state.model.selectedMissionId) return "no mission selected";
   }
-  if (hit?.kind === "detail-section" && snapshot) {
-    actions.updateModel((model) =>
-      setMissionDetailSection(model, snapshot, hit.section, layoutSize),
-    );
-    return true;
-  }
-  if (hit && snapshot) {
-    actions.updateModel((model) => applyMissionWorkspaceHit(model, snapshot, hit, layoutSize));
-    if (hit.kind === "card" || hit.kind === "history") {
-      actions.updateModel((model) => openMissionDetail(model, snapshot, layoutSize));
-      actions.refresh();
-    }
-    return true;
-  }
-  return false;
+  return undefined;
+}
+
+function missionSurfaceCommandTarget(payload: MissionSurfaceCommandPayload): string | undefined {
+  if (payload.type === "follow-deep-link") return payload.kind;
+  if (payload.type === "set-detail-section") return payload.section;
+  if (payload.type === "set-mode") return payload.mode;
+  if (payload.type === "move-selection") return payload.movement;
+  if (payload.type === "select-hit") return payload.hit.kind;
+  if (payload.type === "scroll") return payload.hit?.kind ?? "current";
+  return undefined;
 }

--- a/packages/daemon/src/tui/mirror/missions-surface.test.ts
+++ b/packages/daemon/src/tui/mirror/missions-surface.test.ts
@@ -7,6 +7,8 @@ import {
   handleMissionSurfaceKey,
   handleMissionSurfacePointerDown,
   handleMissionSurfaceScroll,
+  missionSurfaceCommandsForHit,
+  missionSurfaceCommandsForKey,
   type MissionSurfaceControllerActions,
 } from "./missions-surface-controller.ts";
 
@@ -51,6 +53,83 @@ function actionsFor(modelRef: { model: ReturnType<typeof defaultMissionWorkspace
 }
 
 describe("missions surface boundary", () => {
+  it("exposes stable local command descriptors for keyboard and mouse actions", () => {
+    const state = {
+      model: defaultMissionWorkspaceModel("mis_demo", "tsk_demo"),
+      snapshot: snapshot(),
+      layoutSize,
+      persistedTaskId: "tsk_saved",
+    };
+
+    expect(
+      missionSurfaceCommandsForKey(
+        { name: "return", ctrl: false, meta: false, shift: false },
+        state,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: "mission.detail.open",
+        label: "Open mission detail",
+        role: "open",
+        disabled: false,
+        payload: {
+          type: "open-detail",
+          persist: true,
+          selectedMissionId: "mis_demo",
+          selectedTaskId: "tsk_demo",
+        },
+        metadata: { source: "keyboard", target: undefined },
+      }),
+    ]);
+
+    expect(
+      missionSurfaceCommandsForHit(
+        { kind: "card", missionId: "mis_demo", column: "planned", index: 0, hoverKey: 0 },
+        state,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: "mission.select.card",
+        role: "navigate",
+        payload: expect.objectContaining({ type: "select-hit" }),
+        metadata: { source: "mouse", target: "card" },
+      }),
+      expect.objectContaining({
+        id: "mission.detail.open",
+        role: "open",
+        payload: expect.objectContaining({
+          type: "open-detail",
+          persist: false,
+          selectedMissionId: "mis_demo",
+        }),
+        metadata: { source: "mouse", target: undefined },
+      }),
+    ]);
+  });
+
+  it("marks snapshot-dependent commands disabled while keeping global commands available", () => {
+    const state = {
+      model: defaultMissionWorkspaceModel(),
+      snapshot: null,
+      layoutSize,
+      persistedTaskId: null,
+    };
+
+    expect(
+      missionSurfaceCommandsForKey(
+        { name: "down", ctrl: false, meta: false, shift: false },
+        state,
+      )[0],
+    ).toMatchObject({
+      id: "mission.selection.down",
+      disabled: true,
+      disabledReason: "mission snapshot is not loaded",
+    });
+    expect(
+      missionSurfaceCommandsForKey({ name: "r", ctrl: false, meta: false, shift: false }, state)[0],
+    ).toMatchObject({ id: "mission.refresh", disabled: false });
+  });
+
   it("maps keys to explicit navigation and action dependencies", () => {
     const state = {
       model: defaultMissionWorkspaceModel("mis_demo"),


### PR DESCRIPTION
## Summary
- expose stable local command descriptors for Missions keyboard and pointer interactions
- centralize command execution at the Missions surface boundary
- retain selection persistence, deep links, density, collapse, zoom and detail navigation
- prepare Missions actions for the future contribution/command registry

## Verification
- focused Missions controller suite: 6 passed
- full OpenTUI renderer suite: 39 passed / 22 snapshots
- daemon typecheck and formatting
- full pnpm check: 1,954 unit tests, docs, pack and native deps
- compiled TUI smoke at 80x24, 120x40 and 200x60
- Ctrl-C remained forwarded; Ctrl-Q exited cleanly