### PR TITLE
Add app-native chrome to every terminal pane

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -217,8 +217,6 @@ import { Sidebar } from "./sidebar.tsx";
 import {
   ACCENT,
   BADGE_BG,
-  BUTTON_HOVER_BG,
-  CHIP_ATTN_BG,
   DEFAULT_BG,
   DEFAULT_FG,
   FOCUS_BORDER_FG,
@@ -353,6 +351,16 @@ import {
   projectAgentTerminalCanvas,
 } from "./workspace/agent-terminal-canvas.ts";
 import { AgentTerminalCanvas } from "./workspace/agent-terminal-canvas-view.tsx";
+import {
+  dispatchTerminalPaneChromePointerIntent,
+  projectTerminalPaneChrome,
+  reconcileTerminalPaneChromeActionTarget,
+  terminalPaneChromeMotionState,
+  terminalPaneChromePointerIntent,
+  type TerminalPaneChromeActionTarget,
+  type TerminalPaneChromeMetadata,
+} from "./workspace/terminal-pane-chrome.ts";
+import { TerminalPaneChromeLayer } from "./workspace/terminal-pane-chrome-view.tsx";
 import {
   resolveWorkbenchPasteTarget,
   workbenchCanvasPanelForShortcut,
@@ -543,7 +551,6 @@ import {
   AGENTS_GAP_ROWS,
   type AgentRowInput,
 } from "./agent-rows.ts";
-import { STATUS_COLOR, STATUS_GLYPH } from "./status-grammar.ts";
 import {
   findMatches,
   visitOrder,
@@ -605,7 +612,7 @@ import {
   type SpawnWhere,
 } from "./agent-lifecycle.ts";
 import { getManifests } from "../detect/manifest-loader.ts";
-import { agentsByPane, chipLabel } from "./agent-chip.ts";
+import { agentsByPane } from "./agent-chip.ts";
 import { focusStrips } from "./focus-border.ts";
 import { scrollThumb, trackZone, pageTop, dragTop } from "./scrollbar-model.ts";
 import {
@@ -1171,6 +1178,9 @@ try {
     const panesById = createMemo(() => new Map(panes().map((p) => [p.id, p])));
     const [windowTabs, setWindowTabs] = createSignal<WindowTab[]>([]);
     const [projectsData, setProjectsData] = createSignal<FleetProject[]>([]);
+    // The fleet payload's per-pane entries join directly to tmux's live %pane_id.
+    // Drag policy and pane chrome consume this same authority-derived map.
+    const agentByPane = createMemo(() => agentsByPane(projectsData()));
     // Pointer-hover feedback. One nullable signal names the hovered target as a
     // {region, index}; the same coordinate math that routes clicks resolves it on
     // motion events, and each hoverable render reads it for a subtle HOVER_BG. It
@@ -1667,6 +1677,66 @@ try {
         footerRows: search() ? 1 : 0,
       }),
     );
+    const [hoveredTerminalPaneAction, setHoveredTerminalPaneAction] =
+      createSignal<TerminalPaneChromeActionTarget | null>(null);
+    const [pressedTerminalPaneAction, setPressedTerminalPaneAction] =
+      createSignal<TerminalPaneChromeActionTarget | null>(null);
+    const clearTerminalPaneActionState = () => {
+      if (hoveredTerminalPaneAction() !== null) setHoveredTerminalPaneAction(null);
+      if (pressedTerminalPaneAction() !== null) setPressedTerminalPaneAction(null);
+    };
+    const terminalPaneChromeMetadata = createMemo(() => {
+      const metadata = new Map<string, TerminalPaneChromeMetadata>();
+      const appStatus = status();
+      const appStatusTone: TerminalPaneChromeMetadata["statusTone"] = appStatus.startsWith("error")
+        ? "blocked"
+        : appStatus === "live"
+          ? "done"
+          : "working";
+      for (const pane of panes()) {
+        const agent = agentByPane().get(pane.id);
+        metadata.set(pane.id, {
+          // SessionMirror may add title/currentCommand descriptors later. Null
+          // deliberately leaves that seam to the pure projection, which falls
+          // back to the always-distinct live %pane_id today.
+          title: agent?.displayName ?? agent?.kind ?? null,
+          subtitle: agent
+            ? `${agent.displayName ? `${agent.kind} · ` : ""}${curTarget()} · ${pane.id}`
+            : `${curTarget()} · ${pane.id}`,
+          status: agent?.statusText ?? agent?.state ?? appStatus,
+          statusTone: agent?.state ?? appStatusTone,
+          attention: agent?.state === "blocked" || (!agent && appStatusTone === "blocked"),
+        });
+      }
+      return metadata;
+    });
+    const terminalPaneChromeLayout = createMemo(() =>
+      projectTerminalPaneChrome({
+        canvas: terminalCanvasProjection(),
+        panes: panes(),
+        metadataByPane: terminalPaneChromeMetadata(),
+        hoveredAction: hoveredTerminalPaneAction(),
+        pressedAction: pressedTerminalPaneAction(),
+      }),
+    );
+    createEffect(() => {
+      const paneIds = new Set(panes().map((pane) => pane.id));
+      const terminalsActive = canvasPanel() === "terminals";
+      const hovered = hoveredTerminalPaneAction();
+      const pressed = pressedTerminalPaneAction();
+      const nextHovered = reconcileTerminalPaneChromeActionTarget(
+        hovered,
+        paneIds,
+        terminalsActive,
+      );
+      const nextPressed = reconcileTerminalPaneChromeActionTarget(
+        pressed,
+        paneIds,
+        terminalsActive,
+      );
+      if (nextHovered !== hovered) setHoveredTerminalPaneAction(nextHovered);
+      if (nextPressed !== pressed) setPressedTerminalPaneAction(nextPressed);
+    });
     /** Exact tmux framebuffer dimensions, excluding shell tab chrome, focus rail,
      *  terminal chrome, and native workbench dock. Search overlays the last row. */
     const canvasCols = () => terminalCanvasProjection().framebuffer.width;
@@ -5304,13 +5374,13 @@ try {
           diffPath: join(diffDir(), row.entry.path),
         };
       }
-      // mirror: gy=0 is the target/status row (no menu); gy=1 is the WINDOW STRIP —
+      // mirror: gy=0 is the WINDOW STRIP; gy=1 is per-pane native chrome —
       // a right-click there opens the window menu. The window under a label span is
       // the target; an empty-area / button right-click (span miss) falls back to the
       // ACTIVE window. This dual targeting means the menu still opens even if the
       // strip's known label-cell click swallow (see windowStripParts) eats the hit,
       // because the empty area to the right of the labels always routes.
-      if (gy === 1) {
+      if (gy === 0) {
         const i = spanHit(windowSpans(), x);
         const tabs = windowTabs();
         const w = i >= 0 ? tabs[i] : tabs.find((t) => t.active);
@@ -5322,7 +5392,7 @@ try {
           windowIndex: w.index,
         };
       }
-      // The pane canvas lives below the header (gy=0) + window strip (gy=1).
+      // The pane canvas lives below the window strip (gy=0) + pane chrome (gy=1).
       if (gy < HEADER_ROWS) return null;
       const cx = x - sidebarW();
       const cy = gy - HEADER_ROWS;
@@ -5387,8 +5457,13 @@ try {
     };
 
     /** Open the context menu at the pointer, clamped fully on-screen. */
-    const openMenu = (targetX: number, y: number, screenX = targetX) => {
-      const t = resolveMenuTarget(targetX, y);
+    const openMenu = (
+      targetX: number,
+      y: number,
+      screenX = targetX,
+      explicitTarget?: Omit<MenuState, "left" | "top" | "width" | "height">,
+    ) => {
+      const t = explicitTarget ?? resolveMenuTarget(targetX, y);
       if (!t) {
         closeMenu();
         return;
@@ -6120,26 +6195,6 @@ try {
     // reports the same value; reading the focused pane keeps the intent clear).
     const focusedLivePane = () => panes().find((p) => p.active);
     const isZoomed = () => focusedLivePane()?.zoomed ?? false;
-    /** Buttons on the terminal window-strip row (gy=1): zoom-toggle then a vertical
-     *  split of the focused pane. Placed on the far right, clear of the window-label
-     *  cells. The zoom chip renders active-tinted while the window is zoomed. */
-    const stripButtons = createMemo<{ defs: HeaderButton[]; spans: Span[] }>(() => {
-      const defs: HeaderButton[] =
-        mode() === "mirror" && panes().length > 0
-          ? [
-              { id: "zoom", label: "[⛶]", active: isZoomed() },
-              { id: "split", label: "[+ split]" },
-            ]
-          : [];
-      return {
-        defs,
-        spans: spansFromRight(
-          defs.map((d) => d.label),
-          buttonRightEdge(),
-          1,
-        ),
-      };
-    });
     const runHomeAction = (id: HomeActionId, itemIndex = clampedSel()) => {
       if (id === "open-folder") void openFolderFlow();
       else if (id === "new-agent") newAgentFromHome(homeItems()[itemIndex] ?? selectedHomeItem());
@@ -6172,22 +6227,10 @@ try {
       else if (id === "refresh") refreshTree();
     };
 
-    /** Run a header/strip button by id. Reload re-reads the open file from disk
-     *  (discarding unsaved edits — the ● dot warns first); split forks the focused
-     *  pane via the control client, same command the context menu issues. */
-    const runButton = (id: string) => {
-      if (id === "save") saveEditor();
-      else if (id === "reload") {
-        const p = editorPath();
-        if (p) openEditor(p);
-      } else if (id === "refresh") refreshStatus();
-      else if (id === "split") {
-        const pid = mirror?.focusedPane();
-        if (pid) void mirror?.command(`split-window -h -t ${pid}`).catch(() => {});
-      } else if (id === "zoom") {
-        const pid = mirror?.focusedPane();
-        if (pid) void mirror?.command(`resize-pane -Z -t ${pid}`).catch(() => {});
-      }
+    /** The root pane-chrome dispatcher focuses before calling this command edge. */
+    const runTerminalPaneAction = (paneId: string, id: string) => {
+      if (id === "split") void mirror?.command(`split-window -h -t ${paneId}`).catch(() => {});
+      else if (id === "zoom") void mirror?.command(`resize-pane -Z -t ${paneId}`).catch(() => {});
     };
 
     /** The strip as THREE static texts (pre/active/post) whose STRINGS update.
@@ -6469,14 +6512,9 @@ try {
         }
         return;
       }
-      // mirror mode: the per-window strip lives on gy=1, with the [+ split] button
-      // on its right (checked first, matching the click router's precedence).
-      if (gy === 1) {
-        const bi = spanHit(stripButtons().spans, x);
-        if (bi >= 0) {
-          setHoverIf({ region: "button", index: bi });
-          return;
-        }
+      // mirror mode: the per-window strip lives on gy=0. Pane actions occupy the
+      // segmented native row immediately above each framebuffer on gy=1.
+      if (gy === 0) {
         const i = spanHit(windowSpans(), x);
         setHoverIf(i >= 0 ? { region: "windowtab", index: i } : null);
         return;
@@ -6511,17 +6549,75 @@ try {
      *  rail), and every dock event is consumed so wheel/right-click/drag can
      *  never leak into the terminal transport beneath it. */
     const routeWorkbenchPointer = (e: RouteEvent): boolean => {
-      if (e.y < TABBAR_H || e.x < sidebarW()) return false;
+      if (e.y < TABBAR_H || e.x < sidebarW()) {
+        clearTerminalPaneActionState();
+        return false;
+      }
       const hit = workbenchShellHitTest(workbenchProjection(), e.x - sidebarW(), e.y - TABBAR_H);
-      if (!hit) return false;
+      if (!hit) {
+        clearTerminalPaneActionState();
+        return false;
+      }
+      if (hit.kind !== "canvas") clearTerminalPaneActionState();
       const releaseAtBoundary =
         hit.kind !== "canvas" &&
         (e.type === "up" || e.type === "drag-end" || e.type === "drop" || e.type === "out");
       if (releaseAtBoundary) {
+        setPressedTerminalPaneAction(null);
         settleTerminalGestureBoundary(e);
         return true;
       }
       if (hit.kind === "canvas") {
+        if (e.type === "up" || e.type === "drag-end" || e.type === "drop" || e.type === "out") {
+          setPressedTerminalPaneAction(null);
+        }
+        if (canvasPanel() === "terminals") {
+          const paneChromeIntent = terminalPaneChromePointerIntent(
+            terminalPaneChromeLayout(),
+            hit.localX,
+            hit.localY,
+            e.type,
+            e.button ?? 0,
+          );
+          if (e.type === "move" || e.type === "over" || e.type === "drag") {
+            const motion = terminalPaneChromeMotionState(
+              paneChromeIntent,
+              pressedTerminalPaneAction(),
+            );
+            setHoveredTerminalPaneAction(motion.hovered);
+            setPressedTerminalPaneAction(motion.pressed);
+          }
+          if (paneChromeIntent) {
+            setWorkbenchFocusZone("canvas");
+            touchedWorkspaceDock = true;
+            dispatchTerminalPaneChromePointerIntent(paneChromeIntent, {
+              hover: setHoveredTerminalPaneAction,
+              focus: (paneId) => mirror?.focus(paneId),
+              action: (paneId, actionId, actionIndex) => {
+                setPressedTerminalPaneAction({ paneId, actionIndex });
+                runTerminalPaneAction(paneId, actionId);
+              },
+              menu: (paneId) => {
+                const pane = panesById().get(paneId);
+                if (!pane) return;
+                openMenu(hit.localX, e.y, e.x, {
+                  region: "pane",
+                  title: pane.id,
+                  items: paneMenuItems(
+                    pane.appMouse,
+                    selectModePane() === pane.id,
+                    paneDrag(pane.id),
+                  ),
+                  paneId: pane.id,
+                });
+              },
+              settle: () => settleTerminalGestureBoundary(e),
+            });
+            return true;
+          }
+        } else {
+          clearTerminalPaneActionState();
+        }
         const terminalPolicy =
           canvasPanel() === "terminals"
             ? agentTerminalCanvasPointerPolicy(
@@ -7404,18 +7500,10 @@ try {
         selectDiffFile(hit.fileIndex);
         return;
       }
-      // The per-window strip (gy=1) — resolved by the SAME x-span math the render
+      // The per-window strip (gy=0) — resolved by the SAME x-span math the render
       // lays out, so the formerly-swallowed segment clicks now land.
-      if (gy === 1) {
+      if (gy === 0) {
         if (type !== "down") return;
-        // The right side of the strip carries the [+ split] button (clear of the
-        // window-label cells); it wins the hit test over the window spans.
-        const sbtn = stripButtons();
-        const bi = spanHit(sbtn.spans, x);
-        if (bi >= 0) {
-          runButton(sbtn.defs[bi]!.id);
-          return;
-        }
         const i = spanHit(windowSpans(), x);
         const w = windowTabs()[i];
         if (w) mirror?.switchWindow(w.index);
@@ -7492,53 +7580,6 @@ try {
       }
     };
 
-    // ── Per-pane agent chips (M22.3) ─────────────────────────────────────────
-    // The fleet payload's per-pane agent entries (M22.1), joined by tmux pane id
-    // (the mirror's pane ids are the same %N ids). Consumes the 3s fleet poll's
-    // signal as-is; staleness is already applied by the report, and a missing
-    // `agents` field (older payload) degrades to an empty map.
-    const agentByPane = createMemo(() => agentsByPane(projectsData()));
-    // A pane's agent chip: glyph + kind at the pane's TOP-LEFT (the scroll badge
-    // owns the top-right), colored by the app's status grammar — reference sites:
-    // STATUS_GLYPH + STATUS_COLOR (this file). PASSIVE by design: no handler, and
-    // the label is a TEXT run covering its wrapper box, so a press lands on text
-    // and bubbles to the router (same law as the scrollbar cells above) — pane
-    // forwarding and the right-click menu are untouched. Blocked is the only
-    // attention state: bold, attention bg, and the label spells `blocked` plus
-    // the authority age ("blocked 4m"). The label re-derives on every fleet tick;
-    // width changes re-truncate (chipLabel degrades label → glyph → hidden). The
-    // chip is anchored to the pane box, so zoom/resize/focus moves ride along.
-    const agentChipOverlay = (pane: () => { id: string; width: number } | undefined) => {
-      const entry = () => {
-        const p = pane();
-        return p ? agentByPane().get(p.id) : undefined;
-      };
-      const label = () => {
-        const e = entry();
-        const p = pane();
-        if (!e || !p) return null;
-        // Budget: pane width minus the left inset (1) + padding (2), capped so a
-        // wide pane's chip stays a chip (and clears the top-right scroll badge).
-        // A self-reported status text earns a wider cap (M25.4) — "● claude ·
-        // refactoring auth" needs the room; chipLabel still truncates to fit.
-        const cap = e.statusText ? 44 : 28;
-        return chipLabel(e, STATUS_GLYPH[e.state], Date.now(), Math.min(p.width - 3, cap));
-      };
-      return (
-        <Show when={label()}>
-          <box position="absolute" left={1} top={0} flexDirection="row">
-            <text
-              fg={STATUS_COLOR[entry()!.state]}
-              bg={entry()!.state === "blocked" ? CHIP_ATTN_BG : BADGE_BG}
-              attributes={entry()!.state === "blocked" ? 1 : 0}
-            >
-              {` ${label()} `}
-            </text>
-          </box>
-        </Show>
-      );
-    };
-
     // A 1-col scrollbar drawn in an always-present container's right column: a
     // faint track with a brighter thumb, both single-cell bg fills. Each cell is a
     // TEXT run (not a box) so a click lands on text and bubbles to the router —
@@ -7557,27 +7598,6 @@ try {
         </box>
       </Show>
     );
-    /** The right-aligned affordance-button run for a header/strip row: a flexGrow
-     *  spacer pushes the chips flush to the container right edge, matching the
-     *  `spansFromRight` layout the router hit-tests. Hover lifts the chip. */
-    const buttonRow = (buttons: () => { defs: HeaderButton[]; spans: Span[] }) => (
-      <>
-        <box flexGrow={1} />
-        <For each={buttons().defs}>
-          {(b, i) => (
-            <text
-              fg={BUTTON_FG}
-              bg={
-                b.active ? BUTTON_ACTIVE_BG : isHovered("button", i()) ? BUTTON_HOVER_BG : BUTTON_BG
-              }
-            >
-              {b.label}
-            </text>
-          )}
-        </For>
-      </>
-    );
-
     return (
       <box
         flexDirection="column"
@@ -7643,13 +7663,7 @@ try {
                       projection={terminalCanvasProjection()}
                       chrome={
                         <>
-                          <box paddingLeft={1} flexDirection="row" gap={1}>
-                            <text fg={DEFAULT_FG} attributes={1}>
-                              {curTarget()}
-                            </text>
-                            <text fg={MUTED}>{status()}</text>
-                          </box>
-                          {/* The per-window strip (gy=1). Rendered as bare styled TEXT runs (no
+                          {/* The per-window strip (gy=0). Rendered as bare styled TEXT runs (no
                 per-window <box> wrapper) so the late-mounted segments bubble
                 clicks to the main-column router instead of swallowing them the
                 way late-mounted boxes do; `route` hit-tests `windowSpans`, whose
@@ -7661,27 +7675,30 @@ try {
                               {windowStripParts().active}
                             </text>
                             <text fg={MUTED}>{windowStripParts().post}</text>
-                            {/* Zoomed indicator: the focused pane's id + a [Z] chip, shown only
-                  while the window is zoomed. Left-aligned after the labels; the
-                  button row's flexGrow spacer keeps the [⛶]/[+ split] chips pinned
-                  right regardless, and windowSpans are measured from the left, so
-                  neither the click routing nor the button spans shift. */}
+                            {/* Window-level indicators remain on row zero; pane-level
+                  zoom/split controls now live in each pane's own chrome row. */}
                             <Show when={isZoomed()}>
                               <text fg={ACCENT} bg={TAB_ACTIVE_BG} attributes={1}>
                                 {` ${focusedLivePane()?.id ?? ""} [Z] `}
                               </text>
                             </Show>
                             {/* Synchronize-panes indicator (M20.2): shown while the active
-                  window's synchronize-panes option is on. Left-aligned after the
-                  labels like [Z]; the button row's flexGrow spacer keeps the
-                  right-pinned chips and their spans unaffected. */}
+                  window's synchronize-panes option is on, left-aligned after the
+                  labels like [Z]. */}
                             <Show when={syncOn()}>
                               <text fg={BUTTON_FG} bg={BUTTON_ACTIVE_BG} attributes={1}>
                                 {" [SYNC] "}
                               </text>
                             </Show>
-                            {buttonRow(stripButtons)}
                           </box>
+                          {/* Segmented pane chrome occupies gy=1, immediately above
+                  the exact tmux framebuffer. The layer is passive; root routing
+                  owns every action and lifecycle effect. */}
+                          <TerminalPaneChromeLayer
+                            theme={semanticTheme()}
+                            layout={terminalPaneChromeLayout()}
+                            layer="native"
+                          />
                         </>
                       }
                       framebuffer={
@@ -7750,7 +7767,6 @@ try {
                                         </text>
                                       </Show>
                                     </box>
-                                    {agentChipOverlay(() => pane)}
                                     {/* Right-edge scrollbar — only while scrolled up, so a live
                             terminal stays clean (mirrorScrollGeom gates on offset). */}
                                     {scrollbarOverlay(() => mirrorScrollGeom(pane))}
@@ -7817,7 +7833,6 @@ try {
                                           </text>
                                         </Show>
                                       </box>
-                                      {agentChipOverlay(pane)}
                                       {scrollbarOverlay(() => mirrorScrollGeom(pane()!))}
                                     </box>
                                   </Show>
@@ -7860,6 +7875,15 @@ try {
                               </box>
                             )}
                           </For>
+                          {/* Lower-pane headers reuse only tmux's existing horizontal
+                  separator cells. Render after focus strips so semantic pane
+                  chrome wins visually, while the pure projection proves no
+                  emitted rectangle intersects a pane framebuffer. */}
+                          <TerminalPaneChromeLayer
+                            theme={semanticTheme()}
+                            layout={terminalPaneChromeLayout()}
+                            layer="framebuffer"
+                          />
                           {/* Size-truth hint (M22.8): quiet, dismiss-free, shown ONLY while
                   a co-attached terminal has sized the window away from our canvas
                   (the letterboxed grid is centered beneath it). It states the

--- a/packages/daemon/src/tui/mirror/workspace/__snapshots__/agent-terminal-canvas-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/workspace/__snapshots__/agent-terminal-canvas-renderer.test.tsx.snap
@@ -132,3 +132,217 @@ tmux framebuffer 200x58
 
  /blocked 1/3"
 `;
+
+exports[`AgentTerminalCanvas OpenTUI renderer renders pane chrome at %sx%s without covering framebuffer sentinels 1`] = `
+" 0:agents 1:shell
+:: ▣ ❯ Codex PM          ●   ○ Z   ○ +  :: ○ ❯ Codex implementer  ●   ○ Z   ○ +
+A1A ·······························     A2A ································
+
+
+
+
+
+
+
+                                        │
+                                                                            Z2Z
+                                        :: ! ❯ Claude reviewer    !   ○ Z   ○ +
+                                        A3A ································
+
+
+
+
+
+
+
+
+│                                       │
+                                   Z1Z                                      Z3Z"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer renders pane chrome at %sx%s without covering framebuffer sentinels 2`] = `
+" 0:agents 1:shell
+:: ▣ ❯ Codex PM                              ●   ○ Z   ○ +  :: ○ ❯ Codex implementer                      ●   ○ Z   ○ +
+A1A ···················································     A2A ····················································
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                            │
+                                                                                                                    Z2Z
+                                                            :: ! ❯ Claude reviewer                        !   ○ Z   ○ +
+                                                            A3A ····················································
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+│                                                           │
+                                                       Z1Z                                                          Z3Z"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer renders pane chrome at %sx%s without covering framebuffer sentinels 3`] = `
+" 0:agents 1:shell
+:: ▣ ❯ Codex PM                                                                      ●   ○ Z   ○ +  :: ○ ❯ Codex implementer                                                              ●   ○ Z   ○ +
+A1A ···························································································     A2A ····························································································
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                                                    │
+                                                                                                                                                                                                    Z2Z
+                                                                                                    :: ! ❯ Claude reviewer                                                                !   ○ Z   ○ +
+                                                                                                    A3A ····························································································
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+│                                                                                                   │
+                                                                                               Z1Z                                                                                                  Z3Z"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 1`] = `
+"
+Z
+B
+
+
+"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 2`] = `
+"
+R
+B
+
+
+"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 3`] = `
+"
+Z
+B
+
+
+"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 4`] = `
+"
+R
+B
+
+
+"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 5`] = `
+"
+ ○ Z
+B
+
+
+"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 6`] = `
+" window
+%7  ○ Z
+B
+
+
+"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 7`] = `
+" window
+%7      ○ Z
+B
+
+
+"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 8`] = `
+" window
+%7 ○ Z   ○ +
+B
+
+
+"
+`;
+
+exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 9`] = `
+" window
+%7    ○ Z   ○ +
+B
+
+
+"
+`;

--- a/packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx
@@ -4,6 +4,12 @@ import { createSemanticThemeSnapshot } from "../theme.ts";
 import { expectFrameBounds, renderForTest, stableFrame } from "../testing/renderer-harness.test.ts";
 import { projectAgentTerminalCanvas } from "./agent-terminal-canvas.ts";
 import { AgentTerminalCanvas } from "./agent-terminal-canvas-view.tsx";
+import {
+  projectTerminalPaneChrome,
+  terminalPaneChromeHitTest,
+  terminalPaneChromeOverlapsBodies,
+} from "./terminal-pane-chrome.ts";
+import { TerminalPaneChromeLayer } from "./terminal-pane-chrome-view.tsx";
 
 describe("AgentTerminalCanvas OpenTUI renderer", () => {
   it.each([
@@ -50,5 +56,184 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
       `tmux framebuffer ${projection.tmuxSize!.cols}x${projection.tmuxSize!.rows}`,
     );
     expect(stableFrame(frame)).toContain("/blocked 1/3");
+    setup.renderer.destroy();
   });
+
+  it.each([
+    [80, 24],
+    [120, 40],
+    [200, 60],
+  ] as const)(
+    "renders pane chrome at %sx%s without covering framebuffer sentinels",
+    async (width, height) => {
+      const theme = createSemanticThemeSnapshot({ mode: "dark" });
+      const projection = projectAgentTerminalCanvas({ width, height, chromeRows: 2 });
+      const framebuffer = projection.framebuffer;
+      const leftWidth = Math.floor((framebuffer.width - 1) / 2);
+      const rightLeft = leftWidth + 1;
+      const rightWidth = framebuffer.width - rightLeft;
+      const topHeight = Math.floor((framebuffer.height - 1) / 2);
+      const lowerTop = topHeight + 1;
+      const panes = [
+        {
+          id: "%1",
+          left: 0,
+          top: 0,
+          width: leftWidth,
+          height: framebuffer.height,
+          active: true,
+          zoomed: false,
+        },
+        {
+          id: "%2",
+          left: rightLeft,
+          top: 0,
+          width: rightWidth,
+          height: topHeight,
+          active: false,
+          zoomed: false,
+        },
+        {
+          id: "%3",
+          left: rightLeft,
+          top: lowerTop,
+          width: rightWidth,
+          height: framebuffer.height - lowerTop,
+          active: false,
+          zoomed: false,
+        },
+      ];
+      const layout = projectTerminalPaneChrome({
+        canvas: projection,
+        panes,
+        metadataByPane: new Map([
+          ["%1", { title: "Codex PM", status: "working", statusTone: "working" as const }],
+          ["%2", { title: "Codex implementer", status: "working", statusTone: "working" as const }],
+          [
+            "%3",
+            {
+              title: "Claude reviewer",
+              status: "blocked",
+              statusTone: "blocked" as const,
+              attention: true,
+            },
+          ],
+        ]),
+      });
+      const sentinel = (id: string, paneWidth: number, paneHeight: number) => (
+        <>
+          <box position="absolute" left={0} top={0} width={4} height={1}>
+            <text>{`A${id.slice(1)}A`}</text>
+          </box>
+          <box position="absolute" right={0} bottom={0} width={4} height={1}>
+            <text>{`Z${id.slice(1)}Z`}</text>
+          </box>
+          <box position="absolute" left={4} top={0} width={Math.max(0, paneWidth - 8)} height={1}>
+            <text>{"·".repeat(Math.max(0, paneWidth - 8))}</text>
+          </box>
+          <box position="absolute" left={0} top={Math.max(0, paneHeight - 2)} width={1} height={1}>
+            <text>│</text>
+          </box>
+        </>
+      );
+      const setup = await renderForTest(
+        () => (
+          <AgentTerminalCanvas
+            theme={theme}
+            projection={projection}
+            chrome={
+              <>
+                <text fg={theme.colors.mutedForeground}> 0:agents 1:shell</text>
+                <TerminalPaneChromeLayer theme={theme} layout={layout} layer="native" />
+              </>
+            }
+            framebuffer={
+              <box position="relative" width={framebuffer.width} height={framebuffer.height}>
+                {panes.map((pane) => (
+                  <box
+                    position="absolute"
+                    left={pane.left}
+                    top={pane.top}
+                    width={pane.width}
+                    height={pane.height}
+                    overflow="hidden"
+                  >
+                    {sentinel(pane.id, pane.width, pane.height)}
+                  </box>
+                ))}
+                <TerminalPaneChromeLayer theme={theme} layout={layout} layer="framebuffer" />
+              </box>
+            }
+          />
+        ),
+        { width, height },
+      );
+      await setup.renderOnce();
+      const frame = setup.captureCharFrame();
+      const stable = stableFrame(frame);
+      expectFrameBounds(frame, width, height);
+      expect(projection.tmuxSize).toEqual({ cols: width, rows: height - 2 });
+      expect(stable).toMatchSnapshot();
+      for (const id of ["1", "2", "3"]) {
+        expect(stable).toContain(`A${id}A`);
+        expect(stable).toContain(`Z${id}Z`);
+      }
+      expect(stable).toContain("Claude reviewer");
+      setup.renderer.destroy();
+    },
+  );
+
+  it.each([1, 2, 3, 4, 5, 8, 12, 13, 16] as const)(
+    "keeps compact zoom chrome visible at width %s",
+    async (width) => {
+      const height = 6;
+      const theme = createSemanticThemeSnapshot({ mode: "dark" });
+      const projection = projectAgentTerminalCanvas({ width, height, chromeRows: 2 });
+      const zoomed = width <= 4 && width % 2 === 0;
+      const pane = {
+        id: "%7",
+        left: 0,
+        top: 0,
+        width,
+        height: projection.framebuffer.height,
+        active: true,
+        zoomed,
+      };
+      const layout = projectTerminalPaneChrome({ canvas: projection, panes: [pane] });
+      const setup = await renderForTest(
+        () => (
+          <AgentTerminalCanvas
+            theme={theme}
+            projection={projection}
+            chrome={
+              <>
+                <text fg={theme.colors.mutedForeground}> window</text>
+                <TerminalPaneChromeLayer theme={theme} layout={layout} layer="native" />
+              </>
+            }
+            framebuffer={<text>B</text>}
+          />
+        ),
+        { width, height },
+      );
+      await setup.renderOnce();
+      const stable = stableFrame(setup.captureCharFrame());
+      const header = layout.native[0]!;
+      const zoom = header.frame!.actions.find((action) => action.id === "zoom")!;
+      expect(stable).toMatchSnapshot();
+      expect(stable).toContain(zoomed ? "R" : "Z");
+      expect(stable).toContain("B");
+      expect(
+        terminalPaneChromeHitTest(
+          layout,
+          header.canvasRect.x + zoom.start + Math.floor((zoom.width - 1) / 2),
+          header.canvasRect.y,
+        ),
+      ).toMatchObject({ paneId: "%7", hit: { area: "action", actionId: "zoom" } });
+      expect(terminalPaneChromeOverlapsBodies({ canvas: projection, panes: [pane] }, header)).toBe(
+        false,
+      );
+      setup.renderer.destroy();
+    },
+  );
 });

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome-view.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome-view.tsx
@@ -1,0 +1,80 @@
+/* @jsxImportSource @opentui/solid */
+import { For, Show } from "solid-js";
+import { actionChipWidth, recipePalette } from "../recipes.ts";
+import type { SemanticThemeSnapshot } from "../theme.ts";
+import { PaneFrameHeader } from "./pane-frame.tsx";
+import type {
+  TerminalPaneChromeLayout,
+  TerminalPaneChromeProjection,
+} from "./terminal-pane-chrome.ts";
+
+export interface TerminalPaneChromeLayerProps {
+  theme: SemanticThemeSnapshot;
+  layout: TerminalPaneChromeLayout;
+  layer: "native" | "framebuffer";
+}
+
+function NarrowTerminalAction(props: {
+  theme: SemanticThemeSnapshot;
+  action: NonNullable<TerminalPaneChromeProjection["frame"]>["actions"][number];
+}) {
+  const palette = () =>
+    recipePalette(props.theme, {
+      hovered: props.action.hovered,
+      pressed: props.action.pressed,
+      selected: props.action.active,
+      disabled: props.action.disabled,
+      attention: props.action.attention,
+    });
+  const text = () => props.action.label.slice(0, props.action.width).padEnd(props.action.width);
+  return (
+    <box
+      position="absolute"
+      left={props.action.start}
+      top={0}
+      width={props.action.width}
+      height={1}
+      backgroundColor={palette().background}
+      overflow="hidden"
+    >
+      <text fg={palette().foreground}>{text()}</text>
+    </box>
+  );
+}
+
+/** Passive projection surface; the application root remains the only input owner. */
+export function TerminalPaneChromeLayer(props: TerminalPaneChromeLayerProps) {
+  const projections = (): readonly TerminalPaneChromeProjection[] =>
+    props.layer === "native" ? props.layout.native : props.layout.framebuffer;
+  return (
+    <For each={projections()}>
+      {(pane) => (
+        <Show when={pane.frame}>
+          {(frame) => (
+            <box
+              position="absolute"
+              left={pane.layerRect.x}
+              top={pane.layerRect.y}
+              width={pane.layerRect.width}
+              height={pane.layerRect.height}
+              overflow="hidden"
+            >
+              <PaneFrameHeader theme={props.theme} projection={frame()} />
+              {/* The shared ActionChip reserves two marker cells. At widths 1–4
+                  that would leave a correct hit target but no visible Z/R. Keep
+                  the shared recipe untouched and overlay only terminal zoom's
+                  literal glyph inside the exact same projected action span. */}
+              <For
+                each={frame().actions.filter(
+                  (action) => action.id === "zoom" && action.width < actionChipWidth(action.label),
+                )}
+              >
+                {(action) => <NarrowTerminalAction theme={props.theme} action={action} />}
+              </For>
+            </box>
+          )}
+        </Show>
+      )}
+    </For>
+  );
+}

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import { projectAgentTerminalCanvas } from "./agent-terminal-canvas.ts";
+import {
+  dispatchTerminalPaneChromePointerIntent,
+  projectTerminalPaneChrome,
+  reconcileTerminalPaneChromeActionTarget,
+  terminalPaneChromeHitTest,
+  terminalPaneChromeMotionState,
+  terminalPaneChromeOverlapsBodies,
+  terminalPaneChromePointerIntent,
+  terminalPaneChromeTitle,
+  type TerminalPaneChromePane,
+} from "./terminal-pane-chrome.ts";
+
+const canvas = projectAgentTerminalCanvas({ width: 120, height: 40, chromeRows: 2 });
+
+function pane(overrides: Partial<TerminalPaneChromePane>): TerminalPaneChromePane {
+  return {
+    id: "%1",
+    left: 0,
+    top: 0,
+    width: 120,
+    height: 38,
+    active: true,
+    zoomed: false,
+    ...overrides,
+  };
+}
+
+describe("terminal pane chrome projection", () => {
+  it("segments the native header for horizontal panes without touching either body", () => {
+    const panes = [
+      pane({ id: "%1", width: 59 }),
+      pane({ id: "%2", left: 60, width: 60, active: false }),
+    ];
+    const layout = projectTerminalPaneChrome({ canvas, panes });
+    expect(layout.native.map((item) => [item.paneId, item.layerRect])).toEqual([
+      ["%1", { x: 0, y: 1, width: 59, height: 1 }],
+      ["%2", { x: 60, y: 1, width: 60, height: 1 }],
+    ]);
+    expect(layout.framebuffer).toEqual([]);
+    expect(
+      layout.native.every((item) => !terminalPaneChromeOverlapsBodies({ canvas, panes }, item)),
+    ).toBe(true);
+  });
+
+  it("uses the existing horizontal separator for a lower pane", () => {
+    const panes = [
+      pane({ id: "%1", height: 18 }),
+      pane({ id: "%2", top: 19, height: 19, active: false }),
+    ];
+    const layout = projectTerminalPaneChrome({ canvas, panes });
+    expect(layout.native[0]?.placement).toBe("native-header");
+    expect(layout.framebuffer[0]).toMatchObject({
+      paneId: "%2",
+      placement: "gutter-header",
+      layerRect: { x: 0, y: 18, width: 120, height: 1 },
+      canvasRect: { x: 0, y: 20, width: 120, height: 1 },
+    });
+    expect(
+      layout.framebuffer.every(
+        (item) => !terminalPaneChromeOverlapsBodies({ canvas, panes }, item),
+      ),
+    ).toBe(true);
+  });
+
+  it("compacts nested lower-pane chrome around a neighboring full-height body", () => {
+    const panes = [
+      pane({ id: "%1", width: 59 }),
+      pane({ id: "%2", left: 60, width: 60, height: 18, active: false }),
+      pane({ id: "%3", left: 60, top: 19, width: 60, height: 19, active: false }),
+    ];
+    const layout = projectTerminalPaneChrome({ canvas, panes });
+    const lower = layout.framebuffer.find((item) => item.paneId === "%3")!;
+    expect(lower).toMatchObject({
+      placement: "gutter-header",
+      layerRect: { x: 60, y: 18, width: 60, height: 1 },
+    });
+    expect(terminalPaneChromeOverlapsBodies({ canvas, panes }, lower)).toBe(false);
+  });
+
+  it("reflects zoom as an active restore action while retaining exact tmux size", () => {
+    const panes = [pane({ zoomed: true })];
+    const before = canvas.tmuxSize;
+    const layout = projectTerminalPaneChrome({ canvas, panes });
+    const zoom = layout.native[0]!.frame!.actions.find((action) => action.id === "zoom")!;
+    expect(zoom).toMatchObject({ fullLabel: "restore", label: "R", active: true });
+    expect(canvas.tmuxSize).toEqual(before);
+    expect(layout.framebuffer).toEqual([]);
+  });
+
+  it.each([1, 2, 3, 4, 5, 8, 12, 13, 16])(
+    "reserves a bounded zoom hit span at width %s",
+    (width) => {
+      const narrowCanvas = projectAgentTerminalCanvas({ width, height: 6, chromeRows: 2 });
+      const panes = [pane({ width, height: narrowCanvas.framebuffer.height })];
+      const layout = projectTerminalPaneChrome({ canvas: narrowCanvas, panes });
+      const header = layout.native[0]!;
+      const zoom = header.frame!.actions.find((action) => action.id === "zoom")!;
+      expect(zoom).toBeDefined();
+      expect(zoom.width).toBeGreaterThan(0);
+      expect(zoom.start).toBeGreaterThanOrEqual(0);
+      expect(zoom.start + zoom.width).toBeLessThanOrEqual(width);
+      expect(
+        terminalPaneChromeHitTest(
+          layout,
+          header.canvasRect.x + zoom.start + Math.floor((zoom.width - 1) / 2),
+          header.canvasRect.y,
+        ),
+      ).toMatchObject({ paneId: "%1", hit: { area: "action", actionId: "zoom" } });
+      expect(terminalPaneChromeOverlapsBodies({ canvas: narrowCanvas, panes }, header)).toBe(false);
+    },
+  );
+
+  it("uses live descriptors when present and otherwise keeps pane ids visibly distinct", () => {
+    const panes = [
+      pane({ id: "%1", width: 59 }),
+      pane({ id: "%2", left: 60, width: 60, active: false }),
+    ];
+    const layout = projectTerminalPaneChrome({ canvas, panes });
+    expect(layout.native[0]!.frame!.titleSpan.text).toContain("%1");
+    expect(layout.native[1]!.frame!.titleSpan.text).toContain("%2");
+    expect(terminalPaneChromeTitle(pane({ title: "API server" }))).toBe("API server");
+    expect(terminalPaneChromeTitle(pane({ currentCommand: "pnpm dev" }))).toBe("pnpm dev");
+    expect(
+      terminalPaneChromeTitle(pane({ title: "API server" }), { title: "Codex implementer" }),
+    ).toBe("Codex implementer");
+  });
+
+  it("keeps tiny and malformed layouts bounded and reports unavailable chrome", () => {
+    const tinyCanvas = projectAgentTerminalCanvas({ width: 8, height: 6, chromeRows: 2 });
+    const panes = [
+      pane({ id: "%1", width: 8, height: 4 }),
+      pane({ id: "%2", top: 1, width: 8, height: 3, active: false }),
+    ];
+    const layout = projectTerminalPaneChrome({ canvas: tinyCanvas, panes });
+    const malformed = layout.framebuffer[0]!;
+    expect(malformed.placement).toBe("unavailable");
+    expect(malformed.frame).toBeNull();
+    expect(malformed.diagnostic).toContain("no non-body cell");
+    expect(terminalPaneChromeOverlapsBodies({ canvas: tinyCanvas, panes }, malformed)).toBe(false);
+    for (const item of [...layout.native, ...layout.framebuffer]) {
+      expect(item.layerRect.width).toBeGreaterThanOrEqual(0);
+      expect(item.layerRect.height).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("uses the widest safe compact segment when only part of a gutter is free", () => {
+    const partialCanvas = projectAgentTerminalCanvas({ width: 20, height: 12, chromeRows: 2 });
+    const panes = [
+      pane({ id: "%1", width: 8, height: 6 }),
+      pane({ id: "%2", top: 6, width: 20, height: 4, active: false }),
+    ];
+    const layout = projectTerminalPaneChrome({ canvas: partialCanvas, panes });
+    const compact = layout.framebuffer[0]!;
+    expect(compact).toMatchObject({
+      paneId: "%2",
+      placement: "compact-gutter",
+      layerRect: { x: 8, y: 5, width: 12, height: 1 },
+    });
+    expect(compact.diagnostic).toContain("compacted");
+    expect(terminalPaneChromeOverlapsBodies({ canvas: partialCanvas, panes }, compact)).toBe(false);
+  });
+
+  it("hit-tests actions and returns root-owned focus/action/settle intents", () => {
+    const panes = [
+      pane({ id: "%1", width: 59 }),
+      pane({ id: "%2", left: 60, width: 60, active: false }),
+    ];
+    const layout = projectTerminalPaneChrome({ canvas, panes });
+    const second = layout.native[1]!;
+    const zoom = second.frame!.actions.find((action) => action.id === "zoom")!;
+    const zoomIndex = second.frame!.actions.findIndex((action) => action.id === "zoom");
+    const x = second.canvasRect.x + zoom.start;
+    const y = second.canvasRect.y;
+    expect(terminalPaneChromeHitTest(layout, x, y)).toMatchObject({
+      paneId: "%2",
+      hit: { area: "action", actionId: "zoom" },
+    });
+    expect(terminalPaneChromePointerIntent(layout, x, y, "down")).toEqual({
+      kind: "action",
+      paneId: "%2",
+      actionId: "zoom",
+      actionIndex: zoomIndex,
+    });
+    expect(terminalPaneChromePointerIntent(layout, second.canvasRect.x, y, "down")).toEqual({
+      kind: "focus",
+      paneId: "%2",
+    });
+    expect(terminalPaneChromePointerIntent(layout, x, y, "up")).toEqual({
+      kind: "settle",
+      paneId: "%2",
+    });
+  });
+
+  it("dispatches nonfocused zoom as focus then effect with no PTY transport", () => {
+    const calls: string[] = [];
+    const ptyWrites: string[] = [];
+    dispatchTerminalPaneChromePointerIntent(
+      { kind: "action", paneId: "%9", actionId: "zoom", actionIndex: 0 },
+      {
+        hover: () => calls.push("hover"),
+        focus: (paneId) => calls.push(`focus:${paneId}`),
+        action: (paneId, actionId) => calls.push(`${actionId}:${paneId}`),
+        menu: (paneId) => calls.push(`menu:${paneId}`),
+        settle: (paneId) => calls.push(`settle:${paneId}`),
+      },
+    );
+    expect(calls).toEqual(["focus:%9", "zoom:%9"]);
+    expect(ptyWrites).toEqual([]);
+  });
+
+  it("lets non-action lower-header cells fall through to separator resize", () => {
+    const panes = [
+      pane({ id: "%1", height: 18 }),
+      pane({ id: "%2", top: 19, height: 19, active: false }),
+    ];
+    const layout = projectTerminalPaneChrome({ canvas, panes });
+    const lower = layout.framebuffer[0]!;
+    const zoom = lower.frame!.actions.find((action) => action.id === "zoom")!;
+    expect(
+      terminalPaneChromePointerIntent(
+        layout,
+        lower.canvasRect.x + zoom.start,
+        lower.canvasRect.y,
+        "down",
+      ),
+    ).toMatchObject({ kind: "action", paneId: "%2", actionId: "zoom" });
+    expect(
+      terminalPaneChromePointerIntent(
+        layout,
+        lower.canvasRect.x + lower.frame!.grip!.x,
+        lower.canvasRect.y,
+        "down",
+      ),
+    ).toBeNull();
+  });
+
+  it("clears motion and lifecycle state outside live terminal chrome", () => {
+    const target = { paneId: "%2", actionIndex: 0 };
+    expect(terminalPaneChromeMotionState({ kind: "hover", target: { ...target } }, target)).toEqual(
+      { hovered: target, pressed: target },
+    );
+    expect(terminalPaneChromeMotionState(null, target)).toEqual({ hovered: null, pressed: null });
+    expect(reconcileTerminalPaneChromeActionTarget(target, new Set(["%2"]), true)).toBe(target);
+    expect(reconcileTerminalPaneChromeActionTarget(target, new Set(["%1"]), true)).toBeNull();
+    expect(reconcileTerminalPaneChromeActionTarget(target, new Set(["%2"]), false)).toBeNull();
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts
@@ -1,0 +1,477 @@
+import { terminalDisplayWidth } from "../panel-host.ts";
+import { actionChipWidth, type RecipeTone, type Rect } from "../recipes.ts";
+import type { AgentTerminalCanvasProjection } from "./agent-terminal-canvas.ts";
+import {
+  paneFrameHitTest,
+  projectPaneFrame,
+  type PaneFrameActionChip,
+  type PaneFrameHit,
+  type PaneFrameProjection,
+} from "./pane-frame.ts";
+import { clipWorkspaceText } from "./text.ts";
+
+export interface TerminalPaneChromePane {
+  id: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  active: boolean;
+  zoomed: boolean;
+  /** Optional future SessionMirror descriptor fields. */
+  title?: string | null;
+  currentCommand?: string | null;
+}
+
+export interface TerminalPaneChromeMetadata {
+  title?: string | null;
+  subtitle?: string | null;
+  status?: string | null;
+  statusTone?: Exclude<RecipeTone, "neutral" | "accent">;
+  attention?: boolean;
+}
+
+export interface TerminalPaneChromeActionTarget {
+  paneId: string;
+  actionIndex: number;
+}
+
+export type TerminalPaneChromePlacement =
+  | "native-header"
+  | "gutter-header"
+  | "compact-gutter"
+  | "unavailable";
+
+export interface TerminalPaneChromeProjection {
+  paneId: string;
+  placement: TerminalPaneChromePlacement;
+  /** Coordinates in the complete AgentTerminalCanvas. */
+  canvasRect: Rect;
+  /** Coordinates in the native chrome layer or framebuffer layer. */
+  layerRect: Rect;
+  layer: "native" | "framebuffer";
+  frame: PaneFrameProjection | null;
+  diagnostic: string | null;
+}
+
+export interface TerminalPaneChromeLayout {
+  native: readonly TerminalPaneChromeProjection[];
+  framebuffer: readonly TerminalPaneChromeProjection[];
+  diagnostics: readonly string[];
+}
+
+export interface TerminalPaneChromeInput {
+  canvas: AgentTerminalCanvasProjection;
+  panes: readonly TerminalPaneChromePane[];
+  metadataByPane?: ReadonlyMap<string, TerminalPaneChromeMetadata>;
+  hoveredAction?: TerminalPaneChromeActionTarget | null;
+  pressedAction?: TerminalPaneChromeActionTarget | null;
+}
+
+export interface TerminalPaneChromeHit {
+  paneId: string;
+  placement: TerminalPaneChromePlacement;
+  hit: Exclude<PaneFrameHit, null>;
+}
+
+export type TerminalPaneChromePointerIntent =
+  | { kind: "hover"; target: TerminalPaneChromeActionTarget | null }
+  | { kind: "focus"; paneId: string }
+  | { kind: "action"; paneId: string; actionId: string; actionIndex: number }
+  | { kind: "menu"; paneId: string }
+  | { kind: "settle"; paneId: string }
+  | { kind: "consume"; paneId: string }
+  | null;
+
+export interface TerminalPaneChromePointerEffects {
+  hover(target: TerminalPaneChromeActionTarget | null): void;
+  focus(paneId: string): void;
+  action(paneId: string, actionId: string, actionIndex: number): void;
+  menu(paneId: string): void;
+  settle(paneId: string): void;
+}
+
+export interface TerminalPaneChromeMotionState {
+  hovered: TerminalPaneChromeActionTarget | null;
+  pressed: TerminalPaneChromeActionTarget | null;
+}
+
+interface Segment {
+  start: number;
+  end: number;
+}
+
+/**
+ * Project one-row pane chrome without changing the tmux framebuffer contract.
+ *
+ * Top panes share the app-owned row immediately above the framebuffer (after
+ * the global window strip). Lower panes reuse only cells in their existing
+ * separator row. Every candidate is subtracted against every
+ * tmux body rectangle before a frame is emitted, so malformed/nested geometry
+ * can degrade but can never cover terminal output.
+ */
+export function projectTerminalPaneChrome(
+  input: TerminalPaneChromeInput,
+): TerminalPaneChromeLayout {
+  const native: TerminalPaneChromeProjection[] = [];
+  const framebuffer: TerminalPaneChromeProjection[] = [];
+  const diagnostics: string[] = [];
+  const panes = input.panes.map(normalizePane).filter((pane) => pane.width > 0 && pane.height > 0);
+  const framebufferRect = input.canvas.framebuffer;
+
+  for (const pane of panes) {
+    let placement: TerminalPaneChromePlacement;
+    let layer: TerminalPaneChromeProjection["layer"];
+    let layerRect: Rect;
+    let diagnostic: string | null = null;
+
+    if (pane.top === 0) {
+      const start = clamp(pane.left, 0, input.canvas.chrome.width);
+      const end = clamp(pane.left + pane.width, start, input.canvas.chrome.width);
+      const nativeHeaderY = Math.max(0, input.canvas.chrome.height - 1);
+      placement = "native-header";
+      layer = "native";
+      layerRect = {
+        x: start,
+        y: nativeHeaderY,
+        width: end - start,
+        height: end > start && input.canvas.chrome.height > 0 ? 1 : 0,
+      };
+      if (layerRect.width !== pane.width) {
+        diagnostic = `${pane.id}: native header clipped to canvas`;
+      }
+    } else {
+      const row = pane.top - 1;
+      const requested: Segment = {
+        start: clamp(pane.left, 0, framebufferRect.width),
+        end: clamp(pane.left + pane.width, 0, framebufferRect.width),
+      };
+      const occupied = panes
+        .filter((candidate) => row >= candidate.top && row < candidate.top + candidate.height)
+        .map((candidate) => ({
+          start: clamp(candidate.left, requested.start, requested.end),
+          end: clamp(candidate.left + candidate.width, requested.start, requested.end),
+        }))
+        .filter((segment) => segment.end > segment.start);
+      const safe = subtractSegments(requested, occupied).sort(
+        (a, b) => b.end - b.start - (a.end - a.start) || a.start - b.start,
+      );
+      const chosen = safe[0];
+      if (!chosen || row < 0 || row >= framebufferRect.height) {
+        placement = "unavailable";
+        layer = "framebuffer";
+        layerRect = { x: 0, y: 0, width: 0, height: 0 };
+        diagnostic = `${pane.id}: no non-body cell available for pane chrome`;
+      } else {
+        const full = chosen.start === requested.start && chosen.end === requested.end;
+        placement = full ? "gutter-header" : "compact-gutter";
+        layer = "framebuffer";
+        layerRect = { x: chosen.start, y: row, width: chosen.end - chosen.start, height: 1 };
+        if (!full) diagnostic = `${pane.id}: pane chrome compacted around occupied cells`;
+      }
+    }
+
+    const canvasRect: Rect = {
+      x: layerRect.x + (layer === "native" ? input.canvas.chrome.x : framebufferRect.x),
+      y: layerRect.y + (layer === "native" ? input.canvas.chrome.y : framebufferRect.y),
+      width: layerRect.width,
+      height: layerRect.height,
+    };
+    const frame =
+      placement === "unavailable" || layerRect.width === 0
+        ? null
+        : paneHeaderFrame(
+            pane,
+            input.metadataByPane?.get(pane.id),
+            layerRect.width,
+            input.hoveredAction,
+            input.pressedAction,
+          );
+    const projection: TerminalPaneChromeProjection = {
+      paneId: pane.id,
+      placement,
+      canvasRect,
+      layerRect,
+      layer,
+      frame,
+      diagnostic,
+    };
+    if (diagnostic) diagnostics.push(diagnostic);
+    if (layer === "native") native.push(projection);
+    else framebuffer.push(projection);
+  }
+
+  return { native, framebuffer, diagnostics };
+}
+
+export function terminalPaneChromeHitTest(
+  layout: TerminalPaneChromeLayout,
+  canvasX: number,
+  canvasY: number,
+): TerminalPaneChromeHit | null {
+  if (!Number.isFinite(canvasX) || !Number.isFinite(canvasY)) return null;
+  const x = Math.floor(canvasX);
+  const y = Math.floor(canvasY);
+  for (const projection of [...layout.native, ...layout.framebuffer]) {
+    if (!projection.frame || !contains(projection.canvasRect, x, y)) continue;
+    const hit = paneFrameHitTest(
+      projection.frame,
+      x - projection.canvasRect.x,
+      y - projection.canvasRect.y,
+    );
+    if (hit) return { paneId: projection.paneId, placement: projection.placement, hit };
+  }
+  return null;
+}
+
+/** Root-owned pointer policy. A chrome cell is always consumed and never PTY-routed. */
+export function terminalPaneChromePointerIntent(
+  layout: TerminalPaneChromeLayout,
+  canvasX: number,
+  canvasY: number,
+  eventType: string,
+  button = 0,
+): TerminalPaneChromePointerIntent {
+  const result = terminalPaneChromeHitTest(layout, canvasX, canvasY);
+  if (!result) return null;
+  const gutterPassThrough = result.placement !== "native-header" && result.hit.area !== "action";
+  if (eventType === "down" && button === 2) return { kind: "menu", paneId: result.paneId };
+  // Lower headers paint the existing resize separator. Only their concrete
+  // action chips capture left-pointer input; title/grip cells retain tmux's
+  // established separator-resize path.
+  if (gutterPassThrough) return null;
+  if (isRelease(eventType)) return { kind: "settle", paneId: result.paneId };
+  if (eventType === "move" || eventType === "over" || eventType === "drag") {
+    return {
+      kind: "hover",
+      target:
+        result.hit.area === "action"
+          ? { paneId: result.paneId, actionIndex: result.hit.actionIndex }
+          : null,
+    };
+  }
+  if (eventType === "down" && result.hit.area === "action") {
+    return {
+      kind: "action",
+      paneId: result.paneId,
+      actionId: result.hit.actionId,
+      actionIndex: result.hit.actionIndex,
+    };
+  }
+  if (eventType === "down") return { kind: "focus", paneId: result.paneId };
+  return { kind: "consume", paneId: result.paneId };
+}
+
+/**
+ * Root adapter with an explicit ordering contract: a pane is focused before
+ * its action or context menu runs. There is intentionally no PTY forwarding
+ * effect in this boundary.
+ */
+export function dispatchTerminalPaneChromePointerIntent(
+  intent: Exclude<TerminalPaneChromePointerIntent, null>,
+  effects: TerminalPaneChromePointerEffects,
+): void {
+  if (intent.kind === "hover") effects.hover(intent.target);
+  else if (intent.kind === "focus") effects.focus(intent.paneId);
+  else if (intent.kind === "action") {
+    effects.focus(intent.paneId);
+    effects.action(intent.paneId, intent.actionId, intent.actionIndex);
+  } else if (intent.kind === "menu") {
+    effects.focus(intent.paneId);
+    effects.menu(intent.paneId);
+  } else if (intent.kind === "settle") effects.settle(intent.paneId);
+}
+
+/** Motion keeps a pressed visual only while the pointer remains on that action. */
+export function terminalPaneChromeMotionState(
+  intent: TerminalPaneChromePointerIntent,
+  pressed: TerminalPaneChromeActionTarget | null,
+): TerminalPaneChromeMotionState {
+  const hovered = intent?.kind === "hover" ? intent.target : null;
+  return {
+    hovered,
+    pressed: sameActionTarget(hovered, pressed) ? pressed : null,
+  };
+}
+
+/** Drop transient action state when its pane dies or Terminals stops being active. */
+export function reconcileTerminalPaneChromeActionTarget(
+  target: TerminalPaneChromeActionTarget | null,
+  paneIds: ReadonlySet<string>,
+  terminalsActive: boolean,
+): TerminalPaneChromeActionTarget | null {
+  return target && terminalsActive && paneIds.has(target.paneId) ? target : null;
+}
+
+export function terminalPaneChromeOverlapsBodies(
+  input: Pick<TerminalPaneChromeInput, "canvas" | "panes">,
+  projection: TerminalPaneChromeProjection,
+): boolean {
+  return input.panes.some((pane) =>
+    overlaps(projection.canvasRect, {
+      x: input.canvas.framebuffer.x + pane.left,
+      y: input.canvas.framebuffer.y + pane.top,
+      width: pane.width,
+      height: pane.height,
+    }),
+  );
+}
+
+function paneHeaderFrame(
+  pane: TerminalPaneChromePane,
+  metadata: TerminalPaneChromeMetadata | undefined,
+  width: number,
+  hovered: TerminalPaneChromeActionTarget | null | undefined,
+  pressed: TerminalPaneChromeActionTarget | null | undefined,
+): PaneFrameProjection {
+  const title = terminalPaneChromeTitle(pane, metadata);
+  const actions = [
+    {
+      id: "zoom",
+      label: pane.zoomed ? "restore" : "zoom",
+      compactLabel: pane.zoomed ? "R" : "Z",
+      description: pane.zoomed ? "Restore pane layout" : "Zoom this pane",
+      active: pane.zoomed,
+    },
+    {
+      id: "split",
+      label: "split",
+      compactLabel: "+",
+      description: "Split this pane",
+    },
+  ] as const;
+  const input = {
+    width,
+    height: 1,
+    title,
+    kind: "terminals" as const,
+    subtitle: metadata?.subtitle ?? pane.id,
+    focused: pane.active,
+    terminalFocused: pane.active,
+    attention: metadata?.attention === true,
+    status: metadata?.status,
+    statusTone: metadata?.statusTone,
+    hoveredActionIndex: hovered?.paneId === pane.id ? hovered.actionIndex : null,
+    pressedActionIndex: pressed?.paneId === pane.id ? pressed.actionIndex : null,
+    actions,
+  };
+  const full = projectPaneFrame(input);
+  if (
+    full.actions.some((action) => action.id === "zoom") &&
+    full.actions.some((action) => action.id === "split")
+  )
+    return full;
+
+  // PaneFrame's general recipe protects a minimum title/status budget and may
+  // remove all actions in very narrow rows. A terminal header has a stricter
+  // safety contract: zoom is its guaranteed escape hatch. Build a compact
+  // action-first projection, then spend whatever remains on the pane identity.
+  const base = projectPaneFrame({ ...input, status: null, actions: [] });
+  const zoomNaturalWidth = actionChipWidth(actions[0].compactLabel);
+  const zoomWidth = Math.min(width, zoomNaturalWidth);
+  const splitWidth = actionChipWidth(actions[1].compactLabel);
+  const minimumIdentityWidth = 2;
+  const showSplit = width >= zoomWidth + 1 + splitWidth + minimumIdentityWidth;
+  const actionWidth = zoomWidth + (showSplit ? 1 + splitWidth : 0);
+  let actionX = Math.max(0, width - actionWidth);
+  const projectedActions: PaneFrameActionChip[] = [];
+  const pushAction = (index: number, chipWidth: number) => {
+    const action = actions[index]!;
+    projectedActions.push({
+      ...action,
+      kind: "action",
+      label: action.compactLabel,
+      fullLabel: action.label,
+      start: actionX,
+      width: chipWidth,
+      hovered: hovered?.paneId === pane.id && hovered.actionIndex === index,
+      pressed: pressed?.paneId === pane.id && pressed.actionIndex === index,
+    });
+    actionX += chipWidth + 1;
+  };
+  pushAction(0, zoomWidth);
+  if (showSplit) pushAction(1, splitWidth);
+
+  const identityBudget = projectedActions[0]?.start ?? width;
+  const titleText = clipWorkspaceText(title, identityBudget);
+  const titleWidth = terminalDisplayWidth(titleText);
+  return {
+    ...base,
+    grip: null,
+    title: titleText,
+    subtitle: "",
+    titleSpan: { text: titleText, x: 0, y: 0, width: titleWidth, height: 1 },
+    subtitleSpan: null,
+    chips: projectedActions,
+    actions: projectedActions,
+  };
+}
+
+export function terminalPaneChromeTitle(
+  pane: TerminalPaneChromePane,
+  metadata?: TerminalPaneChromeMetadata,
+): string {
+  const candidates = [metadata?.title, pane.title, pane.currentCommand, pane.id];
+  return candidates
+    .find((value): value is string => typeof value === "string" && value.trim() !== "")!
+    .trim();
+}
+
+function normalizePane(pane: TerminalPaneChromePane): TerminalPaneChromePane {
+  return {
+    ...pane,
+    left: cell(pane.left),
+    top: cell(pane.top),
+    width: cell(pane.width),
+    height: cell(pane.height),
+  };
+}
+
+function subtractSegments(requested: Segment, occupied: readonly Segment[]): Segment[] {
+  let safe = requested.end > requested.start ? [requested] : [];
+  for (const block of [...occupied].sort((a, b) => a.start - b.start)) {
+    safe = safe.flatMap((segment) => {
+      if (block.end <= segment.start || block.start >= segment.end) return [segment];
+      const parts: Segment[] = [];
+      if (block.start > segment.start) parts.push({ start: segment.start, end: block.start });
+      if (block.end < segment.end) parts.push({ start: block.end, end: segment.end });
+      return parts;
+    });
+  }
+  return safe.filter((segment) => segment.end > segment.start);
+}
+
+function contains(rect: Rect, x: number, y: number): boolean {
+  return x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height;
+}
+
+function overlaps(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+}
+
+function isRelease(eventType: string): boolean {
+  return (
+    eventType === "up" || eventType === "drag-end" || eventType === "drop" || eventType === "out"
+  );
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+function cell(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function sameActionTarget(
+  left: TerminalPaneChromeActionTarget | null,
+  right: TerminalPaneChromeActionTarget | null,
+): boolean {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      left.paneId === right.paneId &&
+      left.actionIndex === right.actionIndex)
+  );
+}


### PR DESCRIPTION
Adds Gloomberb-inspired app-native chrome per visible tmux pane. Top panes receive segmented headers directly above their framebuffers; stacked panes reuse proven-safe separator cells. Each pane gets targeted zoom/restore and split controls, agent/status/attention metadata, distinct shell identity, and existing right-click actions. Zoom remains visibly available down to one column. Root routing owns all effects; PTY content, Ctrl-C, paste, mouse forwarding, tmux size truth, and separator resizing remain intact.\n\nValidation: focused model and command tests; renderer snapshots at 80x24, 120x40, 200x60 and widths 1-16; daemon typecheck; TUI build; full pnpm check before rebase; post-rebase focused tests/build.