### PR TITLE
Add shared command registry and root routing

### DIFF
--- a/packages/contracts/src/__tests__/commands.test.ts
+++ b/packages/contracts/src/__tests__/commands.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMMAND_PROTOCOL_VERSION,
+  CommandAvailabilitySchemaZ,
+  CommandDescriptorSchemaZ,
+  CommandInvocationSchemaZ,
+  WORKSPACE_WINDOW_MODE_COMMAND_IDS,
+  type CommandDescriptor,
+  type CommandInvocation,
+} from "../commands.ts";
+
+const descriptor: CommandDescriptor = {
+  version: COMMAND_PROTOCOL_VERSION,
+  id: "workspace.view.activate",
+  owner: "renderer",
+  label: "Activate view",
+  category: "workspace",
+  schemas: { input: "workspace.view.activate.input.v1" },
+  dangerous: false,
+  confirmation: "none",
+};
+
+const invocation: CommandInvocation = {
+  version: COMMAND_PROTOCOL_VERSION,
+  id: descriptor.id,
+  source: { kind: "keyboard", surface: "workbench" },
+  args: { viewId: "terminals", nested: { selected: true }, rows: [1, 2] },
+};
+
+describe("command protocol", () => {
+  it("round-trips serializable descriptors and invocations", () => {
+    expect(CommandDescriptorSchemaZ.parse(JSON.parse(JSON.stringify(descriptor)))).toEqual(
+      descriptor,
+    );
+    expect(CommandInvocationSchemaZ.parse(JSON.parse(JSON.stringify(invocation)))).toEqual(
+      invocation,
+    );
+  });
+
+  it("rejects non-namespaced ids and non-JSON arguments", () => {
+    expect(CommandDescriptorSchemaZ.safeParse({ ...descriptor, id: "quit" }).success).toBe(false);
+    expect(
+      CommandInvocationSchemaZ.safeParse({
+        ...invocation,
+        args: { callback: () => undefined },
+      }).success,
+    ).toBe(false);
+    expect(
+      CommandInvocationSchemaZ.safeParse({
+        ...invocation,
+        args: { count: Number.NaN },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("keeps availability outcomes serializable and explicit", () => {
+    expect(CommandAvailabilitySchemaZ.parse({ available: true })).toEqual({ available: true });
+    expect(
+      CommandAvailabilitySchemaZ.parse({ available: false, reason: "no active view" }),
+    ).toEqual({ available: false, reason: "no active view" });
+  });
+
+  it("reserves valid window-mode ids without registering behavior", () => {
+    expect(WORKSPACE_WINDOW_MODE_COMMAND_IDS).toEqual([
+      "workspace.windowMode.enter",
+      "workspace.windowMode.exit",
+      "workspace.windowMode.cancel",
+      "workspace.windowMode.focus",
+      "workspace.windowMode.move",
+      "workspace.windowMode.resize",
+      "workspace.windowMode.float.toggle",
+      "workspace.windowMode.maximize.toggle",
+      "workspace.windowMode.close",
+    ]);
+    for (const id of WORKSPACE_WINDOW_MODE_COMMAND_IDS) {
+      expect(CommandDescriptorSchemaZ.safeParse({ ...descriptor, id }).success).toBe(true);
+    }
+  });
+});

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+
+/**
+ * Stable, process-neutral command protocol shared by daemon and renderer hosts.
+ *
+ * Descriptors and invocations are data only. Runtime schemas, availability
+ * predicates, and effect handlers deliberately stay in their owning process.
+ */
+export const COMMAND_PROTOCOL_VERSION = 1 as const;
+
+export const CommandIdSchemaZ = z
+  .string()
+  .min(3)
+  .max(160)
+  .regex(
+    /^[a-z][A-Za-z0-9-]*(?:\.[A-Za-z0-9-]+)+$/,
+    "command id must be a dot-namespaced identifier",
+  );
+
+export const CommandOwnerSchemaZ = z.enum(["daemon", "renderer"]);
+
+export const CommandSourceKindSchemaZ = z.enum([
+  "cli",
+  "http",
+  "local-control",
+  "keyboard",
+  "palette",
+  "menu",
+  "mouse",
+  "wheel",
+  "program",
+]);
+
+export const CommandSourceSchemaZ = z
+  .object({
+    kind: CommandSourceKindSchemaZ,
+    surface: z.string().min(1).max(80).optional(),
+  })
+  .strict();
+
+export const CommandSchemaReferencesSchemaZ = z
+  .object({
+    input: z.string().min(1).max(160),
+    result: z.string().min(1).max(160).optional(),
+  })
+  .strict();
+
+export const CommandConfirmationSchemaZ = z.enum(["none", "inline", "dialog"]);
+
+export const CommandDescriptorSchemaZ = z
+  .object({
+    version: z.literal(COMMAND_PROTOCOL_VERSION),
+    id: CommandIdSchemaZ,
+    owner: CommandOwnerSchemaZ,
+    label: z.string().min(1).max(160),
+    description: z.string().min(1).max(500).optional(),
+    category: z.string().min(1).max(80),
+    schemas: CommandSchemaReferencesSchemaZ,
+    dangerous: z.boolean(),
+    confirmation: CommandConfirmationSchemaZ,
+  })
+  .strict();
+
+/** Commands accept one JSON object so they can cross every current bridge. */
+export const CommandArgumentsSchemaZ = z.record(z.string(), z.json());
+
+export const CommandInvocationSchemaZ = z
+  .object({
+    version: z.literal(COMMAND_PROTOCOL_VERSION),
+    id: CommandIdSchemaZ,
+    source: CommandSourceSchemaZ,
+    args: CommandArgumentsSchemaZ,
+  })
+  .strict();
+
+export const CommandAvailabilitySchemaZ = z.discriminatedUnion("available", [
+  z.object({ available: z.literal(true) }).strict(),
+  z
+    .object({
+      available: z.literal(false),
+      reason: z.string().min(1).max(500),
+    })
+    .strict(),
+]);
+
+export const CommandResolutionErrorCodeSchemaZ = z.enum([
+  "unknown-command",
+  "invalid-invocation",
+  "invalid-input",
+  "unavailable",
+]);
+
+export const CommandResolutionErrorSchemaZ = z
+  .object({
+    code: CommandResolutionErrorCodeSchemaZ,
+    message: z.string().min(1),
+    commandId: CommandIdSchemaZ.optional(),
+    details: z.json().optional(),
+  })
+  .strict();
+
+export type CommandId = z.infer<typeof CommandIdSchemaZ>;
+export type CommandOwner = z.infer<typeof CommandOwnerSchemaZ>;
+export type CommandSourceKind = z.infer<typeof CommandSourceKindSchemaZ>;
+export type CommandSource = z.infer<typeof CommandSourceSchemaZ>;
+export type CommandDescriptor = z.infer<typeof CommandDescriptorSchemaZ>;
+export type CommandArguments = z.infer<typeof CommandArgumentsSchemaZ>;
+export type CommandInvocation = z.infer<typeof CommandInvocationSchemaZ>;
+export type CommandAvailability = z.infer<typeof CommandAvailabilitySchemaZ>;
+export type CommandResolutionErrorCode = z.infer<typeof CommandResolutionErrorCodeSchemaZ>;
+export type CommandResolutionError = z.infer<typeof CommandResolutionErrorSchemaZ>;
+
+/**
+ * Names reserved for the Gloomberb-inspired window-control work. They are not
+ * command registrations yet and therefore cannot be invoked by Card07.
+ */
+export const WORKSPACE_WINDOW_MODE_COMMAND_IDS = [
+  "workspace.windowMode.enter",
+  "workspace.windowMode.exit",
+  "workspace.windowMode.cancel",
+  "workspace.windowMode.focus",
+  "workspace.windowMode.move",
+  "workspace.windowMode.resize",
+  "workspace.windowMode.float.toggle",
+  "workspace.windowMode.maximize.toggle",
+  "workspace.windowMode.close",
+] as const satisfies readonly CommandId[];
+
+export type WorkspaceWindowModeCommandId = (typeof WORKSPACE_WINDOW_MODE_COMMAND_IDS)[number];

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -26,3 +26,4 @@ export * from "./actions-contract.ts";
 export * from "./actions-errors.ts";
 export * from "./terminals.ts";
 export * from "./control.ts";
+export * from "./commands.ts";

--- a/packages/daemon/src/command-center/actions/command-definitions.test.ts
+++ b/packages/daemon/src/command-center/actions/command-definitions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTION_NAMES,
+  ActionContractsZ,
+  WORKSPACE_WINDOW_MODE_COMMAND_IDS,
+} from "@tmux-ide/contracts";
+import {
+  DAEMON_ACTION_COMMAND_DEFINITIONS,
+  daemonActionCommandRegistry,
+} from "./command-definitions.ts";
+
+describe("daemon action command definitions", () => {
+  it("registers every existing action id exactly once in contract order", () => {
+    expect(daemonActionCommandRegistry.descriptors().map((item) => item.id)).toEqual(ACTION_NAMES);
+    expect(new Set(ACTION_NAMES).size).toBe(15);
+  });
+
+  it("reuses the exact action input/result schemas", () => {
+    for (const definition of DAEMON_ACTION_COMMAND_DEFINITIONS) {
+      const name = definition.descriptor.id as keyof typeof ActionContractsZ;
+      expect(definition.descriptor.owner).toBe("daemon");
+      expect(definition.inputSchema).toBe(ActionContractsZ[name].input);
+      expect(definition.resultSchema).toBe(ActionContractsZ[name].result);
+    }
+  });
+
+  it("recursively freezes the exported daemon command catalog", () => {
+    expect(Object.isFrozen(DAEMON_ACTION_COMMAND_DEFINITIONS)).toBe(true);
+    for (const definition of DAEMON_ACTION_COMMAND_DEFINITIONS) {
+      expect(Object.isFrozen(definition)).toBe(true);
+      expect(Object.isFrozen(definition.descriptor)).toBe(true);
+      expect(Object.isFrozen(definition.descriptor.schemas)).toBe(true);
+    }
+
+    const first = DAEMON_ACTION_COMMAND_DEFINITIONS[0];
+    expect(first).toBeDefined();
+    expect(() => {
+      if (first) first.descriptor.schemas.input = "mutated.input.v1";
+    }).toThrow(TypeError);
+    expect(DAEMON_ACTION_COMMAND_DEFINITIONS[0]?.descriptor.schemas.input).toBe(
+      "project.openTerminal.input.v1",
+    );
+  });
+
+  it("does not register reserved window-mode renderer commands", () => {
+    for (const id of WORKSPACE_WINDOW_MODE_COMMAND_IDS) {
+      expect(daemonActionCommandRegistry.has(id)).toBe(false);
+    }
+  });
+});

--- a/packages/daemon/src/command-center/actions/command-definitions.ts
+++ b/packages/daemon/src/command-center/actions/command-definitions.ts
@@ -1,0 +1,71 @@
+import {
+  ACTION_NAMES,
+  ActionContractsZ,
+  COMMAND_PROTOCOL_VERSION,
+  type ActionName,
+  type CommandDescriptor,
+} from "@tmux-ide/contracts";
+import type { ZodType } from "zod";
+import { CommandRegistry, type CommandDefinition } from "../../lib/command-registry.ts";
+
+interface ActionCommandMetadata {
+  label: string;
+  category: string;
+  dangerous?: boolean;
+}
+
+const ACTION_COMMAND_METADATA: Record<ActionName, ActionCommandMetadata> = {
+  "project.openTerminal": { label: "Open project terminal", category: "project" },
+  "project.launch": { label: "Launch project", category: "project" },
+  "project.stop": { label: "Stop project", category: "project", dangerous: true },
+  "project.restart": { label: "Restart project", category: "project", dangerous: true },
+  "project.activate": { label: "Activate project", category: "project" },
+  "terminal.respawn": { label: "Respawn terminal", category: "terminal" },
+  "terminal.stop": { label: "Stop terminal", category: "terminal", dangerous: true },
+  "config.set": { label: "Set configuration value", category: "configuration" },
+  "config.addPane": { label: "Add configuration pane", category: "configuration" },
+  "config.removePane": {
+    label: "Remove configuration pane",
+    category: "configuration",
+    dangerous: true,
+  },
+  "config.addRow": { label: "Add configuration row", category: "configuration" },
+  "config.enableTeam": { label: "Enable legacy team configuration", category: "compatibility" },
+  "config.disableTeam": {
+    label: "Disable legacy team configuration",
+    category: "compatibility",
+  },
+  "app.setRemoteAccess": { label: "Set remote access", category: "application" },
+  "daemon.shutdown": { label: "Shut down daemon", category: "daemon", dangerous: true },
+};
+
+function actionDescriptor(name: ActionName): CommandDescriptor {
+  const metadata = ACTION_COMMAND_METADATA[name];
+  return Object.freeze({
+    version: COMMAND_PROTOCOL_VERSION,
+    id: name,
+    owner: "daemon",
+    label: metadata.label,
+    category: metadata.category,
+    schemas: Object.freeze({
+      input: `${name}.input.v1`,
+      result: `${name}.result.v1`,
+    }),
+    dangerous: metadata.dangerous === true,
+    // Existing HTTP/CLI compatibility paths do not add interactive prompts.
+    confirmation: "none",
+  });
+}
+
+/** Every existing action adapted to the shared, handler-free command catalog. */
+export const DAEMON_ACTION_COMMAND_DEFINITIONS: readonly CommandDefinition[] = Object.freeze(
+  ACTION_NAMES.map((name) =>
+    Object.freeze({
+      descriptor: actionDescriptor(name),
+      inputSchema: ActionContractsZ[name].input as ZodType<unknown>,
+      resultSchema: ActionContractsZ[name].result as ZodType<unknown>,
+    }),
+  ),
+);
+
+export const daemonActionCommandRegistry = new CommandRegistry(DAEMON_ACTION_COMMAND_DEFINITIONS);

--- a/packages/daemon/src/command-center/actions/dispatcher.test.ts
+++ b/packages/daemon/src/command-center/actions/dispatcher.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { ActionContractsZ } from "./contract.ts";
+import { createActionDispatcher } from "./dispatcher.ts";
+import { setDaemonShutdownBackend } from "./handlers/daemon-shutdown.ts";
+
+const actionApp = (broadcast = vi.fn()) => {
+  const app = new Hono();
+  app.post("/api/v2/action/:name", createActionDispatcher({ broadcast }));
+  return { app, broadcast };
+};
+
+afterEach(() => {
+  setDaemonShutdownBackend(null);
+});
+
+describe("command-backed action dispatcher compatibility", () => {
+  it("keeps unknown action transport behavior unchanged", async () => {
+    const { app } = actionApp();
+    const response = await app.request("http://localhost/api/v2/action/no.suchAction", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: {
+        code: "validation_failed",
+        message: "Unknown action: no.suchAction",
+        details: { name: "no.suchAction" },
+      },
+    });
+  });
+
+  it("keeps malformed JSON a 400 transport failure", async () => {
+    const { app } = actionApp();
+    const response = await app.request("http://localhost/api/v2/action/project.launch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+    });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: { code: "validation_failed" },
+    });
+  });
+
+  it("keeps schema failures in the existing HTTP-200 action envelope", async () => {
+    const { app } = actionApp();
+    const response = await app.request("http://localhost/api/v2/action/project.launch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "" }),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: {
+        code: "validation_failed",
+        message: "Input failed schema validation",
+        details: { issues: expect.any(Array) },
+      },
+    });
+  });
+
+  it.each([
+    ["null", null],
+    ["array", []],
+    ["scalar", 7],
+  ])("keeps exact action-schema validation details for %s bodies", async (_kind, body) => {
+    const direct = ActionContractsZ["project.launch"].input.safeParse(body);
+    expect(direct.success).toBe(false);
+    if (direct.success) throw new Error("test body unexpectedly passed the action schema");
+
+    const { app } = actionApp();
+    const response = await app.request("http://localhost/api/v2/action/project.launch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: {
+        code: "validation_failed",
+        message: "Input failed schema validation",
+        details: { issues: direct.error.issues },
+      },
+    });
+  });
+
+  it("keeps success results and action.complete broadcast payloads unchanged", async () => {
+    setDaemonShutdownBackend(() => undefined);
+    const { app, broadcast } = actionApp();
+    const response = await app.request("http://localhost/api/v2/action/daemon.shutdown", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reason: "compatibility test" }),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, result: { stopping: true } });
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    expect(broadcast).toHaveBeenCalledWith("daemon.shutdown", { stopping: true });
+  });
+});

--- a/packages/daemon/src/command-center/actions/dispatcher.ts
+++ b/packages/daemon/src/command-center/actions/dispatcher.ts
@@ -18,10 +18,16 @@
 
 import type { Context } from "hono";
 import { ZodError } from "zod";
-import { isActionName, type ActionErrorEnvelope, type ActionName } from "./contract.ts";
+import {
+  COMMAND_PROTOCOL_VERSION,
+  isActionName,
+  type ActionErrorEnvelope,
+  type ActionName,
+} from "./contract.ts";
 import { ActionError, wrapInternalError } from "./errors.ts";
 import { getLooseActionEntry } from "./registry.ts";
 import { broadcastActionComplete } from "../ws-events.ts";
+import { daemonActionCommandRegistry } from "./command-definitions.ts";
 
 export interface DispatcherDeps {
   /** Override the WS broadcaster (tests / non-default daemons). */
@@ -106,20 +112,54 @@ export function createActionDispatcher(deps: DispatcherDeps = {}) {
     const actionName: ActionName = name;
     const entry = getLooseActionEntry(actionName);
 
+    // Preserve the public v2 action contract exactly: HTTP request bodies are
+    // validated by the action schema before they are adapted to commands. In
+    // particular, null/array/scalar bodies must keep the action schema's issue
+    // paths rather than gaining a command-envelope `args` prefix.
     const inputParsed = entry.inputSchema.safeParse(body);
     if (!inputParsed.success) {
       return c.json(zodErrorEnvelope(inputParsed.error) satisfies ActionErrorEnvelope, 200);
     }
 
+    const commandResolution = daemonActionCommandRegistry.resolve(
+      {
+        version: COMMAND_PROTOCOL_VERSION,
+        id: actionName,
+        source: { kind: "http" },
+        args: inputParsed.data,
+      },
+      undefined,
+    );
+    if (!commandResolution.ok) {
+      // The command adapter uses the same schema object as the action entry,
+      // so this is an internal registry drift rather than a client failure.
+      console.error("[actions] command adapter rejected action-schema-validated input", {
+        actionName,
+        error: commandResolution.error,
+      });
+      return c.json(
+        {
+          ok: false,
+          error: {
+            code: "internal",
+            message: "Action command adapter rejected validated input",
+          },
+        } satisfies ActionErrorEnvelope,
+        200,
+      );
+    }
+
     let result: unknown;
     try {
-      result = await entry.handler(inputParsed.data);
+      result = await entry.handler(commandResolution.command.input);
     } catch (err) {
       const wrapped = wrapInternalError(err);
       return c.json(errorEnvelope(wrapped) satisfies ActionErrorEnvelope, 200);
     }
 
-    const outputParsed = entry.resultSchema.safeParse(result);
+    const outputParsed = (commandResolution.command.resultSchema ?? entry.resultSchema).safeParse(
+      result,
+    );
     if (!outputParsed.success) {
       return c.json(outputZodErrorEnvelope(outputParsed.error) satisfies ActionErrorEnvelope, 200);
     }

--- a/packages/daemon/src/lib/__tests__/command-registry.test.ts
+++ b/packages/daemon/src/lib/__tests__/command-registry.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { COMMAND_PROTOCOL_VERSION, type CommandInvocation } from "@tmux-ide/contracts";
+import { CommandRegistry, type CommandDefinition } from "../command-registry.ts";
+
+interface Context {
+  active: boolean;
+}
+
+const definition = (): CommandDefinition<Context, { viewId: string }, { changed: boolean }> => ({
+  descriptor: {
+    version: COMMAND_PROTOCOL_VERSION,
+    id: "workspace.view.activate",
+    owner: "renderer",
+    label: "Activate view",
+    category: "workspace",
+    schemas: {
+      input: "workspace.view.activate.input.v1",
+      result: "workspace.view.activate.result.v1",
+    },
+    dangerous: false,
+    confirmation: "none",
+  },
+  inputSchema: z.object({ viewId: z.string().min(1) }).strict(),
+  resultSchema: z.object({ changed: z.boolean() }).strict(),
+  availability: (context) =>
+    context.active ? { available: true } : { available: false, reason: "workspace is inactive" },
+});
+
+const invocation = (overrides: Partial<CommandInvocation> = {}): CommandInvocation => ({
+  version: COMMAND_PROTOCOL_VERSION,
+  id: "workspace.view.activate",
+  source: { kind: "keyboard", surface: "workbench" },
+  args: { viewId: "terminals" },
+  ...overrides,
+});
+
+describe("CommandRegistry", () => {
+  it("prepares a schema-validated available command without running an effect", () => {
+    let availabilityCalls = 0;
+    const item = definition();
+    item.availability = (context) => {
+      availabilityCalls += 1;
+      return context.active
+        ? { available: true }
+        : { available: false, reason: "workspace is inactive" };
+    };
+    const registry = new CommandRegistry<Context>([item]);
+
+    const resolved = registry.resolve(invocation(), { active: true });
+
+    expect(resolved).toMatchObject({
+      ok: true,
+      command: {
+        descriptor: { id: "workspace.view.activate", owner: "renderer" },
+        input: { viewId: "terminals" },
+      },
+    });
+    expect(availabilityCalls).toBe(1);
+  });
+
+  it("rejects duplicate ids deterministically", () => {
+    expect(() => new CommandRegistry([definition(), definition()])).toThrow(
+      "duplicate command id: workspace.view.activate",
+    );
+  });
+
+  it("returns structured unknown, invalid-envelope, and invalid-input errors", () => {
+    const registry = new CommandRegistry<Context>([definition()]);
+    expect(
+      registry.resolve(invocation({ id: "workspace.view.missing" }), { active: true }),
+    ).toMatchObject({ ok: false, error: { code: "unknown-command" } });
+    expect(registry.resolve({ id: "workspace.view.activate" }, { active: true })).toMatchObject({
+      ok: false,
+      error: { code: "invalid-invocation", commandId: "workspace.view.activate" },
+    });
+    expect(registry.resolve(invocation({ args: { viewId: 7 } }), { active: true })).toMatchObject({
+      ok: false,
+      error: { code: "invalid-input" },
+    });
+  });
+
+  it("returns a reason and no prepared command when unavailable", () => {
+    expect(new CommandRegistry([definition()]).resolve(invocation(), { active: false })).toEqual({
+      ok: false,
+      error: {
+        code: "unavailable",
+        commandId: "workspace.view.activate",
+        message: "workspace is inactive",
+      },
+    });
+  });
+
+  it("keeps descriptors in registration order and exposes no definition or handler surface", () => {
+    const second = definition();
+    second.descriptor = { ...second.descriptor, id: "workspace.home.open", label: "Open home" };
+    const registry = new CommandRegistry([definition(), second]);
+    expect(registry.descriptors().map((item) => item.id)).toEqual([
+      "workspace.view.activate",
+      "workspace.home.open",
+    ]);
+    expect(registry).not.toHaveProperty("definition");
+    for (const descriptor of registry.descriptors()) {
+      expect(descriptor).not.toHaveProperty("handler");
+      expect(descriptor).not.toHaveProperty("execute");
+    }
+  });
+
+  it("copies and deeply freezes descriptor data at registration", () => {
+    const item = definition();
+    const registry = new CommandRegistry([item]);
+
+    item.descriptor.label = "Mutated outside registry";
+    item.descriptor.schemas.input = "mutated.input.v1";
+
+    const descriptors = registry.descriptors();
+    expect(descriptors[0]).toMatchObject({
+      label: "Activate view",
+      schemas: { input: "workspace.view.activate.input.v1" },
+    });
+    expect(Object.isFrozen(descriptors)).toBe(true);
+    expect(Object.isFrozen(descriptors[0])).toBe(true);
+    expect(Object.isFrozen(descriptors[0]?.schemas)).toBe(true);
+    expect(() => {
+      if (descriptors[0]) descriptors[0].schemas.input = "mutated.from-reader.v1";
+    }).toThrow(TypeError);
+    expect(registry.descriptors()[0]?.schemas.input).toBe("workspace.view.activate.input.v1");
+  });
+});

--- a/packages/daemon/src/lib/command-registry.ts
+++ b/packages/daemon/src/lib/command-registry.ts
@@ -1,0 +1,152 @@
+import {
+  CommandAvailabilitySchemaZ,
+  CommandDescriptorSchemaZ,
+  CommandIdSchemaZ,
+  CommandInvocationSchemaZ,
+  type CommandAvailability,
+  type CommandDescriptor,
+  type CommandInvocation,
+  type CommandResolutionError,
+} from "@tmux-ide/contracts";
+import type { ZodError, ZodType } from "zod";
+
+/** A command's data contract and pure availability predicate — never an effect. */
+export interface CommandDefinition<Context = unknown, Input = unknown, Result = unknown> {
+  descriptor: CommandDescriptor;
+  inputSchema: ZodType<Input>;
+  resultSchema?: ZodType<Result>;
+  availability?: (context: Context, input: Input) => CommandAvailability;
+}
+
+export interface PreparedCommand<Input = unknown, Result = unknown> {
+  descriptor: CommandDescriptor;
+  invocation: CommandInvocation;
+  input: Input;
+  resultSchema?: ZodType<Result>;
+}
+
+export type CommandResolution<Input = unknown, Result = unknown> =
+  | { ok: true; command: PreparedCommand<Input, Result> }
+  | { ok: false; error: CommandResolutionError };
+
+type LooseDefinition<Context> = CommandDefinition<Context, unknown, unknown>;
+
+function issues(error: ZodError): NonNullable<CommandResolutionError["details"]> {
+  return JSON.parse(JSON.stringify({ issues: error.issues })) as NonNullable<
+    CommandResolutionError["details"]
+  >;
+}
+
+function recoverCommandId(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || !("id" in value)) return undefined;
+  const id = (value as { id?: unknown }).id;
+  const parsed = CommandIdSchemaZ.safeParse(id);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function immutableDescriptor(rawDescriptor: CommandDescriptor): CommandDescriptor {
+  const descriptor = CommandDescriptorSchemaZ.parse(rawDescriptor);
+  return Object.freeze({
+    ...descriptor,
+    schemas: Object.freeze({ ...descriptor.schemas }),
+  });
+}
+
+/**
+ * Handler-free registry. Resolving is deterministic given the invocation and
+ * caller-supplied context; executing the prepared command belongs to its host.
+ */
+export class CommandRegistry<Context = unknown> {
+  private readonly definitions = new Map<string, LooseDefinition<Context>>();
+
+  constructor(definitions: readonly LooseDefinition<Context>[] = []) {
+    for (const definition of definitions) this.register(definition);
+  }
+
+  register<Input, Result>(definition: CommandDefinition<Context, Input, Result>): void {
+    const descriptor = immutableDescriptor(definition.descriptor);
+    if (this.definitions.has(descriptor.id)) {
+      throw new Error(`duplicate command id: ${descriptor.id}`);
+    }
+    this.definitions.set(descriptor.id, {
+      ...definition,
+      descriptor: Object.freeze(descriptor),
+    } as LooseDefinition<Context>);
+  }
+
+  has(id: string): boolean {
+    return this.definitions.has(id);
+  }
+
+  descriptors(): readonly CommandDescriptor[] {
+    return Object.freeze([...this.definitions.values()].map((definition) => definition.descriptor));
+  }
+
+  resolve(rawInvocation: unknown, context: Context): CommandResolution {
+    const invocationResult = CommandInvocationSchemaZ.safeParse(rawInvocation);
+    if (!invocationResult.success) {
+      const commandId = recoverCommandId(rawInvocation);
+      return {
+        ok: false,
+        error: {
+          code: "invalid-invocation",
+          message: "Command invocation failed envelope validation",
+          ...(commandId ? { commandId } : {}),
+          details: issues(invocationResult.error),
+        },
+      };
+    }
+    const invocation = invocationResult.data;
+    const definition = this.definitions.get(invocation.id);
+    if (!definition) {
+      return {
+        ok: false,
+        error: {
+          code: "unknown-command",
+          commandId: invocation.id,
+          message: `Unknown command: ${invocation.id}`,
+        },
+      };
+    }
+    const inputResult = definition.inputSchema.safeParse(invocation.args);
+    if (!inputResult.success) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid-input",
+          commandId: invocation.id,
+          message: "Command input failed schema validation",
+          details: issues(inputResult.error),
+        },
+      };
+    }
+    const availability = CommandAvailabilitySchemaZ.parse(
+      definition.availability?.(context, inputResult.data) ?? { available: true },
+    );
+    if (!availability.available) {
+      return {
+        ok: false,
+        error: {
+          code: "unavailable",
+          commandId: invocation.id,
+          message: availability.reason,
+        },
+      };
+    }
+    return {
+      ok: true,
+      command: {
+        descriptor: definition.descriptor,
+        invocation,
+        input: inputResult.data,
+        resultSchema: definition.resultSchema,
+      },
+    };
+  }
+}
+
+export function createCommandRegistry<Context>(
+  definitions: readonly CommandDefinition<Context, unknown, unknown>[],
+): CommandRegistry<Context> {
+  return new CommandRegistry(definitions);
+}

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -424,6 +424,16 @@ import {
   resolveQuitLifecycleCommand,
 } from "./input-lifecycle.ts";
 import {
+  RENDERER_COMMAND_IDS,
+  createRendererCommandExecutor,
+  rendererCommandInvocation,
+  rendererInvocationForCanvas,
+  rendererInvocationForDock,
+  rendererInvocationForGlobal,
+  rendererInvocationForLifecycle,
+  rendererInvocationForView,
+} from "./renderer-commands.ts";
+import {
   WorkspaceUiStateController,
   absoluteProjectPath,
   chooseInitialWorkspaceView,
@@ -3841,14 +3851,6 @@ try {
       createSession(raw, selectedHomeDir());
     };
 
-    /** Switch tabs preserving each surface's state: the editor buffer and diff
-     *  selection SURVIVE a round trip (only lazily initialized when a surface is
-     *  first shown empty). The Terminal tab never re-attaches here — the mirror is
-     *  already streaming in the background. */
-    const selectTab = (t: Tab) => {
-      setTab(t);
-    };
-
     // ── COMMAND PALETTE (M18.4, mouse-complete M21.9) ───────────────────────
     // A centered overlay (F5 / ^p / the tab bar's palette chip) — a fuzzy input
     // line + result list over the action model in palette.ts. The overlay is
@@ -3971,6 +3973,35 @@ try {
       switchClientBack: (callback) => execFile("tmux", ["switch-client", "-l"], callback),
       detachClient: () => execFile("tmux", ["detach-client"], () => {}),
     });
+    const rendererCommandExecutor = createRendererCommandExecutor({
+      context: () => ({
+        // Composite workspace views no longer own runtime pixels/input in the
+        // native workbench, so their legacy cycle command remains unavailable.
+        compositeFocusAvailable: false,
+        editorAvailable:
+          Boolean(editBuffer) || (mode() === "diff" && Boolean(diffVisibleFiles()[diffSel()])),
+      }),
+      effects: {
+        openPalette,
+        runLifecycle: (command) => lifecycleExecutor.run(command),
+        cycleCompositeFocus: () => {},
+        activateShortcut: (key) => {
+          const view = canvasHostedViews().find((candidate) => candidate.shortcut?.key === key);
+          if (view) selectView(view.id);
+        },
+        activateView: (viewId) => selectView(viewId),
+        activateCanvas: (panel) => activateCanvasPanel(panel),
+        activateDock: (tabId) => activateDockTab(tabId),
+        openHome: () => {
+          if (mode() !== "home") goHome();
+        },
+        toggleEditor: () => {
+          if (mode() === "diff") openSelectedInEditor();
+          else toggleEditor();
+        },
+      },
+    });
+    const executeRendererCommand = rendererCommandExecutor.execute;
     const runPaletteAction = (a: PaletteAction) => {
       // Usage history (M24.4): every dispatched action bumps its stable key —
       // count + lastUsed feed the "recent" group and the ranking tie-break.
@@ -3993,10 +4024,26 @@ try {
           openSearch();
           break;
         case "tab":
-          selectTab(a.tab);
+          if (a.tab === "home" || a.tab === "terminal") {
+            executeRendererCommand(
+              rendererInvocationForCanvas(a.tab === "home" ? "home" : "terminals", {
+                kind: "palette",
+                surface: "palette",
+              }),
+            );
+          } else {
+            executeRendererCommand(
+              rendererInvocationForDock(a.tab === "files" ? "files" : "changes", {
+                kind: "palette",
+                surface: "palette",
+              }),
+            );
+          }
           break;
         case "view":
-          selectView(a.viewId);
+          executeRendererCommand(
+            rendererInvocationForView(a.viewId, { kind: "palette", surface: "palette" }),
+          );
           break;
         case "open-folder":
           void openFolderFlow();
@@ -4127,7 +4174,11 @@ try {
           void runSettingsCommand(a.id);
           break;
         case "quit":
-          lifecycleExecutor.run(resolveQuitLifecycleCommand({ hosted: HOSTED }, "palette"));
+          executeRendererCommand(
+            rendererInvocationForLifecycle(
+              resolveQuitLifecycleCommand({ hosted: HOSTED }, "palette"),
+            ),
+          );
           break;
       }
     };
@@ -5637,11 +5688,17 @@ try {
         { hosted: HOSTED },
       );
       if (layer.kind === "lifecycle") {
-        lifecycleExecutor.run(layer.command);
+        executeRendererCommand(rendererInvocationForLifecycle(layer.command));
         return;
       }
       if (layer.kind === "kitty-super-palette") {
-        openPalette();
+        executeRendererCommand(
+          rendererCommandInvocation(
+            RENDERER_COMMAND_IDS.openPalette,
+            {},
+            { kind: "keyboard", surface: "workbench" },
+          ),
+        );
         return;
       }
       if (layer.kind === "kitty-super-suppressed") return;
@@ -5663,33 +5720,23 @@ try {
       }
       const canvasShortcut = workbenchCanvasPanelForShortcut(evt);
       if (canvasShortcut) {
-        activateCanvasPanel(canvasShortcut);
+        executeRendererCommand(
+          rendererInvocationForCanvas(canvasShortcut, {
+            kind: "keyboard",
+            surface: "workbench",
+          }),
+        );
         return;
       }
       const dockShortcut = workbenchDockTabForShortcut(evt);
       if (dockShortcut) {
-        activateDockTab(dockShortcut);
+        executeRendererCommand(
+          rendererInvocationForDock(dockShortcut, { kind: "keyboard", surface: "workbench" }),
+        );
         return;
       }
       if (layer.kind === "global") {
-        switch (layer.command.kind) {
-          case "open-palette":
-            openPalette();
-            break;
-          case "select-hosted-view": {
-            const shortcutKey = layer.command.key;
-            const fView = canvasHostedViews().find((view) => view.shortcut?.key === shortcutKey);
-            if (fView) selectView(fView.id);
-            break;
-          }
-          case "go-home":
-            if (mode() !== "home") goHome();
-            break;
-          case "toggle-editor":
-            if (mode() === "diff") openSelectedInEditor();
-            else toggleEditor();
-            break;
-        }
+        executeRendererCommand(rendererInvocationForGlobal(layer.command));
         return;
       }
       if (workbenchProjection().focusZone === "dock-tabs") {
@@ -6182,8 +6229,15 @@ try {
       };
     });
     const runTabbarButton = (id: string) => {
-      if (id === "tab-palette") openPalette();
-      else if (id === "tab-context" && contextSession()) switchTarget(contextSession());
+      if (id === "tab-palette") {
+        executeRendererCommand(
+          rendererCommandInvocation(
+            RENDERER_COMMAND_IDS.openPalette,
+            {},
+            { kind: "mouse", surface: "workbench" },
+          ),
+        );
+      } else if (id === "tab-context" && contextSession()) switchTarget(contextSession());
     };
     /** Which chip (if any) column `x` hits on the row for `it`. */
     const homeChipAt = (
@@ -6505,7 +6559,11 @@ try {
         }
       }
       if (hit.kind === "dock-tab") {
-        if (e.type === "down" && e.button !== 2) activateDockTab(hit.tabId);
+        if (e.type === "down" && e.button !== 2) {
+          executeRendererCommand(
+            rendererInvocationForDock(hit.tabId, { kind: "mouse", surface: "workbench" }),
+          );
+        }
         return true;
       }
       if (hit.kind === "dock-action") {
@@ -6920,14 +6978,25 @@ try {
           }
           const i = spanHit(surfaceSpans(), x);
           const view = canvasHostedViews()[i];
-          if (view?.panel === "home" || view?.panel === "terminals")
-            activateCanvasPanel(view.panel);
+          if (view?.panel === "home" || view?.panel === "terminals") {
+            executeRendererCommand(
+              rendererInvocationForCanvas(view.panel, { kind: "mouse", surface: "workbench" }),
+            );
+          }
           return;
         }
         const gy = y - TABBAR_H;
         if (x < sidebarW()) {
           if (y === dims().height - 1) {
-            if (spanHit([sidebarHint().buttonSpan], x) === 0) openPalette();
+            if (spanHit([sidebarHint().buttonSpan], x) === 0) {
+              executeRendererCommand(
+                rendererCommandInvocation(
+                  RENDERER_COMMAND_IDS.openPalette,
+                  {},
+                  { kind: "mouse", surface: "sidebar" },
+                ),
+              );
+            }
             return;
           }
           const hit = sidebarHit(gy, fleet().length, fleetAgents().length);
@@ -7179,7 +7248,11 @@ try {
         }
         const i = spanHit(surfaceSpans(), x);
         const view = canvasHostedViews()[i];
-        if (view?.panel === "home" || view?.panel === "terminals") activateCanvasPanel(view.panel);
+        if (view?.panel === "home" || view?.panel === "terminals") {
+          executeRendererCommand(
+            rendererInvocationForCanvas(view.panel, { kind: "mouse", surface: "workbench" }),
+          );
+        }
         return;
       }
       const gy = y - TABBAR_H;
@@ -7187,7 +7260,15 @@ try {
         if (type !== "down") return;
         // The footer hint's "F5 palette" segment is a chip (last screen row).
         if (y === dims().height - 1) {
-          if (spanHit([sidebarHint().buttonSpan], x) === 0) openPalette();
+          if (spanHit([sidebarHint().buttonSpan], x) === 0) {
+            executeRendererCommand(
+              rendererCommandInvocation(
+                RENDERER_COMMAND_IDS.openPalette,
+                {},
+                { kind: "mouse", surface: "sidebar" },
+              ),
+            );
+          }
           return;
         }
         // Session rows switch the workspace; agent rows JUMP to their exact pane

--- a/packages/daemon/src/tui/mirror/renderer-commands.test.ts
+++ b/packages/daemon/src/tui/mirror/renderer-commands.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from "vitest";
+import { COMMAND_PROTOCOL_VERSION, type CommandInvocation } from "@tmux-ide/contracts";
+import { z } from "zod";
+import { CommandRegistry } from "../../lib/command-registry.ts";
+import {
+  RENDERER_COMMAND_BYPASS_CHANNELS,
+  RENDERER_COMMAND_DEFINITIONS,
+  RENDERER_COMMAND_IDS,
+  createRendererCommandExecutor,
+  createRendererCommandRegistry,
+  rendererCommandInvocation,
+  rendererInvocationForCanvas,
+  rendererInvocationForDock,
+  rendererInvocationForGlobal,
+  rendererInvocationForLifecycle,
+  rendererInvocationForView,
+  rendererRegistersReservedWindowModeCommand,
+  type RendererCommandContext,
+  type RendererCommandEffects,
+} from "./renderer-commands.ts";
+
+const effects = (): RendererCommandEffects => ({
+  openPalette: vi.fn(),
+  runLifecycle: vi.fn(),
+  cycleCompositeFocus: vi.fn(),
+  activateShortcut: vi.fn(),
+  activateView: vi.fn(),
+  activateCanvas: vi.fn(),
+  activateDock: vi.fn(),
+  openHome: vi.fn(),
+  toggleEditor: vi.fn(),
+});
+
+const available: RendererCommandContext = {
+  compositeFocusAvailable: true,
+  editorAvailable: true,
+};
+
+describe("renderer command boundary", () => {
+  it("keeps the root lifecycle/global adapters stable", () => {
+    expect(rendererInvocationForGlobal({ kind: "open-palette" })).toMatchObject({
+      id: "app.palette.open",
+      source: { kind: "keyboard" },
+      args: {},
+    });
+    expect(rendererInvocationForGlobal({ kind: "select-hosted-view", key: "f2" })).toMatchObject({
+      id: "workspace.shortcut.activate",
+      args: { key: "f2" },
+    });
+    expect(rendererInvocationForLifecycle({ kind: "hosted-detach", source: "keyboard" })).toEqual({
+      version: 1,
+      id: "app.quit",
+      source: { kind: "keyboard", surface: "application" },
+      args: { kind: "hosted-detach", source: "keyboard" },
+    });
+    expect(
+      rendererInvocationForLifecycle({ kind: "destroy-renderer", source: "palette" }),
+    ).toMatchObject({
+      id: "app.quit",
+      source: { kind: "palette" },
+      args: { kind: "destroy-renderer", source: "palette" },
+    });
+  });
+
+  it("adapts canvas, dock, and configured view activations", () => {
+    expect(rendererInvocationForCanvas("home", { kind: "keyboard" })).toMatchObject({
+      id: "workspace.canvas.activate",
+      args: { panel: "home" },
+    });
+    expect(rendererInvocationForDock("missions", { kind: "keyboard" })).toMatchObject({
+      id: "workspace.dock.activate",
+      args: { tab: "missions" },
+    });
+    expect(rendererInvocationForView("my-view", { kind: "palette" })).toMatchObject({
+      id: "workspace.view.activate",
+      args: { viewId: "my-view" },
+    });
+  });
+
+  it("executes every converted effect through one injected seam", () => {
+    const calls = effects();
+    const executor = createRendererCommandExecutor({ context: () => available, effects: calls });
+    executor.execute(rendererInvocationForGlobal({ kind: "open-palette" }));
+    executor.execute(rendererInvocationForGlobal({ kind: "cycle-composite-focus" }));
+    executor.execute(rendererInvocationForGlobal({ kind: "go-home" }));
+    executor.execute(rendererInvocationForGlobal({ kind: "toggle-editor" }));
+    executor.execute(rendererInvocationForCanvas("terminals", { kind: "mouse" }));
+    executor.execute(rendererInvocationForDock("changes", { kind: "keyboard" }));
+    executor.execute(rendererInvocationForView("focus", { kind: "palette" }));
+
+    expect(calls.openPalette).toHaveBeenCalledTimes(1);
+    expect(calls.cycleCompositeFocus).toHaveBeenCalledTimes(1);
+    expect(calls.openHome).toHaveBeenCalledTimes(1);
+    expect(calls.toggleEditor).toHaveBeenCalledTimes(1);
+    expect(calls.activateCanvas).toHaveBeenCalledWith("terminals");
+    expect(calls.activateDock).toHaveBeenCalledWith("changes");
+    expect(calls.activateView).toHaveBeenCalledWith("focus");
+  });
+
+  it("preserves hosted keyboard detach and palette destroy lifecycle commands", () => {
+    const calls = effects();
+    const executor = createRendererCommandExecutor({ context: () => available, effects: calls });
+    executor.execute(rendererInvocationForLifecycle({ kind: "hosted-detach", source: "keyboard" }));
+    executor.execute(
+      rendererInvocationForLifecycle({ kind: "destroy-renderer", source: "palette" }),
+    );
+    expect(calls.runLifecycle).toHaveBeenNthCalledWith(1, {
+      kind: "hosted-detach",
+      source: "keyboard",
+    });
+    expect(calls.runLifecycle).toHaveBeenNthCalledWith(2, {
+      kind: "destroy-renderer",
+      source: "palette",
+    });
+  });
+
+  it("keeps unavailable commands from reaching effects", () => {
+    const calls = effects();
+    const rejected = vi.fn();
+    const executor = createRendererCommandExecutor({
+      context: () => ({ compositeFocusAvailable: false, editorAvailable: false }),
+      effects: calls,
+      onRejected: rejected,
+    });
+    expect(executor.execute(rendererInvocationForGlobal({ kind: "toggle-editor" }))).toMatchObject({
+      ok: false,
+      error: { code: "unavailable", message: "no file is open" },
+    });
+    expect(calls.toggleEditor).not.toHaveBeenCalled();
+    expect(rejected).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores an injected custom registry and rejects its unknown renderer ids", () => {
+    const calls = effects();
+    const rejected = vi.fn();
+    const maliciousRegistry = new CommandRegistry<RendererCommandContext>([
+      {
+        descriptor: {
+          version: COMMAND_PROTOCOL_VERSION,
+          id: "app.malicious",
+          owner: "renderer",
+          label: "Run arbitrary effect",
+          category: "application",
+          schemas: { input: "app.malicious.input.v1" },
+          dangerous: false,
+          confirmation: "none",
+        },
+        inputSchema: z.object({}).strict(),
+      },
+    ]);
+    const executorInput = {
+      registry: maliciousRegistry,
+      context: () => available,
+      effects: calls,
+      onRejected: rejected,
+    };
+    const executor = createRendererCommandExecutor(executorInput);
+    const invocation: CommandInvocation = {
+      version: COMMAND_PROTOCOL_VERSION,
+      id: "app.malicious",
+      source: { kind: "program" },
+      args: {},
+    };
+
+    expect(executor.execute(invocation)).toMatchObject({
+      ok: false,
+      error: { code: "unknown-command", commandId: "app.malicious" },
+    });
+    expect(rejected).toHaveBeenCalledTimes(1);
+    for (const effect of Object.values(calls)) expect(effect).not.toHaveBeenCalled();
+  });
+
+  it("ignores injected schema drift and validates effects with canonical schemas", () => {
+    const calls = effects();
+    const driftedRegistry = new CommandRegistry<RendererCommandContext>([
+      {
+        descriptor: {
+          version: COMMAND_PROTOCOL_VERSION,
+          id: RENDERER_COMMAND_IDS.quit,
+          owner: "renderer",
+          label: "Drifted quit",
+          category: "application",
+          schemas: { input: "app.quit.drifted.input.v1" },
+          dangerous: false,
+          confirmation: "none",
+        },
+        inputSchema: z.object({ kind: z.string(), source: z.string() }).strict(),
+      },
+    ]);
+    const executorInput = {
+      registry: driftedRegistry,
+      context: () => available,
+      effects: calls,
+    };
+    const executor = createRendererCommandExecutor(executorInput);
+    const invalidLifecycle: CommandInvocation = {
+      version: COMMAND_PROTOCOL_VERSION,
+      id: RENDERER_COMMAND_IDS.quit,
+      source: { kind: "program" },
+      args: { kind: "hosted-detach", source: "palette" },
+    };
+
+    expect(executor.execute(invalidLifecycle)).toMatchObject({
+      ok: false,
+      error: { code: "invalid-input", commandId: RENDERER_COMMAND_IDS.quit },
+    });
+    expect(calls.runLifecycle).not.toHaveBeenCalled();
+  });
+
+  it("keeps raw Ctrl-C, paste, PTY output, and resize outside the catalog", () => {
+    expect(RENDERER_COMMAND_BYPASS_CHANNELS).toEqual(["ctrl-c", "paste", "pty-output", "resize"]);
+    const ids = createRendererCommandRegistry()
+      .descriptors()
+      .map((item) => item.id);
+    for (const channel of RENDERER_COMMAND_BYPASS_CHANNELS) {
+      expect(ids.some((id) => id.includes(channel))).toBe(false);
+    }
+  });
+
+  it("does not register or execute the reserved Card12 window-mode ids", () => {
+    expect(rendererRegistersReservedWindowModeCommand()).toBe(false);
+  });
+
+  it("keeps every definition data-only and serializable", () => {
+    for (const definition of RENDERER_COMMAND_DEFINITIONS) {
+      expect(JSON.parse(JSON.stringify(definition.descriptor))).toEqual(definition.descriptor);
+      expect(definition).not.toHaveProperty("handler");
+      expect(definition).not.toHaveProperty("execute");
+      expect(Object.isFrozen(definition)).toBe(true);
+      expect(Object.isFrozen(definition.descriptor)).toBe(true);
+      expect(Object.isFrozen(definition.descriptor.schemas)).toBe(true);
+    }
+    expect(Object.isFrozen(RENDERER_COMMAND_DEFINITIONS)).toBe(true);
+    const registry = createRendererCommandRegistry();
+    expect(
+      registry.resolve(
+        rendererCommandInvocation(RENDERER_COMMAND_IDS.openPalette, {}, { kind: "keyboard" }),
+        available,
+      ),
+    ).toMatchObject({ ok: true });
+  });
+});

--- a/packages/daemon/src/tui/mirror/renderer-commands.ts
+++ b/packages/daemon/src/tui/mirror/renderer-commands.ts
@@ -1,0 +1,331 @@
+import {
+  COMMAND_PROTOCOL_VERSION,
+  WORKSPACE_WINDOW_MODE_COMMAND_IDS,
+  type CommandArguments,
+  type CommandDescriptor,
+  type CommandInvocation,
+  type CommandResolutionError,
+  type CommandSource,
+} from "@tmux-ide/contracts";
+import { z } from "zod";
+import { CommandRegistry, type CommandDefinition } from "../../lib/command-registry.ts";
+import type { TuiGlobalCommand, TuiLifecycleCommand } from "./input-lifecycle.ts";
+import type { WorkbenchCanvasPanel } from "./workspace/workbench-controller.ts";
+import type { WorkbenchDockTabId } from "./workspace/workbench-shell.ts";
+
+export const RENDERER_COMMAND_IDS = {
+  openPalette: "app.palette.open",
+  quit: "app.quit",
+  cycleCompositeFocus: "workspace.composite.focusCycle",
+  activateShortcut: "workspace.shortcut.activate",
+  activateView: "workspace.view.activate",
+  activateCanvas: "workspace.canvas.activate",
+  activateDock: "workspace.dock.activate",
+  openHome: "workspace.home.open",
+  toggleEditor: "workspace.editor.toggle",
+} as const;
+
+export type RendererCommandId = (typeof RENDERER_COMMAND_IDS)[keyof typeof RENDERER_COMMAND_IDS];
+
+/** Raw terminal channels are transport/data paths, never semantic commands. */
+export const RENDERER_COMMAND_BYPASS_CHANNELS = [
+  "ctrl-c",
+  "paste",
+  "pty-output",
+  "resize",
+] as const;
+
+export interface RendererCommandContext {
+  compositeFocusAvailable: boolean;
+  editorAvailable: boolean;
+}
+
+export interface RendererCommandEffects {
+  openPalette: () => void;
+  runLifecycle: (command: TuiLifecycleCommand) => void;
+  cycleCompositeFocus: () => void;
+  activateShortcut: (key: string) => void;
+  activateView: (viewId: string) => void;
+  activateCanvas: (panel: WorkbenchCanvasPanel) => void;
+  activateDock: (tab: WorkbenchDockTabId) => void;
+  openHome: () => void;
+  toggleEditor: () => void;
+}
+
+export type RendererCommandExecution =
+  | { ok: true; commandId: RendererCommandId }
+  | { ok: false; error: CommandResolutionError };
+
+const EmptyInputSchemaZ = z.object({}).strict();
+const LifecycleInputSchemaZ = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("destroy-renderer"),
+      source: z.enum(["keyboard", "palette", "error"]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("hosted-detach"),
+      source: z.literal("keyboard"),
+    })
+    .strict(),
+]);
+const ShortcutInputSchemaZ = z.object({ key: z.string().min(1).max(32) }).strict();
+const ViewInputSchemaZ = z.object({ viewId: z.string().min(1).max(160) }).strict();
+const CanvasInputSchemaZ = z.object({ panel: z.enum(["home", "terminals"]) }).strict();
+const DockInputSchemaZ = z
+  .object({ tab: z.enum(["files", "changes", "missions", "activity"]) })
+  .strict();
+
+interface RendererCommandMetadata {
+  id: RendererCommandId;
+  label: string;
+  category: string;
+  inputSchema: z.ZodType;
+  availability?: CommandDefinition<RendererCommandContext>["availability"];
+}
+
+const metadata: readonly RendererCommandMetadata[] = [
+  {
+    id: RENDERER_COMMAND_IDS.openPalette,
+    label: "Open command palette",
+    category: "application",
+    inputSchema: EmptyInputSchemaZ,
+  },
+  {
+    id: RENDERER_COMMAND_IDS.quit,
+    label: "Quit or detach",
+    category: "application",
+    inputSchema: LifecycleInputSchemaZ,
+  },
+  {
+    id: RENDERER_COMMAND_IDS.cycleCompositeFocus,
+    label: "Cycle composite focus",
+    category: "workspace",
+    inputSchema: EmptyInputSchemaZ,
+    availability: (context) =>
+      context.compositeFocusAvailable
+        ? { available: true }
+        : { available: false, reason: "composite focus is unavailable" },
+  },
+  {
+    id: RENDERER_COMMAND_IDS.activateShortcut,
+    label: "Activate workspace shortcut",
+    category: "workspace",
+    inputSchema: ShortcutInputSchemaZ,
+  },
+  {
+    id: RENDERER_COMMAND_IDS.activateView,
+    label: "Activate workspace view",
+    category: "workspace",
+    inputSchema: ViewInputSchemaZ,
+  },
+  {
+    id: RENDERER_COMMAND_IDS.activateCanvas,
+    label: "Activate canvas panel",
+    category: "workspace",
+    inputSchema: CanvasInputSchemaZ,
+  },
+  {
+    id: RENDERER_COMMAND_IDS.activateDock,
+    label: "Activate dock panel",
+    category: "workspace",
+    inputSchema: DockInputSchemaZ,
+  },
+  {
+    id: RENDERER_COMMAND_IDS.openHome,
+    label: "Open Home",
+    category: "workspace",
+    inputSchema: EmptyInputSchemaZ,
+  },
+  {
+    id: RENDERER_COMMAND_IDS.toggleEditor,
+    label: "Toggle editor",
+    category: "workspace",
+    inputSchema: EmptyInputSchemaZ,
+    availability: (context) =>
+      context.editorAvailable
+        ? { available: true }
+        : { available: false, reason: "no file is open" },
+  },
+];
+
+function descriptor(item: RendererCommandMetadata): CommandDescriptor {
+  return Object.freeze({
+    version: COMMAND_PROTOCOL_VERSION,
+    id: item.id,
+    owner: "renderer",
+    label: item.label,
+    category: item.category,
+    schemas: Object.freeze({ input: `${item.id}.input.v1` }),
+    dangerous: false,
+    confirmation: "none",
+  });
+}
+
+export const RENDERER_COMMAND_DEFINITIONS: readonly CommandDefinition<RendererCommandContext>[] =
+  Object.freeze(
+    metadata.map((item) =>
+      Object.freeze({
+        descriptor: descriptor(item),
+        inputSchema: item.inputSchema,
+        ...(item.availability ? { availability: item.availability } : {}),
+      }),
+    ),
+  );
+
+export function createRendererCommandRegistry(): CommandRegistry<RendererCommandContext> {
+  return new CommandRegistry(RENDERER_COMMAND_DEFINITIONS);
+}
+
+const canonicalRendererCommandRegistry = createRendererCommandRegistry();
+
+const rendererCommandIds = new Set<string>(Object.values(RENDERER_COMMAND_IDS));
+
+function isRendererCommandId(id: string): id is RendererCommandId {
+  return rendererCommandIds.has(id);
+}
+
+export function rendererCommandInvocation(
+  id: RendererCommandId,
+  args: CommandArguments,
+  source: CommandSource,
+): CommandInvocation {
+  return {
+    version: COMMAND_PROTOCOL_VERSION,
+    id,
+    source,
+    args,
+  };
+}
+
+export function rendererInvocationForLifecycle(command: TuiLifecycleCommand): CommandInvocation {
+  return rendererCommandInvocation(
+    RENDERER_COMMAND_IDS.quit,
+    { kind: command.kind, source: command.source },
+    {
+      kind:
+        command.source === "keyboard"
+          ? "keyboard"
+          : command.source === "palette"
+            ? "palette"
+            : "program",
+      surface: "application",
+    },
+  );
+}
+
+export function rendererInvocationForGlobal(command: TuiGlobalCommand): CommandInvocation {
+  const source: CommandSource = { kind: "keyboard", surface: "workbench" };
+  switch (command.kind) {
+    case "cycle-composite-focus":
+      return rendererCommandInvocation(RENDERER_COMMAND_IDS.cycleCompositeFocus, {}, source);
+    case "open-palette":
+      return rendererCommandInvocation(RENDERER_COMMAND_IDS.openPalette, {}, source);
+    case "select-hosted-view":
+      return rendererCommandInvocation(
+        RENDERER_COMMAND_IDS.activateShortcut,
+        { key: command.key },
+        source,
+      );
+    case "go-home":
+      return rendererCommandInvocation(RENDERER_COMMAND_IDS.openHome, {}, source);
+    case "toggle-editor":
+      return rendererCommandInvocation(RENDERER_COMMAND_IDS.toggleEditor, {}, source);
+  }
+}
+
+export function rendererInvocationForCanvas(
+  panel: WorkbenchCanvasPanel,
+  source: CommandSource,
+): CommandInvocation {
+  return rendererCommandInvocation(RENDERER_COMMAND_IDS.activateCanvas, { panel }, source);
+}
+
+export function rendererInvocationForDock(
+  tab: WorkbenchDockTabId,
+  source: CommandSource,
+): CommandInvocation {
+  return rendererCommandInvocation(RENDERER_COMMAND_IDS.activateDock, { tab }, source);
+}
+
+export function rendererInvocationForView(
+  viewId: string,
+  source: CommandSource,
+): CommandInvocation {
+  return rendererCommandInvocation(RENDERER_COMMAND_IDS.activateView, { viewId }, source);
+}
+
+export function createRendererCommandExecutor(input: {
+  context: () => RendererCommandContext;
+  effects: RendererCommandEffects;
+  onRejected?: (error: CommandResolutionError) => void;
+}): { execute(invocation: CommandInvocation): RendererCommandExecution } {
+  // Keep execution closed over the canonical catalog. Tests can inject state,
+  // effects, and rejection observation, but never alternate IDs or schemas.
+  return {
+    execute(invocation) {
+      const resolved = canonicalRendererCommandRegistry.resolve(invocation, input.context());
+      if (!resolved.ok) {
+        input.onRejected?.(resolved.error);
+        return resolved;
+      }
+      if (resolved.command.descriptor.owner !== "renderer") {
+        const error: CommandResolutionError = {
+          code: "unavailable",
+          commandId: resolved.command.descriptor.id,
+          message: `Command is owned by ${resolved.command.descriptor.owner}`,
+        };
+        input.onRejected?.(error);
+        return { ok: false, error };
+      }
+      const commandId = resolved.command.descriptor.id;
+      if (!isRendererCommandId(commandId)) {
+        const error: CommandResolutionError = {
+          code: "unknown-command",
+          commandId,
+          message: `Unknown renderer command: ${commandId}`,
+        };
+        input.onRejected?.(error);
+        return { ok: false, error };
+      }
+      switch (commandId) {
+        case RENDERER_COMMAND_IDS.openPalette:
+          input.effects.openPalette();
+          break;
+        case RENDERER_COMMAND_IDS.quit:
+          input.effects.runLifecycle(LifecycleInputSchemaZ.parse(resolved.command.input));
+          break;
+        case RENDERER_COMMAND_IDS.cycleCompositeFocus:
+          input.effects.cycleCompositeFocus();
+          break;
+        case RENDERER_COMMAND_IDS.activateShortcut:
+          input.effects.activateShortcut(ShortcutInputSchemaZ.parse(resolved.command.input).key);
+          break;
+        case RENDERER_COMMAND_IDS.activateView:
+          input.effects.activateView(ViewInputSchemaZ.parse(resolved.command.input).viewId);
+          break;
+        case RENDERER_COMMAND_IDS.activateCanvas:
+          input.effects.activateCanvas(CanvasInputSchemaZ.parse(resolved.command.input).panel);
+          break;
+        case RENDERER_COMMAND_IDS.activateDock:
+          input.effects.activateDock(DockInputSchemaZ.parse(resolved.command.input).tab);
+          break;
+        case RENDERER_COMMAND_IDS.openHome:
+          input.effects.openHome();
+          break;
+        case RENDERER_COMMAND_IDS.toggleEditor:
+          input.effects.toggleEditor();
+          break;
+      }
+      return { ok: true, commandId };
+    },
+  };
+}
+
+/** Drift guard: Card07 only reserves these names; Card12 owns their behavior. */
+export function rendererRegistersReservedWindowModeCommand(): boolean {
+  const registered = new Set(RENDERER_COMMAND_DEFINITIONS.map((item) => item.descriptor.id));
+  return WORKSPACE_WINDOW_MODE_COMMAND_IDS.some((id) => registered.has(id));
+}


### PR DESCRIPTION
Adds the Card07A process-neutral command protocol and handler-free registry, adapts all existing daemon actions without changing their HTTP envelopes, and routes root lifecycle/navigation effects through a closed renderer executor. Raw Ctrl-C, paste, PTY, and resize paths remain direct transport. Includes compatibility, immutability, availability, and renderer boundary coverage.\n\nValidation: full pnpm check; focused review suites; contracts and daemon typechecks; TUI build and multi-size Ctrl-C/Ctrl-Q smoke tests.