### PR TITLE
Integrate stable workspace and tmux pane identity

### DIFF
--- a/packages/contracts/src/__tests__/ide-config.test.ts
+++ b/packages/contracts/src/__tests__/ide-config.test.ts
@@ -44,3 +44,21 @@ describe("IdeConfigSchema — sidebar", () => {
     expect(cfg.rows[0]!.panes[0]!.type).toBe("sidebar");
   });
 });
+
+describe("IdeConfigSchema — pane identity", () => {
+  it("accepts workspace-safe explicit pane ids", () => {
+    const config = IdeConfigSchema.parse({
+      rows: [{ panes: [{ id: "agent.lead-1", title: "Lead" }] }],
+    });
+    expect(config.rows[0]!.panes[0]!.id).toBe("agent.lead-1");
+  });
+
+  it("rejects invalid and duplicate explicit pane ids", () => {
+    expect(() => IdeConfigSchema.parse({ rows: [{ panes: [{ id: "bad id" }] }] })).toThrow();
+    expect(() =>
+      IdeConfigSchema.parse({
+        rows: [{ panes: [{ id: "agent" }] }, { panes: [{ id: "agent" }] }],
+      }),
+    ).toThrow(/Duplicate pane id/u);
+  });
+});

--- a/packages/contracts/src/__tests__/workspace-config.test.ts
+++ b/packages/contracts/src/__tests__/workspace-config.test.ts
@@ -7,6 +7,23 @@ describe("WorkspaceConfigV1SchemaZ", () => {
     expect(WorkspaceConfigV1SchemaZ.parse({ version: 1 })).toEqual({ version: 1 });
   });
 
+  it("accepts unique workspace-safe pane ids and rejects duplicates", () => {
+    expect(
+      WorkspaceConfigV1SchemaZ.parse({
+        version: 1,
+        terminal: { rows: [{ panes: [{ id: "agent-1" }, { id: "shell" }] }] },
+      }).terminal?.rows[0]?.panes.map((pane) => pane.id),
+    ).toEqual(["agent-1", "shell"]);
+    expect(() =>
+      WorkspaceConfigV1SchemaZ.parse({
+        version: 1,
+        terminal: {
+          rows: [{ panes: [{ id: "duplicate" }] }, { panes: [{ id: "duplicate" }] }],
+        },
+      }),
+    ).toThrow(/Duplicate pane id/u);
+  });
+
   it("keeps harnesses, adapters, commands, and models provider-neutral", () => {
     const result = WorkspaceConfigV1SchemaZ.parse({
       version: 1,

--- a/packages/contracts/src/ide-config.ts
+++ b/packages/contracts/src/ide-config.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { AuthConfigSchema } from "./lib-internal/auth.ts";
 import { HQConfigSchema } from "./lib-internal/hq.ts";
+import { WorkspaceIdSchemaZ } from "./workspace-state.ts";
 
 const sizeField = z
   .string()
@@ -15,6 +16,8 @@ export const ThemeConfigSchema = z.object({
 });
 
 export const PaneSchema = z.object({
+  /** Stable semantic identity. Strongly recommended for long-lived agent panes. */
+  id: WorkspaceIdSchemaZ.optional(),
   title: z.string().optional(),
   command: z.string().optional(),
   type: z
@@ -120,26 +123,43 @@ export const SidebarConfigSchema = z.union([
   z.object({ width: z.string().optional() }),
 ]);
 
-export const IdeConfigSchema = z.object({
-  name: z.string().optional(),
-  before: z.string().optional(),
-  team: z
-    .object({
-      name: z.string(),
-      model: z.string().optional(),
-      permissions: z.array(z.string()).optional(),
-    })
-    .optional(),
-  rows: z.array(RowSchema).min(1),
-  sidebar: SidebarConfigSchema.optional(),
-  theme: ThemeConfigSchema.optional(),
-  orchestrator: OrchestratorYamlConfigSchema.optional(),
-  command_center: CommandCenterConfigSchema.optional(),
-  dashboard: DashboardConfigSchema.optional(),
-  auth: AuthConfigSchema.optional(),
-  tunnel: TunnelConfigSchema.optional(),
-  hq: HQConfigSchema.optional(),
-});
+export const IdeConfigSchema = z
+  .object({
+    name: z.string().optional(),
+    before: z.string().optional(),
+    team: z
+      .object({
+        name: z.string(),
+        model: z.string().optional(),
+        permissions: z.array(z.string()).optional(),
+      })
+      .optional(),
+    rows: z.array(RowSchema).min(1),
+    sidebar: SidebarConfigSchema.optional(),
+    theme: ThemeConfigSchema.optional(),
+    orchestrator: OrchestratorYamlConfigSchema.optional(),
+    command_center: CommandCenterConfigSchema.optional(),
+    dashboard: DashboardConfigSchema.optional(),
+    auth: AuthConfigSchema.optional(),
+    tunnel: TunnelConfigSchema.optional(),
+    hq: HQConfigSchema.optional(),
+  })
+  .superRefine((config, context) => {
+    const explicitPaneIds = new Set<string>();
+    for (const [rowIndex, row] of config.rows.entries()) {
+      for (const [paneIndex, pane] of row.panes.entries()) {
+        if (!pane.id) continue;
+        if (explicitPaneIds.has(pane.id)) {
+          context.addIssue({
+            code: "custom",
+            path: ["rows", rowIndex, "panes", paneIndex, "id"],
+            message: `Duplicate pane id "${pane.id}"`,
+          });
+        }
+        explicitPaneIds.add(pane.id);
+      }
+    }
+  });
 
 export const PaneActionSchema = z.object({
   targetPane: z.string(),

--- a/packages/contracts/src/workspace-config.ts
+++ b/packages/contracts/src/workspace-config.ts
@@ -24,6 +24,7 @@ export const WorkspaceCommandSchemaZ = z.union([
  * role/task/specialty/skill metadata into the new workspace contract.
  */
 export const WorkspaceTerminalPaneSchemaZ = PaneSchema.pick({
+  id: true,
   title: true,
   command: true,
   type: true,
@@ -159,6 +160,21 @@ const WorkspaceConfigV1ObjectSchemaZ = z.strictObject({
  */
 export const WorkspaceConfigV1SchemaZ = WorkspaceConfigV1ObjectSchemaZ.superRefine(
   (config, context) => {
+    const explicitPaneIds = new Set<string>();
+    for (const [rowIndex, row] of (config.terminal?.rows ?? []).entries()) {
+      for (const [paneIndex, pane] of row.panes.entries()) {
+        if (!pane.id) continue;
+        if (explicitPaneIds.has(pane.id)) {
+          context.addIssue({
+            code: "custom",
+            path: ["terminal", "rows", rowIndex, "panes", paneIndex, "id"],
+            message: `Duplicate pane id "${pane.id}"`,
+          });
+        }
+        explicitPaneIds.add(pane.id);
+      }
+    }
+
     const harnessNames = new Set(Object.keys(config.harnesses ?? {}));
     for (const [agentName, agent] of Object.entries(config.agents ?? {})) {
       if (!harnessNames.has(agent.harness)) {

--- a/packages/contracts/src/workspace-state.ts
+++ b/packages/contracts/src/workspace-state.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 /** Shared, serializable workspace-domain contract. No renderer or tmux dependencies. */
 export const WORKSPACE_STATE_VERSION = 1 as const;
+/** Durable semantic pane identity stamped as a tmux pane-local user option. */
+export const WORKSPACE_SEMANTIC_PANE_OPTION = "@tmux_ide_pane_id" as const;
 export const WORKSPACE_STATE_MAX_LAYOUTS = 32;
 export const WORKSPACE_STATE_MAX_CHECKOUTS = 16;
 export const WORKSPACE_STATE_MAX_PANES = 128;

--- a/packages/daemon/src/detect.ts
+++ b/packages/daemon/src/detect.ts
@@ -143,8 +143,8 @@ export function suggestConfig(dir: string, detected: DetectedStack): IdeConfig {
       {
         size: "70%",
         panes: [
-          { title: "Claude 1", command: "claude" },
-          { title: "Claude 2", command: "claude" },
+          { id: "agent-1", title: "Claude 1", command: "claude" },
+          { id: "agent-2", title: "Claude 2", command: "claude" },
         ],
       },
       {
@@ -158,42 +158,42 @@ export function suggestConfig(dir: string, detected: DetectedStack): IdeConfig {
 
   // Add 3rd claude pane for complex stacks
   if (frameworks.length >= 2) {
-    config.rows[0]!.panes.push({ title: "Claude 3", command: "claude" });
+    config.rows[0]!.panes.push({ id: "agent-3", title: "Claude 3", command: "claude" });
   }
 
   // Add dev servers
   if (frameworks.includes("next")) {
-    bottom.push({ title: "Next.js", command: `${run} dev` });
+    bottom.push({ id: "dev", title: "Next.js", command: `${run} dev` });
   } else if (frameworks.includes("vite")) {
-    bottom.push({ title: "Vite", command: `${run} dev` });
+    bottom.push({ id: "dev", title: "Vite", command: `${run} dev` });
   } else if (frameworks.includes("nuxt")) {
-    bottom.push({ title: "Nuxt", command: `${run} dev` });
+    bottom.push({ id: "dev", title: "Nuxt", command: `${run} dev` });
   } else if (frameworks.includes("remix")) {
-    bottom.push({ title: "Remix", command: `${run} dev` });
+    bottom.push({ id: "dev", title: "Remix", command: `${run} dev` });
   } else if (frameworks.includes("astro")) {
-    bottom.push({ title: "Astro", command: `${run} dev` });
+    bottom.push({ id: "dev", title: "Astro", command: `${run} dev` });
   } else if (frameworks.includes("svelte")) {
-    bottom.push({ title: "SvelteKit", command: `${run} dev` });
+    bottom.push({ id: "dev", title: "SvelteKit", command: `${run} dev` });
   } else if (frameworks.includes("fastapi")) {
-    bottom.push({ title: "FastAPI", command: "uvicorn main:app --reload" });
+    bottom.push({ id: "dev", title: "FastAPI", command: "uvicorn main:app --reload" });
   } else if (frameworks.includes("django")) {
-    bottom.push({ title: "Django", command: "python manage.py runserver" });
+    bottom.push({ id: "dev", title: "Django", command: "python manage.py runserver" });
   } else if (frameworks.includes("flask")) {
-    bottom.push({ title: "Flask", command: "flask run --reload" });
+    bottom.push({ id: "dev", title: "Flask", command: "flask run --reload" });
   } else if (frameworks.includes("cargo")) {
-    bottom.push({ title: "Cargo", command: "cargo watch -x run" });
+    bottom.push({ id: "dev", title: "Cargo", command: "cargo watch -x run" });
   } else if (frameworks.includes("go")) {
-    bottom.push({ title: "Go", command: "go run ." });
+    bottom.push({ id: "dev", title: "Go", command: "go run ." });
   } else if (detected.devCommand) {
-    bottom.push({ title: "Dev Server", command: detected.devCommand });
+    bottom.push({ id: "dev", title: "Dev Server", command: detected.devCommand });
   }
 
   if (frameworks.includes("convex")) {
-    bottom.push({ title: "Convex", command: "npx convex dev" });
+    bottom.push({ id: "convex", title: "Convex", command: "npx convex dev" });
   }
 
   // Always add shell
-  bottom.push({ title: "Shell" });
+  bottom.push({ id: "shell", title: "Shell" });
 
   return config;
 }

--- a/packages/daemon/src/launch.ts
+++ b/packages/daemon/src/launch.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import { resolveProjectConfigContext, type ProjectConfigContext } from "./lib/config-context.ts";
 import { computeSizes, toSplitPercents } from "./lib/sizes.ts";
 import { outputError } from "./lib/output.ts";
-import { collectPaneStartupPlan } from "./lib/launch-plan.ts";
+import { collectPaneStartupPlan, paneIdentityOptions } from "./lib/launch-plan.ts";
 import { buildSessionOptions } from "./lib/session-options.ts";
 import {
   attachSession,
@@ -260,17 +260,26 @@ export async function launch(
     ({ targetPane, direction, cwd, percent }) => splitPane(targetPane, direction, cwd, percent),
   );
 
-  const { focusPane, paneActions } = collectPaneStartupPlan(rows, paneMap, firstPanesOfRows, dir);
+  const {
+    focusPane,
+    paneActions,
+    diagnostics: launchDiagnostics,
+  } = collectPaneStartupPlan(rows, paneMap, firstPanesOfRows, dir);
+  for (const diagnostic of launchDiagnostics) {
+    console.error(`tmux-ide: warning: ${diagnostic.message}`);
+  }
 
   for (const action of paneActions) {
     if (action.title) {
       setPaneTitle(action.targetPane, action.title);
     }
 
-    // Set pane identity options for discovery by orchestrator/widgets
-    setPaneOption(action.targetPane, "@ide_role", action.paneRole ?? "shell");
-    setPaneOption(action.targetPane, "@ide_name", action.title ?? "");
-    setPaneOption(action.targetPane, "@ide_type", action.paneType ?? "shell");
+    // Stamp semantic identity before compatibility metadata. `%pane_id` remains
+    // a live tmux address only; this durable option is what workspace restore
+    // correlates across app and tmux-server restarts.
+    for (const [option, value] of paneIdentityOptions(action)) {
+      setPaneOption(action.targetPane, option, value);
+    }
 
     // Lock agent pane titles so Claude Code can't overwrite them
     if (action.paneRole === "lead" || action.paneRole === "teammate") {

--- a/packages/daemon/src/lib/__tests__/config-context.test.ts
+++ b/packages/daemon/src/lib/__tests__/config-context.test.ts
@@ -109,4 +109,18 @@ describe("resolveProjectConfigContext", () => {
       configWriteRoot: realpathSync(dir),
     });
   });
+
+  it("threads a config-free project root hint through the normal config context path", async () => {
+    const dir = tempDir();
+    const nested = join(dir, "packages", "app", "src");
+    mkdirSync(nested, { recursive: true });
+
+    await expect(
+      resolveProjectConfigContext(nested, { resolveOptions: { projectRootHint: dir } }),
+    ).resolves.toMatchObject({
+      configKind: "none",
+      projectRoot: realpathSync(dir),
+      configWriteRoot: realpathSync(dir),
+    });
+  });
 });

--- a/packages/daemon/src/lib/__tests__/legacy-config-migration.test.ts
+++ b/packages/daemon/src/lib/__tests__/legacy-config-migration.test.ts
@@ -5,7 +5,10 @@ import { tmpdir } from "node:os";
 import yaml from "js-yaml";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { IdeConfig } from "../../types.ts";
-import { convertLegacyConfigToWorkspace } from "../legacy-config-migration.ts";
+import {
+  convertLegacyConfigToWorkspace,
+  workspaceConfigToLegacyProjection,
+} from "../legacy-config-migration.ts";
 import {
   resolveConfig,
   UnsupportedLegacyConfigMutationError,
@@ -52,6 +55,7 @@ describe("legacy config migration", () => {
           size: "70%",
           panes: [
             {
+              id: "app-dev",
               title: "App",
               command: "pnpm dev",
               dir: "apps/web",
@@ -80,6 +84,7 @@ describe("legacy config migration", () => {
             size: "70%",
             panes: [
               {
+                id: "app-dev",
                 title: "App",
                 command: "pnpm dev",
                 dir: "apps/web",
@@ -101,6 +106,14 @@ describe("legacy config migration", () => {
       "diff",
       "missions",
     ]);
+  });
+
+  it("round-trips explicit pane identity through workspace projection", () => {
+    const legacy: IdeConfig = { rows: [{ panes: [{ id: "agent-lead", title: "Lead" }] }] };
+    const migrated = convertLegacyConfigToWorkspace(legacy).workspace;
+
+    expect(migrated.terminal?.rows[0]?.panes[0]?.id).toBe("agent-lead");
+    expect(workspaceConfigToLegacyProjection(migrated).rows[0]?.panes[0]?.id).toBe("agent-lead");
   });
 
   it("reports every unsupported root section and pane metadata field with stable codes and paths", () => {

--- a/packages/daemon/src/lib/__tests__/project-resolver.test.ts
+++ b/packages/daemon/src/lib/__tests__/project-resolver.test.ts
@@ -121,6 +121,61 @@ describe("resolveProject", () => {
     expect(result.config).toEqual({ kind: "none", path: null, explicit: false });
   });
 
+  it("lets a workspace boundary outrank a nearer nested package manifest", async () => {
+    const io = fakeIo({ files: ["/repo/apps/web/package.json", "/repo/pnpm-workspace.yaml"] });
+
+    const source = await resolveWithIo("/repo/apps/web/src/components", io);
+    const tests = await resolveWithIo("/repo/apps/web/test/unit", io);
+
+    expect(source.projectRoot).toBe("/repo");
+    expect(tests.projectRoot).toBe("/repo");
+    expect(source.identityKey).toBe(tests.identityKey);
+  });
+
+  it("uses the nearest package manifest when no workspace boundary exists", async () => {
+    const io = fakeIo({ files: ["/repo/apps/web/package.json"] });
+
+    expect((await resolveWithIo("/repo/apps/web/src/components", io)).projectRoot).toBe(
+      "/repo/apps/web",
+    );
+  });
+
+  it("ignores generic unrelated ancestor files as project evidence", async () => {
+    const io = fakeIo({ files: ["/README.md", "/Makefile"] });
+
+    expect((await resolveWithIo("/repo/apps/web", io)).projectRoot).toBe("/repo/apps/web");
+  });
+
+  it("uses a containing explicit root hint before ancestor markers outside Git/config", async () => {
+    const io = fakeIo({ files: ["/repo/apps/web/package.json"] });
+    const result = await resolveWithIo("/repo/apps/web/src", io, {
+      projectRootHint: "../../..",
+    });
+
+    expect(result.projectRoot).toBe("/repo");
+    expect(result.identityAnchor).toBe("/repo");
+  });
+
+  it("rejects a root hint that does not contain the canonical input", async () => {
+    await expect(
+      resolveWithIo("/repo/apps/web", fakeIo(), { projectRootHint: "/another/project" }),
+    ).rejects.toThrow(/does not contain input directory/u);
+  });
+
+  it("keeps Git and config roots authoritative over an explicit root hint", async () => {
+    const git = await resolveWithIo("/repo/apps/web", gitIo("/repo", ".git"), {
+      projectRootHint: "/repo/apps",
+    });
+    const configured = await resolveWithIo(
+      "/repo/apps/web/src",
+      fakeIo({ files: ["/repo/apps/web/.tmux-ide/workspace.yml"] }),
+      { projectRootHint: "/repo" },
+    );
+
+    expect(git.projectRoot).toBe("/repo");
+    expect(configured.projectRoot).toBe("/repo/apps/web");
+  });
+
   it("handles unavailable Git and malformed output safely and deterministically", async () => {
     const unavailable = fakeIo({
       runGit: async () => {

--- a/packages/daemon/src/lib/launch-plan.test.ts
+++ b/packages/daemon/src/lib/launch-plan.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "bun:test";
-import { buildPaneCommand, collectPaneStartupPlan } from "./launch-plan.ts";
+import { WORKSPACE_SEMANTIC_PANE_OPTION } from "@tmux-ide/contracts";
+import {
+  buildPaneCommand,
+  collectPaneStartupPlan,
+  paneIdentityOptions,
+  semanticPaneIdForPane,
+} from "./launch-plan.ts";
 import type { Row } from "../types.ts";
 
 describe("buildPaneCommand", () => {
@@ -20,12 +26,25 @@ describe("collectPaneStartupPlan", () => {
     const rows = [
       {
         panes: [
-          { title: "Lead", command: "claude", role: "lead", focus: true, env: { PORT: 3000 } },
-          { title: "Worker", command: "claude", role: "teammate", task: "Review" },
+          {
+            id: "agent-lead",
+            title: "Lead",
+            command: "claude",
+            role: "lead",
+            focus: true,
+            env: { PORT: 3000 },
+          },
+          {
+            id: "agent-worker",
+            title: "Worker",
+            command: "claude",
+            role: "teammate",
+            task: "Review",
+          },
         ],
       },
       {
-        panes: [{ title: "Shell", dir: "apps/web" }],
+        panes: [{ id: "shell-main", title: "Shell", dir: "apps/web" }],
       },
     ];
 
@@ -40,6 +59,7 @@ describe("collectPaneStartupPlan", () => {
     expect(result.paneActions).toEqual([
       {
         targetPane: "%1",
+        semanticPaneId: "agent-lead",
         title: "Lead",
         chdir: null,
         exports: [`export 'PORT'='3000'`],
@@ -51,6 +71,7 @@ describe("collectPaneStartupPlan", () => {
       },
       {
         targetPane: "%2",
+        semanticPaneId: "agent-worker",
         title: "Worker",
         chdir: null,
         exports: [],
@@ -62,6 +83,7 @@ describe("collectPaneStartupPlan", () => {
       },
       {
         targetPane: "%3",
+        semanticPaneId: "shell-main",
         title: "Shell",
         chdir: "/workspace/apps/web",
         exports: [],
@@ -71,6 +93,83 @@ describe("collectPaneStartupPlan", () => {
         paneRole: "shell",
         paneType: "shell",
       },
+    ]);
+  });
+
+  it("uses explicit ids and deterministic metadata ids instead of row/column positions", () => {
+    expect(semanticPaneIdForPane({ id: "agent-lead", title: "Renamed" })).toBe("agent-lead");
+    const derived = semanticPaneIdForPane({ title: "Lead", command: "claude" });
+    expect(derived).toMatch(/^pane-lead-[a-f0-9]{16}$/u);
+    expect(
+      semanticPaneIdForPane({
+        title: "Lead",
+        command: "claude",
+        env: { B: "2", A: "1" },
+      }),
+    ).toBe(
+      semanticPaneIdForPane({
+        title: "Lead",
+        command: "claude",
+        env: { A: "1", B: "2" },
+      }),
+    );
+
+    expect(
+      paneIdentityOptions({
+        semanticPaneId: "agent-lead",
+        paneRole: "lead",
+        paneType: "agent",
+        title: "Lead",
+      }),
+    ).toEqual([
+      [WORKSPACE_SEMANTIC_PANE_OPTION, "agent-lead"],
+      ["@ide_role", "lead"],
+      ["@ide_name", "Lead"],
+      ["@ide_type", "agent"],
+    ]);
+  });
+
+  it("keeps derived identities stable across insert, reorder, and delete", () => {
+    const original: Row[] = [
+      {
+        panes: [
+          { title: "Planner", command: "claude" },
+          { title: "Implementer", command: "codex" },
+        ],
+      },
+    ];
+    const changed: Row[] = [
+      {
+        panes: [
+          { title: "Reviewer", command: "claude" },
+          { title: "Implementer", command: "codex" },
+          { title: "Planner", command: "claude" },
+        ],
+      },
+    ];
+    const deleted: Row[] = [{ panes: [{ title: "Planner", command: "claude" }] }];
+    const first = collectPaneStartupPlan(original, [["%1", "%2"]], new Set(["%1"]), "/repo");
+    const second = collectPaneStartupPlan(changed, [["%3", "%4", "%5"]], new Set(["%3"]), "/repo");
+    const third = collectPaneStartupPlan(deleted, [["%6"]], new Set(["%6"]), "/repo");
+    const byTitle = (plan: typeof first) =>
+      new Map(plan.paneActions.map((action) => [action.title, action.semanticPaneId]));
+
+    expect(byTitle(second).get("Planner")).toBe(byTitle(first).get("Planner"));
+    expect(byTitle(second).get("Implementer")).toBe(byTitle(first).get("Implementer"));
+    expect(byTitle(third).get("Planner")).toBe(byTitle(first).get("Planner"));
+  });
+
+  it("keeps identical implicit legacy panes launchable but diagnoses durable ambiguity", () => {
+    const result = collectPaneStartupPlan(
+      [{ panes: [{ command: "zsh" }, { command: "zsh" }] }],
+      [["%1", "%2"]],
+      new Set(["%1"]),
+      "/repo",
+    );
+
+    expect(new Set(result.paneActions.map((action) => action.semanticPaneId)).size).toBe(2);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ code: "AMBIGUOUS_IMPLICIT_PANE_ID" }),
     ]);
   });
 

--- a/packages/daemon/src/lib/launch-plan.ts
+++ b/packages/daemon/src/lib/launch-plan.ts
@@ -1,6 +1,53 @@
 import { resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { WORKSPACE_SEMANTIC_PANE_OPTION } from "@tmux-ide/contracts";
 import type { Pane, Row, PaneAction } from "../types.ts";
 import { shellEscape } from "./shell.ts";
+
+export interface LaunchPaneAction extends PaneAction {
+  /** Stable across tmux restarts and config insertion/reorder for this pane. */
+  semanticPaneId: string;
+}
+
+export interface LaunchPlanDiagnostic {
+  code: "AMBIGUOUS_IMPLICIT_PANE_ID";
+  message: string;
+}
+
+/**
+ * Explicit `pane.id` is authoritative. The fallback hashes declarative pane
+ * metadata, never its row/column. A title is part of fallback identity so two
+ * same-command agents remain distinct across reorder; users who want title
+ * edits to preserve identity should set `id` (new onboarding does so).
+ */
+export function semanticPaneIdForPane(pane: Pane): string {
+  if (pane.id) return pane.id;
+  const metadata = JSON.stringify({
+    title: pane.title ?? null,
+    command: pane.command ?? null,
+    type: pane.type ?? null,
+    target: pane.target ?? null,
+    dir: pane.dir ?? null,
+    role: pane.role ?? null,
+    env: Object.entries(pane.env ?? {}).sort(([left], [right]) =>
+      left < right ? -1 : left > right ? 1 : 0,
+    ),
+  });
+  const digest = createHash("sha256").update(metadata).digest("hex").slice(0, 16);
+  const label = paneIdentityLabel(pane);
+  return `pane-${label}-${digest}`;
+}
+
+export function paneIdentityOptions(
+  action: Pick<LaunchPaneAction, "semanticPaneId" | "paneRole" | "paneType" | "title">,
+): ReadonlyArray<readonly [option: string, value: string]> {
+  return [
+    [WORKSPACE_SEMANTIC_PANE_OPTION, action.semanticPaneId],
+    ["@ide_role", action.paneRole ?? "shell"],
+    ["@ide_name", action.title ?? ""],
+    ["@ide_type", action.paneType ?? "shell"],
+  ];
+}
 
 export function buildPaneCommand(pane: Pane): string | null {
   if (!pane.command) return null;
@@ -12,9 +59,11 @@ export function collectPaneStartupPlan(
   paneMap: string[][],
   firstPanesOfRows: Set<string>,
   dir: string,
-): { focusPane: string; paneActions: PaneAction[] } {
+): { focusPane: string; paneActions: LaunchPaneAction[]; diagnostics: LaunchPlanDiagnostic[] } {
   let focusPane = paneMap[0]![0]!;
-  const paneActions: PaneAction[] = [];
+  const paneActions: LaunchPaneAction[] = [];
+  const diagnostics: LaunchPlanDiagnostic[] = [];
+  const paneIdentities = assignPaneIdentities(rows, diagnostics);
 
   for (let rowIdx = 0; rowIdx < rows.length; rowIdx++) {
     const row = rows[rowIdx]!;
@@ -45,8 +94,9 @@ export function collectPaneStartupPlan(
         paneType = "shell";
       }
 
-      const action: PaneAction = {
+      const action: LaunchPaneAction = {
         targetPane: tmuxPane,
+        semanticPaneId: paneIdentities[rowIdx]![paneIdx]!,
         title: pane.title ?? null,
         chdir: null,
         exports: [],
@@ -86,5 +136,62 @@ export function collectPaneStartupPlan(
     }
   }
 
-  return { focusPane, paneActions };
+  return { focusPane, paneActions, diagnostics };
+}
+
+function assignPaneIdentities(
+  rows: readonly Row[],
+  diagnostics: LaunchPlanDiagnostic[],
+): string[][] {
+  const bases = rows.map((row) => row.panes.map(semanticPaneIdForPane));
+  const implicitCounts = new Map<string, number>();
+  const explicitIds = new Set<string>();
+  for (const [rowIndex, row] of rows.entries()) {
+    for (const [paneIndex, pane] of row.panes.entries()) {
+      const base = bases[rowIndex]![paneIndex]!;
+      if (pane.id) {
+        if (explicitIds.has(base)) throw new Error(`duplicate explicit pane id "${base}"`);
+        explicitIds.add(base);
+      } else {
+        implicitCounts.set(base, (implicitCounts.get(base) ?? 0) + 1);
+      }
+    }
+  }
+
+  const occurrences = new Map<string, number>();
+  const assigned = new Set(explicitIds);
+  return rows.map((row, rowIndex) =>
+    row.panes.map((pane, paneIndex) => {
+      const base = bases[rowIndex]![paneIndex]!;
+      if (pane.id) return base;
+      const total = implicitCounts.get(base) ?? 1;
+      const occurrence = (occurrences.get(base) ?? 0) + 1;
+      occurrences.set(base, occurrence);
+      const candidate = total === 1 ? base : `${base}-${occurrence}`;
+      if (assigned.has(candidate)) {
+        throw new Error(
+          `explicit pane id "${candidate}" collides with a derived pane identity; choose another explicit id`,
+        );
+      }
+      assigned.add(candidate);
+      if (total > 1 && occurrence === 1) {
+        diagnostics.push({
+          code: "AMBIGUOUS_IMPLICIT_PANE_ID",
+          message: `${total} panes produce the same implicit identity fingerprint. Assigned occurrence suffixes for compatibility; add explicit pane ids to preserve their individual identity across insert/delete.`,
+        });
+      }
+      return candidate;
+    }),
+  );
+}
+
+function paneIdentityLabel(pane: Pane): string {
+  const raw =
+    pane.title ?? pane.type ?? pane.role ?? pane.command?.trim().split(/\s+/u)[0] ?? "shell";
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .slice(0, 32);
+  return slug || "pane";
 }

--- a/packages/daemon/src/lib/legacy-config-migration.ts
+++ b/packages/daemon/src/lib/legacy-config-migration.ts
@@ -63,6 +63,7 @@ function cloneTerminalPane(
   pane: Pane,
 ): NonNullable<WorkspaceConfigV1["terminal"]>["rows"][number]["panes"][number] {
   const result: NonNullable<WorkspaceConfigV1["terminal"]>["rows"][number]["panes"][number] = {};
+  if (pane.id !== undefined) result.id = pane.id;
   if (pane.title !== undefined) result.title = pane.title;
   if (pane.command !== undefined) result.command = pane.command;
   if (pane.type !== undefined) result.type = pane.type;
@@ -124,6 +125,7 @@ export function workspaceConfigToLegacyProjection(workspace: WorkspaceConfigV1):
     rows: (workspace.terminal?.rows ?? [{ panes: [{ title: "Shell" }] }]).map((row) => ({
       ...(row.size === undefined ? {} : { size: row.size }),
       panes: row.panes.map((pane) => ({
+        ...(pane.id === undefined ? {} : { id: pane.id }),
         ...(pane.title === undefined ? {} : { title: pane.title }),
         ...(pane.command === undefined ? {} : { command: pane.command }),
         ...(pane.type === undefined ? {} : { type: pane.type }),

--- a/packages/daemon/src/lib/project-onboard.test.ts
+++ b/packages/daemon/src/lib/project-onboard.test.ts
@@ -33,6 +33,7 @@ describe("composeIdeYmlConfig", () => {
     expect(config.rows).toHaveLength(2);
     expect(config.rows[0]!.panes).toHaveLength(1);
     expect(config.rows[0]!.panes[0]).toMatchObject({
+      id: "agent-1",
       title: "Claude 1",
       command: "claude",
       focus: true,
@@ -46,11 +47,13 @@ describe("composeIdeYmlConfig", () => {
     expect(config.team).toBeUndefined();
     expect(config.rows[0]!.panes).toHaveLength(2);
     expect(config.rows[0]!.panes[0]).toMatchObject({
+      id: "agent-1",
       title: "Lead",
       command: "claude",
       focus: true,
     });
     expect(config.rows[0]!.panes[1]).toMatchObject({
+      id: "agent-2",
       title: "Teammate 1",
       command: "claude",
     });
@@ -74,20 +77,20 @@ describe("composeIdeYmlConfig", () => {
       devCommand: "pnpm dev",
     });
     expect(config.rows[1]!.panes).toEqual([
-      { title: "Dev", command: "pnpm dev" },
-      { title: "Shell" },
+      { id: "dev", title: "Dev", command: "pnpm dev" },
+      { id: "shell", title: "Shell" },
     ]);
   });
 
   it("omits the Dev pane when devCommand is null/undefined/empty", () => {
     expect(
       composeIdeYmlConfig({ name: "alpha", agents: 1, devCommand: null }).rows[1]!.panes,
-    ).toEqual([{ title: "Shell" }]);
+    ).toEqual([{ id: "shell", title: "Shell" }]);
     expect(
       composeIdeYmlConfig({ name: "alpha", agents: 1, devCommand: "  " }).rows[1]!.panes,
-    ).toEqual([{ title: "Shell" }]);
+    ).toEqual([{ id: "shell", title: "Shell" }]);
     expect(composeIdeYmlConfig({ name: "alpha", agents: 1 }).rows[1]!.panes).toEqual([
-      { title: "Shell" },
+      { id: "shell", title: "Shell" },
     ]);
   });
 

--- a/packages/daemon/src/lib/project-onboard.ts
+++ b/packages/daemon/src/lib/project-onboard.ts
@@ -89,6 +89,7 @@ export function composeIdeYmlConfig(input: ComposeIdeYmlInput): IdeConfig {
     const fallback = agentsCount > 1 ? (i === 0 ? "Lead" : `Teammate ${i}`) : `Claude ${i + 1}`;
     const customTitle = customNames?.[i]?.trim();
     const pane: Pane = {
+      id: `agent-${i + 1}`,
       title: customTitle && customTitle.length > 0 ? customTitle : fallback,
       command: "claude",
     };
@@ -101,9 +102,9 @@ export function composeIdeYmlConfig(input: ComposeIdeYmlInput): IdeConfig {
   const bottomPanes: Pane[] = [];
   const devCommand = input.devCommand?.trim();
   if (devCommand) {
-    bottomPanes.push({ title: "Dev", command: devCommand });
+    bottomPanes.push({ id: "dev", title: "Dev", command: devCommand });
   }
-  bottomPanes.push({ title: "Shell" });
+  bottomPanes.push({ id: "shell", title: "Shell" });
 
   const rows: Row[] = [{ size: "70%", panes: topPanes }, { panes: bottomPanes }];
 

--- a/packages/daemon/src/lib/project-resolver.ts
+++ b/packages/daemon/src/lib/project-resolver.ts
@@ -3,9 +3,12 @@
  *
  * A working tree keeps its own project root, while linked Git worktrees share
  * an identity through Git's common directory. Non-Git projects use the root
- * selected by their nearest config (or the canonical input directory when no
- * config exists). All filesystem and process I/O is injectable for focused,
- * deterministic tests.
+ * selected by their nearest config, an explicit root hint, an ancestor
+ * workspace/lock boundary, or the nearest package manifest (in that order).
+ * A truly markerless tree cannot be inferred safely, so it deliberately falls
+ * back to the canonical input directory.
+ * All filesystem and process I/O is injectable for focused, deterministic
+ * tests.
  */
 
 import { execFile } from "node:child_process";
@@ -14,6 +17,40 @@ import { existsSync, realpathSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 const GIT_TIMEOUT_MS = 2_000;
+
+/** Explicit workspace/lock boundaries outrank nested package manifests. */
+export const WORKSPACE_ROOT_MARKERS = [
+  ".tmux-ide",
+  "pnpm-workspace.yaml",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "package-lock.json",
+  "bun.lock",
+  "bun.lockb",
+  "uv.lock",
+  "go.work",
+  "Cargo.lock",
+  "settings.gradle",
+  "settings.gradle.kts",
+] as const;
+
+/** Nearest language/package manifest when no workspace boundary exists. */
+export const PACKAGE_ROOT_MARKERS = [
+  "deno.json",
+  "deno.jsonc",
+  "package.json",
+  "Cargo.toml",
+  "go.mod",
+  "pyproject.toml",
+  "Gemfile",
+  "composer.json",
+  "mix.exs",
+  "Package.swift",
+  "pom.xml",
+] as const;
+
+/** All intentionally strong markers; generic README/Makefile files are omitted. */
+export const PROJECT_ROOT_MARKERS = [...WORKSPACE_ROOT_MARKERS, ...PACKAGE_ROOT_MARKERS] as const;
 
 export type ProjectIdentitySource = "git-common-dir" | "canonical-realpath";
 export type ProjectConfigKind = "workspace" | "legacy" | "none";
@@ -52,6 +89,12 @@ export interface ProjectResolverIo {
 export interface ResolveProjectOptions {
   /** Caller-selected config. Relative paths resolve from the canonical input directory. */
   explicitConfigPath?: string | null;
+  /**
+   * Explicit config-free project boundary. It is considered only outside Git
+   * and when no workspace/legacy config was discovered, and must contain the
+   * canonical input directory.
+   */
+  projectRootHint?: string | null;
   /** Override any subset of filesystem/process operations. */
   io?: Partial<ProjectResolverIo>;
 }
@@ -218,6 +261,38 @@ function configProjectRoot(config: ProjectConfigSource, inputDir: string): strin
   return configDir;
 }
 
+function hintedProjectRoot(
+  hint: string | null | undefined,
+  inputDir: string,
+  io: ProjectResolverIo,
+): string | null {
+  if (!hint || hint.trim().length === 0) return null;
+  const root = canonicalize(isAbsolute(hint) ? hint : resolve(inputDir, hint), io);
+  if (!isWithin(inputDir, root)) {
+    throw new Error(`Project root hint "${root}" does not contain input directory "${inputDir}"`);
+  }
+  return root;
+}
+
+function markedProjectRoot(inputDir: string, io: ProjectResolverIo): string | null {
+  let current = inputDir;
+  let nearestPackageRoot: string | null = null;
+  while (true) {
+    if (WORKSPACE_ROOT_MARKERS.some((marker) => safeExists(join(current, marker), io))) {
+      return current;
+    }
+    if (
+      nearestPackageRoot === null &&
+      PACKAGE_ROOT_MARKERS.some((marker) => safeExists(join(current, marker), io))
+    ) {
+      nearestPackageRoot = current;
+    }
+    const parent = dirname(current);
+    if (parent === current) return nearestPackageRoot;
+    current = parent;
+  }
+}
+
 function projectIdentityKey(source: ProjectIdentitySource, anchor: string): string {
   const prefix = source === "git-common-dir" ? "git" : "path";
   const digest = createHash("sha256").update(source).update("\0").update(anchor).digest("hex");
@@ -227,7 +302,11 @@ function projectIdentityKey(source: ProjectIdentitySource, anchor: string): stri
 /**
  * Resolve the canonical project root, shared identity, and winning config for
  * `dir`. Git failures (including missing executables and malformed output)
- * degrade to canonical-realpath identity without throwing.
+ * degrade to canonical-realpath identity without throwing. For a config-free,
+ * non-Git tree, a validated explicit root hint wins over marker inference;
+ * workspace/lock markers then outrank nearer package manifests. With neither,
+ * the canonical input directory remains the honest fallback: there is no safe
+ * evidence that its parent is the project.
  */
 export async function resolveProject(
   dir: string,
@@ -245,7 +324,13 @@ export async function resolveProject(
 
   const discovered = discoverConfigs(inputDir, gitProjectRoot, io);
   const config = chooseConfig(options.explicitConfigPath, inputDir, discovered, io);
-  const projectRoot = gitProjectRoot ?? configProjectRoot(config, inputDir);
+  const configuredRoot = config.kind === "none" ? null : configProjectRoot(config, inputDir);
+  const inferredRoot =
+    gitProjectRoot || configuredRoot
+      ? null
+      : (hintedProjectRoot(options.projectRootHint, inputDir, io) ??
+        markedProjectRoot(inputDir, io));
+  const projectRoot = gitProjectRoot ?? configuredRoot ?? inferredRoot ?? inputDir;
   const identitySource: ProjectIdentitySource = gitCommonDir
     ? "git-common-dir"
     : "canonical-realpath";

--- a/packages/daemon/src/lib/resolved-config.ts
+++ b/packages/daemon/src/lib/resolved-config.ts
@@ -146,6 +146,7 @@ export async function resolveConfig(
 ): Promise<ResolvedConfig> {
   const resolution = await resolveProject(dir, {
     explicitConfigPath: options.explicitConfigPath ?? options.resolveOptions?.explicitConfigPath,
+    projectRootHint: options.resolveOptions?.projectRootHint,
     io: options.resolverIo ?? options.resolveOptions?.io,
   });
 
@@ -291,6 +292,7 @@ const LAUNCH_CONFIG_KEYS = new Set([
 ]);
 const ROW_KEYS = new Set(["size", "panes"]);
 const PANE_KEYS = new Set([
+  "id",
   "title",
   "command",
   "type",

--- a/packages/daemon/src/tui/mirror/session-descriptor-discovery.test.ts
+++ b/packages/daemon/src/tui/mirror/session-descriptor-discovery.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SESSION_PANE_DESCRIPTOR_FORMAT,
+  SessionDescriptorDiscovery,
+  decodeTmuxArgument,
+  parseSessionPaneDescriptors,
+} from "./session-descriptor-discovery.ts";
+
+function line(runtimePaneId: string, cwd = "/repo", title = "Shell"): string {
+  return `${runtimePaneId}\tpane-one\tshell\tshell\tzsh\t${cwd}\t0\tmain\t@1\t${title}`;
+}
+
+function controlModeBytes(value: string): string {
+  return Buffer.from(value, "utf8").toString("latin1");
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (cause: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("SessionDescriptorDiscovery", () => {
+  it("uses qa encoding and decodes tabs, newlines, spaces, and backslashes", () => {
+    expect(SESSION_PANE_DESCRIPTOR_FORMAT).toContain("#{qa:pane_current_path}");
+    expect(decodeTmuxArgument("/repo/a\\tb\\nline\\\\tail\\ path")).toBe(
+      "/repo/a\tb\nline\\tail path",
+    );
+    expect(decodeTmuxArgument('"bad stamp\\tvalue"')).toBe("bad stamp\tvalue");
+  });
+
+  it("recovers UTF-8 cwd and title values from ControlModeClient latin1 byte strings", () => {
+    const cwd = "/repo/café 😀";
+    const title = "Review café 😀";
+    const replyLine = controlModeBytes(
+      `%21\t"pane-one"\t"lead"\t"agent"\t"codex"\t"${cwd}"\t0\t"mission"\t@1\t"${title}"`,
+    );
+
+    expect(parseSessionPaneDescriptors([replyLine])).toEqual([
+      expect.objectContaining({
+        runtimePaneId: "%21",
+        cwd,
+        title,
+      }),
+    ]);
+  });
+
+  it("rejects malformed UTF-8 safely and exposes a discovery diagnostic", async () => {
+    const malformed = Buffer.concat([
+      Buffer.from("%7\tpane-one\tshell\tshell\tzsh\t/repo/", "ascii"),
+      Buffer.from([0xff]),
+      Buffer.from("\t0\tmain\t@1\tShell", "ascii"),
+    ]).toString("latin1");
+    const statuses: unknown[] = [];
+    const discovery = new SessionDescriptorDiscovery({
+      query: () => Promise.resolve([malformed]),
+      onDescriptors: () => {},
+      onStatus: (status) => statuses.push(status),
+      maxAttempts: 1,
+    });
+
+    expect(() => parseSessionPaneDescriptors([malformed])).not.toThrow();
+    expect(parseSessionPaneDescriptors([malformed])).toEqual([]);
+    discovery.discover(new Set(["%7"]));
+    await flushPromises();
+    expect(statuses.at(-1)).toMatchObject({
+      status: "failed",
+      degraded: true,
+      attempt: 1,
+      message: expect.stringContaining("malformed UTF-8 record was omitted"),
+    });
+  });
+
+  it("publishes healthy descriptors from a mixed reply and reports partial degradation", async () => {
+    const malformed = Buffer.concat([
+      Buffer.from("%8\tpane-two\tshell\tshell\tzsh\t/repo/", "ascii"),
+      Buffer.from([0xff]),
+      Buffer.from("\t0\tmain\t@1\tBroken", "ascii"),
+    ]).toString("latin1");
+    const statuses: unknown[] = [];
+    const discoveries: unknown[] = [];
+    const scheduled: unknown[] = [];
+    const discovery = new SessionDescriptorDiscovery({
+      query: () =>
+        Promise.resolve([controlModeBytes(line("%7", "/repo/café", "Healthy 😀")), malformed]),
+      onDescriptors: (descriptors) => discoveries.push(descriptors),
+      onStatus: (status) => statuses.push(status),
+      schedule: (callback, delayMs) => {
+        scheduled.push({ callback, delayMs });
+        return () => {};
+      },
+    });
+
+    discovery.discover(new Set(["%7", "%8"]));
+    await flushPromises();
+
+    expect(discoveries).toEqual([
+      [expect.objectContaining({ runtimePaneId: "%7", cwd: "/repo/café", title: "Healthy 😀" })],
+    ]);
+    expect(statuses.at(-1)).toMatchObject({
+      status: "partial",
+      degraded: true,
+      attempt: 1,
+      retryInMs: null,
+      message: expect.stringContaining("published 1 of 2 live panes"),
+    });
+    expect(scheduled).toEqual([]);
+  });
+
+  it("retries with bounded backoff and clears the diagnostic after success", async () => {
+    let queryCount = 0;
+    const scheduled: Array<{ callback: () => void; delayMs: number }> = [];
+    const statuses: unknown[] = [];
+    const discoveries: unknown[] = [];
+    const discovery = new SessionDescriptorDiscovery({
+      query: () => {
+        queryCount += 1;
+        return queryCount === 1
+          ? Promise.reject(new Error("temporary failure"))
+          : Promise.resolve([line("%7", "/repo/apps\\tweb")]);
+      },
+      onDescriptors: (descriptors) => discoveries.push(descriptors),
+      onStatus: (status) => statuses.push(status),
+      maxAttempts: 3,
+      baseDelayMs: 10,
+      schedule: (callback, delayMs) => {
+        scheduled.push({ callback, delayMs });
+        return () => {};
+      },
+    });
+
+    discovery.discover(new Set(["%7"]));
+    await flushPromises();
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]!.delayMs).toBe(10);
+    expect(statuses[0]).toMatchObject({ status: "retrying", attempt: 1, retryInMs: 10 });
+
+    scheduled[0]!.callback();
+    await flushPromises();
+    expect(queryCount).toBe(2);
+    expect(statuses.at(-1)).toBeNull();
+    expect(discoveries).toEqual([
+      [expect.objectContaining({ runtimePaneId: "%7", cwd: "/repo/apps\tweb" })],
+    ]);
+  });
+
+  it("drops superseded and disposed replies without retries or stale publication", async () => {
+    const first = deferred<string[]>();
+    const second = deferred<string[]>();
+    const third = deferred<string[]>();
+    const pending = [first, second, third];
+    const discoveries: string[][] = [];
+    const statuses: unknown[] = [];
+    const scheduled: unknown[] = [];
+    const discovery = new SessionDescriptorDiscovery({
+      query: () => pending.shift()!.promise,
+      onDescriptors: (descriptors) =>
+        discoveries.push(descriptors.map((descriptor) => descriptor.runtimePaneId)),
+      onStatus: (status) => statuses.push(status),
+      schedule: (callback, delayMs) => {
+        scheduled.push({ callback, delayMs });
+        return () => {};
+      },
+    });
+
+    discovery.discover(new Set(["%1"]));
+    discovery.discover(new Set(["%2"]));
+    first.resolve([line("%1")]);
+    second.resolve([line("%2")]);
+    await flushPromises();
+    expect(discoveries).toEqual([["%2"]]);
+
+    discovery.discover(new Set(["%3"]));
+    discovery.dispose();
+    third.reject(new Error("late failure"));
+    await flushPromises();
+    expect(discoveries).toEqual([["%2"]]);
+    expect(scheduled).toEqual([]);
+    expect(statuses).toEqual([null]);
+  });
+
+  it("stops after the configured attempt bound and exposes terminal failure", async () => {
+    const scheduled: Array<() => void> = [];
+    const statuses: unknown[] = [];
+    const discovery = new SessionDescriptorDiscovery({
+      query: () => Promise.reject(new Error("offline")),
+      onDescriptors: () => {},
+      onStatus: (status) => statuses.push(status),
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      schedule: (callback) => {
+        scheduled.push(callback);
+        return () => {};
+      },
+    });
+
+    discovery.discover(new Set(["%9"]));
+    await flushPromises();
+    scheduled[0]!();
+    await flushPromises();
+    scheduled[1]!();
+    await flushPromises();
+    expect(statuses.slice(0, 2)).toEqual([
+      expect.objectContaining({ status: "retrying", attempt: 1, retryInMs: 1 }),
+      expect.objectContaining({ status: "retrying", attempt: 2, retryInMs: 2 }),
+    ]);
+    expect(statuses.at(-1)).toMatchObject({ status: "failed", attempt: 3, retryInMs: null });
+    expect(scheduled).toHaveLength(2);
+  });
+});

--- a/packages/daemon/src/tui/mirror/session-descriptor-discovery.ts
+++ b/packages/daemon/src/tui/mirror/session-descriptor-discovery.ts
@@ -1,0 +1,298 @@
+export interface SessionPaneDescriptor {
+  runtimePaneId: string;
+  semanticPaneId: string | null;
+  role: string | null;
+  type: string | null;
+  currentCommand: string | null;
+  cwd: string | null;
+  title: string | null;
+  windowIndex: number | null;
+  windowName: string | null;
+  windowId: string | null;
+}
+
+/**
+ * `qa` asks tmux to escape each value as a command argument. In particular,
+ * embedded tabs/newlines/backslashes become escapes, leaving our record tabs
+ * unambiguous. This modifier is supported by the tmux version we already use
+ * for control-mode mirroring.
+ */
+export const SESSION_PANE_DESCRIPTOR_FORMAT = [
+  "#{pane_id}",
+  "#{qa:@tmux_ide_pane_id}",
+  "#{qa:@ide_role}",
+  "#{qa:@ide_type}",
+  "#{qa:pane_current_command}",
+  "#{qa:pane_current_path}",
+  "#{window_index}",
+  "#{qa:window_name}",
+  "#{window_id}",
+  "#{qa:pane_title}",
+].join("\t");
+
+/** Decode the escapes emitted by tmux's `qa` format modifier. */
+export function decodeTmuxArgument(value: string): string {
+  const encoded =
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+      ? value.slice(1, -1)
+      : value;
+  let decoded = "";
+  for (let index = 0; index < encoded.length; index += 1) {
+    const current = encoded[index]!;
+    if (current !== "\\" || index + 1 >= encoded.length) {
+      decoded += current;
+      continue;
+    }
+    const escaped = encoded[++index]!;
+    if (escaped === "e") decoded += "\x1b";
+    else if (escaped === "n") decoded += "\n";
+    else if (escaped === "r") decoded += "\r";
+    else if (escaped === "t") decoded += "\t";
+    else if (/[0-7]/u.test(escaped)) {
+      let octal = escaped;
+      while (octal.length < 3 && /[0-7]/u.test(encoded[index + 1] ?? "")) {
+        octal += encoded[++index]!;
+      }
+      decoded += String.fromCodePoint(Number.parseInt(octal, 8));
+    } else if (escaped === "u") {
+      const remaining = encoded.slice(index + 1);
+      const unicode = remaining.match(/^(?:[0-9A-Fa-f]{8}|[0-9A-Fa-f]{4})/u)?.[0];
+      if (unicode) {
+        decoded += String.fromCodePoint(Number.parseInt(unicode, 16));
+        index += unicode.length;
+      } else {
+        decoded += "u";
+      }
+    } else {
+      decoded += escaped;
+    }
+  }
+  return decoded;
+}
+
+interface ParsedSessionPaneDescriptorReply {
+  descriptors: SessionPaneDescriptor[];
+  malformedUtf8Records: number;
+}
+
+/**
+ * PURE — parse one qa-escaped, tab-delimited descriptor record per pane.
+ * ControlModeClient deliberately exposes stdout as latin1 so each JS code
+ * unit preserves one wire byte. Recover UTF-8 before interpreting tmux's
+ * ASCII qa escapes; doing it afterwards would leave non-ASCII metadata as
+ * mojibake while decoding the whole string with the default replacement mode
+ * would silently persist corrupt metadata.
+ */
+export function parseSessionPaneDescriptors(lines: readonly string[]): SessionPaneDescriptor[] {
+  return parseSessionPaneDescriptorReply(lines).descriptors;
+}
+
+function parseSessionPaneDescriptorReply(
+  lines: readonly string[],
+): ParsedSessionPaneDescriptorReply {
+  const descriptors: SessionPaneDescriptor[] = [];
+  let malformedUtf8Records = 0;
+  for (const line of lines) {
+    const utf8Line = decodeControlReplyUtf8(line);
+    if (utf8Line === null) {
+      malformedUtf8Records += 1;
+      continue;
+    }
+    const encoded = utf8Line.split("\t");
+    if (encoded.length !== 10) continue;
+    const [
+      runtimePaneId = "",
+      semanticPaneId = "",
+      role = "",
+      type = "",
+      currentCommand = "",
+      cwd = "",
+      windowIndexRaw = "",
+      windowName = "",
+      windowId = "",
+      title = "",
+    ] = encoded.map(decodeTmuxArgument);
+    if (!/^%[0-9]+$/u.test(runtimePaneId)) continue;
+    const parsedWindowIndex = Number(windowIndexRaw);
+    const windowIndex =
+      Number.isSafeInteger(parsedWindowIndex) && parsedWindowIndex >= 0 ? parsedWindowIndex : null;
+    descriptors.push({
+      runtimePaneId,
+      semanticPaneId: nonempty(semanticPaneId),
+      role: nonempty(role),
+      type: nonempty(type),
+      currentCommand: nonempty(currentCommand),
+      cwd: nonempty(cwd),
+      title: nonempty(title),
+      windowIndex,
+      windowName: nonempty(windowName),
+      windowId: /^@[0-9]+$/u.test(windowId) ? windowId : null,
+    });
+  }
+  return { descriptors, malformedUtf8Records };
+}
+
+export interface SessionDescriptorDiscoveryDiagnostic {
+  status: "partial" | "retrying" | "failed";
+  /** Any non-null discovery diagnostic means descriptor truth is degraded. */
+  degraded: true;
+  attempt: number;
+  maxAttempts: number;
+  retryInMs: number | null;
+  message: string;
+}
+
+export interface SessionDescriptorDiscoveryOptions {
+  query: () => Promise<string[]>;
+  onDescriptors: (
+    descriptors: readonly SessionPaneDescriptor[],
+    listedRuntimePaneIds: ReadonlySet<string>,
+  ) => void;
+  onStatus?: (status: SessionDescriptorDiscoveryDiagnostic | null) => void;
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  schedule?: (callback: () => void, delayMs: number) => () => void;
+}
+
+/** Bounded, epoch-safe descriptor query/retry coordinator. */
+export class SessionDescriptorDiscovery {
+  private readonly options: Required<
+    Pick<SessionDescriptorDiscoveryOptions, "maxAttempts" | "baseDelayMs" | "schedule">
+  > &
+    Omit<SessionDescriptorDiscoveryOptions, "maxAttempts" | "baseDelayMs" | "schedule">;
+  private epoch = 0;
+  private cancelScheduled: (() => void) | null = null;
+  private disposed = false;
+
+  constructor(options: SessionDescriptorDiscoveryOptions) {
+    this.options = {
+      ...options,
+      maxAttempts: positiveInteger(options.maxAttempts, 3),
+      baseDelayMs: positiveInteger(options.baseDelayMs, 50),
+      schedule:
+        options.schedule ??
+        ((callback, delayMs) => {
+          const timer = setTimeout(callback, delayMs);
+          return () => clearTimeout(timer);
+        }),
+    };
+  }
+
+  discover(listedRuntimePaneIds: ReadonlySet<string>): void {
+    if (this.disposed) return;
+    this.invalidatePending();
+    const epoch = this.epoch;
+    this.attempt(epoch, new Set(listedRuntimePaneIds), 1);
+  }
+
+  invalidate(): void {
+    if (this.disposed) return;
+    this.invalidatePending();
+    this.options.onStatus?.(null);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.invalidatePending();
+    this.disposed = true;
+  }
+
+  private invalidatePending(): void {
+    this.epoch += 1;
+    this.cancelScheduled?.();
+    this.cancelScheduled = null;
+  }
+
+  private attempt(epoch: number, listed: ReadonlySet<string>, attempt: number): void {
+    void this.options
+      .query()
+      .then((lines) => {
+        if (!this.isCurrent(epoch)) return;
+        const parsed = parseSessionPaneDescriptorReply(lines);
+        const descriptorByRuntimePane = new Map(
+          parsed.descriptors
+            .filter((descriptor) => listed.has(descriptor.runtimePaneId))
+            .map((descriptor) => [descriptor.runtimePaneId, descriptor]),
+        );
+        const descriptors = [...descriptorByRuntimePane.values()];
+        if (listed.size > 0 && descriptors.length === 0) {
+          const malformedDetail =
+            parsed.malformedUtf8Records > 0
+              ? `; ${parsed.malformedUtf8Records} malformed UTF-8 record${parsed.malformedUtf8Records === 1 ? " was" : "s were"} omitted`
+              : "";
+          throw new Error(
+            `descriptor reply covered 0 of ${listed.size} live panes${malformedDetail}`,
+          );
+        }
+        if (descriptors.length !== listed.size || parsed.malformedUtf8Records > 0) {
+          const malformedDetail =
+            parsed.malformedUtf8Records > 0
+              ? `; omitted ${parsed.malformedUtf8Records} malformed UTF-8 record${parsed.malformedUtf8Records === 1 ? "" : "s"}`
+              : "";
+          this.options.onStatus?.({
+            status: "partial",
+            degraded: true,
+            attempt,
+            maxAttempts: this.options.maxAttempts,
+            retryInMs: null,
+            message: `Pane descriptor discovery published ${descriptors.length} of ${listed.size} live panes${malformedDetail}.`,
+          });
+        } else {
+          this.options.onStatus?.(null);
+        }
+        this.options.onDescriptors(descriptors, listed);
+      })
+      .catch((cause: unknown) => {
+        if (!this.isCurrent(epoch)) return;
+        const detail = cause instanceof Error ? cause.message : String(cause);
+        if (attempt >= this.options.maxAttempts) {
+          this.options.onStatus?.({
+            status: "failed",
+            degraded: true,
+            attempt,
+            maxAttempts: this.options.maxAttempts,
+            retryInMs: null,
+            message: `Pane descriptor discovery failed after ${attempt} attempts: ${detail}`,
+          });
+          return;
+        }
+        const retryInMs = this.options.baseDelayMs * 2 ** (attempt - 1);
+        this.options.onStatus?.({
+          status: "retrying",
+          degraded: true,
+          attempt,
+          maxAttempts: this.options.maxAttempts,
+          retryInMs,
+          message: `Pane descriptor discovery attempt ${attempt} failed: ${detail}`,
+        });
+        this.cancelScheduled = this.options.schedule(() => {
+          this.cancelScheduled = null;
+          if (this.isCurrent(epoch)) this.attempt(epoch, listed, attempt + 1);
+        }, retryInMs);
+      });
+  }
+
+  private isCurrent(epoch: number): boolean {
+    return !this.disposed && epoch === this.epoch;
+  }
+}
+
+function nonempty(value: string): string | null {
+  return value.length > 0 ? value : null;
+}
+
+const STRICT_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+
+function decodeControlReplyUtf8(value: string): string | null {
+  try {
+    return STRICT_UTF8_DECODER.decode(Buffer.from(value, "latin1"));
+  } catch {
+    return null;
+  }
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  return Number.isSafeInteger(value) && value! > 0 ? value! : fallback;
+}

--- a/packages/daemon/src/tui/mirror/session-mirror.test.ts
+++ b/packages/daemon/src/tui/mirror/session-mirror.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parsePaneGeometry, geometryFromLeaves, type PaneGeometry } from "./session-mirror.ts";
+import {
+  parsePaneGeometry,
+  geometryFromLeaves,
+  parseSessionPaneDescriptors,
+  type PaneGeometry,
+} from "./session-mirror.ts";
 import { parseLayout } from "./layout-parse.ts";
 
 const g = (id: string, left: number, top: number, w: number, h: number, active = false) =>
@@ -24,6 +29,51 @@ describe("parsePaneGeometry", () => {
   });
   it("ignores extra trailing fields (the sync format appends window_id)", () => {
     expect(parsePaneGeometry(["%1 0 0 80 20 1 0 0 @387"])).toEqual([g("%1", 0, 0, 80, 20, true)]);
+  });
+});
+
+describe("parseSessionPaneDescriptors", () => {
+  it("discovers semantic identity, role/type, process, cwd, title, and window facts", () => {
+    expect(
+      parseSessionPaneDescriptors([
+        "%42\tagent-alpha\tlead\tagent\tcodex\t/repo/apps/web\t3\tmission one\t@9\tImplement home page",
+      ]),
+    ).toEqual([
+      {
+        runtimePaneId: "%42",
+        semanticPaneId: "agent-alpha",
+        role: "lead",
+        type: "agent",
+        currentCommand: "codex",
+        cwd: "/repo/apps/web",
+        title: "Implement home page",
+        windowIndex: 3,
+        windowName: "mission one",
+        windowId: "@9",
+      },
+    ]);
+  });
+
+  it("preserves raw invalid stamps for reconciliation and degrades malformed optional facts", () => {
+    expect(
+      parseSessionPaneDescriptors([
+        "%7\tbad stamp\t\t\tzsh\t/tmp\\twith-tab\tnan\tmain\tnot-a-window\tShell\\twith tab",
+        "not-a-pane\tignored",
+      ]),
+    ).toEqual([
+      {
+        runtimePaneId: "%7",
+        semanticPaneId: "bad stamp",
+        role: null,
+        type: null,
+        currentCommand: "zsh",
+        cwd: "/tmp\twith-tab",
+        title: "Shell\twith tab",
+        windowIndex: null,
+        windowName: "main",
+        windowId: null,
+      },
+    ]);
   });
 });
 

--- a/packages/daemon/src/tui/mirror/session-mirror.ts
+++ b/packages/daemon/src/tui/mirror/session-mirror.ts
@@ -45,6 +45,19 @@ import {
   type LayoutLeaf,
 } from "./layout-parse.ts";
 import { effectiveWindowSize, type Size } from "./size-truth.ts";
+import {
+  SESSION_PANE_DESCRIPTOR_FORMAT,
+  SessionDescriptorDiscovery,
+  type SessionDescriptorDiscoveryDiagnostic,
+  type SessionPaneDescriptor,
+} from "./session-descriptor-discovery.ts";
+
+export {
+  decodeTmuxArgument,
+  parseSessionPaneDescriptors,
+  type SessionDescriptorDiscoveryDiagnostic,
+  type SessionPaneDescriptor,
+} from "./session-descriptor-discovery.ts";
 
 /** One pane's geometry inside the window, in cells (tmux coordinates). */
 export interface PaneGeometry {
@@ -145,7 +158,13 @@ export interface SessionMirrorOptions {
   /** Called whenever any pane's content or the layout changed (coalesce upstream). */
   onDirty?: () => void;
   onStatus?: (msg: string) => void;
+  onDescriptorStatus?: (status: SessionDescriptorDiscoveryDiagnostic | null) => void;
   onExit?: () => void;
+  descriptorRetry?: {
+    maxAttempts?: number;
+    baseDelayMs?: number;
+    schedule?: (callback: () => void, delayMs: number) => () => void;
+  };
 }
 
 /** Control-mode notifications (sans `%`) that still fall back to the slow
@@ -162,6 +181,9 @@ const STRUCTURAL_NOTIFICATIONS = new Set([
 export class SessionMirror {
   private readonly client: ControlModeClient;
   private readonly mirrors = new Map<string, PaneMirror>();
+  private readonly descriptorsByPane = new Map<string, SessionPaneDescriptor>();
+  private readonly descriptorDiscovery: SessionDescriptorDiscovery;
+  private descriptorDiagnostic: SessionDescriptorDiscoveryDiagnostic | null = null;
   private geometry: PaneGeometry[] = [];
   private focused = "";
   private syncQueued = false;
@@ -243,6 +265,27 @@ export class SessionMirror {
         else if (STRUCTURAL_NOTIFICATIONS.has(name)) this.queueSync();
       },
       onExit: () => opts.onExit?.(),
+    });
+    this.descriptorDiscovery = new SessionDescriptorDiscovery({
+      query: () =>
+        this.client.command(
+          `list-panes -t ${this.opts.target} -F "${SESSION_PANE_DESCRIPTOR_FORMAT}"`,
+        ),
+      onDescriptors: (descriptors, listed) => {
+        this.descriptorsByPane.clear();
+        for (const descriptor of descriptors) {
+          if (listed.has(descriptor.runtimePaneId)) {
+            this.descriptorsByPane.set(descriptor.runtimePaneId, descriptor);
+          }
+        }
+        this.opts.onDirty?.();
+      },
+      onStatus: (status) => {
+        this.descriptorDiagnostic = status ? { ...status } : null;
+        this.opts.onDescriptorStatus?.(status ? { ...status } : null);
+        this.opts.onDirty?.();
+      },
+      ...opts.descriptorRetry,
     });
   }
 
@@ -396,6 +439,10 @@ export class SessionMirror {
     if (!ev) return;
     this.activeWindow = ev.windowId;
     this.lastVisibleLayout = "";
+    // Descriptor rows belong to the old window until the queued discovery
+    // lands. Empty is safer than exposing stale semantic identity meanwhile.
+    this.descriptorDiscovery.invalidate();
+    this.descriptorsByPane.clear();
     this.queueSync();
   }
 
@@ -424,6 +471,16 @@ export class SessionMirror {
           ({ rows: [], cursorX: 0, cursorY: 0, scrollOffset: 0 } as const),
       };
     });
+  }
+
+  /** Detached snapshot of active-window descriptor discovery. */
+  paneDescriptors(): SessionPaneDescriptor[] {
+    return [...this.descriptorsByPane.values()].map((descriptor) => ({ ...descriptor }));
+  }
+
+  /** Latest bounded discovery retry/failure status, detached for observers. */
+  paneDescriptorDiagnostic(): SessionDescriptorDiscoveryDiagnostic | null {
+    return this.descriptorDiagnostic ? { ...this.descriptorDiagnostic } : null;
   }
 
   /** Blit a pane's visible grid into a framebuffer's packed arrays (M21.3) — the
@@ -610,8 +667,11 @@ export class SessionMirror {
       this.sizeMode = "auto";
     }
     this.client.dispose();
+    this.descriptorDiscovery.dispose();
+    this.descriptorDiagnostic = null;
     for (const m of this.mirrors.values()) m.dispose();
     this.mirrors.clear();
+    this.descriptorsByPane.clear();
   }
 
   /** Queue the SLOW path (M23.5: reconciler, flag source, seed driver, sole
@@ -677,6 +737,14 @@ export class SessionMirror {
     // pane is visible, and its listed rect is the full window.
     this.geometry = this.zoomedNow ? all.filter((p) => p.active) : all;
     this.winSize = effectiveWindowSize(all) ?? this.winSize;
+
+    // Drop descriptors for closed panes synchronously, then refresh remaining
+    // metadata out-of-band so this extra discovery never delays geometry,
+    // content seeding, or input. Failed discovery preserves surviving facts.
+    for (const runtimePaneId of this.descriptorsByPane.keys()) {
+      if (!listed.has(runtimePaneId)) this.descriptorsByPane.delete(runtimePaneId);
+    }
+    this.descriptorDiscovery.discover(listed);
     this.opts.onStatus?.(`${this.geometry.length} panes`);
     this.opts.onDirty?.();
 

--- a/packages/daemon/src/tui/mirror/workspace-tmux-adapter.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace-tmux-adapter.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  WORKSPACE_SEMANTIC_PANE_OPTION,
+  WorkspaceObservationSchemaZ,
+  type WorkspacePaneBinding,
+} from "@tmux-ide/contracts";
+
+import {
+  finalizeWorkspaceTmuxReconciliation,
+  planWorkspaceTmuxReconciliation,
+  workspaceObservationFromTmux,
+  type WorkspaceTmuxPaneSnapshot,
+} from "./workspace-tmux-adapter.ts";
+
+const NOW = "2026-07-20T10:00:00.000Z";
+const WORKBENCH = {
+  canvasPanel: "terminals" as const,
+  dock: {
+    activeTab: "files" as const,
+    mode: "open" as const,
+    preferredHeight: 12,
+    focusZone: "canvas" as const,
+  },
+};
+
+function pane(
+  runtimePaneId: string,
+  semanticPaneId: string | null,
+  overrides: Partial<WorkspaceTmuxPaneSnapshot> = {},
+): WorkspaceTmuxPaneSnapshot {
+  return {
+    runtimePaneId,
+    semanticPaneId,
+    role: "shell",
+    type: "shell",
+    currentCommand: "zsh",
+    cwd: "/repo",
+    title: "Shell",
+    rect: { left: 0, top: 0, width: 80, height: 40 },
+    active: false,
+    ...overrides,
+  };
+}
+
+function generator(values: readonly string[]): () => string {
+  let index = 0;
+  return () => values[index++] ?? "generator-exhausted";
+}
+
+describe("workspace/tmux identity reconciliation", () => {
+  it("accepts unique valid pane-local stamps without emitting effects", () => {
+    const plan = planWorkspaceTmuxReconciliation({
+      panes: [pane("%1", "agent-alpha"), pane("%2", "shell-beta")],
+      generateSemanticPaneId: () => "unused",
+    });
+
+    expect(
+      plan.panes.map(({ semanticPaneId, identitySource }) => ({ semanticPaneId, identitySource })),
+    ).toEqual([
+      { semanticPaneId: "agent-alpha", identitySource: "stamp" },
+      { semanticPaneId: "shell-beta", identitySource: "stamp" },
+    ]);
+    expect(plan.stampEffects).toEqual([]);
+    expect(plan.degraded).toBe(false);
+  });
+
+  it("heals missing, invalid, and every duplicate stamp with explicit unique stamp-back effects", () => {
+    const plan = planWorkspaceTmuxReconciliation({
+      panes: [
+        pane("%1", null),
+        pane("%2", "bad stamp"),
+        pane("%3", "duplicate"),
+        pane("%4", "duplicate"),
+      ],
+      generateSemanticPaneId: generator(["fresh-a", "fresh-b", "fresh-c", "fresh-d"]),
+    });
+
+    expect(plan.panes.map((item) => item.semanticPaneId)).toEqual([
+      "fresh-a",
+      "fresh-b",
+      "fresh-c",
+      "fresh-d",
+    ]);
+    expect(plan.stampEffects).toEqual([
+      {
+        kind: "set-pane-option",
+        runtimePaneId: "%1",
+        option: WORKSPACE_SEMANTIC_PANE_OPTION,
+        value: "fresh-a",
+      },
+      {
+        kind: "set-pane-option",
+        runtimePaneId: "%2",
+        option: WORKSPACE_SEMANTIC_PANE_OPTION,
+        value: "fresh-b",
+      },
+      {
+        kind: "set-pane-option",
+        runtimePaneId: "%3",
+        option: WORKSPACE_SEMANTIC_PANE_OPTION,
+        value: "fresh-c",
+      },
+      {
+        kind: "set-pane-option",
+        runtimePaneId: "%4",
+        option: WORKSPACE_SEMANTIC_PANE_OPTION,
+        value: "fresh-d",
+      },
+    ]);
+    expect(plan.diagnostics.map((item) => item.code)).toEqual([
+      "MISSING_SEMANTIC_STAMP",
+      "INVALID_SEMANTIC_STAMP",
+      "DUPLICATE_SEMANTIC_STAMP",
+      "DUPLICATE_SEMANTIC_STAMP",
+    ]);
+    expect(plan.degraded).toBe(false);
+  });
+
+  it("never revives a persisted semantic identity when tmux reuses a runtime pane id", () => {
+    const previousBindings: Record<string, WorkspacePaneBinding> = {
+      "old-agent": {
+        semanticPaneId: "old-agent",
+        runtimePaneId: "%7",
+        lastSeenAt: NOW,
+      },
+    };
+    const plan = planWorkspaceTmuxReconciliation({
+      panes: [pane("%7", "new-shell")],
+      previousBindings,
+      generateSemanticPaneId: () => "unused",
+    });
+
+    expect(plan.panes[0]?.semanticPaneId).toBe("new-shell");
+    expect(plan.panes[0]?.semanticPaneId).not.toBe("old-agent");
+    expect(plan.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "STALE_RUNTIME_BINDING_IGNORED",
+        runtimePaneId: "%7",
+        semanticPaneId: "old-agent",
+      }),
+    );
+  });
+
+  it("degrades and omits a pane when the injected id generator cannot produce a valid unique id", () => {
+    const plan = planWorkspaceTmuxReconciliation({
+      panes: [pane("%8", null)],
+      generateSemanticPaneId: () => "bad id",
+      maxGenerationAttempts: 2,
+    });
+
+    expect(plan.panes).toEqual([]);
+    expect(plan.stampEffects).toEqual([]);
+    expect(plan.degraded).toBe(true);
+    expect(plan.diagnostics.at(-1)?.code).toBe("SEMANTIC_ID_GENERATION_FAILED");
+  });
+
+  it("excludes a generated identity when stamp-back fails and reports degraded truth", () => {
+    const plan = planWorkspaceTmuxReconciliation({
+      panes: [pane("%1", "stable"), pane("%2", null)],
+      generateSemanticPaneId: () => "generated",
+    });
+    const finalized = finalizeWorkspaceTmuxReconciliation(plan, [
+      { runtimePaneId: "%2", ok: false, error: "pane disappeared" },
+    ]);
+
+    expect(finalized.panes.map((item) => item.semanticPaneId)).toEqual(["stable"]);
+    expect(finalized.degraded).toBe(true);
+    expect(finalized.diagnostics.at(-1)).toMatchObject({
+      code: "SEMANTIC_STAMP_BACK_FAILED",
+      runtimePaneId: "%2",
+      semanticPaneId: "generated",
+    });
+  });
+
+  it("maps live focus to semantic focus and projects harness/window metadata", () => {
+    const plan = planWorkspaceTmuxReconciliation({
+      panes: [
+        pane("%11", "shell-left", { active: true }),
+        pane("%22", "agent-right", {
+          role: "lead",
+          type: "agent",
+          currentCommand: "/usr/local/bin/codex --yolo",
+          cwd: "/repo/apps/web",
+          title: "Implementer",
+          rect: { left: 81, top: 0, width: 79, height: 40 },
+        }),
+      ],
+      generateSemanticPaneId: () => "unused",
+    });
+    const finalized = finalizeWorkspaceTmuxReconciliation(plan, []);
+    const projection = workspaceObservationFromTmux(finalized, {
+      checkoutKey: "checkout-main",
+      projectRoot: "/repo",
+      observedAt: NOW,
+      sessionName: "tmux-ide",
+      windowIndex: 3,
+      windowName: "mission-one",
+      focusedRuntimePaneId: "%22",
+      workbench: WORKBENCH,
+    });
+    const observation = projection.observation;
+
+    expect(WorkspaceObservationSchemaZ.safeParse(observation).success).toBe(true);
+    expect(observation.focusedPaneId).toBe("agent-right");
+    expect(observation.windowIndex).toBe(3);
+    expect(observation.windowName).toBe("mission-one");
+    expect(observation.panes[1]).toMatchObject({
+      semanticPaneId: "agent-right",
+      runtimePaneId: "%22",
+      role: "agent",
+      harness: "codex",
+      command: "/usr/local/bin/codex --yolo",
+      cwd: "/repo/apps/web",
+      title: "Implementer",
+    });
+  });
+
+  it("normalizes oversized and NUL-bearing live metadata without throwing", () => {
+    const longHarness = `codex-${"h".repeat(200)}`;
+    const plan = planWorkspaceTmuxReconciliation({
+      panes: [
+        pane("%31", "agent-long", {
+          role: "agent",
+          type: "agent",
+          currentCommand: `/usr/local/bin/${longHarness}\0${"c".repeat(700)}`,
+          cwd: `/repo/${"d".repeat(5000)}\0tail`,
+          title: `${"t".repeat(120)}\0tail`,
+        }),
+      ],
+      generateSemanticPaneId: () => "unused",
+    });
+    const projection = workspaceObservationFromTmux(finalizeWorkspaceTmuxReconciliation(plan, []), {
+      checkoutKey: "checkout-main",
+      projectRoot: "/repo",
+      observedAt: NOW,
+      sessionName: `${"s".repeat(300)}\0tail`,
+      windowIndex: 0,
+      windowName: `${"w".repeat(300)}\0tail`,
+      focusedRuntimePaneId: "%31",
+      workbench: WORKBENCH,
+    });
+
+    expect(WorkspaceObservationSchemaZ.safeParse(projection.observation).success).toBe(true);
+    expect(projection.observation.sessionName).toHaveLength(256);
+    expect(projection.observation.windowName).toHaveLength(256);
+    expect(projection.observation.panes[0]!.harness).toHaveLength(80);
+    expect(projection.observation.panes[0]!.title).toHaveLength(80);
+    expect(projection.observation.panes[0]!.command).toHaveLength(512);
+    expect(projection.observation.panes[0]!.cwd).toHaveLength(4096);
+    expect(JSON.stringify(projection.observation)).not.toContain("\\u0000");
+    expect(
+      projection.diagnostics.filter((diagnostic) => diagnostic.code === "LIVE_METADATA_NORMALIZED"),
+    ).toHaveLength(6);
+    expect(projection.degraded).toBe(true);
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace-tmux-adapter.ts
+++ b/packages/daemon/src/tui/mirror/workspace-tmux-adapter.ts
@@ -1,0 +1,470 @@
+import {
+  WORKSPACE_SEMANTIC_PANE_OPTION,
+  WorkspaceIdSchemaZ,
+  WorkspaceObservationSchemaZ,
+  type WorkspaceObservation,
+  type WorkspacePaneBinding,
+  type WorkspacePaneRect,
+  type WorkspaceWorkbenchState,
+} from "@tmux-ide/contracts";
+
+const RUNTIME_PANE_ID = /^%[0-9]+$/u;
+const DEFAULT_GENERATION_ATTEMPTS = 32;
+
+/** Raw tmux facts. A pane stamp remains untrusted until reconciliation. */
+export interface WorkspaceTmuxPaneSnapshot {
+  runtimePaneId: string;
+  semanticPaneId: string | null;
+  role: string | null;
+  type: string | null;
+  currentCommand: string | null;
+  cwd: string | null;
+  title: string | null;
+  rect: WorkspacePaneRect;
+  active: boolean;
+}
+
+export type WorkspaceTmuxDiagnosticCode =
+  | "INVALID_RUNTIME_PANE"
+  | "DUPLICATE_RUNTIME_PANE"
+  | "MISSING_SEMANTIC_STAMP"
+  | "INVALID_SEMANTIC_STAMP"
+  | "DUPLICATE_SEMANTIC_STAMP"
+  | "STALE_RUNTIME_BINDING_IGNORED"
+  | "SEMANTIC_ID_GENERATION_FAILED"
+  | "SEMANTIC_STAMP_BACK_FAILED"
+  | "LIVE_METADATA_NORMALIZED";
+
+export interface WorkspaceTmuxDiagnostic {
+  code: WorkspaceTmuxDiagnosticCode;
+  runtimePaneId: string | null;
+  semanticPaneId: string | null;
+  message: string;
+  /** True when this pane cannot safely enter a durable workspace observation. */
+  degraded: boolean;
+}
+
+export interface WorkspaceTmuxStampEffect {
+  kind: "set-pane-option";
+  runtimePaneId: string;
+  option: typeof WORKSPACE_SEMANTIC_PANE_OPTION;
+  value: string;
+}
+
+export interface ReconciledWorkspaceTmuxPane extends WorkspaceTmuxPaneSnapshot {
+  semanticPaneId: string;
+  identitySource: "stamp" | "generated";
+  requiresStampBack: boolean;
+}
+
+export interface WorkspaceTmuxReconciliationPlan {
+  panes: readonly ReconciledWorkspaceTmuxPane[];
+  stampEffects: readonly WorkspaceTmuxStampEffect[];
+  diagnostics: readonly WorkspaceTmuxDiagnostic[];
+  degraded: boolean;
+}
+
+export interface WorkspaceTmuxStampOutcome {
+  runtimePaneId: string;
+  ok: boolean;
+  error?: string | null;
+}
+
+export interface WorkspaceTmuxReconciliation {
+  panes: readonly ReconciledWorkspaceTmuxPane[];
+  diagnostics: readonly WorkspaceTmuxDiagnostic[];
+  degraded: boolean;
+}
+
+export interface PlanWorkspaceTmuxReconciliationInput {
+  panes: readonly WorkspaceTmuxPaneSnapshot[];
+  generateSemanticPaneId: () => string;
+  /** Persisted bindings are diagnostics only; they are never identity input. */
+  previousBindings?: Readonly<Record<string, WorkspacePaneBinding>>;
+  maxGenerationAttempts?: number;
+}
+
+/**
+ * Pure identity reconciliation. `%pane_id` is accepted only as a live address.
+ * Every missing, invalid, or duplicated semantic stamp receives a new semantic
+ * id and an explicit pane-local stamp-back effect. For duplicates, every copy
+ * is replaced so reconciliation never chooses a winner from tmux ordering.
+ */
+export function planWorkspaceTmuxReconciliation(
+  input: PlanWorkspaceTmuxReconciliationInput,
+): WorkspaceTmuxReconciliationPlan {
+  const diagnostics: WorkspaceTmuxDiagnostic[] = [];
+  const panes: WorkspaceTmuxPaneSnapshot[] = [];
+  const runtimeIds = new Set<string>();
+
+  for (const pane of input.panes) {
+    if (!RUNTIME_PANE_ID.test(pane.runtimePaneId)) {
+      diagnostics.push(
+        diagnostic(
+          "INVALID_RUNTIME_PANE",
+          null,
+          pane.semanticPaneId,
+          `Ignored invalid live tmux pane address ${JSON.stringify(pane.runtimePaneId)}.`,
+          true,
+        ),
+      );
+      continue;
+    }
+    if (runtimeIds.has(pane.runtimePaneId)) {
+      diagnostics.push(
+        diagnostic(
+          "DUPLICATE_RUNTIME_PANE",
+          pane.runtimePaneId,
+          pane.semanticPaneId,
+          `Ignored duplicate live tmux pane address ${pane.runtimePaneId}.`,
+          true,
+        ),
+      );
+      continue;
+    }
+    runtimeIds.add(pane.runtimePaneId);
+    panes.push(pane);
+  }
+
+  const validStampCounts = new Map<string, number>();
+  for (const pane of panes) {
+    if (!validSemanticPaneId(pane.semanticPaneId)) continue;
+    validStampCounts.set(pane.semanticPaneId, (validStampCounts.get(pane.semanticPaneId) ?? 0) + 1);
+  }
+
+  // Reserve every observed valid value, including duplicates. Duplicate panes
+  // must all move to newly generated identities rather than arbitrarily keeping
+  // one value based on tmux list order.
+  const claimedSemanticIds = new Set(validStampCounts.keys());
+  const priorByRuntime = previousBindingsByRuntime(input.previousBindings);
+  const reconciled: ReconciledWorkspaceTmuxPane[] = [];
+  const stampEffects: WorkspaceTmuxStampEffect[] = [];
+  const maxAttempts = normalizeAttempts(input.maxGenerationAttempts);
+
+  for (const pane of panes) {
+    const rawStamp = pane.semanticPaneId;
+    const stampIsValid = validSemanticPaneId(rawStamp);
+    const stampIsUnique = stampIsValid && validStampCounts.get(rawStamp) === 1;
+    const priorSemanticId = priorByRuntime.get(pane.runtimePaneId) ?? null;
+
+    if (priorSemanticId && priorSemanticId !== (stampIsUnique ? rawStamp : null)) {
+      diagnostics.push(
+        diagnostic(
+          "STALE_RUNTIME_BINDING_IGNORED",
+          pane.runtimePaneId,
+          priorSemanticId,
+          `Ignored persisted binding ${priorSemanticId} -> ${pane.runtimePaneId}; runtime pane ids are reusable addresses, not identity.`,
+          false,
+        ),
+      );
+    }
+
+    if (stampIsUnique) {
+      reconciled.push({
+        ...pane,
+        semanticPaneId: rawStamp,
+        identitySource: "stamp",
+        requiresStampBack: false,
+      });
+      continue;
+    }
+
+    if (rawStamp === null || rawStamp.length === 0) {
+      diagnostics.push(
+        diagnostic(
+          "MISSING_SEMANTIC_STAMP",
+          pane.runtimePaneId,
+          null,
+          `Pane ${pane.runtimePaneId} has no semantic identity stamp; a fresh id will be stamped back.`,
+          false,
+        ),
+      );
+    } else if (!stampIsValid) {
+      diagnostics.push(
+        diagnostic(
+          "INVALID_SEMANTIC_STAMP",
+          pane.runtimePaneId,
+          rawStamp,
+          `Pane ${pane.runtimePaneId} has an invalid semantic identity stamp; a fresh id will be stamped back.`,
+          false,
+        ),
+      );
+    } else {
+      diagnostics.push(
+        diagnostic(
+          "DUPLICATE_SEMANTIC_STAMP",
+          pane.runtimePaneId,
+          rawStamp,
+          `Pane ${pane.runtimePaneId} shares semantic identity ${rawStamp}; every duplicate will be restamped.`,
+          false,
+        ),
+      );
+    }
+
+    const generated = generateUnclaimedSemanticPaneId(
+      input.generateSemanticPaneId,
+      claimedSemanticIds,
+      maxAttempts,
+    );
+    if (!generated) {
+      diagnostics.push(
+        diagnostic(
+          "SEMANTIC_ID_GENERATION_FAILED",
+          pane.runtimePaneId,
+          rawStamp,
+          `Could not generate a valid unique semantic identity for ${pane.runtimePaneId}.`,
+          true,
+        ),
+      );
+      continue;
+    }
+
+    claimedSemanticIds.add(generated);
+    reconciled.push({
+      ...pane,
+      semanticPaneId: generated,
+      identitySource: "generated",
+      requiresStampBack: true,
+    });
+    stampEffects.push({
+      kind: "set-pane-option",
+      runtimePaneId: pane.runtimePaneId,
+      option: WORKSPACE_SEMANTIC_PANE_OPTION,
+      value: generated,
+    });
+  }
+
+  return {
+    panes: reconciled,
+    stampEffects,
+    diagnostics,
+    degraded: diagnostics.some((item) => item.degraded),
+  };
+}
+
+/**
+ * Pure effect acknowledgement. Generated ids become observable only after the
+ * caller confirms the corresponding tmux stamp succeeded. Missing and failed
+ * acknowledgements degrade explicitly and exclude that pane from persistence.
+ */
+export function finalizeWorkspaceTmuxReconciliation(
+  plan: WorkspaceTmuxReconciliationPlan,
+  outcomes: readonly WorkspaceTmuxStampOutcome[],
+): WorkspaceTmuxReconciliation {
+  const byRuntime = new Map(outcomes.map((outcome) => [outcome.runtimePaneId, outcome]));
+  const diagnostics = [...plan.diagnostics];
+  const panes: ReconciledWorkspaceTmuxPane[] = [];
+
+  for (const pane of plan.panes) {
+    if (!pane.requiresStampBack) {
+      panes.push(pane);
+      continue;
+    }
+    const outcome = byRuntime.get(pane.runtimePaneId);
+    if (outcome?.ok) {
+      panes.push(pane);
+      continue;
+    }
+    const reason = outcome?.error?.trim();
+    diagnostics.push(
+      diagnostic(
+        "SEMANTIC_STAMP_BACK_FAILED",
+        pane.runtimePaneId,
+        pane.semanticPaneId,
+        `Could not stamp semantic identity ${pane.semanticPaneId} onto ${pane.runtimePaneId}${reason ? `: ${reason}` : "."}`,
+        true,
+      ),
+    );
+  }
+
+  return {
+    panes,
+    diagnostics,
+    degraded: diagnostics.some((item) => item.degraded),
+  };
+}
+
+export interface WorkspaceObservationFromTmuxInput {
+  checkoutKey: string;
+  projectRoot: string;
+  observedAt: string;
+  sessionName: string | null;
+  windowIndex: number | null;
+  windowName: string | null;
+  focusedRuntimePaneId: string | null;
+  workbench: WorkspaceWorkbenchState;
+}
+
+export interface WorkspaceTmuxObservationProjection {
+  observation: WorkspaceObservation;
+  diagnostics: readonly WorkspaceTmuxDiagnostic[];
+  degraded: boolean;
+}
+
+/**
+ * Pure projection from acknowledged tmux truth into the durable contract.
+ * Arbitrary legal tmux metadata is NUL-cleaned and bounded before validation,
+ * so a long title/path/window name can never crash workspace capture.
+ */
+export function workspaceObservationFromTmux(
+  reconciliation: WorkspaceTmuxReconciliation,
+  input: WorkspaceObservationFromTmuxInput,
+): WorkspaceTmuxObservationProjection {
+  const diagnostics = [...reconciliation.diagnostics];
+  const focused =
+    reconciliation.panes.find((pane) => pane.runtimePaneId === input.focusedRuntimePaneId) ??
+    reconciliation.panes.find((pane) => pane.active) ??
+    null;
+
+  const observation = WorkspaceObservationSchemaZ.parse({
+    checkoutKey: input.checkoutKey,
+    projectRoot: input.projectRoot,
+    observedAt: input.observedAt,
+    sessionName: normalizedLiveText(
+      input.sessionName,
+      256,
+      "session name",
+      null,
+      null,
+      diagnostics,
+    ),
+    windowIndex: input.windowIndex,
+    windowName: normalizedLiveText(input.windowName, 256, "window name", null, null, diagnostics),
+    panes: reconciliation.panes.map((pane) => {
+      const role = workspaceRole(pane);
+      return {
+        semanticPaneId: pane.semanticPaneId,
+        runtimePaneId: pane.runtimePaneId,
+        role,
+        harness:
+          role === "agent"
+            ? normalizedLiveText(
+                commandBasename(pane.currentCommand),
+                80,
+                "harness",
+                pane.runtimePaneId,
+                pane.semanticPaneId,
+                diagnostics,
+              )
+            : null,
+        title: normalizedLiveText(
+          pane.title,
+          80,
+          "pane title",
+          pane.runtimePaneId,
+          pane.semanticPaneId,
+          diagnostics,
+        ),
+        command: normalizedLiveText(
+          pane.currentCommand,
+          512,
+          "pane command",
+          pane.runtimePaneId,
+          pane.semanticPaneId,
+          diagnostics,
+        ),
+        cwd: normalizedLiveText(
+          pane.cwd,
+          4096,
+          "pane cwd",
+          pane.runtimePaneId,
+          pane.semanticPaneId,
+          diagnostics,
+        ),
+        rect: pane.rect,
+        active: pane.active,
+      };
+    }),
+    focusedPaneId: focused?.semanticPaneId ?? null,
+    workbench: input.workbench,
+  });
+  return {
+    observation,
+    diagnostics,
+    degraded: diagnostics.some((item) => item.degraded),
+  };
+}
+
+function validSemanticPaneId(value: string | null): value is string {
+  return value !== null && WorkspaceIdSchemaZ.safeParse(value).success;
+}
+
+function normalizeAttempts(value: number | undefined): number {
+  return Number.isSafeInteger(value) && value! > 0 ? value! : DEFAULT_GENERATION_ATTEMPTS;
+}
+
+function generateUnclaimedSemanticPaneId(
+  generate: () => string,
+  claimed: ReadonlySet<string>,
+  maxAttempts: number,
+): string | null {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const candidate = generate();
+    if (validSemanticPaneId(candidate) && !claimed.has(candidate)) return candidate;
+  }
+  return null;
+}
+
+function previousBindingsByRuntime(
+  bindings: Readonly<Record<string, WorkspacePaneBinding>> | undefined,
+): Map<string, string> {
+  const byRuntime = new Map<string, string>();
+  for (const binding of Object.values(bindings ?? {})) {
+    if (RUNTIME_PANE_ID.test(binding.runtimePaneId)) {
+      byRuntime.set(binding.runtimePaneId, binding.semanticPaneId);
+    }
+  }
+  return byRuntime;
+}
+
+function workspaceRole(pane: WorkspaceTmuxPaneSnapshot): "agent" | "shell" {
+  const role = pane.role?.toLowerCase();
+  const type = pane.type?.toLowerCase();
+  return type === "agent" ||
+    role === "agent" ||
+    role === "lead" ||
+    role === "teammate" ||
+    role === "planner"
+    ? "agent"
+    : "shell";
+}
+
+function commandBasename(command: string | null): string | null {
+  const executable = command?.trim().split(/\s+/u)[0];
+  if (!executable) return null;
+  return executable.split(/[/\\]/u).at(-1) ?? null;
+}
+
+function normalizedLiveText(
+  value: string | null,
+  maxLength: number,
+  field: string,
+  runtimePaneId: string | null,
+  semanticPaneId: string | null,
+  diagnostics: WorkspaceTmuxDiagnostic[],
+): string | null {
+  if (value === null || value.length === 0) return null;
+  const normalized = value.replaceAll("\0", "").slice(0, maxLength);
+  if (normalized !== value) {
+    diagnostics.push(
+      diagnostic(
+        "LIVE_METADATA_NORMALIZED",
+        runtimePaneId,
+        semanticPaneId,
+        `Normalized ${field} to the durable workspace contract limit (${maxLength} characters, no NUL bytes).`,
+        true,
+      ),
+    );
+  }
+  return normalized.length > 0 ? normalized : null;
+}
+
+function diagnostic(
+  code: WorkspaceTmuxDiagnosticCode,
+  runtimePaneId: string | null,
+  semanticPaneId: string | null,
+  message: string,
+  degraded: boolean,
+): WorkspaceTmuxDiagnostic {
+  return { code, runtimePaneId, semanticPaneId, message, degraded };
+}

--- a/templates/agent-team-monorepo.yml
+++ b/templates/agent-team-monorepo.yml
@@ -11,21 +11,27 @@ terminal:
   rows:
     - size: 70%
       panes:
-        - title: Lead — Architect
+        - id: agent-lead
+          title: Lead — Architect
           command: claude
           focus: true
-        - title: Frontend Agent
+        - id: agent-frontend
+          title: Frontend Agent
           command: claude
           dir: apps/web
-        - title: Backend Agent
+        - id: agent-backend
+          title: Backend Agent
           command: claude
           dir: apps/api
 
     - panes:
-        - title: Frontend
+        - id: dev-frontend
+          title: Frontend
           command: pnpm dev
           dir: apps/web
-        - title: Backend
+        - id: dev-backend
+          title: Backend
           command: pnpm dev
           dir: apps/api
-        - title: Shell
+        - id: shell
+          title: Shell

--- a/templates/agent-team-nextjs.yml
+++ b/templates/agent-team-nextjs.yml
@@ -11,17 +11,23 @@ terminal:
   rows:
     - size: 70%
       panes:
-        - title: Lead
+        - id: agent-lead
+          title: Lead
           command: claude
           focus: true
-        - title: Frontend
+        - id: agent-frontend
+          title: Frontend
           command: claude
-        - title: Backend
+        - id: agent-backend
+          title: Backend
           command: claude
 
     - panes:
-        - title: Next.js
+        - id: dev
+          title: Next.js
           command: pnpm dev
-        - title: Changes
+        - id: changes
+          title: Changes
           type: changes # live git changes widget
-        - title: Shell
+        - id: shell
+          title: Shell

--- a/templates/agent-team.yml
+++ b/templates/agent-team.yml
@@ -11,17 +11,23 @@ terminal:
   rows:
     - size: 70%
       panes:
-        - title: Lead
+        - id: agent-lead
+          title: Lead
           command: claude
           focus: true
-        - title: Teammate 1
+        - id: agent-1
+          title: Teammate 1
           command: claude
-        - title: Teammate 2
+        - id: agent-2
+          title: Teammate 2
           command: claude
 
     - panes:
-        - title: Changes
+        - id: changes
+          title: Changes
           type: changes # live git changes widget
-        - title: Dev Server
+        - id: dev
+          title: Dev Server
           # command: npm run dev
-        - title: Shell
+        - id: shell
+          title: Shell

--- a/templates/convex.yml
+++ b/templates/convex.yml
@@ -7,17 +7,23 @@ terminal:
   rows:
     - size: 70%
       panes:
-        - title: Claude 1 — feature
+        - id: agent-1
+          title: Claude 1 — feature
           command: claude
-        - title: Claude 2 — review
+        - id: agent-2
+          title: Claude 2 — review
           command: claude
-        - title: Claude 3 — explore
+        - id: agent-3
+          title: Claude 3 — explore
           command: claude
 
     - panes:
-        - title: Next.js
+        - id: dev
+          title: Next.js
           command: pnpm dev
-        - title: Convex
+        - id: convex
+          title: Convex
           command: npx convex dev
-        - title: Shell
+        - id: shell
+          title: Shell
           focus: true

--- a/templates/default.yml
+++ b/templates/default.yml
@@ -7,20 +7,25 @@ terminal:
   rows:
     - size: 70%
       panes:
-        - title: Claude 1
+        - id: agent-1
+          title: Claude 1
           command: claude
-        - title: Claude 2
+        - id: agent-2
+          title: Claude 2
           command: claude
 
     - panes:
         # Widget panes render native UI instead of a command:
         #   type: explorer | changes | preview | config
-        - title: Changes
+        - id: changes
+          title: Changes
           type: changes # live git changes — no command, tmux-ide draws it
-        - title: Dev Server
+        - id: dev
+          title: Dev Server
           # command: npm run dev
           # dir: apps/web          # per-pane working directory
           # env:                   # per-pane environment variables
           #   PORT: "3000"
-        - title: Shell
+        - id: shell
+          title: Shell
           focus: true # give this pane initial focus

--- a/templates/go.yml
+++ b/templates/go.yml
@@ -7,15 +7,20 @@ terminal:
   rows:
     - size: 70%
       panes:
-        - title: Claude 1 — feature
+        - id: agent-1
+          title: Claude 1 — feature
           command: claude
-        - title: Claude 2 — review
+        - id: agent-2
+          title: Claude 2 — review
           command: claude
 
     - panes:
-        - title: Go
+        - id: dev
+          title: Go
           command: go run .
-        - title: Changes
+        - id: changes
+          title: Changes
           type: changes # live git changes widget
-        - title: Shell
+        - id: shell
+          title: Shell
           focus: true

--- a/templates/missions.yml
+++ b/templates/missions.yml
@@ -9,18 +9,24 @@ terminal:
   rows:
     - size: 70%
       panes:
-        - title: Lead
+        - id: agent-lead
+          title: Lead
           command: claude
           focus: true
-        - title: Frontend
+        - id: agent-frontend
+          title: Frontend
           command: claude
-        - title: Backend
+        - id: agent-backend
+          title: Backend
           command: claude
 
     - size: 30%
       panes:
-        - title: Validator
+        - id: agent-validator
+          title: Validator
           command: claude
-        - title: Researcher
+        - id: agent-researcher
+          title: Researcher
           command: claude
-        - title: Shell
+        - id: shell
+          title: Shell

--- a/templates/nextjs.yml
+++ b/templates/nextjs.yml
@@ -7,17 +7,23 @@ terminal:
   rows:
     - size: 70%
       panes:
-        - title: Claude 1 — feature
+        - id: agent-1
+          title: Claude 1 — feature
           command: claude
-        - title: Claude 2 — review
+        - id: agent-2
+          title: Claude 2 — review
           command: claude
-        - title: Claude 3 — explore
+        - id: agent-3
+          title: Claude 3 — explore
           command: claude
 
     - panes:
-        - title: Next.js
+        - id: dev
+          title: Next.js
           command: pnpm dev
-        - title: Changes
+        - id: changes
+          title: Changes
           type: changes # live git changes widget
-        - title: Shell
+        - id: shell
+          title: Shell
           focus: true

--- a/templates/python.yml
+++ b/templates/python.yml
@@ -7,15 +7,20 @@ terminal:
   rows:
     - size: 70%
       panes:
-        - title: Claude 1 — feature
+        - id: agent-1
+          title: Claude 1 — feature
           command: claude
-        - title: Claude 2 — review
+        - id: agent-2
+          title: Claude 2 — review
           command: claude
 
     - panes:
-        - title: Server
+        - id: dev
+          title: Server
           # command: uvicorn main:app --reload
-        - title: Changes
+        - id: changes
+          title: Changes
           type: changes # live git changes widget
-        - title: Shell
+        - id: shell
+          title: Shell
           focus: true

--- a/templates/vite.yml
+++ b/templates/vite.yml
@@ -7,15 +7,20 @@ terminal:
   rows:
     - size: 70%
       panes:
-        - title: Claude 1 — feature
+        - id: agent-1
+          title: Claude 1 — feature
           command: claude
-        - title: Claude 2 — review
+        - id: agent-2
+          title: Claude 2 — review
           command: claude
 
     - panes:
-        - title: Vite
+        - id: dev
+          title: Vite
           command: pnpm dev
-        - title: Changes
+        - id: changes
+          title: Changes
           type: changes # live git changes widget
-        - title: Shell
+        - id: shell
+          title: Shell
           focus: true


### PR DESCRIPTION
Completes Card06 B1: config-free project identity, explicit and reorder-stable pane IDs, tmux pane stamping, safe live descriptor discovery, and projection into the durable workspace contract. Descriptor discovery is asynchronous, bounded, epoch-safe, delimiter-safe, UTF-8-correct, and publishes healthy records from partial replies. Onboarding, detection, migrations, and templates now generate explicit pane IDs while legacy identical panes remain launchable with a diagnostic.\n\nValidation: full pnpm check before final fixes; 64 post-rebase Vitest tests plus 7 Bun launch tests; contracts and daemon typechecks; repeated adversarial review; diff check.