### PR TITLE
feat(workspace): add durable workspace state kernel

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -20,6 +20,7 @@ export * from "./domain.ts";
 export * from "./mission-projections.ts";
 export * from "./tmux.ts";
 export * from "./workspace.ts";
+export * from "./workspace-state.ts";
 export * from "./workspace-config.ts";
 export * from "./actions-contract.ts";
 export * from "./actions-errors.ts";

--- a/packages/contracts/src/workspace-state.ts
+++ b/packages/contracts/src/workspace-state.ts
@@ -1,0 +1,527 @@
+import { z } from "zod";
+
+/** Shared, serializable workspace-domain contract. No renderer or tmux dependencies. */
+export const WORKSPACE_STATE_VERSION = 1 as const;
+export const WORKSPACE_STATE_MAX_LAYOUTS = 32;
+export const WORKSPACE_STATE_MAX_CHECKOUTS = 16;
+export const WORKSPACE_STATE_MAX_PANES = 128;
+export const WORKSPACE_STATE_MAX_TREE_DEPTH = 32;
+export const WORKSPACE_STATE_MAX_TREE_NODES = 255;
+export const WORKSPACE_STATE_MAX_ID_LENGTH = 128;
+export const WORKSPACE_STATE_MAX_NAME_LENGTH = 80;
+
+const RESERVED_RECORD_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+const SafeStringSchemaZ = (max: number) =>
+  z
+    .string()
+    .min(1)
+    .max(max)
+    .refine((value) => !value.includes("\0"), "text must not contain NUL bytes");
+export const WorkspaceIdSchemaZ = z
+  .string()
+  .min(1)
+  .max(WORKSPACE_STATE_MAX_ID_LENGTH)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/u)
+  .refine((value) => !RESERVED_RECORD_KEYS.has(value), "reserved record key is not allowed");
+const NullableTextSchemaZ = (max: number) => SafeStringSchemaZ(max).nullable();
+const AbsolutePathSchemaZ = SafeStringSchemaZ(4096).refine(
+  (value) => /^(?:[/\\]{1,2}|[A-Za-z]:[/\\])/u.test(value),
+  "path must be absolute",
+);
+export const WorkspaceTimestampSchemaZ = z.string().datetime({ offset: false });
+
+export const WorkspaceProjectIdentitySchemaZ = z
+  .object({
+    identityKey: WorkspaceIdSchemaZ,
+    identitySource: z.enum(["git-common-dir", "canonical-realpath"]),
+    identityAnchor: SafeStringSchemaZ(4096),
+  })
+  .strict();
+export type WorkspaceProjectIdentity = z.infer<typeof WorkspaceProjectIdentitySchemaZ>;
+
+export const WorkspacePaneRectSchemaZ = z
+  .object({
+    left: z.number().int().nonnegative(),
+    top: z.number().int().nonnegative(),
+    width: z.number().int().positive(),
+    height: z.number().int().positive(),
+  })
+  .strict();
+export type WorkspacePaneRect = z.infer<typeof WorkspacePaneRectSchemaZ>;
+
+export const WorkspacePaneCwdSchemaZ = z.discriminatedUnion("kind", [
+  z
+    .object({ kind: z.literal("project-relative"), path: SafeStringSchemaZ(4096) })
+    .strict()
+    .refine(
+      (cwd) => projectRelativePathStaysContained(cwd.path),
+      "project-relative cwd must remain inside the checkout",
+    ),
+  z
+    .object({ kind: z.literal("absolute"), path: SafeStringSchemaZ(4096) })
+    .strict()
+    .refine(
+      (cwd) => /^(?:[/\\]{1,2}|[A-Za-z]:[/\\])/u.test(cwd.path),
+      "absolute cwd must use an absolute path",
+    ),
+]);
+export type WorkspacePaneCwd = z.infer<typeof WorkspacePaneCwdSchemaZ>;
+
+function projectRelativePathStaysContained(path: string): boolean {
+  if (/^(?:[/\\]|[A-Za-z]:)/u.test(path)) return false;
+  let depth = 0;
+  for (const segment of path.split(/[/\\]+/u)) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (depth === 0) return false;
+      depth -= 1;
+    } else {
+      depth += 1;
+    }
+  }
+  return true;
+}
+
+export const WorkspacePaneDefinitionSchemaZ = z
+  .object({
+    id: WorkspaceIdSchemaZ,
+    /** Split-node id in the semantic tree; null only for a single-pane root. */
+    parentId: WorkspaceIdSchemaZ.nullable(),
+    role: z.enum(["agent", "shell"]),
+    harness: NullableTextSchemaZ(WORKSPACE_STATE_MAX_NAME_LENGTH),
+    title: NullableTextSchemaZ(WORKSPACE_STATE_MAX_NAME_LENGTH),
+    command: NullableTextSchemaZ(512),
+    /** Portable named-layout path; project-relative paths rebase across linked checkouts. */
+    cwd: WorkspacePaneCwdSchemaZ.nullable(),
+    rect: WorkspacePaneRectSchemaZ,
+  })
+  .strict();
+export type WorkspacePaneDefinition = z.infer<typeof WorkspacePaneDefinitionSchemaZ>;
+export type WorkspacePaneRole = WorkspacePaneDefinition["role"];
+
+type WorkspacePaneTreeNodeShape =
+  | { type: "pane"; nodeId: string; paneId: string }
+  | {
+      type: "split";
+      nodeId: string;
+      axis: "horizontal" | "vertical";
+      children: WorkspacePaneTreeNodeShape[];
+      weights: number[];
+    };
+
+const WorkspacePaneTreeNodeRecursiveSchemaZ: z.ZodType<WorkspacePaneTreeNodeShape> = z.lazy(() =>
+  z.discriminatedUnion("type", [
+    z
+      .object({
+        type: z.literal("pane"),
+        nodeId: WorkspaceIdSchemaZ,
+        paneId: WorkspaceIdSchemaZ,
+      })
+      .strict(),
+    z
+      .object({
+        type: z.literal("split"),
+        nodeId: WorkspaceIdSchemaZ,
+        axis: z.enum(["horizontal", "vertical"]),
+        children: z.array(WorkspacePaneTreeNodeRecursiveSchemaZ).min(2).max(8),
+        weights: z.array(z.number().int().positive()).min(2).max(8),
+      })
+      .strict()
+      .refine((node) => node.children.length === node.weights.length, {
+        message: "split weights must match children",
+      }),
+  ]),
+);
+export const WorkspacePaneTreeNodeSchemaZ: z.ZodType<WorkspacePaneTreeNodeShape> = z
+  .unknown()
+  .superRefine((value, ctx) => {
+    const failure = paneTreeLimitFailure(value);
+    if (failure) ctx.addIssue({ code: z.ZodIssueCode.custom, message: failure });
+  })
+  .pipe(WorkspacePaneTreeNodeRecursiveSchemaZ);
+export type WorkspacePaneTreeNode = z.infer<typeof WorkspacePaneTreeNodeSchemaZ>;
+
+function paneTreeLimitFailure(value: unknown): string | null {
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 1 }];
+  let nodes = 0;
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    nodes += 1;
+    if (nodes > WORKSPACE_STATE_MAX_TREE_NODES) return "pane tree node limit exceeded";
+    if (current.depth > WORKSPACE_STATE_MAX_TREE_DEPTH) return "pane tree depth limit exceeded";
+    if (
+      current.value &&
+      typeof current.value === "object" &&
+      !Array.isArray(current.value) &&
+      "type" in current.value &&
+      current.value.type === "split" &&
+      "children" in current.value &&
+      Array.isArray(current.value.children)
+    ) {
+      if (current.value.children.length > 8) return "split child limit exceeded";
+      for (const child of current.value.children) {
+        stack.push({ value: child, depth: current.depth + 1 });
+      }
+    }
+  }
+  return null;
+}
+
+export const WorkspacePaneTopologySchemaZ = z
+  .object({
+    panes: z.record(WorkspaceIdSchemaZ, WorkspacePaneDefinitionSchemaZ),
+    root: WorkspacePaneTreeNodeSchemaZ.nullable(),
+  })
+  .strict()
+  .superRefine((topology, ctx) => {
+    const paneIds = Object.keys(topology.panes);
+    if (paneIds.length > WORKSPACE_STATE_MAX_PANES) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "pane limit exceeded",
+        path: ["panes"],
+      });
+    }
+    for (const [key, pane] of Object.entries(topology.panes)) {
+      if (key !== pane.id) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "pane record key must match pane id",
+          path: ["panes", key, "id"],
+        });
+      }
+    }
+    if ((topology.root === null) !== (paneIds.length === 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "topology root and panes must either both be empty or both be present",
+        path: ["root"],
+      });
+      return;
+    }
+    const visitedPanes = new Set<string>();
+    const visitedNodes = new Set<string>();
+    const visit = (node: WorkspacePaneTreeNodeShape, parentId: string | null): void => {
+      if (visitedNodes.has(node.nodeId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "tree node ids must be unique",
+          path: ["root"],
+        });
+      }
+      visitedNodes.add(node.nodeId);
+      if (node.type === "split") {
+        for (const child of node.children) visit(child, node.nodeId);
+        return;
+      }
+      const pane = topology.panes[node.paneId];
+      if (!pane || visitedPanes.has(node.paneId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "tree pane references must be unique and resolve",
+          path: ["root"],
+        });
+        return;
+      }
+      visitedPanes.add(node.paneId);
+      if (pane.parentId !== parentId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "pane parentId must match its semantic split parent",
+          path: ["panes", node.paneId, "parentId"],
+        });
+      }
+    };
+    if (topology.root) visit(topology.root, null);
+    if (visitedPanes.size !== paneIds.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "every pane must occur exactly once in the tree",
+        path: ["root"],
+      });
+    }
+  });
+export type WorkspacePaneTopology = z.infer<typeof WorkspacePaneTopologySchemaZ>;
+
+export const WorkspaceDockSnapshotSchemaZ = z
+  .object({
+    activeTab: z.enum(["files", "changes", "missions", "activity"]),
+    mode: z.enum(["collapsed", "open", "maximized"]),
+    preferredHeight: z.number().int().nonnegative().nullable(),
+    focusZone: z.enum(["canvas", "dock-tabs", "dock-body"]),
+  })
+  .strict();
+export type WorkspaceDockSnapshot = z.infer<typeof WorkspaceDockSnapshotSchemaZ>;
+
+export const WorkspaceWorkbenchStateSchemaZ = z
+  .object({
+    canvasPanel: z.enum(["home", "terminals"]),
+    dock: WorkspaceDockSnapshotSchemaZ,
+  })
+  .strict();
+export type WorkspaceWorkbenchState = z.infer<typeof WorkspaceWorkbenchStateSchemaZ>;
+export type WorkspaceCanvasPanel = WorkspaceWorkbenchState["canvasPanel"];
+
+export const WorkspaceLayoutSnapshotSchemaZ = z
+  .object({
+    topology: WorkspacePaneTopologySchemaZ,
+    focusedPaneId: WorkspaceIdSchemaZ.nullable(),
+    workbench: WorkspaceWorkbenchStateSchemaZ,
+  })
+  .strict()
+  .superRefine((snapshot, ctx) => {
+    if (snapshot.focusedPaneId && !snapshot.topology.panes[snapshot.focusedPaneId]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "focused pane must exist in topology",
+        path: ["focusedPaneId"],
+      });
+    }
+  });
+export type WorkspaceLayoutSnapshot = z.infer<typeof WorkspaceLayoutSnapshotSchemaZ>;
+
+export const WorkspaceNamedLayoutSchemaZ = z
+  .object({
+    id: WorkspaceIdSchemaZ,
+    name: SafeStringSchemaZ(WORKSPACE_STATE_MAX_NAME_LENGTH).refine(
+      (value) => value.trim().length > 0,
+      "layout name must contain visible text",
+    ),
+    revision: z.number().int().positive(),
+    createdAt: WorkspaceTimestampSchemaZ,
+    updatedAt: WorkspaceTimestampSchemaZ,
+    snapshot: WorkspaceLayoutSnapshotSchemaZ,
+  })
+  .strict();
+export type WorkspaceNamedLayout = z.infer<typeof WorkspaceNamedLayoutSchemaZ>;
+
+export const WorkspacePaneBindingSchemaZ = z
+  .object({
+    semanticPaneId: WorkspaceIdSchemaZ,
+    runtimePaneId: z.string().regex(/^%[0-9]+$/u),
+    lastSeenAt: WorkspaceTimestampSchemaZ,
+  })
+  .strict();
+export type WorkspacePaneBinding = z.infer<typeof WorkspacePaneBindingSchemaZ>;
+
+export const WorkspaceRecoveryStateSchemaZ = z
+  .object({
+    status: z.enum(["empty", "clean", "reconciled"]),
+    capturedAt: WorkspaceTimestampSchemaZ.nullable(),
+    sessionName: NullableTextSchemaZ(256),
+    windowIndex: z.number().int().nonnegative().nullable(),
+    windowName: NullableTextSchemaZ(256),
+    missingPaneIds: z.array(WorkspaceIdSchemaZ).max(WORKSPACE_STATE_MAX_PANES),
+    externalPaneIds: z.array(WorkspaceIdSchemaZ).max(WORKSPACE_STATE_MAX_PANES),
+  })
+  .strict();
+export type WorkspaceRecoveryState = z.infer<typeof WorkspaceRecoveryStateSchemaZ>;
+
+export const WorkspaceCheckoutStateSchemaZ = z
+  .object({
+    checkoutKey: WorkspaceIdSchemaZ,
+    projectRoot: AbsolutePathSchemaZ,
+    activeLayoutId: WorkspaceIdSchemaZ.nullable(),
+    topology: WorkspacePaneTopologySchemaZ,
+    focusedPaneId: WorkspaceIdSchemaZ.nullable(),
+    workbench: WorkspaceWorkbenchStateSchemaZ,
+    bindings: z.record(WorkspaceIdSchemaZ, WorkspacePaneBindingSchemaZ),
+    recovery: WorkspaceRecoveryStateSchemaZ,
+  })
+  .strict()
+  .superRefine((checkout, ctx) => {
+    if (checkout.focusedPaneId && !checkout.topology.panes[checkout.focusedPaneId]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "focused pane must exist in topology",
+        path: ["focusedPaneId"],
+      });
+    }
+    const runtimePaneIds = new Set<string>();
+    for (const [key, binding] of Object.entries(checkout.bindings)) {
+      if (key !== binding.semanticPaneId || !checkout.topology.panes[key]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "binding key must match a live semantic pane",
+          path: ["bindings", key],
+        });
+      }
+      if (runtimePaneIds.has(binding.runtimePaneId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "runtime pane bindings must be injective",
+          path: ["bindings", key, "runtimePaneId"],
+        });
+      }
+      runtimePaneIds.add(binding.runtimePaneId);
+    }
+  });
+export type WorkspaceCheckoutState = z.infer<typeof WorkspaceCheckoutStateSchemaZ>;
+
+export const WorkspaceStateV1SchemaZ = z
+  .object({
+    version: z.literal(WORKSPACE_STATE_VERSION),
+    project: WorkspaceProjectIdentitySchemaZ,
+    layouts: z.record(WorkspaceIdSchemaZ, WorkspaceNamedLayoutSchemaZ),
+    checkouts: z.record(WorkspaceIdSchemaZ, WorkspaceCheckoutStateSchemaZ),
+  })
+  .strict()
+  .superRefine((state, ctx) => {
+    if (Object.keys(state.layouts).length > WORKSPACE_STATE_MAX_LAYOUTS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "layout limit exceeded",
+        path: ["layouts"],
+      });
+    }
+    if (Object.keys(state.checkouts).length > WORKSPACE_STATE_MAX_CHECKOUTS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "checkout limit exceeded",
+        path: ["checkouts"],
+      });
+    }
+    for (const [key, layout] of Object.entries(state.layouts)) {
+      if (key !== layout.id) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "layout record key must match layout id",
+          path: ["layouts", key, "id"],
+        });
+      }
+    }
+    for (const [key, checkout] of Object.entries(state.checkouts)) {
+      if (key !== checkout.checkoutKey) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "checkout record key must match checkout key",
+          path: ["checkouts", key, "checkoutKey"],
+        });
+      }
+      if (checkout.activeLayoutId && !state.layouts[checkout.activeLayoutId]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "active layout must exist",
+          path: ["checkouts", key, "activeLayoutId"],
+        });
+      }
+    }
+  });
+export type WorkspaceStateV1 = z.infer<typeof WorkspaceStateV1SchemaZ>;
+
+export const WorkspaceObservedPaneSchemaZ = z
+  .object({
+    semanticPaneId: WorkspaceIdSchemaZ,
+    runtimePaneId: z.string().regex(/^%[0-9]+$/u),
+    role: z.enum(["agent", "shell"]),
+    harness: NullableTextSchemaZ(WORKSPACE_STATE_MAX_NAME_LENGTH).optional(),
+    title: NullableTextSchemaZ(WORKSPACE_STATE_MAX_NAME_LENGTH).optional(),
+    command: NullableTextSchemaZ(512).optional(),
+    cwd: NullableTextSchemaZ(4096).optional(),
+    rect: WorkspacePaneRectSchemaZ,
+    active: z.boolean().optional(),
+  })
+  .strict();
+export type WorkspaceObservedPane = z.infer<typeof WorkspaceObservedPaneSchemaZ>;
+
+export const WorkspaceObservationSchemaZ = z
+  .object({
+    checkoutKey: WorkspaceIdSchemaZ,
+    projectRoot: AbsolutePathSchemaZ,
+    observedAt: WorkspaceTimestampSchemaZ,
+    sessionName: NullableTextSchemaZ(256),
+    windowIndex: z.number().int().nonnegative().nullable(),
+    windowName: NullableTextSchemaZ(256),
+    panes: z.array(WorkspaceObservedPaneSchemaZ).max(WORKSPACE_STATE_MAX_PANES),
+    focusedPaneId: WorkspaceIdSchemaZ.nullable(),
+    workbench: WorkspaceWorkbenchStateSchemaZ,
+  })
+  .strict()
+  .superRefine((observation, ctx) => {
+    const semanticPaneIds = new Set<string>();
+    const runtimePaneIds = new Set<string>();
+    for (const [index, pane] of observation.panes.entries()) {
+      if (semanticPaneIds.has(pane.semanticPaneId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "observed semantic pane ids must be unique",
+          path: ["panes", index, "semanticPaneId"],
+        });
+      }
+      if (runtimePaneIds.has(pane.runtimePaneId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "observed runtime pane ids must be unique",
+          path: ["panes", index, "runtimePaneId"],
+        });
+      }
+      semanticPaneIds.add(pane.semanticPaneId);
+      runtimePaneIds.add(pane.runtimePaneId);
+    }
+  });
+export type WorkspaceObservation = z.infer<typeof WorkspaceObservationSchemaZ>;
+
+export const WorkspaceLayoutApplyPlanSchemaZ = z
+  .object({
+    layoutId: WorkspaceIdSchemaZ,
+    checkoutKey: WorkspaceIdSchemaZ,
+    projectRoot: AbsolutePathSchemaZ,
+    sessionName: NullableTextSchemaZ(256),
+    windowIndex: z.number().int().nonnegative().nullable(),
+    windowName: NullableTextSchemaZ(256),
+    targetTopology: WorkspacePaneTopologySchemaZ,
+    materializedPaneCwds: z.record(WorkspaceIdSchemaZ, NullableTextSchemaZ(4096)),
+    targetFocusedPaneId: WorkspaceIdSchemaZ.nullable(),
+    liveFocusedPaneId: WorkspaceIdSchemaZ.nullable(),
+    workbench: WorkspaceWorkbenchStateSchemaZ,
+    retainedBindings: z.record(WorkspaceIdSchemaZ, WorkspacePaneBindingSchemaZ),
+    retainedPaneIds: z.array(WorkspaceIdSchemaZ),
+    missingPaneIds: z.array(WorkspaceIdSchemaZ),
+    externalPaneIds: z.array(WorkspaceIdSchemaZ),
+  })
+  .strict()
+  .superRefine((plan, ctx) => {
+    if (plan.targetFocusedPaneId && !plan.targetTopology.panes[plan.targetFocusedPaneId]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "target focus must exist in target topology",
+        path: ["targetFocusedPaneId"],
+      });
+    }
+    for (const [paneId, binding] of Object.entries(plan.retainedBindings)) {
+      if (
+        paneId !== binding.semanticPaneId ||
+        !plan.targetTopology.panes[paneId] ||
+        !plan.retainedPaneIds.includes(paneId)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "retained binding must correlate to a retained target pane",
+          path: ["retainedBindings", paneId],
+        });
+      }
+    }
+  });
+export type WorkspaceLayoutApplyPlan = z.infer<typeof WorkspaceLayoutApplyPlanSchemaZ>;
+
+export const WorkspaceStateDiagnosticSchemaZ = z
+  .object({
+    code: z.enum([
+      "MALFORMED",
+      "UNSUPPORTED_VERSION",
+      "INVALID_FIELD",
+      "OVERSIZED",
+      "IDENTITY_MISMATCH",
+      "PROJECT_RELINKED",
+    ]),
+    path: z.string(),
+    message: z.string(),
+  })
+  .strict();
+export type WorkspaceStateDiagnostic = z.infer<typeof WorkspaceStateDiagnosticSchemaZ>;
+
+export interface ParsedWorkspaceState {
+  state: WorkspaceStateV1;
+  diagnostics: WorkspaceStateDiagnostic[];
+  writeProtected: boolean;
+}

--- a/packages/daemon/src/lib/__tests__/fixtures/workspace-state-writer.ts
+++ b/packages/daemon/src/lib/__tests__/fixtures/workspace-state-writer.ts
@@ -1,0 +1,69 @@
+import { existsSync, writeFileSync } from "node:fs";
+
+import { createProjectRuntimeRepository } from "../../project-runtime-repository.ts";
+import { captureWorkspaceObservation, createWorkspaceLayout } from "../../workspace-state.ts";
+import {
+  loadWorkspaceState,
+  workspaceCheckoutKey,
+  writeWorkspaceStateWithRetry,
+} from "../../workspace-state-repository.ts";
+
+const [home, projectRoot, layoutId, readyPath, goPath] = process.argv.slice(2);
+if (!home || !projectRoot || !layoutId || !readyPath || !goPath) {
+  throw new Error("home, projectRoot, layoutId, readyPath, and goPath are required");
+}
+
+const repository = createProjectRuntimeRepository(
+  {
+    inputDir: projectRoot,
+    projectRoot,
+    identityKey: `git-${"c".repeat(64)}`,
+    identitySource: "git-common-dir",
+    identityAnchor: "/shared/.git",
+    config: { kind: "none", path: null, explicit: false },
+    workspaceConfigPath: null,
+    legacyConfigPath: null,
+    hasLegacyConfigAtInput: false,
+  },
+  { home },
+);
+const loaded = loadWorkspaceState(repository);
+const checkoutKey = workspaceCheckoutKey(projectRoot);
+let next = captureWorkspaceObservation(loaded.state, {
+  checkoutKey,
+  projectRoot,
+  observedAt: "2026-07-20T12:00:00.000Z",
+  sessionName: null,
+  windowIndex: null,
+  windowName: null,
+  panes: [],
+  focusedPaneId: null,
+  workbench: {
+    canvasPanel: "home",
+    dock: { activeTab: "files", mode: "open", preferredHeight: null, focusZone: "canvas" },
+  },
+});
+next = createWorkspaceLayout(next, {
+  id: layoutId,
+  name: layoutId,
+  checkoutKey,
+  now: "2026-07-20T12:00:00.000Z",
+});
+
+writeFileSync(readyPath, "ready\n", "utf8");
+while (!existsSync(goPath)) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+
+const result = writeWorkspaceStateWithRetry({
+  repository,
+  revision: loaded.revision,
+  next,
+  touchedLayoutIds: new Set([layoutId]),
+  checkoutIntents: new Map([
+    [checkoutKey, new Set(["live", "workbench", "focus", "active-layout"] as const)],
+  ]),
+  lock: { timeoutMs: 5_000 },
+});
+if (!result.saved) {
+  process.stderr.write(`${JSON.stringify(result.diagnostics)}\n`);
+  process.exitCode = 1;
+}

--- a/packages/daemon/src/lib/__tests__/workspace-state-repository.test.ts
+++ b/packages/daemon/src/lib/__tests__/workspace-state-repository.test.ts
@@ -1,0 +1,958 @@
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ProjectResolution } from "../project-resolver.ts";
+import { createProjectRuntimeRepository } from "../project-runtime-repository.ts";
+import {
+  captureWorkspaceObservation,
+  createWorkspaceLayout,
+  defaultWorkspaceState,
+  renameWorkspaceLayout,
+} from "../workspace-state.ts";
+import {
+  WORKSPACE_STATE_LOCK_FILENAME,
+  WORKSPACE_STATE_PATH,
+  WorkspaceStateLockRecoveryError,
+  WorkspaceStateLockTimeoutError,
+  clearWorkspaceStateLockOffline,
+  inspectWorkspaceStateLock,
+  loadWorkspaceState,
+  withWorkspaceStateLock,
+  workspaceCheckoutKey,
+  workspaceProjectIdentity,
+  writeWorkspaceStateWithRetry,
+} from "../workspace-state-repository.ts";
+
+const roots: string[] = [];
+const IDENTITY_KEY = `git-${"c".repeat(64)}`;
+const NOW = "2026-07-20T12:00:00.000Z";
+
+function temporaryRoot(prefix = "workspace-state-"): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function resolution(projectRoot: string, identityAnchor = "/shared/.git"): ProjectResolution {
+  return {
+    inputDir: projectRoot,
+    projectRoot,
+    identityKey: IDENTITY_KEY,
+    identitySource: "git-common-dir",
+    identityAnchor,
+    config: { kind: "none", path: null, explicit: false },
+    workspaceConfigPath: null,
+    legacyConfigPath: null,
+    hasLegacyConfigAtInput: false,
+  };
+}
+
+function addEmptyLayout(
+  state: ReturnType<typeof defaultWorkspaceState>,
+  projectRoot: string,
+  layoutId: string,
+) {
+  const checkoutKey = workspaceCheckoutKey(projectRoot);
+  const captured = captureWorkspaceObservation(state, {
+    checkoutKey,
+    projectRoot,
+    observedAt: NOW,
+    sessionName: null,
+    windowIndex: null,
+    windowName: null,
+    panes: [],
+    focusedPaneId: null,
+    workbench: {
+      canvasPanel: "home",
+      dock: { activeTab: "files", mode: "open", preferredHeight: null, focusZone: "canvas" },
+    },
+  });
+  return {
+    checkoutKey,
+    state: createWorkspaceLayout(captured, {
+      id: layoutId,
+      name: layoutId,
+      checkoutKey,
+      now: NOW,
+    }),
+  };
+}
+
+function writeRaw(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents, "utf8");
+}
+
+function lockOwner(
+  token = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  processInstanceId = "11111111-1111-4111-8111-111111111111",
+) {
+  return { version: 1, token, processInstanceId, pid: 4242, createdAtMs: 123_456 } as const;
+}
+
+function expectLockRecoveryError(
+  action: () => unknown,
+  code: WorkspaceStateLockRecoveryError["code"],
+): void {
+  try {
+    action();
+    throw new Error("expected workspace lock recovery to fail");
+  } catch (error) {
+    expect(error).toBeInstanceOf(WorkspaceStateLockRecoveryError);
+    expect((error as WorkspaceStateLockRecoveryError).code).toBe(code);
+  }
+}
+
+function checkoutIntents(
+  checkoutKey: string,
+  ...domains: Array<"live" | "workbench" | "focus" | "active-layout">
+) {
+  return new Map([[checkoutKey, new Set(domains)]]);
+}
+
+function waitForFile(path: string, timeoutMs = 5_000): void {
+  const startedAt = Date.now();
+  while (!existsSync(path)) {
+    if (Date.now() - startedAt > timeoutMs) throw new Error(`timed out waiting for ${path}`);
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+  }
+}
+
+function childExit(child: ReturnType<typeof spawn>): Promise<void> {
+  return new Promise((resolvePromise, reject) => {
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => (stderr += String(chunk)));
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`child exited ${String(code)}: ${stderr}`));
+    });
+  });
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("workspace state repository", () => {
+  it("loads missing state, deterministically migrates V2, writes, and reopens outside checkout", () => {
+    const home = temporaryRoot("workspace-home-");
+    const projectRoot = temporaryRoot("workspace-project-");
+    const repository = createProjectRuntimeRepository(resolution(projectRoot), { home });
+    const legacy = {
+      version: 2,
+      active: { viewId: "home", panel: "home" },
+      dock: {
+        activeTab: "changes",
+        mode: "open",
+        preferredHeight: 10,
+        focusZone: "dock-tabs",
+      },
+      surfaces: {},
+      views: {},
+    };
+    const loaded = loadWorkspaceState(repository, {
+      legacyWorkspaceUiState: legacy,
+      migratedAt: NOW,
+    });
+    const checkoutKey = workspaceCheckoutKey(projectRoot);
+
+    expect(loaded).toMatchObject({ revision: null, writeProtected: false });
+    expect(loaded.diagnostics).toContainEqual(expect.objectContaining({ code: "MIGRATED" }));
+    expect(loaded.state.checkouts[checkoutKey]!.workbench).toMatchObject({
+      canvasPanel: "home",
+      dock: { activeTab: "changes" },
+    });
+
+    const written = writeWorkspaceStateWithRetry({
+      repository,
+      revision: loaded.revision,
+      next: loaded.state,
+      touchedLayoutIds: new Set(["default"]),
+      checkoutIntents: checkoutIntents(checkoutKey, "live", "workbench", "focus", "active-layout"),
+    });
+    expect(written).toMatchObject({ saved: true, revision: 1 });
+    expect(
+      loadWorkspaceState(createProjectRuntimeRepository(resolution(projectRoot), { home })),
+    ).toMatchObject({
+      state: written.state,
+      revision: 1,
+      writeProtected: false,
+    });
+    expect(existsSync(join(projectRoot, ".tmux-ide"))).toBe(false);
+  });
+
+  it("preserves a future-version payload byte-for-byte", () => {
+    const home = temporaryRoot("workspace-home-");
+    const projectRoot = temporaryRoot("workspace-project-");
+    const repository = createProjectRuntimeRepository(resolution(projectRoot), { home });
+    const path = join(repository.runtimeRoot, WORKSPACE_STATE_PATH);
+    const future =
+      '{\n  "version": 1,\n  "revision": 7,\n  "payload": {"version": 42, "opaque": [3, 2, 1]}\n}\n';
+    writeRaw(path, future);
+
+    const loaded = loadWorkspaceState(repository);
+    expect(loaded.writeProtected).toBe(true);
+    const result = writeWorkspaceStateWithRetry({
+      repository,
+      revision: loaded.revision,
+      next: defaultWorkspaceState(workspaceProjectIdentity(repository)),
+      touchedLayoutIds: new Set(),
+    });
+
+    expect(result.saved).toBe(false);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({ code: "WRITE_PROTECTED" }));
+    expect(readFileSync(path, "utf8")).toBe(future);
+  });
+
+  it("write-protects a corrupt existing envelope instead of replacing evidence", () => {
+    const home = temporaryRoot("workspace-home-");
+    const projectRoot = temporaryRoot("workspace-project-");
+    const repository = createProjectRuntimeRepository(resolution(projectRoot), { home });
+    const path = join(repository.runtimeRoot, WORKSPACE_STATE_PATH);
+    const corrupt = "{not valid JSON\n";
+    writeRaw(path, corrupt);
+
+    const loaded = loadWorkspaceState(repository);
+    expect(loaded).toMatchObject({ revision: null, writeProtected: true });
+    const result = writeWorkspaceStateWithRetry({
+      repository,
+      revision: null,
+      next: defaultWorkspaceState(workspaceProjectIdentity(repository)),
+      touchedLayoutIds: new Set(),
+    });
+
+    expect(result.saved).toBe(false);
+    expect(readFileSync(path, "utf8")).toBe(corrupt);
+  });
+
+  it("preserves structurally corrupt supported V1 payload bytes", () => {
+    const home = temporaryRoot("workspace-home-");
+    const projectRoot = temporaryRoot("workspace-project-");
+    const repository = createProjectRuntimeRepository(resolution(projectRoot), { home });
+    const path = join(repository.runtimeRoot, WORKSPACE_STATE_PATH);
+    const corruptV1 = `${JSON.stringify(
+      {
+        version: 1,
+        revision: 4,
+        payload: {
+          version: 1,
+          project: workspaceProjectIdentity(repository),
+          layouts: [],
+          checkouts: {},
+        },
+      },
+      null,
+      2,
+    )}\n`;
+    writeRaw(path, corruptV1);
+
+    const loaded = loadWorkspaceState(repository);
+    expect(loaded.writeProtected).toBe(true);
+    const result = writeWorkspaceStateWithRetry({
+      repository,
+      revision: loaded.revision,
+      next: defaultWorkspaceState(workspaceProjectIdentity(repository)),
+      touchedLayoutIds: new Set(),
+    });
+
+    expect(result.saved).toBe(false);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({ code: "WRITE_PROTECTED" }));
+    expect(readFileSync(path, "utf8")).toBe(corruptV1);
+  });
+
+  it("merges stale shared layouts while isolating live bindings by linked checkout", () => {
+    const home = temporaryRoot("workspace-home-");
+    const mainRoot = temporaryRoot("workspace-main-");
+    const linkedRoot = temporaryRoot("workspace-linked-");
+    const main = createProjectRuntimeRepository(resolution(mainRoot), { home });
+    const linked = createProjectRuntimeRepository(resolution(linkedRoot), { home });
+    const mainLoaded = loadWorkspaceState(main);
+    const linkedLoaded = loadWorkspaceState(linked);
+    const mainLocal = addEmptyLayout(mainLoaded.state, mainRoot, "main-layout");
+    const linkedLocal = addEmptyLayout(linkedLoaded.state, linkedRoot, "linked-layout");
+
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository: main,
+        revision: mainLoaded.revision,
+        next: mainLocal.state,
+        touchedLayoutIds: new Set(["main-layout"]),
+        checkoutIntents: checkoutIntents(
+          mainLocal.checkoutKey,
+          "live",
+          "workbench",
+          "focus",
+          "active-layout",
+        ),
+      }).saved,
+    ).toBe(true);
+    const linkedWrite = writeWorkspaceStateWithRetry({
+      repository: linked,
+      revision: linkedLoaded.revision,
+      next: linkedLocal.state,
+      touchedLayoutIds: new Set(["linked-layout"]),
+      checkoutIntents: checkoutIntents(
+        linkedLocal.checkoutKey,
+        "live",
+        "workbench",
+        "focus",
+        "active-layout",
+      ),
+    });
+    expect(linkedWrite.saved).toBe(true);
+    expect(linkedWrite.diagnostics).toContainEqual(expect.objectContaining({ code: "STALE" }));
+
+    const final = loadWorkspaceState(main);
+    expect(Object.keys(final.state.layouts)).toEqual(["linked-layout", "main-layout"]);
+    expect(Object.keys(final.state.checkouts)).toEqual(
+      [linkedLocal.checkoutKey, mainLocal.checkoutKey].sort(),
+    );
+    expect(final.state.checkouts[mainLocal.checkoutKey]!.projectRoot).toBe(mainRoot);
+    expect(final.state.checkouts[linkedLocal.checkoutKey]!.projectRoot).toBe(linkedRoot);
+    expect(final.revision).toBe(2);
+  });
+
+  it("merges stale checkout subdomains without regressing bindings or workbench state", () => {
+    const home = temporaryRoot("workspace-home-");
+    const projectRoot = temporaryRoot("workspace-project-");
+    const repository = createProjectRuntimeRepository(resolution(projectRoot), { home });
+    const checkoutKey = workspaceCheckoutKey(projectRoot);
+    const capture = (
+      state: ReturnType<typeof defaultWorkspaceState>,
+      runtimePaneId: `%${number}`,
+      activeTab: "files" | "changes" | "missions",
+      observedAt: string,
+    ) =>
+      captureWorkspaceObservation(state, {
+        checkoutKey,
+        projectRoot,
+        observedAt,
+        sessionName: "workspace",
+        windowIndex: 0,
+        windowName: "main",
+        panes: [
+          {
+            semanticPaneId: "agent",
+            runtimePaneId,
+            role: "agent",
+            harness: "codex",
+            title: "Agent",
+            command: "codex",
+            cwd: projectRoot,
+            rect: { left: 0, top: 0, width: 80, height: 40 },
+            active: true,
+          },
+        ],
+        focusedPaneId: "agent",
+        workbench: {
+          canvasPanel: "terminals",
+          dock: { activeTab, mode: "open", preferredHeight: 12, focusZone: "canvas" },
+        },
+      });
+    const initial = capture(
+      defaultWorkspaceState(workspaceProjectIdentity(repository)),
+      "%1",
+      "files",
+      NOW,
+    );
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: null,
+        next: initial,
+        touchedLayoutIds: new Set(),
+        checkoutIntents: checkoutIntents(
+          checkoutKey,
+          "live",
+          "workbench",
+          "focus",
+          "active-layout",
+        ),
+      }).saved,
+    ).toBe(true);
+
+    const liveBase = loadWorkspaceState(repository);
+    const tuiBase = loadWorkspaceState(repository);
+    const liveNext = capture(liveBase.state, "%2", "files", "2026-07-20T12:01:00.000Z");
+    const tuiNext = structuredClone(tuiBase.state);
+    tuiNext.checkouts[checkoutKey]!.workbench.dock.activeTab = "missions";
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: liveBase.revision,
+        next: liveNext,
+        touchedLayoutIds: new Set(),
+        checkoutIntents: checkoutIntents(checkoutKey, "live", "focus"),
+      }).saved,
+    ).toBe(true);
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: tuiBase.revision,
+        next: tuiNext,
+        touchedLayoutIds: new Set(),
+        checkoutIntents: checkoutIntents(checkoutKey, "workbench"),
+      }).saved,
+    ).toBe(true);
+    let final = loadWorkspaceState(repository);
+    expect(final.state.checkouts[checkoutKey]!.bindings.agent!.runtimePaneId).toBe("%2");
+    expect(final.state.checkouts[checkoutKey]!.workbench.dock.activeTab).toBe("missions");
+
+    const tuiFirstBase = loadWorkspaceState(repository);
+    const staleLiveBase = loadWorkspaceState(repository);
+    const tuiFirst = structuredClone(tuiFirstBase.state);
+    tuiFirst.checkouts[checkoutKey]!.workbench.dock.activeTab = "changes";
+    const staleLive = capture(staleLiveBase.state, "%3", "files", "2026-07-20T12:02:00.000Z");
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: tuiFirstBase.revision,
+        next: tuiFirst,
+        touchedLayoutIds: new Set(),
+        checkoutIntents: checkoutIntents(checkoutKey, "workbench"),
+      }).saved,
+    ).toBe(true);
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: staleLiveBase.revision,
+        next: staleLive,
+        touchedLayoutIds: new Set(),
+        checkoutIntents: checkoutIntents(checkoutKey, "live", "focus"),
+      }).saved,
+    ).toBe(true);
+    final = loadWorkspaceState(repository);
+    expect(final.state.checkouts[checkoutKey]!.bindings.agent!.runtimePaneId).toBe("%3");
+    expect(final.state.checkouts[checkoutKey]!.workbench.dock.activeTab).toBe("changes");
+  });
+
+  it("returns a typed conflict when stale focus targets a concurrently removed live pane", () => {
+    const home = temporaryRoot("workspace-home-");
+    const projectRoot = temporaryRoot("workspace-project-");
+    const repository = createProjectRuntimeRepository(resolution(projectRoot), { home });
+    const checkoutKey = workspaceCheckoutKey(projectRoot);
+    const initial = captureWorkspaceObservation(
+      defaultWorkspaceState(workspaceProjectIdentity(repository)),
+      {
+        checkoutKey,
+        projectRoot,
+        observedAt: NOW,
+        sessionName: "workspace",
+        windowIndex: 0,
+        windowName: "main",
+        panes: [
+          {
+            semanticPaneId: "agent",
+            runtimePaneId: "%1",
+            role: "agent",
+            harness: "codex",
+            title: "Agent",
+            command: "codex",
+            cwd: projectRoot,
+            rect: { left: 0, top: 0, width: 80, height: 40 },
+            active: true,
+          },
+        ],
+        focusedPaneId: "agent",
+        workbench: {
+          canvasPanel: "terminals",
+          dock: { activeTab: "files", mode: "open", preferredHeight: 12, focusZone: "canvas" },
+        },
+      },
+    );
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: null,
+        next: initial,
+        touchedLayoutIds: new Set(),
+        checkoutIntents: checkoutIntents(checkoutKey, "live", "workbench", "focus"),
+      }).saved,
+    ).toBe(true);
+
+    const focusBase = loadWorkspaceState(repository);
+    const liveBase = loadWorkspaceState(repository);
+    const paneRemoved = structuredClone(liveBase.state);
+    paneRemoved.checkouts[checkoutKey]!.topology = { panes: {}, root: null };
+    paneRemoved.checkouts[checkoutKey]!.focusedPaneId = null;
+    paneRemoved.checkouts[checkoutKey]!.bindings = {};
+    paneRemoved.checkouts[checkoutKey]!.recovery = {
+      status: "empty",
+      capturedAt: "2026-07-20T12:01:00.000Z",
+      sessionName: "workspace",
+      windowIndex: 0,
+      windowName: "main",
+      missingPaneIds: ["agent"],
+      externalPaneIds: [],
+    };
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: liveBase.revision,
+        next: paneRemoved,
+        touchedLayoutIds: new Set(),
+        checkoutIntents: checkoutIntents(checkoutKey, "live"),
+      }).saved,
+    ).toBe(true);
+
+    const result = writeWorkspaceStateWithRetry({
+      repository,
+      revision: focusBase.revision,
+      next: focusBase.state,
+      touchedLayoutIds: new Set(),
+      checkoutIntents: checkoutIntents(checkoutKey, "focus"),
+    });
+
+    expect(result.saved).toBe(false);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "CONFLICT",
+        path: `$.checkouts.${checkoutKey}.focusedPaneId`,
+      }),
+    );
+    expect(result.diagnostics).not.toContainEqual(
+      expect.objectContaining({ code: "WRITE_FAILED" }),
+    );
+    expect(loadWorkspaceState(repository).state.checkouts[checkoutKey]).toMatchObject({
+      focusedPaneId: null,
+      topology: { panes: {} },
+    });
+  });
+
+  it("rejects stale same-layout edits when their base revision changed", () => {
+    const home = temporaryRoot("workspace-home-");
+    const projectRoot = temporaryRoot("workspace-project-");
+    const repository = createProjectRuntimeRepository(resolution(projectRoot), { home });
+    const initial = addEmptyLayout(
+      defaultWorkspaceState(workspaceProjectIdentity(repository)),
+      projectRoot,
+      "shared-layout",
+    );
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: null,
+        next: initial.state,
+        touchedLayoutIds: new Set(["shared-layout"]),
+        checkoutIntents: checkoutIntents(
+          initial.checkoutKey,
+          "live",
+          "workbench",
+          "focus",
+          "active-layout",
+        ),
+      }).saved,
+    ).toBe(true);
+    const firstBase = loadWorkspaceState(repository);
+    const secondBase = loadWorkspaceState(repository);
+    const first = renameWorkspaceLayout(
+      firstBase.state,
+      "shared-layout",
+      "First rename",
+      "2026-07-20T12:01:00.000Z",
+    );
+    const second = renameWorkspaceLayout(
+      secondBase.state,
+      "shared-layout",
+      "Second rename",
+      "2026-07-20T12:02:00.000Z",
+    );
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: firstBase.revision,
+        next: first,
+        touchedLayoutIds: new Set(["shared-layout"]),
+        layoutBaseRevisions: new Map([["shared-layout", 1]]),
+      }).saved,
+    ).toBe(true);
+    const conflict = writeWorkspaceStateWithRetry({
+      repository,
+      revision: secondBase.revision,
+      next: second,
+      touchedLayoutIds: new Set(["shared-layout"]),
+      layoutBaseRevisions: new Map([["shared-layout", 1]]),
+    });
+
+    expect(conflict.saved).toBe(false);
+    expect(conflict.diagnostics).toContainEqual(expect.objectContaining({ code: "CONFLICT" }));
+    expect(loadWorkspaceState(repository).state.layouts["shared-layout"]!.name).toBe(
+      "First rename",
+    );
+  });
+
+  it("rejects deprecated whole-checkout replacement when its document is stale", () => {
+    const home = temporaryRoot("workspace-home-");
+    const projectRoot = temporaryRoot("workspace-project-");
+    const repository = createProjectRuntimeRepository(resolution(projectRoot), { home });
+    const initial = addEmptyLayout(
+      defaultWorkspaceState(workspaceProjectIdentity(repository)),
+      projectRoot,
+      "layout",
+    );
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: null,
+        next: initial.state,
+        touchedLayoutIds: new Set(["layout"]),
+        touchedCheckoutKeys: new Set([initial.checkoutKey]),
+      }).saved,
+    ).toBe(true);
+    const legacyBase = loadWorkspaceState(repository);
+    const competingBase = loadWorkspaceState(repository);
+    const competing = structuredClone(competingBase.state);
+    competing.checkouts[initial.checkoutKey]!.workbench.dock.activeTab = "missions";
+    expect(
+      writeWorkspaceStateWithRetry({
+        repository,
+        revision: competingBase.revision,
+        next: competing,
+        touchedLayoutIds: new Set(),
+        checkoutIntents: checkoutIntents(initial.checkoutKey, "workbench"),
+      }).saved,
+    ).toBe(true);
+    const legacyNext = structuredClone(legacyBase.state);
+    legacyNext.checkouts[initial.checkoutKey]!.workbench.dock.activeTab = "changes";
+    const result = writeWorkspaceStateWithRetry({
+      repository,
+      revision: legacyBase.revision,
+      next: legacyNext,
+      touchedLayoutIds: new Set(),
+      touchedCheckoutKeys: new Set([initial.checkoutKey]),
+    });
+
+    expect(result.saved).toBe(false);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({ code: "CONFLICT" }));
+    expect(
+      loadWorkspaceState(repository).state.checkouts[initial.checkoutKey]!.workbench.dock.activeTab,
+    ).toBe("missions");
+  });
+
+  it.each([
+    ["empty", ""],
+    ["malformed", "not-json\n"],
+  ])("never reclaims an existing %s lock file", (_label, contents) => {
+    const home = temporaryRoot("workspace-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const lockPath = join(repository.runtimeRoot, "workspace", WORKSPACE_STATE_LOCK_FILENAME);
+    writeRaw(lockPath, contents);
+
+    expect(() =>
+      withWorkspaceStateLock(
+        repository,
+        { timeoutMs: 25, pollMs: 5, staleAfterMs: 1 },
+        () => undefined,
+      ),
+    ).toThrow(WorkspaceStateLockTimeoutError);
+    expect(readFileSync(lockPath, "utf8")).toBe(contents);
+  });
+
+  it.each([
+    ["ancient live owner", process.pid, "11111111-1111-4111-8111-111111111111"],
+    ["dead-looking owner", 2_147_000_000, "22222222-2222-4222-8222-222222222222"],
+    ["PID-reused-looking owner", process.pid, "33333333-3333-4333-8333-333333333333"],
+  ])("never reclaims a structured %s lock", (_label, pid, processInstanceId) => {
+    const home = temporaryRoot("workspace-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const lockPath = join(repository.runtimeRoot, "workspace", WORKSPACE_STATE_LOCK_FILENAME);
+    const contents = `${JSON.stringify({
+      version: 1,
+      token: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      processInstanceId,
+      pid,
+      createdAtMs: 0,
+    })}\n`;
+    writeRaw(lockPath, contents);
+
+    expect(() =>
+      withWorkspaceStateLock(repository, { timeoutMs: 25, pollMs: 5 }, () => undefined),
+    ).toThrow(WorkspaceStateLockTimeoutError);
+    expect(readFileSync(lockPath, "utf8")).toBe(contents);
+  });
+
+  it("inspects exact lock ownership and preserves bytes without confirmation or on mismatch", () => {
+    const home = temporaryRoot("workspace-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const lockPath = join(repository.runtimeRoot, "workspace", WORKSPACE_STATE_LOCK_FILENAME);
+    const owner = lockOwner();
+    const contents = `${JSON.stringify(owner)}\n`;
+    writeRaw(lockPath, contents);
+
+    const inspected = inspectWorkspaceStateLock(repository);
+    expect(inspected).toMatchObject({
+      status: "valid",
+      lockPath,
+      owner: {
+        version: 1,
+        token: owner.token,
+        processInstanceId: owner.processInstanceId,
+        pid: owner.pid,
+        createdAt: owner.createdAtMs,
+      },
+    });
+    if (inspected.status !== "valid") throw new Error("expected valid lock inspection");
+    expectLockRecoveryError(
+      () =>
+        clearWorkspaceStateLockOffline(repository, {
+          expectedToken: owner.token,
+          expectedProcessInstanceId: owner.processInstanceId,
+          expectedDevice: inspected.device,
+          expectedInode: inspected.inode,
+          confirmAllWritersStopped: false as true,
+        }),
+      "CONFIRMATION_REQUIRED",
+    );
+    expect(readFileSync(lockPath, "utf8")).toBe(contents);
+
+    expectLockRecoveryError(
+      () =>
+        clearWorkspaceStateLockOffline(repository, {
+          expectedToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          expectedProcessInstanceId: owner.processInstanceId,
+          expectedDevice: inspected.device,
+          expectedInode: inspected.inode,
+          confirmAllWritersStopped: true,
+        }),
+      "OWNER_MISMATCH",
+    );
+    expect(readFileSync(lockPath, "utf8")).toBe(contents);
+  });
+
+  it("clears an explicitly confirmed structured abandoned lock and allows acquisition", () => {
+    const home = temporaryRoot("workspace-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const lockPath = join(repository.runtimeRoot, "workspace", WORKSPACE_STATE_LOCK_FILENAME);
+    const owner = lockOwner();
+    writeRaw(lockPath, `${JSON.stringify(owner)}\n`);
+    const inspected = inspectWorkspaceStateLock(repository);
+    expect(inspected.status).toBe("valid");
+    if (inspected.status !== "valid") throw new Error("expected valid lock inspection");
+
+    expect(
+      clearWorkspaceStateLockOffline(repository, {
+        expectedToken: inspected.owner.token,
+        expectedProcessInstanceId: inspected.owner.processInstanceId,
+        expectedDevice: inspected.device,
+        expectedInode: inspected.inode,
+        confirmAllWritersStopped: true,
+      }),
+    ).toMatchObject({
+      cleared: true,
+      lockPath,
+      owner: inspected.owner,
+      device: inspected.device,
+      inode: inspected.inode,
+    });
+    expect(inspectWorkspaceStateLock(repository)).toEqual({ status: "absent", lockPath });
+    expect(withWorkspaceStateLock(repository, { timeoutMs: 100 }, () => "acquired")).toBe(
+      "acquired",
+    );
+  });
+
+  it("refuses malformed offline locks and preserves their bytes", () => {
+    const home = temporaryRoot("workspace-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const lockPath = join(repository.runtimeRoot, "workspace", WORKSPACE_STATE_LOCK_FILENAME);
+    const contents = "not-json\n";
+    writeRaw(lockPath, contents);
+
+    const inspected = inspectWorkspaceStateLock(repository);
+    expect(inspected).toMatchObject({
+      status: "malformed",
+      lockPath,
+    });
+    if (inspected.status !== "malformed") throw new Error("expected malformed lock inspection");
+    expectLockRecoveryError(
+      () =>
+        clearWorkspaceStateLockOffline(repository, {
+          expectedToken: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          expectedProcessInstanceId: "11111111-1111-4111-8111-111111111111",
+          expectedDevice: inspected.device,
+          expectedInode: inspected.inode,
+          confirmAllWritersStopped: true,
+        }),
+      "LOCK_MALFORMED",
+    );
+    expect(readFileSync(lockPath, "utf8")).toBe(contents);
+  });
+
+  it("does not delete a replacement lock that differs from the inspected owner", () => {
+    const home = temporaryRoot("workspace-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const lockPath = join(repository.runtimeRoot, "workspace", WORKSPACE_STATE_LOCK_FILENAME);
+    const original = lockOwner();
+    writeRaw(lockPath, `${JSON.stringify(original)}\n`);
+    const inspected = inspectWorkspaceStateLock(repository);
+    expect(inspected.status).toBe("valid");
+    if (inspected.status !== "valid") throw new Error("expected valid lock inspection");
+
+    const replacement = lockOwner(
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "22222222-2222-4222-8222-222222222222",
+    );
+    const replacementContents = `${JSON.stringify(replacement)}\n`;
+    const replacementPath = `${lockPath}.replacement`;
+    writeRaw(replacementPath, replacementContents);
+    renameSync(replacementPath, lockPath);
+
+    expectLockRecoveryError(
+      () =>
+        clearWorkspaceStateLockOffline(repository, {
+          expectedToken: original.token,
+          expectedProcessInstanceId: original.processInstanceId,
+          expectedDevice: inspected.device,
+          expectedInode: inspected.inode,
+          confirmAllWritersStopped: true,
+        }),
+      "OWNER_MISMATCH",
+    );
+    expect(readFileSync(lockPath, "utf8")).toBe(replacementContents);
+  });
+
+  it("preserves a byte-identical replacement installed on a new inode", () => {
+    const home = temporaryRoot("workspace-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const lockPath = join(repository.runtimeRoot, "workspace", WORKSPACE_STATE_LOCK_FILENAME);
+    const owner = lockOwner();
+    const contents = `${JSON.stringify(owner)}\n`;
+    writeRaw(lockPath, contents);
+    const inspected = inspectWorkspaceStateLock(repository);
+    expect(inspected.status).toBe("valid");
+    if (inspected.status !== "valid") throw new Error("expected valid lock inspection");
+
+    const replacementPath = `${lockPath}.replacement-identical`;
+    writeRaw(replacementPath, contents);
+    const replacementIdentity = lstatSync(replacementPath);
+    expect({ device: replacementIdentity.dev, inode: replacementIdentity.ino }).not.toEqual({
+      device: inspected.device,
+      inode: inspected.inode,
+    });
+    renameSync(replacementPath, lockPath);
+
+    expectLockRecoveryError(
+      () =>
+        clearWorkspaceStateLockOffline(repository, {
+          expectedToken: inspected.owner.token,
+          expectedProcessInstanceId: inspected.owner.processInstanceId,
+          expectedDevice: inspected.device,
+          expectedInode: inspected.inode,
+          confirmAllWritersStopped: true,
+        }),
+      "LOCK_CHANGED",
+    );
+    expect(readFileSync(lockPath, "utf8")).toBe(contents);
+    expect(lstatSync(lockPath)).toMatchObject({
+      dev: replacementIdentity.dev,
+      ino: replacementIdentity.ino,
+    });
+  });
+
+  it("installs and releases a fully populated lock atomically", () => {
+    const home = temporaryRoot("workspace-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const lockPath = join(repository.runtimeRoot, "workspace", WORKSPACE_STATE_LOCK_FILENAME);
+    expect(
+      withWorkspaceStateLock(repository, { timeoutMs: 100 }, () => {
+        const owner = JSON.parse(readFileSync(lockPath, "utf8")) as Record<string, unknown>;
+        expect(owner).toMatchObject({ version: 1, pid: process.pid });
+        expect(owner.token).toMatch(/^[0-9a-f-]{36}$/iu);
+        expect(owner.processInstanceId).toMatch(/^[0-9a-f-]{36}$/iu);
+        return "done";
+      }),
+    ).toBe("done");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("keeps a successful document write saved when lock release fails", () => {
+    const home = temporaryRoot("workspace-home-");
+    const projectRoot = temporaryRoot("workspace-project-");
+    let runtimeRoot = "";
+    const repository = createProjectRuntimeRepository(resolution(projectRoot), {
+      home,
+      io: {
+        rename: (from, to) => {
+          renameSync(from, to);
+          if (to.endsWith(WORKSPACE_STATE_PATH)) {
+            const lockPath = join(runtimeRoot, "workspace", WORKSPACE_STATE_LOCK_FILENAME);
+            const owner = JSON.parse(readFileSync(lockPath, "utf8")) as { token: string };
+            const collision = `${lockPath}.released-${owner.token}`;
+            mkdirSync(collision, { recursive: true });
+            writeFileSync(join(collision, "occupied"), "occupied\n", "utf8");
+          }
+        },
+      },
+    });
+    runtimeRoot = repository.runtimeRoot;
+    const result = writeWorkspaceStateWithRetry({
+      repository,
+      revision: null,
+      next: defaultWorkspaceState(workspaceProjectIdentity(repository)),
+      touchedLayoutIds: new Set(),
+    });
+
+    expect(result).toMatchObject({ saved: true, revision: 1 });
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "LOCK_RELEASE_FAILED" }),
+    );
+    expect(loadWorkspaceState(repository).revision).toBe(1);
+  });
+
+  it("rejects a symlinked runtime root without writing through it", () => {
+    const home = temporaryRoot("workspace-home-");
+    const external = temporaryRoot("workspace-external-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    mkdirSync(dirname(repository.runtimeRoot), { recursive: true });
+    symlinkSync(external, repository.runtimeRoot, "dir");
+
+    expect(() => withWorkspaceStateLock(repository, { timeoutMs: 25 }, () => undefined)).toThrow(
+      /symbolic link/u,
+    );
+    expect(existsSync(join(external, "workspace"))).toBe(false);
+  });
+
+  it("serializes stale writers across real processes without losing disjoint changes", async () => {
+    const home = temporaryRoot("workspace-home-");
+    const firstRoot = temporaryRoot("workspace-child-a-");
+    const secondRoot = temporaryRoot("workspace-child-b-");
+    const barrier = temporaryRoot("workspace-barrier-");
+    const readyA = join(barrier, "ready-a");
+    const readyB = join(barrier, "ready-b");
+    const go = join(barrier, "go");
+    const fixture = fileURLToPath(new URL("./fixtures/workspace-state-writer.ts", import.meta.url));
+    const tsx = fileURLToPath(new URL("../../../node_modules/.bin/tsx", import.meta.url));
+    const first = spawn(tsx, [fixture, home, firstRoot, "layout-a", readyA, go], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const second = spawn(tsx, [fixture, home, secondRoot, "layout-b", readyB, go], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const firstExit = childExit(first);
+    const secondExit = childExit(second);
+    waitForFile(readyA);
+    waitForFile(readyB);
+    writeFileSync(go, "go\n", "utf8");
+    await Promise.all([firstExit, secondExit]);
+
+    const repository = createProjectRuntimeRepository(resolution(firstRoot), { home });
+    const final = loadWorkspaceState(repository);
+    expect(final.revision).toBe(2);
+    expect(Object.keys(final.state.layouts)).toEqual(["layout-a", "layout-b"]);
+    expect(Object.keys(final.state.checkouts)).toHaveLength(2);
+  }, 15_000);
+});

--- a/packages/daemon/src/lib/__tests__/workspace-state.test.ts
+++ b/packages/daemon/src/lib/__tests__/workspace-state.test.ts
@@ -1,0 +1,756 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  WorkspaceLayoutApplyPlanSchemaZ,
+  WorkspaceObservationSchemaZ,
+  WorkspacePaneCwdSchemaZ,
+  WorkspacePaneTopologySchemaZ,
+  WorkspacePaneTreeNodeSchemaZ,
+  WorkspaceStateV1SchemaZ,
+  type WorkspaceObservation,
+} from "@tmux-ide/contracts";
+
+import {
+  applyWorkspaceLayout,
+  captureWorkspaceObservation,
+  createWorkspaceLayout,
+  defaultWorkspaceState,
+  deleteWorkspaceLayout,
+  migrateWorkspaceUiStateV2,
+  parseWorkspaceStateValue,
+  projectWorkspaceTopology,
+  renameWorkspaceLayout,
+  saveWorkspaceLayout,
+  serializeWorkspaceState,
+} from "../workspace-state.ts";
+
+const PROJECT = {
+  identityKey: `git-${"a".repeat(64)}`,
+  identitySource: "git-common-dir" as const,
+  identityAnchor: "/repo/.git",
+};
+const NOW = "2026-07-20T10:00:00.000Z";
+const LATER = "2026-07-20T10:01:00.000Z";
+
+function observation(
+  panes: WorkspaceObservation["panes"],
+  overrides: Partial<WorkspaceObservation> = {},
+): WorkspaceObservation {
+  return {
+    checkoutKey: "checkout-main",
+    projectRoot: "/repo",
+    observedAt: NOW,
+    sessionName: "tmux-ide",
+    windowIndex: 0,
+    windowName: "workspace",
+    panes,
+    focusedPaneId: panes[0]?.semanticPaneId ?? null,
+    workbench: {
+      canvasPanel: "terminals",
+      dock: {
+        activeTab: "files",
+        mode: "open",
+        preferredHeight: 12,
+        focusZone: "canvas",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function pane(
+  semanticPaneId: string,
+  runtimePaneId: `%${number}`,
+  left: number,
+  overrides: Partial<WorkspaceObservation["panes"][number]> = {},
+): WorkspaceObservation["panes"][number] {
+  return {
+    semanticPaneId,
+    runtimePaneId,
+    role: "agent",
+    harness: "codex",
+    title: "Implementer",
+    command: "codex --yolo",
+    cwd: "/repo",
+    rect: { left, top: 0, width: 80, height: 40 },
+    ...overrides,
+  };
+}
+
+describe("workspace topology and capture", () => {
+  it("keeps duplicate-looking panes distinct and assigns deterministic tree parent ids", () => {
+    const panes = [pane("agent-alpha", "%1", 0), pane("agent-beta", "%2", 80)];
+    const first = projectWorkspaceTopology(panes, "/repo");
+    const second = projectWorkspaceTopology([...panes].reverse(), "/repo");
+
+    expect(first).toEqual(second);
+    expect(Object.keys(first.panes)).toEqual(["agent-alpha", "agent-beta"]);
+    expect(first.root).toMatchObject({ type: "split", axis: "horizontal" });
+    expect(first.panes["agent-alpha"]!.parentId).toBe(first.root?.nodeId);
+    expect(first.panes["agent-beta"]!.parentId).toBe(first.root?.nodeId);
+    expect(
+      WorkspaceStateV1SchemaZ.safeParse({
+        ...defaultWorkspaceState(PROJECT),
+        checkouts: {
+          main: {
+            checkoutKey: "main",
+            projectRoot: "/repo",
+            activeLayoutId: null,
+            topology: first,
+            focusedPaneId: "agent-alpha",
+            workbench: observation([]).workbench,
+            bindings: {},
+            recovery: {
+              status: "clean",
+              capturedAt: NOW,
+              sessionName: "tmux-ide",
+              windowIndex: 0,
+              windowName: "workspace",
+              missingPaneIds: [],
+              externalPaneIds: [],
+            },
+          },
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("preserves semantic pane identity while replacing checkout-scoped runtime bindings", () => {
+    const initial = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("agent-alpha", "%1", 0)]),
+    );
+    const rebound = captureWorkspaceObservation(
+      initial,
+      observation([pane("agent-alpha", "%99", 0)], { observedAt: LATER }),
+    );
+
+    expect(rebound.checkouts["checkout-main"]!.topology).toEqual(
+      initial.checkouts["checkout-main"]!.topology,
+    );
+    expect(rebound.checkouts["checkout-main"]!.bindings["agent-alpha"]).toEqual({
+      semanticPaneId: "agent-alpha",
+      runtimePaneId: "%99",
+      lastSeenAt: LATER,
+    });
+    expect(
+      captureWorkspaceObservation(
+        rebound,
+        observation([pane("agent-alpha", "%99", 0)], { observedAt: LATER }),
+      ),
+    ).toEqual(rebound);
+  });
+
+  it("rejects duplicate semantic/runtime ids and checkout-key/root mismatches", () => {
+    const duplicateSemantic = observation([pane("agent", "%1", 0), pane("agent", "%2", 80)]);
+    const duplicateRuntime = observation([pane("agent-a", "%1", 0), pane("agent-b", "%1", 80)]);
+
+    expect(WorkspaceObservationSchemaZ.safeParse(duplicateSemantic).success).toBe(false);
+    expect(WorkspaceObservationSchemaZ.safeParse(duplicateRuntime).success).toBe(false);
+    expect(() =>
+      captureWorkspaceObservation(defaultWorkspaceState(PROJECT), duplicateSemantic),
+    ).toThrow(/semantic pane ids must be unique/u);
+    expect(() =>
+      captureWorkspaceObservation(defaultWorkspaceState(PROJECT), duplicateRuntime),
+    ).toThrow(/runtime pane ids must be unique/u);
+
+    const captured = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("agent", "%1", 0)]),
+    );
+    expect(() =>
+      captureWorkspaceObservation(
+        captured,
+        observation([pane("agent", "%2", 0)], {
+          projectRoot: "/different-repo",
+          observedAt: LATER,
+        }),
+      ),
+    ).toThrow(/different project root/u);
+
+    const invalidBindings = structuredClone(captured);
+    invalidBindings.checkouts["checkout-main"]!.topology = projectWorkspaceTopology(
+      [pane("agent", "%1", 0), pane("second", "%2", 80)],
+      "/repo",
+    );
+    invalidBindings.checkouts["checkout-main"]!.bindings.second = {
+      semanticPaneId: "second",
+      runtimePaneId: "%1",
+      lastSeenAt: NOW,
+    };
+    expect(WorkspaceStateV1SchemaZ.safeParse(invalidBindings).success).toBe(false);
+  });
+
+  it("preserves the last recoverable topology on empty or older observations", () => {
+    const captured = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation(
+        [
+          pane("lead", "%7", 0, { command: "codex --yolo", cwd: "/repo/apps/web" }),
+          pane("shell", "%8", 80, {
+            role: "shell",
+            harness: null,
+            title: "Dev shell",
+            command: "pnpm dev",
+            cwd: "/repo/apps/site",
+          }),
+        ],
+        { observedAt: LATER },
+      ),
+    );
+    const partial = captureWorkspaceObservation(
+      captured,
+      observation([pane("lead", "%70", 0)], {
+        observedAt: "2026-07-20T10:02:00.000Z",
+      }),
+    );
+    const partialAgain = captureWorkspaceObservation(
+      partial,
+      observation([pane("lead", "%71", 0)], {
+        observedAt: "2026-07-20T10:03:00.000Z",
+      }),
+    );
+    const empty = captureWorkspaceObservation(
+      partialAgain,
+      observation([], { observedAt: "2026-07-20T10:04:00.000Z", focusedPaneId: null }),
+    );
+    const stale = captureWorkspaceObservation(
+      empty,
+      observation([pane("stale", "%1", 0)], { observedAt: NOW }),
+    );
+
+    expect(partial.checkouts["checkout-main"]!.topology.panes.shell).toEqual(
+      captured.checkouts["checkout-main"]!.topology.panes.shell,
+    );
+    expect(partialAgain.checkouts["checkout-main"]!.topology.root).toEqual(
+      captured.checkouts["checkout-main"]!.topology.root,
+    );
+    expect(partialAgain.checkouts["checkout-main"]!.bindings.shell).toEqual(
+      captured.checkouts["checkout-main"]!.bindings.shell,
+    );
+    expect(empty.checkouts["checkout-main"]).toMatchObject({
+      topology: partialAgain.checkouts["checkout-main"]!.topology,
+      focusedPaneId: "lead",
+      bindings: partialAgain.checkouts["checkout-main"]!.bindings,
+      recovery: { status: "empty", missingPaneIds: ["lead", "shell"] },
+    });
+    expect(stale).toEqual(empty);
+  });
+
+  it("keeps the first observation when timestamps are equal", () => {
+    const first = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("lead", "%1", 0)]),
+    );
+    const equalTimestamp = captureWorkspaceObservation(
+      first,
+      observation([pane("replacement", "%9", 0)]),
+    );
+
+    expect(equalTimestamp).toEqual(first);
+  });
+
+  it("builds a schema-valid bounded tree for more than eight overlapping panes", () => {
+    const overlapping = Array.from({ length: 9 }, (_, index) =>
+      pane(`agent-${index}`, `%${index + 1}` as `%${number}`, 0),
+    );
+    const topology = projectWorkspaceTopology(overlapping, "/repo");
+
+    expect(Object.keys(topology.panes)).toHaveLength(9);
+    expect(
+      WorkspaceStateV1SchemaZ.safeParse({
+        ...defaultWorkspaceState(PROJECT),
+        checkouts: {
+          main: {
+            ...captureWorkspaceObservation(
+              defaultWorkspaceState(PROJECT),
+              observation(overlapping, { checkoutKey: "main" }),
+            ).checkouts.main,
+          },
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it.each([33, 128])("balances %i linear panes within tree depth limits", (count) => {
+    const linear = Array.from({ length: count }, (_, index) =>
+      pane(`agent-${index}`, `%${index + 1}` as `%${number}`, index * 2, {
+        rect: { left: index * 2, top: 0, width: 1, height: 40 },
+      }),
+    );
+    const topology = projectWorkspaceTopology(linear, "/repo");
+    let depth = 0;
+    const stack = topology.root ? [{ node: topology.root, depth: 1 }] : [];
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      depth = Math.max(depth, current.depth);
+      if (current.node.type === "split") {
+        for (const child of current.node.children) {
+          stack.push({ node: child, depth: current.depth + 1 });
+        }
+      }
+    }
+
+    expect(WorkspacePaneTopologySchemaZ.safeParse(topology).success).toBe(true);
+    expect(Object.keys(topology.panes)).toHaveLength(count);
+    expect(depth).toBeLessThanOrEqual(9);
+  });
+});
+
+describe("named workspace layouts", () => {
+  it("round-trips create, rename, save, and delete without mutating earlier values", () => {
+    const captured = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("lead", "%1", 0), pane("implementer", "%2", 80)]),
+    );
+    const created = createWorkspaceLayout(captured, {
+      id: "pairing",
+      name: "Pairing",
+      checkoutKey: "checkout-main",
+      now: NOW,
+    });
+    const renamed = renameWorkspaceLayout(created, "pairing", "Mission Pair", LATER);
+    const changedLive = captureWorkspaceObservation(
+      renamed,
+      observation([pane("lead", "%1", 0)], { observedAt: LATER }),
+    );
+    const saved = saveWorkspaceLayout(changedLive, "pairing", "checkout-main", LATER);
+    const deleted = deleteWorkspaceLayout(saved, "pairing");
+
+    expect(captured.layouts).toEqual({});
+    expect(created.layouts.pairing).toMatchObject({ name: "Pairing", revision: 1 });
+    expect(renamed.layouts.pairing).toMatchObject({ name: "Mission Pair", revision: 2 });
+    expect(Object.keys(saved.layouts.pairing!.snapshot.topology.panes)).toEqual(["lead"]);
+    expect(saved.layouts.pairing!.revision).toBe(3);
+    expect(deleted.layouts).toEqual({});
+    expect(deleted.checkouts["checkout-main"]!.activeLayoutId).toBeNull();
+  });
+
+  it("returns the full desired topology in a pure apply plan while reporting drift", () => {
+    const captured = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("lead", "%1", 0), pane("implementer", "%2", 80)]),
+    );
+    const withLayout = createWorkspaceLayout(captured, {
+      id: "pairing",
+      name: "Pairing",
+      checkoutKey: "checkout-main",
+      now: NOW,
+    });
+    const live = observation(
+      [
+        pane("lead", "%9", 0),
+        pane("external-shell", "%10", 80, { role: "shell", harness: null, title: "Shell" }),
+      ],
+      { observedAt: LATER },
+    );
+    const beforeLayout = structuredClone(withLayout.layouts.pairing);
+    const applied = applyWorkspaceLayout(withLayout, "pairing", live);
+
+    expect(Object.keys(applied.plan.targetTopology.panes)).toEqual(["implementer", "lead"]);
+    expect(applied.plan).toMatchObject({
+      retainedPaneIds: ["lead"],
+      missingPaneIds: ["implementer"],
+      externalPaneIds: ["external-shell"],
+      targetFocusedPaneId: "lead",
+      liveFocusedPaneId: "lead",
+      checkoutKey: "checkout-main",
+      sessionName: "tmux-ide",
+      windowIndex: 0,
+      windowName: "workspace",
+      retainedBindings: {
+        lead: { semanticPaneId: "lead", runtimePaneId: "%9", lastSeenAt: LATER },
+      },
+    });
+    expect(applied.state.checkouts["checkout-main"]!.topology.panes).toHaveProperty(
+      "external-shell",
+    );
+    expect(withLayout.layouts.pairing).toEqual(beforeLayout);
+    expect(WorkspaceLayoutApplyPlanSchemaZ.safeParse(applied.plan).success).toBe(true);
+  });
+
+  it("rebases project-relative cwd across linked checkouts and keeps absolute cwd absolute", () => {
+    const main = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([
+        pane("lead", "%1", 0, { cwd: "/repo/apps/web" }),
+        pane("tool", "%2", 80, { cwd: "/opt/shared-tool" }),
+      ]),
+    );
+    const withLayout = createWorkspaceLayout(main, {
+      id: "portable",
+      name: "Portable",
+      checkoutKey: "checkout-main",
+      now: NOW,
+    });
+    const linkedObservation = observation(
+      [
+        pane("lead", "%11", 0, { cwd: "/linked/repo/apps/web" }),
+        pane("tool", "%12", 80, { cwd: "/opt/shared-tool" }),
+      ],
+      {
+        checkoutKey: "checkout-linked",
+        projectRoot: "/linked/repo",
+        observedAt: LATER,
+        sessionName: "linked-session",
+        windowIndex: 3,
+        windowName: "agents",
+      },
+    );
+    const applied = applyWorkspaceLayout(withLayout, "portable", linkedObservation);
+
+    expect(withLayout.layouts.portable!.snapshot.topology.panes.lead!.cwd).toEqual({
+      kind: "project-relative",
+      path: "apps/web",
+    });
+    expect(withLayout.layouts.portable!.snapshot.topology.panes.tool!.cwd).toEqual({
+      kind: "absolute",
+      path: "/opt/shared-tool",
+    });
+    expect(applied.plan).toMatchObject({
+      checkoutKey: "checkout-linked",
+      projectRoot: "/linked/repo",
+      sessionName: "linked-session",
+      windowIndex: 3,
+      windowName: "agents",
+      materializedPaneCwds: {
+        lead: "/linked/repo/apps/web",
+        tool: "/opt/shared-tool",
+      },
+    });
+  });
+
+  it("rejects project-relative traversal and materializes contained nested and dot paths", () => {
+    for (const path of [
+      "nested/../../../outside",
+      "nested\\..\\..\\outside",
+      "C:\\outside",
+      "/outside",
+    ]) {
+      expect(WorkspacePaneCwdSchemaZ.safeParse({ kind: "project-relative", path }).success).toBe(
+        false,
+      );
+    }
+    for (const path of ["apps/web", ".", "apps/../web", "apps\\..\\web"]) {
+      expect(WorkspacePaneCwdSchemaZ.safeParse({ kind: "project-relative", path }).success).toBe(
+        true,
+      );
+    }
+
+    const captured = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([
+        pane("nested", "%1", 0, { cwd: "/repo/apps/web" }),
+        pane("root", "%2", 80, { cwd: "/repo" }),
+      ]),
+    );
+    const invalidSnapshot = structuredClone({
+      topology: captured.checkouts["checkout-main"]!.topology,
+      focusedPaneId: "nested",
+      workbench: captured.checkouts["checkout-main"]!.workbench,
+    });
+    invalidSnapshot.topology.panes.nested!.cwd = {
+      kind: "project-relative",
+      path: "nested/../../../outside",
+    };
+    expect(() =>
+      createWorkspaceLayout(captured, {
+        id: "escaping",
+        name: "Escaping",
+        checkoutKey: "checkout-main",
+        now: NOW,
+        snapshot: invalidSnapshot,
+      }),
+    ).toThrow(/remain inside the checkout/u);
+
+    const withLayout = createWorkspaceLayout(captured, {
+      id: "contained",
+      name: "Contained",
+      checkoutKey: "checkout-main",
+      now: NOW,
+    });
+    const applied = applyWorkspaceLayout(
+      withLayout,
+      "contained",
+      observation(
+        [
+          pane("nested", "%10", 0, { cwd: "/linked/apps/web" }),
+          pane("root", "%11", 80, { cwd: "/linked" }),
+        ],
+        {
+          checkoutKey: "checkout-linked",
+          projectRoot: "/linked",
+          observedAt: LATER,
+        },
+      ),
+    );
+    expect(applied.plan.materializedPaneCwds).toEqual({
+      nested: "/linked/apps/web",
+      root: "/linked",
+    });
+
+    const corrupted = structuredClone(withLayout);
+    corrupted.layouts.contained!.snapshot.topology.panes.nested!.cwd = {
+      kind: "project-relative",
+      path: "nested/../../../outside",
+    };
+    expect(() =>
+      applyWorkspaceLayout(
+        corrupted,
+        "contained",
+        observation([pane("nested", "%20", 0)], { observedAt: LATER }),
+      ),
+    ).toThrow(/remain inside the checkout/u);
+  });
+
+  it("keeps desired target focus separate from an external live focus", () => {
+    const captured = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("lead", "%1", 0)]),
+    );
+    const withLayout = createWorkspaceLayout(captured, {
+      id: "lead-only",
+      name: "Lead only",
+      checkoutKey: "checkout-main",
+      now: NOW,
+    });
+    const applied = applyWorkspaceLayout(
+      withLayout,
+      "lead-only",
+      observation([pane("external", "%9", 0, { active: true })], {
+        observedAt: LATER,
+        focusedPaneId: "external",
+      }),
+    );
+
+    expect(applied.plan).toMatchObject({
+      targetFocusedPaneId: "lead",
+      liveFocusedPaneId: "external",
+      missingPaneIds: ["lead"],
+      externalPaneIds: ["external"],
+    });
+    expect(applied.state.checkouts["checkout-main"]!.focusedPaneId).toBe("external");
+  });
+});
+
+describe("workspace state parsing and migration", () => {
+  it("serializes records canonically and protects future versions", () => {
+    const state = defaultWorkspaceState(PROJECT);
+    const parsed = parseWorkspaceStateValue({ version: 99, opaque: { keep: true } }, PROJECT);
+    expect(parsed.writeProtected).toBe(true);
+    expect(parsed.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "UNSUPPORTED_VERSION" }),
+    );
+    expect(parseWorkspaceStateValue({ version: "1" }, PROJECT).writeProtected).toBe(true);
+
+    state.checkouts.zeta = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("z", "%1", 0)], { checkoutKey: "zeta" }),
+    ).checkouts.zeta!;
+    state.checkouts.alpha = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("a", "%2", 0)], { checkoutKey: "alpha" }),
+    ).checkouts.alpha!;
+    expect(serializeWorkspaceState(state).indexOf('"alpha"')).toBeLessThan(
+      serializeWorkspaceState(state).indexOf('"zeta"'),
+    );
+  });
+
+  it("preserves every schema-accepted canonical id, timestamp, and tree id", () => {
+    const captured = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("Agent.Mixed_id-1", "%7", 0)], {
+        observedAt: "2026-07-20T10:00:00Z",
+        focusedPaneId: "Agent.Mixed_id-1",
+      }),
+    );
+    const state = createWorkspaceLayout(captured, {
+      id: "Layout.Mixed_id-1",
+      name: "  Exact name  ",
+      checkoutKey: "checkout-main",
+      now: "2026-07-20T10:00:00Z",
+    });
+    const wireValue = JSON.parse(serializeWorkspaceState(state));
+
+    expect(WorkspaceStateV1SchemaZ.safeParse(wireValue).success).toBe(true);
+    const parsed = parseWorkspaceStateValue(wireValue, PROJECT);
+    expect(parsed).toMatchObject({ writeProtected: false, diagnostics: [] });
+    expect(parsed.state).toEqual(state);
+    expect(parsed.state.layouts["Layout.Mixed_id-1"]!.name).toBe("  Exact name  ");
+    expect(parsed.state.layouts["Layout.Mixed_id-1"]!.createdAt).toBe("2026-07-20T10:00:00Z");
+  });
+
+  it("write-protects supported V1 structural corruption instead of dropping fields", () => {
+    const state = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("lead", "%1", 0)]),
+    );
+    const corrupt = structuredClone(state) as unknown as {
+      checkouts: { "checkout-main": { topology: { panes: { lead: { id: string } } } } };
+    };
+    corrupt.checkouts["checkout-main"].topology.panes.lead.id = "different-id";
+    const parsed = parseWorkspaceStateValue(corrupt, PROJECT);
+
+    expect(parsed.writeProtected).toBe(true);
+    expect(parsed.state).toEqual(defaultWorkspaceState(PROJECT));
+    expect(parsed.diagnostics).toContainEqual(expect.objectContaining({ code: "INVALID_FIELD" }));
+  });
+
+  it("throws on invalid CRUD snapshots and layout limit overflow", () => {
+    const captured = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("lead", "%1", 0)]),
+    );
+    expect(() =>
+      createWorkspaceLayout(captured, {
+        id: "invalid",
+        name: "Invalid",
+        checkoutKey: "checkout-main",
+        now: NOW,
+        snapshot: {
+          topology: { panes: {}, root: null },
+          focusedPaneId: "missing",
+          workbench: observation([]).workbench,
+        },
+      }),
+    ).toThrow(/focused pane/u);
+
+    const template = createWorkspaceLayout(captured, {
+      id: "template",
+      name: "Template",
+      checkoutKey: "checkout-main",
+      now: NOW,
+    }).layouts.template!;
+    const full = structuredClone(captured);
+    full.layouts = Object.fromEntries(
+      Array.from({ length: 32 }, (_, index) => {
+        const id = `layout-${index}`;
+        return [id, { ...template, id, name: id }];
+      }),
+    );
+    expect(WorkspaceStateV1SchemaZ.safeParse(full).success).toBe(true);
+    expect(() =>
+      createWorkspaceLayout(full, {
+        id: "overflow",
+        name: "Overflow",
+        checkoutKey: "checkout-main",
+        now: LATER,
+      }),
+    ).toThrow(/layout limit exceeded/u);
+  });
+
+  it("enforces topology invariants and write-protects oversized records without truncation", () => {
+    const captured = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("lead", "%1", 0), pane("implementer", "%2", 80)]),
+    );
+    const invalidParent = structuredClone(captured);
+    invalidParent.checkouts["checkout-main"]!.topology.panes.lead!.parentId = "wrong-parent";
+    expect(WorkspaceStateV1SchemaZ.safeParse(invalidParent).success).toBe(false);
+
+    const template = createWorkspaceLayout(captured, {
+      id: "template",
+      name: "Template",
+      checkoutKey: "checkout-main",
+      now: NOW,
+    }).layouts.template!;
+    const layouts = Object.fromEntries(
+      Array.from({ length: 34 }, (_, index) => {
+        const id = `layout-${String(33 - index).padStart(2, "0")}`;
+        return [id, { ...template, id, name: id }];
+      }),
+    );
+    const parsed = parseWorkspaceStateValue(
+      { ...defaultWorkspaceState(PROJECT), layouts },
+      PROJECT,
+    );
+
+    expect(parsed.state.layouts).toEqual({});
+    expect(parsed.writeProtected).toBe(true);
+    expect(parsed.diagnostics).toContainEqual(expect.objectContaining({ code: "OVERSIZED" }));
+  });
+
+  it("rejects deeply nested raw trees in an iterative preflight before recursive parsing", () => {
+    let deepTree: unknown = { type: "pane", nodeId: "leaf-root", paneId: "lead" };
+    for (let depth = 0; depth < 40; depth += 1) {
+      deepTree = {
+        type: "split",
+        nodeId: `split-${depth}`,
+        axis: "horizontal",
+        children: [deepTree, { type: "pane", nodeId: `leaf-${depth}`, paneId: "lead" }],
+        weights: [1, 1],
+      };
+    }
+    expect(() => WorkspacePaneTreeNodeSchemaZ.safeParse(deepTree)).not.toThrow();
+    expect(WorkspacePaneTreeNodeSchemaZ.safeParse(deepTree).success).toBe(false);
+
+    const captured = captureWorkspaceObservation(
+      defaultWorkspaceState(PROJECT),
+      observation([pane("lead", "%1", 0)]),
+    );
+    const state = createWorkspaceLayout(captured, {
+      id: "deep",
+      name: "Deep",
+      checkoutKey: "checkout-main",
+      now: NOW,
+    });
+    const raw = structuredClone(state) as unknown as {
+      layouts: { deep: { snapshot: { topology: { root: unknown } } } };
+    };
+    raw.layouts.deep.snapshot.topology.root = deepTree;
+    const parsed = parseWorkspaceStateValue(raw, PROJECT);
+
+    expect(parsed.state.layouts).toEqual({});
+    expect(parsed.diagnostics).toContainEqual(expect.objectContaining({ code: "OVERSIZED" }));
+  });
+
+  it("rejects pane trees whose total node count exceeds the bounded contract", () => {
+    let sequence = 0;
+    const broadTree = (remaining: number): unknown => {
+      const id = sequence++;
+      if (remaining === 0) return { type: "pane", nodeId: `leaf-${id}`, paneId: `pane-${id}` };
+      return {
+        type: "split",
+        nodeId: `split-${id}`,
+        axis: "vertical",
+        children: [broadTree(remaining - 1), broadTree(remaining - 1)],
+        weights: [1, 1],
+      };
+    };
+    const value = broadTree(8);
+
+    expect(() => WorkspacePaneTreeNodeSchemaZ.safeParse(value)).not.toThrow();
+    expect(WorkspacePaneTreeNodeSchemaZ.safeParse(value).success).toBe(false);
+  });
+
+  it("migrates only compatible V2 workbench data without mutating the UI projection", () => {
+    const legacy = {
+      version: 2,
+      active: { viewId: "missions", panel: "missions" },
+      dock: {
+        activeTab: "missions",
+        mode: "maximized",
+        preferredHeight: 20,
+        focusZone: "dock-body",
+      },
+      surfaces: { missions: { selectedMissionId: "m-1" } },
+      views: { missions: { panel: "missions", layout: { future: true } } },
+      futureProjectionField: { preserve: true },
+    };
+    const before = structuredClone(legacy);
+    const migrated = migrateWorkspaceUiStateV2(PROJECT, "checkout-main", "/repo", legacy, NOW);
+
+    expect(legacy).toEqual(before);
+    expect(migrated.layouts).toEqual({});
+    expect(migrated.checkouts["checkout-main"]).toMatchObject({
+      activeLayoutId: null,
+      topology: { panes: {}, root: null },
+      workbench: {
+        canvasPanel: "terminals",
+        dock: { activeTab: "missions", mode: "maximized" },
+      },
+    });
+    expect(JSON.stringify(migrated)).not.toContain("futureProjectionField");
+    expect(WorkspaceStateV1SchemaZ.safeParse(migrated).success).toBe(true);
+  });
+});

--- a/packages/daemon/src/lib/workspace-state-repository.ts
+++ b/packages/daemon/src/lib/workspace-state-repository.ts
@@ -1,0 +1,1203 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import type { Stats } from "node:fs";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+
+import {
+  WorkspaceStateV1SchemaZ,
+  type WorkspaceProjectIdentity,
+  type WorkspaceStateDiagnostic,
+  type WorkspaceStateV1,
+} from "@tmux-ide/contracts";
+
+import {
+  RevisionConflictError,
+  type ProjectRuntimeRepository,
+} from "./project-runtime-repository.ts";
+import {
+  cloneWorkspaceState,
+  defaultWorkspaceState,
+  migrateWorkspaceUiStateV2,
+  parseWorkspaceStateValue,
+  serializeWorkspaceState,
+} from "./workspace-state.ts";
+
+export const WORKSPACE_STATE_PATH = "workspace/state.json";
+export const WORKSPACE_STATE_LOCK_FILENAME = ".state.lock";
+const WORKSPACE_STATE_LOCK_MAX_BYTES = 4_096;
+const WORKSPACE_STATE_PROCESS_INSTANCE_ID = randomUUID();
+
+export type WorkspaceStateRepositoryDiagnosticCode =
+  | WorkspaceStateDiagnostic["code"]
+  | "MISSING"
+  | "MIGRATED"
+  | "READ_FAILED"
+  | "WRITE_FAILED"
+  | "WRITE_PROTECTED"
+  | "STALE"
+  | "LOCK_TIMEOUT"
+  | "INVALID_STATE"
+  | "CONFLICT"
+  | "LOCK_RELEASE_FAILED";
+
+export interface WorkspaceStateRepositoryDiagnostic {
+  code: WorkspaceStateRepositoryDiagnosticCode;
+  path: string;
+  message: string;
+}
+
+export interface LoadedWorkspaceState {
+  state: WorkspaceStateV1;
+  revision: number | null;
+  writeProtected: boolean;
+  diagnostics: WorkspaceStateRepositoryDiagnostic[];
+}
+
+export interface LoadWorkspaceStateOptions {
+  /** Optional, independently loaded ui/workspace.json V2 payload. It is never mutated. */
+  legacyWorkspaceUiState?: unknown;
+  checkoutKey?: string;
+  projectRoot?: string;
+  migratedAt?: string;
+}
+
+export interface WorkspaceStateLockOptions {
+  timeoutMs?: number;
+  pollMs?: number;
+  /** @deprecated Existing locks are never reclaimed automatically. */
+  staleAfterMs?: number;
+}
+
+export type WorkspaceCheckoutSubdomain = "live" | "workbench" | "focus" | "active-layout";
+
+export interface WorkspaceStateMergeOptions {
+  /** Explicit checkout field ownership; safe to merge across stale document revisions. */
+  checkoutIntents?: ReadonlyMap<string, ReadonlySet<WorkspaceCheckoutSubdomain>>;
+  deletedCheckoutKeys?: ReadonlySet<string>;
+  /** Layout revision observed before the local edit (`null` for create). */
+  layoutBaseRevisions?: ReadonlyMap<string, number | null>;
+  documentIsStale?: boolean;
+}
+
+export interface WorkspaceStateSaveRequest {
+  repository: ProjectRuntimeRepository;
+  revision: number | null;
+  next: WorkspaceStateV1;
+  touchedLayoutIds: ReadonlySet<string>;
+  deletedLayoutIds?: ReadonlySet<string>;
+  checkoutIntents?: ReadonlyMap<string, ReadonlySet<WorkspaceCheckoutSubdomain>>;
+  deletedCheckoutKeys?: ReadonlySet<string>;
+  layoutBaseRevisions?: ReadonlyMap<string, number | null>;
+  /**
+   * @deprecated Use checkoutIntents. A legacy whole-checkout write is accepted
+   * only against the document revision it loaded; stale replacement conflicts.
+   */
+  touchedCheckoutKeys?: ReadonlySet<string>;
+  lock?: WorkspaceStateLockOptions;
+  maxRevisionRetries?: number;
+}
+
+export interface WriteWorkspaceStateResult extends LoadedWorkspaceState {
+  saved: boolean;
+}
+
+export interface WorkspaceStateLockOwnerInspection {
+  version: 1;
+  token: string;
+  processInstanceId: string;
+  pid: number;
+  /** Unix epoch milliseconds, reported exactly from the lock's `createdAtMs` field. */
+  createdAt: number;
+}
+
+export type WorkspaceStateLockInspection =
+  | { status: "absent"; lockPath: string }
+  | {
+      status: "malformed";
+      lockPath: string;
+      device: number;
+      inode: number;
+      reason: string;
+    }
+  | {
+      status: "valid";
+      lockPath: string;
+      owner: WorkspaceStateLockOwnerInspection;
+      device: number;
+      inode: number;
+    };
+
+export interface ClearWorkspaceStateLockOfflineOptions {
+  expectedToken: string;
+  expectedProcessInstanceId: string;
+  expectedDevice: number;
+  expectedInode: number;
+  confirmAllWritersStopped: true;
+}
+
+export interface ClearedWorkspaceStateLock {
+  cleared: true;
+  lockPath: string;
+  owner: WorkspaceStateLockOwnerInspection;
+  device: number;
+  inode: number;
+}
+
+export type WorkspaceStateLockRecoveryErrorCode =
+  | "CONFIRMATION_REQUIRED"
+  | "LOCK_ABSENT"
+  | "LOCK_MALFORMED"
+  | "OWNER_MISMATCH"
+  | "LOCK_CHANGED"
+  | "RECOVERY_FAILED";
+
+export class WorkspaceStateLockRecoveryError extends Error {
+  readonly code: WorkspaceStateLockRecoveryErrorCode;
+  readonly lockPath: string;
+
+  constructor(code: WorkspaceStateLockRecoveryErrorCode, lockPath: string, message: string) {
+    super(message);
+    this.name = "WorkspaceStateLockRecoveryError";
+    this.code = code;
+    this.lockPath = lockPath;
+  }
+}
+
+export class WorkspaceStateLockTimeoutError extends Error {
+  readonly lockPath: string;
+  readonly timeoutMs: number;
+
+  constructor(lockPath: string, timeoutMs: number) {
+    super(`Timed out after ${timeoutMs}ms waiting for workspace-state lock "${lockPath}"`);
+    this.name = "WorkspaceStateLockTimeoutError";
+    this.lockPath = lockPath;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export class WorkspaceStateMergeConflictError extends Error {
+  readonly path: string;
+
+  constructor(path: string, message: string) {
+    super(message);
+    this.name = "WorkspaceStateMergeConflictError";
+    this.path = path;
+  }
+}
+
+export function workspaceProjectIdentity(
+  repository: ProjectRuntimeRepository,
+): WorkspaceProjectIdentity {
+  return {
+    identityKey: repository.metadata.identityKey,
+    identitySource: repository.metadata.identitySource,
+    identityAnchor: repository.metadata.identityAnchor,
+  };
+}
+
+/** Checkout bindings are deliberately path-scoped even when linked worktrees share identity. */
+export function workspaceCheckoutKey(projectRoot: string): string {
+  const digest = createHash("sha256").update(resolve(projectRoot)).digest("hex").slice(0, 32);
+  return `checkout-${digest}`;
+}
+
+export function loadWorkspaceState(
+  repository: ProjectRuntimeRepository,
+  options: LoadWorkspaceStateOptions = {},
+): LoadedWorkspaceState {
+  const project = workspaceProjectIdentity(repository);
+  let document;
+  try {
+    document = repository.readDocument<unknown>(WORKSPACE_STATE_PATH);
+  } catch (error) {
+    return {
+      state: defaultWorkspaceState(project),
+      revision: null,
+      writeProtected: true,
+      diagnostics: [
+        diagnostic(
+          "READ_FAILED",
+          WORKSPACE_STATE_PATH,
+          `workspace state could not be read safely: ${(error as Error).message}`,
+        ),
+      ],
+    };
+  }
+  if (!document.found) {
+    if (options.legacyWorkspaceUiState !== undefined) {
+      try {
+        const projectRoot = options.projectRoot ?? repository.metadata.projectRoot;
+        const checkoutKey = options.checkoutKey ?? workspaceCheckoutKey(projectRoot);
+        const migratedAt = options.migratedAt;
+        if (!migratedAt) throw new Error("a deterministic migratedAt timestamp is required");
+        return {
+          state: migrateWorkspaceUiStateV2(
+            project,
+            checkoutKey,
+            projectRoot,
+            options.legacyWorkspaceUiState,
+            migratedAt,
+          ),
+          revision: null,
+          writeProtected: false,
+          diagnostics: [
+            diagnostic(
+              "MIGRATED",
+              WORKSPACE_STATE_PATH,
+              "workspace domain was deterministically seeded from ui/workspace.json V2",
+            ),
+          ],
+        };
+      } catch (error) {
+        return {
+          state: defaultWorkspaceState(project),
+          revision: null,
+          writeProtected: false,
+          diagnostics: [
+            diagnostic("MISSING", WORKSPACE_STATE_PATH, "workspace state is absent"),
+            diagnostic(
+              "INVALID_STATE",
+              "ui/workspace.json",
+              `workspace UI state was not eligible for migration: ${(error as Error).message}`,
+            ),
+          ],
+        };
+      }
+    }
+    return {
+      state: defaultWorkspaceState(project),
+      revision: null,
+      writeProtected: false,
+      diagnostics: [diagnostic("MISSING", WORKSPACE_STATE_PATH, "workspace state is absent")],
+    };
+  }
+  const parsed = parseWorkspaceStateValue(document.payload, project);
+  const structuralCorruption = parsed.diagnostics.some((entry) =>
+    ["MALFORMED", "INVALID_FIELD", "OVERSIZED", "IDENTITY_MISMATCH"].includes(entry.code),
+  );
+  return {
+    state: parsed.state,
+    revision: document.revision,
+    writeProtected: parsed.writeProtected || structuralCorruption,
+    diagnostics: parsed.diagnostics,
+  };
+}
+
+/**
+ * Revision merge is field-domain based: shared named layouts merge independently
+ * from checkout-scoped live topology/bindings. Layout deletion also clears any
+ * active reference so the merged document remains referentially valid.
+ */
+export function mergeWorkspaceStateForSave(
+  latest: WorkspaceStateV1,
+  local: WorkspaceStateV1,
+  touchedLayoutIds: ReadonlySet<string>,
+  deletedLayoutIds: ReadonlySet<string> = new Set(),
+  touchedCheckoutKeys: ReadonlySet<string> = new Set(),
+  options: WorkspaceStateMergeOptions = {},
+): WorkspaceStateV1 {
+  if (latest.project.identityKey !== local.project.identityKey) {
+    throw new Error("cannot merge workspace states from different project identities");
+  }
+  assertLayoutMergeIsSafe(latest, local, touchedLayoutIds, deletedLayoutIds, options);
+  const next = cloneWorkspaceState(latest);
+  for (const id of [...touchedLayoutIds].sort()) {
+    const layout = local.layouts[id];
+    if (layout) next.layouts[id] = structuredClone(layout);
+    else delete next.layouts[id];
+  }
+  for (const id of [...deletedLayoutIds].sort()) delete next.layouts[id];
+  mergeCheckoutSubdomains(next, local, touchedCheckoutKeys, options);
+  for (const checkout of Object.values(next.checkouts)) {
+    if (checkout.activeLayoutId && !next.layouts[checkout.activeLayoutId]) {
+      checkout.activeLayoutId = null;
+    }
+  }
+  return JSON.parse(serializeWorkspaceState(next)) as WorkspaceStateV1;
+}
+
+function assertLayoutMergeIsSafe(
+  latest: WorkspaceStateV1,
+  local: WorkspaceStateV1,
+  touchedLayoutIds: ReadonlySet<string>,
+  deletedLayoutIds: ReadonlySet<string>,
+  options: WorkspaceStateMergeOptions,
+): void {
+  for (const id of new Set([...touchedLayoutIds, ...deletedLayoutIds])) {
+    const latestRevision = latest.layouts[id]?.revision ?? null;
+    const localLayout = local.layouts[id];
+    const hasBase = options.layoutBaseRevisions?.has(id) === true;
+    const baseRevision = hasBase ? (options.layoutBaseRevisions?.get(id) ?? null) : undefined;
+    if (hasBase && baseRevision !== latestRevision) {
+      throw new WorkspaceStateMergeConflictError(
+        `$.layouts.${id}`,
+        `layout "${id}" changed from base revision ${String(baseRevision)} to ${String(
+          latestRevision,
+        )}`,
+      );
+    }
+    if (
+      options.documentIsStale &&
+      !hasBase &&
+      !(latestRevision === null && localLayout?.revision === 1 && !deletedLayoutIds.has(id))
+    ) {
+      throw new WorkspaceStateMergeConflictError(
+        `$.layouts.${id}`,
+        `stale edit to layout "${id}" requires its base layout revision`,
+      );
+    }
+    if (
+      hasBase &&
+      localLayout &&
+      ((baseRevision === null && localLayout.revision !== 1) ||
+        (baseRevision !== undefined &&
+          baseRevision !== null &&
+          localLayout.revision <= baseRevision))
+    ) {
+      throw new WorkspaceStateMergeConflictError(
+        `$.layouts.${id}.revision`,
+        `layout "${id}" revision does not advance its declared base`,
+      );
+    }
+  }
+}
+
+function mergeCheckoutSubdomains(
+  next: WorkspaceStateV1,
+  local: WorkspaceStateV1,
+  legacyTouchedCheckoutKeys: ReadonlySet<string>,
+  options: WorkspaceStateMergeOptions,
+): void {
+  for (const key of legacyTouchedCheckoutKeys) {
+    if (options.checkoutIntents?.has(key)) {
+      throw new WorkspaceStateMergeConflictError(
+        `$.checkouts.${key}`,
+        `checkout "${key}" cannot use both legacy replacement and explicit subdomain intents`,
+      );
+    }
+  }
+  for (const key of [...(options.deletedCheckoutKeys ?? [])].sort()) {
+    if (options.documentIsStale && next.checkouts[key]) {
+      throw new WorkspaceStateMergeConflictError(
+        `$.checkouts.${key}`,
+        `stale deletion of checkout "${key}" is not safe`,
+      );
+    }
+    delete next.checkouts[key];
+  }
+  for (const key of [...legacyTouchedCheckoutKeys].sort()) {
+    const localCheckout = local.checkouts[key];
+    if (options.documentIsStale && next.checkouts[key]) {
+      throw new WorkspaceStateMergeConflictError(
+        `$.checkouts.${key}`,
+        `stale whole-checkout replacement for "${key}" requires explicit subdomain intents`,
+      );
+    }
+    if (localCheckout) next.checkouts[key] = structuredClone(localCheckout);
+    else delete next.checkouts[key];
+  }
+  for (const [key, requestedDomains] of [...(options.checkoutIntents ?? new Map()).entries()].sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    const domains = validateCheckoutDomains(key, requestedDomains);
+    const localCheckout = local.checkouts[key];
+    if (!localCheckout) {
+      throw new WorkspaceStateMergeConflictError(
+        `$.checkouts.${key}`,
+        `checkout "${key}" is absent from the local state; use deletedCheckoutKeys to delete it`,
+      );
+    }
+    const latestCheckout = next.checkouts[key];
+    if (!latestCheckout) {
+      next.checkouts[key] = structuredClone(localCheckout);
+      continue;
+    }
+    if (latestCheckout.projectRoot !== localCheckout.projectRoot) {
+      throw new WorkspaceStateMergeConflictError(
+        `$.checkouts.${key}.projectRoot`,
+        `checkout "${key}" project root changed unexpectedly`,
+      );
+    }
+    if (domains.has("live")) {
+      latestCheckout.topology = structuredClone(localCheckout.topology);
+      latestCheckout.bindings = structuredClone(localCheckout.bindings);
+      latestCheckout.recovery = structuredClone(localCheckout.recovery);
+      if (
+        latestCheckout.focusedPaneId &&
+        !latestCheckout.topology.panes[latestCheckout.focusedPaneId]
+      ) {
+        latestCheckout.focusedPaneId = null;
+      }
+    }
+    if (domains.has("workbench")) {
+      latestCheckout.workbench = structuredClone(localCheckout.workbench);
+    }
+    if (domains.has("focus")) {
+      if (
+        localCheckout.focusedPaneId &&
+        !latestCheckout.topology.panes[localCheckout.focusedPaneId]
+      ) {
+        throw new WorkspaceStateMergeConflictError(
+          `$.checkouts.${key}.focusedPaneId`,
+          `checkout "${key}" cannot focus pane "${localCheckout.focusedPaneId}" because it no longer exists in the latest live topology`,
+        );
+      }
+      latestCheckout.focusedPaneId = localCheckout.focusedPaneId;
+    }
+    if (domains.has("active-layout")) {
+      latestCheckout.activeLayoutId = localCheckout.activeLayoutId;
+    }
+  }
+}
+
+function validateCheckoutDomains(
+  checkoutKey: string,
+  domains: ReadonlySet<WorkspaceCheckoutSubdomain>,
+): ReadonlySet<WorkspaceCheckoutSubdomain> {
+  if (domains.size === 0) {
+    throw new WorkspaceStateMergeConflictError(
+      `$.checkouts.${checkoutKey}`,
+      `checkout "${checkoutKey}" has no declared save subdomain`,
+    );
+  }
+  const allowed = new Set<WorkspaceCheckoutSubdomain>([
+    "live",
+    "workbench",
+    "focus",
+    "active-layout",
+  ]);
+  for (const domain of domains) {
+    if (!allowed.has(domain)) {
+      throw new WorkspaceStateMergeConflictError(
+        `$.checkouts.${checkoutKey}`,
+        `checkout "${checkoutKey}" uses unknown save subdomain "${String(domain)}"`,
+      );
+    }
+  }
+  return domains;
+}
+
+export function writeWorkspaceStateWithRetry(
+  request: WorkspaceStateSaveRequest,
+): WriteWorkspaceStateResult {
+  const validation = WorkspaceStateV1SchemaZ.safeParse(request.next);
+  if (!validation.success) {
+    const loaded = loadWorkspaceState(request.repository);
+    return {
+      ...loaded,
+      saved: false,
+      diagnostics: [
+        ...loaded.diagnostics,
+        diagnostic(
+          "INVALID_STATE",
+          WORKSPACE_STATE_PATH,
+          validation.error.issues.map((issue) => issue.message).join("; "),
+        ),
+      ],
+    };
+  }
+
+  try {
+    const outcome = withWorkspaceStateLockOutcome<WriteWorkspaceStateResult>(
+      request.repository,
+      request.lock,
+      () => {
+        const diagnostics: WorkspaceStateRepositoryDiagnostic[] = [];
+        const retries = boundedInteger(request.maxRevisionRetries, 2, 0, 8);
+        for (let attempt = 0; attempt <= retries; attempt += 1) {
+          const latest = loadWorkspaceState(request.repository);
+          if (latest.writeProtected) {
+            return {
+              ...latest,
+              saved: false,
+              diagnostics: [
+                ...latest.diagnostics,
+                diagnostic(
+                  "WRITE_PROTECTED",
+                  WORKSPACE_STATE_PATH,
+                  "workspace state was preserved because its current payload is not safe to overwrite",
+                ),
+              ],
+            };
+          }
+          if (
+            request.revision !== latest.revision &&
+            !diagnostics.some((entry) => entry.code === "STALE")
+          ) {
+            diagnostics.push(
+              diagnostic(
+                "STALE",
+                WORKSPACE_STATE_PATH,
+                `merged stale revision ${String(request.revision)} with current revision ${String(
+                  latest.revision,
+                )}`,
+              ),
+            );
+          }
+          let merged: WorkspaceStateV1;
+          try {
+            merged = mergeWorkspaceStateForSave(
+              latest.state,
+              validation.data,
+              request.touchedLayoutIds,
+              request.deletedLayoutIds,
+              request.touchedCheckoutKeys,
+              {
+                checkoutIntents: request.checkoutIntents,
+                deletedCheckoutKeys: request.deletedCheckoutKeys,
+                layoutBaseRevisions: request.layoutBaseRevisions,
+                documentIsStale: request.revision !== latest.revision,
+              },
+            );
+          } catch (error) {
+            if (error instanceof WorkspaceStateMergeConflictError) {
+              return {
+                ...latest,
+                saved: false,
+                diagnostics: [
+                  ...latest.diagnostics,
+                  ...diagnostics,
+                  diagnostic("CONFLICT", error.path, error.message),
+                ],
+              };
+            }
+            throw error;
+          }
+          const mergedValidation = WorkspaceStateV1SchemaZ.safeParse(merged);
+          if (!mergedValidation.success) {
+            return {
+              ...latest,
+              saved: false,
+              diagnostics: [
+                ...latest.diagnostics,
+                ...diagnostics,
+                diagnostic(
+                  "INVALID_STATE",
+                  WORKSPACE_STATE_PATH,
+                  mergedValidation.error.issues.map((issue) => issue.message).join("; "),
+                ),
+              ],
+            };
+          }
+          try {
+            const written = request.repository.writeDocument(
+              WORKSPACE_STATE_PATH,
+              JSON.parse(serializeWorkspaceState(mergedValidation.data)),
+              { expectedRevision: latest.revision },
+            );
+            return {
+              state: mergedValidation.data,
+              revision: written.revision,
+              writeProtected: false,
+              saved: true,
+              diagnostics: [
+                ...latest.diagnostics.filter((entry) => entry.code !== "MISSING"),
+                ...diagnostics,
+              ],
+            };
+          } catch (error) {
+            if (error instanceof RevisionConflictError && attempt < retries) continue;
+            return {
+              ...latest,
+              saved: false,
+              diagnostics: [
+                ...latest.diagnostics,
+                ...diagnostics,
+                diagnostic(
+                  "WRITE_FAILED",
+                  WORKSPACE_STATE_PATH,
+                  `workspace state could not be written: ${(error as Error).message}`,
+                ),
+              ],
+            };
+          }
+        }
+        throw new Error("unreachable workspace-state retry exhaustion");
+      },
+    );
+    if (!outcome.releaseError) return outcome.value;
+    return {
+      ...outcome.value,
+      diagnostics: [
+        ...outcome.value.diagnostics,
+        diagnostic(
+          "LOCK_RELEASE_FAILED",
+          WORKSPACE_STATE_PATH,
+          `workspace state lock was abandoned after the operation completed: ${outcome.releaseError.message}`,
+        ),
+      ],
+    };
+  } catch (error) {
+    const loaded = loadWorkspaceState(request.repository);
+    const code = error instanceof WorkspaceStateLockTimeoutError ? "LOCK_TIMEOUT" : "WRITE_FAILED";
+    return {
+      ...loaded,
+      saved: false,
+      diagnostics: [
+        ...loaded.diagnostics,
+        diagnostic(code, WORKSPACE_STATE_PATH, (error as Error).message),
+      ],
+    };
+  }
+}
+
+/**
+ * Inspect the project-scoped workspace writer lock without reclaiming it.
+ * Valid ownership values and filesystem identity are returned exactly so an
+ * operator can pass the same owner identity to the offline clear operation.
+ * PID and age are evidence only; neither is used to infer that a lock is stale.
+ */
+export function inspectWorkspaceStateLock(
+  repository: ProjectRuntimeRepository,
+): WorkspaceStateLockInspection {
+  const lockPath = resolveWorkspaceStateLockPath(repository, false);
+  return inspectWorkspaceLockArtifact(lockPath);
+}
+
+/**
+ * Explicit offline crash recovery. Before calling this function, every
+ * tmux-ide process that can write beneath this repository's runtime root must
+ * be stopped. The caller must inspect the lock, provide its exact token,
+ * process-instance id, device, and inode, and affirm that offline precondition.
+ * There is no PID-liveness or age-based inference and malformed locks are never
+ * cleared.
+ */
+export function clearWorkspaceStateLockOffline(
+  repository: ProjectRuntimeRepository,
+  options: ClearWorkspaceStateLockOfflineOptions,
+): ClearedWorkspaceStateLock {
+  const lockPath = resolveWorkspaceStateLockPath(repository, false);
+  if (options?.confirmAllWritersStopped !== true) {
+    throw new WorkspaceStateLockRecoveryError(
+      "CONFIRMATION_REQUIRED",
+      lockPath,
+      "offline workspace-lock recovery requires confirmation that all tmux-ide writers for this runtime root are stopped",
+    );
+  }
+
+  const inspected = inspectWorkspaceLockArtifact(lockPath);
+  if (inspected.status === "absent") {
+    throw new WorkspaceStateLockRecoveryError(
+      "LOCK_ABSENT",
+      lockPath,
+      `workspace-state lock "${lockPath}" is absent`,
+    );
+  }
+  if (inspected.status === "malformed") {
+    throw new WorkspaceStateLockRecoveryError(
+      "LOCK_MALFORMED",
+      lockPath,
+      `workspace-state lock "${lockPath}" is malformed and was preserved: ${inspected.reason}`,
+    );
+  }
+  if (
+    inspected.owner.token !== options.expectedToken ||
+    inspected.owner.processInstanceId !== options.expectedProcessInstanceId
+  ) {
+    throw new WorkspaceStateLockRecoveryError(
+      "OWNER_MISMATCH",
+      lockPath,
+      `workspace-state lock "${lockPath}" does not match the inspected owner identity`,
+    );
+  }
+  if (inspected.device !== options.expectedDevice || inspected.inode !== options.expectedInode) {
+    throw new WorkspaceStateLockRecoveryError(
+      "LOCK_CHANGED",
+      lockPath,
+      `workspace-state lock "${lockPath}" no longer has the inspected filesystem identity and was preserved`,
+    );
+  }
+
+  const revalidated = inspectWorkspaceLockArtifact(lockPath);
+  if (revalidated.status !== "valid" || !sameInspectedLock(inspected, revalidated)) {
+    throw new WorkspaceStateLockRecoveryError(
+      "LOCK_CHANGED",
+      lockPath,
+      `workspace-state lock "${lockPath}" changed before offline recovery and was preserved`,
+    );
+  }
+
+  let quarantine: WorkspaceStateLockQuarantine;
+  try {
+    quarantine = reserveWorkspaceLockQuarantine(lockPath);
+  } catch (error) {
+    throw new WorkspaceStateLockRecoveryError(
+      "RECOVERY_FAILED",
+      lockPath,
+      `unable to reserve a unique quarantine for workspace-state lock "${lockPath}": ${(error as Error).message}`,
+    );
+  }
+
+  try {
+    renameSync(lockPath, quarantine.path);
+  } catch (error) {
+    removeEmptyQuarantineDirectory(quarantine.directory);
+    throw new WorkspaceStateLockRecoveryError(
+      "RECOVERY_FAILED",
+      lockPath,
+      `unable to quarantine workspace-state lock "${lockPath}": ${(error as Error).message}`,
+    );
+  }
+
+  const moved = inspectWorkspaceLockArtifact(quarantine.path);
+  if (moved.status !== "valid" || !sameInspectedLock(inspected, moved)) {
+    const restored = preserveUnexpectedQuarantinedLock(lockPath, quarantine, moved);
+    throw new WorkspaceStateLockRecoveryError(
+      "LOCK_CHANGED",
+      lockPath,
+      restored
+        ? `workspace-state lock changed during offline recovery; the unexpected artifact was restored at "${lockPath}"`
+        : `workspace-state lock changed during offline recovery; the unexpected artifact was preserved at "${quarantine.path}"`,
+    );
+  }
+
+  try {
+    rmSync(quarantine.path, { force: false });
+    rmdirSync(quarantine.directory);
+  } catch (error) {
+    throw new WorkspaceStateLockRecoveryError(
+      "RECOVERY_FAILED",
+      lockPath,
+      `verified workspace-state lock quarantine could not be removed safely: ${(error as Error).message}`,
+    );
+  }
+  return {
+    cleared: true,
+    lockPath,
+    owner: inspected.owner,
+    device: inspected.device,
+    inode: inspected.inode,
+  };
+}
+
+export function withWorkspaceStateLock<T>(
+  repository: ProjectRuntimeRepository,
+  options: WorkspaceStateLockOptions | undefined,
+  action: () => T,
+): T {
+  const outcome = withWorkspaceStateLockOutcome(repository, options, action);
+  if (outcome.releaseError) throw outcome.releaseError;
+  return outcome.value;
+}
+
+interface WorkspaceStateLockOutcome<T> {
+  value: T;
+  releaseError: Error | null;
+}
+
+function withWorkspaceStateLockOutcome<T>(
+  repository: ProjectRuntimeRepository,
+  options: WorkspaceStateLockOptions | undefined,
+  action: () => T,
+): WorkspaceStateLockOutcome<T> {
+  const timeoutMs = boundedInteger(options?.timeoutMs, 2_000, 1, 60_000);
+  const pollMs = boundedInteger(options?.pollMs, 10, 1, 250);
+  const lockPath = resolveWorkspaceStateLockPath(repository);
+  const owner: WorkspaceStateLockOwner = {
+    version: 1,
+    token: randomUUID(),
+    processInstanceId: WORKSPACE_STATE_PROCESS_INSTANCE_ID,
+    pid: process.pid,
+    createdAtMs: Date.now(),
+  };
+  const candidatePath = prepareWorkspaceLockCandidate(lockPath, owner);
+  const startedAt = Date.now();
+  let installed = false;
+
+  try {
+    for (;;) {
+      try {
+        linkSync(candidatePath, lockPath);
+        installed = true;
+      } catch (error) {
+        if (!isLockContentionError(error)) throw error;
+        if (Date.now() - startedAt >= timeoutMs) {
+          throw new WorkspaceStateLockTimeoutError(lockPath, timeoutMs);
+        }
+        sleepSync(Math.min(pollMs, Math.max(1, timeoutMs - (Date.now() - startedAt))));
+        continue;
+      }
+      try {
+        removeLockArtifact(candidatePath);
+      } catch (error) {
+        const releaseError = releaseOwnedLock(lockPath, owner);
+        installed = releaseError !== null;
+        if (releaseError) {
+          throw new Error(
+            `workspace lock candidate cleanup failed and the installed lock was abandoned: ${releaseError.message}`,
+            { cause: error },
+          );
+        }
+        throw error;
+      }
+      let value: T;
+      try {
+        value = action();
+      } catch (error) {
+        const releaseError = releaseOwnedLock(lockPath, owner);
+        if (releaseError) {
+          throw new Error(
+            `workspace action failed and its lock was abandoned: ${releaseError.message}`,
+            { cause: error },
+          );
+        }
+        throw error;
+      }
+      return { value, releaseError: releaseOwnedLock(lockPath, owner) };
+    }
+  } finally {
+    if (!installed) removeLockArtifact(candidatePath);
+  }
+}
+
+interface WorkspaceStateLockOwner {
+  version: 1;
+  token: string;
+  processInstanceId: string;
+  pid: number;
+  createdAtMs: number;
+}
+
+interface WorkspaceStateLockSnapshot {
+  owner: WorkspaceStateLockOwner;
+  device: number;
+  inode: number;
+}
+
+interface WorkspaceStateLockQuarantine {
+  directory: string;
+  path: string;
+}
+
+/**
+ * The workspace domain has one writer boundary. Generic runtime document writes
+ * must not target WORKSPACE_STATE_PATH; callers use writeWorkspaceStateWithRetry
+ * so revision merge and this project-scoped lock cannot be bypassed accidentally.
+ */
+function resolveWorkspaceStateLockPath(
+  repository: ProjectRuntimeRepository,
+  createDirectories = true,
+): string {
+  const runtimeRoot = resolve(repository.runtimeRoot);
+  const workspaceDirectory = resolve(runtimeRoot, "workspace");
+  const relativePath = relative(runtimeRoot, workspaceDirectory);
+  if (relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    throw new Error("workspace lock path escapes the project runtime root");
+  }
+  if (createDirectories) {
+    mkdirSync(runtimeRoot, { recursive: true });
+    assertWorkspaceLockDirectory(runtimeRoot);
+    mkdirSync(workspaceDirectory, { recursive: true });
+    assertWorkspaceLockDirectory(workspaceDirectory);
+  } else {
+    const runtimeStat = lstatIfPresent(runtimeRoot);
+    if (runtimeStat) assertWorkspaceLockDirectory(runtimeRoot, runtimeStat);
+    const workspaceStat = runtimeStat ? lstatIfPresent(workspaceDirectory) : null;
+    if (workspaceStat) assertWorkspaceLockDirectory(workspaceDirectory, workspaceStat);
+  }
+  return join(workspaceDirectory, WORKSPACE_STATE_LOCK_FILENAME);
+}
+
+function assertWorkspaceLockDirectory(path: string, stat = lstatSync(path)): void {
+  if (stat.isSymbolicLink()) {
+    throw new Error(`workspace lock path must not traverse symbolic link "${path}"`);
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(`workspace lock path component must be a directory "${path}"`);
+  }
+}
+
+function lstatIfPresent(path: string): Stats | null {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function prepareWorkspaceLockCandidate(lockPath: string, owner: WorkspaceStateLockOwner): string {
+  const candidatePath = `${lockPath}.candidate-${owner.token}`;
+  let descriptor: number | null = null;
+  try {
+    descriptor = openSync(candidatePath, "wx", 0o600);
+    writeFileSync(descriptor, `${JSON.stringify(owner)}\n`, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = null;
+    return candidatePath;
+  } catch (error) {
+    if (descriptor !== null) {
+      try {
+        closeSync(descriptor);
+      } catch {
+        // Preserve the original setup error.
+      }
+    }
+    removeLockArtifact(candidatePath);
+    throw error;
+  }
+}
+
+function releaseOwnedLock(lockPath: string, owner: WorkspaceStateLockOwner): Error | null {
+  try {
+    const snapshot = inspectWorkspaceLock(lockPath);
+    if (
+      !snapshot ||
+      snapshot.owner.token !== owner.token ||
+      snapshot.owner.processInstanceId !== owner.processInstanceId
+    ) {
+      return new Error(`workspace lock ownership was lost before release of "${lockPath}"`);
+    }
+    const releasedPath = `${lockPath}.released-${owner.token}`;
+    renameSync(lockPath, releasedPath);
+    const moved = inspectWorkspaceLock(releasedPath);
+    if (!moved || !sameLockSnapshot(snapshot, moved)) {
+      return new Error(`workspace lock ownership changed while releasing "${lockPath}"`);
+    }
+    removeLockArtifact(releasedPath);
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+function inspectWorkspaceLock(lockPath: string): WorkspaceStateLockSnapshot | null {
+  const inspected = inspectWorkspaceLockArtifact(lockPath);
+  if (inspected.status !== "valid") return null;
+  return {
+    owner: {
+      version: inspected.owner.version,
+      token: inspected.owner.token,
+      processInstanceId: inspected.owner.processInstanceId,
+      pid: inspected.owner.pid,
+      createdAtMs: inspected.owner.createdAt,
+    },
+    device: inspected.device,
+    inode: inspected.inode,
+  };
+}
+
+function inspectWorkspaceLockArtifact(lockPath: string): WorkspaceStateLockInspection {
+  const stat = lstatIfPresent(lockPath);
+  if (!stat) return { status: "absent", lockPath };
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    return {
+      status: "malformed",
+      lockPath,
+      device: stat.dev,
+      inode: stat.ino,
+      reason: "lock artifact is not a regular file",
+    };
+  }
+  if (stat.size > WORKSPACE_STATE_LOCK_MAX_BYTES) {
+    return {
+      status: "malformed",
+      lockPath,
+      device: stat.dev,
+      inode: stat.ino,
+      reason: `lock owner exceeds ${WORKSPACE_STATE_LOCK_MAX_BYTES} bytes`,
+    };
+  }
+  const raw = readFileSync(lockPath, "utf8");
+  const afterRead = lstatIfPresent(lockPath);
+  if (!afterRead) return { status: "absent", lockPath };
+  if (
+    afterRead.dev !== stat.dev ||
+    afterRead.ino !== stat.ino ||
+    !afterRead.isFile() ||
+    afterRead.isSymbolicLink()
+  ) {
+    return {
+      status: "malformed",
+      lockPath,
+      device: afterRead.dev,
+      inode: afterRead.ino,
+      reason: "lock artifact changed while it was being inspected",
+    };
+  }
+  if (Buffer.byteLength(raw, "utf8") > WORKSPACE_STATE_LOCK_MAX_BYTES) {
+    return {
+      status: "malformed",
+      lockPath,
+      device: afterRead.dev,
+      inode: afterRead.ino,
+      reason: `lock owner exceeds ${WORKSPACE_STATE_LOCK_MAX_BYTES} bytes`,
+    };
+  }
+  const owner = parseWorkspaceLockOwner(raw);
+  if (!owner) {
+    return {
+      status: "malformed",
+      lockPath,
+      device: afterRead.dev,
+      inode: afterRead.ino,
+      reason: "lock owner is not a valid version 1 owner record",
+    };
+  }
+  return {
+    status: "valid",
+    lockPath,
+    owner: {
+      version: owner.version,
+      token: owner.token,
+      processInstanceId: owner.processInstanceId,
+      pid: owner.pid,
+      createdAt: owner.createdAtMs,
+    },
+    device: afterRead.dev,
+    inode: afterRead.ino,
+  };
+}
+
+function parseWorkspaceLockOwner(raw: string): WorkspaceStateLockOwner | null {
+  try {
+    const value = JSON.parse(raw) as Partial<WorkspaceStateLockOwner>;
+    if (
+      value.version !== 1 ||
+      typeof value.token !== "string" ||
+      !/^[0-9a-f-]{36}$/iu.test(value.token) ||
+      typeof value.processInstanceId !== "string" ||
+      !/^[0-9a-f-]{36}$/iu.test(value.processInstanceId) ||
+      !Number.isSafeInteger(value.pid) ||
+      (value.pid ?? 0) < 1 ||
+      typeof value.createdAtMs !== "number" ||
+      !Number.isSafeInteger(value.createdAtMs) ||
+      value.createdAtMs < 0
+    ) {
+      return null;
+    }
+    return value as WorkspaceStateLockOwner;
+  } catch {
+    return null;
+  }
+}
+
+function sameLockSnapshot(
+  left: WorkspaceStateLockSnapshot,
+  right: WorkspaceStateLockSnapshot,
+): boolean {
+  return (
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.owner.version === right.owner.version &&
+    left.owner.token === right.owner.token &&
+    left.owner.processInstanceId === right.owner.processInstanceId &&
+    left.owner.pid === right.owner.pid &&
+    left.owner.createdAtMs === right.owner.createdAtMs
+  );
+}
+
+function sameInspectedLock(
+  left: Extract<WorkspaceStateLockInspection, { status: "valid" }>,
+  right: Extract<WorkspaceStateLockInspection, { status: "valid" }>,
+): boolean {
+  return (
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.owner.version === right.owner.version &&
+    left.owner.token === right.owner.token &&
+    left.owner.processInstanceId === right.owner.processInstanceId &&
+    left.owner.pid === right.owner.pid &&
+    left.owner.createdAt === right.owner.createdAt
+  );
+}
+
+function reserveWorkspaceLockQuarantine(lockPath: string): WorkspaceStateLockQuarantine {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const directory = `${lockPath}.offline-quarantine-${randomUUID()}`;
+    try {
+      mkdirSync(directory, { mode: 0o700 });
+      return { directory, path: join(directory, WORKSPACE_STATE_LOCK_FILENAME) };
+    } catch (error) {
+      if (isNodeError(error) && error.code === "EEXIST") continue;
+      throw error;
+    }
+  }
+  throw new Error("unable to allocate a unique workspace-lock quarantine path");
+}
+
+function preserveUnexpectedQuarantinedLock(
+  lockPath: string,
+  quarantine: WorkspaceStateLockQuarantine,
+  moved: WorkspaceStateLockInspection,
+): boolean {
+  try {
+    linkSync(quarantine.path, lockPath);
+  } catch {
+    return false;
+  }
+  const restored = inspectWorkspaceLockArtifact(lockPath);
+  const safelyRestored =
+    moved.status === "valid" && restored.status === "valid"
+      ? sameInspectedLock(moved, restored)
+      : moved.status === "malformed" &&
+        restored.status === "malformed" &&
+        moved.device === restored.device &&
+        moved.inode === restored.inode;
+  if (!safelyRestored) return false;
+  try {
+    rmSync(quarantine.path, { force: false });
+    removeEmptyQuarantineDirectory(quarantine.directory);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function removeEmptyQuarantineDirectory(directory: string): void {
+  try {
+    rmdirSync(directory);
+  } catch {
+    // A non-empty or replaced quarantine is evidence and must be preserved.
+  }
+}
+
+function removeLockArtifact(path: string): void {
+  rmSync(path, { recursive: true, force: true });
+}
+
+function isLockContentionError(error: unknown): boolean {
+  return (
+    isNodeError(error) && ["EEXIST", "ENOTEMPTY", "ENOTDIR", "EISDIR"].includes(error.code ?? "")
+  );
+}
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function diagnostic(
+  code: WorkspaceStateRepositoryDiagnosticCode,
+  path: string,
+  message: string,
+): WorkspaceStateRepositoryDiagnostic {
+  return { code, path, message };
+}
+
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  return typeof value === "number" && Number.isSafeInteger(value)
+    ? Math.min(maximum, Math.max(minimum, value))
+    : fallback;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/daemon/src/lib/workspace-state.ts
+++ b/packages/daemon/src/lib/workspace-state.ts
@@ -1,0 +1,960 @@
+import { createHash } from "node:crypto";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+import {
+  WORKSPACE_STATE_MAX_CHECKOUTS,
+  WORKSPACE_STATE_MAX_ID_LENGTH,
+  WORKSPACE_STATE_MAX_LAYOUTS,
+  WORKSPACE_STATE_MAX_NAME_LENGTH,
+  WORKSPACE_STATE_MAX_PANES,
+  WORKSPACE_STATE_MAX_TREE_DEPTH,
+  WORKSPACE_STATE_MAX_TREE_NODES,
+  WORKSPACE_STATE_VERSION,
+  WorkspaceCheckoutStateSchemaZ,
+  WorkspaceLayoutApplyPlanSchemaZ,
+  WorkspaceLayoutSnapshotSchemaZ,
+  WorkspaceObservationSchemaZ,
+  WorkspaceObservedPaneSchemaZ,
+  WorkspaceProjectIdentitySchemaZ,
+  WorkspaceStateV1SchemaZ,
+  WorkspaceTimestampSchemaZ,
+  type ParsedWorkspaceState,
+  type WorkspaceCheckoutState,
+  type WorkspaceDockSnapshot,
+  type WorkspaceLayoutApplyPlan,
+  type WorkspaceLayoutSnapshot,
+  type WorkspaceNamedLayout,
+  type WorkspaceObservation,
+  type WorkspaceObservedPane,
+  type WorkspacePaneBinding,
+  type WorkspacePaneCwd,
+  type WorkspacePaneDefinition,
+  type WorkspacePaneTopology,
+  type WorkspacePaneTreeNode,
+  type WorkspaceProjectIdentity,
+  type WorkspaceStateDiagnostic,
+  type WorkspaceStateV1,
+  type WorkspaceWorkbenchState,
+} from "@tmux-ide/contracts";
+
+export * from "@tmux-ide/contracts";
+
+const EMPTY_DOCK: WorkspaceDockSnapshot = {
+  activeTab: "files",
+  mode: "open",
+  preferredHeight: null,
+  focusZone: "canvas",
+};
+const RESERVED_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+export function defaultWorkspaceState(project: WorkspaceProjectIdentity): WorkspaceStateV1 {
+  return {
+    version: WORKSPACE_STATE_VERSION,
+    project: WorkspaceProjectIdentitySchemaZ.parse(project),
+    layouts: {},
+    checkouts: {},
+  };
+}
+
+export function defaultWorkspaceWorkbenchState(): WorkspaceWorkbenchState {
+  return { canvasPanel: "home", dock: { ...EMPTY_DOCK } };
+}
+
+export function emptyWorkspaceTopology(): WorkspacePaneTopology {
+  return { panes: {}, root: null };
+}
+
+export function emptyWorkspaceCheckout(
+  checkoutKey: string,
+  projectRoot: string,
+): WorkspaceCheckoutState {
+  const checkout = {
+    checkoutKey: requireId(checkoutKey, "checkout key"),
+    projectRoot: requireProjectRoot(projectRoot),
+    activeLayoutId: null,
+    topology: emptyWorkspaceTopology(),
+    focusedPaneId: null,
+    workbench: defaultWorkspaceWorkbenchState(),
+    bindings: {},
+    recovery: {
+      status: "empty",
+      capturedAt: null,
+      sessionName: null,
+      windowIndex: null,
+      windowName: null,
+      missingPaneIds: [],
+      externalPaneIds: [],
+    },
+  };
+  return WorkspaceCheckoutStateSchemaZ.parse(checkout);
+}
+
+export function projectWorkspaceTopology(
+  observedPanes: readonly WorkspaceObservedPane[],
+  projectRoot: string,
+): WorkspacePaneTopology {
+  const root = requireProjectRoot(projectRoot);
+  const parsedPanes = WorkspaceObservedPaneSchemaZ.array()
+    .max(WORKSPACE_STATE_MAX_PANES)
+    .parse(observedPanes);
+  const panes: Record<string, WorkspacePaneDefinition> = {};
+  const semanticPaneIds = new Set<string>();
+  const runtimePaneIds = new Set<string>();
+  for (const pane of parsedPanes) {
+    const id = pane.semanticPaneId;
+    if (semanticPaneIds.has(id)) throw new Error(`duplicate semantic pane id "${id}"`);
+    if (runtimePaneIds.has(pane.runtimePaneId)) {
+      throw new Error(`duplicate runtime pane id "${pane.runtimePaneId}"`);
+    }
+    semanticPaneIds.add(id);
+    runtimePaneIds.add(pane.runtimePaneId);
+    panes[id] = {
+      id,
+      parentId: null,
+      role: pane.role,
+      harness: pane.harness ?? null,
+      title: pane.title ?? null,
+      command: pane.command ?? null,
+      cwd: normalizePaneCwd(pane.cwd ?? null, root),
+      rect: { ...pane.rect },
+    };
+  }
+  const definitions = Object.values(panes).sort(comparePanes);
+  return WorkspaceLayoutSnapshotSchemaZ.shape.topology.parse(
+    finalizeTopology(panes, buildPaneTree(definitions)),
+  );
+}
+
+/**
+ * Deterministically seeds the shared workspace domain from the independent V2
+ * OpenTUI projection. The projection remains untouched and authoritative for
+ * its view/surface state; only the compatible canvas and dock snapshot crosses
+ * this boundary.
+ */
+export function migrateWorkspaceUiStateV2(
+  project: WorkspaceProjectIdentity,
+  checkoutKey: string,
+  projectRoot: string,
+  value: unknown,
+  migratedAt: string,
+): WorkspaceStateV1 {
+  if (!isRecord(value) || value.version !== 2) {
+    throw new Error("workspace UI state V2 is required for migration");
+  }
+  const key = requireId(checkoutKey, "checkout key");
+  const root = requireProjectRoot(projectRoot);
+  requireTimestamp(migratedAt);
+  const active = isRecord(value.active) ? value.active : null;
+  const canvasPanel = active?.panel === "home" ? "home" : "terminals";
+  const dock = cleanLegacyDock(value.dock);
+  const checkout = emptyWorkspaceCheckout(key, root);
+  checkout.workbench = { canvasPanel, dock };
+  return orderWorkspaceState({
+    version: WORKSPACE_STATE_VERSION,
+    project: WorkspaceProjectIdentitySchemaZ.parse(project),
+    layouts: {},
+    checkouts: { [key]: checkout },
+  });
+}
+
+/**
+ * Capture current tmux truth without mutating named layout definitions.
+ * Repeating the same observation is byte-for-byte idempotent.
+ */
+export function captureWorkspaceObservation(
+  state: WorkspaceStateV1,
+  observation: WorkspaceObservation,
+): WorkspaceStateV1 {
+  const current = requireWorkspaceState(state);
+  const observed = WorkspaceObservationSchemaZ.parse(observation);
+  const checkoutKey = observed.checkoutKey;
+  const projectRoot = requireProjectRoot(observed.projectRoot);
+  const observedAt = observed.observedAt;
+  const previous =
+    current.checkouts[checkoutKey] ?? emptyWorkspaceCheckout(checkoutKey, projectRoot);
+  if (resolve(previous.projectRoot) !== projectRoot) {
+    throw new Error(`checkout "${checkoutKey}" belongs to a different project root`);
+  }
+  if (
+    previous.recovery.capturedAt &&
+    Date.parse(observedAt) <= Date.parse(previous.recovery.capturedAt)
+  ) {
+    return cloneWorkspaceState(current);
+  }
+
+  const observedTopology = projectWorkspaceTopology(observed.panes, projectRoot);
+  const observedIds = Object.keys(observedTopology.panes);
+  const layout = previous.activeLayoutId ? current.layouts[previous.activeLayoutId] : null;
+  const previousIds = Object.keys(previous.topology.panes);
+  const missingPreviousPane = previousIds.some((id) => !observedTopology.panes[id]);
+  const preservesPriorTopology =
+    previous.topology.root !== null &&
+    (observedIds.length === 0 || (!layout && missingPreviousPane));
+  const topology = preservesPriorTopology
+    ? mergeRecoverableTopology(previous.topology, observedTopology)
+    : observedTopology;
+  const desiredIds = layout
+    ? Object.keys(layout.snapshot.topology.panes)
+    : Object.keys(previous.topology.panes);
+  const missingPaneIds = desiredIds.filter((id) => !observedTopology.panes[id]).sort();
+  const externalPaneIds = layout
+    ? observedIds.filter((id) => !layout.snapshot.topology.panes[id]).sort()
+    : [];
+  const requestedFocus = observed.focusedPaneId;
+  const focusedPaneId = preservesPriorTopology
+    ? previous.focusedPaneId
+    : ((requestedFocus && topology.panes[requestedFocus] ? requestedFocus : null) ??
+      observedIds.find((id) =>
+        observed.panes.some((pane) => pane.semanticPaneId === id && pane.active),
+      ) ??
+      observedIds[0] ??
+      null);
+  const bindings: Record<string, WorkspacePaneBinding> = preservesPriorTopology
+    ? structuredClone(previous.bindings)
+    : {};
+  for (const pane of observed.panes) {
+    for (const [boundPaneId, binding] of Object.entries(bindings)) {
+      if (boundPaneId !== pane.semanticPaneId && binding.runtimePaneId === pane.runtimePaneId) {
+        delete bindings[boundPaneId];
+      }
+    }
+    bindings[pane.semanticPaneId] = {
+      semanticPaneId: pane.semanticPaneId,
+      runtimePaneId: pane.runtimePaneId,
+      lastSeenAt: observedAt,
+    };
+  }
+  const nextCheckout: WorkspaceCheckoutState = {
+    checkoutKey,
+    projectRoot,
+    activeLayoutId:
+      previous.activeLayoutId && current.layouts[previous.activeLayoutId]
+        ? previous.activeLayoutId
+        : null,
+    topology,
+    focusedPaneId,
+    workbench: structuredClone(observed.workbench),
+    bindings: orderedRecord(bindings),
+    recovery: {
+      status:
+        observedIds.length === 0
+          ? "empty"
+          : missingPaneIds.length || externalPaneIds.length
+            ? "reconciled"
+            : "clean",
+      capturedAt: observedAt,
+      sessionName: observed.sessionName,
+      windowIndex: observed.windowIndex,
+      windowName: observed.windowName,
+      missingPaneIds,
+      externalPaneIds,
+    },
+  };
+  const next = cloneWorkspaceState(current);
+  next.checkouts[checkoutKey] = nextCheckout;
+  return requireWorkspaceState(next);
+}
+
+export function createWorkspaceLayout(
+  state: WorkspaceStateV1,
+  input: {
+    id: string;
+    name: string;
+    checkoutKey: string;
+    now: string;
+    snapshot?: WorkspaceLayoutSnapshot;
+  },
+): WorkspaceStateV1 {
+  const current = requireWorkspaceState(state);
+  const id = requireId(input.id, "layout id");
+  if (current.layouts[id]) throw new Error(`workspace layout "${id}" already exists`);
+  if (Object.keys(current.layouts).length >= WORKSPACE_STATE_MAX_LAYOUTS) {
+    throw new Error("workspace layout limit exceeded");
+  }
+  const checkout = requireCheckout(current, input.checkoutKey);
+  const now = requireTimestamp(input.now);
+  const snapshot = requireSnapshot(input.snapshot ?? snapshotFromCheckout(checkout));
+  const next = cloneWorkspaceState(current);
+  next.layouts[id] = {
+    id,
+    name: requireName(input.name),
+    revision: 1,
+    createdAt: now,
+    updatedAt: now,
+    snapshot,
+  };
+  next.layouts = orderedRecord(next.layouts);
+  next.checkouts[input.checkoutKey]!.activeLayoutId = id;
+  return requireWorkspaceState(next);
+}
+
+export function renameWorkspaceLayout(
+  state: WorkspaceStateV1,
+  layoutId: string,
+  name: string,
+  now: string,
+): WorkspaceStateV1 {
+  const current = requireWorkspaceState(state);
+  const layout = requireLayout(current, layoutId);
+  const next = cloneWorkspaceState(current);
+  next.layouts[layout.id] = {
+    ...layout,
+    name: requireName(name),
+    revision: layout.revision + 1,
+    updatedAt: requireTimestamp(now),
+  };
+  return requireWorkspaceState(next);
+}
+
+export function saveWorkspaceLayout(
+  state: WorkspaceStateV1,
+  layoutId: string,
+  checkoutKey: string,
+  now: string,
+): WorkspaceStateV1 {
+  const current = requireWorkspaceState(state);
+  const layout = requireLayout(current, layoutId);
+  const checkout = requireCheckout(current, checkoutKey);
+  const next = cloneWorkspaceState(current);
+  next.layouts[layout.id] = {
+    ...layout,
+    revision: layout.revision + 1,
+    updatedAt: requireTimestamp(now),
+    snapshot: requireSnapshot(snapshotFromCheckout(checkout)),
+  };
+  next.checkouts[checkoutKey]!.activeLayoutId = layout.id;
+  return requireWorkspaceState(next);
+}
+
+export function deleteWorkspaceLayout(state: WorkspaceStateV1, layoutId: string): WorkspaceStateV1 {
+  const current = requireWorkspaceState(state);
+  const id = requireId(layoutId, "layout id");
+  if (!current.layouts[id]) return cloneWorkspaceState(current);
+  const next = cloneWorkspaceState(current);
+  delete next.layouts[id];
+  for (const checkout of Object.values(next.checkouts)) {
+    if (checkout.activeLayoutId === id) checkout.activeLayoutId = null;
+  }
+  return requireWorkspaceState(next);
+}
+
+/** Build an adapter plan only; this function never issues tmux commands. */
+export function applyWorkspaceLayout(
+  state: WorkspaceStateV1,
+  layoutId: string,
+  observation: WorkspaceObservation,
+): { state: WorkspaceStateV1; plan: WorkspaceLayoutApplyPlan } {
+  const current = requireWorkspaceState(state);
+  const observed = WorkspaceObservationSchemaZ.parse(observation);
+  const layout = requireLayout(current, layoutId);
+  const captured = captureWorkspaceObservation(current, observed);
+  const checkout = requireCheckout(captured, observed.checkoutKey);
+  if (resolve(checkout.projectRoot) !== requireProjectRoot(observed.projectRoot)) {
+    throw new Error(`checkout "${observed.checkoutKey}" belongs to a different project root`);
+  }
+  const liveIds = observed.panes.map((pane) => pane.semanticPaneId).sort();
+  const desiredIds = Object.keys(layout.snapshot.topology.panes);
+  const liveIdSet = new Set(liveIds);
+  const retainedPaneIds = desiredIds.filter((id) => liveIdSet.has(id)).sort();
+  const missingPaneIds = desiredIds.filter((id) => !liveIdSet.has(id)).sort();
+  const externalPaneIds = liveIds.filter((id) => !layout.snapshot.topology.panes[id]).sort();
+  const targetTopology = requireSnapshot(layout.snapshot).topology;
+  const targetFocusedPaneId =
+    (layout.snapshot.focusedPaneId && targetTopology.panes[layout.snapshot.focusedPaneId]
+      ? layout.snapshot.focusedPaneId
+      : null) ??
+    [...desiredIds].sort()[0] ??
+    null;
+  const liveFocusedPaneId =
+    (observed.focusedPaneId && liveIdSet.has(observed.focusedPaneId)
+      ? observed.focusedPaneId
+      : null) ??
+    observed.panes.find((pane) => pane.active)?.semanticPaneId ??
+    liveIds[0] ??
+    null;
+  const retainedBindings = orderedRecord(
+    Object.fromEntries(
+      retainedPaneIds.flatMap((paneId) => {
+        const binding = checkout.bindings[paneId];
+        return binding ? [[paneId, { ...binding }] as const] : [];
+      }),
+    ),
+  );
+  const next = cloneWorkspaceState(captured);
+  const nextCheckout = next.checkouts[observed.checkoutKey]!;
+  nextCheckout.activeLayoutId = layout.id;
+  nextCheckout.focusedPaneId = liveFocusedPaneId ?? nextCheckout.focusedPaneId;
+  nextCheckout.workbench = cloneWorkbench(layout.snapshot.workbench);
+  nextCheckout.recovery = {
+    ...nextCheckout.recovery,
+    status:
+      observed.panes.length === 0
+        ? "empty"
+        : missingPaneIds.length || externalPaneIds.length
+          ? "reconciled"
+          : "clean",
+    missingPaneIds,
+    externalPaneIds,
+  };
+  const plan = WorkspaceLayoutApplyPlanSchemaZ.parse({
+    layoutId: layout.id,
+    checkoutKey: observed.checkoutKey,
+    projectRoot: requireProjectRoot(observed.projectRoot),
+    sessionName: observed.sessionName,
+    windowIndex: observed.windowIndex,
+    windowName: observed.windowName,
+    targetTopology,
+    materializedPaneCwds: orderedRecord(
+      Object.fromEntries(
+        Object.entries(targetTopology.panes).map(([paneId, pane]) => [
+          paneId,
+          materializePaneCwd(pane.cwd, observed.projectRoot),
+        ]),
+      ),
+    ),
+    targetFocusedPaneId,
+    liveFocusedPaneId,
+    workbench: cloneWorkbench(layout.snapshot.workbench),
+    retainedBindings,
+    retainedPaneIds,
+    missingPaneIds,
+    externalPaneIds,
+  });
+  return {
+    state: requireWorkspaceState(next),
+    plan,
+  };
+}
+
+export function serializeWorkspaceState(state: WorkspaceStateV1): string {
+  return `${JSON.stringify(orderWorkspaceState(requireWorkspaceState(state)), null, 2)}\n`;
+}
+
+export function parseWorkspaceStateValue(
+  value: unknown,
+  expectedProject: WorkspaceProjectIdentity,
+): ParsedWorkspaceState {
+  if (!isRecord(value)) {
+    return {
+      state: defaultWorkspaceState(expectedProject),
+      diagnostics: [{ code: "MALFORMED", path: "$", message: "workspace state must be an object" }],
+      writeProtected: true,
+    };
+  }
+  if (value.version !== WORKSPACE_STATE_VERSION) {
+    return {
+      state: defaultWorkspaceState(expectedProject),
+      diagnostics: [
+        {
+          code: Number.isInteger(value.version) ? "UNSUPPORTED_VERSION" : "MALFORMED",
+          path: "$.version",
+          message: `unsupported workspace state version ${String(value.version)}`,
+        },
+      ],
+      writeProtected: true,
+    };
+  }
+  const preflightFailure = workspaceStateLimitFailure(value);
+  if (preflightFailure) {
+    return {
+      state: defaultWorkspaceState(expectedProject),
+      diagnostics: [
+        { code: "OVERSIZED", path: preflightFailure.path, message: preflightFailure.message },
+      ],
+      writeProtected: true,
+    };
+  }
+  const parsed = WorkspaceStateV1SchemaZ.safeParse(value);
+  if (!parsed.success) {
+    return {
+      state: defaultWorkspaceState(expectedProject),
+      diagnostics: parsed.error.issues.map((issue) => ({
+        code: issue.message.includes("limit exceeded") ? "OVERSIZED" : "INVALID_FIELD",
+        path: issue.path.length ? `$.${issue.path.join(".")}` : "$",
+        message: issue.message,
+      })),
+      writeProtected: true,
+    };
+  }
+  const expected = WorkspaceProjectIdentitySchemaZ.parse(expectedProject);
+  const project = parsed.data.project;
+  if (
+    project.identityKey !== expected.identityKey ||
+    project.identitySource !== expected.identitySource
+  ) {
+    return {
+      state: defaultWorkspaceState(expectedProject),
+      diagnostics: [
+        {
+          code: "IDENTITY_MISMATCH",
+          path: "$.project.identityKey",
+          message: "workspace state belongs to a different project identity",
+        },
+      ],
+      writeProtected: true,
+    };
+  }
+  const diagnostics: WorkspaceStateDiagnostic[] = [];
+  if (project.identityAnchor !== expectedProject.identityAnchor) {
+    diagnostics.push({
+      code: "PROJECT_RELINKED",
+      path: "$.project.identityAnchor",
+      message: "workspace project identity anchor was refreshed",
+    });
+  }
+  return {
+    state: orderWorkspaceState({
+      ...parsed.data,
+      project: expected,
+    }),
+    diagnostics,
+    writeProtected: false,
+  };
+}
+
+export function cloneWorkspaceState(state: WorkspaceStateV1): WorkspaceStateV1 {
+  return WorkspaceStateV1SchemaZ.parse(JSON.parse(serializeWorkspaceState(state)));
+}
+
+function cleanLegacyDock(value: unknown): WorkspaceDockSnapshot {
+  return cleanWorkbench({
+    canvasPanel: "terminals",
+    dock: isRecord(value) ? (value as WorkspaceDockSnapshot) : { ...EMPTY_DOCK },
+  }).dock;
+}
+
+function cleanWorkbench(value: WorkspaceWorkbenchState): WorkspaceWorkbenchState {
+  const dock = value.dock;
+  return {
+    canvasPanel: value.canvasPanel === "terminals" ? "terminals" : "home",
+    dock: {
+      activeTab:
+        dock?.activeTab === "changes" ||
+        dock?.activeTab === "missions" ||
+        dock?.activeTab === "activity"
+          ? dock.activeTab
+          : "files",
+      mode: dock?.mode === "collapsed" || dock?.mode === "maximized" ? dock.mode : "open",
+      preferredHeight: cleanNullableInt(dock?.preferredHeight),
+      focusZone:
+        dock?.focusZone === "dock-tabs" || dock?.focusZone === "dock-body"
+          ? dock.focusZone
+          : "canvas",
+    },
+  };
+}
+
+function snapshotFromCheckout(checkout: WorkspaceCheckoutState): WorkspaceLayoutSnapshot {
+  return {
+    topology: structuredClone(checkout.topology),
+    focusedPaneId: checkout.focusedPaneId,
+    workbench: cloneWorkbench(checkout.workbench),
+  };
+}
+
+function mergeRecoverableTopology(
+  previous: WorkspacePaneTopology,
+  observed: WorkspacePaneTopology,
+): WorkspacePaneTopology {
+  const panes = Object.fromEntries(
+    Object.entries(previous.panes).map(([paneId, pane]) => [paneId, structuredClone(pane)]),
+  ) as Record<string, WorkspacePaneDefinition>;
+  for (const [paneId, pane] of Object.entries(observed.panes)) {
+    panes[paneId] = structuredClone(pane);
+  }
+  const hasNewPane = Object.keys(observed.panes).some((paneId) => !previous.panes[paneId]);
+  const root = hasNewPane
+    ? buildPaneTree(Object.values(panes).sort(comparePanes))
+    : previous.root
+      ? structuredClone(previous.root)
+      : null;
+  return finalizeTopology(panes, root);
+}
+
+function buildPaneTree(panes: readonly WorkspacePaneDefinition[]): WorkspacePaneTreeNode | null {
+  if (panes.length === 0) return null;
+  if (panes.length === 1) {
+    const paneId = panes[0]!.id;
+    return { type: "pane", nodeId: paneNodeId(paneId), paneId };
+  }
+  const split = findGeometricSplit(panes);
+  if (split) {
+    const children = [buildPaneTree(split.before)!, buildPaneTree(split.after)!];
+    return {
+      type: "split",
+      nodeId: splitNodeId(split.axis, children),
+      axis: split.axis,
+      children,
+      weights: [span(split.before, split.axis), span(split.after, split.axis)],
+    };
+  }
+  const ordered = [...panes].sort(comparePanes);
+  const midpoint = Math.ceil(ordered.length / 2);
+  const before = ordered.slice(0, midpoint);
+  const after = ordered.slice(midpoint);
+  const children = [buildPaneTree(before)!, buildPaneTree(after)!];
+  return {
+    type: "split",
+    nodeId: splitNodeId("horizontal", children),
+    axis: "horizontal",
+    children,
+    weights: [before.length, after.length],
+  };
+}
+
+function finalizeTopology(
+  panes: Record<string, WorkspacePaneDefinition>,
+  root: WorkspacePaneTreeNode | null,
+): WorkspacePaneTopology {
+  const finalized = Object.fromEntries(
+    Object.entries(panes).map(([id, pane]) => [id, { ...pane, parentId: null }]),
+  ) as Record<string, WorkspacePaneDefinition>;
+  const visit = (node: WorkspacePaneTreeNode, parentId: string | null): void => {
+    if (node.type === "pane") {
+      const pane = finalized[node.paneId];
+      if (pane) pane.parentId = parentId;
+      return;
+    }
+    for (const child of node.children) visit(child, node.nodeId);
+  };
+  if (root) visit(root, null);
+  return { panes: orderedRecord(finalized), root };
+}
+
+function paneNodeId(paneId: string): string {
+  return `node.pane.${stableNodeDigest(paneId)}`;
+}
+
+function splitNodeId(
+  axis: "horizontal" | "vertical",
+  children: readonly WorkspacePaneTreeNode[],
+): string {
+  return `node.split.${stableNodeDigest(
+    `${axis}\0${children
+      .map((child) => child.nodeId)
+      .sort()
+      .join("\0")}`,
+  )}`;
+}
+
+function stableNodeDigest(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 24);
+}
+
+function findGeometricSplit(panes: readonly WorkspacePaneDefinition[]): {
+  axis: "horizontal" | "vertical";
+  before: WorkspacePaneDefinition[];
+  after: WorkspacePaneDefinition[];
+} | null {
+  let best: {
+    axis: "horizontal" | "vertical";
+    before: WorkspacePaneDefinition[];
+    after: WorkspacePaneDefinition[];
+    imbalance: number;
+    axisRank: number;
+    boundary: number;
+  } | null = null;
+  for (const [axisRank, axis] of (["horizontal", "vertical"] as const).entries()) {
+    const start = (pane: WorkspacePaneDefinition) =>
+      axis === "horizontal" ? pane.rect.left : pane.rect.top;
+    const end = (pane: WorkspacePaneDefinition) =>
+      start(pane) + (axis === "horizontal" ? pane.rect.width : pane.rect.height);
+    const boundaries = [...new Set(panes.flatMap((pane) => [start(pane), end(pane)]))].sort(
+      (a, b) => a - b,
+    );
+    for (const boundary of boundaries) {
+      const before = panes.filter((pane) => end(pane) <= boundary);
+      const after = panes.filter((pane) => start(pane) >= boundary);
+      if (before.length > 0 && after.length > 0 && before.length + after.length === panes.length) {
+        const candidate = {
+          axis,
+          before: [...before].sort(comparePanes),
+          after: [...after].sort(comparePanes),
+          imbalance: Math.abs(before.length - after.length),
+          axisRank,
+          boundary,
+        };
+        if (
+          !best ||
+          candidate.imbalance < best.imbalance ||
+          (candidate.imbalance === best.imbalance && candidate.axisRank < best.axisRank) ||
+          (candidate.imbalance === best.imbalance &&
+            candidate.axisRank === best.axisRank &&
+            candidate.boundary < best.boundary)
+        ) {
+          best = candidate;
+        }
+      }
+    }
+  }
+  return best ? { axis: best.axis, before: best.before, after: best.after } : null;
+}
+
+function span(panes: readonly WorkspacePaneDefinition[], axis: "horizontal" | "vertical"): number {
+  const starts = panes.map((pane) => (axis === "horizontal" ? pane.rect.left : pane.rect.top));
+  const ends = panes.map(
+    (pane) =>
+      (axis === "horizontal" ? pane.rect.left : pane.rect.top) +
+      (axis === "horizontal" ? pane.rect.width : pane.rect.height),
+  );
+  return Math.max(1, Math.max(...ends) - Math.min(...starts));
+}
+
+function comparePanes(a: WorkspacePaneDefinition, b: WorkspacePaneDefinition): number {
+  return a.rect.top - b.rect.top || a.rect.left - b.rect.left || a.id.localeCompare(b.id);
+}
+
+function orderWorkspaceState(state: WorkspaceStateV1): WorkspaceStateV1 {
+  const layouts: Record<string, WorkspaceNamedLayout> = {};
+  for (const id of Object.keys(state.layouts).sort()) {
+    const layout = state.layouts[id]!;
+    layouts[id] = {
+      ...layout,
+      snapshot: {
+        topology: orderTopology(layout.snapshot.topology),
+        focusedPaneId: layout.snapshot.focusedPaneId,
+        workbench: cloneWorkbench(layout.snapshot.workbench),
+      },
+    };
+  }
+  const checkouts: Record<string, WorkspaceCheckoutState> = {};
+  for (const id of Object.keys(state.checkouts).sort()) {
+    const checkout = state.checkouts[id]!;
+    checkouts[id] = {
+      ...checkout,
+      topology: orderTopology(checkout.topology),
+      workbench: cloneWorkbench(checkout.workbench),
+      bindings: orderedRecord(
+        Object.fromEntries(
+          Object.entries(checkout.bindings).map(([key, binding]) => [key, { ...binding }]),
+        ),
+      ),
+      recovery: {
+        ...checkout.recovery,
+        missingPaneIds: [...checkout.recovery.missingPaneIds].sort(),
+        externalPaneIds: [...checkout.recovery.externalPaneIds].sort(),
+      },
+    };
+  }
+  return {
+    version: WORKSPACE_STATE_VERSION,
+    project: { ...state.project },
+    layouts,
+    checkouts,
+  };
+}
+
+function orderTopology(topology: WorkspacePaneTopology): WorkspacePaneTopology {
+  return {
+    panes: orderedRecord(
+      Object.fromEntries(
+        Object.entries(topology.panes).map(([key, pane]) => [
+          key,
+          {
+            ...pane,
+            cwd: pane.cwd ? { ...pane.cwd } : null,
+            rect: { ...pane.rect },
+          },
+        ]),
+      ),
+    ),
+    root: topology.root ? structuredClone(topology.root) : null,
+  };
+}
+
+function cloneWorkbench(value: WorkspaceWorkbenchState): WorkspaceWorkbenchState {
+  return { canvasPanel: value.canvasPanel, dock: { ...value.dock } };
+}
+
+function requireLayout(state: WorkspaceStateV1, layoutId: string): WorkspaceNamedLayout {
+  const id = requireId(layoutId, "layout id");
+  const layout = state.layouts[id];
+  if (!layout) throw new Error(`workspace layout "${id}" does not exist`);
+  return layout;
+}
+
+function requireCheckout(state: WorkspaceStateV1, checkoutKey: string): WorkspaceCheckoutState {
+  const id = requireId(checkoutKey, "checkout key");
+  const checkout = state.checkouts[id];
+  if (!checkout) throw new Error(`workspace checkout "${id}" does not exist`);
+  return checkout;
+}
+
+function requireWorkspaceState(state: WorkspaceStateV1): WorkspaceStateV1 {
+  return WorkspaceStateV1SchemaZ.parse(state);
+}
+
+function requireSnapshot(snapshot: WorkspaceLayoutSnapshot): WorkspaceLayoutSnapshot {
+  return WorkspaceLayoutSnapshotSchemaZ.parse(snapshot);
+}
+
+function requireProjectRoot(projectRoot: string): string {
+  const root = cleanRequiredText(projectRoot, 4096);
+  if (!root || !isAbsolute(root)) throw new Error("workspace project root must be absolute");
+  return resolve(root);
+}
+
+function normalizePaneCwd(cwd: string | null, projectRoot: string): WorkspacePaneCwd | null {
+  if (cwd === null) return null;
+  const absolutePath = resolve(projectRoot, cwd);
+  const portablePath = relative(projectRoot, absolutePath);
+  const remainsInsideProject =
+    portablePath === "" ||
+    (portablePath !== ".." && !portablePath.startsWith(`..${sep}`) && !isAbsolute(portablePath));
+  return remainsInsideProject
+    ? { kind: "project-relative", path: portablePath || "." }
+    : { kind: "absolute", path: absolutePath };
+}
+
+function materializePaneCwd(cwd: WorkspacePaneCwd | null, projectRoot: string): string | null {
+  if (!cwd) return null;
+  if (cwd.kind === "absolute") return cwd.path;
+  const root = requireProjectRoot(projectRoot);
+  const materialized = resolve(root, cwd.path.replace(/[/\\]+/gu, sep));
+  const relativePath = relative(root, materialized);
+  if (relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    throw new Error(`project-relative pane cwd "${cwd.path}" escapes checkout root`);
+  }
+  return materialized;
+}
+
+interface WorkspaceStateLimitFailure {
+  path: string;
+  message: string;
+}
+
+function workspaceStateLimitFailure(
+  value: Record<string, unknown>,
+): WorkspaceStateLimitFailure | null {
+  if (isRecord(value.layouts)) {
+    const layoutIds = Object.keys(value.layouts);
+    if (layoutIds.length > WORKSPACE_STATE_MAX_LAYOUTS) {
+      return { path: "$.layouts", message: "workspace layout limit exceeded" };
+    }
+    for (const layoutId of layoutIds) {
+      const layout = value.layouts[layoutId];
+      const snapshot = isRecord(layout) ? layout.snapshot : null;
+      const failure = topologyLimitFailure(
+        isRecord(snapshot) ? snapshot.topology : null,
+        `$.layouts.${layoutId}.snapshot.topology`,
+      );
+      if (failure) return failure;
+    }
+  }
+  if (isRecord(value.checkouts)) {
+    const checkoutKeys = Object.keys(value.checkouts);
+    if (checkoutKeys.length > WORKSPACE_STATE_MAX_CHECKOUTS) {
+      return { path: "$.checkouts", message: "workspace checkout limit exceeded" };
+    }
+    for (const checkoutKey of checkoutKeys) {
+      const checkout = value.checkouts[checkoutKey];
+      if (!isRecord(checkout)) continue;
+      const failure = topologyLimitFailure(
+        checkout.topology,
+        `$.checkouts.${checkoutKey}.topology`,
+      );
+      if (failure) return failure;
+      if (
+        isRecord(checkout.bindings) &&
+        Object.keys(checkout.bindings).length > WORKSPACE_STATE_MAX_PANES
+      ) {
+        return {
+          path: `$.checkouts.${checkoutKey}.bindings`,
+          message: "workspace binding limit exceeded",
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function topologyLimitFailure(value: unknown, path: string): WorkspaceStateLimitFailure | null {
+  if (!isRecord(value)) return null;
+  if (isRecord(value.panes) && Object.keys(value.panes).length > WORKSPACE_STATE_MAX_PANES) {
+    return { path: `${path}.panes`, message: "workspace pane limit exceeded" };
+  }
+  if (value.root === null || value.root === undefined) return null;
+  const stack: Array<{ value: unknown; depth: number }> = [{ value: value.root, depth: 1 }];
+  let nodes = 0;
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    nodes += 1;
+    if (nodes > WORKSPACE_STATE_MAX_TREE_NODES) {
+      return { path: `${path}.root`, message: "workspace pane tree node limit exceeded" };
+    }
+    if (current.depth > WORKSPACE_STATE_MAX_TREE_DEPTH) {
+      return { path: `${path}.root`, message: "workspace pane tree depth limit exceeded" };
+    }
+    if (isRecord(current.value) && current.value.type === "split") {
+      if (!Array.isArray(current.value.children)) continue;
+      if (current.value.children.length > 8) {
+        return { path: `${path}.root`, message: "workspace split child limit exceeded" };
+      }
+      for (const child of current.value.children) {
+        stack.push({ value: child, depth: current.depth + 1 });
+      }
+    }
+  }
+  return null;
+}
+
+function requireId(value: string, label: string): string {
+  const id = cleanId(value);
+  if (!id) throw new Error(`${label} is invalid`);
+  return id;
+}
+
+function requireName(value: string): string {
+  const name = cleanRequiredText(value, WORKSPACE_STATE_MAX_NAME_LENGTH);
+  if (!name || name.trim().length === 0) throw new Error("workspace layout name is required");
+  return name;
+}
+
+function requireTimestamp(value: string): string {
+  return WorkspaceTimestampSchemaZ.parse(value);
+}
+
+function cleanId(value: unknown): string | null {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > WORKSPACE_STATE_MAX_ID_LENGTH
+  )
+    return null;
+  if (
+    value.includes("\0") ||
+    RESERVED_KEYS.has(value) ||
+    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(value)
+  )
+    return null;
+  return value;
+}
+
+function cleanNonnegativeInt(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function cleanNullableInt(value: unknown): number | null {
+  return value === null || value === undefined ? null : cleanNonnegativeInt(value);
+}
+
+function cleanRequiredText(value: unknown, max: number): string | null {
+  return typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= max &&
+    !value.includes("\0")
+    ? value
+    : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function orderedRecord<T>(value: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, value[key]!]),
+  ) as Record<string, T>;
+}


### PR DESCRIPTION
## Summary

- add a versioned shared workspace-state contract for semantic agent pane topology, checkout-scoped runtime bindings, named layouts, focus, dock state, and recovery
- add deterministic capture, migration, layout CRUD/apply planning, canonical serialization, linked-worktree cwd rebasing, and bounded topology construction
- add a project-runtime repository adapter with intent-aware stale merges, same-layout conflicts, corrupt/future payload protection, atomic complete locks, and explicit offline crash-lock recovery

## Deliberate boundary

This is Slice A: pure contracts, domain operations, repository persistence, and tests. It does not yet wire app.tsx, project resolution, tmux semantic stamping/reconciliation, terminals.json migration, or Ctrl-Q flushing. Those remain Slice B.

## Safety evidence

- 44 focused tests, including real concurrent child processes
- partial and empty tmux loss preserve recoverable panes
- linked checkouts retain portable cwd semantics
- stale UI and live topology writes merge by explicit subdomain
- corrupt and future payloads remain byte-protected
- automatic stale-lock reclamation is forbidden; offline clearing requires exact token, process instance, device, inode, and explicit all-writers-stopped confirmation
- two independent adversarial reviews: clean
- pnpm check passes after rebasing onto current main