### PR TITLE
feat(tui): evolve app window chrome

### DIFF
--- a/packages/daemon/src/tui/mirror/workspace/README.md
+++ b/packages/daemon/src/tui/mirror/workspace/README.md
@@ -28,18 +28,22 @@ is the migration boundary between app-owned presentation and runtime adapters.
 Card 01 is intentionally behavior-neutral: it records the responsive shell
 baseline and makes architectural back-edges fail before new window behavior lands.
 
-## PaneFrame v1
+## PaneFrame window chrome
 
 `pane-frame.ts` projects one reusable window contract for terminals, files,
 changes, missions, previews, and home surfaces. It owns responsive title/status/
 action geometry and hit targets; `pane-frame.tsx` paints that projection without
 installing input hooks. Semantic status survives narrow layouts before optional
-actions, while terminal focus, attention, keyboard focus, and idle state keep
-distinct markers.
+actions, while terminal focus, attention, keyboard focus, window-edit selection,
+floating, maximized, and idle state remain orthogonal. The projection explicitly
+models border, grip, header, body, status/state chips, and action cells; hit
+testing returns only those zones so the root controller can remain the single
+keyboard, pointer, lifecycle, and tmux-command owner.
 
-The live composite workspace now uses `PaneFrameHeader`. Action descriptors are
-already represented and renderer-tested, but production command routing remains
-with the root controller and will be connected by the command-adapter card.
+Action descriptors are represented and renderer-tested, but production command
+routing and any app/root integration remain with later cards. PaneFrame must not
+consume or reflow tmux framebuffer cells unless a future integration card changes
+the root canvas geometry and tests that explicitly.
 
 ## WorkbenchShell and bottom dock
 

--- a/packages/daemon/src/tui/mirror/workspace/__snapshots__/pane-frame-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/workspace/__snapshots__/pane-frame-renderer.test.tsx.snap
@@ -1,134 +1,349 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
+exports[`PaneFrame OpenTUI renderer renders the %sx%s compact window chrome 1`] = `
+"┌──────────────────────────────────────────────────────────────────────────────┐
+│:: ▣ ❯ Codex implementer •                            ●   M   ○ A   ○ M   ○ N │
+│● Mission: ship application-grade window chrome                            M31│
+│› Task: PaneFrame projection and renderer                              running│
+│● Harness: Codex                                                       gpt-5.5│
+│ terminal framebuffer remains opaque                                          │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘"
+`;
+
 exports[`PaneFrame OpenTUI renderer renders the %sx%s standard window chrome 1`] = `
-" ▣ ❯ Codex implementer • · %7 · task/142-…  working   ○ zoom   ○ split   ○ more
-● Mission: ship application-grade window chrome                              M31
-› Task: PaneFrame projection and renderer                                running
-● Harness: Codex                                                         gpt-5.5
- terminal framebuffer remains opaque
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-"
+"┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│:: ▣ ❯ Codex implementer • · %7 · task/142-pane-frame                  working   max   ○ agent   ○ mission   ○ native │
+│● Mission: ship application-grade window chrome                                                                    M31│
+│› Task: PaneFrame projection and renderer                                                                      running│
+│● Harness: Codex                                                                                               gpt-5.5│
+│ terminal framebuffer remains opaque                                                                                  │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘"
 `;
 
 exports[`PaneFrame OpenTUI renderer renders the %sx%s wide window chrome 1`] = `
-" ▣ ❯ Codex implementer • · %7 · task/142-pane-frame                                 working   ○ zoom   ○ split   ○ more
-● Mission: ship application-grade window chrome                                                                      M31
-› Task: PaneFrame projection and renderer                                                                        running
-● Harness: Codex                                                                                                 gpt-5.5
- terminal framebuffer remains opaque
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-"
+"┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│:: ▣ ❯ Codex implementer • · %7 · task/142-pane-frame                                                                                                  working   max   ○ agent   ○ mission   ○ native │
+│● Mission: ship application-grade window chrome                                                                                                                                                    M31│
+│› Task: PaneFrame projection and renderer                                                                                                                                                      running│
+│● Harness: Codex                                                                                                                                                                               gpt-5.5│
+│ terminal framebuffer remains opaque                                                                                                                                                                  │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+│                                                                                                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘"
 `;
 
-exports[`PaneFrame OpenTUI renderer renders the %sx%s wide window chrome 2`] = `
-" ▣ ❯ Codex implementer • · %7 · task/142-pane-frame                                                                                                                 working   ○ zoom   ○ split   ○ more
-● Mission: ship application-grade window chrome                                                                                                                                                      M31
-› Task: PaneFrame projection and renderer                                                                                                                                                        running
-● Harness: Codex                                                                                                                                                                                 gpt-5.5
- terminal framebuffer remains opaque
+exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, and semantic header colors 1`] = `
+"┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│:: ○ ▣ Idle agent                                                                                                     │
+│ body keeps framebuffer ownership elsewhere                                                                           │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘"
+`;
 
+exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, and semantic header colors 2`] = `
+"┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│:: ! ◆ Keyboard mission attention                                                                             blocked │
+│ body keeps framebuffer ownership elsewhere                                                                           │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘"
+`;
 
+exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, and semantic header colors 3`] = `
+"┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│:: ▣ ❯ Terminal agent attention                                                                               blocked │
+│ body keeps framebuffer ownership elsewhere                                                                           │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘"
+`;
 
+exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, and semantic header colors 4`] = `
+"┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃:: ◇ ▣ Mission native surface                           blocked   edit   float   max   ○ agent   ○ mission   ○ native ┃
+┃ body keeps framebuffer ownership elsewhere                                                                           ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┃                                                                                                                      ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛"
+`;
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-"
+exports[`PaneFrame OpenTUI renderer pins disabled, hovered, and mouse-down pressed action states before release 1`] = `
+"┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│:: ● ▣ Action state matrix                                                             · agent   × mission   ◆ native │
+│ action state evidence                                                                                                │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘"
 `;

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
@@ -4,26 +4,65 @@ import { useKeyboard } from "@opentui/solid";
 import { createSignal } from "solid-js";
 import { describe, expect, it } from "bun:test";
 import { SelectableRow } from "../recipes.tsx";
-import { createSemanticThemeSnapshot } from "../theme.ts";
+import { recipePalette } from "../recipes.ts";
+import { colorToThemeBytes, createSemanticThemeSnapshot } from "../theme.ts";
 import { expectFrameBounds, renderForTest, stableFrame } from "../testing/renderer-harness.test.ts";
+import type { PaneFrameInput } from "./pane-frame.ts";
 import { paneFrameHitTest, projectPaneFrame } from "./pane-frame.ts";
 import { PaneFrame } from "./pane-frame.tsx";
 
 const actions = [
-  { id: "zoom", label: "zoom", compactLabel: "Z", description: "Toggle zoom" },
-  { id: "split", label: "split", compactLabel: "+", description: "Split pane" },
-  { id: "more", label: "more", compactLabel: "…", description: "More actions" },
+  { id: "agent", label: "agent", compactLabel: "A", description: "Open agent controls" },
+  { id: "mission", label: "mission", compactLabel: "M", description: "Open mission proof" },
+  { id: "native", label: "native", compactLabel: "N", description: "Open native surface" },
 ] as const;
+
+function colorKey(color: Parameters<typeof colorToThemeBytes>[0]): string {
+  return colorToThemeBytes(color).join(",");
+}
+
+function spanContaining(
+  setup: Awaited<ReturnType<typeof renderForTest>>,
+  text: string,
+  lineIndex?: number,
+) {
+  const lines =
+    lineIndex === undefined ? setup.captureSpans().lines : [setup.captureSpans().lines[lineIndex]!];
+  return lines.flatMap((line) => line.spans).find((span) => span.text.includes(text));
+}
+
+async function renderStaticPane(input: Omit<PaneFrameInput, "width" | "height">) {
+  const theme = createSemanticThemeSnapshot({ mode: "dark" });
+  const width = 120;
+  const height = 40;
+  const projection = projectPaneFrame({
+    width,
+    height,
+    ...input,
+  });
+  const setup = await renderForTest(
+    () => (
+      <PaneFrame theme={theme} projection={projection}>
+        <text fg={theme.colors.mutedForeground}> body keeps framebuffer ownership elsewhere</text>
+      </PaneFrame>
+    ),
+    { width, height },
+  );
+  await setup.renderOnce();
+  return { setup, theme, projection };
+}
 
 async function renderPane(width: number, height: number) {
   const theme = createSemanticThemeSnapshot({ mode: "dark" });
   const calls: string[] = [];
   let focusedValue = true;
   let statusValue = "working";
+  let pressedValue: number | null = null;
 
   function Harness() {
     const [focused, setFocused] = createSignal(focusedValue);
     const [status, setStatus] = createSignal(statusValue);
+    const [pressed, setPressed] = createSignal<number | null>(pressedValue);
     const projection = () =>
       projectPaneFrame({
         width,
@@ -35,8 +74,12 @@ async function renderPane(width: number, height: number) {
         terminalFocused: focused(),
         attention: status() === "blocked",
         dirty: true,
+        windowEditSelected: status() === "blocked",
+        floating: status() === "blocked",
+        maximized: focused(),
         status: status(),
         statusTone: status() === "blocked" ? "blocked" : "working",
+        pressedActionIndex: pressed(),
         actions,
       });
     useKeyboard((event) => {
@@ -58,7 +101,15 @@ async function renderPane(width: number, height: number) {
         overflow="hidden"
         onMouseDown={(event) => {
           const hit = paneFrameHitTest(projection(), event.x, event.y);
-          if (hit?.area === "header" && hit.actionId) calls.push(`mouse:${hit.actionId}`);
+          if (hit?.area === "action") {
+            pressedValue = hit.actionIndex;
+            setPressed(pressedValue);
+            calls.push(`mouse:${hit.actionId}`);
+          }
+        }}
+        onMouseUp={() => {
+          pressedValue = null;
+          setPressed(null);
         }}
       >
         <PaneFrame theme={theme} projection={projection()}>
@@ -66,21 +117,21 @@ async function renderPane(width: number, height: number) {
             theme={theme}
             label="Mission: ship application-grade window chrome"
             meta="M31"
-            width={width}
+            width={Math.max(0, projection().body.width)}
             selected
           />
           <SelectableRow
             theme={theme}
             label="Task: PaneFrame projection and renderer"
             meta="running"
-            width={width}
+            width={Math.max(0, projection().body.width)}
             focused
           />
           <SelectableRow
             theme={theme}
             label="Harness: Codex"
             meta="gpt-5.5"
-            width={width}
+            width={Math.max(0, projection().body.width)}
             status="working"
             tone="working"
           />
@@ -97,6 +148,7 @@ async function renderPane(width: number, height: number) {
     calls,
     focused: () => focusedValue,
     status: () => statusValue,
+    pressed: () => pressedValue,
     projection: () =>
       projectPaneFrame({
         width,
@@ -108,8 +160,12 @@ async function renderPane(width: number, height: number) {
         terminalFocused: focusedValue,
         attention: statusValue === "blocked",
         dirty: true,
+        windowEditSelected: statusValue === "blocked",
+        floating: statusValue === "blocked",
+        maximized: focusedValue,
         status: statusValue,
         statusTone: statusValue === "blocked" ? "blocked" : "working",
+        pressedActionIndex: pressedValue,
         actions,
       }),
     frame: () => setup.captureCharFrame(),
@@ -118,8 +174,8 @@ async function renderPane(width: number, height: number) {
 
 describe("PaneFrame OpenTUI renderer", () => {
   it.each([
-    [80, 24, "standard"],
-    [120, 40, "wide"],
+    [80, 24, "compact"],
+    [120, 40, "standard"],
     [200, 60, "wide"],
   ] as const)("renders the %sx%s %s window chrome", async (width, height, variant) => {
     const harness = await renderPane(width, height);
@@ -127,23 +183,211 @@ describe("PaneFrame OpenTUI renderer", () => {
     expectFrameBounds(frame, width, height);
     expect(harness.projection().variant).toBe(variant);
     expect(stableFrame(frame)).toMatchSnapshot();
-    expect(stableFrame(frame)).toContain("Codex implementer");
-    expect(stableFrame(frame)).toContain("working");
-    expect(stableFrame(frame)).toContain("zoom");
+    expect(stableFrame(frame)).toContain(harness.projection().titleSpan.text.slice(0, 8));
+    expect(stableFrame(frame)).toContain(variant === "compact" ? "●" : "working");
+    expect(stableFrame(frame)).toContain(variant === "compact" ? "A" : "agent");
+    harness.setup.renderer.destroy();
   });
 
   it("routes projected action spans and keeps keyboard ownership in the harness", async () => {
     const harness = await renderPane(120, 40);
-    const zoom = harness.projection().actions.find((action) => action.id === "zoom")!;
+    const agent = harness.projection().actions.find((action) => action.id === "agent")!;
     await harness.setup.mockMouse.click(
-      zoom.start + Math.floor(zoom.width / 2),
-      0,
+      agent.start + Math.floor(agent.width / 2),
+      harness.projection().header.y,
       MouseButtons.LEFT,
     );
     harness.setup.mockInput.pressKey("b");
     await harness.setup.renderOnce();
     expect(harness.status()).toBe("blocked");
     expect(stableFrame(harness.frame())).toContain("blocked");
-    expect(harness.calls).toEqual(["mouse:zoom", "keyboard:block"]);
+    expect(stableFrame(harness.frame())).toContain("float");
+    expect(harness.calls).toEqual(["mouse:agent", "keyboard:block"]);
+    harness.setup.renderer.destroy();
+  });
+
+  it("pins rendered state-matrix glyphs, borders, and semantic header colors", async () => {
+    const cases = [
+      {
+        label: "idle-unfocused",
+        input: {
+          title: "Idle agent",
+          kind: "native",
+          focused: false,
+        },
+        marker: "○",
+        borderStart: "┌",
+        paletteState: {},
+      },
+      {
+        label: "keyboard-focus-attention",
+        input: {
+          title: "Keyboard mission attention",
+          kind: "missions",
+          focused: true,
+          attention: true,
+          status: "blocked",
+          statusTone: "blocked",
+        },
+        marker: "!",
+        borderStart: "┌",
+        paletteState: { focused: true, attention: true },
+      },
+      {
+        label: "terminal-focus-attention",
+        input: {
+          title: "Terminal agent attention",
+          kind: "terminals",
+          focused: false,
+          terminalFocused: true,
+          attention: true,
+          status: "blocked",
+          statusTone: "blocked",
+        },
+        marker: "▣",
+        borderStart: "┌",
+        paletteState: { focused: true, attention: true },
+      },
+      {
+        label: "edit-floating-maximized",
+        input: {
+          title: "Mission native surface",
+          kind: "native",
+          focused: false,
+          terminalFocused: true,
+          attention: true,
+          windowEditSelected: true,
+          floating: true,
+          maximized: true,
+          status: "blocked",
+          statusTone: "blocked",
+          actions,
+        },
+        marker: "◇",
+        borderStart: "┏",
+        paletteState: { selected: true, focused: true, attention: true },
+      },
+    ] as const;
+
+    for (const { label, input, marker, borderStart, paletteState } of cases) {
+      const { setup, theme, projection } = await renderStaticPane(input);
+      const stable = stableFrame(setup.captureCharFrame());
+      expect(stable, label).toMatchSnapshot();
+      expect(stable.startsWith(borderStart), label).toBe(true);
+      expect(projection.marker, label).toBe(marker);
+      expect(projection.titleSpan.text, label).toContain(marker);
+      const palette = recipePalette(theme, paletteState);
+      const borderSpan = setup.captureSpans().lines[0]!.spans[0]!;
+      expect(colorKey(borderSpan.fg), label).toBe(colorKey(palette.border));
+      const titleSpan = spanContaining(setup, projection.titleSpan.text, projection.header.y);
+      expect(titleSpan, label).toBeDefined();
+      expect(colorKey(titleSpan!.fg), label).toBe(colorKey(palette.foreground));
+      expect(colorKey(titleSpan!.bg), label).toBe(colorKey(palette.background));
+      if (label === "edit-floating-maximized") {
+        expect(stable).toContain("edit");
+        expect(stable).toContain("float");
+        expect(stable).toContain("max");
+      }
+      setup.renderer.destroy();
+    }
+  });
+
+  it("pins disabled, hovered, and mouse-down pressed action states before release", async () => {
+    const theme = createSemanticThemeSnapshot({ mode: "dark" });
+    const calls: string[] = [];
+    let pressedValue: number | null = null;
+
+    function Harness() {
+      const [pressed, setPressed] = createSignal<number | null>(pressedValue);
+      const projection = () =>
+        projectPaneFrame({
+          width: 120,
+          height: 40,
+          title: "Action state matrix",
+          kind: "native",
+          focused: true,
+          hoveredActionIndex: 0,
+          pressedActionIndex: pressed(),
+          actions: [actions[0], { ...actions[1], disabled: true }, actions[2]],
+        });
+      return (
+        <box
+          width={120}
+          height={40}
+          overflow="hidden"
+          onMouseDown={(event) => {
+            const hit = paneFrameHitTest(projection(), event.x, event.y);
+            if (hit?.area === "action") {
+              pressedValue = hit.actionIndex;
+              setPressed(pressedValue);
+              calls.push(`down:${hit.actionId}`);
+            }
+          }}
+          onMouseUp={() => {
+            pressedValue = null;
+            setPressed(null);
+            calls.push("up");
+          }}
+        >
+          <PaneFrame theme={theme} projection={projection()}>
+            <text fg={theme.colors.mutedForeground}> action state evidence</text>
+          </PaneFrame>
+        </box>
+      );
+    }
+
+    const setup = await renderForTest(() => <Harness />, { width: 120, height: 40 });
+    await setup.renderOnce();
+    const initialProjection = projectPaneFrame({
+      width: 120,
+      height: 40,
+      title: "Action state matrix",
+      kind: "native",
+      focused: true,
+      hoveredActionIndex: 0,
+      actions: [actions[0], { ...actions[1], disabled: true }, actions[2]],
+    });
+    const hoveredPalette = recipePalette(theme, { hovered: true });
+    const disabledPalette = recipePalette(theme, { disabled: true });
+    const hoveredLabel = spanContaining(setup, " agent ", initialProjection.header.y);
+    const disabledLabel = spanContaining(setup, " mission ", initialProjection.header.y);
+    const disabledMarker = spanContaining(setup, "×", initialProjection.header.y);
+    expect(hoveredLabel).toBeDefined();
+    expect(disabledLabel).toBeDefined();
+    expect(disabledMarker).toBeDefined();
+    expect(colorKey(hoveredLabel!.bg)).toBe(colorKey(hoveredPalette.background));
+    expect(colorKey(disabledLabel!.fg)).toBe(colorKey(disabledPalette.foreground));
+    expect(colorKey(disabledMarker!.fg)).toBe(colorKey(disabledPalette.accent));
+
+    const native = initialProjection.actions.find((action) => action.id === "native")!;
+    await setup.mockMouse.pressDown(
+      native.start + Math.floor(native.width / 2),
+      initialProjection.header.y,
+      MouseButtons.LEFT,
+    );
+    await setup.renderOnce();
+    const pressedFrame = stableFrame(setup.captureCharFrame());
+    expect(pressedFrame).toMatchSnapshot();
+    expect(calls).toEqual(["down:native"]);
+    expect(pressedValue).toBe(2);
+    const pressedPalette = recipePalette(theme, { pressed: true });
+    const pressedLabel = spanContaining(setup, " native ", initialProjection.header.y);
+    const pressedMarker = spanContaining(setup, "◆", initialProjection.header.y);
+    expect(pressedLabel).toBeDefined();
+    expect(pressedMarker).toBeDefined();
+    expect(colorKey(pressedLabel!.bg)).toBe(colorKey(pressedPalette.background));
+    expect(colorKey(pressedLabel!.fg)).toBe(colorKey(pressedPalette.foreground));
+    expect(colorKey(pressedMarker!.fg)).toBe(colorKey(pressedPalette.accent));
+
+    await setup.mockMouse.release(
+      native.start + Math.floor(native.width / 2),
+      initialProjection.header.y,
+      MouseButtons.LEFT,
+    );
+    await setup.renderOnce();
+    expect(calls).toEqual(["down:native", "up"]);
+    expect(pressedValue).toBeNull();
+    expect(stableFrame(setup.captureCharFrame())).not.toContain("◆ native");
+    setup.renderer.destroy();
   });
 });

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.test.ts
@@ -1,18 +1,20 @@
 import { describe, expect, it } from "vitest";
+import { terminalDisplayWidth } from "../panel-host.ts";
 import { paneFrameHitTest, paneFrameVariant, projectPaneFrame } from "./pane-frame.ts";
 
 const actions = [
-  { id: "zoom", label: "zoom", compactLabel: "Z", description: "Toggle zoom" },
-  { id: "split", label: "split", compactLabel: "+", description: "Split pane" },
-  { id: "more", label: "more", compactLabel: "…", description: "More actions" },
+  { id: "agent", label: "agent", compactLabel: "A", description: "Open agent controls" },
+  { id: "mission", label: "mission", compactLabel: "M", description: "Open mission proof" },
+  { id: "native", label: "native", compactLabel: "N", description: "Open native surface" },
 ] as const;
 
 describe("PaneFrame projection", () => {
   it.each([
     [48, 12, "compact"],
-    [90, 24, "standard"],
-    [140, 40, "wide"],
-  ] as const)("selects the %s×%s %s chrome", (width, height, variant) => {
+    [80, 24, "compact"],
+    [120, 40, "standard"],
+    [200, 60, "wide"],
+  ] as const)("selects deterministic %s×%s %s chrome", (width, height, variant) => {
     expect(paneFrameVariant(width, height)).toBe(variant);
     const projection = projectPaneFrame({
       width,
@@ -21,15 +23,17 @@ describe("PaneFrame projection", () => {
       kind: "terminals",
       subtitle: "%7 · codex",
       focused: true,
+      terminalFocused: true,
       status: "working",
       statusTone: "working",
       actions,
     });
     expect(projection.variant).toBe(variant);
-    expect(projection.header).toEqual({ x: 0, y: 0, width, height: 1 });
-    expect(projection.body).toEqual({ x: 0, y: 1, width, height: height - 1 });
+    expect(projection.outer).toEqual({ x: 0, y: 0, width, height });
+    expect(projection.header).toEqual({ x: 1, y: 1, width: width - 2, height: 1 });
+    expect(projection.body).toEqual({ x: 1, y: 2, width: width - 2, height: height - 3 });
     expect(projection.title).toContain("API server");
-    expect(projection.chips.every((chip) => chip.start + chip.width <= width)).toBe(true);
+    expect(projection.chips.every((chip) => chip.start + chip.width <= width - 1)).toBe(true);
     expect(
       projection.chips.every(
         (chip, index) => index === 0 || chip.start > projection.chips[index - 1]!.start,
@@ -37,30 +41,139 @@ describe("PaneFrame projection", () => {
     ).toBe(true);
   });
 
-  it("prioritizes terminal focus, attention, focus, and idle markers", () => {
+  it("keeps tiny frames bounded and avoids negative rectangles", () => {
+    for (const [width, height] of [
+      [0, 0],
+      [1, 1],
+      [2, 2],
+      [7, 3],
+      [8, 4],
+    ] as const) {
+      const projection = projectPaneFrame({
+        width,
+        height,
+        title: "tiny",
+        kind: "native",
+        focused: false,
+        actions,
+      });
+      for (const rect of [
+        projection.outer,
+        projection.header,
+        projection.body,
+        projection.titleSpan,
+        ...(projection.grip ? [projection.grip] : []),
+      ]) {
+        expect(rect.width).toBeGreaterThanOrEqual(0);
+        expect(rect.height).toBeGreaterThanOrEqual(0);
+        expect(rect.x + rect.width).toBeLessThanOrEqual(projection.width);
+        expect(rect.y + rect.height).toBeLessThanOrEqual(projection.height);
+      }
+    }
+  });
+
+  it("keeps title, subtitle, grip, and chips inside the header rectangle in tiny frames", () => {
+    for (const [width, height] of [
+      [0, 0],
+      [1, 1],
+      [2, 2],
+      [7, 3],
+      [8, 4],
+      [12, 4],
+      [28, 8],
+    ] as const) {
+      const projection = projectPaneFrame({
+        width,
+        height,
+        title: "tiny native mission agent pane with a very long semantic title",
+        kind: "native",
+        subtitle: "mission/attempt/proof/native-surface",
+        focused: true,
+        terminalFocused: true,
+        attention: true,
+        windowEditSelected: true,
+        floating: true,
+        maximized: true,
+        status: "blocked",
+        statusTone: "blocked",
+        actions,
+      });
+      const spans = [
+        projection.titleSpan,
+        ...(projection.subtitleSpan ? [projection.subtitleSpan] : []),
+        ...(projection.grip ? [projection.grip] : []),
+        ...projection.chips.map((chip) => ({
+          x: chip.start,
+          y: projection.header.y,
+          width: chip.width,
+          height: 1,
+          text: chip.label,
+        })),
+      ];
+      for (const span of spans) {
+        expect(span.x).toBeGreaterThanOrEqual(projection.header.x);
+        expect(span.y).toBeGreaterThanOrEqual(projection.header.y);
+        expect(span.x + span.width).toBeLessThanOrEqual(
+          projection.header.x + projection.header.width,
+        );
+        expect(span.y + span.height).toBeLessThanOrEqual(
+          projection.header.y + projection.header.height,
+        );
+      }
+    }
+  });
+
+  it("prioritizes marker state without losing orthogonal chips", () => {
     const marker = (overrides: Partial<Parameters<typeof projectPaneFrame>[0]>) =>
       projectPaneFrame({
-        width: 80,
-        height: 24,
+        width: 120,
+        height: 40,
         title: "pane",
         kind: "files",
         focused: false,
         ...overrides,
-      }).marker;
-    expect(marker({ terminalFocused: true, attention: true, focused: true })).toBe("▣");
-    expect(marker({ attention: true, focused: true })).toBe("!");
-    expect(marker({ focused: true })).toBe("●");
-    expect(marker({})).toBe("○");
+      });
+    expect(
+      marker({
+        windowEditSelected: true,
+        terminalFocused: true,
+        attention: true,
+        focused: true,
+        floating: true,
+        maximized: true,
+      }).marker,
+    ).toBe("◇");
+    expect(marker({ terminalFocused: true, attention: true, focused: true }).marker).toBe("▣");
+    expect(marker({ attention: true, focused: true }).marker).toBe("!");
+    expect(marker({ focused: true }).marker).toBe("●");
+    expect(marker({ floating: true }).marker).toBe("◌");
+    expect(marker({}).marker).toBe("○");
+    const projection = marker({
+      windowEditSelected: true,
+      floating: true,
+      maximized: true,
+      status: "blocked",
+      statusTone: "blocked",
+    });
+    expect(projection.chips.map((chip) => (chip.kind === "state" ? chip.id : chip.kind))).toEqual([
+      "status",
+      "edit",
+      "float",
+      "maximized",
+    ]);
   });
 
-  it("keeps semantic status while progressively dropping actions on narrow panes", () => {
+  it("keeps semantic status while progressively dropping actions then state on narrow panes", () => {
     const projection = projectPaneFrame({
-      width: 24,
+      width: 28,
       height: 8,
       title: "very long pane title",
       kind: "missions",
       focused: false,
       attention: true,
+      windowEditSelected: true,
+      floating: true,
+      maximized: true,
       status: "blocked",
       statusTone: "blocked",
       actions,
@@ -68,10 +181,35 @@ describe("PaneFrame projection", () => {
     expect(projection.chips[0]).toMatchObject({ kind: "status", label: "!" });
     expect(projection.actions.length).toBeLessThan(actions.length);
     expect(projection.title.length).toBeGreaterThan(0);
-    expect(projection.title.length).toBeLessThanOrEqual(projection.chips[0]!.start);
+    expect(projection.titleSpan.x + projection.titleSpan.width).toBeLessThanOrEqual(
+      projection.chips[0]!.start,
+    );
   });
 
-  it("routes enabled actions while leaving status and disabled actions inert", () => {
+  it("clips title and subtitle by terminal display width", () => {
+    const projection = projectPaneFrame({
+      width: 120,
+      height: 40,
+      title: "Pair 👨‍💻 implements exact title geometry for a very long native panel",
+      kind: "native",
+      subtitle: "apps/api/%7 · Nederlands 🇳🇱 keycap 1️⃣",
+      focused: true,
+      status: "working",
+      statusTone: "working",
+      actions,
+    });
+    expect(terminalDisplayWidth(projection.titleSpan.text)).toBe(projection.titleSpan.width);
+    if (projection.subtitleSpan) {
+      expect(terminalDisplayWidth(projection.subtitleSpan.text)).toBe(
+        projection.subtitleSpan.width,
+      );
+      expect(projection.subtitleSpan.x + projection.subtitleSpan.width).toBeLessThanOrEqual(
+        projection.chips[0]!.start,
+      );
+    }
+  });
+
+  it("routes grip, header, enabled action, body, and border zones explicitly", () => {
     const projection = projectPaneFrame({
       width: 120,
       height: 30,
@@ -80,20 +218,32 @@ describe("PaneFrame projection", () => {
       focused: true,
       status: "working",
       statusTone: "working",
-      actions: [actions[0], { ...actions[1], disabled: true }],
+      actions: [
+        { ...actions[0], pressed: true },
+        { ...actions[1], disabled: true },
+      ],
     });
-    const zoom = projection.actions.find((action) => action.id === "zoom")!;
-    const split = projection.actions.find((action) => action.id === "split")!;
-    expect(paneFrameHitTest(projection, zoom.start, 0)).toEqual({
-      area: "header",
-      actionId: "zoom",
+    const agent = projection.actions.find((action) => action.id === "agent")!;
+    const mission = projection.actions.find((action) => action.id === "mission")!;
+    expect(agent.pressed).toBe(true);
+    expect(paneFrameHitTest(projection, agent.start, projection.header.y)).toEqual({
+      area: "action",
+      actionId: "agent",
       actionIndex: 0,
     });
-    expect(paneFrameHitTest(projection, split.start, 0)).toEqual({ area: "header" });
-    expect(paneFrameHitTest(projection, projection.chips[0]!.start, 0)).toEqual({
+    expect(paneFrameHitTest(projection, mission.start, projection.header.y)).toEqual({
       area: "header",
     });
-    expect(paneFrameHitTest(projection, 2, 2)).toEqual({ area: "body" });
+    expect(paneFrameHitTest(projection, projection.grip!.x, projection.grip!.y)).toEqual({
+      area: "grip",
+    });
+    expect(paneFrameHitTest(projection, projection.titleSpan.x, projection.titleSpan.y)).toEqual({
+      area: "header",
+    });
+    expect(paneFrameHitTest(projection, projection.body.x, projection.body.y)).toEqual({
+      area: "body",
+    });
+    expect(paneFrameHitTest(projection, 0, 0)).toEqual({ area: "border" });
     expect(paneFrameHitTest(projection, -1, 0)).toBeNull();
   });
 });

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
@@ -3,7 +3,15 @@ import { actionChipWidth, type RecipeTone, type Rect } from "../recipes.ts";
 import { clipWorkspaceText } from "./text.ts";
 
 export type PaneFrameVariant = "compact" | "standard" | "wide";
-export type PaneFrameKind = "home" | "terminals" | "files" | "diff" | "missions" | "preview";
+export type PaneFrameKind =
+  | "home"
+  | "terminals"
+  | "files"
+  | "diff"
+  | "missions"
+  | "activity"
+  | "preview"
+  | "native";
 
 export interface PaneFrameAction {
   id: string;
@@ -13,6 +21,7 @@ export interface PaneFrameAction {
   active?: boolean;
   disabled?: boolean;
   attention?: boolean;
+  pressed?: boolean;
 }
 
 export interface PaneFrameInput {
@@ -25,10 +34,22 @@ export interface PaneFrameInput {
   terminalFocused?: boolean;
   attention?: boolean;
   dirty?: boolean;
+  windowEditSelected?: boolean;
+  floating?: boolean;
+  maximized?: boolean;
   status?: string | null;
   statusTone?: Exclude<RecipeTone, "neutral" | "accent">;
   actions?: readonly PaneFrameAction[];
   hoveredActionIndex?: number | null;
+  pressedActionIndex?: number | null;
+}
+
+export interface PaneFrameSpan extends Rect {
+  text: string;
+}
+
+export interface PaneFrameGripSpan extends PaneFrameSpan {
+  kind: "grip";
 }
 
 export interface PaneFrameStatusChip {
@@ -39,34 +60,61 @@ export interface PaneFrameStatusChip {
   width: number;
 }
 
+export interface PaneFrameStateChip {
+  kind: "state";
+  id: "edit" | "float" | "maximized";
+  label: string;
+  tone: RecipeTone;
+  start: number;
+  width: number;
+}
+
 export interface PaneFrameActionChip extends PaneFrameAction {
   kind: "action";
+  label: string;
+  fullLabel: string;
   start: number;
   width: number;
   hovered: boolean;
+  pressed: boolean;
 }
 
-export type PaneFrameChip = PaneFrameStatusChip | PaneFrameActionChip;
+export type PaneFrameChip = PaneFrameStatusChip | PaneFrameStateChip | PaneFrameActionChip;
+
+export type PaneFrameBorderStyle = "none" | "single" | "strong";
 
 export interface PaneFrameProjection {
   width: number;
   height: number;
   variant: PaneFrameVariant;
+  outer: Rect;
+  border: Rect;
+  borderStyle: PaneFrameBorderStyle;
   header: Rect;
   body: Rect;
+  grip: PaneFrameGripSpan | null;
+  titleSpan: PaneFrameSpan;
+  subtitleSpan: PaneFrameSpan | null;
   marker: string;
   glyph: string;
   title: string;
+  subtitle: string;
   focused: boolean;
   terminalFocused: boolean;
   attention: boolean;
+  windowEditSelected: boolean;
+  floating: boolean;
+  maximized: boolean;
   chips: readonly PaneFrameChip[];
   actions: readonly PaneFrameActionChip[];
 }
 
 export type PaneFrameHit =
-  | { area: "header"; actionId?: string; actionIndex?: number }
+  | { area: "grip" }
+  | { area: "header" }
+  | { area: "action"; actionId: string; actionIndex: number }
   | { area: "body" }
+  | { area: "border" }
   | null;
 
 const KIND_GLYPHS: Readonly<Record<PaneFrameKind, string>> = {
@@ -75,7 +123,9 @@ const KIND_GLYPHS: Readonly<Record<PaneFrameKind, string>> = {
   files: "▤",
   diff: "±",
   missions: "◆",
+  activity: "◷",
   preview: "◫",
+  native: "▣",
 };
 
 const STATUS_GLYPHS: Readonly<Record<Exclude<RecipeTone, "neutral" | "accent">, string>> = {
@@ -87,8 +137,8 @@ const STATUS_GLYPHS: Readonly<Record<Exclude<RecipeTone, "neutral" | "accent">, 
 };
 
 export function paneFrameVariant(width: number, height: number): PaneFrameVariant {
-  if (width >= 120 && height >= 32) return "wide";
-  if (width >= 72 && height >= 18) return "standard";
+  if (width >= 160 && height >= 44) return "wide";
+  if (width >= 100 && height >= 28) return "standard";
   return "compact";
 }
 
@@ -96,43 +146,119 @@ export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
   const width = Math.max(0, Math.floor(input.width));
   const height = Math.max(0, Math.floor(input.height));
   const variant = paneFrameVariant(width, height);
-  const headerHeight = Math.min(1, height);
+  const bordered = width >= 8 && height >= 4;
+  const inset = bordered ? 1 : 0;
+  const innerWidth = Math.max(0, width - inset * 2);
+  const innerHeight = Math.max(0, height - inset * 2);
+  const headerHeight = Math.min(1, innerHeight);
+  const bodyHeight = Math.max(0, innerHeight - headerHeight);
+  const header: Rect = { x: inset, y: inset, width: innerWidth, height: headerHeight };
+  const body: Rect = { x: inset, y: inset + headerHeight, width: innerWidth, height: bodyHeight };
+  const terminalFocused = input.terminalFocused === true;
+  const attention = input.attention === true;
+  const windowEditSelected = input.windowEditSelected === true;
+  const floating = input.floating === true;
+  const maximized = input.maximized === true;
+  const marker = paneFrameMarker({
+    windowEditSelected,
+    terminalFocused,
+    attention,
+    focused: input.focused,
+    floating,
+  });
   const status = statusChip(input.status, input.statusTone, variant);
+  const stateChips = projectStateChips({ windowEditSelected, floating, maximized, variant });
   const actions = (input.actions ?? []).map((action, index) => ({
     ...action,
     kind: "action" as const,
+    fullLabel: action.label,
     label: variant === "compact" ? (action.compactLabel ?? action.label) : action.label,
     hovered: input.hoveredActionIndex === index,
+    pressed: input.pressedActionIndex === index || action.pressed === true,
   }));
-  const visible = fitChips(width, variant, status, actions);
-  const chips = positionChips(width, visible);
-  const firstChip = chips[0]?.start ?? width;
-  const titleBudget = Math.max(0, firstChip - (chips.length > 0 ? 1 : 0));
-  const terminalFocused = input.terminalFocused === true;
-  const attention = input.attention === true;
-  const marker = terminalFocused ? "▣" : attention ? "!" : input.focused ? "●" : "○";
+  const visible = fitChips(header.width, variant, status, stateChips, actions);
+  const chips = positionChips(header.x + header.width, visible);
+  const firstChip = chips[0]?.start ?? header.x + header.width;
+  const gripText = header.width >= 3 ? "::" : "";
+  const grip: PaneFrameGripSpan | null =
+    gripText && header.height > 0
+      ? { kind: "grip", text: gripText, x: header.x, y: header.y, width: 2, height: 1 }
+      : null;
+  const titleStart = header.x + (grip ? grip.width + 1 : 0);
+  const titleBudget = Math.max(0, firstChip - titleStart - (chips.length > 0 ? 1 : 0));
   const dirty = input.dirty ? " •" : "";
-  const subtitle = input.subtitle && variant !== "compact" ? ` · ${input.subtitle}` : "";
-  const title = clipWorkspaceText(
-    ` ${marker} ${KIND_GLYPHS[input.kind]} ${input.title}${dirty}${subtitle}`,
-    titleBudget,
-  );
+  const titlePrefix = `${marker} ${KIND_GLYPHS[input.kind]} `;
+  const requestedTitle = `${titlePrefix}${input.title}${dirty}`;
+  const showSubtitle = variant !== "compact" && !!input.subtitle;
+  const subtitleDividerWidth = showSubtitle ? 3 : 0;
+  const subtitlePreferred = showSubtitle ? ` · ${input.subtitle}` : "";
+  const titleOnlyBudget = showSubtitle
+    ? Math.max(4, Math.floor(titleBudget * (variant === "wide" ? 0.58 : 0.68)))
+    : titleBudget;
+  const titleText = clipWorkspaceText(requestedTitle, Math.max(0, titleOnlyBudget));
+  const titleWidth = terminalDisplayWidth(titleText);
+  const subtitleBudget = Math.max(0, titleBudget - titleWidth - subtitleDividerWidth);
+  const subtitleText =
+    showSubtitle && subtitleBudget > 0
+      ? clipWorkspaceText(subtitlePreferred, subtitleBudget + subtitleDividerWidth)
+      : "";
+  const subtitleSpan =
+    subtitleText && titleStart + titleWidth < firstChip
+      ? {
+          text: subtitleText,
+          x: titleStart + titleWidth,
+          y: header.y,
+          width: terminalDisplayWidth(subtitleText),
+          height: 1,
+        }
+      : null;
 
   return {
     width,
     height,
     variant,
-    header: { x: 0, y: 0, width, height: headerHeight },
-    body: { x: 0, y: headerHeight, width, height: Math.max(0, height - headerHeight) },
+    outer: { x: 0, y: 0, width, height },
+    border: { x: 0, y: 0, width, height },
+    borderStyle: bordered ? (windowEditSelected ? "strong" : "single") : "none",
+    header,
+    body,
+    grip,
+    titleSpan: {
+      text: titleText,
+      x: titleStart,
+      y: header.y,
+      width: titleWidth,
+      height: headerHeight,
+    },
+    subtitleSpan,
     marker,
     glyph: KIND_GLYPHS[input.kind],
-    title,
+    title: titleText,
+    subtitle: subtitleText,
     focused: input.focused,
     terminalFocused,
     attention,
+    windowEditSelected,
+    floating,
+    maximized,
     chips,
     actions: chips.filter((chip): chip is PaneFrameActionChip => chip.kind === "action"),
   };
+}
+
+function paneFrameMarker(state: {
+  windowEditSelected: boolean;
+  terminalFocused: boolean;
+  attention: boolean;
+  focused: boolean;
+  floating: boolean;
+}): string {
+  if (state.windowEditSelected) return "◇";
+  if (state.terminalFocused) return "▣";
+  if (state.attention) return "!";
+  if (state.focused) return "●";
+  if (state.floating) return "◌";
+  return "○";
 }
 
 function statusChip(
@@ -149,28 +275,57 @@ function statusChip(
   };
 }
 
+function projectStateChips(input: {
+  windowEditSelected: boolean;
+  floating: boolean;
+  maximized: boolean;
+  variant: PaneFrameVariant;
+}): Omit<PaneFrameStateChip, "start" | "width">[] {
+  const compact = input.variant === "compact";
+  const chips: Omit<PaneFrameStateChip, "start" | "width">[] = [];
+  if (input.windowEditSelected) {
+    chips.push({ kind: "state", id: "edit", label: compact ? "E" : "edit", tone: "accent" });
+  }
+  if (input.floating) {
+    chips.push({ kind: "state", id: "float", label: compact ? "F" : "float", tone: "neutral" });
+  }
+  if (input.maximized) {
+    chips.push({ kind: "state", id: "maximized", label: compact ? "M" : "max", tone: "accent" });
+  }
+  return chips;
+}
+
 function chipWidth(
-  chip: Omit<PaneFrameStatusChip, "start" | "width"> | Omit<PaneFrameActionChip, "start" | "width">,
+  chip:
+    | Omit<PaneFrameStatusChip, "start" | "width">
+    | Omit<PaneFrameStateChip, "start" | "width">
+    | Omit<PaneFrameActionChip, "start" | "width">,
 ): number {
-  return chip.kind === "status"
-    ? terminalDisplayWidth(chip.label) + 2
-    : actionChipWidth(chip.label);
+  return chip.kind === "action"
+    ? actionChipWidth(chip.label)
+    : terminalDisplayWidth(chip.label) + 2;
 }
 
 function fitChips(
-  width: number,
+  availableWidth: number,
   variant: PaneFrameVariant,
   status: Omit<PaneFrameStatusChip, "start" | "width"> | null,
+  stateChips: readonly Omit<PaneFrameStateChip, "start" | "width">[],
   actions: readonly Omit<PaneFrameActionChip, "start" | "width">[],
-): (Omit<PaneFrameStatusChip, "start" | "width"> | Omit<PaneFrameActionChip, "start" | "width">)[] {
-  const minimumTitle = variant === "compact" ? 8 : variant === "standard" ? 18 : 24;
+): (
+  | Omit<PaneFrameStatusChip, "start" | "width">
+  | Omit<PaneFrameStateChip, "start" | "width">
+  | Omit<PaneFrameActionChip, "start" | "width">
+)[] {
+  const minimumTitle = variant === "compact" ? 8 : variant === "standard" ? 20 : 30;
   const chips: (
     | Omit<PaneFrameStatusChip, "start" | "width">
+    | Omit<PaneFrameStateChip, "start" | "width">
     | Omit<PaneFrameActionChip, "start" | "width">
-  )[] = status ? [status, ...actions] : [...actions];
+  )[] = [...(status ? [status] : []), ...stateChips, ...actions];
   const fits = () => {
     const widthUsed = chips.reduce((sum, chip) => sum + chipWidth(chip), 0);
-    return widthUsed + Math.max(0, chips.length - 1) + minimumTitle <= width;
+    return widthUsed + Math.max(0, chips.length - 1) + minimumTitle <= availableWidth;
   };
   while (chips.length > 0 && !fits()) {
     let lastAction = -1;
@@ -180,22 +335,34 @@ function fitChips(
         break;
       }
     }
-    if (lastAction >= 0) chips.splice(lastAction, 1);
+    if (lastAction >= 0) {
+      chips.splice(lastAction, 1);
+      continue;
+    }
+    let lastState = -1;
+    for (let index = chips.length - 1; index >= 0; index -= 1) {
+      if (chips[index]?.kind === "state") {
+        lastState = index;
+        break;
+      }
+    }
+    if (lastState >= 0) chips.splice(lastState, 1);
     else chips.pop();
   }
   return chips;
 }
 
 function positionChips(
-  width: number,
+  rightEdge: number,
   chips: readonly (
     | Omit<PaneFrameStatusChip, "start" | "width">
+    | Omit<PaneFrameStateChip, "start" | "width">
     | Omit<PaneFrameActionChip, "start" | "width">
   )[],
 ): PaneFrameChip[] {
   const widths = chips.map(chipWidth);
   const total = widths.reduce((sum, value) => sum + value, 0) + Math.max(0, widths.length - 1);
-  let x = Math.max(0, width - total);
+  let x = Math.max(0, rightEdge - total);
   return chips.map((chip, index) => {
     const span = { ...chip, start: x, width: widths[index]! } as PaneFrameChip;
     x += span.width + 1;
@@ -214,12 +381,38 @@ export function paneFrameHitTest(
   if (cellX < 0 || cellY < 0 || cellX >= projection.width || cellY >= projection.height) {
     return null;
   }
-  if (cellY < projection.header.height) {
-    const actionIndex = projection.actions.findIndex(
-      (action) => !action.disabled && cellX >= action.start && cellX < action.start + action.width,
-    );
-    const action = projection.actions[actionIndex];
-    return action ? { area: "header", actionId: action.id, actionIndex } : { area: "header" };
+  const actionIndex = projection.actions.findIndex(
+    (action) =>
+      !action.disabled &&
+      cellY === projection.header.y &&
+      cellX >= action.start &&
+      cellX < action.start + action.width,
+  );
+  const action = projection.actions[actionIndex];
+  if (action) return { area: "action", actionId: action.id, actionIndex };
+  if (
+    projection.grip &&
+    cellX >= projection.grip.x &&
+    cellX < projection.grip.x + projection.grip.width &&
+    cellY === projection.grip.y
+  ) {
+    return { area: "grip" };
   }
-  return { area: "body" };
+  if (
+    cellX >= projection.header.x &&
+    cellX < projection.header.x + projection.header.width &&
+    cellY >= projection.header.y &&
+    cellY < projection.header.y + projection.header.height
+  ) {
+    return { area: "header" };
+  }
+  if (
+    cellX >= projection.body.x &&
+    cellX < projection.body.x + projection.body.width &&
+    cellY >= projection.body.y &&
+    cellY < projection.body.y + projection.body.height
+  ) {
+    return { area: "body" };
+  }
+  return projection.borderStyle === "none" ? null : { area: "border" };
 }

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
@@ -1,59 +1,135 @@
 /* @jsxImportSource @opentui/solid */
 import type { JSX } from "@opentui/solid";
 import { For, Show } from "solid-js";
-import { ActionChip, StatusChip } from "../recipes.tsx";
+import { ActionChip, Badge, StatusChip } from "../recipes.tsx";
 import { recipePalette } from "../recipes.ts";
 import type { SemanticThemeSnapshot } from "../theme.ts";
-import type { PaneFrameProjection } from "./pane-frame.ts";
+import type { PaneFrameChip, PaneFrameProjection } from "./pane-frame.ts";
 
 export interface PaneFrameHeaderProps {
   theme: SemanticThemeSnapshot;
   projection: PaneFrameProjection;
 }
 
+function framePalette(theme: SemanticThemeSnapshot, projection: PaneFrameProjection) {
+  return recipePalette(theme, {
+    selected: projection.windowEditSelected,
+    focused: projection.focused || projection.terminalFocused,
+    attention: projection.attention,
+  });
+}
+
+function borderGlyphs(style: PaneFrameProjection["borderStyle"]) {
+  if (style === "strong") return { tl: "┏", tr: "┓", bl: "┗", br: "┛", h: "━", v: "┃" };
+  return { tl: "┌", tr: "┐", bl: "└", br: "┘", h: "─", v: "│" };
+}
+
+function Chip(props: { theme: SemanticThemeSnapshot; chip: PaneFrameChip }) {
+  return (
+    <Show
+      when={props.chip.kind === "action" ? props.chip : null}
+      fallback={
+        <Show
+          when={props.chip.kind === "status" ? props.chip : null}
+          fallback={
+            <Badge
+              theme={props.theme}
+              label={props.chip.label}
+              width={props.chip.width}
+              tone={props.chip.kind === "state" ? props.chip.tone : "neutral"}
+              state={{
+                selected: props.chip.kind === "state" && props.chip.id === "edit",
+                focused: props.chip.kind === "state" && props.chip.id === "maximized",
+              }}
+            />
+          }
+        >
+          {(status) => (
+            <StatusChip
+              theme={props.theme}
+              label={status().label}
+              width={status().width}
+              tone={status().tone}
+            />
+          )}
+        </Show>
+      }
+    >
+      {(action) => (
+        <ActionChip
+          theme={props.theme}
+          label={action().label}
+          width={action().width}
+          hovered={action().hovered}
+          pressed={action().pressed}
+          selected={action().active}
+          disabled={action().disabled}
+          attention={action().attention}
+        />
+      )}
+    </Show>
+  );
+}
+
 export function PaneFrameHeader(props: PaneFrameHeaderProps) {
-  const palette = () =>
-    recipePalette(props.theme, {
-      focused: props.projection.focused || props.projection.terminalFocused,
-      attention: props.projection.attention,
-    });
+  const palette = () => framePalette(props.theme, props.projection);
   return (
     <box
+      position="absolute"
+      left={props.projection.header.x}
+      top={props.projection.header.y}
       width={props.projection.header.width}
       height={props.projection.header.height}
-      position="relative"
       backgroundColor={palette().background}
       overflow="hidden"
     >
-      <text fg={palette().foreground} attributes={props.projection.focused ? 1 : 0}>
-        {props.projection.title}
-      </text>
+      <Show when={props.projection.grip}>
+        {(grip) => (
+          <box
+            position="absolute"
+            left={grip().x - props.projection.header.x}
+            top={0}
+            width={grip().width}
+            height={1}
+          >
+            <text fg={palette().accent}>{grip().text}</text>
+          </box>
+        )}
+      </Show>
+      <box
+        position="absolute"
+        left={props.projection.titleSpan.x - props.projection.header.x}
+        top={0}
+        width={props.projection.titleSpan.width}
+        height={1}
+      >
+        <text fg={palette().foreground} attributes={props.projection.focused ? 1 : 0}>
+          {props.projection.titleSpan.text}
+        </text>
+      </box>
+      <Show when={props.projection.subtitleSpan}>
+        {(subtitle) => (
+          <box
+            position="absolute"
+            left={subtitle().x - props.projection.header.x}
+            top={0}
+            width={subtitle().width}
+            height={1}
+          >
+            <text fg={props.theme.colors.mutedForeground}>{subtitle().text}</text>
+          </box>
+        )}
+      </Show>
       <For each={props.projection.chips}>
         {(chip) => (
-          <box position="absolute" left={chip.start} top={0} width={chip.width} height={1}>
-            <Show
-              when={chip.kind === "action" ? chip : null}
-              fallback={
-                <StatusChip
-                  theme={props.theme}
-                  label={chip.label}
-                  width={chip.width}
-                  tone={chip.kind === "status" ? chip.tone : "unknown"}
-                />
-              }
-            >
-              {(action) => (
-                <ActionChip
-                  theme={props.theme}
-                  label={action().label}
-                  width={action().width}
-                  hovered={action().hovered}
-                  selected={action().active}
-                  disabled={action().disabled}
-                  attention={action().attention}
-                />
-              )}
-            </Show>
+          <box
+            position="absolute"
+            left={chip.start - props.projection.header.x}
+            top={0}
+            width={chip.width}
+            height={1}
+          >
+            <Chip theme={props.theme} chip={chip} />
           </box>
         )}
       </For>
@@ -66,19 +142,65 @@ export interface PaneFrameProps extends PaneFrameHeaderProps {
 }
 
 export function PaneFrame(props: PaneFrameProps) {
+  const palette = () => framePalette(props.theme, props.projection);
+  const glyphs = () => borderGlyphs(props.projection.borderStyle);
   return (
     <box
       width={props.projection.width}
       height={props.projection.height}
-      flexDirection="column"
+      position="relative"
       backgroundColor={props.theme.colors.background}
       overflow="hidden"
     >
+      <Show when={props.projection.borderStyle !== "none" && props.projection.width > 1}>
+        <box position="absolute" left={0} top={0} width={props.projection.width} height={1}>
+          <text fg={palette().border}>
+            {`${glyphs().tl}${glyphs().h.repeat(Math.max(0, props.projection.width - 2))}${glyphs().tr}`}
+          </text>
+        </box>
+        <box
+          position="absolute"
+          left={0}
+          top={Math.max(0, props.projection.height - 1)}
+          width={props.projection.width}
+          height={1}
+        >
+          <text fg={palette().border}>
+            {`${glyphs().bl}${glyphs().h.repeat(Math.max(0, props.projection.width - 2))}${glyphs().br}`}
+          </text>
+        </box>
+        <Show when={props.projection.height > 2}>
+          <box position="absolute" left={0} top={1} width={1} height={props.projection.height - 2}>
+            <text fg={palette().border}>
+              {Array(props.projection.height - 2)
+                .fill(glyphs().v)
+                .join("\n")}
+            </text>
+          </box>
+          <box
+            position="absolute"
+            left={Math.max(0, props.projection.width - 1)}
+            top={1}
+            width={1}
+            height={props.projection.height - 2}
+          >
+            <text fg={palette().border}>
+              {Array(props.projection.height - 2)
+                .fill(glyphs().v)
+                .join("\n")}
+            </text>
+          </box>
+        </Show>
+      </Show>
       <PaneFrameHeader theme={props.theme} projection={props.projection} />
       <box
+        position="absolute"
+        left={props.projection.body.x}
+        top={props.projection.body.y}
         width={props.projection.body.width}
         height={props.projection.body.height}
         flexDirection="column"
+        backgroundColor={props.theme.colors.background}
         overflow="hidden"
       >
         {props.children}


### PR DESCRIPTION
## Summary

- evolve the reusable PaneFrame into polished tmux-ide app-window chrome
- add grip, focus hierarchy, edit/floating/maximized states, compact actions, and exact hit zones
- add compact, standard, and wide OpenTUI snapshots plus rendered state-matrix and semantic-span coverage

## Deliberate boundary

This card does not integrate app.tsx, mutate tmux geometry, consume framebuffer cells, or add a second input/lifecycle owner. Live integration follows through the command and workspace-state cards.

## Verification

- focused PaneFrame model and renderer tests
- full TUI renderer suite: 63 tests, 42 snapshots
- daemon lint and typecheck
- pnpm build:tui
- pnpm check
- independent final review: clean