### PR TITLE
feat(tui): add responsive pane frames

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -142,6 +142,8 @@ export default [
                 "**/mirror/pane-mirror.ts",
                 "../control-client.ts",
                 "**/mirror/control-client.ts",
+                "../missions-workspace.ts",
+                "**/mirror/missions-workspace.ts",
                 "**/command-center/**",
                 "**/server/**",
                 "**/lib/**",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run typecheck:workspace && pnpm run test:unit && pnpm run test:tui-renderer && pnpm run docs:build && pnpm run pack:check && pnpm run check:native-deps",
     "postinstall": "node scripts/postinstall.js",
     "docs": "turbo run dev --filter=@tmux-ide/docs",
-    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx",
+    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx",
     "test:tui-smoke": "node scripts/smoke-tui-missions.mjs"
   },
   "keywords": [

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -352,8 +352,10 @@ import {
   type HostedPanelKind,
   type HostedPanelView,
 } from "./panel-host.ts";
-import { ShellCompositeLeafChrome, ShellTabBar } from "./shell-chrome.tsx";
+import { ShellTabBar } from "./shell-chrome.tsx";
 import { shellChromeLayout, shellSidebarHint, shellSurfaceTabSpans } from "./shell-chrome.ts";
+import { projectPaneFrame } from "./workspace/pane-frame.ts";
+import { PaneFrameHeader } from "./workspace/pane-frame.tsx";
 import {
   MissionWorkspaceLoader,
   clipTerminal,
@@ -7046,16 +7048,16 @@ try {
 
     const compositeLeafChrome = (leaf: CompositePanelLeaf) => {
       const viewport = compositeLeafViewport(leaf.rect, 0);
-      return (
-        <ShellCompositeLeafChrome
-          theme={semanticTheme()}
-          title={leaf.title}
-          panel={leaf.panel}
-          width={viewport.innerWidth}
-          focused={leaf.focused}
-          terminalFocused={leaf.panel === "terminals" && leaf.focused}
-        />
-      );
+      const projection = projectPaneFrame({
+        width: viewport.innerWidth,
+        height: viewport.innerHeight,
+        title: leaf.title,
+        kind: leaf.panel,
+        subtitle: leaf.nodeId,
+        focused: leaf.focused,
+        terminalFocused: leaf.panel === "terminals" && leaf.focused,
+      });
+      return <PaneFrameHeader theme={semanticTheme()} projection={projection} />;
     };
 
     const compositeTerminalLeaf = (leaf: CompositePanelLeaf) => {

--- a/packages/daemon/src/tui/mirror/workspace/README.md
+++ b/packages/daemon/src/tui/mirror/workspace/README.md
@@ -24,5 +24,18 @@ is the migration boundary between app-owned presentation and runtime adapters.
 6. Command descriptors and a contribution registry.
 7. Harness-neutral mission runtime, followed by the native desktop host.
 
-The first card is intentionally behavior-neutral: it records the responsive
-shell baseline and makes architectural back-edges fail before `PaneFrame` lands.
+Card 01 is intentionally behavior-neutral: it records the responsive shell
+baseline and makes architectural back-edges fail before new window behavior lands.
+
+## PaneFrame v1
+
+`pane-frame.ts` projects one reusable window contract for terminals, files,
+changes, missions, previews, and home surfaces. It owns responsive title/status/
+action geometry and hit targets; `pane-frame.tsx` paints that projection without
+installing input hooks. Semantic status survives narrow layouts before optional
+actions, while terminal focus, attention, keyboard focus, and idle state keep
+distinct markers.
+
+The live composite workspace now uses `PaneFrameHeader`. Action descriptors are
+already represented and renderer-tested, but production command routing remains
+with the root controller and will be connected by the command-adapter card.

--- a/packages/daemon/src/tui/mirror/workspace/__snapshots__/pane-frame-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/workspace/__snapshots__/pane-frame-renderer.test.tsx.snap
@@ -1,0 +1,134 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`PaneFrame OpenTUI renderer renders the %sx%s standard window chrome 1`] = `
+" ▣ ❯ Codex implementer • · %7 · task/142-…  working   ○ zoom   ○ split   ○ more
+● Mission: ship application-grade window chrome                              M31
+› Task: PaneFrame projection and renderer                                running
+● Harness: Codex                                                         gpt-5.5
+ terminal framebuffer remains opaque
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+"
+`;
+
+exports[`PaneFrame OpenTUI renderer renders the %sx%s wide window chrome 1`] = `
+" ▣ ❯ Codex implementer • · %7 · task/142-pane-frame                                 working   ○ zoom   ○ split   ○ more
+● Mission: ship application-grade window chrome                                                                      M31
+› Task: PaneFrame projection and renderer                                                                        running
+● Harness: Codex                                                                                                 gpt-5.5
+ terminal framebuffer remains opaque
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+"
+`;
+
+exports[`PaneFrame OpenTUI renderer renders the %sx%s wide window chrome 2`] = `
+" ▣ ❯ Codex implementer • · %7 · task/142-pane-frame                                                                                                                 working   ○ zoom   ○ split   ○ more
+● Mission: ship application-grade window chrome                                                                                                                                                      M31
+› Task: PaneFrame projection and renderer                                                                                                                                                        running
+● Harness: Codex                                                                                                                                                                                 gpt-5.5
+ terminal framebuffer remains opaque
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+"
+`;

--- a/packages/daemon/src/tui/mirror/workspace/boundaries.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/boundaries.test.ts
@@ -10,6 +10,7 @@ const FORBIDDEN_IMPORTS = [
   /(?:^|\/)session-mirror\.ts$/u,
   /(?:^|\/)pane-mirror\.ts$/u,
   /(?:^|\/)control-client\.ts$/u,
+  /(?:^|\/)missions-workspace\.ts$/u,
   /(?:^|\/)command-center(?:\/|$)/u,
   /(?:^|\/)server(?:\/|$)/u,
   /(?:^|\/)lib(?:\/|$)/u,

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
@@ -1,0 +1,149 @@
+/* @jsxImportSource @opentui/solid */
+import { MouseButtons } from "@opentui/core/testing";
+import { useKeyboard } from "@opentui/solid";
+import { createSignal } from "solid-js";
+import { describe, expect, it } from "bun:test";
+import { SelectableRow } from "../recipes.tsx";
+import { createSemanticThemeSnapshot } from "../theme.ts";
+import { expectFrameBounds, renderForTest, stableFrame } from "../testing/renderer-harness.test.ts";
+import { paneFrameHitTest, projectPaneFrame } from "./pane-frame.ts";
+import { PaneFrame } from "./pane-frame.tsx";
+
+const actions = [
+  { id: "zoom", label: "zoom", compactLabel: "Z", description: "Toggle zoom" },
+  { id: "split", label: "split", compactLabel: "+", description: "Split pane" },
+  { id: "more", label: "more", compactLabel: "…", description: "More actions" },
+] as const;
+
+async function renderPane(width: number, height: number) {
+  const theme = createSemanticThemeSnapshot({ mode: "dark" });
+  const calls: string[] = [];
+  let focusedValue = true;
+  let statusValue = "working";
+
+  function Harness() {
+    const [focused, setFocused] = createSignal(focusedValue);
+    const [status, setStatus] = createSignal(statusValue);
+    const projection = () =>
+      projectPaneFrame({
+        width,
+        height,
+        title: "Codex implementer",
+        kind: "terminals",
+        subtitle: "%7 · task/142-pane-frame",
+        focused: focused(),
+        terminalFocused: focused(),
+        attention: status() === "blocked",
+        dirty: true,
+        status: status(),
+        statusTone: status() === "blocked" ? "blocked" : "working",
+        actions,
+      });
+    useKeyboard((event) => {
+      if (event.name === "f") {
+        focusedValue = !focused();
+        setFocused(focusedValue);
+        calls.push("keyboard:focus");
+      }
+      if (event.name === "b") {
+        statusValue = "blocked";
+        setStatus(statusValue);
+        calls.push("keyboard:block");
+      }
+    });
+    return (
+      <box
+        width={width}
+        height={height}
+        overflow="hidden"
+        onMouseDown={(event) => {
+          const hit = paneFrameHitTest(projection(), event.x, event.y);
+          if (hit?.area === "header" && hit.actionId) calls.push(`mouse:${hit.actionId}`);
+        }}
+      >
+        <PaneFrame theme={theme} projection={projection()}>
+          <SelectableRow
+            theme={theme}
+            label="Mission: ship application-grade window chrome"
+            meta="M31"
+            width={width}
+            selected
+          />
+          <SelectableRow
+            theme={theme}
+            label="Task: PaneFrame projection and renderer"
+            meta="running"
+            width={width}
+            focused
+          />
+          <SelectableRow
+            theme={theme}
+            label="Harness: Codex"
+            meta="gpt-5.5"
+            width={width}
+            status="working"
+            tone="working"
+          />
+          <text fg={theme.colors.mutedForeground}> terminal framebuffer remains opaque</text>
+        </PaneFrame>
+      </box>
+    );
+  }
+
+  const setup = await renderForTest(() => <Harness />, { width, height });
+  await setup.renderOnce();
+  return {
+    setup,
+    calls,
+    focused: () => focusedValue,
+    status: () => statusValue,
+    projection: () =>
+      projectPaneFrame({
+        width,
+        height,
+        title: "Codex implementer",
+        kind: "terminals",
+        subtitle: "%7 · task/142-pane-frame",
+        focused: focusedValue,
+        terminalFocused: focusedValue,
+        attention: statusValue === "blocked",
+        dirty: true,
+        status: statusValue,
+        statusTone: statusValue === "blocked" ? "blocked" : "working",
+        actions,
+      }),
+    frame: () => setup.captureCharFrame(),
+  };
+}
+
+describe("PaneFrame OpenTUI renderer", () => {
+  it.each([
+    [80, 24, "standard"],
+    [120, 40, "wide"],
+    [200, 60, "wide"],
+  ] as const)("renders the %sx%s %s window chrome", async (width, height, variant) => {
+    const harness = await renderPane(width, height);
+    const frame = harness.frame();
+    expectFrameBounds(frame, width, height);
+    expect(harness.projection().variant).toBe(variant);
+    expect(stableFrame(frame)).toMatchSnapshot();
+    expect(stableFrame(frame)).toContain("Codex implementer");
+    expect(stableFrame(frame)).toContain("working");
+    expect(stableFrame(frame)).toContain("zoom");
+  });
+
+  it("routes projected action spans and keeps keyboard ownership in the harness", async () => {
+    const harness = await renderPane(120, 40);
+    const zoom = harness.projection().actions.find((action) => action.id === "zoom")!;
+    await harness.setup.mockMouse.click(
+      zoom.start + Math.floor(zoom.width / 2),
+      0,
+      MouseButtons.LEFT,
+    );
+    harness.setup.mockInput.pressKey("b");
+    await harness.setup.renderOnce();
+    expect(harness.status()).toBe("blocked");
+    expect(stableFrame(harness.frame())).toContain("blocked");
+    expect(harness.calls).toEqual(["mouse:zoom", "keyboard:block"]);
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { paneFrameHitTest, paneFrameVariant, projectPaneFrame } from "./pane-frame.ts";
+
+const actions = [
+  { id: "zoom", label: "zoom", compactLabel: "Z", description: "Toggle zoom" },
+  { id: "split", label: "split", compactLabel: "+", description: "Split pane" },
+  { id: "more", label: "more", compactLabel: "…", description: "More actions" },
+] as const;
+
+describe("PaneFrame projection", () => {
+  it.each([
+    [48, 12, "compact"],
+    [90, 24, "standard"],
+    [140, 40, "wide"],
+  ] as const)("selects the %s×%s %s chrome", (width, height, variant) => {
+    expect(paneFrameVariant(width, height)).toBe(variant);
+    const projection = projectPaneFrame({
+      width,
+      height,
+      title: "API server",
+      kind: "terminals",
+      subtitle: "%7 · codex",
+      focused: true,
+      status: "working",
+      statusTone: "working",
+      actions,
+    });
+    expect(projection.variant).toBe(variant);
+    expect(projection.header).toEqual({ x: 0, y: 0, width, height: 1 });
+    expect(projection.body).toEqual({ x: 0, y: 1, width, height: height - 1 });
+    expect(projection.title).toContain("API server");
+    expect(projection.chips.every((chip) => chip.start + chip.width <= width)).toBe(true);
+    expect(
+      projection.chips.every(
+        (chip, index) => index === 0 || chip.start > projection.chips[index - 1]!.start,
+      ),
+    ).toBe(true);
+  });
+
+  it("prioritizes terminal focus, attention, focus, and idle markers", () => {
+    const marker = (overrides: Partial<Parameters<typeof projectPaneFrame>[0]>) =>
+      projectPaneFrame({
+        width: 80,
+        height: 24,
+        title: "pane",
+        kind: "files",
+        focused: false,
+        ...overrides,
+      }).marker;
+    expect(marker({ terminalFocused: true, attention: true, focused: true })).toBe("▣");
+    expect(marker({ attention: true, focused: true })).toBe("!");
+    expect(marker({ focused: true })).toBe("●");
+    expect(marker({})).toBe("○");
+  });
+
+  it("keeps semantic status while progressively dropping actions on narrow panes", () => {
+    const projection = projectPaneFrame({
+      width: 24,
+      height: 8,
+      title: "very long pane title",
+      kind: "missions",
+      focused: false,
+      attention: true,
+      status: "blocked",
+      statusTone: "blocked",
+      actions,
+    });
+    expect(projection.chips[0]).toMatchObject({ kind: "status", label: "!" });
+    expect(projection.actions.length).toBeLessThan(actions.length);
+    expect(projection.title.length).toBeGreaterThan(0);
+    expect(projection.title.length).toBeLessThanOrEqual(projection.chips[0]!.start);
+  });
+
+  it("routes enabled actions while leaving status and disabled actions inert", () => {
+    const projection = projectPaneFrame({
+      width: 120,
+      height: 30,
+      title: "Terminal",
+      kind: "terminals",
+      focused: true,
+      status: "working",
+      statusTone: "working",
+      actions: [actions[0], { ...actions[1], disabled: true }],
+    });
+    const zoom = projection.actions.find((action) => action.id === "zoom")!;
+    const split = projection.actions.find((action) => action.id === "split")!;
+    expect(paneFrameHitTest(projection, zoom.start, 0)).toEqual({
+      area: "header",
+      actionId: "zoom",
+      actionIndex: 0,
+    });
+    expect(paneFrameHitTest(projection, split.start, 0)).toEqual({ area: "header" });
+    expect(paneFrameHitTest(projection, projection.chips[0]!.start, 0)).toEqual({
+      area: "header",
+    });
+    expect(paneFrameHitTest(projection, 2, 2)).toEqual({ area: "body" });
+    expect(paneFrameHitTest(projection, -1, 0)).toBeNull();
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
@@ -1,0 +1,225 @@
+import { terminalDisplayWidth } from "../panel-host.ts";
+import { actionChipWidth, type RecipeTone, type Rect } from "../recipes.ts";
+import { clipWorkspaceText } from "./text.ts";
+
+export type PaneFrameVariant = "compact" | "standard" | "wide";
+export type PaneFrameKind = "home" | "terminals" | "files" | "diff" | "missions" | "preview";
+
+export interface PaneFrameAction {
+  id: string;
+  label: string;
+  compactLabel?: string;
+  description: string;
+  active?: boolean;
+  disabled?: boolean;
+  attention?: boolean;
+}
+
+export interface PaneFrameInput {
+  width: number;
+  height: number;
+  title: string;
+  kind: PaneFrameKind;
+  subtitle?: string | null;
+  focused: boolean;
+  terminalFocused?: boolean;
+  attention?: boolean;
+  dirty?: boolean;
+  status?: string | null;
+  statusTone?: Exclude<RecipeTone, "neutral" | "accent">;
+  actions?: readonly PaneFrameAction[];
+  hoveredActionIndex?: number | null;
+}
+
+export interface PaneFrameStatusChip {
+  kind: "status";
+  label: string;
+  tone: Exclude<RecipeTone, "neutral" | "accent">;
+  start: number;
+  width: number;
+}
+
+export interface PaneFrameActionChip extends PaneFrameAction {
+  kind: "action";
+  start: number;
+  width: number;
+  hovered: boolean;
+}
+
+export type PaneFrameChip = PaneFrameStatusChip | PaneFrameActionChip;
+
+export interface PaneFrameProjection {
+  width: number;
+  height: number;
+  variant: PaneFrameVariant;
+  header: Rect;
+  body: Rect;
+  marker: string;
+  glyph: string;
+  title: string;
+  focused: boolean;
+  terminalFocused: boolean;
+  attention: boolean;
+  chips: readonly PaneFrameChip[];
+  actions: readonly PaneFrameActionChip[];
+}
+
+export type PaneFrameHit =
+  | { area: "header"; actionId?: string; actionIndex?: number }
+  | { area: "body" }
+  | null;
+
+const KIND_GLYPHS: Readonly<Record<PaneFrameKind, string>> = {
+  home: "⌂",
+  terminals: "❯",
+  files: "▤",
+  diff: "±",
+  missions: "◆",
+  preview: "◫",
+};
+
+const STATUS_GLYPHS: Readonly<Record<Exclude<RecipeTone, "neutral" | "accent">, string>> = {
+  blocked: "!",
+  working: "●",
+  done: "✓",
+  idle: "○",
+  unknown: "?",
+};
+
+export function paneFrameVariant(width: number, height: number): PaneFrameVariant {
+  if (width >= 120 && height >= 32) return "wide";
+  if (width >= 72 && height >= 18) return "standard";
+  return "compact";
+}
+
+export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
+  const width = Math.max(0, Math.floor(input.width));
+  const height = Math.max(0, Math.floor(input.height));
+  const variant = paneFrameVariant(width, height);
+  const headerHeight = Math.min(1, height);
+  const status = statusChip(input.status, input.statusTone, variant);
+  const actions = (input.actions ?? []).map((action, index) => ({
+    ...action,
+    kind: "action" as const,
+    label: variant === "compact" ? (action.compactLabel ?? action.label) : action.label,
+    hovered: input.hoveredActionIndex === index,
+  }));
+  const visible = fitChips(width, variant, status, actions);
+  const chips = positionChips(width, visible);
+  const firstChip = chips[0]?.start ?? width;
+  const titleBudget = Math.max(0, firstChip - (chips.length > 0 ? 1 : 0));
+  const terminalFocused = input.terminalFocused === true;
+  const attention = input.attention === true;
+  const marker = terminalFocused ? "▣" : attention ? "!" : input.focused ? "●" : "○";
+  const dirty = input.dirty ? " •" : "";
+  const subtitle = input.subtitle && variant !== "compact" ? ` · ${input.subtitle}` : "";
+  const title = clipWorkspaceText(
+    ` ${marker} ${KIND_GLYPHS[input.kind]} ${input.title}${dirty}${subtitle}`,
+    titleBudget,
+  );
+
+  return {
+    width,
+    height,
+    variant,
+    header: { x: 0, y: 0, width, height: headerHeight },
+    body: { x: 0, y: headerHeight, width, height: Math.max(0, height - headerHeight) },
+    marker,
+    glyph: KIND_GLYPHS[input.kind],
+    title,
+    focused: input.focused,
+    terminalFocused,
+    attention,
+    chips,
+    actions: chips.filter((chip): chip is PaneFrameActionChip => chip.kind === "action"),
+  };
+}
+
+function statusChip(
+  status: string | null | undefined,
+  tone: PaneFrameInput["statusTone"],
+  variant: PaneFrameVariant,
+): Omit<PaneFrameStatusChip, "start" | "width"> | null {
+  if (!status) return null;
+  const resolvedTone = tone ?? "unknown";
+  return {
+    kind: "status",
+    label: variant === "compact" ? STATUS_GLYPHS[resolvedTone] : status,
+    tone: resolvedTone,
+  };
+}
+
+function chipWidth(
+  chip: Omit<PaneFrameStatusChip, "start" | "width"> | Omit<PaneFrameActionChip, "start" | "width">,
+): number {
+  return chip.kind === "status"
+    ? terminalDisplayWidth(chip.label) + 2
+    : actionChipWidth(chip.label);
+}
+
+function fitChips(
+  width: number,
+  variant: PaneFrameVariant,
+  status: Omit<PaneFrameStatusChip, "start" | "width"> | null,
+  actions: readonly Omit<PaneFrameActionChip, "start" | "width">[],
+): (Omit<PaneFrameStatusChip, "start" | "width"> | Omit<PaneFrameActionChip, "start" | "width">)[] {
+  const minimumTitle = variant === "compact" ? 8 : variant === "standard" ? 18 : 24;
+  const chips: (
+    | Omit<PaneFrameStatusChip, "start" | "width">
+    | Omit<PaneFrameActionChip, "start" | "width">
+  )[] = status ? [status, ...actions] : [...actions];
+  const fits = () => {
+    const widthUsed = chips.reduce((sum, chip) => sum + chipWidth(chip), 0);
+    return widthUsed + Math.max(0, chips.length - 1) + minimumTitle <= width;
+  };
+  while (chips.length > 0 && !fits()) {
+    let lastAction = -1;
+    for (let index = chips.length - 1; index >= 0; index -= 1) {
+      if (chips[index]?.kind === "action") {
+        lastAction = index;
+        break;
+      }
+    }
+    if (lastAction >= 0) chips.splice(lastAction, 1);
+    else chips.pop();
+  }
+  return chips;
+}
+
+function positionChips(
+  width: number,
+  chips: readonly (
+    | Omit<PaneFrameStatusChip, "start" | "width">
+    | Omit<PaneFrameActionChip, "start" | "width">
+  )[],
+): PaneFrameChip[] {
+  const widths = chips.map(chipWidth);
+  const total = widths.reduce((sum, value) => sum + value, 0) + Math.max(0, widths.length - 1);
+  let x = Math.max(0, width - total);
+  return chips.map((chip, index) => {
+    const span = { ...chip, start: x, width: widths[index]! } as PaneFrameChip;
+    x += span.width + 1;
+    return span;
+  });
+}
+
+export function paneFrameHitTest(
+  projection: PaneFrameProjection,
+  x: number,
+  y: number,
+): PaneFrameHit {
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  const cellX = Math.floor(x);
+  const cellY = Math.floor(y);
+  if (cellX < 0 || cellY < 0 || cellX >= projection.width || cellY >= projection.height) {
+    return null;
+  }
+  if (cellY < projection.header.height) {
+    const actionIndex = projection.actions.findIndex(
+      (action) => !action.disabled && cellX >= action.start && cellX < action.start + action.width,
+    );
+    const action = projection.actions[actionIndex];
+    return action ? { area: "header", actionId: action.id, actionIndex } : { area: "header" };
+  }
+  return { area: "body" };
+}

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
@@ -1,0 +1,88 @@
+/* @jsxImportSource @opentui/solid */
+import type { JSX } from "@opentui/solid";
+import { For, Show } from "solid-js";
+import { ActionChip, StatusChip } from "../recipes.tsx";
+import { recipePalette } from "../recipes.ts";
+import type { SemanticThemeSnapshot } from "../theme.ts";
+import type { PaneFrameProjection } from "./pane-frame.ts";
+
+export interface PaneFrameHeaderProps {
+  theme: SemanticThemeSnapshot;
+  projection: PaneFrameProjection;
+}
+
+export function PaneFrameHeader(props: PaneFrameHeaderProps) {
+  const palette = () =>
+    recipePalette(props.theme, {
+      focused: props.projection.focused || props.projection.terminalFocused,
+      attention: props.projection.attention,
+    });
+  return (
+    <box
+      width={props.projection.header.width}
+      height={props.projection.header.height}
+      position="relative"
+      backgroundColor={palette().background}
+      overflow="hidden"
+    >
+      <text fg={palette().foreground} attributes={props.projection.focused ? 1 : 0}>
+        {props.projection.title}
+      </text>
+      <For each={props.projection.chips}>
+        {(chip) => (
+          <box position="absolute" left={chip.start} top={0} width={chip.width} height={1}>
+            <Show
+              when={chip.kind === "action" ? chip : null}
+              fallback={
+                <StatusChip
+                  theme={props.theme}
+                  label={chip.label}
+                  width={chip.width}
+                  tone={chip.kind === "status" ? chip.tone : "unknown"}
+                />
+              }
+            >
+              {(action) => (
+                <ActionChip
+                  theme={props.theme}
+                  label={action().label}
+                  width={action().width}
+                  hovered={action().hovered}
+                  selected={action().active}
+                  disabled={action().disabled}
+                  attention={action().attention}
+                />
+              )}
+            </Show>
+          </box>
+        )}
+      </For>
+    </box>
+  );
+}
+
+export interface PaneFrameProps extends PaneFrameHeaderProps {
+  children?: JSX.Element;
+}
+
+export function PaneFrame(props: PaneFrameProps) {
+  return (
+    <box
+      width={props.projection.width}
+      height={props.projection.height}
+      flexDirection="column"
+      backgroundColor={props.theme.colors.background}
+      overflow="hidden"
+    >
+      <PaneFrameHeader theme={props.theme} projection={props.projection} />
+      <box
+        width={props.projection.body.width}
+        height={props.projection.body.height}
+        flexDirection="column"
+        overflow="hidden"
+      >
+        {props.children}
+      </box>
+    </box>
+  );
+}

--- a/packages/daemon/src/tui/mirror/workspace/text.ts
+++ b/packages/daemon/src/tui/mirror/workspace/text.ts
@@ -1,0 +1,28 @@
+import { terminalDisplayWidth } from "../panel-host.ts";
+
+/** Cell-aware clipping kept in the presentational workspace layer. */
+export function clipWorkspaceText(text: string, width: number): string {
+  if (width <= 0) return "";
+  if (terminalDisplayWidth(text) <= width) return text;
+  const ellipsis = "…";
+  const limit = Math.max(0, width - terminalDisplayWidth(ellipsis));
+  let out = "";
+  let used = 0;
+  for (const segment of graphemes(text)) {
+    const segmentWidth = terminalDisplayWidth(segment);
+    if (used + segmentWidth > limit) break;
+    out += segment;
+    used += segmentWidth;
+  }
+  return out + ellipsis;
+}
+
+function graphemes(text: string): string[] {
+  const Segmenter = Intl.Segmenter;
+  if (Segmenter) {
+    return [...new Segmenter(undefined, { granularity: "grapheme" }).segment(text)].map(
+      (entry) => entry.segment,
+    );
+  }
+  return [...text];
+}


### PR DESCRIPTION
## Summary
- add a pure responsive PaneFrame projection and cell-aware header renderer
- expose semantic focus, terminal-focus, attention, dirty, status, and optional action states
- adopt the frame for composite workspace leaves without adding dead production actions
- enforce workspace boundary isolation and add OpenTUI renderer coverage

## Verification
- pnpm check
- pnpm build:tui
- pnpm test:tui-smoke
- 1923 daemon tests, 48 OpenTUI renderer tests / 28 snapshots
- compiled smoke at 80x24, 120x40, 200x60; Ctrl-C stays alive and Ctrl-Q exits cleanly