### PR TITLE
feat(tui): add pane-native icon chrome

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -357,6 +357,7 @@ import {
   terminalPaneChromeMotionState,
   terminalPaneChromePointerIntent,
   type TerminalPaneChromeActionTarget,
+  type TerminalPaneChromeHoverTarget,
   type TerminalPaneChromeMetadata,
 } from "./workspace/terminal-pane-chrome.ts";
 import { TerminalPaneChromeLayer } from "./workspace/terminal-pane-chrome-view.tsx";
@@ -1676,7 +1677,7 @@ try {
       }),
     );
     const [hoveredTerminalPaneAction, setHoveredTerminalPaneAction] =
-      createSignal<TerminalPaneChromeActionTarget | null>(null);
+      createSignal<TerminalPaneChromeHoverTarget | null>(null);
     const [pressedTerminalPaneAction, setPressedTerminalPaneAction] =
       createSignal<TerminalPaneChromeActionTarget | null>(null);
     const clearTerminalPaneActionState = () => {
@@ -5409,6 +5410,7 @@ try {
     };
 
     const closeMenu = () => {
+      clearTerminalPaneActionState();
       setMenuConfirm(null);
       setMenuInput(null);
       setMenuSub(null);
@@ -6227,8 +6229,7 @@ try {
 
     /** The root pane-chrome dispatcher focuses before calling this command edge. */
     const runTerminalPaneAction = (paneId: string, id: string) => {
-      if (id === "split") void mirror?.command(`split-window -h -t ${paneId}`).catch(() => {});
-      else if (id === "zoom") void mirror?.command(`resize-pane -Z -t ${paneId}`).catch(() => {});
+      if (id === "zoom") void mirror?.command(`resize-pane -Z -t ${paneId}`).catch(() => {});
     };
 
     /** The strip as THREE static texts (pre/active/post) whose STRINGS update.
@@ -6588,27 +6589,29 @@ try {
           if (paneChromeIntent) {
             setWorkbenchFocusZone("canvas");
             touchedWorkspaceDock = true;
+            const openPaneActions = (paneId: string) => {
+              const pane = panesById().get(paneId);
+              if (!pane) return;
+              openMenu(hit.localX, e.y, e.x, {
+                region: "pane",
+                title: pane.id,
+                items: paneMenuItems(
+                  pane.appMouse,
+                  selectModePane() === pane.id,
+                  paneDrag(pane.id),
+                ),
+                paneId: pane.id,
+              });
+            };
             dispatchTerminalPaneChromePointerIntent(paneChromeIntent, {
               hover: setHoveredTerminalPaneAction,
               focus: (paneId) => mirror?.focus(paneId),
               action: (paneId, actionId, actionIndex) => {
                 setPressedTerminalPaneAction({ paneId, actionIndex });
-                runTerminalPaneAction(paneId, actionId);
+                if (actionId === "menu") openPaneActions(paneId);
+                else runTerminalPaneAction(paneId, actionId);
               },
-              menu: (paneId) => {
-                const pane = panesById().get(paneId);
-                if (!pane) return;
-                openMenu(hit.localX, e.y, e.x, {
-                  region: "pane",
-                  title: pane.id,
-                  items: paneMenuItems(
-                    pane.appMouse,
-                    selectModePane() === pane.id,
-                    paneDrag(pane.id),
-                  ),
-                  paneId: pane.id,
-                });
-              },
+              menu: openPaneActions,
               settle: () => settleTerminalGestureBoundary(e),
             });
             return true;

--- a/packages/daemon/src/tui/mirror/recipes.ts
+++ b/packages/daemon/src/tui/mirror/recipes.ts
@@ -82,6 +82,20 @@ export function actionChipText(label: string, width?: number): string {
   return clipTerminal(` ${label}`, Math.max(0, geometry.bodyWidth - 1)) + " ";
 }
 
+/** Gloomberb-style line icon centered in a compact, exact-width hit target. */
+export function iconButtonWidth(width?: number): number {
+  return Math.max(0, Math.floor(width ?? 3));
+}
+
+export function iconButtonText(icon: string, width?: number): string {
+  const resolved = iconButtonWidth(width);
+  if (resolved <= 0) return "";
+  const glyph = clipTerminal(icon, 1);
+  if (resolved === 1) return glyph;
+  const left = Math.floor((resolved - 1) / 2);
+  return `${" ".repeat(left)}${glyph}${" ".repeat(Math.max(0, resolved - left - 1))}`;
+}
+
 export function actionChipSpansFromRight<T extends { label: string }>(
   actions: readonly T[],
   rightEdge: number,

--- a/packages/daemon/src/tui/mirror/recipes.tsx
+++ b/packages/daemon/src/tui/mirror/recipes.tsx
@@ -4,6 +4,8 @@ import { For, Show } from "solid-js";
 import {
   actionChipGeometry,
   actionChipText,
+  iconButtonText,
+  iconButtonWidth,
   recipePalette,
   rowParts,
   scrollbarGlyphs,
@@ -119,6 +121,34 @@ export function Button(props: ButtonProps) {
 }
 
 export const ActionChip = Button;
+
+export interface IconButtonProps extends ThemeProps, RecipeInteractionState {
+  icon: string;
+  tone?: RecipeTone;
+  width?: number;
+  hidden?: boolean;
+}
+
+/** Presentation-only icon control; the owning surface keeps all input policy. */
+export function IconButton(props: IconButtonProps) {
+  const palette = () => recipePalette(props.theme, props, props.tone ?? "accent");
+  const content = () => iconButtonText(props.hidden ? " " : props.icon, props.width);
+  const paintsState = () => !props.hidden && palette().state !== "base";
+  return (
+    <box
+      height={1}
+      width={iconButtonWidth(props.width)}
+      backgroundColor={paintsState() ? palette().background : undefined}
+      overflow="hidden"
+    >
+      <text
+        fg={palette().state === "base" ? props.theme.colors.mutedForeground : palette().foreground}
+      >
+        {content()}
+      </text>
+    </box>
+  );
+}
 
 export interface BadgeProps extends ThemeProps {
   label: string;

--- a/packages/daemon/src/tui/mirror/workspace/__snapshots__/agent-terminal-canvas-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/workspace/__snapshots__/agent-terminal-canvas-renderer.test.tsx.snap
@@ -135,7 +135,7 @@ tmux framebuffer 200x58
 
 exports[`AgentTerminalCanvas OpenTUI renderer renders pane chrome at %sx%s without covering framebuffer sentinels 1`] = `
 " 0:agents 1:shell
-▌: ▣ ❯ Codex PM          ●   ○ Z   ○ +  :: ○ ❯ Codex implementer  ●   ○ Z   ○ +
+:: ▣ ❯ Codex PM              ●   □   ⋯  :: ○ ❯ Codex implementer      ●
 A1A ·······························     A2A ································
 
 
@@ -146,7 +146,7 @@ A1A ·······························     A2A ··�
 
                                         │
                                                                             Z2Z
-                                        :: ! ❯ Claude reviewer    !   ○ Z   ○ +
+                                        :: ! ❯ Claude reviewer        !
                                         A3A ································
 
 
@@ -162,7 +162,7 @@ A1A ·······························     A2A ··�
 
 exports[`AgentTerminalCanvas OpenTUI renderer renders pane chrome at %sx%s without covering framebuffer sentinels 2`] = `
 " 0:agents 1:shell
-▌: ▣ ❯ Codex PM                              ●   ○ Z   ○ +  :: ○ ❯ Codex implementer                      ●   ○ Z   ○ +
+:: ▣ ❯ Codex PM                                  ●   □   ⋯  :: ○ ❯ Codex implementer                          ●
 A1A ···················································     A2A ····················································
 
 
@@ -181,7 +181,7 @@ A1A ······································
 
                                                             │
                                                                                                                     Z2Z
-                                                            :: ! ❯ Claude reviewer                        !   ○ Z   ○ +
+                                                            :: ! ❯ Claude reviewer                            !
                                                             A3A ····················································
 
 
@@ -205,7 +205,7 @@ A1A ······································
 
 exports[`AgentTerminalCanvas OpenTUI renderer renders pane chrome at %sx%s without covering framebuffer sentinels 3`] = `
 " 0:agents 1:shell
-▌: ▣ ❯ Codex PM                                                                      ●   ○ Z   ○ +  :: ○ ❯ Codex implementer                                                              ●   ○ Z   ○ +
+:: ▣ ❯ Codex PM                                                                          ●   □   ⋯  :: ○ ❯ Codex implementer                                                                  ●
 A1A ···························································································     A2A ····························································································
 
 
@@ -234,7 +234,7 @@ A1A ······································
 
                                                                                                     │
                                                                                                                                                                                                     Z2Z
-                                                                                                    :: ! ❯ Claude reviewer                                                                !   ○ Z   ○ +
+                                                                                                    :: ! ❯ Claude reviewer                                                                    !
                                                                                                     A3A ····························································································
 
 
@@ -268,7 +268,7 @@ A1A ······································
 
 exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 1`] = `
 "
-Z
+□
 B
 
 
@@ -277,7 +277,7 @@ B
 
 exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 2`] = `
 "
-R
+▣
 B
 
 
@@ -286,7 +286,7 @@ B
 
 exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 3`] = `
 "
-Z
+ □
 B
 
 
@@ -295,7 +295,7 @@ B
 
 exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 4`] = `
 "
-R
+… ▣
 B
 
 
@@ -304,7 +304,7 @@ B
 
 exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 5`] = `
 "
- ○ Z
+%7 □
 B
 
 
@@ -313,7 +313,7 @@ B
 
 exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 6`] = `
 " window
-%7  ○ Z
+%7    □
 B
 
 
@@ -322,7 +322,7 @@ B
 
 exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 7`] = `
 " window
-%7      ○ Z
+%7    □   ⋯
 B
 
 
@@ -331,7 +331,7 @@ B
 
 exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 8`] = `
 " window
-%7 ○ Z   ○ +
+%7     □   ⋯
 B
 
 
@@ -340,7 +340,7 @@ B
 
 exports[`AgentTerminalCanvas OpenTUI renderer keeps compact zoom chrome visible at width %s 9`] = `
 " window
-%7    ○ Z   ○ +
+:: ▣ ❯ …  □   ⋯
 B
 
 

--- a/packages/daemon/src/tui/mirror/workspace/__snapshots__/pane-frame-renderer.test.tsx.snap
+++ b/packages/daemon/src/tui/mirror/workspace/__snapshots__/pane-frame-renderer.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PaneFrame OpenTUI renderer renders the %sx%s compact window chrome 1`] = `
 "┌──────────────────────────────────────────────────────────────────────────────┐
-│▌: ▣ ❯ Codex implementer •                            ●   M   ○ A   ○ M   ○ N │
+│:: ▣ ❯ Codex implementer •                            ●   M   ○ A   ○ M   ○ N │
 │● Mission: ship application-grade window chrome                            M31│
 │› Task: PaneFrame projection and renderer                              running│
 │● Harness: Codex                                                       gpt-5.5│
@@ -29,7 +29,7 @@ exports[`PaneFrame OpenTUI renderer renders the %sx%s compact window chrome 1`] 
 
 exports[`PaneFrame OpenTUI renderer renders the %sx%s standard window chrome 1`] = `
 "┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│▌: ▣ ❯ Codex implementer • · %7 · task/142-pane-frame                  working   max   ○ agent   ○ mission   ○ native │
+│:: ▣ ❯ Codex implementer • · %7 · task/142-pane-frame                  working   max   ○ agent   ○ mission   ○ native │
 │● Mission: ship application-grade window chrome                                                                    M31│
 │› Task: PaneFrame projection and renderer                                                                      running│
 │● Harness: Codex                                                                                               gpt-5.5│
@@ -72,7 +72,7 @@ exports[`PaneFrame OpenTUI renderer renders the %sx%s standard window chrome 1`]
 
 exports[`PaneFrame OpenTUI renderer renders the %sx%s wide window chrome 1`] = `
 "┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│▌: ▣ ❯ Codex implementer • · %7 · task/142-pane-frame                                                                                                  working   max   ○ agent   ○ mission   ○ native │
+│:: ▣ ❯ Codex implementer • · %7 · task/142-pane-frame                                                                                                  working   max   ○ agent   ○ mission   ○ native │
 │● Mission: ship application-grade window chrome                                                                                                                                                    M31│
 │› Task: PaneFrame projection and renderer                                                                                                                                                      running│
 │● Harness: Codex                                                                                                                                                                               gpt-5.5│
@@ -178,7 +178,7 @@ exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, 
 
 exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, and semantic header colors 2`] = `
 "┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│▌: ! ◆ Keyboard mission attention                                                                             blocked │
+│:: ! ◆ Keyboard mission attention                                                                             blocked │
 │ body keeps framebuffer ownership elsewhere                                                                           │
 │                                                                                                                      │
 │                                                                                                                      │
@@ -221,7 +221,7 @@ exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, 
 
 exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, and semantic header colors 3`] = `
 "┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│▌: ▣ ❯ Terminal agent attention                                                                               blocked │
+│:: ▣ ❯ Terminal agent attention                                                                               blocked │
 │ body keeps framebuffer ownership elsewhere                                                                           │
 │                                                                                                                      │
 │                                                                                                                      │
@@ -264,7 +264,7 @@ exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, 
 
 exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, and semantic header colors 4`] = `
 "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃▌: ◇ ▣ Mission native surface                           blocked   edit   float   max   ○ agent   ○ mission   ○ native ┃
+┃:: ◇ ▣ Mission native surface                           blocked   edit   float   max   ○ agent   ○ mission   ○ native ┃
 ┃ body keeps framebuffer ownership elsewhere                                                                           ┃
 ┃                                                                                                                      ┃
 ┃                                                                                                                      ┃
@@ -307,7 +307,7 @@ exports[`PaneFrame OpenTUI renderer pins rendered state-matrix glyphs, borders, 
 
 exports[`PaneFrame OpenTUI renderer pins disabled, hovered, and mouse-down pressed action states before release 1`] = `
 "┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│▌: ● ▣ Action state matrix                                                             · agent   × mission   ◆ native │
+│:: ● ▣ Action state matrix                                                             · agent   × mission   ◆ native │
 │ action state evidence                                                                                                │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx
@@ -1,7 +1,7 @@
 /* @jsxImportSource @opentui/solid */
 import { describe, expect, it } from "bun:test";
 import { createMemo, createSignal } from "solid-js";
-import { createSemanticThemeSnapshot } from "../theme.ts";
+import { colorToThemeBytes, createSemanticThemeSnapshot } from "../theme.ts";
 import { expectFrameBounds, renderForTest, stableFrame } from "../testing/renderer-harness.test.ts";
 import { projectAgentTerminalCanvas } from "./agent-terminal-canvas.ts";
 import { AgentTerminalCanvas } from "./agent-terminal-canvas-view.tsx";
@@ -31,6 +31,10 @@ function renderableTree(node: TestRenderable): readonly unknown[] {
 
 function renderableCount(node: TestRenderable): number {
   return renderableTree(node).length;
+}
+
+function colorKey(color: Parameters<typeof colorToThemeBytes>[0]): string {
+  return colorToThemeBytes(color).join(",");
 }
 
 describe("AgentTerminalCanvas OpenTUI renderer", () => {
@@ -201,6 +205,12 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
         expect(stable).toContain(`Z${id}Z`);
       }
       expect(stable).toContain("Claude reviewer");
+      const maximizeSpan = setup
+        .captureSpans()
+        .lines[projection.chrome.height - 1]!.spans.find((span) => span.text.includes("□"));
+      expect(maximizeSpan).toBeDefined();
+      expect(colorKey(maximizeSpan!.bg)).toBe(colorKey(theme.colors.accentMuted));
+      expect(colorKey(maximizeSpan!.fg)).toBe(colorKey(theme.colors.mutedForeground));
       setup.renderer.destroy();
     },
   );
@@ -243,7 +253,7 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
       const header = layout.native[0]!;
       const zoom = header.frame!.actions.find((action) => action.id === "zoom")!;
       expect(stable).toMatchSnapshot();
-      expect(stable).toContain(zoomed ? "R" : "Z");
+      expect(stable).toContain(zoom.label);
       expect(stable).toContain("B");
       expect(
         terminalPaneChromeHitTest(

--- a/packages/daemon/src/tui/mirror/workspace/icons.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/icons.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { terminalDisplayWidth } from "../panel-host.ts";
+import { iconButtonText } from "../recipes.ts";
+import { WORKSPACE_ICONS, workspaceIcon, workspaceIconLabel } from "./icons.ts";
+
+describe("workspace icon grammar", () => {
+  it("keeps every Unicode glyph and ASCII fallback to exactly one terminal cell", () => {
+    for (const [id, icon] of Object.entries(WORKSPACE_ICONS)) {
+      expect(terminalDisplayWidth(icon.glyph), `${id} Unicode glyph`).toBe(1);
+      expect(terminalDisplayWidth(icon.fallback), `${id} ASCII fallback`).toBe(1);
+    }
+  });
+
+  it("resolves semantic glyphs without losing their human label", () => {
+    expect(workspaceIcon("maximize")).toBe("□");
+    expect(workspaceIcon("maximize", "ascii")).toBe("Z");
+    expect(workspaceIconLabel("maximize")).toBe("Maximize");
+    expect(workspaceIcon("more")).toBe("⋯");
+    expect(workspaceIcon("close")).toBe("×");
+  });
+
+  it("centers an icon without exceeding narrow hit geometry", () => {
+    for (const width of [0, 1, 2, 3, 4, 8]) {
+      expect(terminalDisplayWidth(iconButtonText(workspaceIcon("maximize"), width))).toBe(width);
+    }
+    expect(iconButtonText(workspaceIcon("maximize"), 1)).toBe("□");
+    expect(iconButtonText(workspaceIcon("maximize"), 3)).toBe(" □ ");
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace/icons.ts
+++ b/packages/daemon/src/tui/mirror/workspace/icons.ts
@@ -1,0 +1,43 @@
+/**
+ * A terminal-safe icon vocabulary shared by native workspace surfaces.
+ *
+ * The Unicode glyphs are deliberately monochrome, non-emoji symbols with a
+ * one-cell terminal width. ASCII fallbacks keep semantic actions available to
+ * conservative hosts without leaking presentation choices into controllers.
+ */
+export const WORKSPACE_ICONS = {
+  home: { glyph: "⌂", fallback: "H", label: "Home" },
+  terminals: { glyph: "❯", fallback: ">", label: "Terminals" },
+  files: { glyph: "▤", fallback: "F", label: "Files" },
+  diff: { glyph: "±", fallback: "D", label: "Changes" },
+  missions: { glyph: "◆", fallback: "M", label: "Missions" },
+  activity: { glyph: "◷", fallback: "A", label: "Activity" },
+  preview: { glyph: "◫", fallback: "P", label: "Preview" },
+  native: { glyph: "▣", fallback: "N", label: "Native surface" },
+  more: { glyph: "⋯", fallback: ".", label: "More actions" },
+  close: { glyph: "×", fallback: "x", label: "Close" },
+  minimize: { glyph: "−", fallback: "-", label: "Minimize" },
+  maximize: { glyph: "□", fallback: "Z", label: "Maximize" },
+  restore: { glyph: "▣", fallback: "R", label: "Restore" },
+  splitRight: { glyph: "│", fallback: "|", label: "Split side-by-side" },
+  splitDown: { glyph: "─", fallback: "-", label: "Split stacked" },
+  dock: { glyph: "▤", fallback: "D", label: "Dock" },
+  float: { glyph: "◇", fallback: "F", label: "Float" },
+  move: { glyph: "⠿", fallback: "M", label: "Move" },
+  resize: { glyph: "◲", fallback: "R", label: "Resize" },
+  popOut: { glyph: "⇱", fallback: "^", label: "Pop out" },
+  search: { glyph: "⌕", fallback: "/", label: "Search" },
+  command: { glyph: "›", fallback: ">", label: "Command" },
+} as const;
+
+export type WorkspaceIconId = keyof typeof WORKSPACE_ICONS;
+export type WorkspaceIconMode = "unicode" | "ascii";
+
+export function workspaceIcon(id: WorkspaceIconId, mode: WorkspaceIconMode = "unicode"): string {
+  const icon = WORKSPACE_ICONS[id];
+  return mode === "ascii" ? icon.fallback : icon.glyph;
+}
+
+export function workspaceIconLabel(id: WorkspaceIconId): string {
+  return WORKSPACE_ICONS[id].label;
+}

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
@@ -395,4 +395,57 @@ describe("PaneFrame OpenTUI renderer", () => {
     expect(stableFrame(setup.captureCharFrame())).not.toContain("◆ native");
     setup.renderer.destroy();
   });
+
+  it("pins native icon base, hover, disabled, pressed, and hidden states", async () => {
+    const theme = createSemanticThemeSnapshot({ mode: "dark" });
+    const iconActions = [
+      { id: "maximize", label: "maximize", icon: "maximize", description: "Maximize" },
+      { id: "menu", label: "more", icon: "more", description: "More actions" },
+      { id: "close", label: "close", icon: "close", description: "Close", disabled: true },
+      { id: "resize", label: "resize", icon: "resize", description: "Resize" },
+      { id: "dock", label: "dock", icon: "dock", description: "Dock", hidden: true },
+    ] as const;
+    const projection = projectPaneFrame({
+      width: 120,
+      height: 8,
+      title: "Icon action state matrix",
+      kind: "terminals",
+      focused: true,
+      terminalFocused: true,
+      hoveredActionIndex: 1,
+      pressedActionIndex: 3,
+      actions: iconActions,
+    });
+    const setup = await renderForTest(
+      () => (
+        <PaneFrame theme={theme} projection={projection}>
+          <text> icon state evidence</text>
+        </PaneFrame>
+      ),
+      { width: 120, height: 8 },
+    );
+    await setup.renderOnce();
+
+    const base = spanContaining(setup, "□", projection.header.y)!;
+    const hovered = spanContaining(setup, "⋯", projection.header.y)!;
+    const disabled = spanContaining(setup, "×", projection.header.y)!;
+    const pressed = spanContaining(setup, "◲", projection.header.y)!;
+    expect(colorKey(base.bg)).toBe(colorKey(theme.colors.accentMuted));
+    expect(colorKey(base.fg)).toBe(colorKey(theme.colors.mutedForeground));
+    expect(colorKey(hovered.bg)).toBe(colorKey(recipePalette(theme, { hovered: true }).background));
+    expect(colorKey(disabled.fg)).toBe(
+      colorKey(recipePalette(theme, { disabled: true }).foreground),
+    );
+    expect(colorKey(pressed.bg)).toBe(colorKey(recipePalette(theme, { pressed: true }).background));
+    expect(stableFrame(setup.captureCharFrame())).not.toContain("▤");
+    const hidden = projection.actions.find((action) => action.id === "dock")!;
+    expect(
+      paneFrameHitTest(
+        projection,
+        hidden.start + Math.floor(hidden.width / 2),
+        projection.header.y,
+      ),
+    ).toMatchObject({ area: "action", actionId: "dock" });
+    setup.renderer.destroy();
+  });
 });

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
@@ -1,6 +1,7 @@
 import { terminalDisplayWidth } from "../panel-host.ts";
-import { actionChipWidth, type RecipeTone, type Rect } from "../recipes.ts";
+import { actionChipWidth, iconButtonWidth, type RecipeTone, type Rect } from "../recipes.ts";
 import { clipWorkspaceText } from "./text.ts";
+import { workspaceIcon, type WorkspaceIconId } from "./icons.ts";
 
 export type PaneFrameVariant = "compact" | "standard" | "wide";
 export type PaneFrameKind =
@@ -17,11 +18,13 @@ export interface PaneFrameAction {
   id: string;
   label: string;
   compactLabel?: string;
+  icon?: WorkspaceIconId;
   description: string;
   active?: boolean;
   disabled?: boolean;
   attention?: boolean;
   pressed?: boolean;
+  hidden?: boolean;
 }
 
 export interface PaneFrameInput {
@@ -71,6 +74,7 @@ export interface PaneFrameStateChip {
 
 export interface PaneFrameActionChip extends PaneFrameAction {
   kind: "action";
+  appearance: "label" | "icon";
   label: string;
   fullLabel: string;
   start: number;
@@ -117,15 +121,15 @@ export type PaneFrameHit =
   | { area: "border" }
   | null;
 
-const KIND_GLYPHS: Readonly<Record<PaneFrameKind, string>> = {
-  home: "⌂",
-  terminals: "❯",
-  files: "▤",
-  diff: "±",
-  missions: "◆",
-  activity: "◷",
-  preview: "◫",
-  native: "▣",
+const KIND_ICONS: Readonly<Record<PaneFrameKind, WorkspaceIconId>> = {
+  home: "home",
+  terminals: "terminals",
+  files: "files",
+  diff: "diff",
+  missions: "missions",
+  activity: "activity",
+  preview: "preview",
+  native: "native",
 };
 
 const STATUS_GLYPHS: Readonly<Record<Exclude<RecipeTone, "neutral" | "accent">, string>> = {
@@ -172,7 +176,12 @@ export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
     ...action,
     kind: "action" as const,
     fullLabel: action.label,
-    label: variant === "compact" ? (action.compactLabel ?? action.label) : action.label,
+    appearance: action.icon ? ("icon" as const) : ("label" as const),
+    label: action.icon
+      ? workspaceIcon(action.icon)
+      : variant === "compact"
+        ? (action.compactLabel ?? action.label)
+        : action.label,
     hovered: input.hoveredActionIndex === index,
     pressed: input.pressedActionIndex === index || action.pressed === true,
   }));
@@ -187,7 +196,8 @@ export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
   const titleStart = header.x + (grip ? grip.width + 1 : 0);
   const titleBudget = Math.max(0, firstChip - titleStart - (chips.length > 0 ? 1 : 0));
   const dirty = input.dirty ? " •" : "";
-  const titlePrefix = `${marker} ${KIND_GLYPHS[input.kind]} `;
+  const kindGlyph = workspaceIcon(KIND_ICONS[input.kind]);
+  const titlePrefix = `${marker} ${kindGlyph} `;
   const requestedTitle = `${titlePrefix}${input.title}${dirty}`;
   const showSubtitle = variant !== "compact" && !!input.subtitle;
   const subtitleDividerWidth = showSubtitle ? 3 : 0;
@@ -232,7 +242,7 @@ export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
     },
     subtitleSpan,
     marker,
-    glyph: KIND_GLYPHS[input.kind],
+    glyph: kindGlyph,
     title: titleText,
     subtitle: subtitleText,
     focused: input.focused,
@@ -302,7 +312,9 @@ function chipWidth(
     | Omit<PaneFrameActionChip, "start" | "width">,
 ): number {
   return chip.kind === "action"
-    ? actionChipWidth(chip.label)
+    ? chip.appearance === "icon"
+      ? iconButtonWidth()
+      : actionChipWidth(chip.label)
     : terminalDisplayWidth(chip.label) + 2;
 }
 

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
@@ -1,7 +1,7 @@
 /* @jsxImportSource @opentui/solid */
 import type { JSX } from "@opentui/solid";
 import { createMemo, For, Show } from "solid-js";
-import { ActionChip, Badge, StatusChip } from "../recipes.tsx";
+import { ActionChip, Badge, IconButton, StatusChip } from "../recipes.tsx";
 import { recipePalette } from "../recipes.ts";
 import type { SemanticThemeSnapshot } from "../theme.ts";
 import type { PaneFrameChip, PaneFrameProjection } from "./pane-frame.ts";
@@ -76,16 +76,35 @@ function Chip(props: { theme: SemanticThemeSnapshot; chip: PaneFrameChip }) {
         </Show>
       }
     >
-      <ActionChip
-        theme={props.theme}
-        label={action()!.label}
-        width={action()!.width}
-        hovered={action()!.hovered}
-        pressed={action()!.pressed}
-        selected={action()!.active}
-        disabled={action()!.disabled}
-        attention={action()!.attention}
-      />
+      <Show
+        when={action()!.appearance === "icon"}
+        fallback={
+          <ActionChip
+            theme={props.theme}
+            label={action()!.label}
+            width={action()!.width}
+            hovered={action()!.hovered}
+            pressed={action()!.pressed}
+            selected={action()!.active}
+            disabled={action()!.disabled}
+            attention={action()!.attention}
+          />
+        }
+      >
+        <IconButton
+          theme={props.theme}
+          icon={action()!.label}
+          width={action()!.width}
+          hovered={action()!.hovered}
+          pressed={action()!.pressed}
+          // Icon identity (□/▣) communicates toggle state. Keep the idle
+          // control transparent like native window chrome.
+          selected={false}
+          disabled={action()!.disabled}
+          attention={action()!.attention}
+          hidden={action()!.hidden}
+        />
+      </Show>
     </Show>
   );
 }
@@ -122,7 +141,7 @@ export function PaneFrameHeader(props: PaneFrameHeaderProps) {
           height={1}
         >
           <text fg={nativeFocused() ? props.theme.colors.focus : props.theme.colors.border}>
-            {nativeFocused() ? "▌:" : props.projection.grip!.text}
+            {props.projection.grip!.text}
           </text>
         </box>
       </Show>

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome-view.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome-view.tsx
@@ -1,6 +1,5 @@
 /* @jsxImportSource @opentui/solid */
 import { createMemo, For } from "solid-js";
-import { actionChipWidth, recipePalette } from "../recipes.ts";
 import type { SemanticThemeSnapshot } from "../theme.ts";
 import { PaneFrameHeader } from "./pane-frame.tsx";
 import type {
@@ -16,34 +15,6 @@ export interface TerminalPaneChromeLayerProps {
 
 function sameIds(left: readonly string[], right: readonly string[]): boolean {
   return left.length === right.length && left.every((id, index) => id === right[index]);
-}
-
-function NarrowTerminalAction(props: {
-  theme: SemanticThemeSnapshot;
-  action: NonNullable<TerminalPaneChromeProjection["frame"]>["actions"][number];
-}) {
-  const palette = () =>
-    recipePalette(props.theme, {
-      hovered: props.action.hovered,
-      pressed: props.action.pressed,
-      selected: props.action.active,
-      disabled: props.action.disabled,
-      attention: props.action.attention,
-    });
-  const text = () => props.action.label.slice(0, props.action.width).padEnd(props.action.width);
-  return (
-    <box
-      position="absolute"
-      left={props.action.start}
-      top={0}
-      width={props.action.width}
-      height={1}
-      backgroundColor={palette().background}
-      overflow="hidden"
-    >
-      <text fg={palette().foreground}>{text()}</text>
-    </box>
-  );
 }
 
 /** Passive projection surface; the application root remains the only input owner. */
@@ -71,19 +42,6 @@ export function TerminalPaneChromeLayer(props: TerminalPaneChromeLayerProps) {
       {(paneId) => {
         const pane = () => projectionsById().get(paneId)!;
         const frame = () => pane().frame!;
-        const narrowActionIds = createMemo(
-          () =>
-            frame()
-              .actions.filter(
-                (action) => action.id === "zoom" && action.width < actionChipWidth(action.label),
-              )
-              .map((action) => action.id),
-          undefined,
-          { equals: sameIds },
-        );
-        const actionsById = createMemo(
-          () => new Map(frame().actions.map((action) => [action.id, action])),
-        );
         return (
           <box
             id={`terminal-pane-chrome:${props.layer}:${paneId}`}
@@ -95,15 +53,6 @@ export function TerminalPaneChromeLayer(props: TerminalPaneChromeLayerProps) {
             overflow="hidden"
           >
             <PaneFrameHeader theme={props.theme} projection={frame()} />
-            {/* The shared ActionChip reserves two marker cells. At widths 1–4
-                  that would leave a correct hit target but no visible Z/R. Keep
-                  the shared recipe untouched and overlay only terminal zoom's
-                  literal glyph inside the exact same projected action span. */}
-            <For each={narrowActionIds()}>
-              {(actionId) => (
-                <NarrowTerminalAction theme={props.theme} action={actionsById().get(actionId)!} />
-              )}
-            </For>
           </box>
         );
       }}

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.test.ts
@@ -84,9 +84,39 @@ describe("terminal pane chrome projection", () => {
     const before = canvas.tmuxSize;
     const layout = projectTerminalPaneChrome({ canvas, panes });
     const zoom = layout.native[0]!.frame!.actions.find((action) => action.id === "zoom")!;
-    expect(zoom).toMatchObject({ fullLabel: "restore", label: "R", active: true });
+    expect(zoom).toMatchObject({
+      fullLabel: "restore",
+      label: "▣",
+      appearance: "icon",
+      active: true,
+    });
     expect(canvas.tmuxSize).toEqual(before);
     expect(layout.framebuffer).toEqual([]);
+  });
+
+  it("keeps fixed icon hit spans while hiding inactive chrome until hover", () => {
+    const panes = [
+      pane({ id: "%1", width: 59 }),
+      pane({ id: "%2", left: 60, width: 60, active: false }),
+    ];
+    const idle = projectTerminalPaneChrome({ canvas, panes });
+    const idleActions = idle.native[1]!.frame!.actions;
+    expect(idleActions.map((action) => [action.id, action.label, action.hidden])).toEqual([
+      ["zoom", "□", true],
+      ["menu", "⋯", true],
+    ]);
+
+    const hovered = projectTerminalPaneChrome({
+      canvas,
+      panes,
+      hoveredAction: { paneId: "%2", actionIndex: null },
+    });
+    const hoveredActions = hovered.native[1]!.frame!.actions;
+    expect(hoveredActions.map((action) => [action.id, action.start, action.width])).toEqual(
+      idleActions.map((action) => [action.id, action.start, action.width]),
+    );
+    expect(hoveredActions.every((action) => action.hidden === false)).toBe(true);
+    expect(hoveredActions.every((action) => action.hovered === false)).toBe(true);
   });
 
   it.each([1, 2, 3, 4, 5, 8, 12, 13, 16])(
@@ -187,6 +217,14 @@ describe("terminal pane chrome projection", () => {
       kind: "focus",
       paneId: "%2",
     });
+    expect(
+      terminalPaneChromePointerIntent(
+        layout,
+        second.canvasRect.x + second.frame!.titleSpan.x,
+        y,
+        "move",
+      ),
+    ).toEqual({ kind: "hover", target: { paneId: "%2", actionIndex: null } });
     expect(terminalPaneChromePointerIntent(layout, x, y, "up")).toEqual({
       kind: "settle",
       paneId: "%2",
@@ -234,6 +272,22 @@ describe("terminal pane chrome projection", () => {
         "down",
       ),
     ).toBeNull();
+    expect(
+      terminalPaneChromePointerIntent(
+        layout,
+        lower.canvasRect.x + lower.frame!.grip!.x,
+        lower.canvasRect.y,
+        "move",
+      ),
+    ).toEqual({ kind: "hover", target: { paneId: "%2", actionIndex: null } });
+    expect(
+      terminalPaneChromePointerIntent(
+        layout,
+        lower.canvasRect.x + lower.frame!.grip!.x,
+        lower.canvasRect.y,
+        "drag",
+      ),
+    ).toBeNull();
   });
 
   it("clears motion and lifecycle state outside live terminal chrome", () => {
@@ -241,6 +295,12 @@ describe("terminal pane chrome projection", () => {
     expect(terminalPaneChromeMotionState({ kind: "hover", target: { ...target } }, target)).toEqual(
       { hovered: target, pressed: target },
     );
+    expect(
+      terminalPaneChromeMotionState(
+        { kind: "hover", target: { paneId: "%2", actionIndex: null } },
+        target,
+      ),
+    ).toEqual({ hovered: { paneId: "%2", actionIndex: null }, pressed: null });
     expect(terminalPaneChromeMotionState(null, target)).toEqual({ hovered: null, pressed: null });
     expect(reconcileTerminalPaneChromeActionTarget(target, new Set(["%2"]), true)).toBe(target);
     expect(reconcileTerminalPaneChromeActionTarget(target, new Set(["%1"]), true)).toBeNull();

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts
@@ -1,5 +1,5 @@
 import { terminalDisplayWidth } from "../panel-host.ts";
-import { actionChipWidth, type RecipeTone, type Rect } from "../recipes.ts";
+import { iconButtonWidth, type RecipeTone, type Rect } from "../recipes.ts";
 import type { AgentTerminalCanvasProjection } from "./agent-terminal-canvas.ts";
 import {
   paneFrameHitTest,
@@ -9,6 +9,7 @@ import {
   type PaneFrameProjection,
 } from "./pane-frame.ts";
 import { clipWorkspaceText } from "./text.ts";
+import { workspaceIcon } from "./icons.ts";
 
 export interface TerminalPaneChromePane {
   id: string;
@@ -34,6 +35,11 @@ export interface TerminalPaneChromeMetadata {
 export interface TerminalPaneChromeActionTarget {
   paneId: string;
   actionIndex: number;
+}
+
+export interface TerminalPaneChromeHoverTarget {
+  paneId: string;
+  actionIndex: number | null;
 }
 
 export type TerminalPaneChromePlacement =
@@ -64,7 +70,7 @@ export interface TerminalPaneChromeInput {
   canvas: AgentTerminalCanvasProjection;
   panes: readonly TerminalPaneChromePane[];
   metadataByPane?: ReadonlyMap<string, TerminalPaneChromeMetadata>;
-  hoveredAction?: TerminalPaneChromeActionTarget | null;
+  hoveredAction?: TerminalPaneChromeHoverTarget | null;
   pressedAction?: TerminalPaneChromeActionTarget | null;
 }
 
@@ -75,7 +81,7 @@ export interface TerminalPaneChromeHit {
 }
 
 export type TerminalPaneChromePointerIntent =
-  | { kind: "hover"; target: TerminalPaneChromeActionTarget | null }
+  | { kind: "hover"; target: TerminalPaneChromeHoverTarget | null }
   | { kind: "focus"; paneId: string }
   | { kind: "action"; paneId: string; actionId: string; actionIndex: number }
   | { kind: "menu"; paneId: string }
@@ -84,7 +90,7 @@ export type TerminalPaneChromePointerIntent =
   | null;
 
 export interface TerminalPaneChromePointerEffects {
-  hover(target: TerminalPaneChromeActionTarget | null): void;
+  hover(target: TerminalPaneChromeHoverTarget | null): void;
   focus(paneId: string): void;
   action(paneId: string, actionId: string, actionIndex: number): void;
   menu(paneId: string): void;
@@ -92,7 +98,7 @@ export interface TerminalPaneChromePointerEffects {
 }
 
 export interface TerminalPaneChromeMotionState {
-  hovered: TerminalPaneChromeActionTarget | null;
+  hovered: TerminalPaneChromeHoverTarget | null;
   pressed: TerminalPaneChromeActionTarget | null;
 }
 
@@ -236,18 +242,30 @@ export function terminalPaneChromePointerIntent(
   if (!result) return null;
   const gutterPassThrough = result.placement !== "native-header" && result.hit.area !== "action";
   if (eventType === "down" && button === 2) return { kind: "menu", paneId: result.paneId };
-  // Lower headers paint the existing resize separator. Only their concrete
-  // action chips capture left-pointer input; title/grip cells retain tmux's
-  // established separator-resize path.
-  if (gutterPassThrough) return null;
-  if (isRelease(eventType)) return { kind: "settle", paneId: result.paneId };
-  if (eventType === "move" || eventType === "over" || eventType === "drag") {
+  // Passive motion may reveal reserved controls across the whole titlebar,
+  // including lower headers that share a tmux resize separator. Press/drag and
+  // release on those non-action gutter cells still fall through to tmux.
+  if (eventType === "move" || eventType === "over") {
     return {
       kind: "hover",
       target:
         result.hit.area === "action"
           ? { paneId: result.paneId, actionIndex: result.hit.actionIndex }
-          : null,
+          : { paneId: result.paneId, actionIndex: null },
+    };
+  }
+  // Lower headers paint the existing resize separator. Only their concrete
+  // action chips capture left-pointer input; title/grip cells retain tmux's
+  // established separator-resize path.
+  if (gutterPassThrough) return null;
+  if (isRelease(eventType)) return { kind: "settle", paneId: result.paneId };
+  if (eventType === "drag") {
+    return {
+      kind: "hover",
+      target:
+        result.hit.area === "action"
+          ? { paneId: result.paneId, actionIndex: result.hit.actionIndex }
+          : { paneId: result.paneId, actionIndex: null },
     };
   }
   if (eventType === "down" && result.hit.area === "action") {
@@ -295,11 +313,11 @@ export function terminalPaneChromeMotionState(
 }
 
 /** Drop transient action state when its pane dies or Terminals stops being active. */
-export function reconcileTerminalPaneChromeActionTarget(
-  target: TerminalPaneChromeActionTarget | null,
+export function reconcileTerminalPaneChromeActionTarget<T extends { paneId: string }>(
+  target: T | null,
   paneIds: ReadonlySet<string>,
   terminalsActive: boolean,
-): TerminalPaneChromeActionTarget | null {
+): T | null {
   return target && terminalsActive && paneIds.has(target.paneId) ? target : null;
 }
 
@@ -321,23 +339,28 @@ function paneHeaderFrame(
   pane: TerminalPaneChromePane,
   metadata: TerminalPaneChromeMetadata | undefined,
   width: number,
-  hovered: TerminalPaneChromeActionTarget | null | undefined,
+  hovered: TerminalPaneChromeHoverTarget | null | undefined,
   pressed: TerminalPaneChromeActionTarget | null | undefined,
 ): PaneFrameProjection {
   const title = terminalPaneChromeTitle(pane, metadata);
+  const actionsVisible = pane.active || hovered?.paneId === pane.id || pressed?.paneId === pane.id;
   const actions = [
     {
       id: "zoom",
       label: pane.zoomed ? "restore" : "zoom",
       compactLabel: pane.zoomed ? "R" : "Z",
+      icon: pane.zoomed ? "restore" : "maximize",
       description: pane.zoomed ? "Restore pane layout" : "Zoom this pane",
       active: pane.zoomed,
+      hidden: !actionsVisible,
     },
     {
-      id: "split",
-      label: "split",
-      compactLabel: "+",
-      description: "Split this pane",
+      id: "menu",
+      label: "more",
+      compactLabel: ".",
+      icon: "more",
+      description: "Open pane actions",
+      hidden: !actionsVisible,
     },
   ] as const;
   const input = {
@@ -358,7 +381,7 @@ function paneHeaderFrame(
   const full = projectPaneFrame(input);
   if (
     full.actions.some((action) => action.id === "zoom") &&
-    full.actions.some((action) => action.id === "split")
+    full.actions.some((action) => action.id === "menu")
   )
     return full;
 
@@ -367,12 +390,12 @@ function paneHeaderFrame(
   // safety contract: zoom is its guaranteed escape hatch. Build a compact
   // action-first projection, then spend whatever remains on the pane identity.
   const base = projectPaneFrame({ ...input, status: null, actions: [] });
-  const zoomNaturalWidth = actionChipWidth(actions[0].compactLabel);
+  const zoomNaturalWidth = iconButtonWidth();
   const zoomWidth = Math.min(width, zoomNaturalWidth);
-  const splitWidth = actionChipWidth(actions[1].compactLabel);
+  const menuWidth = iconButtonWidth();
   const minimumIdentityWidth = 2;
-  const showSplit = width >= zoomWidth + 1 + splitWidth + minimumIdentityWidth;
-  const actionWidth = zoomWidth + (showSplit ? 1 + splitWidth : 0);
+  const showMenu = width >= zoomWidth + 1 + menuWidth + minimumIdentityWidth;
+  const actionWidth = zoomWidth + (showMenu ? 1 + menuWidth : 0);
   let actionX = Math.max(0, width - actionWidth);
   const projectedActions: PaneFrameActionChip[] = [];
   const pushAction = (index: number, chipWidth: number) => {
@@ -380,7 +403,8 @@ function paneHeaderFrame(
     projectedActions.push({
       ...action,
       kind: "action",
-      label: action.compactLabel,
+      appearance: "icon",
+      label: workspaceIcon(action.icon),
       fullLabel: action.label,
       start: actionX,
       width: chipWidth,
@@ -390,7 +414,7 @@ function paneHeaderFrame(
     actionX += chipWidth + 1;
   };
   pushAction(0, zoomWidth);
-  if (showSplit) pushAction(1, splitWidth);
+  if (showMenu) pushAction(1, menuWidth);
 
   const identityBudget = projectedActions[0]?.start ?? width;
   const titleText = clipWorkspaceText(title, identityBudget);
@@ -464,7 +488,7 @@ function cell(value: number): number {
 }
 
 function sameActionTarget(
-  left: TerminalPaneChromeActionTarget | null,
+  left: TerminalPaneChromeHoverTarget | null,
   right: TerminalPaneChromeActionTarget | null,
 ): boolean {
   return (


### PR DESCRIPTION
## Summary
- introduce a semantic, one-cell workspace icon registry with ASCII fallbacks
- render true icon-only pane controls with exact hit geometry and native hover/pressed/hidden states
- keep a fast maximize/restore control and move heavier pane actions behind a Gloomberb-style overflow menu
- reveal reserved controls on whole-titlebar hover without stealing tmux separator drag behavior
- keep the grip structurally stable across focus and clear action state when menus close

## Validation
- pnpm check
- 2,072 daemon unit tests + 51 contract tests
- 76 OpenTUI renderer tests / 54 snapshots
- width and hit-zone coverage from 1-column headers through 80x24, 120x40, and 200x60
- adversarial Gloomberb parity review: clean