### PR TITLE
feat(workspace): add durable app window state kernel

### DIFF
--- a/packages/contracts/src/app-window-state.ts
+++ b/packages/contracts/src/app-window-state.ts
@@ -106,6 +106,16 @@ export const AppWindowPlacementSchemaZ = z
   });
 export type AppWindowPlacement = z.infer<typeof AppWindowPlacementSchemaZ>;
 
+/** Presentation memory for the native bottom dock, independent from the dock tree. */
+export const AppWindowDockStateSchemaZ = z
+  .object({
+    mode: z.enum(["collapsed", "open", "maximized"]),
+    preferredHeight: z.number().int().nonnegative().max(1_000_000).nullable(),
+    focusZone: z.enum(["canvas", "dock-tabs", "dock-body"]),
+  })
+  .strict();
+export type AppWindowDockState = z.infer<typeof AppWindowDockStateSchemaZ>;
+
 export const AppWindowInstanceSchemaZ = z
   .object({
     id: AppWindowIdSchemaZ,
@@ -211,6 +221,7 @@ const AppWindowSceneShapeSchemaZ = z
   .object({
     windows: z.record(AppWindowIdSchemaZ, AppWindowInstanceSchemaZ),
     dockRoot: AppWindowDockNodeSchemaZ.nullable(),
+    dockState: AppWindowDockStateSchemaZ,
     /** Back-to-front order. The last id is the top-most floating window. */
     floatingOrder: z.array(AppWindowIdSchemaZ).max(APP_WINDOW_MAX_WINDOWS),
     focusedWindowId: AppWindowIdSchemaZ.nullable(),
@@ -239,7 +250,10 @@ function refineScene(
     }
   }
 
-  const dockMembership = new Map<string, { stackId: string; index: number }>();
+  const dockMembership = new Map<
+    string,
+    { stackId: string; index: number; activeWindowId: string }
+  >();
   const nodeIds = new Set<string>();
   const visit = (node: AppWindowDockNodeShape): void => {
     if (nodeIds.has(node.id)) {
@@ -262,7 +276,11 @@ function refineScene(
           path: ["dockRoot"],
         });
       }
-      dockMembership.set(windowId, { stackId: node.id, index });
+      dockMembership.set(windowId, {
+        stackId: node.id,
+        index,
+        activeWindowId: node.activeWindowId,
+      });
     }
   };
   if (scene.dockRoot) visit(scene.dockRoot);
@@ -305,7 +323,7 @@ function refineScene(
     }
   }
   for (const windowId of dockMembership.keys()) {
-    if (!scene.windows[windowId]) {
+    if (!Object.hasOwn(scene.windows, windowId)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "dock tree references an unknown window",
@@ -314,7 +332,7 @@ function refineScene(
     }
   }
   for (const windowId of floatingSet) {
-    if (!scene.windows[windowId]) {
+    if (!Object.hasOwn(scene.windows, windowId)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "floating z-order references an unknown window",
@@ -322,12 +340,34 @@ function refineScene(
       });
     }
   }
-  if (scene.focusedWindowId && !scene.windows[scene.focusedWindowId]) {
+  if (scene.focusedWindowId && !Object.hasOwn(scene.windows, scene.focusedWindowId)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: "focused window must exist",
       path: ["focusedWindowId"],
     });
+  } else if (scene.focusedWindowId) {
+    const focused = scene.windows[scene.focusedWindowId]!;
+    if (
+      focused.placement.mode === "floating" &&
+      scene.floatingOrder.at(-1) !== scene.focusedWindowId
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "focused floating window must be top-most",
+        path: ["focusedWindowId"],
+      });
+    }
+    if (focused.placement.mode === "docked") {
+      const membership = dockMembership.get(scene.focusedWindowId);
+      if (membership && membership.activeWindowId !== scene.focusedWindowId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "focused docked window must be the active window in its stack",
+          path: ["focusedWindowId"],
+        });
+      }
+    }
   }
 }
 
@@ -377,12 +417,21 @@ export const AppWindowDocumentV1SchemaZ = AppWindowSceneShapeSchemaZ.extend({
         });
       }
     }
-    if (document.activeLayoutId && !document.layouts[document.activeLayoutId]) {
+    if (document.activeLayoutId && !Object.hasOwn(document.layouts, document.activeLayoutId)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "active layout must exist",
         path: ["activeLayoutId"],
       });
+    }
+    for (const [key, layout] of Object.entries(document.layouts)) {
+      if (Date.parse(layout.updatedAt) > Date.parse(document.updatedAt)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "layout updatedAt must not exceed document updatedAt",
+          path: ["layouts", key, "updatedAt"],
+        });
+      }
     }
   });
 export type AppWindowDocumentV1 = z.infer<typeof AppWindowDocumentV1SchemaZ>;

--- a/packages/contracts/src/app-window-state.ts
+++ b/packages/contracts/src/app-window-state.ts
@@ -1,0 +1,388 @@
+import { z } from "zod";
+
+/** Durable app-window state. Runtime renderer and tmux correlations never belong here. */
+export const APP_WINDOW_DOCUMENT_VERSION = 1 as const;
+export const APP_WINDOW_MAX_WINDOWS = 128;
+export const APP_WINDOW_MAX_LAYOUTS = 32;
+export const APP_WINDOW_MAX_TREE_DEPTH = 24;
+export const APP_WINDOW_MAX_TREE_NODES = 255;
+export const APP_WINDOW_MAX_ID_LENGTH = 128;
+export const APP_WINDOW_MAX_TITLE_LENGTH = 160;
+
+const RESERVED_RECORD_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+const finiteCoordinate = z.number().finite().min(-1_000_000).max(1_000_000);
+const finiteExtent = z.number().finite().positive().max(1_000_000);
+const VisibleTextSchemaZ = (max: number) =>
+  z
+    .string()
+    .max(max)
+    .refine((value) => !value.includes("\0"), "text must not contain NUL bytes")
+    .refine((value) => value.trim().length > 0, "text must contain visible characters");
+
+export const AppWindowIdSchemaZ = z
+  .string()
+  .min(1)
+  .max(APP_WINDOW_MAX_ID_LENGTH)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/u)
+  .refine((value) => !RESERVED_RECORD_KEYS.has(value), "reserved record key is not allowed");
+export type AppWindowId = z.infer<typeof AppWindowIdSchemaZ>;
+
+export const AppWindowTimestampSchemaZ = z.string().datetime({ offset: false });
+
+export const AppWindowNativeSurfaceSchemaZ = z.enum([
+  "home",
+  "files",
+  "changes",
+  "missions",
+  "activity",
+]);
+export type AppWindowNativeSurface = z.infer<typeof AppWindowNativeSurfaceSchemaZ>;
+
+export const AppWindowSourceSchemaZ = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("native"),
+      surface: AppWindowNativeSurfaceSchemaZ,
+      /** Stable resource identity for multiple instances of one native surface. */
+      resourceId: AppWindowIdSchemaZ.nullable(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("terminal"),
+      /** Durable semantic source id. A live tmux `%pane_id` is intentionally invalid. */
+      terminalSourceId: AppWindowIdSchemaZ,
+    })
+    .strict(),
+]);
+export type AppWindowSource = z.infer<typeof AppWindowSourceSchemaZ>;
+
+export const AppWindowRectSchemaZ = z
+  .object({
+    x: finiteCoordinate,
+    y: finiteCoordinate,
+    width: finiteExtent,
+    height: finiteExtent,
+  })
+  .strict();
+export type AppWindowRect = z.infer<typeof AppWindowRectSchemaZ>;
+
+export const AppWindowDockMemorySchemaZ = z
+  .object({
+    stackId: AppWindowIdSchemaZ,
+    index: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(APP_WINDOW_MAX_WINDOWS - 1),
+  })
+  .strict();
+export type AppWindowDockMemory = z.infer<typeof AppWindowDockMemorySchemaZ>;
+
+export const AppWindowPlacementSchemaZ = z
+  .object({
+    mode: z.enum(["docked", "floating"]),
+    /** Current dock location when docked; last dock location when floating. */
+    docked: AppWindowDockMemorySchemaZ.nullable(),
+    /** Current rect when floating; last floating rect when docked. */
+    floating: AppWindowRectSchemaZ.nullable(),
+  })
+  .strict()
+  .superRefine((placement, ctx) => {
+    if (placement.mode === "docked" && placement.docked === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "docked windows require dock placement memory",
+        path: ["docked"],
+      });
+    }
+    if (placement.mode === "floating" && placement.floating === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "floating windows require a floating rect",
+        path: ["floating"],
+      });
+    }
+  });
+export type AppWindowPlacement = z.infer<typeof AppWindowPlacementSchemaZ>;
+
+export const AppWindowInstanceSchemaZ = z
+  .object({
+    id: AppWindowIdSchemaZ,
+    source: AppWindowSourceSchemaZ,
+    title: VisibleTextSchemaZ(APP_WINDOW_MAX_TITLE_LENGTH).nullable(),
+    placement: AppWindowPlacementSchemaZ,
+  })
+  .strict();
+export type AppWindowInstance = z.infer<typeof AppWindowInstanceSchemaZ>;
+
+export type AppWindowDockNodeShape =
+  | {
+      type: "stack";
+      id: string;
+      windowIds: string[];
+      activeWindowId: string;
+    }
+  | {
+      type: "split";
+      id: string;
+      axis: "horizontal" | "vertical";
+      children: AppWindowDockNodeShape[];
+      weights: number[];
+    };
+
+const AppWindowDockNodeRecursiveSchemaZ: z.ZodType<AppWindowDockNodeShape> = z.lazy(() =>
+  z.discriminatedUnion("type", [
+    z
+      .object({
+        type: z.literal("stack"),
+        id: AppWindowIdSchemaZ,
+        windowIds: z.array(AppWindowIdSchemaZ).min(1).max(APP_WINDOW_MAX_WINDOWS),
+        activeWindowId: AppWindowIdSchemaZ,
+      })
+      .strict()
+      .superRefine((stack, ctx) => {
+        if (new Set(stack.windowIds).size !== stack.windowIds.length) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "stack window ids must be unique",
+            path: ["windowIds"],
+          });
+        }
+        if (!stack.windowIds.includes(stack.activeWindowId)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "active window must belong to the stack",
+            path: ["activeWindowId"],
+          });
+        }
+      }),
+    z
+      .object({
+        type: z.literal("split"),
+        id: AppWindowIdSchemaZ,
+        axis: z.enum(["horizontal", "vertical"]),
+        children: z.array(AppWindowDockNodeRecursiveSchemaZ).min(2).max(8),
+        weights: z.array(z.number().int().positive().max(1_000_000)).min(2).max(8),
+      })
+      .strict()
+      .refine((node) => node.children.length === node.weights.length, {
+        message: "split weights must match children",
+        path: ["weights"],
+      }),
+  ]),
+);
+
+export const AppWindowDockNodeSchemaZ: z.ZodType<AppWindowDockNodeShape> = z
+  .unknown()
+  .superRefine((value, ctx) => {
+    const failure = dockTreeLimitFailure(value);
+    if (failure) ctx.addIssue({ code: z.ZodIssueCode.custom, message: failure });
+  })
+  .pipe(AppWindowDockNodeRecursiveSchemaZ);
+
+function dockTreeLimitFailure(value: unknown): string | null {
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 1 }];
+  let nodes = 0;
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    nodes += 1;
+    if (nodes > APP_WINDOW_MAX_TREE_NODES) return "dock tree node limit exceeded";
+    if (current.depth > APP_WINDOW_MAX_TREE_DEPTH) return "dock tree depth limit exceeded";
+    if (
+      current.value &&
+      typeof current.value === "object" &&
+      !Array.isArray(current.value) &&
+      "type" in current.value &&
+      current.value.type === "split" &&
+      "children" in current.value &&
+      Array.isArray(current.value.children)
+    ) {
+      if (current.value.children.length > 8) return "dock split child limit exceeded";
+      for (const child of current.value.children) {
+        stack.push({ value: child, depth: current.depth + 1 });
+      }
+    }
+  }
+  return null;
+}
+
+const AppWindowSceneShapeSchemaZ = z
+  .object({
+    windows: z.record(AppWindowIdSchemaZ, AppWindowInstanceSchemaZ),
+    dockRoot: AppWindowDockNodeSchemaZ.nullable(),
+    /** Back-to-front order. The last id is the top-most floating window. */
+    floatingOrder: z.array(AppWindowIdSchemaZ).max(APP_WINDOW_MAX_WINDOWS),
+    focusedWindowId: AppWindowIdSchemaZ.nullable(),
+  })
+  .strict();
+
+function refineScene(
+  scene: z.infer<typeof AppWindowSceneShapeSchemaZ>,
+  ctx: z.RefinementCtx,
+): void {
+  const windowEntries = Object.entries(scene.windows);
+  if (windowEntries.length > APP_WINDOW_MAX_WINDOWS) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "app window limit exceeded",
+      path: ["windows"],
+    });
+  }
+  for (const [key, window] of windowEntries) {
+    if (key !== window.id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "window record key must match window id",
+        path: ["windows", key, "id"],
+      });
+    }
+  }
+
+  const dockMembership = new Map<string, { stackId: string; index: number }>();
+  const nodeIds = new Set<string>();
+  const visit = (node: AppWindowDockNodeShape): void => {
+    if (nodeIds.has(node.id)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "dock node ids must be unique",
+        path: ["dockRoot"],
+      });
+    }
+    nodeIds.add(node.id);
+    if (node.type === "split") {
+      for (const child of node.children) visit(child);
+      return;
+    }
+    for (const [index, windowId] of node.windowIds.entries()) {
+      if (dockMembership.has(windowId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "docked window must occur in exactly one stack",
+          path: ["dockRoot"],
+        });
+      }
+      dockMembership.set(windowId, { stackId: node.id, index });
+    }
+  };
+  if (scene.dockRoot) visit(scene.dockRoot);
+
+  const floatingSet = new Set(scene.floatingOrder);
+  if (floatingSet.size !== scene.floatingOrder.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "floating z-order ids must be unique",
+      path: ["floatingOrder"],
+    });
+  }
+
+  for (const [windowId, window] of windowEntries) {
+    const dockedAt = dockMembership.get(windowId);
+    const isFloating = floatingSet.has(windowId);
+    if (window.placement.mode === "docked") {
+      if (!dockedAt || isFloating) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "docked window must occur only in the dock tree",
+          path: ["windows", windowId, "placement"],
+        });
+      } else if (
+        window.placement.docked?.stackId !== dockedAt.stackId ||
+        window.placement.docked.index !== dockedAt.index
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "dock placement memory must match current stack membership",
+          path: ["windows", windowId, "placement", "docked"],
+        });
+      }
+    } else if (dockedAt || !isFloating) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "floating window must occur only in floating z-order",
+        path: ["windows", windowId, "placement"],
+      });
+    }
+  }
+  for (const windowId of dockMembership.keys()) {
+    if (!scene.windows[windowId]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "dock tree references an unknown window",
+        path: ["dockRoot"],
+      });
+    }
+  }
+  for (const windowId of floatingSet) {
+    if (!scene.windows[windowId]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "floating z-order references an unknown window",
+        path: ["floatingOrder"],
+      });
+    }
+  }
+  if (scene.focusedWindowId && !scene.windows[scene.focusedWindowId]) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "focused window must exist",
+      path: ["focusedWindowId"],
+    });
+  }
+}
+
+export const AppWindowSceneSchemaZ = AppWindowSceneShapeSchemaZ.superRefine(refineScene);
+export type AppWindowScene = z.infer<typeof AppWindowSceneSchemaZ>;
+
+export const AppWindowNamedLayoutSchemaZ = z
+  .object({
+    id: AppWindowIdSchemaZ,
+    name: VisibleTextSchemaZ(80),
+    description: VisibleTextSchemaZ(512).nullable(),
+    revision: z.number().int().positive(),
+    createdAt: AppWindowTimestampSchemaZ,
+    updatedAt: AppWindowTimestampSchemaZ,
+    scene: AppWindowSceneSchemaZ,
+  })
+  .strict()
+  .refine((layout) => Date.parse(layout.updatedAt) >= Date.parse(layout.createdAt), {
+    message: "layout updatedAt must not precede createdAt",
+    path: ["updatedAt"],
+  });
+export type AppWindowNamedLayout = z.infer<typeof AppWindowNamedLayoutSchemaZ>;
+
+export const AppWindowDocumentV1SchemaZ = AppWindowSceneShapeSchemaZ.extend({
+  version: z.literal(APP_WINDOW_DOCUMENT_VERSION),
+  revision: z.number().int().nonnegative(),
+  updatedAt: AppWindowTimestampSchemaZ,
+  activeLayoutId: AppWindowIdSchemaZ.nullable(),
+  layouts: z.record(AppWindowIdSchemaZ, AppWindowNamedLayoutSchemaZ),
+})
+  .strict()
+  .superRefine((document, ctx) => {
+    refineScene(document, ctx);
+    if (Object.keys(document.layouts).length > APP_WINDOW_MAX_LAYOUTS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "named layout limit exceeded",
+        path: ["layouts"],
+      });
+    }
+    for (const [key, layout] of Object.entries(document.layouts)) {
+      if (key !== layout.id) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "layout record key must match layout id",
+          path: ["layouts", key, "id"],
+        });
+      }
+    }
+    if (document.activeLayoutId && !document.layouts[document.activeLayoutId]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "active layout must exist",
+        path: ["activeLayoutId"],
+      });
+    }
+  });
+export type AppWindowDocumentV1 = z.infer<typeof AppWindowDocumentV1SchemaZ>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -21,6 +21,7 @@ export * from "./mission-projections.ts";
 export * from "./tmux.ts";
 export * from "./workspace.ts";
 export * from "./workspace-state.ts";
+export * from "./app-window-state.ts";
 export * from "./workspace-config.ts";
 export * from "./actions-contract.ts";
 export * from "./actions-errors.ts";

--- a/packages/daemon/src/tui/mirror/app-window-state.test.ts
+++ b/packages/daemon/src/tui/mirror/app-window-state.test.ts
@@ -83,6 +83,7 @@ function floatingDocument(): AppWindowDocumentV1 {
       },
     },
     dockRoot: null,
+    dockState: { mode: "open", preferredHeight: null, focusZone: "canvas" },
     floatingOrder: [firstId, secondId],
     focusedWindowId: secondId,
     activeLayoutId: null,
@@ -128,6 +129,44 @@ describe("app window state contract", () => {
     expect(AppWindowDocumentV1SchemaZ.safeParse(unknownFocus).success).toBe(false);
   });
 
+  it("never treats prototype properties as owned window, layout, dock, or floating ids", () => {
+    for (const inheritedId of ["toString", "hasOwnProperty"]) {
+      const inheritedFocus = { ...emptyAppWindowDocument(NOW), focusedWindowId: inheritedId };
+      const inheritedLayout = { ...emptyAppWindowDocument(NOW), activeLayoutId: inheritedId };
+      const inheritedDock = {
+        ...emptyAppWindowDocument(NOW),
+        dockRoot: {
+          type: "stack",
+          id: "stack",
+          windowIds: [inheritedId],
+          activeWindowId: inheritedId,
+        },
+      };
+      const inheritedFloat = {
+        ...emptyAppWindowDocument(NOW),
+        floatingOrder: [inheritedId],
+      };
+
+      expect(AppWindowDocumentV1SchemaZ.safeParse(inheritedFocus).success).toBe(false);
+      expect(AppWindowDocumentV1SchemaZ.safeParse(inheritedLayout).success).toBe(false);
+      expect(AppWindowDocumentV1SchemaZ.safeParse(inheritedDock).success).toBe(false);
+      expect(AppWindowDocumentV1SchemaZ.safeParse(inheritedFloat).success).toBe(false);
+      expect(() => focusAppWindow(emptyAppWindowDocument(NOW), inheritedId, LATER)).toThrow(
+        /unknown app window/u,
+      );
+      expect(() =>
+        restoreAppWindowNamedLayout(emptyAppWindowDocument(NOW), inheritedId, LATER),
+      ).toThrow(/unknown app window layout/u);
+    }
+  });
+
+  it("requires focused floating windows to be top-most", () => {
+    const invalid = structuredClone(floatingDocument());
+    invalid.focusedWindowId = invalid.floatingOrder[0]!;
+
+    expect(AppWindowDocumentV1SchemaZ.safeParse(invalid).success).toBe(false);
+  });
+
   it("sanitizes invalid V1 and write-protects future documents", () => {
     const invalid = parseAppWindowDocument(
       {
@@ -149,7 +188,7 @@ describe("app window state contract", () => {
     expect(invalid.diagnostics).toEqual(
       expect.arrayContaining([expect.objectContaining({ code: "INVALID_FIELD" })]),
     );
-    expect(invalid.writeProtected).toBe(false);
+    expect(invalid.writeProtected).toBe(true);
     expect(future.writeProtected).toBe(true);
     expect(future.diagnostics[0]?.code).toBe("UNSUPPORTED_VERSION");
   });
@@ -169,7 +208,7 @@ describe("WorkspaceUiStateV2 app-window migration", () => {
     expect(serializeAppWindowDocument(first.document)).toBe(
       serializeAppWindowDocument(second.document),
     );
-    expect(Object.values(first.document.windows)).toHaveLength(6);
+    expect(Object.values(first.document.windows)).toHaveLength(9);
     expect(
       Object.values(first.document.windows).filter((window) => window.source.kind === "terminal"),
     ).toHaveLength(2);
@@ -192,13 +231,22 @@ describe("WorkspaceUiStateV2 app-window migration", () => {
   });
 
   it("never invents a durable terminal identity from the legacy canvas", () => {
-    const migrated = migrateWorkspaceUiStateV2ToAppWindowDocument(currentWorkspaceUiState(), {
-      migratedAt: NOW,
-    });
+    const migrated = migrateWorkspaceUiStateV2ToAppWindowDocument(
+      currentWorkspaceUiState({
+        dock: {
+          activeTab: "files",
+          mode: "open",
+          preferredHeight: null,
+          focusZone: "canvas",
+        },
+      }),
+      { migratedAt: NOW },
+    );
 
     expect(
       Object.values(migrated.document.windows).some((window) => window.source.kind === "terminal"),
     ).toBe(false);
+    expect(migrated.document.focusedWindowId).toBeNull();
     expect(migrated.diagnostics).toEqual(
       expect.arrayContaining([expect.objectContaining({ code: "TERMINAL_SOURCE_REQUIRED" })]),
     );
@@ -212,6 +260,116 @@ describe("WorkspaceUiStateV2 app-window migration", () => {
         terminalSourceIds: ["%42"],
       }),
     ).toThrow();
+  });
+
+  it.each([
+    ["home", "home", "home-view"],
+    ["files", "files", "files-view"],
+    ["diff", "changes", "diff-view"],
+    ["missions", "missions", "mission-view"],
+  ] as const)(
+    "preserves active %s full-panel view identity as a native %s instance",
+    (panel, surface, viewId) => {
+      const migrated = migrateWorkspaceUiStateV2ToAppWindowDocument(
+        currentWorkspaceUiState({
+          active: { viewId, panel },
+          dock: {
+            activeTab: "missions",
+            mode: "maximized",
+            preferredHeight: 22,
+            focusZone: "canvas",
+          },
+          views: { [viewId]: { panel } },
+        }),
+        { migratedAt: NOW },
+      );
+      const focused = migrated.document.windows[migrated.document.focusedWindowId!];
+
+      expect(focused?.source).toEqual({ kind: "native", surface, resourceId: viewId });
+      expect(migrated.document.dockState).toEqual({
+        mode: "maximized",
+        preferredHeight: 22,
+        focusZone: "canvas",
+      });
+      expect(AppWindowDocumentV1SchemaZ.safeParse(migrated.document).success).toBe(true);
+    },
+  );
+
+  it("uses explicit semantic terminal focus and keeps dock selection independent", () => {
+    const migrated = migrateWorkspaceUiStateV2ToAppWindowDocument(
+      currentWorkspaceUiState({
+        dock: {
+          activeTab: "activity",
+          mode: "collapsed",
+          preferredHeight: 7,
+          focusZone: "canvas",
+        },
+      }),
+      {
+        migratedAt: NOW,
+        terminalSourceIds: ["agent-lead", "agent-reviewer"],
+        focusedTerminalSourceId: "agent-reviewer",
+      },
+    );
+    const focused = migrated.document.windows[migrated.document.focusedWindowId!];
+    const root = migrated.document.dockRoot;
+
+    expect(focused?.source).toEqual({
+      kind: "terminal",
+      terminalSourceId: "agent-reviewer",
+    });
+    expect(root).toMatchObject({
+      type: "split",
+      children: [
+        { type: "stack", activeWindowId: migrated.document.focusedWindowId },
+        { type: "stack" },
+      ],
+    });
+    expect(migrated.document.dockState).toEqual({
+      mode: "collapsed",
+      preferredHeight: 7,
+      focusZone: "canvas",
+    });
+    expect(() =>
+      migrateWorkspaceUiStateV2ToAppWindowDocument(currentWorkspaceUiState(), {
+        migratedAt: NOW,
+        terminalSourceIds: ["agent-lead", "agent-reviewer"],
+        focusedTerminalSourceId: "agent-missing",
+      }),
+    ).toThrow(/must belong/u);
+  });
+
+  it("preserves dock focus and reports composite layout state instead of silently flattening it", () => {
+    const migrated = migrateWorkspaceUiStateV2ToAppWindowDocument(
+      currentWorkspaceUiState({
+        active: { viewId: "workspace-composite", panel: "files" },
+        views: {
+          "workspace-composite": {
+            panel: "files",
+            layout: { focusedLeafId: "files-leaf", activeTabs: {}, splitWeights: {} },
+          },
+        },
+        dock: {
+          activeTab: "missions",
+          mode: "open",
+          preferredHeight: null,
+          focusZone: "dock-tabs",
+        },
+      }),
+      { migratedAt: NOW },
+    );
+    const focused = migrated.document.windows[migrated.document.focusedWindowId!];
+
+    expect(focused?.source).toEqual({ kind: "native", surface: "missions", resourceId: null });
+    expect(migrated.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "COMPOSITE_LAYOUT_DEFERRED" })]),
+    );
+    expect(
+      Object.values(migrated.document.windows).some(
+        (window) =>
+          window.source.kind === "native" && window.source.resourceId === "workspace-composite",
+      ),
+    ).toBe(false);
   });
 });
 
@@ -256,5 +414,46 @@ describe("app window layout kernel", () => {
       createdAt: NOW,
       updatedAt: LATER,
     });
+  });
+
+  it("activates a focused docked window recursively and rejects backwards time", () => {
+    const migrated = migrateWorkspaceUiStateV2ToAppWindowDocument(
+      currentWorkspaceUiState({
+        active: { viewId: "files-a", panel: "files" },
+        views: {
+          "files-a": { panel: "files" },
+          "missions-a": { panel: "missions" },
+        },
+        dock: {
+          activeTab: "files",
+          mode: "open",
+          preferredHeight: null,
+          focusZone: "canvas",
+        },
+      }),
+      { migratedAt: NOW },
+    ).document;
+    const missionsId = Object.values(migrated.windows).find(
+      (window) => window.source.kind === "native" && window.source.resourceId === "missions-a",
+    )!.id;
+    const invalid = structuredClone(migrated);
+    invalid.focusedWindowId = missionsId;
+
+    expect(AppWindowDocumentV1SchemaZ.safeParse(invalid).success).toBe(false);
+    const focused = focusAppWindow(migrated, missionsId, LATER);
+    expect(focused.focusedWindowId).toBe(missionsId);
+    expect(focused.dockRoot).toMatchObject({
+      type: "split",
+      children: [{ type: "stack", activeWindowId: missionsId }, { type: "stack" }],
+    });
+    expect(AppWindowDocumentV1SchemaZ.safeParse(focused).success).toBe(true);
+    expect(() => focusAppWindow(focused, missionsId, NOW)).toThrow(/must not move backwards/u);
+    expect(() =>
+      saveAppWindowNamedLayout(focused, {
+        id: "older",
+        name: "Older",
+        updatedAt: NOW,
+      }),
+    ).toThrow(/must not move backwards/u);
   });
 });

--- a/packages/daemon/src/tui/mirror/app-window-state.test.ts
+++ b/packages/daemon/src/tui/mirror/app-window-state.test.ts
@@ -112,6 +112,31 @@ describe("app window state contract", () => {
     ).toBe(false);
   });
 
+  it("distinguishes the default native instance from a resource literally named default", () => {
+    const singleton = stableAppWindowInstanceId({
+      kind: "native",
+      surface: "files",
+      resourceId: null,
+    });
+    const namedDefault = stableAppWindowInstanceId({
+      kind: "native",
+      surface: "files",
+      resourceId: "default",
+    });
+
+    expect(singleton).not.toBe(namedDefault);
+    expect(singleton).toBe(
+      stableAppWindowInstanceId({ kind: "native", surface: "files", resourceId: null }),
+    );
+    expect(namedDefault).toBe(
+      stableAppWindowInstanceId({
+        kind: "native",
+        surface: "files",
+        resourceId: "default",
+      }),
+    );
+  });
+
   it("validates dock membership, placement memory, floating rects, z-order, and focus", () => {
     const valid = floatingDocument();
     expect(AppWindowDocumentV1SchemaZ.safeParse(valid).success).toBe(true);
@@ -337,6 +362,39 @@ describe("WorkspaceUiStateV2 app-window migration", () => {
         focusedTerminalSourceId: "agent-missing",
       }),
     ).toThrow(/must belong/u);
+  });
+
+  it("keeps a full-panel view named default distinct from the singleton dock surface", () => {
+    const migrated = migrateWorkspaceUiStateV2ToAppWindowDocument(
+      currentWorkspaceUiState({
+        active: { viewId: "default", panel: "files" },
+        views: { default: { panel: "files" } },
+        dock: {
+          activeTab: "files",
+          mode: "open",
+          preferredHeight: null,
+          focusZone: "canvas",
+        },
+      }),
+      { migratedAt: NOW },
+    );
+    const fileWindows = Object.values(migrated.document.windows).filter(
+      (window) => window.source.kind === "native" && window.source.surface === "files",
+    );
+
+    expect(fileWindows).toHaveLength(2);
+    expect(new Set(fileWindows.map((window) => window.id)).size).toBe(2);
+    expect(fileWindows.map((window) => window.source)).toEqual(
+      expect.arrayContaining([
+        { kind: "native", surface: "files", resourceId: null },
+        { kind: "native", surface: "files", resourceId: "default" },
+      ]),
+    );
+    expect(migrated.document.windows[migrated.document.focusedWindowId!]?.source).toEqual({
+      kind: "native",
+      surface: "files",
+      resourceId: "default",
+    });
   });
 
   it("preserves dock focus and reports composite layout state instead of silently flattening it", () => {

--- a/packages/daemon/src/tui/mirror/app-window-state.test.ts
+++ b/packages/daemon/src/tui/mirror/app-window-state.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  APP_WINDOW_DOCUMENT_VERSION,
+  AppWindowDocumentV1SchemaZ,
+  AppWindowSourceSchemaZ,
+  type AppWindowDocumentV1,
+} from "@tmux-ide/contracts";
+
+import {
+  emptyAppWindowDocument,
+  focusAppWindow,
+  migrateWorkspaceUiStateV2ToAppWindowDocument,
+  parseAppWindowDocument,
+  restoreAppWindowNamedLayout,
+  saveAppWindowNamedLayout,
+  serializeAppWindowDocument,
+  stableAppWindowInstanceId,
+} from "./app-window-state.ts";
+
+const NOW = "2026-07-20T12:00:00.000Z";
+const LATER = "2026-07-20T12:01:00.000Z";
+
+function currentWorkspaceUiState(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: 2,
+    active: { viewId: "terminals", panel: "terminals" },
+    dock: {
+      activeTab: "changes",
+      mode: "open",
+      preferredHeight: 14,
+      focusZone: "dock-body",
+    },
+    surfaces: {
+      files: { openPath: null, selectedPath: "src" },
+      diff: { selectedPath: "src/index.ts" },
+      missions: { selectedMissionId: null, selectedTaskId: null },
+      activity: { selectedRowId: null, scrollOffset: 0 },
+    },
+    views: {
+      terminals: { panel: "terminals" },
+      files: { panel: "files" },
+      diff: { panel: "diff" },
+      missions: { panel: "missions" },
+    },
+    ...overrides,
+  };
+}
+
+function floatingDocument(): AppWindowDocumentV1 {
+  const source = { kind: "native" as const, surface: "files" as const, resourceId: null };
+  const firstId = stableAppWindowInstanceId(source);
+  const secondSource = {
+    kind: "native" as const,
+    surface: "changes" as const,
+    resourceId: null,
+  };
+  const secondId = stableAppWindowInstanceId(secondSource);
+  return AppWindowDocumentV1SchemaZ.parse({
+    version: APP_WINDOW_DOCUMENT_VERSION,
+    revision: 0,
+    updatedAt: NOW,
+    windows: {
+      [firstId]: {
+        id: firstId,
+        source,
+        title: "Files",
+        placement: {
+          mode: "floating",
+          docked: { stackId: "main-stack", index: 0 },
+          floating: { x: 8, y: 4, width: 72, height: 32 },
+        },
+      },
+      [secondId]: {
+        id: secondId,
+        source: secondSource,
+        title: "Changes",
+        placement: {
+          mode: "floating",
+          docked: null,
+          floating: { x: 12, y: 6, width: 80, height: 36 },
+        },
+      },
+    },
+    dockRoot: null,
+    floatingOrder: [firstId, secondId],
+    focusedWindowId: secondId,
+    activeLayoutId: null,
+    layouts: {},
+  });
+}
+
+describe("app window state contract", () => {
+  it("keeps terminal identity semantic and excludes live tmux correlation", () => {
+    const source = { kind: "terminal" as const, terminalSourceId: "agent-lead" };
+    const first = stableAppWindowInstanceId(source);
+    const second = stableAppWindowInstanceId(source);
+
+    expect(first).toBe(second);
+    expect(first).toMatch(/^window-terminal-agent-lead-0-/u);
+    expect(AppWindowSourceSchemaZ.safeParse(source).success).toBe(true);
+    expect(
+      AppWindowSourceSchemaZ.safeParse({
+        kind: "terminal",
+        terminalSourceId: "agent-lead",
+        runtimePaneId: "%19",
+      }).success,
+    ).toBe(false);
+    expect(
+      AppWindowSourceSchemaZ.safeParse({ kind: "terminal", terminalSourceId: "%19" }).success,
+    ).toBe(false);
+  });
+
+  it("validates dock membership, placement memory, floating rects, z-order, and focus", () => {
+    const valid = floatingDocument();
+    expect(AppWindowDocumentV1SchemaZ.safeParse(valid).success).toBe(true);
+
+    const duplicateZ = structuredClone(valid);
+    duplicateZ.floatingOrder.push(duplicateZ.floatingOrder[0]!);
+    expect(AppWindowDocumentV1SchemaZ.safeParse(duplicateZ).success).toBe(false);
+
+    const missingRect = structuredClone(valid);
+    missingRect.windows[missingRect.floatingOrder[0]!]!.placement.floating = null;
+    expect(AppWindowDocumentV1SchemaZ.safeParse(missingRect).success).toBe(false);
+
+    const unknownFocus = structuredClone(valid);
+    unknownFocus.focusedWindowId = "window-missing";
+    expect(AppWindowDocumentV1SchemaZ.safeParse(unknownFocus).success).toBe(false);
+  });
+
+  it("sanitizes invalid V1 and write-protects future documents", () => {
+    const invalid = parseAppWindowDocument(
+      {
+        ...emptyAppWindowDocument(NOW),
+        windows: {
+          bad: {
+            id: "different",
+            source: { kind: "terminal", terminalSourceId: "agent" },
+            title: null,
+            placement: { mode: "floating", docked: null, floating: null },
+          },
+        },
+      },
+      NOW,
+    );
+    const future = parseAppWindowDocument({ version: 99, secret: "keep" }, NOW);
+
+    expect(invalid.document).toEqual(emptyAppWindowDocument(NOW));
+    expect(invalid.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "INVALID_FIELD" })]),
+    );
+    expect(invalid.writeProtected).toBe(false);
+    expect(future.writeProtected).toBe(true);
+    expect(future.diagnostics[0]?.code).toBe("UNSUPPORTED_VERSION");
+  });
+});
+
+describe("WorkspaceUiStateV2 app-window migration", () => {
+  it("deterministically migrates native surfaces and supplied semantic terminals", () => {
+    const first = migrateWorkspaceUiStateV2ToAppWindowDocument(currentWorkspaceUiState(), {
+      migratedAt: NOW,
+      terminalSourceIds: ["agent-lead", "agent-worker"],
+    });
+    const second = migrateWorkspaceUiStateV2ToAppWindowDocument(currentWorkspaceUiState(), {
+      migratedAt: NOW,
+      terminalSourceIds: ["agent-lead", "agent-worker"],
+    });
+
+    expect(serializeAppWindowDocument(first.document)).toBe(
+      serializeAppWindowDocument(second.document),
+    );
+    expect(Object.values(first.document.windows)).toHaveLength(6);
+    expect(
+      Object.values(first.document.windows).filter((window) => window.source.kind === "terminal"),
+    ).toHaveLength(2);
+    expect(JSON.stringify(first.document)).not.toContain("%pane");
+    expect(first.document.dockRoot).toMatchObject({
+      type: "split",
+      axis: "vertical",
+      children: [
+        { type: "stack", id: "stack-canvas" },
+        { type: "stack", id: "stack-native-dock" },
+      ],
+    });
+    const focused = first.document.windows[first.document.focusedWindowId!];
+    expect(focused?.source).toEqual({ kind: "native", surface: "changes", resourceId: null });
+    expect(first.document.layouts[first.document.activeLayoutId!]).toMatchObject({
+      name: "Migrated workspace",
+      revision: 1,
+      createdAt: NOW,
+    });
+  });
+
+  it("never invents a durable terminal identity from the legacy canvas", () => {
+    const migrated = migrateWorkspaceUiStateV2ToAppWindowDocument(currentWorkspaceUiState(), {
+      migratedAt: NOW,
+    });
+
+    expect(
+      Object.values(migrated.document.windows).some((window) => window.source.kind === "terminal"),
+    ).toBe(false);
+    expect(migrated.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "TERMINAL_SOURCE_REQUIRED" })]),
+    );
+    expect(AppWindowDocumentV1SchemaZ.safeParse(migrated.document).success).toBe(true);
+  });
+
+  it("rejects live tmux pane ids passed as terminal sources", () => {
+    expect(() =>
+      migrateWorkspaceUiStateV2ToAppWindowDocument(currentWorkspaceUiState(), {
+        migratedAt: NOW,
+        terminalSourceIds: ["%42"],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("app window layout kernel", () => {
+  it("saves versioned named layouts and restores exact scene memory", () => {
+    const initial = floatingDocument();
+    const saved = saveAppWindowNamedLayout(initial, {
+      id: "review-layout",
+      name: "Review layout",
+      description: "Diff beside files",
+      updatedAt: NOW,
+    });
+    const firstId = saved.floatingOrder[0]!;
+    const focused = focusAppWindow(saved, firstId, LATER);
+    const restored = restoreAppWindowNamedLayout(focused, "review-layout", LATER);
+
+    expect(saved.layouts["review-layout"]).toMatchObject({ revision: 1, createdAt: NOW });
+    expect(focused.focusedWindowId).toBe(firstId);
+    expect(focused.floatingOrder.at(-1)).toBe(firstId);
+    expect(restored.focusedWindowId).toBe(initial.focusedWindowId);
+    expect(restored.floatingOrder).toEqual(initial.floatingOrder);
+    expect(restored.activeLayoutId).toBe("review-layout");
+    expect(restored.revision).toBe(3);
+  });
+
+  it("increments existing layout metadata without changing its creation time", () => {
+    const initial = floatingDocument();
+    const saved = saveAppWindowNamedLayout(initial, {
+      id: "review-layout",
+      name: "Review",
+      updatedAt: NOW,
+    });
+    const updated = saveAppWindowNamedLayout(saved, {
+      id: "review-layout",
+      name: "Review updated",
+      updatedAt: LATER,
+    });
+
+    expect(updated.layouts["review-layout"]).toMatchObject({
+      name: "Review updated",
+      revision: 2,
+      createdAt: NOW,
+      updatedAt: LATER,
+    });
+  });
+});

--- a/packages/daemon/src/tui/mirror/app-window-state.ts
+++ b/packages/daemon/src/tui/mirror/app-window-state.ts
@@ -5,6 +5,7 @@ import {
   AppWindowIdSchemaZ,
   AppWindowSourceSchemaZ,
   AppWindowTimestampSchemaZ,
+  type AppWindowDockNodeShape,
   type AppWindowDocumentV1,
   type AppWindowInstance,
   type AppWindowNamedLayout,
@@ -29,7 +30,9 @@ export type AppWindowStateDiagnosticCode =
   | "UNSUPPORTED_VERSION"
   | "INVALID_FIELD"
   | "MIGRATED"
-  | "TERMINAL_SOURCE_REQUIRED";
+  | "TERMINAL_SOURCE_REQUIRED"
+  | "COMPOSITE_LAYOUT_DEFERRED"
+  | "FIELD_DEFAULTED";
 
 export interface AppWindowStateDiagnostic {
   code: AppWindowStateDiagnosticCode;
@@ -52,6 +55,8 @@ export interface MigrateWorkspaceUiStateOptions {
   migratedAt: string;
   /** Durable semantic terminal ids, never live tmux `%pane_id` values. */
   terminalSourceIds?: readonly string[];
+  /** Stable focus input used to select one terminal when several are present. */
+  focusedTerminalSourceId?: string | null;
 }
 
 const NATIVE_DOCK_ORDER = ["files", "changes", "missions", "activity"] as const;
@@ -66,6 +71,7 @@ export function emptyAppWindowDocument(updatedAt: string): AppWindowDocumentV1 {
     updatedAt: timestamp,
     windows: {},
     dockRoot: null,
+    dockState: { mode: "open", preferredHeight: null, focusZone: "canvas" },
     floatingOrder: [],
     focusedWindowId: null,
     activeLayoutId: null,
@@ -96,9 +102,9 @@ export function stableAppWindowInstanceId(source: AppWindowSource, ordinal = 0):
 }
 
 /**
- * Strictly validates durable state. Invalid current-version documents are
- * sanitized to an empty document; newer versions are write-protected so an
- * older binary cannot overwrite data it does not understand.
+ * Strictly validates durable state. Invalid current-version documents expose
+ * an empty recovery projection under write protection; newer versions are
+ * likewise protected so an older binary cannot overwrite unknown data.
  */
 export function parseAppWindowDocument(
   value: unknown,
@@ -112,18 +118,18 @@ export function parseAppWindowDocument(
       writeProtected: false,
     };
   }
-  if (value.version !== APP_WINDOW_DOCUMENT_VERSION) {
+  const version = ownValue(value, "version");
+  if (version !== APP_WINDOW_DOCUMENT_VERSION) {
     return {
       document: fallback,
       diagnostics: [
         diagnostic(
           "UNSUPPORTED_VERSION",
           "$.version",
-          `unsupported app window document version ${String(value.version)}`,
+          `unsupported app window document version ${String(version)}`,
         ),
       ],
-      writeProtected:
-        typeof value.version === "number" && value.version > APP_WINDOW_DOCUMENT_VERSION,
+      writeProtected: typeof version === "number" && version > APP_WINDOW_DOCUMENT_VERSION,
     };
   }
   const parsed = AppWindowDocumentV1SchemaZ.safeParse(value);
@@ -139,7 +145,7 @@ export function parseAppWindowDocument(
         issue.message,
       ),
     ),
-    writeProtected: false,
+    writeProtected: true,
   };
 }
 
@@ -154,23 +160,35 @@ export function migrateWorkspaceUiStateV2ToAppWindowDocument(
   options: MigrateWorkspaceUiStateOptions,
 ): MigratedAppWindowDocument {
   const migratedAt = AppWindowTimestampSchemaZ.parse(options.migratedAt);
-  if (!isRecord(value) || value.version !== 2) {
+  if (!isRecord(value) || ownValue(value, "version") !== 2) {
     throw new Error("WorkspaceUiStateV2 is required for app window migration");
   }
   const diagnostics: AppWindowStateDiagnostic[] = [
     diagnostic("MIGRATED", "$", "migrated WorkspaceUiStateV2 to app window document V1"),
   ];
-  const active = isRecord(value.active) ? value.active : null;
+  const activeValue = ownValue(value, "active");
+  const active = isRecord(activeValue) ? activeValue : null;
+  const activeViewId = ownString(active, "viewId");
+  const activePanelValue = ownValue(active, "panel");
   const activePanel =
-    typeof active?.panel === "string" && LEGACY_PANELS.has(active.panel)
-      ? active.panel
+    typeof activePanelValue === "string" && LEGACY_PANELS.has(activePanelValue)
+      ? activePanelValue
       : "terminals";
-  const dock = isRecord(value.dock) ? value.dock : null;
+  const dockValue = ownValue(value, "dock");
+  const dock = isRecord(dockValue) ? dockValue : null;
+  const dockTabValue = ownValue(dock, "activeTab");
   const requestedDockTab =
-    typeof dock?.activeTab === "string" && LEGACY_DOCK_TABS.has(dock.activeTab as never)
-      ? (dock.activeTab as (typeof NATIVE_DOCK_ORDER)[number])
+    typeof dockTabValue === "string" && LEGACY_DOCK_TABS.has(dockTabValue as never)
+      ? (dockTabValue as (typeof NATIVE_DOCK_ORDER)[number])
       : "files";
+  const dockMode = legacyDockMode(ownValue(dock, "mode"), diagnostics);
+  const preferredHeight = legacyPreferredHeight(ownValue(dock, "preferredHeight"), diagnostics);
+  const focusZone = legacyFocusZone(ownValue(dock, "focusZone"), diagnostics);
   const terminalSourceIds = cleanTerminalSourceIds(options.terminalSourceIds ?? []);
+  const focusedTerminalSourceId = cleanFocusedTerminalSourceId(
+    terminalSourceIds,
+    options.focusedTerminalSourceId,
+  );
   if (activePanel === "terminals" && terminalSourceIds.length === 0) {
     diagnostics.push(
       diagnostic(
@@ -191,18 +209,83 @@ export function migrateWorkspaceUiStateV2ToAppWindowDocument(
   const requestedDockWindowId = dockWindowIds[NATIVE_DOCK_ORDER.indexOf(requestedDockTab)]!;
 
   const canvasWindowIds: string[] = [];
-  if (activePanel === "home") {
-    const source: AppWindowSource = { kind: "native", surface: "home", resourceId: null };
+  const windowIdByViewId = new Map<string, string>();
+  const deferredViewIds = new Set<string>();
+  const viewsValue = ownValue(value, "views");
+  const views = isRecord(viewsValue) ? viewsValue : {};
+  for (const [viewId, rawView] of Object.entries(views).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    if (!isRecord(rawView)) continue;
+    const surface = legacyNativeSurface(ownValue(rawView, "panel"));
+    if (!surface) continue;
+    if (Object.hasOwn(rawView, "layout")) {
+      deferredViewIds.add(viewId);
+      diagnostics.push(
+        diagnostic(
+          "COMPOSITE_LAYOUT_DEFERRED",
+          `$.views.${viewId}.layout`,
+          "composite layout state needs its configured layout tree before app-window migration",
+        ),
+      );
+      continue;
+    }
+    const source: AppWindowSource = {
+      kind: "native",
+      surface,
+      resourceId: stableLegacyResourceId(viewId),
+    };
     const id = stableAppWindowInstanceId(source);
-    windows[id] = dockedWindow(id, source, "Home", "stack-canvas", canvasWindowIds.length);
+    windows[id] = dockedWindow(
+      id,
+      source,
+      nativeTitle(surface),
+      "stack-canvas",
+      canvasWindowIds.length,
+    );
     canvasWindowIds.push(id);
+    windowIdByViewId.set(viewId, id);
   }
+  const activeNativeSurface = legacyNativeSurface(activePanel);
+  if (
+    activeNativeSurface &&
+    activeViewId &&
+    !windowIdByViewId.has(activeViewId) &&
+    !deferredViewIds.has(activeViewId)
+  ) {
+    const source: AppWindowSource = {
+      kind: "native",
+      surface: activeNativeSurface,
+      resourceId: stableLegacyResourceId(activeViewId),
+    };
+    const id = stableAppWindowInstanceId(source);
+    windows[id] = dockedWindow(
+      id,
+      source,
+      nativeTitle(activeNativeSurface),
+      "stack-canvas",
+      canvasWindowIds.length,
+    );
+    canvasWindowIds.push(id);
+    windowIdByViewId.set(activeViewId, id);
+  }
+  const terminalWindowIdBySourceId = new Map<string, string>();
   for (const terminalSourceId of terminalSourceIds) {
     const source: AppWindowSource = { kind: "terminal", terminalSourceId };
     const id = stableAppWindowInstanceId(source);
     windows[id] = dockedWindow(id, source, null, "stack-canvas", canvasWindowIds.length);
     canvasWindowIds.push(id);
+    terminalWindowIdBySourceId.set(terminalSourceId, id);
   }
+  const preferredCanvasWindowId =
+    activePanel === "terminals"
+      ? focusedTerminalSourceId
+        ? terminalWindowIdBySourceId.get(focusedTerminalSourceId)
+        : undefined
+      : activeViewId
+        ? windowIdByViewId.get(activeViewId)
+        : undefined;
+  const activeCanvasWindowId = preferredCanvasWindowId ?? canvasWindowIds[0];
 
   const nativeDock = {
     type: "stack" as const,
@@ -222,19 +305,20 @@ export function migrateWorkspaceUiStateV2ToAppWindowDocument(
               type: "stack" as const,
               id: "stack-canvas",
               windowIds: canvasWindowIds,
-              activeWindowId: canvasWindowIds[0]!,
+              activeWindowId: activeCanvasWindowId!,
             },
             nativeDock,
           ],
           weights: [3, 1],
         };
   const focusedWindowId =
-    dock?.focusZone === "dock-tabs" || dock?.focusZone === "dock-body"
+    focusZone === "dock-tabs" || focusZone === "dock-body"
       ? requestedDockWindowId
-      : (canvasWindowIds[0] ?? null);
+      : (preferredCanvasWindowId ?? null);
   const scene: AppWindowScene = {
     windows,
     dockRoot,
+    dockState: { mode: dockMode, preferredHeight, focusZone },
     floatingOrder: [],
     focusedWindowId,
   };
@@ -266,7 +350,8 @@ export function saveAppWindowNamedLayout(
   const current = AppWindowDocumentV1SchemaZ.parse(document);
   const id = AppWindowIdSchemaZ.parse(input.id);
   const updatedAt = AppWindowTimestampSchemaZ.parse(input.updatedAt);
-  const previous = current.layouts[id];
+  requireNondecreasingTimestamp(current.updatedAt, updatedAt);
+  const previous = Object.hasOwn(current.layouts, id) ? current.layouts[id] : undefined;
   const nextLayout: AppWindowNamedLayout = {
     id,
     name: input.name,
@@ -295,7 +380,8 @@ export function restoreAppWindowNamedLayout(
   const current = AppWindowDocumentV1SchemaZ.parse(document);
   const id = AppWindowIdSchemaZ.parse(layoutId);
   const timestamp = AppWindowTimestampSchemaZ.parse(updatedAt);
-  const layout = current.layouts[id];
+  requireNondecreasingTimestamp(current.updatedAt, timestamp);
+  const layout = Object.hasOwn(current.layouts, id) ? current.layouts[id] : undefined;
   if (!layout) throw new Error(`unknown app window layout "${id}"`);
   return canonicalDocument(
     AppWindowDocumentV1SchemaZ.parse({
@@ -315,18 +401,22 @@ export function focusAppWindow(
 ): AppWindowDocumentV1 {
   const current = AppWindowDocumentV1SchemaZ.parse(document);
   const id = windowId === null ? null : AppWindowIdSchemaZ.parse(windowId);
-  if (id && !current.windows[id]) throw new Error(`unknown app window "${id}"`);
+  const timestamp = AppWindowTimestampSchemaZ.parse(updatedAt);
+  requireNondecreasingTimestamp(current.updatedAt, timestamp);
+  if (id && !Object.hasOwn(current.windows, id)) throw new Error(`unknown app window "${id}"`);
   const floatingOrder =
     id && current.windows[id]?.placement.mode === "floating"
       ? [...current.floatingOrder.filter((candidate) => candidate !== id), id]
       : current.floatingOrder;
+  const dockRoot = id ? activateDockedWindow(current.dockRoot, id) : current.dockRoot;
   return canonicalDocument(
     AppWindowDocumentV1SchemaZ.parse({
       ...current,
       revision: current.revision + 1,
-      updatedAt: AppWindowTimestampSchemaZ.parse(updatedAt),
+      updatedAt: timestamp,
       focusedWindowId: id,
       floatingOrder,
+      dockRoot,
     }),
   );
 }
@@ -369,6 +459,89 @@ function cleanTerminalSourceIds(values: readonly string[]): string[] {
   return result;
 }
 
+function cleanFocusedTerminalSourceId(
+  terminalSourceIds: readonly string[],
+  value: string | null | undefined,
+): string | null {
+  if (value === null || value === undefined) return terminalSourceIds[0] ?? null;
+  const sourceId = AppWindowIdSchemaZ.parse(value);
+  if (!terminalSourceIds.includes(sourceId)) {
+    throw new Error("focused terminal source id must belong to terminalSourceIds");
+  }
+  return sourceId;
+}
+
+function legacyNativeSurface(value: unknown): AppWindowNativeSurface | null {
+  if (value === "home" || value === "files" || value === "missions") return value;
+  if (value === "diff") return "changes";
+  return null;
+}
+
+function stableLegacyResourceId(viewId: string): string {
+  const direct = AppWindowIdSchemaZ.safeParse(viewId);
+  if (direct.success) return direct.data;
+  const slug = viewId
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .slice(0, 80);
+  return AppWindowIdSchemaZ.parse(`view-${slug || "resource"}-${fnv1a(viewId)}`);
+}
+
+function legacyDockMode(
+  value: unknown,
+  diagnostics: AppWindowStateDiagnostic[],
+): "collapsed" | "open" | "maximized" {
+  if (value === "collapsed" || value === "open" || value === "maximized") return value;
+  diagnostics.push(
+    diagnostic("FIELD_DEFAULTED", "$.dock.mode", "invalid dock mode defaulted to open"),
+  );
+  return "open";
+}
+
+function legacyPreferredHeight(
+  value: unknown,
+  diagnostics: AppWindowStateDiagnostic[],
+): number | null {
+  if (value === null) return null;
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 1_000_000) {
+    return value;
+  }
+  diagnostics.push(
+    diagnostic(
+      "FIELD_DEFAULTED",
+      "$.dock.preferredHeight",
+      "invalid preferred dock height defaulted to automatic",
+    ),
+  );
+  return null;
+}
+
+function legacyFocusZone(
+  value: unknown,
+  diagnostics: AppWindowStateDiagnostic[],
+): "canvas" | "dock-tabs" | "dock-body" {
+  if (value === "canvas" || value === "dock-tabs" || value === "dock-body") return value;
+  diagnostics.push(
+    diagnostic("FIELD_DEFAULTED", "$.dock.focusZone", "invalid focus zone defaulted to canvas"),
+  );
+  return "canvas";
+}
+
+function activateDockedWindow(
+  node: AppWindowDockNodeShape | null,
+  windowId: string,
+): AppWindowDockNodeShape | null {
+  if (!node) return null;
+  if (node.type === "stack") {
+    return node.windowIds.includes(windowId) ? { ...node, activeWindowId: windowId } : node;
+  }
+  return {
+    ...node,
+    children: node.children.map((child) => activateDockedWindow(child, windowId)!),
+  };
+}
+
 function nativeTitle(surface: AppWindowNativeSurface): string {
   if (surface === "changes") return "Changes";
   return `${surface[0]!.toUpperCase()}${surface.slice(1)}`;
@@ -378,6 +551,7 @@ function cloneScene(scene: AppWindowScene): AppWindowScene {
   return {
     windows: structuredClone(scene.windows),
     dockRoot: structuredClone(scene.dockRoot),
+    dockState: { ...scene.dockState },
     floatingOrder: [...scene.floatingOrder],
     focusedWindowId: scene.focusedWindowId,
   };
@@ -402,6 +576,7 @@ function canonicalScene(scene: AppWindowScene): AppWindowScene {
       Object.entries(scene.windows).sort(([left], [right]) => left.localeCompare(right)),
     ),
     dockRoot: structuredClone(scene.dockRoot),
+    dockState: { ...scene.dockState },
     floatingOrder: [...scene.floatingOrder],
     focusedWindowId: scene.focusedWindowId,
   };
@@ -417,6 +592,21 @@ function diagnostic(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function ownValue(record: Record<string, unknown> | null, key: string): unknown {
+  return record && Object.hasOwn(record, key) ? record[key] : undefined;
+}
+
+function ownString(record: Record<string, unknown> | null, key: string): string | null {
+  const value = ownValue(record, key);
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function requireNondecreasingTimestamp(previous: string, next: string): void {
+  if (Date.parse(next) < Date.parse(previous)) {
+    throw new Error("app window mutation timestamp must not move backwards");
+  }
 }
 
 function fnv1a(value: string): string {

--- a/packages/daemon/src/tui/mirror/app-window-state.ts
+++ b/packages/daemon/src/tui/mirror/app-window-state.ts
@@ -92,7 +92,7 @@ export function stableAppWindowInstanceId(source: AppWindowSource, ordinal = 0):
   const sourceKey =
     parsed.kind === "terminal"
       ? `terminal:${parsed.terminalSourceId}`
-      : `native:${parsed.surface}:${parsed.resourceId ?? "default"}`;
+      : `native:${parsed.surface}:${parsed.resourceId === null ? "null" : `id:${parsed.resourceId}`}`;
   const slug = sourceKey
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/gu, "-")

--- a/packages/daemon/src/tui/mirror/app-window-state.ts
+++ b/packages/daemon/src/tui/mirror/app-window-state.ts
@@ -1,0 +1,429 @@
+import {
+  APP_WINDOW_DOCUMENT_VERSION,
+  APP_WINDOW_MAX_WINDOWS,
+  AppWindowDocumentV1SchemaZ,
+  AppWindowIdSchemaZ,
+  AppWindowSourceSchemaZ,
+  AppWindowTimestampSchemaZ,
+  type AppWindowDocumentV1,
+  type AppWindowInstance,
+  type AppWindowNamedLayout,
+  type AppWindowNativeSurface,
+  type AppWindowScene,
+  type AppWindowSource,
+} from "@tmux-ide/contracts";
+
+/**
+ * Standalone durable kernel seam; it intentionally does not replace the
+ * current WorkspaceUiStateV2 controller in this slice.
+ *
+ * Integration follow-ups:
+ * - give this document its own project-runtime repository path and revision CAS;
+ * - project root-owned window actions into this kernel before renderer updates;
+ * - correlate terminalSourceId -> live `%pane_id` in an in-memory adapter only;
+ * - retire view/dock layout fields from WorkspaceUiStateV2 after one-way migration.
+ */
+
+export type AppWindowStateDiagnosticCode =
+  | "MALFORMED"
+  | "UNSUPPORTED_VERSION"
+  | "INVALID_FIELD"
+  | "MIGRATED"
+  | "TERMINAL_SOURCE_REQUIRED";
+
+export interface AppWindowStateDiagnostic {
+  code: AppWindowStateDiagnosticCode;
+  path: string;
+  message: string;
+}
+
+export interface ParsedAppWindowDocument {
+  document: AppWindowDocumentV1;
+  diagnostics: AppWindowStateDiagnostic[];
+  writeProtected: boolean;
+}
+
+export interface MigratedAppWindowDocument {
+  document: AppWindowDocumentV1;
+  diagnostics: AppWindowStateDiagnostic[];
+}
+
+export interface MigrateWorkspaceUiStateOptions {
+  migratedAt: string;
+  /** Durable semantic terminal ids, never live tmux `%pane_id` values. */
+  terminalSourceIds?: readonly string[];
+}
+
+const NATIVE_DOCK_ORDER = ["files", "changes", "missions", "activity"] as const;
+const LEGACY_DOCK_TABS = new Set(NATIVE_DOCK_ORDER);
+const LEGACY_PANELS = new Set(["home", "terminals", "files", "diff", "missions"]);
+
+export function emptyAppWindowDocument(updatedAt: string): AppWindowDocumentV1 {
+  const timestamp = AppWindowTimestampSchemaZ.parse(updatedAt);
+  return AppWindowDocumentV1SchemaZ.parse({
+    version: APP_WINDOW_DOCUMENT_VERSION,
+    revision: 0,
+    updatedAt: timestamp,
+    windows: {},
+    dockRoot: null,
+    floatingOrder: [],
+    focusedWindowId: null,
+    activeLayoutId: null,
+    layouts: {},
+  });
+}
+
+/**
+ * Deterministic instance identity derived only from durable source identity.
+ * A caller-provided ordinal distinguishes deliberate duplicate views without
+ * coupling identity to mutable titles, layout coordinates, or runtime handles.
+ */
+export function stableAppWindowInstanceId(source: AppWindowSource, ordinal = 0): string {
+  const parsed = AppWindowSourceSchemaZ.parse(source);
+  if (!Number.isInteger(ordinal) || ordinal < 0 || ordinal >= APP_WINDOW_MAX_WINDOWS) {
+    throw new Error("app window ordinal must be a bounded nonnegative integer");
+  }
+  const sourceKey =
+    parsed.kind === "terminal"
+      ? `terminal:${parsed.terminalSourceId}`
+      : `native:${parsed.surface}:${parsed.resourceId ?? "default"}`;
+  const slug = sourceKey
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .slice(0, 72);
+  return AppWindowIdSchemaZ.parse(`window-${slug || "surface"}-${ordinal}-${fnv1a(sourceKey)}`);
+}
+
+/**
+ * Strictly validates durable state. Invalid current-version documents are
+ * sanitized to an empty document; newer versions are write-protected so an
+ * older binary cannot overwrite data it does not understand.
+ */
+export function parseAppWindowDocument(
+  value: unknown,
+  fallbackTimestamp: string,
+): ParsedAppWindowDocument {
+  const fallback = emptyAppWindowDocument(fallbackTimestamp);
+  if (!isRecord(value)) {
+    return {
+      document: fallback,
+      diagnostics: [diagnostic("MALFORMED", "$", "app window document must be an object")],
+      writeProtected: false,
+    };
+  }
+  if (value.version !== APP_WINDOW_DOCUMENT_VERSION) {
+    return {
+      document: fallback,
+      diagnostics: [
+        diagnostic(
+          "UNSUPPORTED_VERSION",
+          "$.version",
+          `unsupported app window document version ${String(value.version)}`,
+        ),
+      ],
+      writeProtected:
+        typeof value.version === "number" && value.version > APP_WINDOW_DOCUMENT_VERSION,
+    };
+  }
+  const parsed = AppWindowDocumentV1SchemaZ.safeParse(value);
+  if (parsed.success) {
+    return { document: canonicalDocument(parsed.data), diagnostics: [], writeProtected: false };
+  }
+  return {
+    document: fallback,
+    diagnostics: parsed.error.issues.map((issue) =>
+      diagnostic(
+        "INVALID_FIELD",
+        issue.path.length === 0 ? "$" : `$.${issue.path.map(String).join(".")}`,
+        issue.message,
+      ),
+    ),
+    writeProtected: false,
+  };
+}
+
+/**
+ * One-way seam from the current WorkspaceUiStateV2 projection. Native dock
+ * surfaces receive stable app-window instances. Terminals are migrated only
+ * when their semantic source ids are supplied separately; live `%pane_id`
+ * correlation is deliberately neither accepted nor persisted.
+ */
+export function migrateWorkspaceUiStateV2ToAppWindowDocument(
+  value: unknown,
+  options: MigrateWorkspaceUiStateOptions,
+): MigratedAppWindowDocument {
+  const migratedAt = AppWindowTimestampSchemaZ.parse(options.migratedAt);
+  if (!isRecord(value) || value.version !== 2) {
+    throw new Error("WorkspaceUiStateV2 is required for app window migration");
+  }
+  const diagnostics: AppWindowStateDiagnostic[] = [
+    diagnostic("MIGRATED", "$", "migrated WorkspaceUiStateV2 to app window document V1"),
+  ];
+  const active = isRecord(value.active) ? value.active : null;
+  const activePanel =
+    typeof active?.panel === "string" && LEGACY_PANELS.has(active.panel)
+      ? active.panel
+      : "terminals";
+  const dock = isRecord(value.dock) ? value.dock : null;
+  const requestedDockTab =
+    typeof dock?.activeTab === "string" && LEGACY_DOCK_TABS.has(dock.activeTab as never)
+      ? (dock.activeTab as (typeof NATIVE_DOCK_ORDER)[number])
+      : "files";
+  const terminalSourceIds = cleanTerminalSourceIds(options.terminalSourceIds ?? []);
+  if (activePanel === "terminals" && terminalSourceIds.length === 0) {
+    diagnostics.push(
+      diagnostic(
+        "TERMINAL_SOURCE_REQUIRED",
+        "$.active",
+        "terminal canvas was not persisted because no durable terminal source id was supplied",
+      ),
+    );
+  }
+
+  const windows: Record<string, AppWindowInstance> = {};
+  const dockWindowIds = NATIVE_DOCK_ORDER.map((surface, index) => {
+    const source: AppWindowSource = { kind: "native", surface, resourceId: null };
+    const id = stableAppWindowInstanceId(source);
+    windows[id] = dockedWindow(id, source, nativeTitle(surface), "stack-native-dock", index);
+    return id;
+  });
+  const requestedDockWindowId = dockWindowIds[NATIVE_DOCK_ORDER.indexOf(requestedDockTab)]!;
+
+  const canvasWindowIds: string[] = [];
+  if (activePanel === "home") {
+    const source: AppWindowSource = { kind: "native", surface: "home", resourceId: null };
+    const id = stableAppWindowInstanceId(source);
+    windows[id] = dockedWindow(id, source, "Home", "stack-canvas", canvasWindowIds.length);
+    canvasWindowIds.push(id);
+  }
+  for (const terminalSourceId of terminalSourceIds) {
+    const source: AppWindowSource = { kind: "terminal", terminalSourceId };
+    const id = stableAppWindowInstanceId(source);
+    windows[id] = dockedWindow(id, source, null, "stack-canvas", canvasWindowIds.length);
+    canvasWindowIds.push(id);
+  }
+
+  const nativeDock = {
+    type: "stack" as const,
+    id: "stack-native-dock",
+    windowIds: dockWindowIds,
+    activeWindowId: requestedDockWindowId,
+  };
+  const dockRoot =
+    canvasWindowIds.length === 0
+      ? nativeDock
+      : {
+          type: "split" as const,
+          id: "split-workbench",
+          axis: "vertical" as const,
+          children: [
+            {
+              type: "stack" as const,
+              id: "stack-canvas",
+              windowIds: canvasWindowIds,
+              activeWindowId: canvasWindowIds[0]!,
+            },
+            nativeDock,
+          ],
+          weights: [3, 1],
+        };
+  const focusedWindowId =
+    dock?.focusZone === "dock-tabs" || dock?.focusZone === "dock-body"
+      ? requestedDockWindowId
+      : (canvasWindowIds[0] ?? null);
+  const scene: AppWindowScene = {
+    windows,
+    dockRoot,
+    floatingOrder: [],
+    focusedWindowId,
+  };
+  const layoutId = "layout-migrated-workspace";
+  const layout: AppWindowNamedLayout = {
+    id: layoutId,
+    name: "Migrated workspace",
+    description: "Initial app-window layout migrated from WorkspaceUiStateV2",
+    revision: 1,
+    createdAt: migratedAt,
+    updatedAt: migratedAt,
+    scene: cloneScene(scene),
+  };
+  const document = AppWindowDocumentV1SchemaZ.parse({
+    version: APP_WINDOW_DOCUMENT_VERSION,
+    revision: 0,
+    updatedAt: migratedAt,
+    ...scene,
+    activeLayoutId: layoutId,
+    layouts: { [layoutId]: layout },
+  });
+  return { document: canonicalDocument(document), diagnostics };
+}
+
+export function saveAppWindowNamedLayout(
+  document: AppWindowDocumentV1,
+  input: { id: string; name: string; description?: string | null; updatedAt: string },
+): AppWindowDocumentV1 {
+  const current = AppWindowDocumentV1SchemaZ.parse(document);
+  const id = AppWindowIdSchemaZ.parse(input.id);
+  const updatedAt = AppWindowTimestampSchemaZ.parse(input.updatedAt);
+  const previous = current.layouts[id];
+  const nextLayout: AppWindowNamedLayout = {
+    id,
+    name: input.name,
+    description: input.description ?? null,
+    revision: (previous?.revision ?? 0) + 1,
+    createdAt: previous?.createdAt ?? updatedAt,
+    updatedAt,
+    scene: cloneScene(current),
+  };
+  return canonicalDocument(
+    AppWindowDocumentV1SchemaZ.parse({
+      ...current,
+      revision: current.revision + 1,
+      updatedAt,
+      activeLayoutId: id,
+      layouts: { ...current.layouts, [id]: nextLayout },
+    }),
+  );
+}
+
+export function restoreAppWindowNamedLayout(
+  document: AppWindowDocumentV1,
+  layoutId: string,
+  updatedAt: string,
+): AppWindowDocumentV1 {
+  const current = AppWindowDocumentV1SchemaZ.parse(document);
+  const id = AppWindowIdSchemaZ.parse(layoutId);
+  const timestamp = AppWindowTimestampSchemaZ.parse(updatedAt);
+  const layout = current.layouts[id];
+  if (!layout) throw new Error(`unknown app window layout "${id}"`);
+  return canonicalDocument(
+    AppWindowDocumentV1SchemaZ.parse({
+      ...current,
+      ...cloneScene(layout.scene),
+      revision: current.revision + 1,
+      updatedAt: timestamp,
+      activeLayoutId: id,
+    }),
+  );
+}
+
+export function focusAppWindow(
+  document: AppWindowDocumentV1,
+  windowId: string | null,
+  updatedAt: string,
+): AppWindowDocumentV1 {
+  const current = AppWindowDocumentV1SchemaZ.parse(document);
+  const id = windowId === null ? null : AppWindowIdSchemaZ.parse(windowId);
+  if (id && !current.windows[id]) throw new Error(`unknown app window "${id}"`);
+  const floatingOrder =
+    id && current.windows[id]?.placement.mode === "floating"
+      ? [...current.floatingOrder.filter((candidate) => candidate !== id), id]
+      : current.floatingOrder;
+  return canonicalDocument(
+    AppWindowDocumentV1SchemaZ.parse({
+      ...current,
+      revision: current.revision + 1,
+      updatedAt: AppWindowTimestampSchemaZ.parse(updatedAt),
+      focusedWindowId: id,
+      floatingOrder,
+    }),
+  );
+}
+
+export function serializeAppWindowDocument(document: AppWindowDocumentV1): string {
+  return `${JSON.stringify(canonicalDocument(AppWindowDocumentV1SchemaZ.parse(document)), null, 2)}\n`;
+}
+
+function dockedWindow(
+  id: string,
+  source: AppWindowSource,
+  title: string | null,
+  stackId: string,
+  index: number,
+): AppWindowInstance {
+  return {
+    id,
+    source,
+    title,
+    placement: {
+      mode: "docked",
+      docked: { stackId, index },
+      floating: null,
+    },
+  };
+}
+
+function cleanTerminalSourceIds(values: readonly string[]): string[] {
+  if (values.length > APP_WINDOW_MAX_WINDOWS - NATIVE_DOCK_ORDER.length) {
+    throw new Error("terminal source id limit exceeded");
+  }
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const sourceId = AppWindowIdSchemaZ.parse(value);
+    if (seen.has(sourceId)) continue;
+    seen.add(sourceId);
+    result.push(sourceId);
+  }
+  return result;
+}
+
+function nativeTitle(surface: AppWindowNativeSurface): string {
+  if (surface === "changes") return "Changes";
+  return `${surface[0]!.toUpperCase()}${surface.slice(1)}`;
+}
+
+function cloneScene(scene: AppWindowScene): AppWindowScene {
+  return {
+    windows: structuredClone(scene.windows),
+    dockRoot: structuredClone(scene.dockRoot),
+    floatingOrder: [...scene.floatingOrder],
+    focusedWindowId: scene.focusedWindowId,
+  };
+}
+
+function canonicalDocument(document: AppWindowDocumentV1): AppWindowDocumentV1 {
+  const layouts = Object.fromEntries(
+    Object.entries(document.layouts)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([id, layout]) => [id, { ...layout, scene: canonicalScene(layout.scene) }]),
+  );
+  return AppWindowDocumentV1SchemaZ.parse({
+    ...document,
+    ...canonicalScene(document),
+    layouts,
+  });
+}
+
+function canonicalScene(scene: AppWindowScene): AppWindowScene {
+  return {
+    windows: Object.fromEntries(
+      Object.entries(scene.windows).sort(([left], [right]) => left.localeCompare(right)),
+    ),
+    dockRoot: structuredClone(scene.dockRoot),
+    floatingOrder: [...scene.floatingOrder],
+    focusedWindowId: scene.focusedWindowId,
+  };
+}
+
+function diagnostic(
+  code: AppWindowStateDiagnosticCode,
+  path: string,
+  message: string,
+): AppWindowStateDiagnostic {
+  return { code, path, message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function fnv1a(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(36).padStart(7, "0");
+}


### PR DESCRIPTION
## Summary
- introduce a versioned durable app-window document with stable source identity
- model dock trees, floating rect/z-order, focus, dock/floating placement memory, dock presentation, and named layouts
- keep terminal semantic identity separate from live tmux `%pane_id` correlation
- add strict parse/canonical serialization and one-way WorkspaceUiStateV2 migration

## Correctness and recovery
- prototype-safe record membership for all window/layout references
- focused floating window must be top-most; focused docked window must be its stack active tab
- focusing a docked window activates its tab recursively; focusing a float raises it
- invalid current documents are write-protected instead of being silently overwritten
- migration preserves native view/resource identity, active view, dock presentation, and explicit semantic terminal focus
- composite configured layouts are diagnosed as deferred rather than silently flattened
- null and named native resources have unambiguous deterministic IDs
- mutation timestamps cannot move backward

## Validation
- focused app-window/workspace regressions: 19 passed
- contracts: 51 passed
- contracts and daemon typechecks passed
- targeted ESLint/Prettier/diff-check passed
- full `pnpm check` passed on the substantive hardening commit
- final adversarial review: clean

## Deferred integration
- project-runtime repository/CAS path
- root-owned window action projection and layout kernel operations
- in-memory semantic terminal source → live `%pane_id` adapter
- app.tsx renderer/direct-manipulation cutover