### PR TITLE
feat(tui): integrate native dock surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run typecheck:workspace && pnpm run test:unit && pnpm run test:tui-renderer && pnpm run docs:build && pnpm run pack:check && pnpm run check:native-deps",
     "postinstall": "node scripts/postinstall.js",
     "docs": "turbo run dev --filter=@tmux-ide/docs",
-    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/workbench-shell-renderer.test.tsx",
+    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/activity-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/workbench-shell-renderer.test.tsx",
     "test:tui-smoke": "node scripts/smoke-tui-missions.mjs"
   },
   "keywords": [

--- a/packages/daemon/src/tui/mirror/__snapshots__/activity-surface-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/__snapshots__/activity-surface-renderer.test.tsx.snap
@@ -1,0 +1,42 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`ActivitySurface OpenTUI renderer records the %sx%s compact native dock-body baseline 1`] = `
+" Activity · 6 updates · 1 attention · 1 blocked · 1 working
+● Codex 5.5: Building native Activity        12:48 working█
+● mission M31: Files surface verified           12:47 done█
+● ! review: Card 04 needs attention            now blocked░
+● Claude: Waiting for integration               12:44 idle░
+ 1-4 of 6"
+`;
+
+exports[`ActivitySurface OpenTUI renderer records the %sx%s standard native dock-body baseline 1`] = `
+" Activity · 6 updates · 1 attention · 1 blocked · 1 working
+● agent Codex 5.5 · Building native Activity                                12:48 · working
+● event mission M31 · Files surface verified                                   12:47 · done
+● ! event review · Card 04 needs attention                                    now · blocked
+● agent Claude · Waiting for integration                                       12:44 · idle
+● event workspace · Activity feed refreshed                                 12:42 · unknown
+● agent 設計 agent · Checked responsive rows                                   12:40 · done
+
+
+ j/k select · 1-6 of 6"
+`;
+
+exports[`ActivitySurface OpenTUI renderer records the %sx%s wide native dock-body baseline 1`] = `
+" Activity · 6 updates · 1 attention · 1 blocked · 1 working
+● agent Codex 5.5 · Building native Activity — projection and renderer                                                                                      12:48 · working
+● event mission M31 · Files surface verified — 47 tests passed                                                                                                 12:47 · done
+● ! event review · Card 04 needs attention — one renderer snapshot changed                                                                                    now · blocked
+● agent Claude · Waiting for integration                                                                                                                       12:44 · idle
+● event workspace · Activity feed refreshed                                                                                                                 12:42 · unknown
+● agent 設計 agent · Checked responsive rows — compact, standard, and wide                                                                                     12:40 · done
+
+
+
+
+
+
+
+
+ j/k select · enter inspect · 1-6 of 6"
+`;

--- a/packages/daemon/src/tui/mirror/activity-surface-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/activity-surface-renderer.test.tsx
@@ -1,0 +1,141 @@
+/* @jsxImportSource @opentui/solid */
+import { describe, expect, it } from "bun:test";
+import { createSemanticThemeSnapshot } from "./theme.ts";
+import { expectFrameBounds, renderForTest, stableFrame } from "./testing/renderer-harness.test.ts";
+import {
+  projectActivitySurface,
+  type ActivityRowDto,
+  type ActivitySurfaceVariant,
+} from "./activity-surface.ts";
+import { ActivitySurface } from "./activity-surface.tsx";
+
+const ROWS: readonly ActivityRowDto[] = [
+  {
+    kind: "event",
+    id: "evt-review",
+    sequence: 104,
+    timestampText: "now",
+    source: "review",
+    message: "Card 04 needs attention",
+    detail: "one renderer snapshot changed",
+    status: "blocked",
+    attention: true,
+  },
+  {
+    kind: "agent",
+    id: "agent-codex",
+    sequence: 106,
+    timestampText: "12:48",
+    agent: "Codex 5.5",
+    message: "Building native Activity",
+    detail: "projection and renderer",
+    status: "working",
+  },
+  {
+    kind: "event",
+    id: "evt-proof",
+    sequence: 105,
+    timestampText: "12:47",
+    source: "mission M31",
+    message: "Files surface verified",
+    detail: "47 tests passed",
+    status: "done",
+  },
+  {
+    kind: "agent",
+    id: "agent-claude",
+    sequence: 103,
+    timestampText: "12:44",
+    agent: "Claude",
+    message: "Waiting for integration",
+    status: "idle",
+  },
+  {
+    kind: "event",
+    id: "evt-refresh",
+    sequence: 102,
+    timestampText: "12:42",
+    source: "workspace",
+    message: "Activity feed refreshed",
+    status: "unknown",
+  },
+  {
+    kind: "agent",
+    id: "agent-unicode",
+    sequence: 101,
+    timestampText: "12:40",
+    agent: "設計 agent",
+    message: "Checked responsive rows",
+    detail: "compact, standard, and wide",
+    status: "done",
+  },
+];
+
+async function renderActivity(width: number, height: number, selectedRowId = "evt-review") {
+  const projection = projectActivitySurface({
+    width,
+    height,
+    state: "ready",
+    rows: ROWS,
+    selectedRowId,
+    scrollOffset: 0,
+  });
+  const theme = createSemanticThemeSnapshot({ mode: "dark" });
+  const setup = await renderForTest(
+    () => <ActivitySurface theme={theme} projection={projection} />,
+    { width, height },
+  );
+  await setup.renderOnce();
+  return { setup, projection, frame: () => setup.captureCharFrame() };
+}
+
+describe("ActivitySurface OpenTUI renderer", () => {
+  it.each([
+    [59, 6, "compact"],
+    [91, 10, "standard"],
+    [171, 16, "wide"],
+  ] as const)(
+    "records the %sx%s %s native dock-body baseline",
+    async (width, height, variant: ActivitySurfaceVariant) => {
+      const harness = await renderActivity(width, height);
+      const frame = harness.frame();
+      expectFrameBounds(frame, width, height);
+      expect(harness.projection.variant).toBe(variant);
+      expect(stableFrame(frame)).toMatchSnapshot();
+      expect(stableFrame(frame)).toContain("Activity");
+      expect(stableFrame(frame)).toContain("Codex 5.5");
+      expect(stableFrame(frame)).toContain("blocked");
+    },
+  );
+
+  it.each([
+    ["loading", "Loading activity"],
+    ["empty", "No activity yet"],
+    ["error", "Activity unavailable"],
+  ] as const)(
+    "renders the %s state through the same presentational boundary",
+    async (state, text) => {
+      const width = 59;
+      const height = 6;
+      const projection = projectActivitySurface({
+        width,
+        height,
+        state,
+        rows: ROWS,
+        selectedRowId: null,
+        scrollOffset: 0,
+      });
+      const setup = await renderForTest(
+        () => (
+          <ActivitySurface
+            theme={createSemanticThemeSnapshot({ mode: "dark" })}
+            projection={projection}
+          />
+        ),
+        { width, height },
+      );
+      await setup.renderOnce();
+      expect(stableFrame(setup.captureCharFrame())).toContain(text);
+    },
+  );
+});

--- a/packages/daemon/src/tui/mirror/activity-surface.test.ts
+++ b/packages/daemon/src/tui/mirror/activity-surface.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+  activityOrderSequence,
+  activityRowHitTest,
+  activitySurfaceVariant,
+  clampActivityScrollOffset,
+  orderActivityRows,
+  projectActivitySurface,
+  type ActivityRowDto,
+  type ActivitySurfaceInput,
+} from "./activity-surface.ts";
+
+const ROWS: readonly ActivityRowDto[] = [
+  {
+    kind: "event",
+    id: "evt-older",
+    sequence: 7,
+    timestampText: "12:01",
+    source: "mission",
+    message: "Goal created",
+    status: "idle",
+  },
+  {
+    kind: "agent",
+    id: "agent-z",
+    sequence: 9,
+    timestampText: "12:03",
+    agent: "Codex",
+    message: "Implemented activity projection",
+    detail: "tests pending",
+    status: "working",
+  },
+  {
+    kind: "event",
+    id: "event-a",
+    sequence: 9,
+    timestampText: "12:02",
+    source: "quality gate",
+    message: "Renderer failed",
+    status: "blocked",
+    attention: true,
+  },
+];
+
+function input(overrides: Partial<ActivitySurfaceInput> = {}): ActivitySurfaceInput {
+  return {
+    width: 91,
+    height: 10,
+    state: "ready",
+    rows: ROWS,
+    selectedRowId: "agent-z",
+    scrollOffset: 0,
+    ...overrides,
+  };
+}
+
+describe("ActivitySurface projection", () => {
+  it.each([
+    [59, 6, "compact"],
+    [91, 10, "standard"],
+    [171, 16, "wide"],
+  ] as const)("uses the %sx%s %s dock-body projection", (width, height, variant) => {
+    expect(activitySurfaceVariant(width, height)).toBe(variant);
+    const projection = projectActivitySurface(input({ width, height }));
+    expect(projection.variant).toBe(variant);
+    expect(projection.header.height + projection.body.height + projection.footer.height).toBe(
+      height,
+    );
+    expect(projection.list.width + projection.scrollbar.width).toBe(width);
+    expect(
+      projection.rows.every(
+        (row) =>
+          row.x >= 0 &&
+          row.y >= projection.body.y &&
+          row.x + row.width <= width &&
+          row.y + row.height <= projection.footer.y,
+      ),
+    ).toBe(true);
+  });
+
+  it("orders newest first and breaks equal sequences by stable identity", () => {
+    expect(orderActivityRows(ROWS).map((row) => row.id)).toEqual([
+      "agent-z",
+      "event-a",
+      "evt-older",
+    ]);
+    expect(orderActivityRows([...ROWS].reverse()).map((row) => row.id)).toEqual([
+      "agent-z",
+      "event-a",
+      "evt-older",
+    ]);
+  });
+
+  it("normalizes agent epoch-seconds and mission ISO timestamps into one order", () => {
+    const rows: ActivityRowDto[] = [
+      {
+        kind: "agent",
+        id: "agent-old",
+        sequence: activityOrderSequence(1_700_000_000),
+        timestampText: "12:03",
+        agent: "Codex",
+        message: "working",
+        status: "working",
+      },
+      {
+        kind: "event",
+        id: "mission-new",
+        sequence: activityOrderSequence("2024-07-22T12:04:00.000Z", 4),
+        timestampText: "12:04",
+        source: "mission",
+        message: "completed",
+        status: "done",
+      },
+    ];
+    expect(orderActivityRows(rows).map((row) => row.id)).toEqual(["mission-new", "agent-old"]);
+  });
+
+  it.each([
+    ["loading", "Loading recent agent"],
+    ["empty", "Agent work and mission"],
+    ["error", "Activity could not be loaded"],
+  ] as const)("projects the %s state without stale rows", (state, message) => {
+    const projection = projectActivitySurface(input({ state }));
+    expect(projection.state).toBe(state);
+    expect(projection.rows).toEqual([]);
+    expect(projection.message).toContain(message);
+  });
+
+  it("coerces ready-without-rows to the useful empty state", () => {
+    expect(projectActivitySurface(input({ rows: [] }))).toMatchObject({
+      state: "empty",
+      totalRows: 0,
+      rows: [],
+      selectedRowId: null,
+      selectedRowIndex: -1,
+    });
+  });
+
+  it("counts explicit attention and status text independently from selection", () => {
+    const projection = projectActivitySurface(input({ selectedRowId: "event-a" }));
+    expect(projection.attentionCount).toBe(1);
+    expect(projection.statusCounts).toEqual({
+      blocked: 1,
+      working: 1,
+      done: 0,
+      idle: 1,
+      unknown: 0,
+    });
+    expect(projection.summary).toContain("1 attention");
+    expect(projection.rows.find((row) => row.id === "event-a")).toMatchObject({
+      selected: true,
+      attention: true,
+      statusText: "blocked",
+      timestampText: "12:02",
+    });
+  });
+
+  it("clamps scroll and follows a selected row into the visible window", () => {
+    const manyRows: ActivityRowDto[] = Array.from({ length: 12 }, (_, index) => ({
+      kind: "event",
+      id: `event-${String(index).padStart(2, "0")}`,
+      sequence: 12 - index,
+      timestampText: `${index}m`,
+      source: "mission",
+      message: `event ${index}`,
+      status: "unknown",
+    }));
+    expect(clampActivityScrollOffset(manyRows.length, 4, -20)).toBe(0);
+    expect(clampActivityScrollOffset(manyRows.length, 4, 200)).toBe(8);
+
+    const projection = projectActivitySurface(
+      input({
+        width: 59,
+        height: 6,
+        rows: manyRows,
+        selectedRowId: "event-10",
+        scrollOffset: 0,
+      }),
+    );
+    expect(projection.body.height).toBe(4);
+    expect(projection.maximumScrollOffset).toBe(8);
+    expect(projection.scrollOffset).toBe(7);
+    expect(projection.rows.map((row) => row.id)).toEqual([
+      "event-07",
+      "event-08",
+      "event-09",
+      "event-10",
+    ]);
+    expect(projection.rows.at(-1)?.selected).toBe(true);
+  });
+
+  it("hit-tests every projected row cell and rejects header, scrollbar, footer, and blanks", () => {
+    const manyRows = [...ROWS, ...ROWS.map((row, index) => ({ ...row, id: `${row.id}-${index}` }))];
+    const projection = projectActivitySurface(
+      input({ width: 59, height: 6, rows: manyRows, selectedRowId: null }),
+    );
+    const row = projection.rows[1]!;
+    const expected = {
+      kind: "row",
+      rowId: row.id,
+      rowIndex: row.rowIndex,
+      sequence: row.sequence,
+    };
+    expect(activityRowHitTest(projection, row.x, row.y)).toEqual(expected);
+    expect(activityRowHitTest(projection, row.x + row.width - 1, row.y)).toEqual(expected);
+    expect(activityRowHitTest(projection, 1, projection.header.y)).toBeNull();
+    expect(activityRowHitTest(projection, projection.scrollbar.x, row.y)).toBeNull();
+    expect(activityRowHitTest(projection, 1, projection.footer.y)).toBeNull();
+    expect(activityRowHitTest(projection, -1, row.y)).toBeNull();
+    expect(activityRowHitTest(projection, Number.NaN, row.y)).toBeNull();
+
+    const blank = projectActivitySurface(input({ rows: ROWS.slice(0, 1), selectedRowId: null }));
+    expect(activityRowHitTest(blank, 1, blank.body.y + 1)).toBeNull();
+  });
+});

--- a/packages/daemon/src/tui/mirror/activity-surface.ts
+++ b/packages/daemon/src/tui/mirror/activity-surface.ts
@@ -1,0 +1,430 @@
+import stringWidth from "string-width";
+
+export type ActivitySurfaceVariant = "compact" | "standard" | "wide";
+export type ActivitySurfaceState = "loading" | "empty" | "error" | "ready";
+export type ActivityRowStatus = "blocked" | "working" | "done" | "idle" | "unknown";
+
+export interface ActivityRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface ActivityRowDtoBase {
+  /** Stable adapter-owned identity. */
+  id: string;
+  /** Monotonic adapter-owned order. Larger values are newer. */
+  sequence: number;
+  /** Already-formatted display text, for example `12:48` or `2m ago`. */
+  timestampText: string;
+  message: string;
+  detail?: string;
+  status: ActivityRowStatus;
+  attention?: boolean;
+}
+
+export interface ActivityAgentRowDto extends ActivityRowDtoBase {
+  kind: "agent";
+  agent: string;
+}
+
+export interface ActivityEventRowDto extends ActivityRowDtoBase {
+  kind: "event";
+  source: string;
+}
+
+/**
+ * Runtime-neutral row boundary. Adapters may combine agent lifecycle and mission
+ * events before they reach this projection; this module never reads tmux,
+ * command-center, or mission persistence directly.
+ */
+export type ActivityRowDto = ActivityAgentRowDto | ActivityEventRowDto;
+
+export interface ActivitySurfaceInput {
+  width: number;
+  height: number;
+  state: ActivitySurfaceState;
+  rows: readonly ActivityRowDto[];
+  selectedRowId: string | null;
+  scrollOffset: number;
+  message?: string;
+}
+
+export interface ActivityProjectedRow extends ActivityRect {
+  id: string;
+  kind: ActivityRowDto["kind"];
+  rowIndex: number;
+  sequence: number;
+  timestampText: string;
+  status: ActivityRowStatus;
+  statusText: string;
+  sourceText: string;
+  label: string;
+  meta: string;
+  detail: string;
+  selected: boolean;
+  attention: boolean;
+}
+
+export interface ActivityScrollbarProjection extends ActivityRect {
+  glyphs: readonly string[];
+}
+
+export interface ActivitySurfaceProjection {
+  width: number;
+  height: number;
+  variant: ActivitySurfaceVariant;
+  state: ActivitySurfaceState;
+  header: ActivityRect;
+  body: ActivityRect;
+  list: ActivityRect;
+  footer: ActivityRect;
+  scrollbar: ActivityScrollbarProjection;
+  title: string;
+  summary: string;
+  message: string;
+  totalRows: number;
+  attentionCount: number;
+  statusCounts: Readonly<Record<ActivityRowStatus, number>>;
+  selectedRowId: string | null;
+  selectedRowIndex: number;
+  requestedScrollOffset: number;
+  scrollOffset: number;
+  maximumScrollOffset: number;
+  rows: readonly ActivityProjectedRow[];
+  footerText: string;
+}
+
+export interface ActivityRowHit {
+  kind: "row";
+  rowId: string;
+  rowIndex: number;
+  sequence: number;
+}
+
+const STATUS_ORDER: readonly ActivityRowStatus[] = [
+  "blocked",
+  "working",
+  "done",
+  "idle",
+  "unknown",
+];
+
+export function activitySurfaceVariant(width: number, height: number): ActivitySurfaceVariant {
+  const safeWidth = nonNegativeInteger(width);
+  const safeHeight = nonNegativeInteger(height);
+  if (safeWidth >= 140 && safeHeight >= 14) return "wide";
+  if (safeWidth >= 80 && safeHeight >= 9) return "standard";
+  return "compact";
+}
+
+/** Deterministic newest-first order, independent of the adapter's arrival order. */
+export function orderActivityRows(rows: readonly ActivityRowDto[]): readonly ActivityRowDto[] {
+  return rows
+    .map((row, inputIndex) => ({ row, inputIndex, sequence: finiteSequence(row.sequence) }))
+    .sort(
+      (left, right) =>
+        right.sequence - left.sequence ||
+        compareStableId(left.row.id, right.row.id) ||
+        left.inputIndex - right.inputIndex,
+    )
+    .map((entry) => entry.row);
+}
+
+/** Normalize adapter timestamps into one epoch-millisecond ordering domain.
+ * Agent `since` values are epoch seconds; mission events supply ISO timestamps. */
+export function activityOrderSequence(
+  timestamp: number | string | null | undefined,
+  fallback = 0,
+): number {
+  if (typeof timestamp === "string") {
+    const parsed = Date.parse(timestamp);
+    return Number.isFinite(parsed) ? Math.floor(parsed) : finiteSequence(fallback);
+  }
+  if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+    const milliseconds = Math.abs(timestamp) < 10_000_000_000 ? timestamp * 1_000 : timestamp;
+    return Math.floor(milliseconds);
+  }
+  return finiteSequence(fallback);
+}
+
+export function clampActivityScrollOffset(
+  rowCount: number,
+  viewportRows: number,
+  requested: number,
+): number {
+  const maximum = Math.max(0, nonNegativeInteger(rowCount) - nonNegativeInteger(viewportRows));
+  return clamp(nonNegativeInteger(requested), 0, maximum);
+}
+
+export function projectActivitySurface(input: ActivitySurfaceInput): ActivitySurfaceProjection {
+  const width = nonNegativeInteger(input.width);
+  const height = nonNegativeInteger(input.height);
+  const variant = activitySurfaceVariant(width, height);
+  const headerHeight = Math.min(1, height);
+  const footerHeight = height >= 4 ? 1 : 0;
+  const bodyY = headerHeight;
+  const bodyHeight = Math.max(0, height - headerHeight - footerHeight);
+  const orderedRows = orderActivityRows(input.rows);
+  const resolvedState: ActivitySurfaceState =
+    input.state === "ready" && orderedRows.length === 0 ? "empty" : input.state;
+  const rowSource = resolvedState === "ready" ? orderedRows : [];
+  const requestedScrollOffset = nonNegativeInteger(input.scrollOffset);
+  const maximumScrollOffset = Math.max(0, rowSource.length - bodyHeight);
+  const selectedRowIndex =
+    input.selectedRowId === null
+      ? -1
+      : rowSource.findIndex((row) => row.id === input.selectedRowId);
+  let scrollOffset = clampActivityScrollOffset(rowSource.length, bodyHeight, requestedScrollOffset);
+  if (selectedRowIndex >= 0 && bodyHeight > 0) {
+    if (selectedRowIndex < scrollOffset) scrollOffset = selectedRowIndex;
+    if (selectedRowIndex >= scrollOffset + bodyHeight) {
+      scrollOffset = selectedRowIndex - bodyHeight + 1;
+    }
+    scrollOffset = clamp(scrollOffset, 0, maximumScrollOffset);
+  }
+  const scrollbarWidth = rowSource.length > bodyHeight && bodyHeight > 0 && width > 0 ? 1 : 0;
+  const listWidth = Math.max(0, width - scrollbarWidth);
+  const body: ActivityRect = { x: 0, y: bodyY, width, height: bodyHeight };
+  const list: ActivityRect = { x: 0, y: bodyY, width: listWidth, height: bodyHeight };
+  const visible = rowSource.slice(scrollOffset, scrollOffset + bodyHeight);
+  const projectedRows = visible.map((row, visibleIndex) =>
+    projectActivityRow({
+      row,
+      rowIndex: scrollOffset + visibleIndex,
+      y: list.y + visibleIndex,
+      width: list.width,
+      variant,
+      selected: row.id === input.selectedRowId,
+    }),
+  );
+  const statusCounts = countStatuses(orderedRows);
+  const attentionCount = orderedRows.filter((row) => row.attention).length;
+  const summary = activitySummary(resolvedState, orderedRows.length, attentionCount, statusCounts);
+  return {
+    width,
+    height,
+    variant,
+    state: resolvedState,
+    header: { x: 0, y: 0, width, height: headerHeight },
+    body,
+    list,
+    footer: { x: 0, y: Math.max(0, height - footerHeight), width, height: footerHeight },
+    scrollbar: {
+      x: list.width,
+      y: body.y,
+      width: scrollbarWidth,
+      height: body.height,
+      glyphs: activityScrollbarGlyphs(rowSource.length, bodyHeight, scrollOffset),
+    },
+    title: "Activity",
+    summary,
+    message: activityMessage(resolvedState, input.message),
+    totalRows: orderedRows.length,
+    attentionCount,
+    statusCounts,
+    selectedRowId: selectedRowIndex >= 0 ? input.selectedRowId : null,
+    selectedRowIndex,
+    requestedScrollOffset,
+    scrollOffset,
+    maximumScrollOffset,
+    rows: projectedRows,
+    footerText: activityFooterText(variant, rowSource.length, scrollOffset, projectedRows.length),
+  };
+}
+
+/** Local-cell row hit testing. Header, footer, scrollbar, and blank body cells are inert. */
+export function activityRowHitTest(
+  projection: ActivitySurfaceProjection,
+  x: number,
+  y: number,
+): ActivityRowHit | null {
+  const cellX = Math.floor(x);
+  const cellY = Math.floor(y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  if (
+    cellX < projection.list.x ||
+    cellX >= projection.list.x + projection.list.width ||
+    cellY < projection.list.y ||
+    cellY >= projection.list.y + projection.list.height
+  ) {
+    return null;
+  }
+  const row = projection.rows.find(
+    (candidate) => cellY >= candidate.y && cellY < candidate.y + candidate.height,
+  );
+  return row
+    ? { kind: "row", rowId: row.id, rowIndex: row.rowIndex, sequence: row.sequence }
+    : null;
+}
+
+function projectActivityRow(input: {
+  row: ActivityRowDto;
+  rowIndex: number;
+  y: number;
+  width: number;
+  variant: ActivitySurfaceVariant;
+  selected: boolean;
+}): ActivityProjectedRow {
+  const sourceText = normalizedText(
+    input.row.kind === "agent" ? input.row.agent : input.row.source,
+    input.row.kind,
+  );
+  const message = normalizedText(input.row.message, "activity update");
+  const detail = normalizedText(input.row.detail ?? "", "");
+  const attentionPrefix = input.row.attention ? "! " : "";
+  const kindText = input.row.kind === "agent" ? "agent" : "event";
+  const labelText =
+    input.variant === "compact"
+      ? `${attentionPrefix}${sourceText}: ${message}`
+      : input.variant === "standard"
+        ? `${attentionPrefix}${kindText} ${sourceText} · ${message}`
+        : `${attentionPrefix}${kindText} ${sourceText} · ${message}${detail ? ` — ${detail}` : ""}`;
+  const timestampText = normalizedText(input.row.timestampText, "—");
+  const statusText = input.row.status;
+  const meta =
+    input.variant === "compact"
+      ? `${timestampText} ${statusText}`
+      : `${timestampText} · ${statusText}`;
+  return {
+    id: input.row.id,
+    kind: input.row.kind,
+    rowIndex: input.rowIndex,
+    sequence: finiteSequence(input.row.sequence),
+    timestampText,
+    status: input.row.status,
+    statusText,
+    sourceText,
+    label: clipActivityText(labelText, Math.max(0, input.width - 2)),
+    meta: clipActivityText(meta, Math.max(0, input.width - 2)),
+    detail,
+    selected: input.selected,
+    attention: input.row.attention ?? false,
+    x: 0,
+    y: input.y,
+    width: input.width,
+    height: 1,
+  };
+}
+
+function activitySummary(
+  state: ActivitySurfaceState,
+  total: number,
+  attention: number,
+  statuses: Readonly<Record<ActivityRowStatus, number>>,
+): string {
+  if (state === "loading") return "syncing agent and mission activity";
+  if (state === "error") return "activity unavailable";
+  if (state === "empty") return "no activity yet";
+  const parts = [`${total} ${total === 1 ? "update" : "updates"}`];
+  if (attention > 0) parts.push(`${attention} attention`);
+  for (const status of STATUS_ORDER) {
+    if (statuses[status] > 0 && (status === "blocked" || status === "working")) {
+      parts.push(`${statuses[status]} ${status}`);
+    }
+  }
+  return parts.join(" · ");
+}
+
+function activityMessage(state: ActivitySurfaceState, message: string | undefined): string {
+  const normalized = message?.trim();
+  if (normalized) return normalized;
+  if (state === "loading") return "Loading recent agent and mission events…";
+  if (state === "error") return "Activity could not be loaded. Try refreshing the workspace.";
+  if (state === "empty") return "Agent work and mission events will appear here.";
+  return "Newest activity first";
+}
+
+function activityFooterText(
+  variant: ActivitySurfaceVariant,
+  total: number,
+  scrollOffset: number,
+  visibleRows: number,
+): string {
+  const range =
+    total === 0
+      ? "0 updates"
+      : `${scrollOffset + 1}-${Math.min(total, scrollOffset + visibleRows)} of ${total}`;
+  if (variant === "compact") return range;
+  if (variant === "standard") return `j/k select · ${range}`;
+  return `j/k select · enter inspect · ${range}`;
+}
+
+function countStatuses(
+  rows: readonly ActivityRowDto[],
+): Readonly<Record<ActivityRowStatus, number>> {
+  const counts: Record<ActivityRowStatus, number> = {
+    blocked: 0,
+    working: 0,
+    done: 0,
+    idle: 0,
+    unknown: 0,
+  };
+  for (const row of rows) counts[row.status] += 1;
+  return counts;
+}
+
+function activityScrollbarGlyphs(
+  totalRows: number,
+  viewportRows: number,
+  scrollOffset: number,
+): readonly string[] {
+  if (viewportRows <= 0 || totalRows <= viewportRows) return [];
+  const thumbHeight = Math.max(1, Math.floor((viewportRows / totalRows) * viewportRows));
+  const maximumOffset = Math.max(1, totalRows - viewportRows);
+  const thumbTop = Math.min(
+    viewportRows - thumbHeight,
+    Math.floor((scrollOffset / maximumOffset) * (viewportRows - thumbHeight)),
+  );
+  return Array.from({ length: viewportRows }, (_, index) =>
+    index >= thumbTop && index < thumbTop + thumbHeight ? "█" : "░",
+  );
+}
+
+function normalizedText(value: string, fallback: string): string {
+  return value.trim() || fallback;
+}
+
+function clipActivityText(text: string, width: number): string {
+  if (width <= 0) return "";
+  if (stringWidth(text) <= width) return text;
+  const limit = Math.max(0, width - 1);
+  let result = "";
+  let used = 0;
+  for (const segment of graphemes(text)) {
+    const segmentWidth = stringWidth(segment);
+    if (used + segmentWidth > limit) break;
+    result += segment;
+    used += segmentWidth;
+  }
+  return `${result}…`;
+}
+
+function graphemes(text: string): readonly string[] {
+  if (Intl.Segmenter) {
+    return [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(text)].map(
+      (entry) => entry.segment,
+    );
+  }
+  return [...text];
+}
+
+function finiteSequence(value: number): number {
+  return Number.isFinite(value) ? Math.floor(value) : 0;
+}
+
+function compareStableId(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function nonNegativeInteger(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, value));
+}

--- a/packages/daemon/src/tui/mirror/activity-surface.tsx
+++ b/packages/daemon/src/tui/mirror/activity-surface.tsx
@@ -1,0 +1,171 @@
+/* @jsxImportSource @opentui/solid */
+import { For, Show } from "solid-js";
+import { recipePalette } from "./recipes.ts";
+import { SelectableRow } from "./recipes.tsx";
+import type { SemanticThemeSnapshot } from "./theme.ts";
+import type {
+  ActivityProjectedRow,
+  ActivitySurfaceProjection,
+  ActivitySurfaceState,
+} from "./activity-surface.ts";
+
+export interface ActivitySurfaceProps {
+  theme: SemanticThemeSnapshot;
+  projection: ActivitySurfaceProjection;
+}
+
+/** Presentational dock-only aggregate. The application root owns every input and data adapter. */
+export function ActivitySurface(props: ActivitySurfaceProps) {
+  return (
+    <box
+      width={props.projection.width}
+      height={props.projection.height}
+      position="relative"
+      backgroundColor={props.theme.colors.surface}
+      overflow="hidden"
+    >
+      <Show when={props.projection.header.height > 0}>
+        <ActivityHeader theme={props.theme} projection={props.projection} />
+      </Show>
+
+      <Show
+        when={props.projection.state === "ready" && props.projection.rows.length > 0}
+        fallback={
+          <ActivityStateMessage
+            theme={props.theme}
+            state={props.projection.state}
+            message={props.projection.message}
+            projection={props.projection}
+          />
+        }
+      >
+        <For each={props.projection.rows}>
+          {(row) => <ActivityRow theme={props.theme} row={row} />}
+        </For>
+        <For each={props.projection.scrollbar.glyphs}>
+          {(glyph, index) => (
+            <box
+              position="absolute"
+              left={props.projection.scrollbar.x}
+              top={props.projection.scrollbar.y + index()}
+              width={props.projection.scrollbar.width}
+              height={1}
+            >
+              <text
+                fg={glyph === "█" ? props.theme.colors.accent : props.theme.colors.mutedForeground}
+              >
+                {glyph}
+              </text>
+            </box>
+          )}
+        </For>
+      </Show>
+
+      <Show when={props.projection.footer.height > 0}>
+        <box
+          position="absolute"
+          left={props.projection.footer.x}
+          top={props.projection.footer.y}
+          width={props.projection.footer.width}
+          height={props.projection.footer.height}
+          paddingLeft={1}
+          backgroundColor={props.theme.colors.background}
+          overflow="hidden"
+        >
+          <text fg={props.theme.colors.mutedForeground}>{props.projection.footerText}</text>
+        </box>
+      </Show>
+    </box>
+  );
+}
+
+function ActivityHeader(props: {
+  theme: SemanticThemeSnapshot;
+  projection: ActivitySurfaceProjection;
+}) {
+  return (
+    <box
+      position="absolute"
+      left={props.projection.header.x}
+      top={props.projection.header.y}
+      width={props.projection.header.width}
+      height={props.projection.header.height}
+      paddingLeft={1}
+      flexDirection="row"
+      gap={1}
+      backgroundColor={props.theme.colors.surfaceRaised}
+      overflow="hidden"
+    >
+      <text fg={props.theme.colors.accent} attributes={1}>
+        {props.projection.title}
+      </text>
+      <text fg={props.theme.colors.mutedForeground}>{`· ${props.projection.summary}`}</text>
+    </box>
+  );
+}
+
+function ActivityRow(props: { theme: SemanticThemeSnapshot; row: ActivityProjectedRow }) {
+  return (
+    <box
+      position="absolute"
+      left={props.row.x}
+      top={props.row.y}
+      width={props.row.width}
+      height={props.row.height}
+      overflow="hidden"
+    >
+      <SelectableRow
+        theme={props.theme}
+        label={props.row.label}
+        meta={props.row.meta}
+        width={props.row.width}
+        selected={props.row.selected}
+        attention={props.row.attention}
+        status={props.row.status}
+        tone={props.row.status}
+      />
+    </box>
+  );
+}
+
+function ActivityStateMessage(props: {
+  theme: SemanticThemeSnapshot;
+  state: ActivitySurfaceState;
+  message: string;
+  projection: ActivitySurfaceProjection;
+}) {
+  const palette = () =>
+    recipePalette(props.theme, {
+      loading: props.state === "loading",
+      empty: props.state === "empty",
+      status: props.state === "error" ? "blocked" : undefined,
+    });
+  const title = () => {
+    if (props.state === "loading") return "Loading activity";
+    if (props.state === "error") return "Activity unavailable";
+    return "No activity yet";
+  };
+  return (
+    <Show when={props.projection.body.height > 0}>
+      <box
+        position="absolute"
+        left={props.projection.body.x}
+        top={props.projection.body.y}
+        width={props.projection.body.width}
+        height={props.projection.body.height}
+        paddingLeft={1}
+        flexDirection="column"
+        backgroundColor={palette().background}
+        overflow="hidden"
+      >
+        <box height={1} flexDirection="row" overflow="hidden">
+          <text fg={palette().accent}>{palette().marker}</text>
+          <text fg={palette().foreground}>{` ${title()}`}</text>
+        </box>
+        <Show when={props.projection.body.height > 1}>
+          <text fg={props.theme.colors.mutedForeground}>{`  ${props.message}`}</text>
+        </Show>
+      </box>
+    </Show>
+  );
+}

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -357,6 +357,19 @@ import { shellChromeLayout, shellSidebarHint, shellSurfaceTabSpans } from "./she
 import { projectPaneFrame } from "./workspace/pane-frame.ts";
 import { PaneFrameHeader } from "./workspace/pane-frame.tsx";
 import {
+  projectWorkbenchShell,
+  moveWorkbenchDockTab,
+  workbenchShellHitTest,
+  type WorkbenchDockMode,
+  type WorkbenchDockTabId,
+  type WorkbenchFocusZone,
+} from "./workspace/workbench-shell.ts";
+import { WorkbenchShell } from "./workspace/workbench-shell.tsx";
+import {
+  resolveWorkbenchPasteTarget,
+  workbenchDockTabForShortcut,
+} from "./workspace/workbench-controller.ts";
+import {
   MissionWorkspaceLoader,
   clipTerminal,
   defaultMissionWorkspaceModel,
@@ -400,6 +413,14 @@ import {
 } from "./changes-surface.ts";
 import type { FilesActionId } from "./files-surface.ts";
 import {
+  activityOrderSequence,
+  activityRowHitTest,
+  orderActivityRows,
+  projectActivitySurface,
+  type ActivityRowDto,
+} from "./activity-surface.ts";
+import { ActivitySurface } from "./activity-surface.tsx";
+import {
   handleMissionSurfaceKey,
   handleMissionSurfacePointerDown,
   handleMissionSurfaceScroll,
@@ -421,11 +442,13 @@ import {
   loadWorkspaceUiState,
   relativeProjectPath,
   serializeWorkspaceUiState,
+  setWorkspaceDockState,
+  setWorkspaceSurfaceState,
   setWorkspaceViewLayoutState,
   shouldHydrateWorkspaceView,
   viewStateFor,
-  type WorkspaceUiStateV1,
-  type WorkspaceViewState,
+  type WorkspaceUiStateV2,
+  type WorkspaceSurfaceStates,
 } from "./workspace-ui-state.ts";
 import {
   DIALOG_ROWS,
@@ -996,16 +1019,25 @@ try {
       viewsFromResolvedConfig(null),
     );
     const [workspaceUiState, setWorkspaceUiState] =
-      createSignal<WorkspaceUiStateV1>(defaultWorkspaceUiState());
+      createSignal<WorkspaceUiStateV2>(defaultWorkspaceUiState());
     const workspaceUiController = new WorkspaceUiStateController();
     const touchedWorkspaceViewIds = new Set<string>();
+    const touchedWorkspaceSurfaceIds = new Set<keyof WorkspaceSurfaceStates>();
+    const hydratedWorkspaceSurfaceIds = new Set<keyof WorkspaceSurfaceStates>();
+    let touchedWorkspaceDock = false;
+    let touchedWorkspaceActiveView = false;
     const missionWorkspaceLoader = new MissionWorkspaceLoader();
     let currentWorkspaceUiIdentity: string | null = null;
     let currentMissionsLoadIdentity: string | null = null;
     let workspaceUiSaveTimer: ReturnType<typeof setTimeout> | null = null;
     let missionsRefreshTimer: ReturnType<typeof setInterval> | null = null;
+    let flushWorkspaceUiState = () => {};
     let snapshotActiveWorkspaceView = () => {};
     let hydrateActiveWorkspaceView = (_options: { firstProjectLoad?: boolean } = {}) => {};
+    let hydrateWorkspaceView = (
+      _view: HostedPanelView,
+      _options: { firstProjectLoad?: boolean } = {},
+    ) => {};
     const initialView = initialHostedSelection(
       hostedViews(),
       requestedPanel,
@@ -1016,11 +1048,51 @@ try {
     const activeView = createMemo(
       () => findHostedViewById(hostedViews(), activeViewId()) ?? hostedViews()[0]!,
     );
+    const dockTabForPanel = (panel: HostedPanelKind): WorkbenchDockTabId | null => {
+      if (panel === "files") return "files";
+      if (panel === "diff") return "changes";
+      if (panel === "missions") return "missions";
+      return null;
+    };
+    const panelForDockTab = (dockTab: WorkbenchDockTabId): HostedPanelKind | "activity" => {
+      if (dockTab === "files") return "files";
+      if (dockTab === "changes") return "diff";
+      if (dockTab === "missions") return "missions";
+      return "activity";
+    };
+    const initialDockTab = dockTabForPanel(initialView.panel) ?? "files";
+    const [canvasPanel, setCanvasPanel] = createSignal<"home" | "terminals">(
+      initialView.panel === "home" ? "home" : "terminals",
+    );
+    const [activeDockTab, setActiveDockTab] = createSignal<WorkbenchDockTabId>(initialDockTab);
+    const [dockMode, setDockMode] = createSignal<WorkbenchDockMode>("open");
+    const [preferredDockHeight, setPreferredDockHeight] = createSignal<number | null>(null);
+    const [workbenchFocusZone, setWorkbenchFocusZone] = createSignal<WorkbenchFocusZone>(
+      dockTabForPanel(initialView.panel) ? "dock-body" : "canvas",
+    );
+    const [hoveredDockTab, setHoveredDockTab] = createSignal<WorkbenchDockTabId | null>(null);
+    const [activitySelectedId, setActivitySelectedId] = createSignal<string | null>(null);
+    const [activityScrollOffset, setActivityScrollOffset] = createSignal(0);
+    const workbenchProjection = createMemo(() =>
+      projectWorkbenchShell({
+        width: canvasCols(),
+        height: Math.max(0, dims().height - TABBAR_H),
+        dockMode: dockMode(),
+        persistedDockHeight: preferredDockHeight(),
+        activeDockTab: activeDockTab(),
+        focusZone: workbenchFocusZone(),
+        hoveredDockTab: hoveredDockTab(),
+        attentionDockTabs: new Set(),
+        dockTabShortcuts: { files: "F3", changes: "F4", missions: "F6", activity: "F9" },
+      }),
+    );
+    const dockSurfaceWidth = () => workbenchProjection().dockBodyContent.width;
+    const dockSurfaceHeight = () => workbenchProjection().dockBodyContent.height;
     const mainRect = () => ({
       x: 0,
       y: 0,
-      width: canvasCols(),
-      height: canvasRows(),
+      width: workbenchProjection().canvasBody.width,
+      height: workbenchProjection().canvasBody.height,
     });
     const compositeStateForActiveView = (): CompositeLayoutState | null => {
       const view = activeView();
@@ -1046,7 +1118,16 @@ try {
       ) ??
       activeCompositeLayout()?.leaves[0] ??
       null;
-    const activePanel = (): HostedPanelKind => focusedCompositeLeaf()?.panel ?? activeView().panel;
+    const focusedWorkbenchPanel = (): HostedPanelKind | "activity" => {
+      if (workbenchProjection().focusZone === "canvas") {
+        return focusedCompositeLeaf()?.panel ?? canvasPanel();
+      }
+      return panelForDockTab(activeDockTab());
+    };
+    const activePanel = (): HostedPanelKind => {
+      const panel = focusedWorkbenchPanel();
+      return panel === "activity" ? "home" : panel;
+    };
     const tab = (): Tab => legacyTabFromPanelKind(activePanel());
     const mode = (): "home" | "mirror" | "editor" | "diff" | "missions" => panelMode(activePanel());
     const surfaceSpans = createMemo(() =>
@@ -1236,7 +1317,7 @@ try {
       if (selectView(viewId)) focusPanelInActiveComposite(panel);
     };
     const missionLayoutSize = () => {
-      const size = missionDashboardMainSize(canvasCols(), Math.max(4, dims().height - TABBAR_H));
+      const size = missionDashboardMainSize(dockSurfaceWidth(), Math.max(1, dockSurfaceHeight()));
       return { width: size.mainWidth, height: size.height };
     };
     const persistMissionSelection = (missionId: string | null, taskId: string | null = null) => {
@@ -1267,7 +1348,8 @@ try {
       });
     };
     const loadMissionsWorkspace = (reason: "activation" | "refresh" | "cadence" | "project") => {
-      if (mode() !== "missions") return;
+      if (activeDockTab() !== "missions" && activeDockTab() !== "activity" && mode() !== "missions")
+        return;
       const repository = workspaceUiController.snapshot().repository;
       if (!repository) {
         setMissionWorkspaceLoad({ status: "loading", generation: 0, projectKey: null });
@@ -1321,7 +1403,8 @@ try {
         });
     };
     const ensureMissionsLoaded = () => {
-      if (mode() !== "missions") return;
+      if (activeDockTab() !== "missions" && activeDockTab() !== "activity" && mode() !== "missions")
+        return;
       loadMissionsWorkspace("activation");
     };
     const selectView = (viewId: string) => {
@@ -1342,11 +1425,50 @@ try {
       }
       runActivationEffects(plan.effects);
       setActiveViewId(plan.activeViewId);
+      touchedWorkspaceActiveView = true;
+      const selectedDockTab = dockTabForPanel(plan.view.panel);
+      if (selectedDockTab) {
+        setActiveDockTab(selectedDockTab);
+        setDockMode("open");
+        setWorkbenchFocusZone("dock-body");
+        touchedWorkspaceDock = true;
+      } else if (plan.view.panel === "home" || plan.view.panel === "terminals") {
+        setCanvasPanel(plan.view.panel);
+        setWorkbenchFocusZone("canvas");
+        touchedWorkspaceDock = true;
+      }
       hydrateActiveWorkspaceView();
       if (plan.view.layout) runPanelActivation(activePanel());
       else if (plan.view.panel === "missions") ensureMissionsLoaded();
       refreshFocusRecord();
       return true;
+    };
+    const activateDockTab = (tabId: WorkbenchDockTabId): boolean => {
+      if (tabId === "activity") {
+        // Activity is dock-only, so it does not travel through `selectView` (the
+        // hosted-view activation path that normally snapshots the surface being
+        // left). Capture it explicitly before the active-tab effect replaces a
+        // pending debounced save with Activity's state.
+        snapshotActiveWorkspaceView();
+        setActiveDockTab("activity");
+        setDockMode("open");
+        setWorkbenchFocusZone("dock-body");
+        touchedWorkspaceDock = true;
+        loadMissionsWorkspace("activation");
+        return true;
+      }
+      const panel: HostedPanelKind =
+        tabId === "files" ? "files" : tabId === "changes" ? "diff" : "missions";
+      const view = findFirstHostedViewForPanel(hostedViews(), panel);
+      if (!view) {
+        setActiveDockTab(tabId);
+        setDockMode("open");
+        setWorkbenchFocusZone("dock-body");
+        touchedWorkspaceDock = true;
+        runPanelActivation(panel);
+        return true;
+      }
+      return selectView(view.id);
     };
     const selectPanel = (panel: HostedPanelKind) => {
       const result = navigateHostedPanel(hostedViews(), activeViewId(), panel);
@@ -1364,6 +1486,18 @@ try {
     let panelHostResolved = false;
     const loadPanelHostForDir = (dir: string) => {
       const generation = panelGeneration.next();
+      // Finish the old project's pending debounce against its still-live
+      // repository before `beginLoad` invalidates that controller generation.
+      flushWorkspaceUiState();
+      if (workspaceUiSaveTimer) {
+        clearTimeout(workspaceUiSaveTimer);
+        workspaceUiSaveTimer = null;
+      }
+      touchedWorkspaceViewIds.clear();
+      touchedWorkspaceSurfaceIds.clear();
+      touchedWorkspaceDock = false;
+      touchedWorkspaceActiveView = false;
+      hydratedWorkspaceSurfaceIds.clear();
       const uiGeneration = workspaceUiController.beginLoad();
       missionWorkspaceLoader.cancel();
       currentMissionsLoadIdentity = null;
@@ -1378,6 +1512,9 @@ try {
           const loadedUi = loadWorkspaceUiState(repository);
           if (!workspaceUiController.completeLoad(uiGeneration, repository, loadedUi)) return;
           setWorkspaceUiState(loadedUi.state);
+          const hasPersistedWorkspaceUi = !loadedUi.diagnostics.some((entry) =>
+            ["MISSING", "READ_FAILED", "MALFORMED", "UNSUPPORTED_VERSION"].includes(entry.code),
+          );
           const loadDiagnostic = loadedUi.diagnostics.find((entry) => entry.code !== "MISSING");
           if (loadDiagnostic) setStatusNote(loadDiagnostic.message);
           const previous = {
@@ -1413,8 +1550,43 @@ try {
           setHostedViews(nextViews);
           runActivationEffects(nextPlan.effects);
           if (nextPlan.activeViewId) setActiveViewId(nextPlan.activeViewId);
+          const explicitDockTab = requestedPanel ? dockTabForPanel(requestedPanel) : null;
+          const restoredDock = hasPersistedWorkspaceUi
+            ? loadedUi.state.dock
+            : {
+                ...loadedUi.state.dock,
+                activeTab: dockTabForPanel(nextPlan.view?.panel ?? "home") ?? "files",
+                focusZone: dockTabForPanel(nextPlan.view?.panel ?? "home")
+                  ? ("dock-body" as const)
+                  : ("canvas" as const),
+              };
+          const restoredActiveDockTab = explicitDockTab ?? restoredDock.activeTab;
+          setActiveDockTab(restoredActiveDockTab);
+          setDockMode(explicitDockTab ? "open" : restoredDock.mode);
+          setPreferredDockHeight(restoredDock.preferredHeight);
+          setWorkbenchFocusZone(explicitDockTab ? "dock-body" : restoredDock.focusZone);
+          setActivitySelectedId(loadedUi.state.surfaces.activity.selectedRowId);
+          setActivityScrollOffset(loadedUi.state.surfaces.activity.scrollOffset);
+          hydratedWorkspaceSurfaceIds.add("activity");
+          if (nextPlan.view?.panel === "home" || nextPlan.view?.panel === "terminals") {
+            setCanvasPanel(nextPlan.view.panel);
+          }
           hydrateActiveWorkspaceView({ firstProjectLoad });
-          if (nextPlan.view?.panel === "missions") loadMissionsWorkspace("project");
+          const restoredDockPanel = panelForDockTab(restoredActiveDockTab);
+          if (restoredDockPanel !== "activity") {
+            runPanelActivation(restoredDockPanel);
+            const restoredDockView = findFirstHostedViewForPanel(nextViews, restoredDockPanel);
+            if (restoredDockView && restoredDockView.id !== nextPlan.view?.id) {
+              hydrateWorkspaceView(restoredDockView, { firstProjectLoad });
+            }
+          }
+          if (
+            restoredActiveDockTab === "missions" ||
+            restoredActiveDockTab === "activity" ||
+            nextPlan.view?.panel === "missions"
+          ) {
+            loadMissionsWorkspace("project");
+          }
           panelHostResolved = true;
         })
         .catch((error) => {
@@ -1440,7 +1612,9 @@ try {
       workspaceUiState();
       const repository = workspaceUiController.snapshot().repository;
       if (
-        mode() === "missions" &&
+        (activeDockTab() === "missions" ||
+          activeDockTab() === "activity" ||
+          mode() === "missions") &&
         repository &&
         repository.metadata.identityKey !== currentMissionsLoadIdentity
       ) {
@@ -1448,7 +1622,13 @@ try {
       }
     });
     missionsRefreshTimer = setInterval(() => {
-      if (mode() === "missions") loadMissionsWorkspace("cadence");
+      if (
+        activeDockTab() === "missions" ||
+        activeDockTab() === "activity" ||
+        mode() === "missions"
+      ) {
+        loadMissionsWorkspace("cadence");
+      }
     }, 10_000);
     cleanupRegistry.set("missions-refresh-timer", () => {
       if (missionsRefreshTimer) clearInterval(missionsRefreshTimer);
@@ -1675,6 +1855,74 @@ try {
           .filter((a, i, arr) => arr.findIndex((b) => b.paneId === a.paneId) === i),
       ),
     );
+    const activityRows = createMemo<ActivityRowDto[]>(() => {
+      const agentRows: ActivityRowDto[] = fleetAgents().map((agent, index) => ({
+        kind: "agent",
+        id: `agent:${agent.paneId}`,
+        sequence: activityOrderSequence(agent.since, index + 1),
+        timestampText: agent.since
+          ? (agentAgeLabel(agent.state, agent.since, Math.floor(Date.now() / 1000)) ?? "now")
+          : "now",
+        agent: agentDisplayKind(agent),
+        message: agent.statusText ?? agent.state,
+        detail: `${agent.session} · ${agent.paneId}`,
+        status: agent.state,
+        attention: agent.state === "blocked",
+      }));
+      const missionRows: ActivityRowDto[] = (missionWorkspaceSnapshot()?.history ?? [])
+        .filter((entry) => entry.lastEvent !== null)
+        .map((entry) => ({
+          kind: "event" as const,
+          id: `mission:${entry.mission.id}:${entry.lastEvent!.sequence}`,
+          sequence: activityOrderSequence(entry.lastEvent!.timestamp, entry.lastEvent!.sequence),
+          timestampText: entry.lastEvent!.timestamp.slice(11, 16),
+          source: entry.mission.title,
+          message: entry.lastEvent!.label,
+          detail: entry.lastEvent!.reason,
+          status:
+            entry.outcome === "completed"
+              ? ("done" as const)
+              : entry.outcome === "failed"
+                ? ("blocked" as const)
+                : ("idle" as const),
+          attention: entry.outcome === "failed",
+        }));
+      return [...agentRows, ...missionRows];
+    });
+    const activityProjection = createMemo(() => {
+      const rows = activityRows();
+      const load = missionWorkspaceLoad();
+      return projectActivitySurface({
+        width: dockSurfaceWidth(),
+        height: dockSurfaceHeight(),
+        state:
+          rows.length > 0
+            ? "ready"
+            : load.status === "loading"
+              ? "loading"
+              : load.status === "error"
+                ? "error"
+                : "empty",
+        rows,
+        selectedRowId: activitySelectedId(),
+        scrollOffset: activityScrollOffset(),
+        message: load.status === "error" ? load.message : undefined,
+      });
+    });
+    const moveActivitySelection = (delta: -1 | 1) => {
+      const rows = orderActivityRows(activityRows());
+      if (rows.length === 0) return;
+      const current = rows.findIndex((row) => row.id === activitySelectedId());
+      const nextIndex =
+        current < 0
+          ? delta > 0
+            ? 0
+            : rows.length - 1
+          : Math.max(0, Math.min(rows.length - 1, current + delta));
+      setActivitySelectedId(rows[nextIndex]!.id);
+      hydratedWorkspaceSurfaceIds.add("activity");
+      touchedWorkspaceSurfaceIds.add("activity");
+    };
 
     // ── IN-APP ATTENTION (M25.1) ─────────────────────────────────────────────
     // The 3s fleet poll diffs the previous per-pane agent states against the
@@ -1868,7 +2116,7 @@ try {
 
     // Visible text rows = full height minus tab bar (1) + header (1) + rule/banner
     // (1) + footer (1).
-    const editorRows = () => Math.max(1, dims().height - 3 - TABBAR_H);
+    const editorRows = () => Math.max(1, dockSurfaceHeight() - 3);
     const editorLines = createMemo<string[]>(() => {
       editorRev();
       if (!editBuffer) return [""];
@@ -2032,13 +2280,13 @@ try {
     // A diff file to re-select once `git status` repopulates the list: the
     // persisted path on restore, or a verb's follow target — path + preferred
     // group, so a just-staged file is re-selected in its NEW section.
-    let pendingDiffFile: string | null = persisted.diffFile;
+    let pendingDiffFile: string | null = null;
     let pendingDiffGroup: DiffGroup | null = null;
 
     // Body rows below header (1) + rule (1), above the footer (1) — shared by both
     // columns. The left column width is a capped fraction of the canvas.
-    const diffBodyRows = () => Math.max(1, changesBodyRows(dims().height - TABBAR_H));
-    const diffListW = () => changesListWidth(canvasCols());
+    const diffBodyRows = () => Math.max(1, changesBodyRows(dockSurfaceHeight()));
+    const diffListW = () => changesListWidth(dockSurfaceWidth());
     const diffLines = createMemo(() => classifyDiff(diffText()));
     // Grouped rows (section headers + files) and the flat selectable-file order,
     // both from ONE buildDiffRows pass over the filtered entries: the render,
@@ -2064,8 +2312,8 @@ try {
     });
     const changesSurfaceProjection = createMemo(() =>
       projectChangesSurface({
-        width: canvasCols(),
-        height: dims().height - TABBAR_H,
+        width: dockSurfaceWidth(),
+        height: dockSurfaceHeight(),
         dir: diffDir(),
         fileCount: diffVisibleFiles().length,
         totals: diffTotals(),
@@ -2429,7 +2677,7 @@ try {
     // the EDITOR (typing). Opening a file hands focus to the editor; esc hands it
     // back to the list.
     const [filesFocus, setFilesFocus] = createSignal<"list" | "editor">("list");
-    const filesListW = () => filesListWidth(canvasCols());
+    const filesListW = () => filesListWidth(dockSurfaceWidth());
     /** The workspace directory driving both the file list and the diff panel. */
     const workspaceDir = () => contextDir() || invokeCwd;
     const fileStatusMap = createMemo(() => statusMapFromEntries(fileStatusEntries()));
@@ -2454,8 +2702,8 @@ try {
     };
     const filesSurfaceProjection = createMemo(() =>
       projectFilesSurface({
-        width: canvasCols(),
-        height: dims().height - TABBAR_H,
+        width: dockSurfaceWidth(),
+        height: dockSurfaceHeight(),
         workspaceDir: workspaceDir(),
         editorPath: editorPath(),
         editorModified: editorModified(),
@@ -2691,46 +2939,96 @@ try {
 
     const workspaceUiProjectRoot = (): string =>
       workspaceUiController.snapshot().repository?.metadata.projectRoot ?? workspaceDir();
-    const currentLayoutPointer = () => layoutStateForView(workspaceUiState(), activeView().id);
-    const withCurrentLayout = <T extends WorkspaceViewState>(entry: T): T => {
-      const layout = currentLayoutPointer();
-      return layout ? ({ ...entry, layout } as T) : entry;
-    };
-    const currentWorkspaceViewState = (): WorkspaceViewState => {
-      const panel = activePanel();
+    const stateWithCurrentWorkspaceView = (): WorkspaceUiStateV2 => {
+      const view = activeView();
       const root = workspaceUiProjectRoot();
-      if (panel === "files") {
-        return withCurrentLayout({
-          panel,
+      let next = workspaceUiState();
+      if (activeDockTab() === "files" && hydratedWorkspaceSurfaceIds.has("files")) {
+        next = setWorkspaceSurfaceState(next, {
+          panel: "files",
           openPath: relativeProjectPath(root, editorPath()),
           selectedPath: relativeProjectPath(root, visibleFiles()[fileSel()]?.node.path ?? null),
         });
-      }
-      if (panel === "diff") {
-        return withCurrentLayout({
-          panel,
+      } else if (activeDockTab() === "changes" && hydratedWorkspaceSurfaceIds.has("diff")) {
+        next = setWorkspaceSurfaceState(next, {
+          panel: "diff",
           selectedPath: diffVisibleFiles()[diffSel()]?.path ?? null,
         });
+      } else if (activeDockTab() === "missions" && hydratedWorkspaceSurfaceIds.has("missions")) {
+        next = workspaceStateWithMissionModel(next, activeView().id, missionWorkspaceModel());
+      } else if (activeDockTab() === "activity" && hydratedWorkspaceSurfaceIds.has("activity")) {
+        next = setWorkspaceSurfaceState(next, {
+          panel: "activity",
+          selectedRowId: activitySelectedId(),
+          scrollOffset: activityScrollOffset(),
+        });
       }
-      if (panel === "missions") {
-        const model = missionWorkspaceModel();
-        const state = workspaceStateWithMissionModel(workspaceUiState(), activeView().id, model);
-        const entry = state.views[activeView().id];
-        if (entry?.panel === "missions") return withCurrentLayout(entry);
-        return withCurrentLayout({ panel, selectedMissionId: null, selectedTaskId: null });
-      }
-      return withCurrentLayout({ panel });
-    };
-    const stateWithCurrentWorkspaceView = (): WorkspaceUiStateV1 => {
-      const view = activeView();
+      next = setWorkspaceDockState(next, {
+        activeTab: activeDockTab(),
+        mode: dockMode(),
+        preferredHeight: preferredDockHeight(),
+        focusZone: workbenchProjection().focusZone,
+      });
       return {
-        version: 1,
+        ...next,
         active: { viewId: view.id, panel: view.panel },
-        views: {
-          ...workspaceUiState().views,
-          [view.id]: currentWorkspaceViewState(),
-        },
       };
+    };
+    const markWorkspaceUiDomainsTouched = (
+      next: WorkspaceUiStateV2,
+      current: WorkspaceUiStateV2,
+    ) => {
+      for (const surfaceId of ["files", "diff", "missions", "activity"] as const) {
+        if (
+          JSON.stringify(next.surfaces[surfaceId]) !== JSON.stringify(current.surfaces[surfaceId])
+        ) {
+          touchedWorkspaceSurfaceIds.add(surfaceId);
+        }
+      }
+      if (JSON.stringify(next.dock) !== JSON.stringify(current.dock)) {
+        touchedWorkspaceDock = true;
+      }
+      if (JSON.stringify(next.active) !== JSON.stringify(current.active)) {
+        touchedWorkspaceActiveView = true;
+      }
+    };
+    const commitWorkspaceUiState = (generation: number, next: WorkspaceUiStateV2) => {
+      const result = workspaceUiController.save(
+        generation,
+        next,
+        touchedWorkspaceViewIds,
+        touchedWorkspaceSurfaceIds,
+        touchedWorkspaceDock,
+        touchedWorkspaceActiveView,
+      );
+      if (result.saved) {
+        touchedWorkspaceViewIds.clear();
+        touchedWorkspaceSurfaceIds.clear();
+        touchedWorkspaceDock = false;
+        touchedWorkspaceActiveView = false;
+        setWorkspaceUiState(workspaceUiController.snapshot().state);
+      } else if (!result.skipped) {
+        const message = result.diagnostics.at(-1)?.message;
+        if (message) setStatusNote(message);
+      }
+    };
+    flushWorkspaceUiState = () => {
+      const controllerSnapshot = workspaceUiController.snapshot();
+      if (!controllerSnapshot.loaded || !controllerSnapshot.repository) return;
+      if (workspaceUiSaveTimer) {
+        clearTimeout(workspaceUiSaveTimer);
+        workspaceUiSaveTimer = null;
+      }
+      const next = stateWithCurrentWorkspaceView();
+      if (serializeWorkspaceUiState(next) === serializeWorkspaceUiState(controllerSnapshot.state)) {
+        touchedWorkspaceViewIds.clear();
+        touchedWorkspaceSurfaceIds.clear();
+        touchedWorkspaceDock = false;
+        touchedWorkspaceActiveView = false;
+        return;
+      }
+      markWorkspaceUiDomainsTouched(next, controllerSnapshot.state);
+      commitWorkspaceUiState(controllerSnapshot.generation, next);
     };
     snapshotActiveWorkspaceView = () => {
       const view = activeView();
@@ -2738,11 +3036,8 @@ try {
       const next = stateWithCurrentWorkspaceView();
       setWorkspaceUiState(next);
     };
-    hydrateActiveWorkspaceView = ({ firstProjectLoad = false } = {}) => {
-      const view = activeView();
-      const entry = view.layout
-        ? (workspaceUiState().views[view.id] ?? null)
-        : viewStateFor(workspaceUiState(), view);
+    hydrateWorkspaceView = (view, { firstProjectLoad = false } = {}) => {
+      const entry = viewStateFor(workspaceUiState(), view);
       if (!entry) return;
       if (
         !shouldHydrateWorkspaceView({
@@ -2756,6 +3051,7 @@ try {
       }
       const root = workspaceUiProjectRoot();
       if (entry.panel === "files") {
+        hydratedWorkspaceSurfaceIds.add("files");
         const selectedPath = absoluteProjectPath(root, entry.selectedPath);
         pendingFilesSelectionPath = selectedPath;
         if (fileNodes().length > 0 && selectedPath) {
@@ -2765,6 +3061,7 @@ try {
         const openPath = absoluteProjectPath(root, entry.openPath);
         if (openPath) openEditor(openPath);
       } else if (entry.panel === "diff") {
+        hydratedWorkspaceSurfaceIds.add("diff");
         pendingDiffFile = entry.selectedPath;
         if (entry.selectedPath && diffVisibleFiles().length > 0) {
           const idx = diffVisibleFiles().findIndex((file) => file.path === entry.selectedPath);
@@ -2776,6 +3073,7 @@ try {
         }
         if (mode() === "diff") refreshStatus();
       } else if (entry.panel === "missions") {
+        hydratedWorkspaceSurfaceIds.add("missions");
         setMissionWorkspaceModel((current) =>
           reconcileMissionWorkspaceModel(
             missionModelFromWorkspaceState(workspaceUiState(), view, current),
@@ -2785,6 +3083,7 @@ try {
         );
       }
     };
+    hydrateActiveWorkspaceView = (options = {}) => hydrateWorkspaceView(activeView(), options);
     const missionSnapshotForModel = () => missionWorkspaceSnapshot();
     const missionDeepLink = (kind: MissionDeepLinkKind): MissionDeepLinkResolution =>
       resolveMissionDeepLink(
@@ -2899,8 +3198,8 @@ try {
     });
     const missionsLayout = createMemo(() =>
       missionSurfaceLayout(
-        canvasCols(),
-        Math.max(4, dims().height - TABBAR_H),
+        dockSurfaceWidth(),
+        Math.max(1, dockSurfaceHeight()),
         missionWorkspaceModel(),
         missionWorkspaceSnapshot(),
         missionLayoutPresentation(),
@@ -2908,8 +3207,8 @@ try {
     );
     const missionsDashboard = createMemo(() =>
       missionDashboardProjection(
-        canvasCols(),
-        Math.max(4, dims().height - TABBAR_H),
+        dockSurfaceWidth(),
+        Math.max(1, dockSurfaceHeight()),
         missionWorkspaceModel(),
         missionWorkspaceSnapshot(),
         {
@@ -4268,6 +4567,10 @@ try {
     });
     createEffect(() => {
       activeViewId();
+      activeDockTab();
+      dockMode();
+      preferredDockHeight();
+      workbenchFocusZone();
       editorPath();
       visibleFiles()[fileSel()]?.node.path;
       diffVisibleFiles()[diffSel()]?.path;
@@ -4277,18 +4580,12 @@ try {
       const next = stateWithCurrentWorkspaceView();
       if (serializeWorkspaceUiState(next) === serializeWorkspaceUiState(controllerSnapshot.state))
         return;
-      touchedWorkspaceViewIds.add(activeViewId());
+      markWorkspaceUiDomainsTouched(next, controllerSnapshot.state);
       const generation = controllerSnapshot.generation;
       if (workspaceUiSaveTimer) clearTimeout(workspaceUiSaveTimer);
       workspaceUiSaveTimer = setTimeout(() => {
-        const result = workspaceUiController.save(generation, next, touchedWorkspaceViewIds);
-        if (result.saved) {
-          touchedWorkspaceViewIds.clear();
-          setWorkspaceUiState(workspaceUiController.snapshot().state);
-        } else if (!result.skipped) {
-          const message = result.diagnostics.at(-1)?.message;
-          if (message) setStatusNote(message);
-        }
+        workspaceUiSaveTimer = null;
+        commitWorkspaceUiState(generation, next);
       }, 400);
     });
 
@@ -4305,10 +4602,6 @@ try {
       // openFile restores the buffer WITHOUT stealing the restored tab (post-render
       // so the native EditBuffer FFI is loaded).
       if (values.edit) openEditor(values.edit);
-      else if (persisted.openFile) {
-        openEditor(persisted.openFile);
-        setTab(initialTab);
-      }
       if (mode() === "editor" && fileNodes().length === 0) loadFileList(workspaceDir());
       if (mode() === "diff") refreshStatus();
       if (mode() === "mirror" && curTarget()) attach(curTarget());
@@ -4546,8 +4839,15 @@ try {
      *  input and the buffer picker both funnel here. */
     const pasteIntoFocused = (text: string) => {
       if (!text) return;
-      if (isHostedPanelInert(activePanel())) return;
-      if (mode() === "editor" && filesFocus() === "editor" && editBuffer && !editorReadOnly()) {
+      const target = resolveWorkbenchPasteTarget({
+        focusZone: workbenchProjection().focusZone,
+        focusedPanel: focusedWorkbenchPanel(),
+        filesEditorFocused: filesFocus() === "editor",
+        filesEditorWritable: Boolean(editBuffer && !editorReadOnly()),
+        terminalAvailable: Boolean(mirror),
+      });
+      if (target === "consume") return;
+      if (target === "files-editor" && editBuffer) {
         editBuffer.insertText(text); // single insertText call = one undo unit
         setEditorModified(true);
         editorSyncScroll();
@@ -4555,7 +4855,7 @@ try {
         setStatusNote(`pasted ${text.length} chars`);
         return;
       }
-      if (mirror) {
+      if (target === "terminal" && mirror) {
         const pane = mirror.focusedPane();
         if (!pane) return;
         // Chunking under tmux's per-command cap happens in the input coalescer
@@ -4687,6 +4987,14 @@ try {
       clickToCursor({
         cx: x - sidebarW() - filesListW(),
         contentY: gy - HEADER_ROWS,
+        gutterW: gutterWidth(editorLines().length),
+        top: editorTop(),
+        lines: editorLines(),
+      });
+    const editorCellAtDock = (localX: number, localY: number): { line: number; col: number } =>
+      clickToCursor({
+        cx: localX - filesListW(),
+        contentY: localY - HEADER_ROWS,
         gutterW: gutterWidth(editorLines().length),
         top: editorTop(),
         lines: editorLines(),
@@ -4918,6 +5226,7 @@ try {
       if (y === 0) return null; // the surface tab bar owns row 0
       const gy = y - TABBAR_H;
       if (x < sidebarW()) {
+        setHoveredDockTab(null);
         // SESSION rows carry the session menu; AGENT rows carry the lifecycle
         // menu (M23.1 — left-click still jumps). The gap, header, and
         // empty-state line have none. Route through the same sidebarHit the
@@ -5401,6 +5710,11 @@ try {
         searchKey(evt);
         return;
       }
+      const dockShortcut = workbenchDockTabForShortcut(evt);
+      if (dockShortcut) {
+        activateDockTab(dockShortcut);
+        return;
+      }
       if (layer.kind === "global") {
         switch (layer.command.kind) {
           case "cycle-composite-focus":
@@ -5422,6 +5736,38 @@ try {
             if (mode() === "diff") openSelectedInEditor();
             else toggleEditor();
             break;
+        }
+        return;
+      }
+      if (workbenchProjection().focusZone === "dock-tabs") {
+        if (evt.name === "left" || evt.name === "h" || evt.name === "right" || evt.name === "l") {
+          const next = moveWorkbenchDockTab(
+            activeDockTab(),
+            evt.name === "left" || evt.name === "h" ? "previous" : "next",
+          );
+          activateDockTab(next);
+          setWorkbenchFocusZone("dock-tabs");
+          return;
+        }
+        if (evt.name === "return" || evt.name === "enter" || evt.name === "down") {
+          setDockMode("open");
+          setWorkbenchFocusZone("dock-body");
+          touchedWorkspaceDock = true;
+          return;
+        }
+        if (evt.name === "escape" || evt.name === "up") {
+          setWorkbenchFocusZone("canvas");
+          touchedWorkspaceDock = true;
+          return;
+        }
+        return;
+      }
+      if (workbenchProjection().focusZone === "dock-body" && activeDockTab() === "activity") {
+        if (evt.name === "j" || evt.name === "down") moveActivitySelection(1);
+        else if (evt.name === "k" || evt.name === "up") moveActivitySelection(-1);
+        else if (evt.name === "escape") {
+          setWorkbenchFocusZone("dock-tabs");
+          touchedWorkspaceDock = true;
         }
         return;
       }
@@ -5950,6 +6296,55 @@ try {
         } else setHoverIf(null);
         return;
       }
+      const workbenchHit = workbenchShellHitTest(workbenchProjection(), x - sidebarW(), gy);
+      if (workbenchHit?.kind === "canvas-rail" || workbenchHit?.kind === "dock-body-rail") {
+        setHoveredDockTab(null);
+        setHoverIf(null);
+        return;
+      }
+      if (workbenchHit?.kind === "dock-tab") {
+        setHoveredDockTab(workbenchHit.tabId);
+        setHoverIf(null);
+        return;
+      }
+      setHoveredDockTab(null);
+      if (workbenchHit?.kind === "dock-action" || workbenchHit?.kind === "dock-tabs") {
+        setHoverIf(null);
+        return;
+      }
+      if (workbenchHit?.kind === "dock-body") {
+        const localX = workbenchHit.localX;
+        const localY = workbenchHit.localY;
+        if (activeDockTab() === "files") {
+          const hit = filesHitTest(filesSurfaceProjection(), localX, localY);
+          if (hit?.area === "header" && hit.actionIndex !== undefined)
+            setHoverIf({ region: "button", index: hit.actionIndex });
+          else if (hit?.area === "list" && hit.rowIndex !== undefined)
+            setHoverIf({ region: "files", index: hit.rowIndex });
+          else setHoverIf(null);
+        } else if (activeDockTab() === "changes") {
+          const hit = changesHitTest(changesSurfaceProjection(), localX, localY);
+          if (hit?.area === "header" && hit.actionIndex !== undefined)
+            setHoverIf({ region: "button", index: hit.actionIndex });
+          else if (hit?.area === "footer" && hit.actionIndex !== undefined)
+            setHoverIf({ region: "diffverb", index: hit.actionIndex });
+          else if (hit?.area === "list" && hit.rowIndex !== undefined)
+            setHoverIf({ region: "diff", index: hit.rowIndex });
+          else setHoverIf(null);
+        } else if (activeDockTab() === "missions") {
+          const hit = missionDashboardHitTest(missionsDashboard(), localX, localY);
+          if (hit?.kind === "card") setHoverIf({ region: "missioncard", index: hit.hoverKey });
+          else if (hit?.kind === "history" || hit?.kind === "detail-row")
+            setHoverIf({ region: "missionhistory", index: hit.hoverKey });
+          else setHoverIf(null);
+        } else setHoverIf(null);
+        return;
+      }
+      if (workbenchHit?.kind === "canvas") {
+        // Canvas content begins after the shell's one-cell focus rail. The
+        // legacy canvas hover routers expect body-local main-column x values.
+        x = sidebarW() + workbenchHit.localX;
+      }
       const m = mode();
       if (m === "home") {
         const action = homeActionAtProjection(homeSurfaceProjection(), x, gy, sidebarW(), 0);
@@ -6082,6 +6477,248 @@ try {
       setHoverIf(null);
     };
 
+    /** Route the native workbench seam before any legacy surface or tmux pane
+     *  routing. Dock coordinates are content-local (after the one-cell focus
+     *  rail), and every dock event is consumed so wheel/right-click/drag can
+     *  never leak into the terminal transport beneath it. */
+    const routeWorkbenchPointer = (e: RouteEvent): boolean => {
+      if (e.y < TABBAR_H || e.x < sidebarW()) return false;
+      const hit = workbenchShellHitTest(workbenchProjection(), e.x - sidebarW(), e.y - TABBAR_H);
+      if (!hit) return false;
+      const releaseAtBoundary =
+        hit.kind !== "canvas" &&
+        (e.type === "up" || e.type === "drag-end" || e.type === "drop" || e.type === "out");
+      if (releaseAtBoundary) {
+        const activeSelection = selection();
+        if (activeSelection?.surface === "mirror" && selecting?.surface === "mirror") {
+          commitMirrorCopy(activeSelection.paneId, activeSelection.anchor, activeSelection.head);
+        }
+        selecting = null;
+        dragAutoScroll = null;
+        pendingPress = null;
+        if (forwardedDown) {
+          const pane = panesById().get(forwardedDown);
+          forwardedDown = null;
+          if (pane && selectModePane() !== pane.id) {
+            forwardPress(pane, e.x, e.y - TABBAR_H, true);
+          }
+        }
+        return true;
+      }
+      if (hit.kind === "canvas") {
+        if (e.type === "down") {
+          setWorkbenchFocusZone("canvas");
+          touchedWorkspaceDock = true;
+        }
+        return false;
+      }
+      if (hit.kind === "canvas-rail") {
+        setHoveredDockTab(null);
+        setHoverIf(null);
+        if (e.type === "down") {
+          setWorkbenchFocusZone("canvas");
+          touchedWorkspaceDock = true;
+        }
+        return true;
+      }
+
+      if (e.type === "move" || e.type === "over" || e.type === "drag") {
+        if (!(e.type === "drag" && selecting?.surface === "editor")) {
+          resolveHover(e.x, e.y);
+          return true;
+        }
+      }
+      if (hit.kind === "dock-tab") {
+        if (e.type === "down" && e.button !== 2) activateDockTab(hit.tabId);
+        return true;
+      }
+      if (hit.kind === "dock-action") {
+        if (e.type === "down" && e.button !== 2) {
+          setDockMode(hit.nextMode);
+          setWorkbenchFocusZone(hit.nextMode === "collapsed" ? "dock-tabs" : "dock-body");
+          touchedWorkspaceDock = true;
+        }
+        return true;
+      }
+      if (hit.kind === "dock-tabs" || hit.kind === "dock-body-rail") {
+        if (e.type === "down") {
+          setWorkbenchFocusZone(hit.kind === "dock-tabs" ? "dock-tabs" : "dock-body");
+          touchedWorkspaceDock = true;
+        }
+        return true;
+      }
+      if (hit.kind !== "dock-body") return true;
+
+      if (e.type === "down" || e.type === "scroll") {
+        setWorkbenchFocusZone("dock-body");
+        touchedWorkspaceDock = true;
+      }
+      const { localX, localY } = hit;
+      if (activeDockTab() === "files") {
+        const surfaceHit = filesHitTest(filesSurfaceProjection(), localX, localY);
+        if (e.type === "scroll") {
+          const direction = e.scroll?.direction;
+          if (direction === "up" || direction === "down") {
+            const step = direction === "up" ? -SCROLL_STEP : SCROLL_STEP;
+            if (surfaceHit?.area === "list") {
+              setFileTop((top) => clampTop(top + step, visibleFiles().length, editorRows()));
+            } else if (surfaceHit?.area === "editor") {
+              setEditorTop((top) => clampTop(top + step, editorLines().length, editorRows()));
+            }
+          }
+          return true;
+        }
+        if (e.type === "drag" && selecting?.surface === "editor" && editBuffer) {
+          const cell = editorCellAtDock(localX, localY);
+          setSelection({
+            surface: "editor",
+            anchor: selAnchor,
+            head: { row: cell.line, col: cell.col },
+          });
+          editBuffer.setCursor(cell.line, cell.col);
+          setEditorRev((revision) => revision + 1);
+          return true;
+        }
+        if (e.type === "up" || e.type === "drag-end" || e.type === "drop") {
+          if (selecting?.surface === "editor") selecting = null;
+          return true;
+        }
+        if (e.type !== "down" || e.button === 2) return true;
+        hydratedWorkspaceSurfaceIds.add("files");
+        if (surfaceHit?.area === "header" && surfaceHit.actionId) {
+          runFilesAction(surfaceHit.actionId);
+          return true;
+        }
+        if (surfaceHit?.area === "list" && surfaceHit.rowIndex !== undefined) {
+          clearSelection();
+          setFilesFocus("list");
+          activateFile(surfaceHit.rowIndex);
+          return true;
+        }
+        if (surfaceHit?.area !== "editor" || !editBuffer) return true;
+        const { line, col } = editorCellAtDock(localX, localY);
+        setFilesFocus("editor");
+        const now = Date.now();
+        const count = clickCount(lastClick, { row: line, col }, now, CLICK_MS);
+        lastClick = { row: line, col, ts: now, count };
+        if (count >= 2) {
+          const text = editorLines()[line] ?? "";
+          const range = count === 2 ? wordRangeAt(text, col) : lineRangeAt(text);
+          setSelection({
+            surface: "editor",
+            anchor: { row: line, col: range.from },
+            head: { row: line, col: range.to },
+          });
+          editBuffer.setCursor(line, range.to);
+          selecting = null;
+        } else {
+          editBuffer.setCursor(line, col);
+          selAnchor = { row: line, col };
+          selecting = { surface: "editor" };
+          setSelection(null);
+        }
+        setEditorRev((revision) => revision + 1);
+        return true;
+      }
+
+      if (activeDockTab() === "changes") {
+        const surfaceHit = changesHitTest(changesSurfaceProjection(), localX, localY);
+        if (e.type === "scroll") {
+          const direction = e.scroll?.direction;
+          if (direction === "up" || direction === "down") {
+            const step = direction === "up" ? -SCROLL_STEP : SCROLL_STEP;
+            if (surfaceHit?.area === "list") {
+              setDiffFileTop((top) => clampTop(top + step, diffRows().length, diffBodyRows()));
+            } else if (surfaceHit?.area === "diff") {
+              setDiffTop((top) => clampTop(top + step, diffLines().length, diffBodyRows()));
+            }
+          }
+          return true;
+        }
+        if (e.type !== "down" || e.button === 2) return true;
+        hydratedWorkspaceSurfaceIds.add("diff");
+        if (
+          (surfaceHit?.area === "header" || surfaceHit?.area === "footer") &&
+          surfaceHit.actionId
+        ) {
+          runChangesAction(surfaceHit.actionId);
+          return true;
+        }
+        if (surfaceHit?.area === "list" && surfaceHit.fileIndex !== undefined) {
+          if (surfaceHit.actionId) runChangesAction(surfaceHit.actionId, surfaceHit.fileIndex);
+          else selectDiffFile(surfaceHit.fileIndex);
+        }
+        return true;
+      }
+
+      if (activeDockTab() === "missions") {
+        const missionHit = missionDashboardHitTest(missionsDashboard(), localX, localY);
+        if (e.type === "scroll") {
+          const direction = e.scroll?.direction;
+          if (direction === "up" || direction === "down") {
+            handleMissionSurfaceScroll(
+              missionHit,
+              direction,
+              {
+                model: missionWorkspaceModel(),
+                snapshot: missionWorkspaceSnapshot(),
+                layoutSize: missionLayoutSize(),
+                persistedTaskId: missionSelectionFromWorkspaceState(
+                  workspaceUiState(),
+                  activeViewId(),
+                ).selectedTaskId,
+              },
+              { updateModel: updateMissionModel },
+              SCROLL_STEP,
+            );
+          }
+          return true;
+        }
+        if (e.type === "down" && e.button !== 2) {
+          hydratedWorkspaceSurfaceIds.add("missions");
+          handleMissionSurfacePointerDown(
+            missionHit,
+            {
+              model: missionWorkspaceModel(),
+              snapshot: missionWorkspaceSnapshot(),
+              layoutSize: missionLayoutSize(),
+              persistedTaskId: missionSelectionFromWorkspaceState(
+                workspaceUiState(),
+                activeViewId(),
+              ).selectedTaskId,
+            },
+            {
+              updateModel: updateMissionModel,
+              refresh: () => loadMissionsWorkspace("refresh"),
+              followDeepLink: followMissionDeepLink,
+              persistSelection: persistMissionSelection,
+            },
+          );
+        }
+        return true;
+      }
+
+      if (e.type === "scroll") {
+        const direction = e.scroll?.direction;
+        if (direction === "up" || direction === "down") {
+          const delta = direction === "up" ? -SCROLL_STEP : SCROLL_STEP;
+          setActivityScrollOffset((offset) =>
+            Math.max(0, Math.min(activityProjection().maximumScrollOffset, offset + delta)),
+          );
+          hydratedWorkspaceSurfaceIds.add("activity");
+          touchedWorkspaceSurfaceIds.add("activity");
+        }
+        return true;
+      }
+      if (e.type === "down" && e.button !== 2) {
+        const row = activityRowHitTest(activityProjection(), localX, localY);
+        if (row) setActivitySelectedId(row.rowId);
+        hydratedWorkspaceSurfaceIds.add("activity");
+        touchedWorkspaceSurfaceIds.add("activity");
+      }
+      return true;
+    };
+
     /** One router, fed by the three always-present region containers (tab bar,
      *  sidebar, main). Geometry is ours. The tab bar is the top screen row; every
      *  other region is offset below it, so we subtract TABBAR_H once (`gy`) and the
@@ -6116,7 +6753,8 @@ try {
     };
 
     const route = (e: RouteEvent) => {
-      const { type, x, y } = e;
+      const { type, y } = e;
+      let { x } = e;
       zzlog(`${type} ${x},${y}${e.button !== undefined ? ` b${e.button}` : ""}`);
       // The FIRST handler in the bubble chain owns the event — stop here so a click
       // on a leaf container isn't re-processed by the root catch-all (and the
@@ -6255,6 +6893,15 @@ try {
         }
         if (!paletteContains(g, x, y)) setPaletteOpen(false);
         return;
+      }
+      if (!dragging && routeWorkbenchPointer(e)) return;
+      if (e.y >= TABBAR_H && e.x >= sidebarW()) {
+        const shellHit = workbenchShellHitTest(
+          workbenchProjection(),
+          e.x - sidebarW(),
+          e.y - TABBAR_H,
+        );
+        if (shellHit?.kind === "canvas") x = sidebarW() + shellHit.localX;
       }
       const compositeLayout = activeCompositeLayout();
       if (!dragging && compositeLayout && x >= sidebarW() && y >= TABBAR_H) {
@@ -6400,7 +7047,7 @@ try {
           return;
         }
         if (type === "move" || type === "over" || type === "drag") {
-          resolveHover(x, y);
+          resolveHover(e.x, y);
           return;
         }
         if (mode() === "missions" && type === "scroll") {
@@ -6669,7 +7316,7 @@ try {
         return;
       }
       if (type === "move" || type === "over" || type === "drag") {
-        resolveHover(x, y);
+        resolveHover(e.x, y);
         return;
       }
       // Release ends a live selection: the mirror copies what was dragged; the
@@ -7416,356 +8063,389 @@ try {
             overflow="hidden"
             onMouse={(e: RouteEvent) => route(e)}
           >
-            <Show when={activeCompositeLayout()}>
-              {(layout) => (
-                <>
-                  <For each={layout().leaves}>
-                    {(leaf) => (
-                      <box
-                        position="absolute"
-                        left={leaf.rect.x}
-                        top={leaf.rect.y}
-                        width={leaf.rect.width}
-                        height={leaf.rect.height}
-                        flexDirection="column"
-                        backgroundColor={DEFAULT_BG}
-                        overflow="hidden"
-                        border={compositeLeafViewport(leaf.rect, 0).bordered}
-                        borderColor={leaf.focused ? ACCENT : MUTED}
-                      >
-                        {compositeLeafBody(leaf)}
-                      </box>
+            <WorkbenchShell
+              theme={semanticTheme()}
+              projection={workbenchProjection()}
+              canvas={
+                <box
+                  position="relative"
+                  width={workbenchProjection().canvasBody.width}
+                  height={workbenchProjection().canvasBody.height}
+                  flexDirection="column"
+                  backgroundColor={DEFAULT_BG}
+                  overflow="hidden"
+                >
+                  <Show when={activeCompositeLayout()}>
+                    {(layout) => (
+                      <>
+                        <For each={layout().leaves}>
+                          {(leaf) => (
+                            <box
+                              position="absolute"
+                              left={leaf.rect.x}
+                              top={leaf.rect.y}
+                              width={leaf.rect.width}
+                              height={leaf.rect.height}
+                              flexDirection="column"
+                              backgroundColor={DEFAULT_BG}
+                              overflow="hidden"
+                              border={compositeLeafViewport(leaf.rect, 0).bordered}
+                              borderColor={leaf.focused ? ACCENT : MUTED}
+                            >
+                              {compositeLeafBody(leaf)}
+                            </box>
+                          )}
+                        </For>
+                        <For each={layout().separators}>
+                          {(separator) => (
+                            <box
+                              position="absolute"
+                              left={separator.rect.x}
+                              top={separator.rect.y}
+                              width={separator.rect.width}
+                              height={separator.rect.height}
+                            >
+                              <text fg={ACCENT}>
+                                {separator.direction === "horizontal"
+                                  ? Array(separator.rect.height).fill("│").join("\n")
+                                  : "─".repeat(separator.rect.width)}
+                              </text>
+                            </box>
+                          )}
+                        </For>
+                        <For each={layout().tabs}>
+                          {(tab) => (
+                            <box
+                              position="absolute"
+                              left={tab.rect.x}
+                              top={tab.rect.y}
+                              width={tab.rect.width}
+                              height={1}
+                            >
+                              <text
+                                fg={tab.active ? DEFAULT_BG : DEFAULT_FG}
+                                bg={tab.active ? ACCENT : BUTTON_BG}
+                              >
+                                {clipTerminal(tab.label, tab.rect.width)}
+                              </text>
+                            </box>
+                          )}
+                        </For>
+                        <Show when={layout().note}>
+                          <box
+                            position="absolute"
+                            left={1}
+                            top={Math.max(0, canvasRows() - 2)}
+                            height={1}
+                          >
+                            <text fg={BANNER_FG}>
+                              {clipTerminal(layout().note!, Math.max(4, canvasCols() - 2))}
+                            </text>
+                          </box>
+                        </Show>
+                      </>
                     )}
-                  </For>
-                  <For each={layout().separators}>
-                    {(separator) => (
-                      <box
-                        position="absolute"
-                        left={separator.rect.x}
-                        top={separator.rect.y}
-                        width={separator.rect.width}
-                        height={separator.rect.height}
-                      >
-                        <text fg={ACCENT}>
-                          {separator.direction === "horizontal"
-                            ? Array(separator.rect.height).fill("│").join("\n")
-                            : "─".repeat(separator.rect.width)}
-                        </text>
-                      </box>
-                    )}
-                  </For>
-                  <For each={layout().tabs}>
-                    {(tab) => (
-                      <box
-                        position="absolute"
-                        left={tab.rect.x}
-                        top={tab.rect.y}
-                        width={tab.rect.width}
-                        height={1}
-                      >
-                        <text
-                          fg={tab.active ? DEFAULT_BG : DEFAULT_FG}
-                          bg={tab.active ? ACCENT : BUTTON_BG}
-                        >
-                          {clipTerminal(tab.label, tab.rect.width)}
-                        </text>
-                      </box>
-                    )}
-                  </For>
-                  <Show when={layout().note}>
-                    <box
-                      position="absolute"
-                      left={1}
-                      top={Math.max(0, canvasRows() - 2)}
-                      height={1}
-                    >
-                      <text fg={BANNER_FG}>
-                        {clipTerminal(layout().note!, Math.max(4, canvasCols() - 2))}
-                      </text>
-                    </box>
                   </Show>
-                </>
-              )}
-            </Show>
-            <Show when={!activeCompositeLayout() && mode() === "home"}>
-              <HomeSurface
-                theme={semanticTheme()}
-                projection={homeSurfaceProjection()}
-                rollup={rollup()}
-              />
-            </Show>
-            <Show when={!activeCompositeLayout() && mode() === "mirror"}>
-              <box paddingLeft={1} flexDirection="row" gap={1}>
-                <text fg={DEFAULT_FG} attributes={1}>
-                  {curTarget()}
-                </text>
-                <text fg={MUTED}>{status()}</text>
-              </box>
-              {/* The per-window strip (gy=1). Rendered as bare styled TEXT runs (no
+                  <Show when={!activeCompositeLayout() && canvasPanel() === "home"}>
+                    <HomeSurface
+                      theme={semanticTheme()}
+                      projection={homeSurfaceProjection()}
+                      rollup={rollup()}
+                    />
+                  </Show>
+                  <Show when={!activeCompositeLayout() && canvasPanel() === "terminals"}>
+                    <box paddingLeft={1} flexDirection="row" gap={1}>
+                      <text fg={DEFAULT_FG} attributes={1}>
+                        {curTarget()}
+                      </text>
+                      <text fg={MUTED}>{status()}</text>
+                    </box>
+                    {/* The per-window strip (gy=1). Rendered as bare styled TEXT runs (no
                 per-window <box> wrapper) so the late-mounted segments bubble
                 clicks to the main-column router instead of swallowing them the
                 way late-mounted boxes do; `route` hit-tests `windowSpans`, whose
                 labels equal these run strings. Active = accent+tint, hover =
                 subtle tint. */}
-              <box paddingLeft={1} flexDirection="row" gap={1}>
-                <text fg={MUTED}>{windowStripParts().pre}</text>
-                <text fg={ACCENT} bg={TAB_ACTIVE_BG}>
-                  {windowStripParts().active}
-                </text>
-                <text fg={MUTED}>{windowStripParts().post}</text>
-                {/* Zoomed indicator: the focused pane's id + a [Z] chip, shown only
+                    <box paddingLeft={1} flexDirection="row" gap={1}>
+                      <text fg={MUTED}>{windowStripParts().pre}</text>
+                      <text fg={ACCENT} bg={TAB_ACTIVE_BG}>
+                        {windowStripParts().active}
+                      </text>
+                      <text fg={MUTED}>{windowStripParts().post}</text>
+                      {/* Zoomed indicator: the focused pane's id + a [Z] chip, shown only
                   while the window is zoomed. Left-aligned after the labels; the
                   button row's flexGrow spacer keeps the [⛶]/[+ split] chips pinned
                   right regardless, and windowSpans are measured from the left, so
                   neither the click routing nor the button spans shift. */}
-                <Show when={isZoomed()}>
-                  <text fg={ACCENT} bg={TAB_ACTIVE_BG} attributes={1}>
-                    {` ${focusedLivePane()?.id ?? ""} [Z] `}
-                  </text>
-                </Show>
-                {/* Synchronize-panes indicator (M20.2): shown while the active
+                      <Show when={isZoomed()}>
+                        <text fg={ACCENT} bg={TAB_ACTIVE_BG} attributes={1}>
+                          {` ${focusedLivePane()?.id ?? ""} [Z] `}
+                        </text>
+                      </Show>
+                      {/* Synchronize-panes indicator (M20.2): shown while the active
                   window's synchronize-panes option is on. Left-aligned after the
                   labels like [Z]; the button row's flexGrow spacer keeps the
                   right-pinned chips and their spans unaffected. */}
-                <Show when={syncOn()}>
-                  <text fg={BUTTON_FG} bg={BUTTON_ACTIVE_BG} attributes={1}>
-                    {" [SYNC] "}
-                  </text>
-                </Show>
-                {buttonRow(stripButtons)}
-              </box>
-              <box position="relative" flexGrow={1} backgroundColor={GUTTER_BG} overflow="hidden">
-                {/* M21.3 — framebuffer blit (flagged). ONE <pane_surface> per
+                      <Show when={syncOn()}>
+                        <text fg={BUTTON_FG} bg={BUTTON_ACTIVE_BG} attributes={1}>
+                          {" [SYNC] "}
+                        </text>
+                      </Show>
+                      {buttonRow(stripButtons)}
+                    </box>
+                    <box
+                      position="relative"
+                      flexGrow={1}
+                      backgroundColor={GUTTER_BG}
+                      overflow="hidden"
+                    >
+                      {/* M21.3 — framebuffer blit (flagged). ONE <pane_surface> per
                   pane blits the grid straight into packed buffers; the For keys
                   on the stable id list so a content tick reuses each surface (and
                   its framebuffer) instead of tearing it down. Chrome (badge +
                   scrollbar) stays Solid JSX layered over the surface. The old
                   StyledRun path is the fallback, unchanged, default for A/B. */}
-                <Show
-                  when={FB_PANES}
-                  fallback={
-                    <For each={panes()}>
-                      {(pane) => (
-                        <box
-                          position="absolute"
-                          left={pane.left}
-                          top={pane.top}
-                          width={pane.width}
-                          height={pane.height}
-                          flexDirection="column"
-                          backgroundColor={DEFAULT_BG}
-                          overflow="hidden"
-                        >
-                          <For each={paneSelRows(pane)}>
-                            {(runs) => (
-                              <box flexDirection="row" height={1}>
-                                <For each={runs}>
-                                  {(run) => (
-                                    <text
-                                      fg={packedToRgba(run.fg, DEFAULT_FG)}
-                                      bg={packedToRgba(run.bg, DEFAULT_BG)}
-                                      attributes={run.attributes}
-                                    >
-                                      {run.text}
-                                    </text>
+                      <Show
+                        when={FB_PANES}
+                        fallback={
+                          <For each={panes()}>
+                            {(pane) => (
+                              <box
+                                position="absolute"
+                                left={pane.left}
+                                top={pane.top}
+                                width={pane.width}
+                                height={pane.height}
+                                flexDirection="column"
+                                backgroundColor={DEFAULT_BG}
+                                overflow="hidden"
+                              >
+                                <For each={paneSelRows(pane)}>
+                                  {(runs) => (
+                                    <box flexDirection="row" height={1}>
+                                      <For each={runs}>
+                                        {(run) => (
+                                          <text
+                                            fg={packedToRgba(run.fg, DEFAULT_FG)}
+                                            bg={packedToRgba(run.bg, DEFAULT_BG)}
+                                            attributes={run.attributes}
+                                          >
+                                            {run.text}
+                                          </text>
+                                        )}
+                                      </For>
+                                    </box>
                                   )}
                                 </For>
+                                {/* Top-right badge family: the select-mode chip (M22.9,
+                            passive text runs — presses bubble to the router) then
+                            the scroll badge. */}
+                                <box position="absolute" right={1} top={0} flexDirection="row">
+                                  <Show
+                                    when={
+                                      selectModePane() === pane.id && selectBadgeLabel(pane.width)
+                                    }
+                                  >
+                                    <text fg={DEFAULT_FG} bg={BUTTON_ACTIVE_BG} attributes={1}>
+                                      {selectBadgeLabel(pane.width)!}
+                                    </text>
+                                  </Show>
+                                  <Show when={pane.snapshot.scrollOffset > 0}>
+                                    <text fg={DEFAULT_FG} bg={BADGE_BG}>
+                                      {` ↑${pane.snapshot.scrollOffset}/${pane.scrollbackDepth} `}
+                                    </text>
+                                  </Show>
+                                </box>
+                                {agentChipOverlay(() => pane)}
+                                {/* Right-edge scrollbar — only while scrolled up, so a live
+                            terminal stays clean (mirrorScrollGeom gates on offset). */}
+                                {scrollbarOverlay(() => mirrorScrollGeom(pane))}
                               </box>
                             )}
                           </For>
-                          {/* Top-right badge family: the select-mode chip (M22.9,
-                            passive text runs — presses bubble to the router) then
-                            the scroll badge. */}
-                          <box position="absolute" right={1} top={0} flexDirection="row">
-                            <Show
-                              when={selectModePane() === pane.id && selectBadgeLabel(pane.width)}
-                            >
-                              <text fg={DEFAULT_FG} bg={BUTTON_ACTIVE_BG} attributes={1}>
-                                {selectBadgeLabel(pane.width)!}
-                              </text>
-                            </Show>
-                            <Show when={pane.snapshot.scrollOffset > 0}>
-                              <text fg={DEFAULT_FG} bg={BADGE_BG}>
-                                {` ↑${pane.snapshot.scrollOffset}/${pane.scrollbackDepth} `}
-                              </text>
-                            </Show>
-                          </box>
-                          {agentChipOverlay(() => pane)}
-                          {/* Right-edge scrollbar — only while scrolled up, so a live
-                            terminal stays clean (mirrorScrollGeom gates on offset). */}
-                          {scrollbarOverlay(() => mirrorScrollGeom(pane))}
-                        </box>
-                      )}
-                    </For>
-                  }
-                >
-                  <For each={paneIds()}>
-                    {(id) => {
-                      const pane = () => panesById().get(id);
-                      return (
-                        <Show when={pane()}>
-                          <box
-                            position="absolute"
-                            left={pane()!.left}
-                            top={pane()!.top}
-                            width={pane()!.width}
-                            height={pane()!.height}
-                            backgroundColor={DEFAULT_BG}
-                            overflow="hidden"
-                          >
-                            <pane_surface
-                              width={pane()!.width}
-                              height={pane()!.height}
-                              mirror={mirror!}
-                              paneId={id}
-                              defaultFg={DEFAULT_FG_PACKED}
-                              defaultBg={DEFAULT_BG_PACKED}
-                              searchHl={SEARCH_HL}
-                              searchCur={SEARCH_CUR}
-                              scrollOffset={pane()!.snapshot.scrollOffset}
-                              paneFocused={pane()!.active}
-                              contentVersion={pane()!.version}
-                              selRange={mirrorSelForPane(id)}
-                              search={mirrorSearchForPane(pane()!)}
-                            />
-                            {/* Top-right badge family: the select-mode chip
+                        }
+                      >
+                        <For each={paneIds()}>
+                          {(id) => {
+                            const pane = () => panesById().get(id);
+                            return (
+                              <Show when={pane()}>
+                                <box
+                                  position="absolute"
+                                  left={pane()!.left}
+                                  top={pane()!.top}
+                                  width={pane()!.width}
+                                  height={pane()!.height}
+                                  backgroundColor={DEFAULT_BG}
+                                  overflow="hidden"
+                                >
+                                  <pane_surface
+                                    width={pane()!.width}
+                                    height={pane()!.height}
+                                    mirror={mirror!}
+                                    paneId={id}
+                                    defaultFg={DEFAULT_FG_PACKED}
+                                    defaultBg={DEFAULT_BG_PACKED}
+                                    searchHl={SEARCH_HL}
+                                    searchCur={SEARCH_CUR}
+                                    scrollOffset={pane()!.snapshot.scrollOffset}
+                                    paneFocused={pane()!.active}
+                                    contentVersion={pane()!.version}
+                                    selRange={mirrorSelForPane(id)}
+                                    search={mirrorSearchForPane(pane()!)}
+                                  />
+                                  {/* Top-right badge family: the select-mode chip
                               (M22.9, passive text runs — presses bubble to the
                               router) then the scroll badge. */}
-                            <box position="absolute" right={1} top={0} flexDirection="row">
-                              <Show
-                                when={selectModePane() === id && selectBadgeLabel(pane()!.width)}
-                              >
-                                <text fg={DEFAULT_FG} bg={BUTTON_ACTIVE_BG} attributes={1}>
-                                  {selectBadgeLabel(pane()!.width)!}
-                                </text>
+                                  <box position="absolute" right={1} top={0} flexDirection="row">
+                                    <Show
+                                      when={
+                                        selectModePane() === id && selectBadgeLabel(pane()!.width)
+                                      }
+                                    >
+                                      <text fg={DEFAULT_FG} bg={BUTTON_ACTIVE_BG} attributes={1}>
+                                        {selectBadgeLabel(pane()!.width)!}
+                                      </text>
+                                    </Show>
+                                    <Show when={pane()!.snapshot.scrollOffset > 0}>
+                                      <text fg={DEFAULT_FG} bg={BADGE_BG}>
+                                        {` ↑${pane()!.snapshot.scrollOffset}/${pane()!.scrollbackDepth} `}
+                                      </text>
+                                    </Show>
+                                  </box>
+                                  {agentChipOverlay(pane)}
+                                  {scrollbarOverlay(() => mirrorScrollGeom(pane()!))}
+                                </box>
                               </Show>
-                              <Show when={pane()!.snapshot.scrollOffset > 0}>
-                                <text fg={DEFAULT_FG} bg={BADGE_BG}>
-                                  {` ↑${pane()!.snapshot.scrollOffset}/${pane()!.scrollbackDepth} `}
-                                </text>
-                              </Show>
-                            </box>
-                            {agentChipOverlay(pane)}
-                            {scrollbarOverlay(() => mirrorScrollGeom(pane()!))}
-                          </box>
-                        </Show>
-                      );
-                    }}
-                  </For>
-                </Show>
-                {/* Focused-pane border (M22.7): accent strips in the GUTTER cells
+                            );
+                          }}
+                        </For>
+                      </Show>
+                      {/* Focused-pane border (M22.7): accent strips in the GUTTER cells
                   around the active pane — the strips live outside every pane rect
                   so no terminal cell is consumed or tinted, and they're
                   handler-less boxes (gutter presses still bubble to the router,
                   border drags keep working). Single-pane and zoomed windows paint
                   nothing (focusStrips returns [] when the rect fills the canvas
                   or the window has one pane). */}
-                <For
-                  each={(() => {
-                    const focused = panes().find((p) => p.active);
-                    return focused
-                      ? focusStrips(focused, canvasCols(), canvasRows(), panes().length)
-                      : [];
-                  })()}
-                >
-                  {(strip) => (
-                    // A HAIRLINE, not a filled bar (user feedback: bars read as
-                    // extra gutter padding): line glyphs in accent fg on the
-                    // normal canvas bg keep the gutter visually thin. One text
-                    // per strip — newline-joined glyphs render as a column.
-                    <box
-                      position="absolute"
-                      left={strip.left}
-                      top={strip.top}
-                      width={strip.width}
-                      height={strip.height}
-                    >
-                      <text fg={FOCUS_BORDER_FG}>
-                        {strip.height === 1
-                          ? "─".repeat(strip.width)
-                          : Array(strip.height).fill("│").join("\n")}
-                      </text>
-                    </box>
-                  )}
-                </For>
-                {/* Size-truth hint (M22.8): quiet, dismiss-free, shown ONLY while
+                      <For
+                        each={(() => {
+                          const focused = panes().find((p) => p.active);
+                          return focused
+                            ? focusStrips(focused, canvasCols(), canvasRows(), panes().length)
+                            : [];
+                        })()}
+                      >
+                        {(strip) => (
+                          // A HAIRLINE, not a filled bar (user feedback: bars read as
+                          // extra gutter padding): line glyphs in accent fg on the
+                          // normal canvas bg keep the gutter visually thin. One text
+                          // per strip — newline-joined glyphs render as a column.
+                          <box
+                            position="absolute"
+                            left={strip.left}
+                            top={strip.top}
+                            width={strip.width}
+                            height={strip.height}
+                          >
+                            <text fg={FOCUS_BORDER_FG}>
+                              {strip.height === 1
+                                ? "─".repeat(strip.width)
+                                : Array(strip.height).fill("│").join("\n")}
+                            </text>
+                          </box>
+                        )}
+                      </For>
+                      {/* Size-truth hint (M22.8): quiet, dismiss-free, shown ONLY while
                   a co-attached terminal has sized the window away from our canvas
                   (the letterboxed grid is centered beneath it). It states the
                   honest actual size — the iTerm2-style answer — and disappears the
                   moment the sizes agree. A handler-less box in the top gutter, so
                   no pointer routing changes. */}
-                <Show when={windowMismatch()}>
-                  <box position="absolute" left={1} top={0} backgroundColor={BADGE_BG}>
-                    <text fg={MUTED}>{` ${formatSizeHint(windowMismatch()!)} `}</text>
-                  </box>
-                </Show>
-              </box>
-              {/* Scrollback-search input (M20.3) — a bottom-of-canvas line, like the
+                      <Show when={windowMismatch()}>
+                        <box position="absolute" left={1} top={0} backgroundColor={BADGE_BG}>
+                          <text fg={MUTED}>{` ${formatSizeHint(windowMismatch()!)} `}</text>
+                        </box>
+                      </Show>
+                    </box>
+                    {/* Scrollback-search input (M20.3) — a bottom-of-canvas line, like the
                 palette's input but inline. A normal-flow row after the pane canvas
                 (keyboard-only, no mouse handler — search owns the keyboard while
                 open); it steals the canvas's last row only while open, so the pane
                 grid is untouched the rest of the time. `editing` shows a "/query▏"
                 cursor; navigation shows the query + the "3/17 matches" tally. */}
-              <Show when={search()}>
-                <box
-                  flexDirection="row"
-                  backgroundColor={PALETTE_BG}
-                  paddingLeft={1}
-                  paddingRight={1}
-                >
-                  <text fg={ACCENT} attributes={1}>
-                    {search()!.editing ? "/" : "search "}
-                  </text>
-                  <text fg={DEFAULT_FG}>{`${search()!.query}${search()!.editing ? "▏" : ""}`}</text>
-                  <box flexGrow={1} />
-                  <text fg={MUTED}>{searchStatus()}</text>
+                    <Show when={search()}>
+                      <box
+                        flexDirection="row"
+                        backgroundColor={PALETTE_BG}
+                        paddingLeft={1}
+                        paddingRight={1}
+                      >
+                        <text fg={ACCENT} attributes={1}>
+                          {search()!.editing ? "/" : "search "}
+                        </text>
+                        <text
+                          fg={DEFAULT_FG}
+                        >{`${search()!.query}${search()!.editing ? "▏" : ""}`}</text>
+                        <box flexGrow={1} />
+                        <text fg={MUTED}>{searchStatus()}</text>
+                      </box>
+                    </Show>
+                  </Show>
                 </box>
-              </Show>
-            </Show>
-            <Show when={!activeCompositeLayout() && mode() === "editor"}>
-              <FilesSurface
-                theme={semanticTheme()}
-                projection={filesSurfaceProjection()}
-                colors={{
-                  gutterBg: GUTTER_BG,
-                  gutterFg: GUTTER_FG,
-                  cursorBg: CURSOR_BG,
-                  modifiedFg: MODIFIED_FG,
-                  statusLetterFg: STATUS_LETTER_FG,
-                }}
-              />
-            </Show>
-            <Show when={!activeCompositeLayout() && mode() === "diff"}>
-              <ChangesSurface
-                theme={semanticTheme()}
-                projection={changesSurfaceProjection()}
-                colors={{
-                  gutterBg: GUTTER_BG,
-                  gutterFg: GUTTER_FG,
-                  statusLetterFg: STATUS_LETTER_FG,
-                  diffFg: DIFF_FG,
-                  diffLineBg: DIFF_LINE_BG,
-                }}
-              />
-            </Show>
-            <Show when={!activeCompositeLayout() && mode() === "missions"}>
-              <MissionsSurface
-                width={canvasCols()}
-                dashboard={missionsDashboard()}
-                model={missionWorkspaceModel()}
-                snapshot={missionWorkspaceSnapshot()}
-                loadState={missionWorkspaceLoad()}
-                errorMessage={missionLoadErrorMessage()}
-                resolveDeepLink={missionDeepLink}
-                isHovered={isHovered}
-                theme={{
-                  bannerFg: BANNER_FG,
-                  buttonFg: BUTTON_FG,
-                  buttonBg: BUTTON_BG,
-                  buttonActiveBg: BUTTON_ACTIVE_BG,
-                }}
-              />
-            </Show>
+              }
+              dockBody={
+                <>
+                  <Show when={activeDockTab() === "files"}>
+                    <FilesSurface
+                      theme={semanticTheme()}
+                      projection={filesSurfaceProjection()}
+                      colors={{
+                        gutterBg: GUTTER_BG,
+                        gutterFg: GUTTER_FG,
+                        cursorBg: CURSOR_BG,
+                        modifiedFg: MODIFIED_FG,
+                        statusLetterFg: STATUS_LETTER_FG,
+                      }}
+                    />
+                  </Show>
+                  <Show when={activeDockTab() === "changes"}>
+                    <ChangesSurface
+                      theme={semanticTheme()}
+                      projection={changesSurfaceProjection()}
+                      colors={{
+                        gutterBg: GUTTER_BG,
+                        gutterFg: GUTTER_FG,
+                        statusLetterFg: STATUS_LETTER_FG,
+                        diffFg: DIFF_FG,
+                        diffLineBg: DIFF_LINE_BG,
+                      }}
+                    />
+                  </Show>
+                  <Show when={activeDockTab() === "missions"}>
+                    <MissionsSurface
+                      width={dockSurfaceWidth()}
+                      dashboard={missionsDashboard()}
+                      model={missionWorkspaceModel()}
+                      snapshot={missionWorkspaceSnapshot()}
+                      loadState={missionWorkspaceLoad()}
+                      errorMessage={missionLoadErrorMessage()}
+                      resolveDeepLink={missionDeepLink}
+                      isHovered={isHovered}
+                      theme={{
+                        bannerFg: BANNER_FG,
+                        buttonFg: BUTTON_FG,
+                        buttonBg: BUTTON_BG,
+                        buttonActiveBg: BUTTON_ACTIVE_BG,
+                      }}
+                    />
+                  </Show>
+                  <Show when={activeDockTab() === "activity"}>
+                    <ActivitySurface theme={semanticTheme()} projection={activityProjection()} />
+                  </Show>
+                </>
+              }
+            />
           </box>
         </box>
         {/* COMMAND PALETTE overlay (M18.4; mouse-complete M21.9) — centered.

--- a/packages/daemon/src/tui/mirror/missions-workspace.test.ts
+++ b/packages/daemon/src/tui/mirror/missions-workspace.test.ts
@@ -1574,7 +1574,7 @@ describe("missions workspace loader/model", () => {
     ).toBe(false);
   });
 
-  it("persists only selectedMissionId and selectedTaskId per exact missions view without projection blobs", () => {
+  it("persists one dock Missions selection independently of hosted view aliases", () => {
     const state = workspaceStateWithMissionSelection(
       defaultWorkspaceUiState(),
       "mission-a",
@@ -1583,8 +1583,8 @@ describe("missions workspace loader/model", () => {
     );
     const next = workspaceStateWithMissionSelection(state, "mission-b", "mis_two");
     expect(missionSelectionFromWorkspaceState(next, "mission-a")).toEqual({
-      selectedMissionId: "mis_one",
-      selectedTaskId: "tsk_one",
+      selectedMissionId: "mis_two",
+      selectedTaskId: null,
     });
     expect(missionSelectionFromWorkspaceState(next, "mission-b")).toEqual({
       selectedMissionId: "mis_two",
@@ -1597,7 +1597,7 @@ describe("missions workspace loader/model", () => {
     expect(json).not.toContain("projection");
   });
 
-  it("persists exact-view missions navigation without projection blobs and hydrates legacy selection", () => {
+  it("persists one dock Missions navigation model without projection blobs", () => {
     const viewA = {
       id: "mission-a",
       title: "Missions A",
@@ -1632,10 +1632,10 @@ describe("missions workspace loader/model", () => {
       viewB.id,
       defaultMissionWorkspaceModel("mis_two"),
     );
-    expect(missionModelFromWorkspaceState(isolated, viewA).selectedMissionId).toBe("mis_one");
-    expect(missionModelFromWorkspaceState(isolated, viewA).columnScroll.done).toBe(5);
-    expect(missionModelFromWorkspaceState(isolated, viewA).collapsedColumns.running).toBe(true);
-    expect(missionModelFromWorkspaceState(isolated, viewA).zoomColumn).toBe("done");
+    expect(missionModelFromWorkspaceState(isolated, viewA).selectedMissionId).toBe("mis_two");
+    expect(missionModelFromWorkspaceState(isolated, viewA).columnScroll.done).toBe(0);
+    expect(missionModelFromWorkspaceState(isolated, viewA).collapsedColumns.running).toBe(false);
+    expect(missionModelFromWorkspaceState(isolated, viewA).zoomColumn).toBeNull();
     expect(missionModelFromWorkspaceState(isolated, viewB).selectedMissionId).toBe("mis_two");
     const json = serializeWorkspaceUiState(isolated);
     expect(json).toContain('"navigation"');

--- a/packages/daemon/src/tui/mirror/missions-workspace.ts
+++ b/packages/daemon/src/tui/mirror/missions-workspace.ts
@@ -20,7 +20,7 @@ import { MissionRepository, MissionRepositoryError } from "../../lib/mission-rep
 import type { ProjectRuntimeRepository } from "../../lib/project-runtime-repository.ts";
 import type { HostedPanelView } from "./panel-host.ts";
 import { findFirstHostedViewForPanel, terminalDisplayWidth } from "./panel-host.ts";
-import type { WorkspaceMissionsNavigationState, WorkspaceUiStateV1 } from "./workspace-ui-state.ts";
+import type { WorkspaceMissionsNavigationState, WorkspaceUiStateV2 } from "./workspace-ui-state.ts";
 import {
   missionsSelection,
   setMissionsNavigation,
@@ -1208,23 +1208,23 @@ export function densityLabel(density: MissionWorkspaceDensity): string {
 }
 
 export function missionSelectionFromWorkspaceState(
-  state: WorkspaceUiStateV1,
+  state: WorkspaceUiStateV2,
   viewId: string,
 ): { selectedMissionId: string | null; selectedTaskId: string | null } {
   return missionsSelection(state, viewId);
 }
 
 export function workspaceStateWithMissionSelection(
-  state: WorkspaceUiStateV1,
+  state: WorkspaceUiStateV2,
   viewId: string,
   missionId: string | null,
   taskId: string | null = null,
-): WorkspaceUiStateV1 {
+): WorkspaceUiStateV2 {
   return setMissionsSelection(state, viewId, missionId, taskId);
 }
 
 export function missionModelFromWorkspaceState(
-  state: WorkspaceUiStateV1,
+  state: WorkspaceUiStateV2,
   view: HostedPanelView,
   fallback: MissionWorkspaceModel = defaultMissionWorkspaceModel(),
 ): MissionWorkspaceModel {
@@ -1258,10 +1258,10 @@ export function missionModelFromWorkspaceState(
 }
 
 export function workspaceStateWithMissionModel(
-  state: WorkspaceUiStateV1,
+  state: WorkspaceUiStateV2,
   viewId: string,
   model: MissionWorkspaceModel,
-): WorkspaceUiStateV1 {
+): WorkspaceUiStateV2 {
   return setMissionsNavigation(
     state,
     viewId,

--- a/packages/daemon/src/tui/mirror/workspace-ui-state.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace-ui-state.test.ts
@@ -20,12 +20,13 @@ import {
   serializeWorkspaceUiState,
   setMissionsSelection,
   setMissionsNavigation,
+  setWorkspaceSurfaceState,
   setWorkspaceViewLayoutState,
   shouldHydrateWorkspaceView,
   viewStateFor,
   layoutStateForView,
   writeWorkspaceUiStateWithRetry,
-  type WorkspaceUiStateV1,
+  type WorkspaceUiStateV2,
 } from "./workspace-ui-state.ts";
 
 const roots: string[] = [];
@@ -110,6 +111,28 @@ function writeRaw(path: string, contents: string): void {
   writeFileSync(path, contents, "utf-8");
 }
 
+function currentState(
+  overrides: Partial<Omit<WorkspaceUiStateV2, "dock" | "surfaces">> & {
+    dock?: Partial<WorkspaceUiStateV2["dock"]>;
+    surfaces?: Partial<WorkspaceUiStateV2["surfaces"]>;
+  } = {},
+): WorkspaceUiStateV2 {
+  const base = defaultWorkspaceUiState();
+  return {
+    ...base,
+    ...overrides,
+    version: 2,
+    dock: { ...base.dock, ...overrides.dock },
+    surfaces: {
+      files: { ...base.surfaces.files, ...overrides.surfaces?.files },
+      diff: { ...base.surfaces.diff, ...overrides.surfaces?.diff },
+      missions: { ...base.surfaces.missions, ...overrides.surfaces?.missions },
+      activity: { ...base.surfaces.activity, ...overrides.surfaces?.activity },
+    },
+    views: { ...(overrides.views ?? {}) },
+  };
+}
+
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
@@ -117,7 +140,7 @@ afterEach(() => {
 describe("workspace UI-state contract", () => {
   it("parses defaults, malformed input, unsupported versions, caps, and mistyped fields", () => {
     expect(parseWorkspaceUiStateJson("{").state).toEqual(defaultWorkspaceUiState());
-    expect(parseWorkspaceUiStateJson('{"version":2,"active":null,"views":{}}')).toMatchObject({
+    expect(parseWorkspaceUiStateJson('{"version":3,"active":null,"views":{}}')).toMatchObject({
       state: defaultWorkspaceUiState(),
       diagnostics: [{ code: "UNSUPPORTED_VERSION", path: "$.version" }],
     });
@@ -129,68 +152,71 @@ describe("workspace UI-state contract", () => {
     oversizedViews["bad\0id"] = { panel: "diff", selectedPath: "x" };
     const parsed = parseWorkspaceUiStateJson(
       JSON.stringify({
-        version: 1,
+        version: 2,
         active: { viewId: "", panel: "files" },
+        dock: defaultWorkspaceUiState().dock,
+        surfaces: defaultWorkspaceUiState().surfaces,
         views: oversizedViews,
       }),
     );
 
     expect(Object.keys(parsed.state.views)).toHaveLength(WORKSPACE_UI_STATE_MAX_VIEWS);
-    expect(parsed.state.views["view-0"]).toEqual({
-      panel: "files",
-      openPath: "src/0.ts",
-      selectedPath: null,
-    });
+    expect(parsed.state.views["view-0"]).toEqual({ panel: "files" });
     expect(parsed.diagnostics.map((entry) => entry.code)).toContain("OVERSIZED");
     expect(parsed.diagnostics.map((entry) => entry.code)).toContain("INVALID_FIELD");
   });
 
   it("serializes with stable keys, stable field order, and detached output", () => {
-    const state: WorkspaceUiStateV1 = {
-      version: 1,
+    const state = currentState({
       active: { viewId: "z", panel: "diff" },
-      views: {
-        z: { panel: "diff", selectedPath: "z.ts" },
-        a: { panel: "missions", selectedMissionId: "m1", selectedTaskId: "t1" },
+      dock: { activeTab: "changes", focusZone: "dock-body" },
+      surfaces: {
+        diff: { selectedPath: "z.ts" },
+        missions: { selectedMissionId: "m1", selectedTaskId: "t1" },
       },
-    };
+      views: {
+        z: { panel: "diff" },
+        a: { panel: "missions" },
+      },
+    });
 
     const serialized = serializeWorkspaceUiState(state);
 
-    expect(serialized).toBe(
-      [
-        "{",
-        '  "version": 1,',
-        '  "active": {',
-        '    "viewId": "z",',
-        '    "panel": "diff"',
-        "  },",
-        '  "views": {',
-        '    "a": {',
-        '      "panel": "missions",',
-        '      "selectedMissionId": "m1",',
-        '      "selectedTaskId": "t1"',
-        "    },",
-        '    "z": {',
-        '      "panel": "diff",',
-        '      "selectedPath": "z.ts"',
-        "    }",
-        "  }",
-        "}\n",
-      ].join("\n"),
-    );
+    expect(JSON.parse(serialized)).toEqual({
+      version: 2,
+      active: { viewId: "z", panel: "diff" },
+      dock: {
+        activeTab: "changes",
+        mode: "open",
+        preferredHeight: null,
+        focusZone: "dock-body",
+      },
+      surfaces: state.surfaces,
+      views: {
+        a: { panel: "missions" },
+        z: { panel: "diff" },
+      },
+    });
 
     const reparsed = parseWorkspaceUiStateJson(serialized).state;
-    reparsed.views.z = { panel: "diff", selectedPath: "changed.ts" };
-    expect(state.views.z).toEqual({ panel: "diff", selectedPath: "z.ts" });
+    reparsed.views.z = { panel: "home" };
+    expect(state.views.z).toEqual({ panel: "diff" });
   });
 
   it("rejects hostile object keys without prototype mutation or inherited view state", () => {
     const parsed = parseWorkspaceUiStateJson(
-      '{"version":1,"active":null,"views":{"__proto__":{"panel":"files","openPath":"polluted.ts","selectedPath":null},"prototype":{"panel":"diff","selectedPath":"polluted.ts"},"constructor":{"panel":"missions","selectedMissionId":"m","selectedTaskId":"t"},"safe":{"panel":"diff","selectedPath":"safe.ts"}}}',
+      JSON.stringify({
+        version: 2,
+        active: null,
+        dock: defaultWorkspaceUiState().dock,
+        surfaces: defaultWorkspaceUiState().surfaces,
+        views: JSON.parse(
+          '{"__proto__":{"panel":"files","openPath":"polluted.ts","selectedPath":null},"prototype":{"panel":"diff","selectedPath":"polluted.ts"},"constructor":{"panel":"missions","selectedMissionId":"m","selectedTaskId":"t"},"safe":{"panel":"diff","selectedPath":"safe.ts"}}',
+        ),
+      }),
     );
 
-    expect(parsed.state.views).toEqual({ safe: { panel: "diff", selectedPath: "safe.ts" } });
+    expect(parsed.state.views).toEqual({ safe: { panel: "diff" } });
     expect(Object.prototype).not.toHaveProperty("panel");
     expect(Object.prototype).not.toHaveProperty("openPath");
     expect("polluted" in parsed.state.views).toBe(false);
@@ -214,10 +240,7 @@ describe("workspace UI-state contract", () => {
       selectedMissionId: "mission-1",
       selectedTaskId: "task-1",
     });
-    expect(missionsSelection(state, "other")).toEqual({
-      selectedMissionId: null,
-      selectedTaskId: null,
-    });
+    expect(missionsSelection(state, "other")).toEqual(missionsSelection(state, "missions"));
   });
 
   it("round-trips bounded missions navigation and tolerates legacy selection-only state", () => {
@@ -248,8 +271,7 @@ describe("workspace UI-state contract", () => {
       },
     );
     const parsed = parseWorkspaceUiStateJson(serializeWorkspaceUiState(state));
-    expect(parsed.state.views.missions).toMatchObject({
-      panel: "missions",
+    expect(parsed.state.surfaces.missions).toMatchObject({
       selectedMissionId: "mission-1",
       selectedTaskId: "task-1",
       navigation: {
@@ -264,8 +286,7 @@ describe("workspace UI-state contract", () => {
     const legacy = parseWorkspaceUiStateJson(
       '{"version":1,"active":null,"views":{"missions":{"panel":"missions","selectedMissionId":"mission-legacy","selectedTaskId":null}}}',
     );
-    expect(legacy.state.views.missions).toEqual({
-      panel: "missions",
+    expect(legacy.state.surfaces.missions).toEqual({
       selectedMissionId: "mission-legacy",
       selectedTaskId: null,
     });
@@ -286,8 +307,6 @@ describe("workspace UI-state contract", () => {
     const parsed = parseWorkspaceUiStateJson(serializeWorkspaceUiState(state));
     expect(parsed.state.views["files-a"]).toEqual({
       panel: "files",
-      openPath: null,
-      selectedPath: null,
       layout: {
         focusedLeafId: "files-tab",
         activeTabs: { dock: "diff-tab" },
@@ -308,11 +327,10 @@ describe("workspace UI-state contract", () => {
     expect(
       chooseInitialWorkspaceView(views(), {
         requestedPanel: "diff",
-        persisted: {
-          version: 1,
+        persisted: currentState({
           active: { viewId: "files-a", panel: "files" },
           views: {},
-        },
+        }),
         legacyLastTab: "files",
       }),
     ).toMatchObject({ reason: "explicit", view: { id: "diff-a" } });
@@ -320,7 +338,7 @@ describe("workspace UI-state contract", () => {
     expect(
       chooseInitialWorkspaceView(views(), {
         requestedPanel: null,
-        persisted: { version: 1, active: { viewId: "files-b", panel: "files" }, views: {} },
+        persisted: currentState({ active: { viewId: "files-b", panel: "files" } }),
         legacyLastTab: "diff",
       }),
     ).toMatchObject({ reason: "persisted-id", view: { id: "files-b" } });
@@ -328,7 +346,7 @@ describe("workspace UI-state contract", () => {
     expect(
       chooseInitialWorkspaceView(views(), {
         requestedPanel: null,
-        persisted: { version: 1, active: { viewId: "diff-a", panel: "files" }, views: {} },
+        persisted: currentState({ active: { viewId: "diff-a", panel: "files" } }),
         legacyLastTab: "diff",
       }),
     ).toMatchObject({ reason: "persisted-panel", view: { id: "files-a" } });
@@ -342,28 +360,47 @@ describe("workspace UI-state contract", () => {
     ).toMatchObject({ reason: "legacy-tab", view: { id: "diff-a" } });
   });
 
-  it("hydrates only matching per-view panel state for duplicate views", () => {
-    const state: WorkspaceUiStateV1 = {
-      version: 1,
+  it("shares each native surface state while retaining per-view layout pointers", () => {
+    const state = currentState({
+      surfaces: { files: { openPath: "src/shared.ts", selectedPath: "src" } },
       active: null,
       views: {
-        "files-a": { panel: "files", openPath: "src/a.ts", selectedPath: "src" },
-        "files-b": { panel: "files", openPath: "src/b.ts", selectedPath: "src/b.ts" },
-        "diff-a": { panel: "files", openPath: "wrong.ts", selectedPath: null },
+        "files-a": { panel: "files" },
+        "files-b": { panel: "files" },
+        "diff-a": { panel: "files" },
       },
-    };
+    });
 
     expect(viewStateFor(state, views()[1])).toEqual({
       panel: "files",
-      openPath: "src/a.ts",
+      openPath: "src/shared.ts",
       selectedPath: "src",
     });
     expect(viewStateFor(state, views()[3])).toEqual({
       panel: "files",
-      openPath: "src/b.ts",
-      selectedPath: "src/b.ts",
+      openPath: "src/shared.ts",
+      selectedPath: "src",
     });
-    expect(viewStateFor(state, views()[2])).toBeNull();
+    expect(viewStateFor(state, views()[2])).toEqual({ panel: "diff", selectedPath: null });
+  });
+
+  it("updates one hydrated surface without changing inactive dock siblings", () => {
+    const persisted = currentState({
+      surfaces: {
+        files: { openPath: "src/old.ts", selectedPath: "src" },
+        diff: { selectedPath: "src/change.ts" },
+        missions: { selectedMissionId: "mis_saved", selectedTaskId: "tsk_saved" },
+      },
+    });
+    const next = setWorkspaceSurfaceState(persisted, {
+      panel: "files",
+      openPath: "src/new.ts",
+      selectedPath: "src/new.ts",
+    });
+
+    expect(next.surfaces.files.openPath).toBe("src/new.ts");
+    expect(next.surfaces.diff).toEqual(persisted.surfaces.diff);
+    expect(next.surfaces.missions).toEqual(persisted.surfaces.missions);
   });
 
   it("converts project-relative paths safely", () => {
@@ -435,17 +472,21 @@ describe("workspace UI-state repository", () => {
       { home },
     );
 
-    const state: WorkspaceUiStateV1 = {
-      version: 1,
+    const state = currentState({
       active: { viewId: "files-a", panel: "files" },
-      views: { "files-a": { panel: "files", openPath: "src/a.ts", selectedPath: null } },
-    };
+      dock: { focusZone: "dock-body" },
+      surfaces: { files: { openPath: "src/a.ts", selectedPath: null } },
+      views: { "files-a": { panel: "files" } },
+    });
     writeWorkspaceUiStateWithRetry({
       repository: first,
       revision: null,
       current: defaultWorkspaceUiState(),
       next: state,
       touchedViewIds: new Set(["files-a"]),
+      touchedSurfaceIds: new Set(["files"]),
+      touchedDock: true,
+      touchedActiveView: true,
     });
 
     expect(existsSync(join(first.runtimeRoot, WORKSPACE_UI_STATE_PATH))).toBe(true);
@@ -460,62 +501,81 @@ describe("workspace UI-state repository", () => {
     const first = createProjectRuntimeRepository(resolution(project), { home });
     const second = createProjectRuntimeRepository(resolution(project), { home });
 
-    const firstState: WorkspaceUiStateV1 = {
-      version: 1,
+    const firstState = currentState({
       active: { viewId: "files-a", panel: "files" },
-      views: { "files-a": { panel: "files", openPath: "a.ts", selectedPath: null } },
-    };
+      dock: { focusZone: "dock-body" },
+      surfaces: { files: { openPath: "a.ts", selectedPath: null } },
+      views: { "files-a": { panel: "files" } },
+    });
     const created = writeWorkspaceUiStateWithRetry({
       repository: first,
       revision: null,
       current: defaultWorkspaceUiState(),
       next: firstState,
       touchedViewIds: new Set(["files-a"]),
+      touchedSurfaceIds: new Set(["files"]),
+      touchedDock: true,
+      touchedActiveView: true,
     });
     expect(created.revision).toBe(1);
 
     const loadedSecond = loadWorkspaceUiState(second);
-    const latestState: WorkspaceUiStateV1 = {
-      version: 1,
+    const latestState = currentState({
       active: { viewId: "diff-a", panel: "diff" },
+      dock: { activeTab: "changes", focusZone: "dock-body" },
+      surfaces: {
+        files: firstState.surfaces.files,
+        diff: { selectedPath: "b.ts" },
+      },
       views: {
         ...firstState.views,
-        "diff-a": { panel: "diff", selectedPath: "b.ts" },
+        "diff-a": { panel: "diff" },
       },
-    };
+    });
     const updated = writeWorkspaceUiStateWithRetry({
       repository: first,
       revision: created.revision,
       current: firstState,
       next: latestState,
       touchedViewIds: new Set(["diff-a"]),
+      touchedSurfaceIds: new Set(["diff"]),
+      touchedDock: true,
+      touchedActiveView: true,
     });
     expect(updated.revision).toBe(2);
 
-    const localSecond: WorkspaceUiStateV1 = {
-      version: 1,
+    const localSecond = currentState({
       active: { viewId: "files-a", panel: "files" },
+      surfaces: { files: { openPath: "a2.ts", selectedPath: "src" } },
       views: {
-        "files-a": { panel: "files", openPath: "a2.ts", selectedPath: "src" },
+        "files-a": { panel: "files" },
       },
-    };
+    });
     const retried = writeWorkspaceUiStateWithRetry({
       repository: second,
       revision: loadedSecond.revision,
       current: loadedSecond.state,
       next: localSecond,
       touchedViewIds: new Set(["files-a"]),
+      touchedSurfaceIds: new Set(["files"]),
+      touchedActiveView: true,
     });
 
     expect(retried.revision).toBe(3);
-    expect(loadWorkspaceUiState(first).state).toEqual({
-      version: 1,
-      active: { viewId: "files-a", panel: "files" },
-      views: {
-        "files-a": { panel: "files", openPath: "a2.ts", selectedPath: "src" },
-        "diff-a": { panel: "diff", selectedPath: "b.ts" },
-      },
-    });
+    expect(loadWorkspaceUiState(first).state).toEqual(
+      currentState({
+        active: { viewId: "files-a", panel: "files" },
+        dock: { activeTab: "changes", focusZone: "dock-body" },
+        surfaces: {
+          files: { openPath: "a2.ts", selectedPath: "src" },
+          diff: { selectedPath: "b.ts" },
+        },
+        views: {
+          "files-a": { panel: "files" },
+          "diff-a": { panel: "diff" },
+        },
+      }),
+    );
   });
 
   it("tolerates missing, malformed, and unreadable runtime documents", () => {
@@ -536,35 +596,76 @@ describe("workspace UI-state repository", () => {
     });
   });
 
-  it("merges untouched latest view entries only when requested", () => {
-    const merged = mergeWorkspaceUiStateForSave(
-      {
-        version: 1,
-        active: { viewId: "diff-a", panel: "diff" },
-        views: {
-          "files-a": { panel: "files", openPath: "old.ts", selectedPath: null },
-          "diff-a": { panel: "diff", selectedPath: "latest.ts" },
-        },
-      },
-      {
-        version: 1,
-        active: { viewId: "files-a", panel: "files" },
-        views: {
-          "files-a": { panel: "files", openPath: "local.ts", selectedPath: null },
-          "diff-a": { panel: "diff", selectedPath: "stale.ts" },
-        },
-      },
-      new Set(["files-a"]),
+  it("preserves unsupported future documents without writing over them", () => {
+    const home = temporaryRoot();
+    const project = temporaryRoot();
+    const repository = createProjectRuntimeRepository(resolution(project), { home });
+    repository.writeDocument(
+      WORKSPACE_UI_STATE_PATH,
+      { version: 99, future: { dock: "owned-by-newer-client" } },
+      { expectedRevision: null },
     );
+    const loaded = loadWorkspaceUiState(repository);
+    expect(loaded).toMatchObject({ revision: 1, writeProtected: true });
 
-    expect(merged).toEqual({
-      version: 1,
-      active: { viewId: "files-a", panel: "files" },
+    const result = writeWorkspaceUiStateWithRetry({
+      repository,
+      revision: loaded.revision,
+      current: loaded.state,
+      next: currentState({ dock: { activeTab: "activity" } }),
+      touchedViewIds: new Set(),
+      touchedDock: true,
+    });
+    expect(result.diagnostics.map((entry) => entry.code)).toContain("WRITE_PROTECTED");
+    expect(repository.readDocument(WORKSPACE_UI_STATE_PATH)).toMatchObject({
+      revision: 1,
+      payload: { version: 99, future: { dock: "owned-by-newer-client" } },
+    });
+  });
+
+  it("merges disjoint active, dock, layout, and surface conflict domains", () => {
+    const latest = currentState({
+      active: { viewId: "diff-a", panel: "diff" },
+      dock: { activeTab: "changes", mode: "maximized", preferredHeight: 18 },
+      surfaces: {
+        files: { openPath: "old.ts", selectedPath: null },
+        diff: { selectedPath: "latest.ts" },
+        activity: { selectedRowId: "latest-agent", scrollOffset: 4 },
+      },
       views: {
-        "files-a": { panel: "files", openPath: "local.ts", selectedPath: null },
-        "diff-a": { panel: "diff", selectedPath: "latest.ts" },
+        "files-a": { panel: "files" },
+        "diff-a": { panel: "diff" },
       },
     });
+    const local = currentState({
+      active: { viewId: "files-a", panel: "files" },
+      dock: { activeTab: "files", mode: "collapsed" },
+      surfaces: {
+        files: { openPath: "local.ts", selectedPath: null },
+        diff: { selectedPath: "stale.ts" },
+        activity: { selectedRowId: "stale-agent", scrollOffset: 0 },
+      },
+      views: {
+        "files-a": { panel: "files" },
+        "diff-a": { panel: "diff" },
+      },
+    });
+    const merged = mergeWorkspaceUiStateForSave(
+      latest,
+      local,
+      new Set(["files-a"]),
+      new Set(["files"]),
+      false,
+      true,
+    );
+
+    expect(merged.active).toEqual(local.active);
+    expect(merged.dock).toEqual(latest.dock);
+    expect(merged.surfaces.files).toEqual(local.surfaces.files);
+    expect(merged.surfaces.diff).toEqual(latest.surfaces.diff);
+    expect(merged.surfaces.activity).toEqual(latest.surfaces.activity);
+    expect(merged.views["files-a"]).toEqual(local.views["files-a"]);
+    expect(merged.views["diff-a"]).toEqual(latest.views["diff-a"]);
   });
 });
 
@@ -591,20 +692,19 @@ describe("workspace UI-state controller", () => {
 
     expect(controller.completeLoad(stale, first, loadWorkspaceUiState(first))).toBe(false);
     expect(controller.completeLoad(current, second, loadWorkspaceUiState(second))).toBe(true);
-    const next: WorkspaceUiStateV1 = {
-      version: 1,
+    const next = currentState({
       active: { viewId: "files-a", panel: "files" },
-      views: { "files-a": { panel: "files", openPath: "a.ts", selectedPath: null } },
-    };
+      surfaces: { files: { openPath: "a.ts", selectedPath: null } },
+      views: { "files-a": { panel: "files" } },
+    });
     expect(controller.save(stale, next, new Set(["files-a"]))).toMatchObject({
       saved: false,
       skipped: true,
       diagnostics: [{ code: "STALE" }],
     });
-    expect(controller.save(current, next, new Set(["files-a"]))).toMatchObject({
-      saved: true,
-      skipped: false,
-    });
+    expect(
+      controller.save(current, next, new Set(["files-a"]), new Set(["files"]), false, true),
+    ).toMatchObject({ saved: true, skipped: false });
     expect(readFileSync(join(second.runtimeRoot, WORKSPACE_UI_STATE_PATH), "utf-8")).toContain(
       "a.ts",
     );

--- a/packages/daemon/src/tui/mirror/workspace-ui-state.ts
+++ b/packages/daemon/src/tui/mirror/workspace-ui-state.ts
@@ -11,9 +11,15 @@ import { findFirstHostedViewForPanel, findHostedViewById } from "./panel-host.ts
 import type { Tab } from "./app-state.ts";
 import { panelKindFromLegacyTab } from "./panel-host.ts";
 import type { CompositeLayoutState } from "./composite-layout.ts";
+import type {
+  WorkbenchDockMode,
+  WorkbenchDockTabId,
+  WorkbenchFocusZone,
+} from "./workspace/workbench-shell.ts";
 
 export const WORKSPACE_UI_STATE_PATH = "ui/workspace.json";
-export const WORKSPACE_UI_STATE_VERSION = 1;
+export const WORKSPACE_UI_STATE_VERSION = 2;
+export const LEGACY_WORKSPACE_UI_STATE_VERSION = 1;
 export const WORKSPACE_UI_STATE_MAX_VIEWS = 64;
 export const WORKSPACE_UI_STATE_MAX_ID_LENGTH = 128;
 export const WORKSPACE_UI_STATE_MAX_PATH_LENGTH = 4096;
@@ -22,12 +28,14 @@ export type WorkspaceUiStateDiagnosticCode =
   | "MISSING"
   | "MALFORMED"
   | "UNSUPPORTED_VERSION"
+  | "MIGRATED"
   | "OVERSIZED"
   | "INVALID_FIELD"
   | "READ_FAILED"
   | "WRITE_FAILED"
   | "STALE"
-  | "NOT_LOADED";
+  | "NOT_LOADED"
+  | "WRITE_PROTECTED";
 
 export interface WorkspaceUiStateDiagnostic {
   code: WorkspaceUiStateDiagnosticCode;
@@ -90,23 +98,58 @@ export type WorkspaceViewState =
   | WorkspaceMissionsViewState
   | WorkspaceEmptyViewState;
 
-export interface WorkspaceUiStateV1 {
+/** V2 keeps view-scoped composite layout only; dock surface memory lives in `surfaces`. */
+export interface WorkspaceLayoutViewState {
+  panel: HostedPanelKind;
+  layout?: WorkspaceCompositeLayoutViewState;
+}
+
+export interface WorkspaceActivitySurfaceState {
+  selectedRowId: string | null;
+  scrollOffset: number;
+}
+
+export interface WorkspaceSurfaceStates {
+  files: Omit<WorkspaceFilesViewState, "panel" | "layout">;
+  diff: Omit<WorkspaceDiffViewState, "panel" | "layout">;
+  missions: Omit<WorkspaceMissionsViewState, "panel" | "layout">;
+  activity: WorkspaceActivitySurfaceState;
+}
+
+export interface WorkspaceDockState {
+  activeTab: WorkbenchDockTabId;
+  mode: WorkbenchDockMode;
+  preferredHeight: number | null;
+  focusZone: WorkbenchFocusZone;
+}
+
+export interface WorkspaceUiStateV2 {
   version: typeof WORKSPACE_UI_STATE_VERSION;
+  active: WorkspaceActiveViewState | null;
+  dock: WorkspaceDockState;
+  surfaces: WorkspaceSurfaceStates;
+  views: Record<string, WorkspaceLayoutViewState>;
+}
+
+/** Exact legacy payload accepted only by the deterministic V1 migration path. */
+export interface WorkspaceUiStateV1 {
+  version: typeof LEGACY_WORKSPACE_UI_STATE_VERSION;
   active: WorkspaceActiveViewState | null;
   views: Record<string, WorkspaceViewState>;
 }
 
 export interface ParsedWorkspaceUiState {
-  state: WorkspaceUiStateV1;
+  state: WorkspaceUiStateV2;
   diagnostics: WorkspaceUiStateDiagnostic[];
 }
 
 export interface LoadedWorkspaceUiState extends ParsedWorkspaceUiState {
   revision: number | null;
+  writeProtected: boolean;
 }
 
 export interface WriteWorkspaceUiStateResult {
-  state: WorkspaceUiStateV1;
+  state: WorkspaceUiStateV2;
   revision: number | null;
   diagnostics: WorkspaceUiStateDiagnostic[];
 }
@@ -119,16 +162,19 @@ export interface WorkspaceViewRestoreChoice {
 export interface WorkspaceUiSaveRequest {
   repository: ProjectRuntimeRepository;
   revision: number | null;
-  current: WorkspaceUiStateV1;
-  next: WorkspaceUiStateV1;
+  current: WorkspaceUiStateV2;
+  next: WorkspaceUiStateV2;
   touchedViewIds: ReadonlySet<string>;
+  touchedSurfaceIds?: ReadonlySet<keyof WorkspaceSurfaceStates>;
+  touchedDock?: boolean;
+  touchedActiveView?: boolean;
 }
 
 export interface WorkspaceUiControllerSnapshot {
   loaded: boolean;
   repository: ProjectRuntimeRepository | null;
   revision: number | null;
-  state: WorkspaceUiStateV1;
+  state: WorkspaceUiStateV2;
   generation: number;
 }
 
@@ -144,10 +190,25 @@ const MISSION_COLUMNS = ["planned", "running", "blocked", "review", "done"] as c
 const MISSION_MODES = ["board", "history", "detail"] as const;
 const MISSION_DENSITIES = ["compact", "comfortable", "detailed"] as const;
 const MISSION_DETAIL_SECTIONS = ["tasks", "timeline", "attempts", "proof"] as const;
+const DOCK_TABS = ["files", "changes", "missions", "activity"] as const;
+const DOCK_MODES = ["collapsed", "open", "maximized"] as const;
+const FOCUS_ZONES = ["canvas", "dock-tabs", "dock-body"] as const;
 
-export const DEFAULT_WORKSPACE_UI_STATE: WorkspaceUiStateV1 = Object.freeze({
+export const DEFAULT_WORKSPACE_UI_STATE: WorkspaceUiStateV2 = Object.freeze({
   version: WORKSPACE_UI_STATE_VERSION,
   active: null,
+  dock: Object.freeze({
+    activeTab: "files",
+    mode: "open",
+    preferredHeight: null,
+    focusZone: "canvas",
+  }),
+  surfaces: Object.freeze({
+    files: Object.freeze({ openPath: null, selectedPath: null }),
+    diff: Object.freeze({ selectedPath: null }),
+    missions: Object.freeze({ selectedMissionId: null, selectedTaskId: null }),
+    activity: Object.freeze({ selectedRowId: null, scrollOffset: 0 }),
+  }),
   views: Object.freeze({}),
 });
 
@@ -195,6 +256,64 @@ function oneOf<T extends readonly string[]>(value: unknown, allowed: T): T[numbe
 
 function cleanNonnegativeInt(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function cleanDockState(
+  value: unknown,
+  diagnostics: WorkspaceUiStateDiagnostic[],
+): WorkspaceDockState {
+  if (!isRecord(value)) {
+    if (value !== undefined) {
+      diagnostics.push(diagnostic("INVALID_FIELD", "$.dock", "dock state must be an object"));
+    }
+    return { ...DEFAULT_WORKSPACE_UI_STATE.dock };
+  }
+  return {
+    activeTab: oneOf(value.activeTab, DOCK_TABS) ?? "files",
+    mode: oneOf(value.mode, DOCK_MODES) ?? "open",
+    preferredHeight:
+      value.preferredHeight === null ? null : cleanNonnegativeInt(value.preferredHeight),
+    focusZone: oneOf(value.focusZone, FOCUS_ZONES) ?? "canvas",
+  };
+}
+
+function cleanSurfaceStates(
+  value: unknown,
+  diagnostics: WorkspaceUiStateDiagnostic[],
+): WorkspaceSurfaceStates {
+  if (!isRecord(value)) {
+    if (value !== undefined) {
+      diagnostics.push(
+        diagnostic("INVALID_FIELD", "$.surfaces", "surface state must be an object"),
+      );
+    }
+    return defaultWorkspaceSurfaceStates();
+  }
+  const files = isRecord(value.files) ? value.files : {};
+  const diff = isRecord(value.diff) ? value.diff : {};
+  const missions = isRecord(value.missions) ? value.missions : {};
+  const activity = isRecord(value.activity) ? value.activity : {};
+  const navigation = cleanMissionsNavigation(
+    missions.navigation,
+    "$.surfaces.missions.navigation",
+    diagnostics,
+  );
+  return {
+    files: {
+      openPath: cleanPath(files.openPath),
+      selectedPath: cleanPath(files.selectedPath),
+    },
+    diff: { selectedPath: cleanPath(diff.selectedPath) },
+    missions: {
+      selectedMissionId: cleanId(missions.selectedMissionId),
+      selectedTaskId: cleanId(missions.selectedTaskId),
+      ...(navigation ? { navigation } : {}),
+    },
+    activity: {
+      selectedRowId: cleanId(activity.selectedRowId),
+      scrollOffset: cleanNonnegativeInt(activity.scrollOffset) ?? 0,
+    },
+  };
 }
 
 function cleanNumberRecord<const Keys extends readonly string[]>(
@@ -321,6 +440,24 @@ function cleanViewState(
   return { panel, ...(layout ? { layout } : {}) };
 }
 
+function cleanLayoutViewState(
+  key: string,
+  value: unknown,
+  diagnostics: WorkspaceUiStateDiagnostic[],
+): WorkspaceLayoutViewState | null {
+  if (!isRecord(value)) {
+    diagnostics.push(diagnostic("INVALID_FIELD", `$.views.${key}`, "view state must be an object"));
+    return null;
+  }
+  const panel = value.panel;
+  if (!isPanel(panel)) {
+    diagnostics.push(diagnostic("INVALID_FIELD", `$.views.${key}.panel`, "panel is unsupported"));
+    return null;
+  }
+  const layout = cleanLayoutState(value.layout, `$.views.${key}.layout`, diagnostics);
+  return { panel, ...(layout ? { layout } : {}) };
+}
+
 function cleanLayoutState(
   value: unknown,
   path: string,
@@ -372,12 +509,27 @@ function cleanLayoutState(
   return { focusedLeafId, activeTabs, splitWeights };
 }
 
-function cloneState(state: WorkspaceUiStateV1): WorkspaceUiStateV1 {
+function cloneState(state: WorkspaceUiStateV2): WorkspaceUiStateV2 {
   return parseWorkspaceUiStateJson(serializeWorkspaceUiState(state)).state;
 }
 
-export function defaultWorkspaceUiState(): WorkspaceUiStateV1 {
-  return { version: WORKSPACE_UI_STATE_VERSION, active: null, views: {} };
+function defaultWorkspaceSurfaceStates(): WorkspaceSurfaceStates {
+  return {
+    files: { openPath: null, selectedPath: null },
+    diff: { selectedPath: null },
+    missions: { selectedMissionId: null, selectedTaskId: null },
+    activity: { selectedRowId: null, scrollOffset: 0 },
+  };
+}
+
+export function defaultWorkspaceUiState(): WorkspaceUiStateV2 {
+  return {
+    version: WORKSPACE_UI_STATE_VERSION,
+    active: null,
+    dock: { ...DEFAULT_WORKSPACE_UI_STATE.dock },
+    surfaces: defaultWorkspaceSurfaceStates(),
+    views: {},
+  };
 }
 
 export function parseWorkspaceUiStateJson(raw: string): ParsedWorkspaceUiState {
@@ -402,6 +554,9 @@ export function parseWorkspaceUiStateValue(
     diagnostics.push(diagnostic("MALFORMED", "$", "workspace UI state must be an object"));
     return { state: defaultWorkspaceUiState(), diagnostics };
   }
+  if (value.version === LEGACY_WORKSPACE_UI_STATE_VERSION) {
+    return migrateWorkspaceUiStateV1(value, diagnostics);
+  }
   if (value.version !== WORKSPACE_UI_STATE_VERSION) {
     diagnostics.push(
       diagnostic(
@@ -413,7 +568,7 @@ export function parseWorkspaceUiStateValue(
     return { state: defaultWorkspaceUiState(), diagnostics };
   }
 
-  const views: Record<string, WorkspaceViewState> = {};
+  const views: Record<string, WorkspaceLayoutViewState> = {};
   if (isRecord(value.views)) {
     const entries = Object.entries(value.views);
     if (entries.length > WORKSPACE_UI_STATE_MAX_VIEWS) {
@@ -431,7 +586,7 @@ export function parseWorkspaceUiStateValue(
         diagnostics.push(diagnostic("INVALID_FIELD", "$.views", "dropped invalid view id"));
         continue;
       }
-      const clean = cleanViewState(id, rawView, diagnostics);
+      const clean = cleanLayoutViewState(id, rawView, diagnostics);
       if (clean) views[id] = clean;
     }
   } else if (value.views !== undefined) {
@@ -442,48 +597,118 @@ export function parseWorkspaceUiStateValue(
     state: {
       version: WORKSPACE_UI_STATE_VERSION,
       active: cleanActive(value.active, diagnostics),
+      dock: cleanDockState(value.dock, diagnostics),
+      surfaces: cleanSurfaceStates(value.surfaces, diagnostics),
       views,
     },
     diagnostics,
   };
 }
 
-export function serializeWorkspaceUiState(state: WorkspaceUiStateV1): string {
-  const parsed = parseWorkspaceUiStateValue(state).state;
-  const orderedViews: Record<string, WorkspaceViewState> = {};
-  for (const id of Object.keys(parsed.views).sort()) {
-    const view = parsed.views[id]!;
-    if (view.panel === "files") {
-      orderedViews[id] = {
-        panel: "files",
-        openPath: view.openPath,
-        selectedPath: view.selectedPath,
-        ...(view.layout ? { layout: orderedLayoutState(view.layout) } : {}),
-      };
-    } else if (view.panel === "diff") {
-      orderedViews[id] = {
-        panel: "diff",
-        selectedPath: view.selectedPath,
-        ...(view.layout ? { layout: orderedLayoutState(view.layout) } : {}),
-      };
-    } else if (view.panel === "missions") {
-      orderedViews[id] = {
-        panel: "missions",
-        selectedMissionId: view.selectedMissionId,
-        selectedTaskId: view.selectedTaskId,
-        ...(view.navigation ? { navigation: orderedMissionsNavigation(view.navigation) } : {}),
-        ...(view.layout ? { layout: orderedLayoutState(view.layout) } : {}),
-      };
-    } else {
-      orderedViews[id] = {
-        panel: view.panel,
-        ...(view.layout ? { layout: orderedLayoutState(view.layout) } : {}),
-      };
+function migrateWorkspaceUiStateV1(
+  value: Record<string, unknown>,
+  diagnostics: WorkspaceUiStateDiagnostic[],
+): ParsedWorkspaceUiState {
+  const legacyViews: Record<string, WorkspaceViewState> = {};
+  if (isRecord(value.views)) {
+    for (const [key, rawView] of Object.entries(value.views).slice(
+      0,
+      WORKSPACE_UI_STATE_MAX_VIEWS,
+    )) {
+      const id = cleanId(key);
+      if (!id) continue;
+      const clean = cleanViewState(id, rawView, diagnostics);
+      if (clean) legacyViews[id] = clean;
     }
   }
-  const clean: WorkspaceUiStateV1 = {
+  const active = cleanActive(value.active, diagnostics);
+  const pick = <Panel extends WorkspaceViewState["panel"]>(panel: Panel) => {
+    const activeEntry = active?.panel === panel ? legacyViews[active.viewId] : null;
+    if (activeEntry?.panel === panel) return activeEntry;
+    return Object.keys(legacyViews)
+      .sort()
+      .map((id) => legacyViews[id]!)
+      .find((entry) => entry.panel === panel);
+  };
+  const files = pick("files") as WorkspaceFilesViewState | undefined;
+  const diff = pick("diff") as WorkspaceDiffViewState | undefined;
+  const missions = pick("missions") as WorkspaceMissionsViewState | undefined;
+  const activeTab = dockTabFromPanel(active?.panel) ?? "files";
+  diagnostics.push(
+    diagnostic("MIGRATED", "$.version", "workspace UI state migrated from version 1 to version 2"),
+  );
+  return {
+    state: {
+      version: WORKSPACE_UI_STATE_VERSION,
+      active,
+      dock: {
+        activeTab,
+        mode: "open",
+        preferredHeight: null,
+        focusZone: dockTabFromPanel(active?.panel) ? "dock-body" : "canvas",
+      },
+      surfaces: {
+        files: {
+          openPath: files?.openPath ?? null,
+          selectedPath: files?.selectedPath ?? null,
+        },
+        diff: { selectedPath: diff?.selectedPath ?? null },
+        missions: {
+          selectedMissionId: missions?.selectedMissionId ?? null,
+          selectedTaskId: missions?.selectedTaskId ?? null,
+          ...(missions?.navigation
+            ? { navigation: orderedMissionsNavigation(missions.navigation) }
+            : {}),
+        },
+        activity: { selectedRowId: null, scrollOffset: 0 },
+      },
+      views: Object.fromEntries(
+        Object.entries(legacyViews).map(([id, entry]) => [
+          id,
+          {
+            panel: entry.panel,
+            ...(entry.layout ? { layout: orderedLayoutState(entry.layout) } : {}),
+          },
+        ]),
+      ),
+    },
+    diagnostics,
+  };
+}
+
+function dockTabFromPanel(panel: HostedPanelKind | null | undefined): WorkbenchDockTabId | null {
+  if (panel === "files") return "files";
+  if (panel === "diff") return "changes";
+  if (panel === "missions") return "missions";
+  return null;
+}
+
+export function serializeWorkspaceUiState(state: WorkspaceUiStateV2): string {
+  const parsed = parseWorkspaceUiStateValue(state).state;
+  const orderedViews: Record<string, WorkspaceLayoutViewState> = {};
+  for (const id of Object.keys(parsed.views).sort()) {
+    const view = parsed.views[id]!;
+    orderedViews[id] = {
+      panel: view.panel,
+      ...(view.layout ? { layout: orderedLayoutState(view.layout) } : {}),
+    };
+  }
+  const clean: WorkspaceUiStateV2 = {
     version: WORKSPACE_UI_STATE_VERSION,
     active: parsed.active ? { viewId: parsed.active.viewId, panel: parsed.active.panel } : null,
+    dock: { ...parsed.dock },
+    surfaces: {
+      files: { ...parsed.surfaces.files },
+      diff: { ...parsed.surfaces.diff },
+      missions: {
+        selectedMissionId: parsed.surfaces.missions.selectedMissionId,
+        selectedTaskId: parsed.surfaces.missions.selectedTaskId,
+        ...(parsed.surfaces.missions.navigation
+          ? { navigation: orderedMissionsNavigation(parsed.surfaces.missions.navigation) }
+          : {}),
+      },
+      activity: { ...parsed.surfaces.activity },
+    },
     views: orderedViews,
   };
   return `${JSON.stringify(clean, null, 2)}\n`;
@@ -543,7 +768,7 @@ function orderedBooleanRecord<const Keys extends readonly string[]>(
   ) as Record<Keys[number], boolean>;
 }
 
-export function workspaceUiStateToJsonValue(state: WorkspaceUiStateV1): JsonValue {
+export function workspaceUiStateToJsonValue(state: WorkspaceUiStateV2): JsonValue {
   return JSON.parse(serializeWorkspaceUiState(state)) as JsonValue;
 }
 
@@ -555,6 +780,7 @@ export function loadWorkspaceUiState(repository: ProjectRuntimeRepository): Load
     return {
       state: defaultWorkspaceUiState(),
       revision: null,
+      writeProtected: false,
       diagnostics: [
         diagnostic(
           "READ_FAILED",
@@ -568,26 +794,61 @@ export function loadWorkspaceUiState(repository: ProjectRuntimeRepository): Load
     return {
       state: defaultWorkspaceUiState(),
       revision: null,
+      writeProtected: false,
       diagnostics: [diagnostic("MISSING", WORKSPACE_UI_STATE_PATH, "workspace UI state is absent")],
     };
   }
   const parsed = parseWorkspaceUiStateValue(document.payload);
-  return { ...parsed, revision: document.revision };
+  return {
+    ...parsed,
+    revision: document.revision,
+    writeProtected: parsed.diagnostics.some((entry) => entry.code === "UNSUPPORTED_VERSION"),
+  };
 }
 
 export function mergeWorkspaceUiStateForSave(
-  latest: WorkspaceUiStateV1,
-  local: WorkspaceUiStateV1,
+  latest: WorkspaceUiStateV2,
+  local: WorkspaceUiStateV2,
   touchedViewIds: ReadonlySet<string>,
-): WorkspaceUiStateV1 {
-  const views: Record<string, WorkspaceViewState> = { ...latest.views };
+  touchedSurfaceIds: ReadonlySet<keyof WorkspaceSurfaceStates> = new Set(),
+  touchedDock = false,
+  touchedActiveView = false,
+): WorkspaceUiStateV2 {
+  const views: Record<string, WorkspaceLayoutViewState> = { ...latest.views };
   for (const id of touchedViewIds) {
     const localView = local.views[id];
     if (localView) views[id] = localView;
   }
+  const missions = touchedSurfaceIds.has("missions")
+    ? local.surfaces.missions
+    : latest.surfaces.missions;
   return {
     version: WORKSPACE_UI_STATE_VERSION,
-    active: local.active ? { ...local.active } : null,
+    active: touchedActiveView
+      ? local.active
+        ? { ...local.active }
+        : null
+      : latest.active
+        ? { ...latest.active }
+        : null,
+    dock: { ...(touchedDock ? local.dock : latest.dock) },
+    surfaces: {
+      files: {
+        ...(touchedSurfaceIds.has("files") ? local.surfaces.files : latest.surfaces.files),
+      },
+      diff: {
+        ...(touchedSurfaceIds.has("diff") ? local.surfaces.diff : latest.surfaces.diff),
+      },
+      missions: {
+        ...missions,
+        ...(missions.navigation
+          ? { navigation: orderedMissionsNavigation(missions.navigation) }
+          : {}),
+      },
+      activity: {
+        ...(touchedSurfaceIds.has("activity") ? local.surfaces.activity : latest.surfaces.activity),
+      },
+    },
     views,
   };
 }
@@ -596,7 +857,24 @@ export function writeWorkspaceUiStateWithRetry(
   request: WorkspaceUiSaveRequest,
 ): WriteWorkspaceUiStateResult {
   const diagnostics: WorkspaceUiStateDiagnostic[] = [];
-  const writePayload = (state: WorkspaceUiStateV1, revision: number | null) =>
+  if (request.revision !== null) {
+    const existing = loadWorkspaceUiState(request.repository);
+    if (existing.writeProtected) {
+      return {
+        state: request.current,
+        revision: request.revision,
+        diagnostics: [
+          ...existing.diagnostics,
+          diagnostic(
+            "WRITE_PROTECTED",
+            WORKSPACE_UI_STATE_PATH,
+            "newer workspace UI state was preserved without writing",
+          ),
+        ],
+      };
+    }
+  }
+  const writePayload = (state: WorkspaceUiStateV2, revision: number | null) =>
     request.repository.writeDocument(WORKSPACE_UI_STATE_PATH, workspaceUiStateToJsonValue(state), {
       expectedRevision: revision,
     });
@@ -621,7 +899,28 @@ export function writeWorkspaceUiStateWithRetry(
 
   const latest = loadWorkspaceUiState(request.repository);
   diagnostics.push(...latest.diagnostics.filter((entry) => entry.code !== "MISSING"));
-  const merged = mergeWorkspaceUiStateForSave(latest.state, request.next, request.touchedViewIds);
+  if (latest.writeProtected) {
+    return {
+      state: request.current,
+      revision: request.revision,
+      diagnostics: [
+        ...diagnostics,
+        diagnostic(
+          "WRITE_PROTECTED",
+          WORKSPACE_UI_STATE_PATH,
+          "newer workspace UI state was preserved without writing",
+        ),
+      ],
+    };
+  }
+  const merged = mergeWorkspaceUiStateForSave(
+    latest.state,
+    request.next,
+    request.touchedViewIds,
+    request.touchedSurfaceIds,
+    request.touchedDock,
+    request.touchedActiveView,
+  );
   try {
     const written = writePayload(merged, latest.revision);
     return { state: cloneState(merged), revision: written.revision, diagnostics };
@@ -645,7 +944,7 @@ export function chooseInitialWorkspaceView(
   views: readonly HostedPanelView[],
   options: {
     requestedPanel: HostedPanelKind | null | undefined;
-    persisted: WorkspaceUiStateV1 | null | undefined;
+    persisted: WorkspaceUiStateV2 | null | undefined;
     legacyLastTab: Tab | null | undefined;
   },
 ): WorkspaceViewRestoreChoice {
@@ -670,111 +969,141 @@ export function chooseInitialWorkspaceView(
 }
 
 export function viewStateFor(
-  state: WorkspaceUiStateV1,
+  state: WorkspaceUiStateV2,
   view: Pick<HostedPanelView, "id" | "panel"> | null | undefined,
 ): WorkspaceViewState | null {
   if (!view) return null;
-  const entry = state.views[view.id];
-  return entry && entry.panel === view.panel ? entry : null;
+  const layout = state.views[view.id]?.layout;
+  if (view.panel === "files")
+    return { panel: "files", ...state.surfaces.files, ...(layout ? { layout } : {}) };
+  if (view.panel === "diff")
+    return { panel: "diff", ...state.surfaces.diff, ...(layout ? { layout } : {}) };
+  if (view.panel === "missions") {
+    return { panel: "missions", ...state.surfaces.missions, ...(layout ? { layout } : {}) };
+  }
+  return view.panel === "home"
+    ? { panel: "home", ...(layout ? { layout } : {}) }
+    : { panel: "terminals", ...(layout ? { layout } : {}) };
+}
+
+export function workspaceSurfaceState(
+  state: WorkspaceUiStateV2,
+  panel: "files" | "diff" | "missions" | "activity",
+):
+  | WorkspaceFilesViewState
+  | WorkspaceDiffViewState
+  | WorkspaceMissionsViewState
+  | WorkspaceActivitySurfaceState {
+  if (panel === "files") return { panel: "files", ...state.surfaces.files };
+  if (panel === "diff") return { panel: "diff", ...state.surfaces.diff };
+  if (panel === "missions") return { panel: "missions", ...state.surfaces.missions };
+  return { ...state.surfaces.activity };
+}
+
+export function setWorkspaceSurfaceState(
+  state: WorkspaceUiStateV2,
+  entry:
+    | WorkspaceFilesViewState
+    | WorkspaceDiffViewState
+    | WorkspaceMissionsViewState
+    | ({ panel: "activity" } & WorkspaceActivitySurfaceState),
+): WorkspaceUiStateV2 {
+  const next = cloneState(state);
+  if (entry.panel === "files") {
+    next.surfaces.files = {
+      openPath: cleanPath(entry.openPath),
+      selectedPath: cleanPath(entry.selectedPath),
+    };
+  } else if (entry.panel === "diff") {
+    next.surfaces.diff = { selectedPath: cleanPath(entry.selectedPath) };
+  } else if (entry.panel === "missions") {
+    next.surfaces.missions = {
+      selectedMissionId: cleanId(entry.selectedMissionId),
+      selectedTaskId: cleanId(entry.selectedTaskId),
+      ...(entry.navigation ? { navigation: orderedMissionsNavigation(entry.navigation) } : {}),
+    };
+  } else {
+    next.surfaces.activity = {
+      selectedRowId: cleanId(entry.selectedRowId),
+      scrollOffset: cleanNonnegativeInt(entry.scrollOffset) ?? 0,
+    };
+  }
+  return next;
+}
+
+export function setWorkspaceDockState(
+  state: WorkspaceUiStateV2,
+  dock: WorkspaceDockState,
+): WorkspaceUiStateV2 {
+  const next = cloneState(state);
+  next.dock = cleanDockState(dock, []);
+  return next;
 }
 
 export function setMissionsSelection(
-  state: WorkspaceUiStateV1,
+  state: WorkspaceUiStateV2,
   viewId: string,
   missionId: string | null,
   taskId: string | null,
-): WorkspaceUiStateV1 {
+): WorkspaceUiStateV2 {
   const id = cleanId(viewId);
   if (!id) return cloneState(state);
-  return {
-    version: WORKSPACE_UI_STATE_VERSION,
-    active: state.active ? { ...state.active } : null,
-    views: {
-      ...state.views,
-      [id]: {
-        ...(state.views[id]?.layout ? { layout: state.views[id].layout } : {}),
-        panel: "missions",
-        selectedMissionId: cleanId(missionId),
-        selectedTaskId: cleanId(taskId),
-        ...(state.views[id]?.panel === "missions" && state.views[id].navigation
-          ? { navigation: state.views[id].navigation }
-          : {}),
-      },
-    },
+  const next = cloneState(state);
+  next.surfaces.missions = {
+    selectedMissionId: cleanId(missionId),
+    selectedTaskId: cleanId(taskId),
+    ...(state.surfaces.missions.navigation
+      ? { navigation: orderedMissionsNavigation(state.surfaces.missions.navigation) }
+      : {}),
   };
+  return next;
 }
 
 export function setMissionsNavigation(
-  state: WorkspaceUiStateV1,
+  state: WorkspaceUiStateV2,
   viewId: string,
   selection: Pick<WorkspaceMissionsViewState, "selectedMissionId" | "selectedTaskId">,
   navigation: WorkspaceMissionsNavigationState,
-): WorkspaceUiStateV1 {
+): WorkspaceUiStateV2 {
   const id = cleanId(viewId);
   if (!id) return cloneState(state);
-  const existing = state.views[id];
-  return {
-    version: WORKSPACE_UI_STATE_VERSION,
-    active: state.active ? { ...state.active } : null,
-    views: {
-      ...state.views,
-      [id]: {
-        ...(existing?.layout ? { layout: existing.layout } : {}),
-        panel: "missions",
-        selectedMissionId: cleanId(selection.selectedMissionId),
-        selectedTaskId: cleanId(selection.selectedTaskId),
-        navigation: orderedMissionsNavigation(navigation),
-      },
-    },
+  const next = cloneState(state);
+  next.surfaces.missions = {
+    selectedMissionId: cleanId(selection.selectedMissionId),
+    selectedTaskId: cleanId(selection.selectedTaskId),
+    navigation: orderedMissionsNavigation(navigation),
   };
+  return next;
 }
 
 export function layoutStateForView(
-  state: WorkspaceUiStateV1,
+  state: WorkspaceUiStateV2,
   viewId: string,
 ): WorkspaceCompositeLayoutViewState | null {
   return state.views[viewId]?.layout ?? null;
 }
 
 function workspaceViewStateWithLayout(
-  entry: WorkspaceViewState,
+  entry: WorkspaceLayoutViewState,
   layout: WorkspaceCompositeLayoutViewState,
-): WorkspaceViewState {
+): WorkspaceLayoutViewState {
   const cleanLayout = orderedLayoutState(layout);
-  if (entry.panel === "files") {
-    return {
-      panel: "files",
-      openPath: entry.openPath,
-      selectedPath: entry.selectedPath,
-      layout: cleanLayout,
-    };
-  }
-  if (entry.panel === "diff") {
-    return { panel: "diff", selectedPath: entry.selectedPath, layout: cleanLayout };
-  }
-  if (entry.panel === "missions") {
-    return {
-      panel: "missions",
-      selectedMissionId: entry.selectedMissionId,
-      selectedTaskId: entry.selectedTaskId,
-      ...(entry.navigation ? { navigation: orderedMissionsNavigation(entry.navigation) } : {}),
-      layout: cleanLayout,
-    };
-  }
   return { panel: entry.panel, layout: cleanLayout };
 }
 
 export function setWorkspaceViewLayoutState(
-  state: WorkspaceUiStateV1,
+  state: WorkspaceUiStateV2,
   view: Pick<HostedPanelView, "id" | "panel">,
   layout: WorkspaceCompositeLayoutViewState,
-): WorkspaceUiStateV1 {
+): WorkspaceUiStateV2 {
   const id = cleanId(view.id);
   if (!id) return cloneState(state);
   const existing = state.views[id] ?? workspaceViewStateForPanel(view.panel);
   return {
     version: WORKSPACE_UI_STATE_VERSION,
     active: state.active ? { ...state.active } : null,
+    dock: { ...state.dock },
+    surfaces: cloneState(state).surfaces,
     views: {
       ...state.views,
       [id]: workspaceViewStateWithLayout(existing, layout),
@@ -782,22 +1111,19 @@ export function setWorkspaceViewLayoutState(
   };
 }
 
-function workspaceViewStateForPanel(panel: HostedPanelKind): WorkspaceViewState {
-  if (panel === "files") return { panel: "files", openPath: null, selectedPath: null };
-  if (panel === "diff") return { panel: "diff", selectedPath: null };
-  if (panel === "missions") {
-    return { panel: "missions", selectedMissionId: null, selectedTaskId: null };
-  }
+function workspaceViewStateForPanel(panel: HostedPanelKind): WorkspaceLayoutViewState {
   return { panel };
 }
 
 export function missionsSelection(
-  state: WorkspaceUiStateV1,
+  state: WorkspaceUiStateV2,
   viewId: string,
 ): Pick<WorkspaceMissionsViewState, "selectedMissionId" | "selectedTaskId"> {
-  const entry = state.views[viewId];
-  if (entry?.panel !== "missions") return { selectedMissionId: null, selectedTaskId: null };
-  return { selectedMissionId: entry.selectedMissionId, selectedTaskId: entry.selectedTaskId };
+  void viewId;
+  return {
+    selectedMissionId: state.surfaces.missions.selectedMissionId,
+    selectedTaskId: state.surfaces.missions.selectedTaskId,
+  };
 }
 
 export function relativeProjectPath(projectRoot: string, path: string | null): string | null {
@@ -843,8 +1169,9 @@ export class WorkspaceUiStateController {
   #generation = 0;
   #repository: ProjectRuntimeRepository | null = null;
   #revision: number | null = null;
-  #state: WorkspaceUiStateV1 = defaultWorkspaceUiState();
+  #state: WorkspaceUiStateV2 = defaultWorkspaceUiState();
   #loaded = false;
+  #writeProtected = false;
 
   beginLoad(): number {
     this.#generation += 1;
@@ -852,6 +1179,7 @@ export class WorkspaceUiStateController {
     this.#repository = null;
     this.#revision = null;
     this.#state = defaultWorkspaceUiState();
+    this.#writeProtected = false;
     return this.#generation;
   }
 
@@ -865,6 +1193,7 @@ export class WorkspaceUiStateController {
     this.#revision = loaded.revision;
     this.#state = cloneState(loaded.state);
     this.#loaded = true;
+    this.#writeProtected = loaded.writeProtected;
     return true;
   }
 
@@ -874,6 +1203,7 @@ export class WorkspaceUiStateController {
     this.#revision = null;
     this.#state = defaultWorkspaceUiState();
     this.#loaded = true;
+    this.#writeProtected = false;
     return true;
   }
 
@@ -889,8 +1219,11 @@ export class WorkspaceUiStateController {
 
   save(
     generation: number,
-    next: WorkspaceUiStateV1,
+    next: WorkspaceUiStateV2,
     touchedViewIds: ReadonlySet<string>,
+    touchedSurfaceIds: ReadonlySet<keyof WorkspaceSurfaceStates> = new Set(),
+    touchedDock = false,
+    touchedActiveView = false,
   ): WorkspaceUiControllerSaveResult {
     if (generation !== this.#generation) {
       return {
@@ -908,14 +1241,34 @@ export class WorkspaceUiStateController {
         ],
       };
     }
+    if (this.#writeProtected) {
+      return {
+        saved: false,
+        skipped: false,
+        diagnostics: [
+          diagnostic(
+            "WRITE_PROTECTED",
+            WORKSPACE_UI_STATE_PATH,
+            "newer workspace UI state was preserved without writing",
+          ),
+        ],
+      };
+    }
     const result = writeWorkspaceUiStateWithRetry({
       repository: this.#repository,
       revision: this.#revision,
       current: this.#state,
       next,
       touchedViewIds,
+      touchedSurfaceIds,
+      touchedDock,
+      touchedActiveView,
     });
-    if (result.diagnostics.some((entry) => entry.code === "WRITE_FAILED")) {
+    if (
+      result.diagnostics.some(
+        (entry) => entry.code === "WRITE_FAILED" || entry.code === "WRITE_PROTECTED",
+      )
+    ) {
       return { saved: false, skipped: false, diagnostics: result.diagnostics };
     }
     this.#state = cloneState(result.state);

--- a/packages/daemon/src/tui/mirror/workspace/__snapshots__/workbench-shell-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/workspace/__snapshots__/workbench-shell-renderer.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`WorkbenchShell OpenTUI renderer renders the %sx%s wide agent canvas and
 
 
 
- F6  ▤ Files  F7  ± Changes  F8 ●◆ Missions  F9 !◌ Activity                                                                                                                             ▾ close   □ max
+ F3  ▤ Files  F4  ± Changes  F6 ●◆ Missions  F9 !◌ Activity                                                                                                                             ▾ close   □ max
 │● missions dock                                                                                                                                                                open · preferred 20 rows
  ○ Full application parity                                                                                                                                                                  7 / 20 cards
  ● Workbench dock projection                                                                                                                                                                 in progress

--- a/packages/daemon/src/tui/mirror/workspace/workbench-controller.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/workbench-controller.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveWorkbenchPasteTarget,
+  workbenchDockTabForShortcut,
+} from "./workbench-controller.ts";
+
+describe("workbench root controller boundary", () => {
+  it.each([
+    ["f3", "files"],
+    ["f4", "changes"],
+    ["f6", "missions"],
+    ["f9", "activity"],
+  ] as const)("maps %s to the %s native dock tab", (name, tab) => {
+    expect(workbenchDockTabForShortcut({ name })).toBe(tab);
+  });
+
+  it("does not steal modified or unrelated shortcuts", () => {
+    expect(workbenchDockTabForShortcut({ name: "f3", shift: true })).toBeNull();
+    expect(workbenchDockTabForShortcut({ name: "f6", ctrl: true })).toBeNull();
+    expect(workbenchDockTabForShortcut({ name: "f5" })).toBeNull();
+  });
+
+  it("allows paste only into the canvas terminal or writable Files editor", () => {
+    expect(
+      resolveWorkbenchPasteTarget({
+        focusZone: "canvas",
+        focusedPanel: "terminals",
+        filesEditorFocused: false,
+        filesEditorWritable: false,
+        terminalAvailable: true,
+      }),
+    ).toBe("terminal");
+    expect(
+      resolveWorkbenchPasteTarget({
+        focusZone: "dock-body",
+        focusedPanel: "files",
+        filesEditorFocused: true,
+        filesEditorWritable: true,
+        terminalAvailable: true,
+      }),
+    ).toBe("files-editor");
+    expect(
+      resolveWorkbenchPasteTarget({
+        focusZone: "canvas",
+        focusedPanel: "files",
+        filesEditorFocused: true,
+        filesEditorWritable: true,
+        terminalAvailable: true,
+      }),
+    ).toBe("files-editor");
+    for (const focusedPanel of ["diff", "missions", "activity"] as const) {
+      expect(
+        resolveWorkbenchPasteTarget({
+          focusZone: "dock-body",
+          focusedPanel,
+          filesEditorFocused: true,
+          filesEditorWritable: true,
+          terminalAvailable: true,
+        }),
+      ).toBe("consume");
+    }
+    expect(
+      resolveWorkbenchPasteTarget({
+        focusZone: "dock-tabs",
+        focusedPanel: "files",
+        filesEditorFocused: true,
+        filesEditorWritable: true,
+        terminalAvailable: true,
+      }),
+    ).toBe("consume");
+    expect(
+      resolveWorkbenchPasteTarget({
+        focusZone: "canvas",
+        focusedPanel: "diff",
+        filesEditorFocused: false,
+        filesEditorWritable: false,
+        terminalAvailable: true,
+      }),
+    ).toBe("consume");
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace/workbench-controller.ts
+++ b/packages/daemon/src/tui/mirror/workspace/workbench-controller.ts
@@ -1,0 +1,52 @@
+import type { WorkbenchDockTabId, WorkbenchFocusZone } from "./workbench-shell.ts";
+
+export interface WorkbenchShortcutEvent {
+  name: string;
+  ctrl?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+}
+
+const DOCK_SHORTCUTS: Readonly<Record<string, WorkbenchDockTabId>> = {
+  f3: "files",
+  f4: "changes",
+  f6: "missions",
+  f9: "activity",
+};
+
+export function workbenchDockTabForShortcut(
+  event: WorkbenchShortcutEvent,
+): WorkbenchDockTabId | null {
+  if (event.ctrl || event.meta || event.shift) return null;
+  return DOCK_SHORTCUTS[event.name.toLowerCase()] ?? null;
+}
+
+export type WorkbenchPasteTarget = "terminal" | "files-editor" | "consume";
+export type WorkbenchFocusedPanel =
+  | "home"
+  | "terminals"
+  | "files"
+  | "diff"
+  | "missions"
+  | "activity";
+
+export function resolveWorkbenchPasteTarget(input: {
+  focusZone: WorkbenchFocusZone;
+  focusedPanel: WorkbenchFocusedPanel;
+  filesEditorFocused: boolean;
+  filesEditorWritable: boolean;
+  terminalAvailable: boolean;
+}): WorkbenchPasteTarget {
+  if (
+    input.focusZone !== "dock-tabs" &&
+    input.focusedPanel === "files" &&
+    input.filesEditorFocused &&
+    input.filesEditorWritable
+  ) {
+    return "files-editor";
+  }
+  if (input.focusZone === "canvas" && input.focusedPanel === "terminals") {
+    return input.terminalAvailable ? "terminal" : "consume";
+  }
+  return "consume";
+}

--- a/packages/daemon/src/tui/mirror/workspace/workbench-shell.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/workbench-shell.test.ts
@@ -113,6 +113,22 @@ describe("WorkbenchShell projection", () => {
     expect(workbenchShellHitTest(projection, projection.canvasRail.x, 4)).toEqual({
       kind: "canvas-rail",
     });
+    expect(workbenchShellHitTest(projection, projection.canvasBody.x, 4)).toEqual({
+      kind: "canvas",
+      localX: 0,
+      localY: 4,
+    });
+    expect(
+      workbenchShellHitTest(
+        projection,
+        projection.canvasBody.x + projection.canvasBody.width - 1,
+        4,
+      ),
+    ).toEqual({
+      kind: "canvas",
+      localX: projection.canvasBody.width - 1,
+      localY: 4,
+    });
 
     const files = projection.tabs.find((tab) => tab.id === "files")!;
     expect(workbenchShellHitTest(projection, files.x, projection.dockTabs.y)).toEqual({

--- a/packages/daemon/src/tui/mirror/workspace/workbench-shell.ts
+++ b/packages/daemon/src/tui/mirror/workspace/workbench-shell.ts
@@ -12,13 +12,14 @@ export interface WorkbenchShellInput {
   width: number;
   height: number;
   dockMode: WorkbenchDockMode;
-  /** Last user-selected open height. Collapsing or maximizing never replaces it. */
-  persistedDockHeight: number;
+  /** Last user-selected open height; null follows the responsive 30% default. */
+  persistedDockHeight: number | null;
   activeDockTab: WorkbenchDockTabId;
   focusZone: WorkbenchFocusZone;
   hoveredDockTab?: WorkbenchDockTabId | null;
   attentionDockTabs?: ReadonlySet<WorkbenchDockTabId>;
   disabledDockTabs?: ReadonlySet<WorkbenchDockTabId>;
+  dockTabShortcuts?: Partial<Record<WorkbenchDockTabId, string>>;
 }
 
 export interface WorkbenchDockConstraints {
@@ -58,7 +59,7 @@ export interface WorkbenchShellProjection {
   variant: WorkbenchVariant;
   requestedDockMode: WorkbenchDockMode;
   dockMode: WorkbenchDockMode;
-  persistedDockHeight: number;
+  persistedDockHeight: number | null;
   focusZone: WorkbenchFocusZone;
   constraints: WorkbenchDockConstraints;
   canvas: Rect;
@@ -99,9 +100,9 @@ interface DockTabDefinition {
 }
 
 const DOCK_TABS: readonly DockTabDefinition[] = [
-  { id: "files", title: "Files", compactTitle: "Files", glyph: "▤", shortcut: "F6" },
-  { id: "changes", title: "Changes", compactTitle: "Changes", glyph: "±", shortcut: "F7" },
-  { id: "missions", title: "Missions", compactTitle: "Missions", glyph: "◆", shortcut: "F8" },
+  { id: "files", title: "Files", compactTitle: "Files", glyph: "▤", shortcut: "F3" },
+  { id: "changes", title: "Changes", compactTitle: "Changes", glyph: "±", shortcut: "F4" },
+  { id: "missions", title: "Missions", compactTitle: "Missions", glyph: "◆", shortcut: "F6" },
   { id: "activity", title: "Activity", compactTitle: "Activity", glyph: "◌", shortcut: "F9" },
 ];
 
@@ -117,7 +118,8 @@ export function workbenchVariant(width: number, height: number): WorkbenchVarian
 export function projectWorkbenchShell(input: WorkbenchShellInput): WorkbenchShellProjection {
   const width = nonNegativeInteger(input.width);
   const height = nonNegativeInteger(input.height);
-  const persistedDockHeight = nonNegativeInteger(input.persistedDockHeight);
+  const persistedDockHeight =
+    input.persistedDockHeight === null ? null : nonNegativeInteger(input.persistedDockHeight);
   const variant = workbenchVariant(width, height);
   const tabBarHeight = Math.min(TAB_BAR_ROWS, height);
   const minimumCanvasHeight = Math.min(
@@ -130,7 +132,7 @@ export function projectWorkbenchShell(input: WorkbenchShellInput): WorkbenchShel
     maximumOpenDockHeight,
   );
   const preferredOpenDockHeight = clamp(
-    persistedDockHeight,
+    persistedDockHeight ?? Math.round(height * 0.3),
     minimumOpenDockHeight,
     maximumOpenDockHeight,
   );
@@ -276,7 +278,8 @@ function projectDockTabs(
     const selected = definition.id === activeDockTab;
     const attention = input.attentionDockTabs?.has(definition.id) ?? false;
     const disabled = input.disabledDockTabs?.has(definition.id) ?? false;
-    const desired = dockTabLabel(definition, variant, selected, attention, disabled);
+    const shortcut = input.dockTabShortcuts?.[definition.id] ?? definition.shortcut;
+    const desired = dockTabLabel(definition, shortcut, variant, selected, attention, disabled);
     const remainingTabs = DOCK_TABS.length - index;
     const available = Math.max(0, rightEdge - x);
     const fairWidth = remainingTabs > 0 ? Math.floor(available / remainingTabs) : 0;
@@ -286,7 +289,7 @@ function projectDockTabs(
       id: definition.id,
       title: definition.title,
       label,
-      shortcut: definition.shortcut,
+      shortcut,
       selected,
       focused: selected && focusZone === "dock-tabs" && !disabled,
       hovered: input.hoveredDockTab === definition.id,
@@ -360,6 +363,7 @@ function projectDockActions(
 
 function dockTabLabel(
   definition: DockTabDefinition,
+  shortcut: string,
   variant: WorkbenchVariant,
   selected: boolean,
   attention: boolean,
@@ -367,8 +371,8 @@ function dockTabLabel(
 ): string {
   const marker = disabled ? "×" : attention ? "!" : selected ? "●" : " ";
   const title = variant === "compact" ? definition.compactTitle : definition.title;
-  const shortcut = variant === "wide" ? `${definition.shortcut} ` : "";
-  return ` ${shortcut}${marker}${definition.glyph} ${title} `;
+  const shortcutLabel = variant === "wide" && shortcut ? `${shortcut} ` : "";
+  return ` ${shortcutLabel}${marker}${definition.glyph} ${title} `;
 }
 
 function enabledDockTab(


### PR DESCRIPTION
## Summary
- mount the native WorkbenchShell in the production OpenTUI app
- host real Files, Changes, Missions, and Activity surfaces in the bottom dock
- persist independent V2 dock/surface state with deterministic V1 migration and conflict safety
- isolate keyboard, paste, pointer, focus-rail, and cross-boundary input from tmux panes
- add responsive Activity and Workbench renderer coverage

## Validation
- `pnpm check`
- `pnpm build:tui`
- `pnpm test:tui-smoke`
- independent final integration review: clean

## Boundary
Card 05 owns the agent-only canvas and tmux topology/geometry synchronization; this change intentionally does not mutate PTY/tmux lifecycle or resize behavior.