### PR TITLE
feat(tui): add native workbench dock shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run typecheck:workspace && pnpm run test:unit && pnpm run test:tui-renderer && pnpm run docs:build && pnpm run pack:check && pnpm run check:native-deps",
     "postinstall": "node scripts/postinstall.js",
     "docs": "turbo run dev --filter=@tmux-ide/docs",
-    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx",
+    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/workbench-shell-renderer.test.tsx",
     "test:tui-smoke": "node scripts/smoke-tui-missions.mjs"
   },
   "keywords": [

--- a/packages/daemon/src/tui/mirror/workspace/README.md
+++ b/packages/daemon/src/tui/mirror/workspace/README.md
@@ -18,11 +18,12 @@ is the migration boundary between app-owned presentation and runtime adapters.
 
 1. Application boundary and shared renderer harness.
 2. `PaneFrame` v1 with focus, attention, metadata, and action chrome.
-3. Named workspace layouts and persisted restore.
-4. Keyboard/mouse move, resize, dock, and float interactions.
-5. New-pane templates and project lifecycle actions.
-6. Command descriptors and a contribution registry.
-7. Harness-neutral mission runtime, followed by the native desktop host.
+3. Application-owned agent canvas and persistent bottom-dock projection.
+4. Named workspace layouts and persisted restore.
+5. Keyboard/mouse move, resize, dock, and float interactions.
+6. New-pane templates and project lifecycle actions.
+7. Command descriptors and a contribution registry.
+8. Harness-neutral mission runtime, followed by the native desktop host.
 
 Card 01 is intentionally behavior-neutral: it records the responsive shell
 baseline and makes architectural back-edges fail before new window behavior lands.
@@ -39,3 +40,16 @@ distinct markers.
 The live composite workspace now uses `PaneFrameHeader`. Action descriptors are
 already represented and renderer-tested, but production command routing remains
 with the root controller and will be connected by the command-adapter card.
+
+## WorkbenchShell and bottom dock
+
+`workbench-shell.ts` projects the agent canvas and the application-owned bottom
+dock without reading runtime state. The dock exposes Files, Changes, Missions,
+and Activity tabs; collapsed, open, and maximized geometry; a separately
+preserved preferred open height; effective focus zones; responsive minimums;
+and exact tab, action, canvas, and dock-body hit cells.
+
+`workbench-shell.tsx` only paints that projection. Card 03 deliberately does not
+move live surfaces, persist state, or install keyboard, paste, pointer, or
+renderer lifecycle owners. Those effects remain with the root controller until
+the workspace-state and command-adapter cards land.

--- a/packages/daemon/src/tui/mirror/workspace/__snapshots__/workbench-shell-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/workspace/__snapshots__/workbench-shell-renderer.test.tsx.snap
@@ -1,0 +1,134 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`WorkbenchShell OpenTUI renderer renders the %sx%s compact agent canvas and bottom dock 1`] = `
+"▌● Agent canvas                                               compact · 3 agents
+ › Fable · project manager                                               working
+ ○ Codex implementer 1 · terminal %7                                  task M31.3
+ ○ Codex implementer 2 · ready                                           gpt-5.5
+
+
+
+
+
+
+
+
+
+
+  ▤ Files   ± Changes  ●◆ Missions  !◌ Activity                           ▾   □
+│● missions dock                                        open · preferred 10 rows
+ ○ Full application parity                                          7 / 20 cards
+ ● Workbench dock projection                                         in progress
+
+
+
+
+
+"
+`;
+
+exports[`WorkbenchShell OpenTUI renderer renders the %sx%s standard agent canvas and bottom dock 1`] = `
+"▌● Agent canvas                                                                                      standard · 3 agents
+ › Fable · project manager                                                                                       working
+ ○ Codex implementer 1 · terminal %7                                                                          task M31.3
+ ○ Codex implementer 2 · ready                                                                                   gpt-5.5
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  ▤ Files   ± Changes  ●◆ Missions  !◌ Activity                                                         ▾ close   □ max
+│● missions dock                                                                                open · preferred 14 rows
+ ○ Full application parity                                                                                  7 / 20 cards
+ ● Workbench dock projection                                                                                 in progress
+
+
+
+
+
+
+
+
+
+"
+`;
+
+exports[`WorkbenchShell OpenTUI renderer renders the %sx%s wide agent canvas and bottom dock 1`] = `
+"▌● Agent canvas                                                                                                                                                                          wide · 3 agents
+ › Fable · project manager                                                                                                                                                                       working
+ ○ Codex implementer 1 · terminal %7                                                                                                                                                          task M31.3
+ ○ Codex implementer 2 · ready                                                                                                                                                                   gpt-5.5
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ F6  ▤ Files  F7  ± Changes  F8 ●◆ Missions  F9 !◌ Activity                                                                                                                             ▾ close   □ max
+│● missions dock                                                                                                                                                                open · preferred 20 rows
+ ○ Full application parity                                                                                                                                                                  7 / 20 cards
+ ● Workbench dock projection                                                                                                                                                                 in progress
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+"
+`;

--- a/packages/daemon/src/tui/mirror/workspace/workbench-shell-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/workbench-shell-renderer.test.tsx
@@ -1,0 +1,245 @@
+/* @jsxImportSource @opentui/solid */
+import { MouseButtons } from "@opentui/core/testing";
+import { useKeyboard } from "@opentui/solid";
+import { createSignal } from "solid-js";
+import { describe, expect, it } from "bun:test";
+import { SelectableRow } from "../recipes.tsx";
+import { createSemanticThemeSnapshot } from "../theme.ts";
+import { expectFrameBounds, renderForTest, stableFrame } from "../testing/renderer-harness.test.ts";
+import {
+  projectWorkbenchShell,
+  workbenchShellHitTest,
+  type WorkbenchDockMode,
+  type WorkbenchDockTabId,
+  type WorkbenchFocusZone,
+} from "./workbench-shell.ts";
+import { WorkbenchShell } from "./workbench-shell.tsx";
+
+async function renderWorkbench(width: number, height: number) {
+  const theme = createSemanticThemeSnapshot({ mode: "dark" });
+  const calls: string[] = [];
+  let modeValue: WorkbenchDockMode = "open";
+  let activeValue: WorkbenchDockTabId = "missions";
+  let focusValue: WorkbenchFocusZone = "canvas";
+  const preferredHeight = width >= 160 ? 20 : width >= 96 ? 14 : 10;
+
+  function Harness() {
+    const [mode, setMode] = createSignal(modeValue);
+    const [active, setActive] = createSignal(activeValue);
+    const [focus, setFocus] = createSignal(focusValue);
+    const projection = () =>
+      projectWorkbenchShell({
+        width,
+        height,
+        dockMode: mode(),
+        persistedDockHeight: preferredHeight,
+        activeDockTab: active(),
+        focusZone: focus(),
+        hoveredDockTab: null,
+        attentionDockTabs: new Set(["activity"]),
+      });
+    useKeyboard((event) => {
+      if (event.name === "tab") {
+        focusValue = focus() === "canvas" ? "dock-tabs" : "canvas";
+        setFocus(focusValue);
+        calls.push(`keyboard:${focusValue}`);
+      }
+    });
+    return (
+      <box
+        width={width}
+        height={height}
+        overflow="hidden"
+        onMouseDown={(event) => {
+          const hit = workbenchShellHitTest(projection(), event.x, event.y);
+          if (hit?.kind === "dock-tab") {
+            activeValue = hit.tabId;
+            focusValue = "dock-tabs";
+            setActive(activeValue);
+            setFocus(focusValue);
+            calls.push(`mouse:tab:${hit.tabId}`);
+          } else if (hit?.kind === "dock-action") {
+            modeValue = hit.nextMode;
+            setMode(modeValue);
+            calls.push(`mouse:action:${hit.actionId}`);
+          }
+        }}
+      >
+        <WorkbenchShell
+          theme={theme}
+          projection={projection()}
+          canvas={
+            <box
+              width={projection().canvasBody.width}
+              height={projection().canvasBody.height}
+              flexDirection="column"
+              overflow="hidden"
+            >
+              <SelectableRow
+                theme={theme}
+                label="Agent canvas"
+                meta={`${projection().variant} · 3 agents`}
+                width={projection().canvasBody.width}
+                selected
+              />
+              <SelectableRow
+                theme={theme}
+                label="Fable · project manager"
+                meta="working"
+                width={projection().canvasBody.width}
+                focused={projection().focusZone === "canvas"}
+                status="working"
+                tone="working"
+              />
+              <SelectableRow
+                theme={theme}
+                label="Codex implementer 1 · terminal %7"
+                meta="task M31.3"
+                width={projection().canvasBody.width}
+              />
+              <SelectableRow
+                theme={theme}
+                label="Codex implementer 2 · ready"
+                meta="gpt-5.5"
+                width={projection().canvasBody.width}
+              />
+            </box>
+          }
+          dockBody={
+            <box
+              width={projection().dockBodyContent.width}
+              height={projection().dockBodyContent.height}
+              flexDirection="column"
+              overflow="hidden"
+            >
+              <SelectableRow
+                theme={theme}
+                label={`${active()} dock`}
+                meta={`${mode()} · preferred ${preferredHeight} rows`}
+                width={projection().dockBodyContent.width}
+                selected
+              />
+              <SelectableRow
+                theme={theme}
+                label="Full application parity"
+                meta="7 / 20 cards"
+                width={projection().dockBodyContent.width}
+                focused={projection().focusZone === "dock-body"}
+              />
+              <SelectableRow
+                theme={theme}
+                label="Workbench dock projection"
+                meta="in progress"
+                width={projection().dockBodyContent.width}
+                status="working"
+                tone="working"
+              />
+            </box>
+          }
+        />
+      </box>
+    );
+  }
+
+  const setup = await renderForTest(() => <Harness />, { width, height });
+  await setup.renderOnce();
+  return {
+    setup,
+    calls,
+    mode: () => modeValue,
+    active: () => activeValue,
+    focus: () => focusValue,
+    projection: () =>
+      projectWorkbenchShell({
+        width,
+        height,
+        dockMode: modeValue,
+        persistedDockHeight: preferredHeight,
+        activeDockTab: activeValue,
+        focusZone: focusValue,
+        hoveredDockTab: null,
+        attentionDockTabs: new Set(["activity"]),
+      }),
+    frame: () => setup.captureCharFrame(),
+  };
+}
+
+describe("WorkbenchShell OpenTUI renderer", () => {
+  it.each([
+    [80, 24, "compact"],
+    [120, 40, "standard"],
+    [200, 60, "wide"],
+  ] as const)(
+    "renders the %sx%s %s agent canvas and bottom dock",
+    async (width, height, variant) => {
+      const harness = await renderWorkbench(width, height);
+      const frame = harness.frame();
+      expectFrameBounds(frame, width, height);
+      expect(harness.projection().variant).toBe(variant);
+      expect(stableFrame(frame)).toMatchSnapshot();
+      expect(stableFrame(frame)).toContain("Agent canvas");
+      expect(stableFrame(frame)).toContain("Missions");
+      expect(stableFrame(frame)).toContain("Activity");
+      expect(stableFrame(frame)).toContain("preferred");
+    },
+  );
+
+  it("leaves input ownership in the harness while routing projected dock cells", async () => {
+    const harness = await renderWorkbench(120, 40);
+    const files = harness.projection().tabs.find((tab) => tab.id === "files")!;
+    await harness.setup.mockMouse.click(
+      files.x + Math.floor(files.width / 2),
+      harness.projection().dockTabs.y,
+      MouseButtons.LEFT,
+    );
+    await harness.setup.renderOnce();
+    expect(harness.active()).toBe("files");
+    expect(harness.focus()).toBe("dock-tabs");
+
+    const collapse = harness
+      .projection()
+      .actions.find((action) => action.id === "toggle-collapse")!;
+    await harness.setup.mockMouse.click(
+      collapse.x + Math.floor(collapse.width / 2),
+      harness.projection().dockTabs.y,
+      MouseButtons.LEFT,
+    );
+    await harness.setup.renderOnce();
+    expect(harness.mode()).toBe("collapsed");
+    expect(harness.projection().dockBody.height).toBe(0);
+    expect(stableFrame(harness.frame())).not.toContain("preferred");
+
+    const reopen = harness.projection().actions.find((action) => action.id === "toggle-collapse")!;
+    await harness.setup.mockMouse.click(
+      reopen.x + Math.floor(reopen.width / 2),
+      harness.projection().dockTabs.y,
+      MouseButtons.LEFT,
+    );
+    await harness.setup.renderOnce();
+    expect(harness.mode()).toBe("open");
+
+    const maximize = harness
+      .projection()
+      .actions.find((action) => action.id === "toggle-maximize")!;
+    await harness.setup.mockMouse.click(
+      maximize.x + Math.floor(maximize.width / 2),
+      harness.projection().dockTabs.y,
+      MouseButtons.LEFT,
+    );
+    await harness.setup.renderOnce();
+    expect(harness.mode()).toBe("maximized");
+    expect(harness.projection().canvas.height).toBe(0);
+
+    harness.setup.mockInput.pressTab();
+    await harness.setup.renderOnce();
+    expect(harness.focus()).toBe("canvas");
+    expect(harness.projection().focusZone).toBe("dock-body");
+    expect(harness.calls).toEqual([
+      "mouse:tab:files",
+      "mouse:action:toggle-collapse",
+      "mouse:action:toggle-collapse",
+      "mouse:action:toggle-maximize",
+      "keyboard:canvas",
+    ]);
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace/workbench-shell.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/workbench-shell.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectWorkbenchShell,
+  moveWorkbenchDockTab,
+  workbenchShellHitTest,
+  workbenchVariant,
+  type WorkbenchDockTabId,
+  type WorkbenchShellInput,
+} from "./workbench-shell.ts";
+
+const DOCK_EXCLUDES_TERMINAL_AND_HOME: Extract<
+  WorkbenchDockTabId,
+  "terminals" | "home"
+> extends never
+  ? true
+  : false = true;
+
+function input(overrides: Partial<WorkbenchShellInput> = {}): WorkbenchShellInput {
+  return {
+    width: 120,
+    height: 40,
+    dockMode: "open",
+    persistedDockHeight: 14,
+    activeDockTab: "missions",
+    focusZone: "canvas",
+    hoveredDockTab: null,
+    attentionDockTabs: new Set(["activity"]),
+    ...overrides,
+  };
+}
+
+describe("WorkbenchShell projection", () => {
+  it.each([
+    [80, 24, "compact"],
+    [120, 40, "standard"],
+    [200, 60, "wide"],
+  ] as const)("projects a bounded %s×%s %s workbench", (width, height, variant) => {
+    expect(workbenchVariant(width, height)).toBe(variant);
+    const projection = projectWorkbenchShell(input({ width, height }));
+    expect(projection.variant).toBe(variant);
+    expect(projection.canvas.height + projection.dock.height).toBe(height);
+    expect(projection.canvasBody.width + projection.canvasRail.width).toBe(width);
+    expect(projection.dockBodyContent.width + projection.dockBodyRail.width).toBe(width);
+    expect(projection.dock.y).toBe(projection.canvas.height);
+    expect(projection.tabs.map((tab) => tab.id)).toEqual([
+      "files",
+      "changes",
+      "missions",
+      "activity",
+    ]);
+    expect(
+      [...projection.tabs, ...projection.actions].every(
+        (item) => item.x >= 0 && item.x + item.width <= width,
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves the persisted open height while resolving all three dock modes", () => {
+    const collapsed = projectWorkbenchShell(
+      input({ dockMode: "collapsed", persistedDockHeight: 15 }),
+    );
+    const open = projectWorkbenchShell(input({ dockMode: "open", persistedDockHeight: 15 }));
+    const maximized = projectWorkbenchShell(
+      input({ dockMode: "maximized", persistedDockHeight: 15 }),
+    );
+
+    expect(collapsed.persistedDockHeight).toBe(15);
+    expect(open.persistedDockHeight).toBe(15);
+    expect(maximized.persistedDockHeight).toBe(15);
+    expect(collapsed.dock.height).toBe(1);
+    expect(open.dock.height).toBe(15);
+    expect(maximized.dock.height).toBe(40);
+    expect(collapsed.dockBody.height).toBe(0);
+    expect(open.canvas.height).toBe(25);
+    expect(maximized.canvas.height).toBe(0);
+    expect(maximized.actions.find((action) => action.id === "toggle-maximize")).toMatchObject({
+      nextMode: "open",
+      active: true,
+    });
+  });
+
+  it("clamps the open dock without replacing the user's persisted preference", () => {
+    const tooSmall = projectWorkbenchShell(input({ persistedDockHeight: 2 }));
+    const tooLarge = projectWorkbenchShell(input({ persistedDockHeight: 200 }));
+    expect(tooSmall.persistedDockHeight).toBe(2);
+    expect(tooSmall.dock.height).toBe(tooSmall.constraints.minimumOpenDockHeight);
+    expect(tooLarge.persistedDockHeight).toBe(200);
+    expect(tooLarge.dock.height).toBe(tooLarge.constraints.maximumOpenDockHeight);
+    expect(tooLarge.canvas.height).toBe(tooLarge.constraints.minimumCanvasHeight);
+  });
+
+  it("resolves focus away from unavailable canvas and dock-body zones", () => {
+    expect(
+      projectWorkbenchShell(input({ dockMode: "maximized", focusZone: "canvas" })).focusZone,
+    ).toBe("dock-body");
+    expect(
+      projectWorkbenchShell(input({ dockMode: "collapsed", focusZone: "dock-body" })).focusZone,
+    ).toBe("dock-tabs");
+    const tiny = projectWorkbenchShell(
+      input({ height: 1, dockMode: "maximized", focusZone: "canvas" }),
+    );
+    expect(tiny.dockMode).toBe("collapsed");
+    expect(tiny.focusZone).toBe("dock-tabs");
+  });
+
+  it("projects exact canvas, tab, action, and dock-body hit cells", () => {
+    const projection = projectWorkbenchShell(input());
+    expect(workbenchShellHitTest(projection, projection.canvasBody.x + 4, 4)).toEqual({
+      kind: "canvas",
+      localX: 4,
+      localY: 4,
+    });
+    expect(workbenchShellHitTest(projection, projection.canvasRail.x, 4)).toEqual({
+      kind: "canvas-rail",
+    });
+
+    const files = projection.tabs.find((tab) => tab.id === "files")!;
+    expect(workbenchShellHitTest(projection, files.x, projection.dockTabs.y)).toEqual({
+      kind: "dock-tab",
+      tabId: "files",
+      index: 0,
+    });
+
+    const maximize = projection.actions.find((action) => action.id === "toggle-maximize")!;
+    expect(workbenchShellHitTest(projection, maximize.x, projection.dockTabs.y)).toEqual({
+      kind: "dock-action",
+      actionId: "toggle-maximize",
+      nextMode: "maximized",
+      index: 1,
+    });
+    expect(
+      workbenchShellHitTest(
+        projection,
+        projection.dockBodyContent.x + 5,
+        projection.dockBodyContent.y,
+      ),
+    ).toEqual({
+      kind: "dock-body",
+      tabId: "missions",
+      localX: 5,
+      localY: 0,
+    });
+    expect(
+      workbenchShellHitTest(projection, projection.dockBodyRail.x, projection.dockBodyRail.y),
+    ).toEqual({ kind: "dock-body-rail", tabId: "missions" });
+    expect(workbenchShellHitTest(projection, -1, 0)).toBeNull();
+    expect(workbenchShellHitTest(projection, projection.width, 0)).toBeNull();
+  });
+
+  it("keeps dock controls bounded when the workbench is only a few cells wide", () => {
+    for (const width of [0, 1, 2, 3, 6]) {
+      const projection = projectWorkbenchShell(input({ width, height: 8 }));
+      expect(
+        [...projection.tabs, ...projection.actions].every(
+          (item) => item.x >= 0 && item.width >= 0 && item.x + item.width <= width,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("keeps terminal and home out of the canonical dock contract", () => {
+    const projection = projectWorkbenchShell(input());
+    expect(DOCK_EXCLUDES_TERMINAL_AND_HOME).toBe(true);
+    expect(projection.tabs.map((tab) => tab.id)).toEqual([
+      "files",
+      "changes",
+      "missions",
+      "activity",
+    ]);
+    expect(projection.tabs.some((tab) => tab.id === ("terminals" as WorkbenchDockTabId))).toBe(
+      false,
+    );
+    expect(projection.tabs.some((tab) => tab.id === ("home" as WorkbenchDockTabId))).toBe(false);
+  });
+
+  it("keeps disabled tabs visible, inert, and out of keyboard traversal", () => {
+    const disabled = new Set<WorkbenchDockTabId>(["changes", "missions"]);
+    const projection = projectWorkbenchShell(
+      input({ activeDockTab: "changes", disabledDockTabs: disabled, focusZone: "dock-tabs" }),
+    );
+    expect(projection.requestedActiveDockTab).toBe("changes");
+    expect(projection.activeDockTab).toBe("activity");
+    expect(projection.tabs.find((tab) => tab.id === "changes")).toMatchObject({
+      disabled: true,
+      selected: false,
+      focused: false,
+    });
+    const changes = projection.tabs.find((tab) => tab.id === "changes")!;
+    expect(workbenchShellHitTest(projection, changes.x, projection.dockTabs.y)).toEqual({
+      kind: "dock-tabs",
+    });
+    expect(moveWorkbenchDockTab("files", "next", disabled)).toBe("activity");
+    expect(moveWorkbenchDockTab("activity", "previous", disabled)).toBe("files");
+  });
+
+  it("routes every padded tab/action edge and leaves the blank strip inert", () => {
+    const projection = projectWorkbenchShell(input());
+    const tabBarY = projection.dockTabs.y;
+    for (const [index, tab] of projection.tabs.entries()) {
+      const expected = { kind: "dock-tab", tabId: tab.id, index };
+      expect(workbenchShellHitTest(projection, tab.x, tabBarY)).toEqual(expected);
+      expect(workbenchShellHitTest(projection, tab.x + Math.floor(tab.width / 2), tabBarY)).toEqual(
+        expected,
+      );
+      expect(workbenchShellHitTest(projection, tab.x + tab.width - 1, tabBarY)).toEqual(expected);
+    }
+    for (const [index, action] of projection.actions.entries()) {
+      const expected = {
+        kind: "dock-action",
+        actionId: action.id,
+        nextMode: action.nextMode,
+        index,
+      };
+      expect(workbenchShellHitTest(projection, action.x, tabBarY)).toEqual(expected);
+      expect(
+        workbenchShellHitTest(projection, action.x + Math.floor(action.width / 2), tabBarY),
+      ).toEqual(expected);
+      expect(workbenchShellHitTest(projection, action.x + action.width - 1, tabBarY)).toEqual(
+        expected,
+      );
+    }
+    const blankX = projection.tabs.at(-1)!.x + projection.tabs.at(-1)!.width;
+    expect(blankX).toBeLessThan(projection.actions[0]!.x);
+    expect(workbenchShellHitTest(projection, blankX, tabBarY)).toEqual({ kind: "dock-tabs" });
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace/workbench-shell.ts
+++ b/packages/daemon/src/tui/mirror/workspace/workbench-shell.ts
@@ -1,0 +1,435 @@
+import { terminalDisplayWidth } from "../panel-host.ts";
+import type { Rect } from "../recipes.ts";
+import { clipWorkspaceText } from "./text.ts";
+
+export type WorkbenchVariant = "compact" | "standard" | "wide";
+export type WorkbenchDockMode = "collapsed" | "open" | "maximized";
+export type WorkbenchFocusZone = "canvas" | "dock-tabs" | "dock-body";
+export type WorkbenchDockTabId = "files" | "changes" | "missions" | "activity";
+export type WorkbenchDockActionId = "toggle-collapse" | "toggle-maximize";
+
+export interface WorkbenchShellInput {
+  width: number;
+  height: number;
+  dockMode: WorkbenchDockMode;
+  /** Last user-selected open height. Collapsing or maximizing never replaces it. */
+  persistedDockHeight: number;
+  activeDockTab: WorkbenchDockTabId;
+  focusZone: WorkbenchFocusZone;
+  hoveredDockTab?: WorkbenchDockTabId | null;
+  attentionDockTabs?: ReadonlySet<WorkbenchDockTabId>;
+  disabledDockTabs?: ReadonlySet<WorkbenchDockTabId>;
+}
+
+export interface WorkbenchDockConstraints {
+  minimumCanvasHeight: number;
+  minimumOpenDockHeight: number;
+  maximumOpenDockHeight: number;
+  preferredOpenDockHeight: number;
+}
+
+export interface WorkbenchDockTabProjection {
+  id: WorkbenchDockTabId;
+  title: string;
+  label: string;
+  shortcut: string;
+  selected: boolean;
+  focused: boolean;
+  hovered: boolean;
+  attention: boolean;
+  disabled: boolean;
+  x: number;
+  width: number;
+}
+
+export interface WorkbenchDockActionProjection {
+  id: WorkbenchDockActionId;
+  label: string;
+  description: string;
+  nextMode: WorkbenchDockMode;
+  active: boolean;
+  x: number;
+  width: number;
+}
+
+export interface WorkbenchShellProjection {
+  width: number;
+  height: number;
+  variant: WorkbenchVariant;
+  requestedDockMode: WorkbenchDockMode;
+  dockMode: WorkbenchDockMode;
+  persistedDockHeight: number;
+  focusZone: WorkbenchFocusZone;
+  constraints: WorkbenchDockConstraints;
+  canvas: Rect;
+  canvasRail: Rect;
+  canvasBody: Rect;
+  dock: Rect;
+  dockTabs: Rect;
+  dockBody: Rect;
+  dockBodyRail: Rect;
+  dockBodyContent: Rect;
+  tabs: readonly WorkbenchDockTabProjection[];
+  actions: readonly WorkbenchDockActionProjection[];
+  requestedActiveDockTab: WorkbenchDockTabId;
+  activeDockTab: WorkbenchDockTabId;
+}
+
+export type WorkbenchShellHit =
+  | { kind: "canvas"; localX: number; localY: number }
+  | { kind: "canvas-rail" }
+  | { kind: "dock-tab"; tabId: WorkbenchDockTabId; index: number }
+  | {
+      kind: "dock-action";
+      actionId: WorkbenchDockActionId;
+      nextMode: WorkbenchDockMode;
+      index: number;
+    }
+  | { kind: "dock-tabs" }
+  | { kind: "dock-body"; tabId: WorkbenchDockTabId; localX: number; localY: number }
+  | { kind: "dock-body-rail"; tabId: WorkbenchDockTabId }
+  | null;
+
+interface DockTabDefinition {
+  id: WorkbenchDockTabId;
+  title: string;
+  compactTitle: string;
+  glyph: string;
+  shortcut: string;
+}
+
+const DOCK_TABS: readonly DockTabDefinition[] = [
+  { id: "files", title: "Files", compactTitle: "Files", glyph: "▤", shortcut: "F6" },
+  { id: "changes", title: "Changes", compactTitle: "Changes", glyph: "±", shortcut: "F7" },
+  { id: "missions", title: "Missions", compactTitle: "Missions", glyph: "◆", shortcut: "F8" },
+  { id: "activity", title: "Activity", compactTitle: "Activity", glyph: "◌", shortcut: "F9" },
+];
+
+const TAB_BAR_ROWS = 1;
+
+export function workbenchVariant(width: number, height: number): WorkbenchVariant {
+  if (width >= 160 && height >= 45) return "wide";
+  if (width >= 96 && height >= 30) return "standard";
+  return "compact";
+}
+
+/** Pure agent-canvas and bottom-dock geometry. Runtime stores remain outside. */
+export function projectWorkbenchShell(input: WorkbenchShellInput): WorkbenchShellProjection {
+  const width = nonNegativeInteger(input.width);
+  const height = nonNegativeInteger(input.height);
+  const persistedDockHeight = nonNegativeInteger(input.persistedDockHeight);
+  const variant = workbenchVariant(width, height);
+  const tabBarHeight = Math.min(TAB_BAR_ROWS, height);
+  const minimumCanvasHeight = Math.min(
+    minimumCanvasRows(variant),
+    Math.max(0, height - tabBarHeight - 1),
+  );
+  const maximumOpenDockHeight = Math.max(tabBarHeight, height - minimumCanvasHeight);
+  const minimumOpenDockHeight = Math.min(
+    Math.max(tabBarHeight, minimumDockRows(variant)),
+    maximumOpenDockHeight,
+  );
+  const preferredOpenDockHeight = clamp(
+    persistedDockHeight,
+    minimumOpenDockHeight,
+    maximumOpenDockHeight,
+  );
+  const dockMode = effectiveDockMode(input.dockMode, height);
+  const dockHeight =
+    dockMode === "collapsed"
+      ? tabBarHeight
+      : dockMode === "maximized"
+        ? height
+        : preferredOpenDockHeight;
+  const dockY = Math.max(0, height - dockHeight);
+  const canvas = rect(0, 0, width, dockY);
+  const dock = rect(0, dockY, width, dockHeight);
+  const dockTabs = rect(0, dockY, width, Math.min(tabBarHeight, dockHeight));
+  const dockBody = rect(
+    0,
+    dockTabs.y + dockTabs.height,
+    width,
+    Math.max(0, dockHeight - dockTabs.height),
+  );
+  const canvasRail = contentRail(canvas);
+  const canvasBody = contentBody(canvas);
+  const dockBodyRail = contentRail(dockBody);
+  const dockBodyContent = contentBody(dockBody);
+  const focusZone = effectiveFocusZone(input.focusZone, canvas, dockBody);
+  const activeDockTab = enabledDockTab(input.activeDockTab, input.disabledDockTabs);
+  const actions = projectDockActions(width, variant, dockMode);
+  const tabRight = Math.max(0, (actions[0]?.x ?? width) - (actions.length > 0 ? 1 : 0));
+  const tabs = projectDockTabs(input, variant, focusZone, tabRight, activeDockTab);
+
+  return {
+    width,
+    height,
+    variant,
+    requestedDockMode: input.dockMode,
+    dockMode,
+    persistedDockHeight,
+    focusZone,
+    constraints: {
+      minimumCanvasHeight,
+      minimumOpenDockHeight,
+      maximumOpenDockHeight,
+      preferredOpenDockHeight,
+    },
+    canvas,
+    canvasRail,
+    canvasBody,
+    dock,
+    dockTabs,
+    dockBody,
+    dockBodyRail,
+    dockBodyContent,
+    tabs,
+    actions,
+    requestedActiveDockTab: input.activeDockTab,
+    activeDockTab,
+  };
+}
+
+/** Pure keyboard-order helper. Disabled tabs stay visible but are skipped. */
+export function moveWorkbenchDockTab(
+  active: WorkbenchDockTabId,
+  direction: "next" | "previous",
+  disabled: ReadonlySet<WorkbenchDockTabId> = new Set(),
+): WorkbenchDockTabId {
+  const current = Math.max(
+    0,
+    DOCK_TABS.findIndex((tab) => tab.id === active),
+  );
+  const delta = direction === "next" ? 1 : -1;
+  for (let step = 1; step <= DOCK_TABS.length; step += 1) {
+    const index = (current + delta * step + DOCK_TABS.length) % DOCK_TABS.length;
+    const candidate = DOCK_TABS[index]!.id;
+    if (!disabled.has(candidate)) return candidate;
+  }
+  return active;
+}
+
+export function workbenchShellHitTest(
+  projection: WorkbenchShellProjection,
+  x: number,
+  y: number,
+): WorkbenchShellHit {
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  const cellX = Math.floor(x);
+  const cellY = Math.floor(y);
+  if (cellX < 0 || cellY < 0 || cellX >= projection.width || cellY >= projection.height) {
+    return null;
+  }
+
+  if (contains(projection.canvasBody, cellX, cellY)) {
+    return {
+      kind: "canvas",
+      localX: cellX - projection.canvasBody.x,
+      localY: cellY - projection.canvasBody.y,
+    };
+  }
+  if (contains(projection.canvasRail, cellX, cellY)) return { kind: "canvas-rail" };
+  if (contains(projection.dockTabs, cellX, cellY)) {
+    const actionIndex = projection.actions.findIndex(
+      (action) => cellX >= action.x && cellX < action.x + action.width,
+    );
+    const action = projection.actions[actionIndex];
+    if (action) {
+      return {
+        kind: "dock-action",
+        actionId: action.id,
+        nextMode: action.nextMode,
+        index: actionIndex,
+      };
+    }
+    const tabIndex = projection.tabs.findIndex(
+      (tab) => cellX >= tab.x && cellX < tab.x + tab.width,
+    );
+    const tab = projection.tabs[tabIndex];
+    return tab && !tab.disabled
+      ? { kind: "dock-tab", tabId: tab.id, index: tabIndex }
+      : { kind: "dock-tabs" };
+  }
+  if (contains(projection.dockBodyContent, cellX, cellY)) {
+    return {
+      kind: "dock-body",
+      tabId: projection.activeDockTab,
+      localX: cellX - projection.dockBodyContent.x,
+      localY: cellY - projection.dockBodyContent.y,
+    };
+  }
+  if (contains(projection.dockBodyRail, cellX, cellY)) {
+    return { kind: "dock-body-rail", tabId: projection.activeDockTab };
+  }
+  return null;
+}
+
+function projectDockTabs(
+  input: WorkbenchShellInput,
+  variant: WorkbenchVariant,
+  focusZone: WorkbenchFocusZone,
+  rightEdge: number,
+  activeDockTab: WorkbenchDockTabId,
+): WorkbenchDockTabProjection[] {
+  let x = 0;
+  return DOCK_TABS.map((definition, index) => {
+    const selected = definition.id === activeDockTab;
+    const attention = input.attentionDockTabs?.has(definition.id) ?? false;
+    const disabled = input.disabledDockTabs?.has(definition.id) ?? false;
+    const desired = dockTabLabel(definition, variant, selected, attention, disabled);
+    const remainingTabs = DOCK_TABS.length - index;
+    const available = Math.max(0, rightEdge - x);
+    const fairWidth = remainingTabs > 0 ? Math.floor(available / remainingTabs) : 0;
+    const label = clipWorkspaceText(desired, fairWidth);
+    const width = terminalDisplayWidth(label);
+    const projection: WorkbenchDockTabProjection = {
+      id: definition.id,
+      title: definition.title,
+      label,
+      shortcut: definition.shortcut,
+      selected,
+      focused: selected && focusZone === "dock-tabs" && !disabled,
+      hovered: input.hoveredDockTab === definition.id,
+      attention,
+      disabled,
+      x,
+      width,
+    };
+    x += width;
+    return projection;
+  });
+}
+
+function projectDockActions(
+  width: number,
+  variant: WorkbenchVariant,
+  mode: WorkbenchDockMode,
+): WorkbenchDockActionProjection[] {
+  const compact = variant === "compact" || width < 56;
+  const definitions: Omit<WorkbenchDockActionProjection, "x" | "width">[] = [
+    {
+      id: "toggle-collapse",
+      label: compact
+        ? mode === "collapsed"
+          ? " ▴ "
+          : " ▾ "
+        : mode === "collapsed"
+          ? " ▴ open "
+          : " ▾ close ",
+      description: mode === "collapsed" ? "Open bottom dock" : "Collapse bottom dock",
+      nextMode: mode === "collapsed" ? "open" : "collapsed",
+      active: mode !== "collapsed",
+    },
+    {
+      id: "toggle-maximize",
+      label: compact
+        ? mode === "maximized"
+          ? " ▣ "
+          : " □ "
+        : mode === "maximized"
+          ? " ▣ restore "
+          : " □ max ",
+      description: mode === "maximized" ? "Restore bottom dock" : "Maximize bottom dock",
+      nextMode: mode === "maximized" ? "open" : "maximized",
+      active: mode === "maximized",
+    },
+  ];
+  let gap = definitions.length > 1 ? 1 : 0;
+  let widths = definitions.map((definition) => terminalDisplayWidth(definition.label));
+  let total = widths.reduce((sum, value) => sum + value, 0) + gap;
+  if (total > width) {
+    definitions[0]!.label = mode === "collapsed" ? "▴" : "▾";
+    definitions[1]!.label = mode === "maximized" ? "▣" : "□";
+    gap = width >= 3 ? 1 : 0;
+    widths = definitions.map((definition) => terminalDisplayWidth(definition.label));
+    total = widths.reduce((sum, value) => sum + value, 0) + gap;
+  }
+  while (definitions.length > 0 && total > width) {
+    definitions.pop();
+    widths = definitions.map((definition) => terminalDisplayWidth(definition.label));
+    gap = definitions.length > 1 && width >= 3 ? 1 : 0;
+    total = widths.reduce((sum, value) => sum + value, 0) + gap;
+  }
+  let x = Math.max(0, width - total);
+  return definitions.map((definition, index) => {
+    const action = { ...definition, x, width: widths[index]! };
+    x += action.width + gap;
+    return action;
+  });
+}
+
+function dockTabLabel(
+  definition: DockTabDefinition,
+  variant: WorkbenchVariant,
+  selected: boolean,
+  attention: boolean,
+  disabled: boolean,
+): string {
+  const marker = disabled ? "×" : attention ? "!" : selected ? "●" : " ";
+  const title = variant === "compact" ? definition.compactTitle : definition.title;
+  const shortcut = variant === "wide" ? `${definition.shortcut} ` : "";
+  return ` ${shortcut}${marker}${definition.glyph} ${title} `;
+}
+
+function enabledDockTab(
+  requested: WorkbenchDockTabId,
+  disabled: ReadonlySet<WorkbenchDockTabId> | undefined,
+): WorkbenchDockTabId {
+  if (!disabled?.has(requested)) return requested;
+  return moveWorkbenchDockTab(requested, "next", disabled);
+}
+
+function minimumCanvasRows(variant: WorkbenchVariant): number {
+  if (variant === "wide") return 16;
+  if (variant === "standard") return 12;
+  return 8;
+}
+
+function minimumDockRows(variant: WorkbenchVariant): number {
+  if (variant === "wide") return 14;
+  if (variant === "standard") return 10;
+  return 7;
+}
+
+function effectiveDockMode(mode: WorkbenchDockMode, height: number): WorkbenchDockMode {
+  if (height <= TAB_BAR_ROWS) return "collapsed";
+  return mode;
+}
+
+function effectiveFocusZone(
+  requested: WorkbenchFocusZone,
+  canvas: Rect,
+  dockBody: Rect,
+): WorkbenchFocusZone {
+  if (requested === "canvas" && canvas.height === 0) {
+    return dockBody.height > 0 ? "dock-body" : "dock-tabs";
+  }
+  if (requested === "dock-body" && dockBody.height === 0) return "dock-tabs";
+  return requested;
+}
+
+function contentRail(area: Rect): Rect {
+  return rect(area.x, area.y, Math.min(1, area.width), area.height);
+}
+
+function contentBody(area: Rect): Rect {
+  const railWidth = Math.min(1, area.width);
+  return rect(area.x + railWidth, area.y, Math.max(0, area.width - railWidth), area.height);
+}
+
+function contains(area: Rect, x: number, y: number): boolean {
+  return x >= area.x && x < area.x + area.width && y >= area.y && y < area.y + area.height;
+}
+
+function nonNegativeInteger(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+function rect(x: number, y: number, width: number, height: number): Rect {
+  return { x, y, width, height };
+}

--- a/packages/daemon/src/tui/mirror/workspace/workbench-shell.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/workbench-shell.tsx
@@ -1,0 +1,168 @@
+/* @jsxImportSource @opentui/solid */
+import type { JSX } from "@opentui/solid";
+import { For, Show } from "solid-js";
+import { recipePalette } from "../recipes.ts";
+import type { SemanticThemeSnapshot } from "../theme.ts";
+import type {
+  WorkbenchDockActionProjection,
+  WorkbenchDockTabProjection,
+  WorkbenchShellProjection,
+} from "./workbench-shell.ts";
+
+export interface WorkbenchShellProps {
+  theme: SemanticThemeSnapshot;
+  projection: WorkbenchShellProjection;
+  canvas: JSX.Element;
+  dockBody: JSX.Element;
+}
+
+/**
+ * Presentational agent canvas and bottom dock. The application root owns all
+ * keyboard, pointer, persistence, runtime, and renderer lifecycle behavior.
+ */
+export function WorkbenchShell(props: WorkbenchShellProps) {
+  const canvasFocused = () => props.projection.focusZone === "canvas";
+  const dockBodyFocused = () => props.projection.focusZone === "dock-body";
+  return (
+    <box
+      width={props.projection.width}
+      height={props.projection.height}
+      flexDirection="column"
+      backgroundColor={props.theme.colors.background}
+      overflow="hidden"
+    >
+      <box
+        width={props.projection.canvas.width}
+        height={props.projection.canvas.height}
+        flexDirection="row"
+        backgroundColor={props.theme.colors.background}
+        overflow="hidden"
+      >
+        <FocusRail
+          theme={props.theme}
+          width={props.projection.canvasRail.width}
+          height={props.projection.canvasRail.height}
+          focused={canvasFocused()}
+        />
+        <box
+          width={props.projection.canvasBody.width}
+          height={props.projection.canvasBody.height}
+          flexDirection="column"
+          overflow="hidden"
+        >
+          {props.canvas}
+        </box>
+      </box>
+
+      <DockTabBar theme={props.theme} projection={props.projection} />
+
+      <Show when={props.projection.dockBody.height > 0}>
+        <box
+          width={props.projection.dockBody.width}
+          height={props.projection.dockBody.height}
+          flexDirection="row"
+          backgroundColor={props.theme.colors.surface}
+          overflow="hidden"
+        >
+          <FocusRail
+            theme={props.theme}
+            width={props.projection.dockBodyRail.width}
+            height={props.projection.dockBodyRail.height}
+            focused={dockBodyFocused()}
+          />
+          <box
+            width={props.projection.dockBodyContent.width}
+            height={props.projection.dockBodyContent.height}
+            flexDirection="column"
+            overflow="hidden"
+          >
+            {props.dockBody}
+          </box>
+        </box>
+      </Show>
+    </box>
+  );
+}
+
+function DockTabBar(props: { theme: SemanticThemeSnapshot; projection: WorkbenchShellProjection }) {
+  return (
+    <box
+      width={props.projection.dockTabs.width}
+      height={props.projection.dockTabs.height}
+      position="relative"
+      backgroundColor={props.theme.colors.surfaceRaised}
+      overflow="hidden"
+    >
+      <For each={props.projection.tabs}>{(tab) => <DockTab theme={props.theme} tab={tab} />}</For>
+      <For each={props.projection.actions}>
+        {(action) => <DockAction theme={props.theme} action={action} />}
+      </For>
+    </box>
+  );
+}
+
+function DockTab(props: { theme: SemanticThemeSnapshot; tab: WorkbenchDockTabProjection }) {
+  const palette = () =>
+    recipePalette(props.theme, {
+      selected: props.tab.selected,
+      focused: props.tab.focused,
+      hovered: props.tab.hovered,
+      attention: props.tab.attention,
+      disabled: props.tab.disabled,
+    });
+  return (
+    <box
+      position="absolute"
+      left={props.tab.x}
+      top={0}
+      width={props.tab.width}
+      height={1}
+      backgroundColor={palette().background}
+      overflow="hidden"
+    >
+      <text fg={palette().foreground} attributes={props.tab.focused ? 1 : 0}>
+        {props.tab.label}
+      </text>
+    </box>
+  );
+}
+
+function DockAction(props: {
+  theme: SemanticThemeSnapshot;
+  action: WorkbenchDockActionProjection;
+}) {
+  const palette = () => recipePalette(props.theme, { selected: props.action.active });
+  return (
+    <box
+      position="absolute"
+      left={props.action.x}
+      top={0}
+      width={props.action.width}
+      height={1}
+      backgroundColor={palette().background}
+      overflow="hidden"
+    >
+      <text fg={palette().foreground}>{props.action.label}</text>
+    </box>
+  );
+}
+
+function FocusRail(props: {
+  theme: SemanticThemeSnapshot;
+  width: number;
+  height: number;
+  focused: boolean;
+}) {
+  return (
+    <box
+      width={props.width}
+      height={props.height}
+      backgroundColor={props.theme.colors.background}
+      overflow="hidden"
+    >
+      <text fg={props.focused ? props.theme.colors.focus : props.theme.colors.border}>
+        {props.focused ? "▌" : "│"}
+      </text>
+    </box>
+  );
+}


### PR DESCRIPTION
## Summary
- add a pure responsive agent-canvas and bottom-workbench projection
- model Files, Changes, Missions, and Activity tabs with collapsed, open, and maximized modes
- add exact keyboard-order and pointer geometry, disabled tabs, focus zones, and preserved dock height
- add a presentational Solid/OpenTUI renderer with 80x24, 120x40, and 200x60 snapshots

## Boundary
This card deliberately has no production runtime wiring. tmux, filesystem, mission repositories, input ownership, and renderer lifecycle remain outside the workspace presentation boundary for the next integration cards.

## Verification
- pnpm check
- pnpm build:tui
- pnpm test:tui-smoke
- focused model/boundary tests: 13 passed
- focused renderer suite: 4 passed, 3 snapshots