### PR TITLE
M31 Card 01: establish the application workspace boundary

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -125,4 +125,33 @@ export default [
       ],
     },
   },
+  {
+    files: ["packages/daemon/src/tui/mirror/workspace/**/*.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "../app.tsx",
+                "**/mirror/app.tsx",
+                "../session-mirror.ts",
+                "**/mirror/session-mirror.ts",
+                "../pane-mirror.ts",
+                "**/mirror/pane-mirror.ts",
+                "../control-client.ts",
+                "**/mirror/control-client.ts",
+                "**/command-center/**",
+                "**/server/**",
+                "**/lib/**",
+              ],
+              message:
+                "the application-workspace layer is presentational; runtime adapters stay in the root controller",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run typecheck:workspace && pnpm run test:unit && pnpm run test:tui-renderer && pnpm run docs:build && pnpm run pack:check && pnpm run check:native-deps",
     "postinstall": "node scripts/postinstall.js",
     "docs": "turbo run dev --filter=@tmux-ide/docs",
-    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx",
+    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx",
     "test:tui-smoke": "node scripts/smoke-tui-missions.mjs"
   },
   "keywords": [

--- a/packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx
@@ -1,10 +1,9 @@
 /* @jsxImportSource @opentui/solid */
-import { MouseButtons } from "@opentui/core/testing";
-import { testRender, useKeyboard } from "@opentui/solid";
+import { MouseButtons, type TestRendererSetup } from "@opentui/core/testing";
+import { useKeyboard } from "@opentui/solid";
 import { createSignal, onCleanup } from "solid-js";
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { buildHostedPanelViews } from "./panel-host.ts";
-import { terminalDisplayWidth } from "./panel-host.ts";
 import {
   ShellCompositeLeafChrome,
   ShellMiniSidebar,
@@ -25,15 +24,16 @@ import {
 } from "./theme.ts";
 import { Surface, SelectableRow, InputShell } from "./recipes.tsx";
 import { colorToThemeBytes } from "./theme.ts";
+import {
+  expectFrameBounds,
+  frameLines,
+  renderForTest,
+  stableFrame,
+} from "./testing/renderer-harness.test.ts";
 
-type TestSetup = Awaited<ReturnType<typeof testRender>>;
+type TestSetup = TestRendererSetup;
 
 let setup: TestSetup | null = null;
-
-afterEach(() => {
-  setup?.renderer.destroy();
-  setup = null;
-});
 
 const views = buildHostedPanelViews([
   { id: "home", title: "Home", panel: "home" },
@@ -42,23 +42,6 @@ const views = buildHostedPanelViews([
   { id: "diff", title: "Diff", panel: "diff" },
   { id: "missions", title: "Missions", panel: "missions" },
 ]);
-
-function frameLines(frame: string): string[] {
-  const lines = frame.endsWith("\n") ? frame.slice(0, -1).split("\n") : frame.split("\n");
-  return lines.map((line) => line.replace(/\r$/u, ""));
-}
-
-function stableFrame(frame: string): string {
-  return frameLines(frame)
-    .map((line) => line.replace(/\s+$/u, ""))
-    .join("\n");
-}
-
-function expectFrameBounds(frame: string, width: number, height: number): void {
-  const lines = frameLines(frame);
-  expect(lines).toHaveLength(height);
-  for (const line of lines) expect(terminalDisplayWidth(line)).toBeLessThanOrEqual(width);
-}
 
 function colorKey(color: Parameters<typeof colorToThemeBytes>[0]): string {
   return colorToThemeBytes(color).join(",");
@@ -233,7 +216,7 @@ function ShellChromeHarness(props: { width: number; height: number }) {
 }
 
 async function renderShell(width: number, height: number) {
-  setup = await testRender(() => <ShellChromeHarness width={width} height={height} />, {
+  setup = await renderForTest(() => <ShellChromeHarness width={width} height={height} />, {
     width,
     height,
   });
@@ -337,7 +320,7 @@ describe("ShellChrome OpenTUI renderer", () => {
       );
     }
 
-    setup = await testRender(() => <ThemeModeShell />, { width: 80, height: 4 });
+    setup = await renderForTest(() => <ThemeModeShell />, { width: 80, height: 4 });
     await setup.renderOnce();
     const darkBg = setup
       .captureSpans()

--- a/packages/daemon/src/tui/mirror/testing/renderer-harness.test.ts
+++ b/packages/daemon/src/tui/mirror/testing/renderer-harness.test.ts
@@ -1,0 +1,54 @@
+import type { TestRendererOptions, TestRendererSetup } from "@opentui/core/testing";
+import { testRender, type JSX } from "@opentui/solid";
+import { afterEach, expect } from "bun:test";
+import { terminalDisplayWidth } from "../panel-host.ts";
+
+const activeRenderers = new Set<TestRendererSetup>();
+
+/**
+ * Mount a Solid/OpenTUI tree and register it for deterministic teardown.
+ *
+ * Renderer tests must never leak an attached renderer into the next test. A
+ * shared registry makes that invariant automatic while still allowing tests to
+ * destroy a renderer early when they need to assert Solid cleanup behavior.
+ */
+export async function renderForTest(
+  node: () => JSX.Element,
+  options: TestRendererOptions,
+): Promise<TestRendererSetup> {
+  const setup = await testRender(node, options);
+  activeRenderers.add(setup);
+  return setup;
+}
+
+export function destroyTestRenderer(setup: TestRendererSetup | null | undefined): void {
+  if (!setup) return;
+  activeRenderers.delete(setup);
+  setup.renderer.destroy();
+}
+
+export function destroyAllTestRenderers(): void {
+  for (const setup of activeRenderers) setup.renderer.destroy();
+  activeRenderers.clear();
+}
+
+afterEach(() => {
+  destroyAllTestRenderers();
+});
+
+export function frameLines(frame: string): string[] {
+  const lines = frame.endsWith("\n") ? frame.slice(0, -1).split("\n") : frame.split("\n");
+  return lines.map((line) => line.replace(/\r$/u, ""));
+}
+
+export function stableFrame(frame: string): string {
+  return frameLines(frame)
+    .map((line) => line.replace(/\s+$/u, ""))
+    .join("\n");
+}
+
+export function expectFrameBounds(frame: string, width: number, height: number): void {
+  const lines = frameLines(frame);
+  expect(lines).toHaveLength(height);
+  for (const line of lines) expect(terminalDisplayWidth(line)).toBeLessThanOrEqual(width);
+}

--- a/packages/daemon/src/tui/mirror/workspace/README.md
+++ b/packages/daemon/src/tui/mirror/workspace/README.md
@@ -1,0 +1,28 @@
+# Application workspace boundary
+
+M31 turns the mirror TUI into a persistent application workspace. This folder
+is the migration boundary between app-owned presentation and runtime adapters.
+
+## Rules
+
+- `.ts` files project immutable view state, geometry, commands, and hit targets.
+- `.tsx` files only render those projections with Solid/OpenTUI.
+- The root controller remains the single keyboard, pointer-routing, renderer,
+  and shutdown owner during the migration.
+- This layer does not import tmux mirrors, command-center handlers, filesystem or
+  process APIs, or the legacy `app.tsx` root.
+- New surfaces get pure model tests plus headless renderer snapshots at `80x24`,
+  `120x40`, and `200x60`.
+
+## M31 delivery order
+
+1. Application boundary and shared renderer harness.
+2. `PaneFrame` v1 with focus, attention, metadata, and action chrome.
+3. Named workspace layouts and persisted restore.
+4. Keyboard/mouse move, resize, dock, and float interactions.
+5. New-pane templates and project lifecycle actions.
+6. Command descriptors and a contribution registry.
+7. Harness-neutral mission runtime, followed by the native desktop host.
+
+The first card is intentionally behavior-neutral: it records the responsive
+shell baseline and makes architectural back-edges fail before `PaneFrame` lands.

--- a/packages/daemon/src/tui/mirror/workspace/__snapshots__/application-shell-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/workspace/__snapshots__/application-shell-renderer.test.tsx.snap
@@ -1,0 +1,134 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`ApplicationShell OpenTUI renderer records the %sx%s compact acceptance baseline 1`] = `
+" ⌂  ❯  ▤  ±  !                 M31 application workspace ⧉ tmux-ide  !1 blocked
+  tmux              ┌──────────────────────────────────────────────────────────┐
+ ● tmux-ide         │ › compact workspace                                      │
+ ○ website          │● Persistent application shell                    terminal│
+ ○ docs             │› PaneFrame lands in the next card                   M31.2│
+                    │! Mission runtime stays harness-neutral           contract│
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    │                                                          │
+                    └──────────────────────────────────────────────────────────┘
+  F5 · ^q quit       terminal · ready · F5 palette"
+`;
+
+exports[`ApplicationShell OpenTUI renderer records the %sx%s standard acceptance baseline 1`] = `
+" ⌂ Home  ❯ Terminal  ▤ Files  ± Changes  ! Missions                    M31 application workspace ⧉ tmux-ide  !1 blocked
+  tmux-ide                  ┌──────────────────────────────────────────────────────────────────────────────────────────┐
+ ● tmux-ide                 │ › standard workspace                                                                     │
+ ○ website                  │● Persistent application shell                                                    terminal│
+ ○ docs                     │› PaneFrame lands in the next card                                                   M31.2│
+                            │! Mission runtime stays harness-neutral                                           contract│
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            │                                                                                          │
+                            └──────────────────────────────────────────────────────────────────────────────────────────┘
+  F5 palette · ^q quit       tmux-ide · terminal · ready · F5 palette · arrows move · ^q quit"
+`;
+
+exports[`ApplicationShell OpenTUI renderer records the %sx%s wide acceptance baseline 1`] = `
+" F1 ⌂ Home  F2 ❯ Terminal  F3 ▤ Files  F4 ± Changes  F6 ! Missions                                                                                     M31 application workspace ⧉ tmux-ide  !1 blocked
+  tmux-ide                  ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+ ● tmux-ide                 │ › wide workspace                                                                                                                                                         │
+ ○ website                  │● Persistent application shell                                                                                                                                    terminal│
+ ○ docs                     │› PaneFrame lands in the next card                                                                                                                                   M31.2│
+                            │! Mission runtime stays harness-neutral                                                                                                                           contract│
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            │                                                                                                                                                                          │
+                            └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+  F5 palette · ^q quit       tmux-ide · terminal · ready · F5 palette · arrows move · ^q quit"
+`;

--- a/packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx
@@ -1,0 +1,215 @@
+/* @jsxImportSource @opentui/solid */
+import { MouseButtons } from "@opentui/core/testing";
+import { useKeyboard } from "@opentui/solid";
+import { createSignal, onCleanup } from "solid-js";
+import { describe, expect, it } from "bun:test";
+import { buildHostedPanelViews } from "../panel-host.ts";
+import { SelectableRow, Surface } from "../recipes.tsx";
+import { createSemanticThemeSnapshot } from "../theme.ts";
+import {
+  destroyTestRenderer,
+  expectFrameBounds,
+  renderForTest,
+  stableFrame,
+} from "../testing/renderer-harness.test.ts";
+import {
+  applicationShellHitTest,
+  projectApplicationShell,
+  type ApplicationShellSession,
+} from "./application-shell.ts";
+import { ApplicationShell } from "./application-shell.tsx";
+
+const views = buildHostedPanelViews([
+  { id: "home", title: "Home", panel: "home" },
+  { id: "terminal", title: "Terminal", panel: "terminals" },
+  { id: "files", title: "Files", panel: "files" },
+  { id: "changes", title: "Changes", panel: "diff" },
+  { id: "missions", title: "Missions", panel: "missions" },
+]);
+const sessions: readonly ApplicationShellSession[] = [
+  { name: "tmux-ide", status: "working" },
+  { name: "website", status: "blocked" },
+  { name: "docs", status: "idle" },
+];
+
+async function renderShell(width: number, height: number, disposed?: () => void) {
+  const theme = createSemanticThemeSnapshot({ mode: "dark" });
+  const events: string[] = [];
+  let activeValue = "terminal";
+  let messageValue = "ready";
+
+  function Harness() {
+    const [active, setActive] = createSignal(activeValue);
+    const [message, setMessage] = createSignal(messageValue);
+    const projection = () =>
+      projectApplicationShell({
+        width,
+        height,
+        preferredSidebarWidth: 28,
+        views,
+        activeViewId: active(),
+        hoveredTabIndex: null,
+        attentionViewIds: new Set(["missions"]),
+        sessions,
+        activeSession: "tmux-ide",
+        quitHint: "^q quit",
+      });
+    const activate = (viewId: string) => {
+      activeValue = viewId;
+      messageValue = `selected ${viewId}`;
+      setActive(viewId);
+      setMessage(messageValue);
+      events.push(`view:${viewId}`);
+    };
+    useKeyboard((event) => {
+      if (event.name === "right") {
+        const index = views.findIndex((view) => view.id === active());
+        activate(views[Math.min(views.length - 1, index + 1)]!.id);
+      } else if (event.name === "f5") {
+        messageValue = "palette";
+        setMessage(messageValue);
+        events.push("palette");
+      }
+    });
+    onCleanup(() => disposed?.());
+    return (
+      <box
+        width={width}
+        height={height}
+        overflow="hidden"
+        onMouseDown={(event) => {
+          const hit = applicationShellHitTest(projection(), event.x, event.y);
+          if (hit?.kind === "view") activate(hit.viewId);
+          else if (hit?.kind === "session") events.push(`session:${hit.session}`);
+          else if (hit?.kind === "palette") {
+            messageValue = "palette";
+            setMessage(messageValue);
+            events.push("palette");
+          }
+        }}
+      >
+        <ApplicationShell
+          theme={theme}
+          projection={projection()}
+          project="tmux-ide"
+          mode={active()}
+          notification={message()}
+          help="F5 palette · arrows move · ^q quit"
+          note="M31 application workspace"
+          rightChips={[
+            { id: "context", label: "⧉ tmux-ide ", context: true },
+            { id: "mission", label: "!1 blocked ", attention: true },
+          ]}
+        >
+          <Surface
+            theme={theme}
+            title={`${projection().layout.variant} workspace`}
+            focused
+            width={projection().content.width}
+            height={projection().content.height}
+          >
+            <SelectableRow
+              theme={theme}
+              label="Persistent application shell"
+              meta={active()}
+              width={Math.max(1, projection().content.width - 2)}
+              selected
+            />
+            <SelectableRow
+              theme={theme}
+              label="PaneFrame lands in the next card"
+              meta="M31.2"
+              width={Math.max(1, projection().content.width - 2)}
+              focused
+            />
+            <SelectableRow
+              theme={theme}
+              label="Mission runtime stays harness-neutral"
+              meta="contract"
+              width={Math.max(1, projection().content.width - 2)}
+              attention
+              status="blocked"
+              tone="blocked"
+            />
+          </Surface>
+        </ApplicationShell>
+      </box>
+    );
+  }
+
+  const setup = await renderForTest(() => <Harness />, { width, height });
+  await setup.renderOnce();
+  return {
+    setup,
+    events,
+    active: () => activeValue,
+    message: () => messageValue,
+    projection: () =>
+      projectApplicationShell({
+        width,
+        height,
+        preferredSidebarWidth: 28,
+        views,
+        activeViewId: activeValue,
+        hoveredTabIndex: null,
+        attentionViewIds: new Set(["missions"]),
+        sessions,
+        activeSession: "tmux-ide",
+        quitHint: "^q quit",
+      }),
+    frame: () => setup.captureCharFrame(),
+  };
+}
+
+describe("ApplicationShell OpenTUI renderer", () => {
+  it.each([
+    [80, 24, "compact"],
+    [120, 40, "standard"],
+    [200, 60, "wide"],
+  ] as const)("records the %sx%s %s acceptance baseline", async (width, height, variant) => {
+    const harness = await renderShell(width, height);
+    const frame = harness.frame();
+    expectFrameBounds(frame, width, height);
+    expect(stableFrame(frame)).toMatchSnapshot();
+    expect(stableFrame(frame)).toContain(`${variant} workspace`);
+    expect(stableFrame(frame)).toContain("M31 application workspace");
+    expect(stableFrame(frame)).toContain("F5");
+    expect(stableFrame(frame)).toContain("^q quit");
+  });
+
+  it("routes keyboard and pointer actions through the harness input owner", async () => {
+    const harness = await renderShell(120, 40);
+    harness.setup.mockInput.pressArrow("right");
+    await harness.setup.renderOnce();
+    expect(harness.active()).toBe("files");
+    expect(stableFrame(harness.frame())).toContain("selected files");
+
+    const missions = harness.projection().tabs.find((tab) => tab.id === "missions")!;
+    await harness.setup.mockMouse.click(
+      missions.span.start + Math.floor(missions.span.width / 2),
+      0,
+      MouseButtons.LEFT,
+    );
+    await harness.setup.renderOnce();
+    expect(harness.active()).toBe("missions");
+
+    const hint = harness.projection().sidebarHint.buttonSpan;
+    await harness.setup.mockMouse.click(
+      hint.start,
+      harness.projection().layout.sidebar.y + harness.projection().layout.sidebar.height - 1,
+      MouseButtons.LEFT,
+    );
+    await harness.setup.renderOnce();
+    expect(harness.message()).toBe("palette");
+    expect(harness.events).toEqual(["view:files", "view:missions", "palette"]);
+  });
+
+  it("destroys the renderer and disposes the Solid root", async () => {
+    let disposed = false;
+    const harness = await renderShell(80, 24, () => {
+      disposed = true;
+    });
+    destroyTestRenderer(harness.setup);
+    expect(disposed).toBe(true);
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace/application-shell.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/application-shell.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { buildHostedPanelViews } from "../panel-host.ts";
+import {
+  applicationShellHitTest,
+  projectApplicationShell,
+  type ApplicationShellInput,
+} from "./application-shell.ts";
+
+const views = buildHostedPanelViews([
+  { id: "home", title: "Home", panel: "home" },
+  { id: "terminal", title: "Terminal", panel: "terminals" },
+  { id: "files", title: "Files", panel: "files" },
+  { id: "missions", title: "Missions", panel: "missions" },
+]);
+
+function input(overrides: Partial<ApplicationShellInput> = {}): ApplicationShellInput {
+  return {
+    width: 120,
+    height: 40,
+    preferredSidebarWidth: 28,
+    views,
+    activeViewId: "terminal",
+    hoveredTabIndex: null,
+    attentionViewIds: new Set(["missions"]),
+    sessions: [
+      { name: "web", status: "working" },
+      { name: "api", status: "blocked" },
+    ],
+    activeSession: "web",
+    quitHint: "^q quit",
+    ...overrides,
+  };
+}
+
+describe("application shell projection", () => {
+  it.each([
+    [80, 24, "compact"],
+    [120, 40, "standard"],
+    [200, 60, "wide"],
+  ] as const)("projects a bounded %sx%s %s workspace", (width, height, variant) => {
+    const projection = projectApplicationShell(input({ width, height }));
+    expect(projection.layout.variant).toBe(variant);
+    expect(projection.layout.width).toBe(width);
+    expect(projection.layout.height).toBe(height);
+    expect(projection.content.width).toBe(projection.layout.main.width);
+    expect(projection.content.height + projection.layout.status.height).toBe(
+      projection.layout.main.height,
+    );
+    expect(projection.tabs.find((tab) => tab.id === "terminal")?.selected).toBe(true);
+    expect(projection.tabs.find((tab) => tab.id === "missions")?.attention).toBe(true);
+  });
+
+  it("routes tab, session, and palette hits from the rendered geometry", () => {
+    const projection = projectApplicationShell(input());
+    const files = projection.tabs.find((tab) => tab.id === "files")!;
+    expect(
+      applicationShellHitTest(projection, files.span.start + Math.floor(files.span.width / 2), 0),
+    ).toEqual({ kind: "view", viewId: "files", index: 2 });
+
+    expect(applicationShellHitTest(projection, 2, projection.layout.sidebar.y + 1)).toEqual({
+      kind: "session",
+      session: "web",
+      index: 0,
+    });
+
+    const hint = projection.sidebarHint.buttonSpan;
+    expect(
+      applicationShellHitTest(
+        projection,
+        projection.layout.sidebar.x + hint.start,
+        projection.layout.sidebar.y + projection.layout.sidebar.height - 1,
+      ),
+    ).toEqual({ kind: "palette" });
+  });
+
+  it("leaves content and out-of-bounds cells to the active surface", () => {
+    const projection = projectApplicationShell(input());
+    expect(
+      applicationShellHitTest(projection, projection.content.x + 2, projection.content.y + 2),
+    ).toBeNull();
+    expect(applicationShellHitTest(projection, -1, 0)).toBeNull();
+    expect(applicationShellHitTest(projection, projection.layout.width, 0)).toBeNull();
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace/application-shell.ts
+++ b/packages/daemon/src/tui/mirror/workspace/application-shell.ts
@@ -1,0 +1,119 @@
+import type { HostedPanelView } from "../panel-host.ts";
+import {
+  shellChromeLayout,
+  shellSidebarHint,
+  shellSurfaceTabs,
+  type ShellChromeLayout,
+  type ShellSidebarHint,
+  type ShellTabPresentation,
+} from "../shell-chrome.ts";
+import type { Rect } from "../recipes.ts";
+
+export interface ApplicationShellSession {
+  name: string;
+  status: "idle" | "working" | "blocked" | "done" | "unknown";
+}
+
+export interface ApplicationShellInput {
+  width: number;
+  height: number;
+  preferredSidebarWidth: number;
+  views: readonly HostedPanelView[];
+  activeViewId: string;
+  hoveredTabIndex: number | null;
+  attentionViewIds?: ReadonlySet<string>;
+  sessions: readonly ApplicationShellSession[];
+  activeSession: string;
+  quitHint: string;
+}
+
+export interface ApplicationShellProjection {
+  layout: ShellChromeLayout;
+  content: Rect;
+  views: readonly HostedPanelView[];
+  tabs: readonly ShellTabPresentation[];
+  sidebarHint: ShellSidebarHint;
+  sessions: readonly ApplicationShellSession[];
+  activeSession: string;
+  activeViewId: string;
+}
+
+export type ApplicationShellHit =
+  | { kind: "view"; viewId: string; index: number }
+  | { kind: "session"; session: string; index: number }
+  | { kind: "palette" }
+  | null;
+
+/** Pure application-shell geometry. Runtime stores and tmux never enter here. */
+export function projectApplicationShell(input: ApplicationShellInput): ApplicationShellProjection {
+  const layout = shellChromeLayout(input.width, input.height, input.preferredSidebarWidth);
+  const contentHeight = Math.max(0, layout.main.height - layout.status.height);
+  return {
+    layout,
+    content: {
+      x: layout.main.x,
+      y: layout.main.y,
+      width: layout.main.width,
+      height: contentHeight,
+    },
+    views: input.views,
+    tabs: shellSurfaceTabs(
+      input.views,
+      input.activeViewId,
+      layout.variant,
+      input.hoveredTabIndex,
+      input.attentionViewIds,
+    ),
+    sidebarHint: shellSidebarHint(layout.variant, input.quitHint, layout.sidebar.width),
+    sessions: input.sessions,
+    activeSession: input.activeSession,
+    activeViewId: input.activeViewId,
+  };
+}
+
+/**
+ * One coordinate router for shell chrome. Surface/pane hit testing remains with
+ * the active surface and the root application controller.
+ */
+export function applicationShellHitTest(
+  projection: ApplicationShellProjection,
+  x: number,
+  y: number,
+): ApplicationShellHit {
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  const cellX = Math.floor(x);
+  const cellY = Math.floor(y);
+  if (cellX < 0 || cellY < 0 || cellX >= projection.layout.width) return null;
+
+  if (cellY === projection.layout.tabbar.y && projection.layout.tabbar.height > 0) {
+    const index = projection.tabs.findIndex(
+      (tab) => cellX >= tab.span.start && cellX < tab.span.start + tab.span.width,
+    );
+    const tab = projection.tabs[index];
+    return tab ? { kind: "view", viewId: tab.id, index } : null;
+  }
+
+  const sidebar = projection.layout.sidebar;
+  if (
+    cellX < sidebar.x ||
+    cellX >= sidebar.x + sidebar.width ||
+    cellY < sidebar.y ||
+    cellY >= sidebar.y + sidebar.height
+  ) {
+    return null;
+  }
+
+  const hintRow = sidebar.y + sidebar.height - 1;
+  const hint = projection.sidebarHint;
+  if (
+    cellY === hintRow &&
+    cellX >= sidebar.x + hint.buttonSpan.start &&
+    cellX < sidebar.x + hint.buttonSpan.start + hint.buttonSpan.width
+  ) {
+    return { kind: "palette" };
+  }
+
+  const sessionIndex = cellY - sidebar.y - 1;
+  const session = projection.sessions[sessionIndex];
+  return session ? { kind: "session", session: session.name, index: sessionIndex } : null;
+}

--- a/packages/daemon/src/tui/mirror/workspace/application-shell.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/application-shell.tsx
@@ -1,0 +1,91 @@
+/* @jsxImportSource @opentui/solid */
+import type { JSX } from "solid-js";
+import { ShellMiniSidebar, ShellStatusStrip, ShellTabBar } from "../shell-chrome.tsx";
+import type { SemanticThemeSnapshot } from "../theme.ts";
+import type { ApplicationShellProjection } from "./application-shell.ts";
+
+export interface ApplicationShellProps {
+  theme: SemanticThemeSnapshot;
+  projection: ApplicationShellProjection;
+  project: string;
+  mode: string;
+  notification: string | null;
+  help: string;
+  note?: string | null;
+  rightChips?: readonly {
+    id: string;
+    label: string;
+    hovered?: boolean;
+    context?: boolean;
+    attention?: boolean;
+  }[];
+  children: JSX.Element;
+}
+
+/**
+ * Presentational application frame. It deliberately owns no keyboard hooks,
+ * renderer lifecycle, tmux connection, filesystem access, or mutable store.
+ */
+export function ApplicationShell(props: ApplicationShellProps) {
+  return (
+    <box
+      width={props.projection.layout.width}
+      height={props.projection.layout.height}
+      flexDirection="column"
+      backgroundColor={props.theme.colors.background}
+      overflow="hidden"
+    >
+      <ShellTabBar
+        theme={props.theme}
+        width={props.projection.layout.width}
+        variant={props.projection.layout.variant}
+        views={props.projection.views}
+        activeViewId={props.projection.activeViewId}
+        hoveredIndex={props.projection.tabs.findIndex((tab) => tab.hovered)}
+        attentionViewIds={
+          new Set(props.projection.tabs.filter((tab) => tab.attention).map((tab) => tab.id))
+        }
+        note={props.note}
+        rightChips={props.rightChips}
+      />
+      <box
+        width={props.projection.layout.width}
+        height={props.projection.layout.sidebar.height}
+        flexDirection="row"
+        overflow="hidden"
+      >
+        <ShellMiniSidebar
+          theme={props.theme}
+          width={props.projection.layout.sidebar.width}
+          variant={props.projection.layout.variant}
+          sessions={props.projection.sessions}
+          active={props.projection.activeSession}
+          hint={props.projection.sidebarHint}
+        />
+        <box
+          width={props.projection.layout.main.width}
+          height={props.projection.layout.main.height}
+          flexDirection="column"
+          overflow="hidden"
+        >
+          <box
+            width={props.projection.content.width}
+            height={props.projection.content.height}
+            flexDirection="column"
+            overflow="hidden"
+          >
+            {props.children}
+          </box>
+          <ShellStatusStrip
+            theme={props.theme}
+            layout={props.projection.layout}
+            project={props.project}
+            mode={props.mode}
+            notification={props.notification}
+            help={props.help}
+          />
+        </box>
+      </box>
+    </box>
+  );
+}

--- a/packages/daemon/src/tui/mirror/workspace/boundaries.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/boundaries.test.ts
@@ -1,0 +1,66 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const WORKSPACE_DIR = dirname(fileURLToPath(import.meta.url));
+const PRODUCTION_EXTENSIONS = new Set([".ts", ".tsx"]);
+const FORBIDDEN_IMPORTS = [
+  /(?:^|\/)app\.tsx$/u,
+  /(?:^|\/)session-mirror\.ts$/u,
+  /(?:^|\/)pane-mirror\.ts$/u,
+  /(?:^|\/)control-client\.ts$/u,
+  /(?:^|\/)command-center(?:\/|$)/u,
+  /(?:^|\/)server(?:\/|$)/u,
+  /(?:^|\/)lib(?:\/|$)/u,
+  /^node:/u,
+];
+const FORBIDDEN_OWNERS = /\b(?:useKeyboard|usePaste|createCliRenderer|process\.exit)\b/u;
+
+async function productionFiles(dir = WORKSPACE_DIR): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== "__snapshots__") files.push(...(await productionFiles(path)));
+      continue;
+    }
+    if (!PRODUCTION_EXTENSIONS.has(extname(entry.name))) continue;
+    if (entry.name.endsWith(".test.ts") || entry.name.endsWith(".test.tsx")) continue;
+    files.push(path);
+  }
+  return files;
+}
+
+function imports(source: string): string[] {
+  const imports = [
+    ...source.matchAll(/\b(?:from\s+|import\s*\(\s*)["']([^"']+)["']/gu),
+    ...source.matchAll(/^\s*import\s*["']([^"']+)["']/gmu),
+  ];
+  return imports.map((match) => match[1]!);
+}
+
+describe("application workspace boundaries", () => {
+  it("keeps production modules out of runtime and legacy-root adapters", async () => {
+    const violations: string[] = [];
+    for (const file of await productionFiles()) {
+      const source = await readFile(file, "utf8");
+      for (const specifier of imports(source)) {
+        if (FORBIDDEN_IMPORTS.some((pattern) => pattern.test(specifier))) {
+          violations.push(`${file}: forbidden import ${specifier}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps global input and renderer lifecycle in the root controller", async () => {
+    const violations: string[] = [];
+    for (const file of await productionFiles()) {
+      const source = await readFile(file, "utf8");
+      if (FORBIDDEN_OWNERS.test(source)) violations.push(file);
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "src/tui/detect/*.test.ts",
       "src/tui/team/*.test.ts",
       "src/tui/mirror/*.test.ts",
+      "src/tui/mirror/workspace/**/*.test.ts",
       "src/tui/chrome/*.test.ts",
       "src/tui/integrations/*.test.ts",
       "src/widgets/lib/grammar.test.ts",


### PR DESCRIPTION
## Outcome

Establishes the behavior-neutral application workspace boundary needed before PaneFrame v1.

- adds a pure application-shell projection and hit-test layer
- adds a presentational Solid/OpenTUI application frame with no runtime ownership
- enforces workspace import/input/lifecycle boundaries
- adds a shared renderer harness with automatic renderer teardown
- records responsive acceptance snapshots at 80x24, 120x40, and 200x60
- makes nested workspace model tests part of the daemon Vitest gate

## Verification

- `pnpm check`
- 1,917 daemon unit tests and 44 contract tests
- 44 OpenTUI renderer tests / 25 snapshots
- `pnpm build:tui`
- `pnpm test:tui-smoke` (80x24, 120x40, 200x60; Ctrl-C stays alive; Ctrl-Q exits)

## Follow-up

M31 Card 02 adds PaneFrame v1 on this boundary.