### PR TITLE
feat(tui): integrate the native command palette

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -304,19 +304,23 @@ import {
 import {
   paletteRows,
   paletteActionKey,
-  paletteRowText,
-  firstPaletteAction,
-  stepPaletteRow,
   parseBufferList,
   palettePos,
   paletteRowAt,
   paletteContains,
   clampPaletteTop,
   type PaletteAction,
-  type PaletteRow,
   type PaletteGeom,
   type TmuxBuffer,
 } from "./palette.ts";
+import {
+  adaptPaletteRowsToCommands,
+  appendPalettePaste,
+  ensurePaletteSelectionVisible,
+  firstEnabledPaletteCommandId,
+  paletteActionForCommand,
+  stepEnabledPaletteCommandId,
+} from "./palette-surface-adapter.ts";
 import {
   PanelHostLoadGeneration,
   findHostedViewById,
@@ -350,6 +354,11 @@ import {
   projectAgentTerminalCanvas,
 } from "./workspace/agent-terminal-canvas.ts";
 import { AgentTerminalCanvas } from "./workspace/agent-terminal-canvas-view.tsx";
+import {
+  commandPaletteHitTest,
+  projectCommandPalette,
+} from "./workspace/command-palette-surface.ts";
+import { CommandPaletteSurface } from "./workspace/command-palette-surface.tsx";
 import {
   dispatchTerminalPaneChromePointerIntent,
   projectTerminalPaneChrome,
@@ -3920,16 +3929,12 @@ try {
       createSession(raw, selectedHomeDir());
     };
 
-    // ── COMMAND PALETTE (M18.4, mouse-complete M21.9) ───────────────────────
-    // A centered overlay (F5 / ^p / the tab bar's palette chip) — a fuzzy input
-    // line + result list over the action model in palette.ts. The overlay is
-    // late-mounted inside <Show> and carries NO per-node handlers (central-
-    // routing discipline): `route` checks `paletteOpen()` right after the menu
-    // and hit-tests rows with the pure palette geometry (palettePos/paletteRowAt
-    // — the same math the render places the box with). Motion moves the
-    // selection (the selection highlight IS the hover feedback, like the context
-    // menu), a left press on a row runs it, the wheel scrolls `paletteTop`, and
-    // a press outside dismisses. Keyboard behavior is unchanged.
+    // ── COMMAND PALETTE (native surface; root-owned input) ──────────────────
+    // F5 / ^p / host-aware ⌘K opens the native CommandPaletteSurface. The
+    // existing ranked PaletteAction catalog remains canonical; the pure adapter
+    // adds semantic icons/details/availability and stable selection ids. The
+    // component owns no handlers: this root routes keyboard, paste, projected
+    // mouse hits, lifecycle, and execution through the existing action executor.
     const [paletteOpen, setPaletteOpen] = createSignal(false);
     const [paletteQuery, setPaletteQuery] = createSignal("");
     // "Go to file:" source (M24.6): the workspace's ignore-respecting file list,
@@ -3976,7 +3981,13 @@ try {
           .catch(() => setRepoFiles([]));
       });
     };
+    // Buffer selection remains a compact numeric second-level concern. The
+    // command list uses stable semantic ids so re-ranking/query edits never
+    // accidentally execute a different row at the same screen coordinate.
     const [paletteSel, setPaletteSel] = createSignal(0);
+    const [paletteSelectedCommandId, setPaletteSelectedCommandId] = createSignal<string | null>(
+      null,
+    );
     // The wheel-scrolled window top of the result list (0 unless scrolled — the
     // keyboard never moves it, so keyboard-only sessions render exactly as
     // before). Reset wherever the list identity changes (query edits, level
@@ -4007,25 +4018,59 @@ try {
         },
       ),
     );
-    /** The current palette LIST length — buffers level when open, else rows. */
-    const paletteCount = () => paletteBuffers()?.length ?? paletteRowList().length;
-    /** The palette box geometry as placed by the render, for the router. */
+    const paletteEntries = createMemo(() => {
+      // EditBuffer is an imperative native object, so subscribe to its explicit
+      // revision before deriving availability for Save.
+      editorRev();
+      return adaptPaletteRowsToCommands(paletteRowList(), {
+        currentTab: tab(),
+        currentViewId: activeViewId(),
+        currentSession: contextSession(),
+        syncOn: syncOn(),
+        editorAvailable:
+          Boolean(editBuffer) || (mode() === "diff" && Boolean(diffVisibleFiles()[diffSel()])),
+        fallbackGroup: paletteQuery().trim() ? "Results" : "Commands",
+      });
+    });
+    const paletteProjection = createMemo(() =>
+      projectCommandPalette({
+        width: dims().width,
+        height: dims().height,
+        query: paletteQuery(),
+        commands: paletteEntries().map((entry) => entry.descriptor),
+        selectedCommandId: paletteSelectedCommandId(),
+        scrollTop: paletteTop(),
+      }),
+    );
+    /** The legacy centered geometry is now exclusively the paste-buffer level. */
     const paletteGeom = (): PaletteGeom => {
       const { left, top } = palettePos(dims().width, dims().height, paletteW());
+      const count = paletteBuffers()?.length ?? 0;
       return {
         left,
         top,
         width: paletteW(),
-        visibleRows: Math.min(PALETTE_ROWS, Math.max(0, paletteCount() - paletteTop())),
+        visibleRows: Math.min(PALETTE_ROWS, Math.max(0, count - paletteTop())),
       };
+    };
+    const resetPaletteSelection = () => {
+      setPaletteTop(0);
+      setPaletteSelectedCommandId(firstEnabledPaletteCommandId(paletteEntries()));
+    };
+    const setPaletteQueryAndReset = (next: string) => {
+      setPaletteQuery(next);
+      resetPaletteSelection();
+    };
+    const selectPaletteCommand = (commandId: string | null) => {
+      setPaletteSelectedCommandId(commandId);
+      setPaletteTop(
+        ensurePaletteSelectionVisible(paletteProjection(), paletteEntries(), commandId),
+      );
     };
     const openPalette = () => {
       setPaletteQuery("");
-      setPaletteTop(0);
       setPaletteBuffers(null); // always open on the action list, never mid-picker
-      // The selection starts on the first ACTION row — under grouping that is
-      // the row after the "recent" header, keeping F5 → Enter one gesture.
-      setPaletteSel(Math.max(0, firstPaletteAction(paletteRowList())));
+      resetPaletteSelection();
       setHoverIf(null); // the overlay owns the pointer; drop any underlying tint
       loadRepoFiles(); // refresh the "Go to file:" source (async, M24.6)
       setPaletteOpen(true);
@@ -4278,24 +4323,23 @@ try {
         }
         return;
       }
-      const rows = paletteRowList();
       if (evt.name === "escape") {
         setPaletteOpen(false);
       } else if (evt.name === "return") {
-        const r = rows[Math.min(paletteSel(), rows.length - 1)];
-        if (r?.type === "action") runPaletteAction(r.action);
+        const action = paletteActionForCommand(paletteEntries(), paletteSelectedCommandId());
+        if (action) runPaletteAction(action);
       } else if (evt.name === "up") {
-        setPaletteSel((s) => stepPaletteRow(rows, s, -1));
+        selectPaletteCommand(
+          stepEnabledPaletteCommandId(paletteEntries(), paletteSelectedCommandId(), -1),
+        );
       } else if (evt.name === "down") {
-        setPaletteSel((s) => stepPaletteRow(rows, s, 1));
+        selectPaletteCommand(
+          stepEnabledPaletteCommandId(paletteEntries(), paletteSelectedCommandId(), 1),
+        );
       } else if (evt.name === "backspace") {
-        setPaletteQuery((q) => q.slice(0, -1));
-        setPaletteSel(Math.max(0, firstPaletteAction(paletteRowList())));
-        setPaletteTop(0);
+        setPaletteQueryAndReset(paletteQuery().slice(0, -1));
       } else if (evt.name.length === 1 && !evt.ctrl && !evt.meta) {
-        setPaletteQuery((q) => q + (evt.shift ? evt.name.toUpperCase() : evt.name));
-        setPaletteSel(Math.max(0, firstPaletteAction(paletteRowList())));
-        setPaletteTop(0);
+        setPaletteQueryAndReset(paletteQuery() + (evt.shift ? evt.name.toUpperCase() : evt.name));
       }
     };
 
@@ -6143,7 +6187,19 @@ try {
     // EDITOR inserts at the cursor as ONE undo unit; the TERMINAL forwards it to
     // the focused pane re-wrapped in bracketed markers (so apps see a paste, not
     // keystrokes); the input coalescer chunks it under tmux's per-command cap.
-    usePaste((e) => pasteIntoFocused(decodePasteBytes(e.bytes)));
+    usePaste((e) => {
+      const text = decodePasteBytes(e.bytes);
+      if (paletteOpen()) {
+        // The root remains the only paste listener. An action-level paste edits
+        // the query; the buffer picker consumes it. Neither can leak bytes into
+        // a terminal hidden underneath the modal surface.
+        if (paletteBuffers() === null) {
+          setPaletteQueryAndReset(appendPalettePaste(paletteQuery(), text));
+        }
+        return;
+      }
+      pasteIntoFocused(text);
+    });
 
     /** The per-window strip's x-spans — one segment per tmux window, laid out from
      *  the main column's first cell (SIDEBAR_W + paddingLeft 1) with a 1-cell gap,
@@ -6975,20 +7031,52 @@ try {
         else if (!pointInMenu(parentGeom, x, y)) closeMenu();
         return;
       }
-      // While the PALETTE is open it owns pointer routing (M21.9), mirroring the
-      // menu above: motion over a result row moves the selection (the selection
-      // highlight is the hover feedback), the wheel scrolls the visible window,
-      // a left press on a row runs it (action list or paste-buffer level), a
-      // press anywhere else inside the box is a no-op, and a press OUTSIDE
-      // dismisses. Geometry comes from the same pure math the render places the
-      // box with (palettePos/paletteRowAt/paletteContains).
+      // While the PALETTE is open it owns pointer routing. Action-level hits use
+      // the native surface projection; the retained paste-buffer second level
+      // uses its smaller legacy geometry. Both stay handler-free and modal.
       if (paletteOpen()) {
+        const bufs = paletteBuffers();
+        if (bufs === null) {
+          const projection = paletteProjection();
+          if (type === "scroll") {
+            const dir = e.scroll?.direction;
+            if (dir === "up" || dir === "down") {
+              const step = dir === "up" ? -1 : 1;
+              setPaletteTop((top) =>
+                Math.max(0, Math.min(top + step, Math.max(0, projection.contentRowCount - 1))),
+              );
+            }
+            return;
+          }
+          const hit = commandPaletteHitTest(projection, x, y);
+          if (type === "move" || type === "over" || type === "drag") {
+            if (hit?.kind === "command" && !hit.disabled) {
+              setPaletteSelectedCommandId(hit.commandId);
+            }
+            return;
+          }
+          if (type !== "down") return;
+          if (hit?.kind === "command") {
+            if (e.button === 2 || hit.disabled) return;
+            setPaletteSelectedCommandId(hit.commandId);
+            const action = paletteActionForCommand(paletteEntries(), hit.commandId);
+            if (action) runPaletteAction(action);
+            return;
+          }
+          if (hit?.kind === "retry") {
+            if (e.button !== 2) openPalette();
+            return;
+          }
+          if (hit === null) setPaletteOpen(false);
+          return;
+        }
+
         const g = paletteGeom();
         if (type === "scroll") {
           const dir = e.scroll?.direction;
           if (dir === "up" || dir === "down") {
             const step = dir === "up" ? -1 : 1;
-            setPaletteTop((t) => clampPaletteTop(t + step, paletteCount(), PALETTE_ROWS));
+            setPaletteTop((t) => clampPaletteTop(t + step, bufs.length, PALETTE_ROWS));
           }
           return;
         }
@@ -6998,9 +7086,7 @@ try {
           // selection where it was, like the box chrome.
           if (ri >= 0) {
             const abs = paletteTop() + ri;
-            if (paletteBuffers() !== null || paletteRowList()[abs]?.type === "action") {
-              setPaletteSel(abs);
-            }
+            setPaletteSel(abs);
           }
           return;
         }
@@ -7009,18 +7095,9 @@ try {
         if (ri >= 0) {
           if (e.button === 2) return; // right press on a row: no-op, stay open
           const abs = paletteTop() + ri;
-          const bufs = paletteBuffers();
-          if (bufs !== null) {
-            setPaletteSel(abs);
-            const b = bufs[abs];
-            if (b) pasteBuffer(b.name);
-          } else {
-            const r = paletteRowList()[abs];
-            if (r?.type === "action") {
-              setPaletteSel(abs);
-              runPaletteAction(r.action);
-            } // a header click is a no-op — the palette stays open
-          }
+          setPaletteSel(abs);
+          const b = bufs[abs];
+          if (b) pasteBuffer(b.name);
           return;
         }
         if (!paletteContains(g, x, y)) setPaletteOpen(false);
@@ -7948,78 +8025,27 @@ try {
             />
           </box>
         </box>
-        {/* COMMAND PALETTE overlay (M18.4; mouse-complete M21.9) — centered.
-          Late-mounted inside <Show> and still carries NO per-node handlers:
-          clicks bubble to the root box, whose `route` checks `paletteOpen()`
-          and hit-tests rows against the SAME pure geometry placing this box
-          (palettePos). Type to fuzzy-filter; up/down or pointer motion move;
-          enter or a row click runs; wheel scrolls (`paletteTop` windows the
-          slice); esc or an outside click closes. */}
+        {/* Native COMMAND PALETTE overlay. Presentation stays handler-free;
+          the root uses the same projection for render and pointer hit-testing.
+          The original tmux paste-buffer picker remains the second level. */}
         <Show when={paletteOpen()}>
-          <box
-            position="absolute"
-            left={palettePos(dims().width, dims().height, paletteW()).left}
-            top={palettePos(dims().width, dims().height, paletteW()).top}
-            width={paletteW()}
-            flexDirection="column"
-            backgroundColor={PALETTE_BG}
-            border
-            borderColor={PALETTE_BORDER}
-            paddingLeft={1}
-            paddingRight={1}
+          <Show
+            when={paletteBuffers() !== null}
+            fallback={
+              <CommandPaletteSurface theme={semanticTheme()} projection={paletteProjection()} />
+            }
           >
-            {/* Second level (paste-buffer picker) when `paletteBuffers` is set;
-              otherwise the normal fuzzy action list. Same late-mount discipline —
-              no per-row handlers; paletteKey drives both. */}
-            <Show
-              when={paletteBuffers() !== null}
-              fallback={
-                <>
-                  <box flexDirection="row">
-                    <text fg={ACCENT} attributes={1}>
-                      {"⌘ "}
-                    </text>
-                    <text fg={DEFAULT_FG}>{`${paletteQuery()}▏`}</text>
-                  </box>
-                  <text fg={MUTED}>{"─".repeat(paletteW() - 4)}</text>
-                  {/* Rows (M24.4): group headers render as inert muted lines;
-                    action rows carry the selection prefix + a right-aligned
-                    keycap (paletteRowText keeps the keycap inside the width
-                    however long the label). Hit-testing stays row-level — the
-                    router skips headers by row type. */}
-                  <For each={paletteRowList().slice(paletteTop(), paletteTop() + PALETTE_ROWS)}>
-                    {(r, i) => (
-                      <box
-                        height={1}
-                        backgroundColor={
-                          r.type === "action" && paletteTop() + i() === paletteSel()
-                            ? TAB_ACTIVE_BG
-                            : PALETTE_BG
-                        }
-                      >
-                        <Show
-                          when={r.type === "action"}
-                          fallback={
-                            <text fg={MUTED}>{`— ${r.type === "header" ? r.label : ""}`}</text>
-                          }
-                        >
-                          <text fg={paletteTop() + i() === paletteSel() ? DEFAULT_FG : MUTED}>
-                            {(paletteTop() + i() === paletteSel() ? "› " : "  ") +
-                              paletteRowText(
-                                r.type === "action" ? r.action.label : "",
-                                r.type === "action" ? r.shortcut : null,
-                                paletteW() - 6,
-                              )}
-                          </text>
-                        </Show>
-                      </box>
-                    )}
-                  </For>
-                  <Show when={paletteRowList().length === 0}>
-                    <text fg={MUTED}>{"  no matches"}</text>
-                  </Show>
-                </>
-              }
+            <box
+              position="absolute"
+              left={palettePos(dims().width, dims().height, paletteW()).left}
+              top={palettePos(dims().width, dims().height, paletteW()).top}
+              width={paletteW()}
+              flexDirection="column"
+              backgroundColor={PALETTE_BG}
+              border
+              borderColor={PALETTE_BORDER}
+              paddingLeft={1}
+              paddingRight={1}
             >
               <box flexDirection="row">
                 <text fg={ACCENT} attributes={1}>
@@ -8048,8 +8074,8 @@ try {
               <Show when={paletteBuffers()!.length === 0}>
                 <text fg={MUTED}>{"  no buffers"}</text>
               </Show>
-            </Show>
-          </box>
+            </box>
+          </Show>
         </Show>
         {/* RIGHT-CLICK CONTEXT MENU overlay (M19.2) — opened at the pointer,
           clamped on-screen. Late-mounted inside <Show>, so it carries NO mouse

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -316,9 +316,11 @@ import {
 import {
   adaptPaletteRowsToCommands,
   appendPalettePaste,
+  dispatchPaletteCommand,
   ensurePaletteSelectionVisible,
   firstEnabledPaletteCommandId,
-  paletteActionForCommand,
+  PaletteBufferLoadGate,
+  restorePaletteActionLevelFromBuffers,
   stepEnabledPaletteCommandId,
 } from "./palette-surface-adapter.ts";
 import {
@@ -3937,6 +3939,8 @@ try {
     // mouse hits, lifecycle, and execution through the existing action executor.
     const [paletteOpen, setPaletteOpen] = createSignal(false);
     const [paletteQuery, setPaletteQuery] = createSignal("");
+    const paletteBufferLoadGate = new PaletteBufferLoadGate();
+    onCleanup(() => paletteBufferLoadGate.invalidate());
     // "Go to file:" source (M24.6): the workspace's ignore-respecting file list,
     // repo-relative, capped, refreshed on each palette open (async — the rows
     // appear as soon as the list lands). `git ls-files -co --exclude-standard`
@@ -4027,8 +4031,11 @@ try {
         currentViewId: activeViewId(),
         currentSession: contextSession(),
         syncOn: syncOn(),
-        editorAvailable:
-          Boolean(editBuffer) || (mode() === "diff" && Boolean(diffVisibleFiles()[diffSel()])),
+        saveState: {
+          hasBuffer: Boolean(editBuffer),
+          hasPath: Boolean(editorPath()),
+          readOnlyReason: editorReadOnly(),
+        },
         fallbackGroup: paletteQuery().trim() ? "Results" : "Commands",
       });
     });
@@ -4067,7 +4074,21 @@ try {
         ensurePaletteSelectionVisible(paletteProjection(), paletteEntries(), commandId),
       );
     };
+    const closePalette = () => {
+      paletteBufferLoadGate.invalidate();
+      setPaletteBuffers(null);
+      setPaletteOpen(false);
+    };
+    const returnFromPaletteBuffers = () => {
+      paletteBufferLoadGate.invalidate();
+      const restore = restorePaletteActionLevelFromBuffers(paletteProjection(), paletteEntries());
+      setPaletteBuffers(null);
+      setPaletteSel(0);
+      setPaletteSelectedCommandId(restore.selectedCommandId);
+      setPaletteTop(restore.scrollTop);
+    };
     const openPalette = () => {
+      paletteBufferLoadGate.invalidate();
       setPaletteQuery("");
       setPaletteBuffers(null); // always open on the action list, never mid-picker
       resetPaletteSelection();
@@ -4130,7 +4151,7 @@ try {
         loadBuffers();
         return;
       }
-      setPaletteOpen(false);
+      closePalette();
       switch (a.kind) {
         case "search-scrollback":
           // The live-prompt entry to scrollback search — `/` only works while
@@ -4310,9 +4331,7 @@ try {
       const bufs = paletteBuffers();
       if (bufs !== null) {
         if (evt.name === "escape") {
-          setPaletteBuffers(null);
-          setPaletteSel(0);
-          setPaletteTop(0);
+          returnFromPaletteBuffers();
         } else if (evt.name === "return") {
           const b = bufs[Math.min(paletteSel(), bufs.length - 1)];
           if (b) pasteBuffer(b.name);
@@ -4324,10 +4343,9 @@ try {
         return;
       }
       if (evt.name === "escape") {
-        setPaletteOpen(false);
+        closePalette();
       } else if (evt.name === "return") {
-        const action = paletteActionForCommand(paletteEntries(), paletteSelectedCommandId());
-        if (action) runPaletteAction(action);
+        dispatchPaletteCommand(paletteEntries(), paletteSelectedCommandId(), runPaletteAction);
       } else if (evt.name === "up") {
         selectPaletteCommand(
           stepEnabledPaletteCommandId(paletteEntries(), paletteSelectedCommandId(), -1),
@@ -4988,22 +5006,28 @@ try {
      *  over the control client when a session is mirrored, else a plain execFile —
      *  buffers are global tmux state, so either reaches them. */
     const loadBuffers = () => {
+      const generation = paletteBufferLoadGate.begin();
       setPaletteBuffers([]); // loading / empty placeholder
       const fmt = `#{buffer_name}\t#{buffer_sample}`;
       const done = (lines: string[]) => {
-        setPaletteBuffers(parseBufferList(lines));
-        setPaletteSel(0);
-        setPaletteTop(0);
+        paletteBufferLoadGate.commit(generation, () => {
+          setPaletteBuffers(parseBufferList(lines));
+          setPaletteSel(0);
+          setPaletteTop(0);
+        });
+      };
+      const failed = () => {
+        paletteBufferLoadGate.commit(generation, () => setPaletteBuffers([]));
       };
       if (mirror) {
         void mirror
           .command(`list-buffers -F ${tmuxQuote(fmt)}`)
           .then(done)
-          .catch(() => setPaletteBuffers([]));
+          .catch(failed);
         return;
       }
       execFile("tmux", ["list-buffers", "-F", fmt], (err, stdout) => {
-        if (err) return setPaletteBuffers([]);
+        if (err) return failed();
         done(stdout.split("\n").filter((l) => l.length > 0));
       });
     };
@@ -5011,8 +5035,7 @@ try {
      *  latin1 (byte-per-char) so multibyte glyphs must be re-encoded latin1→utf8
      *  (the same fix the pane seed uses) before hitting the paste path. */
     const pasteBuffer = (name: string) => {
-      setPaletteOpen(false);
-      setPaletteBuffers(null);
+      closePalette();
       setPaletteSel(0);
       setPaletteTop(0);
       if (mirror) {
@@ -7059,15 +7082,14 @@ try {
           if (hit?.kind === "command") {
             if (e.button === 2 || hit.disabled) return;
             setPaletteSelectedCommandId(hit.commandId);
-            const action = paletteActionForCommand(paletteEntries(), hit.commandId);
-            if (action) runPaletteAction(action);
+            dispatchPaletteCommand(paletteEntries(), hit.commandId, runPaletteAction);
             return;
           }
           if (hit?.kind === "retry") {
             if (e.button !== 2) openPalette();
             return;
           }
-          if (hit === null) setPaletteOpen(false);
+          if (hit === null) closePalette();
           return;
         }
 
@@ -7100,7 +7122,7 @@ try {
           if (b) pasteBuffer(b.name);
           return;
         }
-        if (!paletteContains(g, x, y)) setPaletteOpen(false);
+        if (!paletteContains(g, x, y)) closePalette();
         return;
       }
       if (!dragging && routeWorkbenchPointer(e)) return;

--- a/packages/daemon/src/tui/mirror/palette-surface-adapter.test.ts
+++ b/packages/daemon/src/tui/mirror/palette-surface-adapter.test.ts
@@ -3,10 +3,13 @@ import type { PaletteAction, PaletteRow } from "./palette.ts";
 import {
   adaptPaletteRowsToCommands,
   appendPalettePaste,
+  dispatchPaletteCommand,
   ensurePaletteSelectionVisible,
   firstEnabledPaletteCommandId,
+  PaletteBufferLoadGate,
   paletteActionForCommand,
   paletteCommandId,
+  restorePaletteActionLevelFromBuffers,
   stepEnabledPaletteCommandId,
 } from "./palette-surface-adapter.ts";
 import {
@@ -28,6 +31,11 @@ const terminals: PaletteAction = {
   label: "Switch tab: Terminal",
 };
 const quit: PaletteAction = { kind: "quit", label: "Quit" };
+const writableSaveState = {
+  hasBuffer: true,
+  hasPath: true,
+  readOnlyReason: null,
+};
 
 describe("live command palette adapter", () => {
   it("preserves ranked groups while projecting semantic command metadata", () => {
@@ -41,7 +49,10 @@ describe("live command palette adapter", () => {
         actionRow(home, "F1"),
         actionRow(quit, "⌘Q"),
       ],
-      { currentTab: "terminal", editorAvailable: false },
+      {
+        currentTab: "terminal",
+        saveState: { hasBuffer: false, hasPath: false, readOnlyReason: null },
+      },
     );
 
     expect(entries.map((entry) => entry.action)).toEqual([terminals, save, home, quit]);
@@ -104,7 +115,7 @@ describe("live command palette adapter", () => {
         actionRow(home),
         actionRow(quit),
       ],
-      { editorAvailable: false },
+      { saveState: { hasBuffer: false, hasPath: false, readOnlyReason: null } },
     );
     const selected = firstEnabledPaletteCommandId(entries);
     expect(selected).toBe(paletteCommandId(terminals));
@@ -112,6 +123,37 @@ describe("live command palette adapter", () => {
     expect(stepEnabledPaletteCommandId(entries, paletteCommandId(home), -1)).toBe(selected);
     expect(paletteActionForCommand(entries, paletteCommandId(save))).toBeNull();
     expect(paletteActionForCommand(entries, paletteCommandId(quit))).toBe(quit);
+
+    const executed: PaletteAction[] = [];
+    expect(
+      dispatchPaletteCommand(entries, paletteCommandId(save), (action) => executed.push(action)),
+    ).toBe(false);
+    expect(executed).toEqual([]);
+    expect(
+      dispatchPaletteCommand(entries, paletteCommandId(quit), (action) => executed.push(action)),
+    ).toBe(true);
+    expect(executed).toEqual([quit]);
+  });
+
+  it.each([
+    [
+      "missing buffer",
+      { hasBuffer: false, hasPath: true, readOnlyReason: null },
+      "No file is open",
+    ],
+    ["missing path", { hasBuffer: true, hasPath: false, readOnlyReason: null }, "No file is open"],
+    [
+      "read-only file",
+      { hasBuffer: true, hasPath: true, readOnlyReason: "binary" },
+      "File is read-only",
+    ],
+    ["writable editor", writableSaveState, null],
+  ] as const)("maps the %s Save executor preconditions exactly", (_label, saveState, reason) => {
+    const entries = adaptPaletteRowsToCommands([actionRow(save), actionRow(quit)], { saveState });
+    const saveEntry = entries[0]!;
+
+    expect(saveEntry.descriptor.disabledReason).toBe(reason);
+    expect(paletteActionForCommand(entries, saveEntry.id)).toBe(reason ? null : save);
   });
 
   it("keeps keyboard selection visible after grouped overflow", () => {
@@ -155,9 +197,77 @@ describe("live command palette adapter", () => {
     );
   });
 
+  it("returns from paste buffers with the parent selected and visible", () => {
+    const actions: PaletteAction[] = [
+      ...Array.from(
+        { length: 10 },
+        (_, index): PaletteAction => ({
+          kind: "go-file",
+          path: `src/before-${index}.ts`,
+          label: `Before ${index}`,
+        }),
+      ),
+      { kind: "paste-buffer", label: "Paste buffer…" },
+      quit,
+    ];
+    const entries = adaptPaletteRowsToCommands(
+      actions.map((action) => actionRow(action)),
+      { fallbackGroup: "Commands", saveState: writableSaveState },
+    );
+    const parentId = entries.find((entry) => entry.action.kind === "paste-buffer")!.id;
+    const atTop = projectCommandPalette({
+      width: 120,
+      height: 40,
+      query: "",
+      commands: entries.map((entry) => entry.descriptor),
+      selectedCommandId: parentId,
+      scrollTop: 0,
+    });
+    expect(atTop.rows.some((row) => row.kind === "command" && row.commandId === parentId)).toBe(
+      false,
+    );
+
+    const restore = restorePaletteActionLevelFromBuffers(atTop, entries);
+    const restored = projectCommandPalette({
+      width: 120,
+      height: 40,
+      query: "",
+      commands: entries.map((entry) => entry.descriptor),
+      selectedCommandId: restore.selectedCommandId,
+      scrollTop: restore.scrollTop,
+    });
+
+    expect(restore.selectedCommandId).toBe(parentId);
+    expect(restored.rows).toContainEqual(
+      expect.objectContaining({ kind: "command", commandId: parentId, selected: true }),
+    );
+  });
+
+  it("rejects stale, closed, reopened, and overlapping buffer loads", () => {
+    const gate = new PaletteBufferLoadGate();
+    const committed: string[] = [];
+    const slow = gate.begin();
+    const fast = gate.begin();
+
+    expect(gate.commit(slow, () => committed.push("slow"))).toBe(false);
+    expect(gate.commit(fast, () => committed.push("fast"))).toBe(true);
+    expect(committed).toEqual(["fast"]);
+
+    const closed = gate.begin();
+    gate.invalidate();
+    expect(gate.commit(closed, () => committed.push("closed"))).toBe(false);
+
+    const beforeReopen = gate.begin();
+    gate.invalidate();
+    const afterReopen = gate.begin();
+    expect(gate.commit(beforeReopen, () => committed.push("before-reopen"))).toBe(false);
+    expect(gate.commit(afterReopen, () => committed.push("after-reopen"))).toBe(true);
+    expect(committed).toEqual(["fast", "after-reopen"]);
+  });
+
   it("routes command, disabled, retry, and outside pointer hits semantically", () => {
     const entries = adaptPaletteRowsToCommands([actionRow(save), actionRow(quit)], {
-      editorAvailable: false,
+      saveState: { hasBuffer: false, hasPath: false, readOnlyReason: null },
     });
     const projection = projectCommandPalette({
       width: 120,

--- a/packages/daemon/src/tui/mirror/palette-surface-adapter.test.ts
+++ b/packages/daemon/src/tui/mirror/palette-surface-adapter.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import type { PaletteAction, PaletteRow } from "./palette.ts";
+import {
+  adaptPaletteRowsToCommands,
+  appendPalettePaste,
+  ensurePaletteSelectionVisible,
+  firstEnabledPaletteCommandId,
+  paletteActionForCommand,
+  paletteCommandId,
+  stepEnabledPaletteCommandId,
+} from "./palette-surface-adapter.ts";
+import {
+  commandPaletteHitTest,
+  projectCommandPalette,
+} from "./workspace/command-palette-surface.ts";
+
+const actionRow = (action: PaletteAction, shortcut: string | null = null): PaletteRow => ({
+  type: "action",
+  action,
+  shortcut,
+});
+
+const save: PaletteAction = { kind: "save", label: "Save file" };
+const home: PaletteAction = { kind: "tab", tab: "home", label: "Switch tab: Home" };
+const terminals: PaletteAction = {
+  kind: "tab",
+  tab: "terminal",
+  label: "Switch tab: Terminal",
+};
+const quit: PaletteAction = { kind: "quit", label: "Quit" };
+
+describe("live command palette adapter", () => {
+  it("preserves ranked groups while projecting semantic command metadata", () => {
+    const entries = adaptPaletteRowsToCommands(
+      [
+        { type: "header", label: "recent" },
+        actionRow(terminals, "F2"),
+        { type: "header", label: "suggested" },
+        actionRow(save, "⌘S"),
+        { type: "header", label: "commands" },
+        actionRow(home, "F1"),
+        actionRow(quit, "⌘Q"),
+      ],
+      { currentTab: "terminal", editorAvailable: false },
+    );
+
+    expect(entries.map((entry) => entry.action)).toEqual([terminals, save, home, quit]);
+    expect(entries.map((entry) => entry.descriptor.group)).toEqual([
+      "recent",
+      "suggested",
+      "commands",
+      "commands",
+    ]);
+    expect(entries[0]!.descriptor).toMatchObject({
+      category: "Navigation",
+      icon: "terminals",
+      current: true,
+      shortcut: "F2",
+    });
+    expect(entries[1]!.descriptor).toMatchObject({
+      category: "Files",
+      disabledReason: "No file is open",
+    });
+    expect(entries[3]!.descriptor).toMatchObject({ category: "Application", icon: "close" });
+
+    const projection = projectCommandPalette({
+      width: 120,
+      height: 40,
+      query: "",
+      commands: entries.map((entry) => entry.descriptor),
+      selectedCommandId: entries[0]!.id,
+    });
+    expect(
+      projection.rows.filter((row) => row.kind === "group").map((row) => row.category),
+    ).toEqual(["recent", "suggested", "commands"]);
+    const saveRow = projection.rows.find(
+      (row) => row.kind === "command" && row.commandId === paletteCommandId(save),
+    );
+    expect(saveRow).toMatchObject({ kind: "command", category: "Files", disabled: true });
+  });
+
+  it("keeps dynamic files and runtime panes uniquely addressable", () => {
+    const firstFile: PaletteAction = { kind: "go-file", path: "src/a.ts", label: "a" };
+    const secondFile: PaletteAction = { kind: "go-file", path: "src/b.ts", label: "b" };
+    const firstPane: PaletteAction = {
+      kind: "jump-agent",
+      session: "demo",
+      paneId: "%1",
+      windowIndex: 0,
+      label: "first",
+    };
+    const secondPane: PaletteAction = { ...firstPane, paneId: "%2", label: "second" };
+    const ids = [firstFile, secondFile, firstPane, secondPane].map(paletteCommandId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("navigates across groups, skips disabled commands, and never executes one", () => {
+    const entries = adaptPaletteRowsToCommands(
+      [
+        { type: "header", label: "recent" },
+        actionRow(save),
+        actionRow(terminals),
+        { type: "header", label: "commands" },
+        actionRow(home),
+        actionRow(quit),
+      ],
+      { editorAvailable: false },
+    );
+    const selected = firstEnabledPaletteCommandId(entries);
+    expect(selected).toBe(paletteCommandId(terminals));
+    expect(stepEnabledPaletteCommandId(entries, selected, 1)).toBe(paletteCommandId(home));
+    expect(stepEnabledPaletteCommandId(entries, paletteCommandId(home), -1)).toBe(selected);
+    expect(paletteActionForCommand(entries, paletteCommandId(save))).toBeNull();
+    expect(paletteActionForCommand(entries, paletteCommandId(quit))).toBe(quit);
+  });
+
+  it("keeps keyboard selection visible after grouped overflow", () => {
+    const actions = Array.from(
+      { length: 24 },
+      (_, index): PaletteAction => ({
+        kind: "open-file",
+        path: `src/file-${index}.ts`,
+        label: `Open file ${index}`,
+      }),
+    );
+    const entries = adaptPaletteRowsToCommands(
+      actions.map((action) => actionRow(action)),
+      {
+        fallbackGroup: "Results",
+      },
+    );
+    const target = entries.at(-1)!.id;
+    const projection = projectCommandPalette({
+      width: 80,
+      height: 24,
+      query: "file",
+      commands: entries.map((entry) => entry.descriptor),
+      selectedCommandId: target,
+      scrollTop: 0,
+    });
+    expect(projection.rows.some((row) => row.kind === "command" && row.commandId === target)).toBe(
+      false,
+    );
+    const scrollTop = ensurePaletteSelectionVisible(projection, entries, target);
+    const scrolled = projectCommandPalette({
+      width: 80,
+      height: 24,
+      query: "file",
+      commands: entries.map((entry) => entry.descriptor),
+      selectedCommandId: target,
+      scrollTop,
+    });
+    expect(scrolled.rows.some((row) => row.kind === "command" && row.commandId === target)).toBe(
+      true,
+    );
+  });
+
+  it("routes command, disabled, retry, and outside pointer hits semantically", () => {
+    const entries = adaptPaletteRowsToCommands([actionRow(save), actionRow(quit)], {
+      editorAvailable: false,
+    });
+    const projection = projectCommandPalette({
+      width: 120,
+      height: 40,
+      query: "",
+      commands: entries.map((entry) => entry.descriptor),
+    });
+    const disabled = projection.rows.find(
+      (row) => row.kind === "command" && row.commandId === paletteCommandId(save),
+    );
+    const executable = projection.rows.find(
+      (row) => row.kind === "command" && row.commandId === paletteCommandId(quit),
+    );
+    expect(disabled?.kind).toBe("command");
+    expect(executable?.kind).toBe("command");
+    if (disabled?.kind === "command" && executable?.kind === "command") {
+      expect(commandPaletteHitTest(projection, disabled.rect.x, disabled.rect.y)).toEqual({
+        kind: "command",
+        commandId: paletteCommandId(save),
+        disabled: true,
+      });
+      expect(commandPaletteHitTest(projection, executable.rect.x, executable.rect.y)).toEqual({
+        kind: "command",
+        commandId: paletteCommandId(quit),
+        disabled: false,
+      });
+    }
+    expect(commandPaletteHitTest(projection, 0, 0)).toBeNull();
+
+    const error = projectCommandPalette({
+      width: 120,
+      height: 40,
+      query: "",
+      commands: [],
+      phase: "error",
+      retryCommandId: "palette.retry",
+    });
+    const retry = error.rows.find((row) => row.kind === "state" && row.state === "retry");
+    expect(retry?.kind).toBe("state");
+    if (retry?.kind === "state") {
+      expect(commandPaletteHitTest(error, retry.rect.x, retry.rect.y)).toEqual({
+        kind: "retry",
+        commandId: "palette.retry",
+      });
+    }
+  });
+
+  it("turns bracketed paste into a safe single-line query", () => {
+    expect(appendPalettePaste("open ", "src/one.ts\n\u001b[31mnext")).toBe(
+      "open src/one.ts [31mnext",
+    );
+  });
+});

--- a/packages/daemon/src/tui/mirror/palette-surface-adapter.ts
+++ b/packages/daemon/src/tui/mirror/palette-surface-adapter.ts
@@ -1,0 +1,334 @@
+import type { Tab } from "./app-state.ts";
+import type { PaletteAction, PaletteRow } from "./palette.ts";
+import type {
+  CommandPaletteDescriptor,
+  CommandPaletteProjection,
+} from "./workspace/command-palette-surface.ts";
+import type { WorkspaceIconId } from "./workspace/icons.ts";
+
+export interface PaletteSurfaceAdapterContext {
+  currentTab?: Tab;
+  currentViewId?: string | null;
+  currentSession?: string | null;
+  syncOn?: boolean;
+  editorAvailable?: boolean;
+  /** Return a reason to disable an otherwise offered action. */
+  disabledReason?: (action: PaletteAction) => string | null | undefined;
+  fallbackGroup?: string;
+}
+
+export interface PaletteSurfaceEntry {
+  id: string;
+  action: PaletteAction;
+  descriptor: CommandPaletteDescriptor;
+  /** Index in CommandPaletteSurface's group + command candidate stream. */
+  candidateIndex: number;
+}
+
+function actionPayload(action: PaletteAction): string {
+  switch (action.kind) {
+    case "tab":
+      return action.tab;
+    case "view":
+      return action.viewId;
+    case "attach":
+      return action.session;
+    case "jump-agent":
+      return `${action.session}:${action.paneId}`;
+    case "restart-agent":
+    case "stop-agent":
+      return `${action.session}:${action.agentKind}:${action.paneId}`;
+    case "open-file":
+    case "go-file":
+      return action.path;
+    case "rename-window":
+      return action.name;
+    case "select-layout":
+      return action.layout;
+    case "settings":
+      return action.id;
+    default:
+      return "";
+  }
+}
+
+/** Runtime-stable identity. Unlike usage keys, dynamic file and pane rows stay distinct. */
+export function paletteCommandId(action: PaletteAction): string {
+  const payload = actionPayload(action);
+  return `palette.${action.kind}${payload ? `:${encodeURIComponent(payload)}` : ""}`;
+}
+
+function iconForAction(action: PaletteAction): WorkspaceIconId {
+  switch (action.kind) {
+    case "tab":
+      return action.tab === "home"
+        ? "home"
+        : action.tab === "terminal"
+          ? "terminals"
+          : action.tab === "files"
+            ? "files"
+            : "diff";
+    case "view":
+      return "native";
+    case "open-folder":
+    case "open-file":
+    case "go-file":
+    case "save":
+      return "files";
+    case "attach":
+    case "jump-agent":
+    case "new-agent":
+    case "new-agent-again":
+    case "manage-team":
+    case "restart-agent":
+    case "stop-agent":
+    case "search-scrollback":
+    case "paste-buffer":
+    case "select-text":
+      return "terminals";
+    case "refresh-diff":
+      return "diff";
+    case "new-window":
+      return "popOut";
+    case "rename-window":
+      return "command";
+    case "kill-window":
+    case "quit":
+      return "close";
+    case "zoom-pane":
+      return "maximize";
+    case "swap-pane":
+    case "rotate-window":
+      return "move";
+    case "break-pane":
+      return "splitRight";
+    case "select-layout":
+    case "resize-window":
+      return "resize";
+    case "sync-toggle":
+      return "refresh";
+    case "settings":
+      return "native";
+  }
+}
+
+function categoryForAction(action: PaletteAction): string {
+  switch (action.kind) {
+    case "tab":
+    case "view":
+    case "open-folder":
+    case "attach":
+      return "Navigation";
+    case "jump-agent":
+    case "new-agent":
+    case "new-agent-again":
+    case "manage-team":
+    case "restart-agent":
+    case "stop-agent":
+      return "Agents";
+    case "open-file":
+    case "go-file":
+    case "save":
+      return "Files";
+    case "refresh-diff":
+      return "Changes";
+    case "paste-buffer":
+    case "search-scrollback":
+    case "select-text":
+      return "Terminal";
+    case "new-window":
+    case "rename-window":
+    case "kill-window":
+    case "zoom-pane":
+    case "swap-pane":
+    case "break-pane":
+    case "rotate-window":
+    case "sync-toggle":
+    case "resize-window":
+      return "Window";
+    case "select-layout":
+      return "Layout";
+    case "settings":
+      return "Settings";
+    case "quit":
+      return "Application";
+  }
+}
+
+function detailForAction(action: PaletteAction): string {
+  switch (action.kind) {
+    case "tab":
+    case "view":
+      return "Switch the active workspace surface";
+    case "open-folder":
+      return "Open or create a workspace from a folder";
+    case "attach":
+      return `Open the ${action.session} workspace`;
+    case "jump-agent":
+      return `Focus ${action.session} pane ${action.paneId}`;
+    case "new-agent":
+      return "Choose a harness and placement";
+    case "new-agent-again":
+      return "Repeat the last agent launch in this context";
+    case "manage-team":
+      return "Jump, restart, stop, or add an agent";
+    case "restart-agent":
+      return `Restart ${action.agentKind} in ${action.session}`;
+    case "stop-agent":
+      return `Stop ${action.agentKind} in ${action.session}`;
+    case "open-file":
+    case "go-file":
+      return action.path;
+    case "save":
+      return "Write the current editor buffer";
+    case "refresh-diff":
+      return "Reload changed files and their diff";
+    case "paste-buffer":
+      return "Choose from tmux paste buffers";
+    case "search-scrollback":
+      return "Search the focused terminal's history";
+    case "new-window":
+      return "Create a tmux window in this workspace";
+    case "rename-window":
+      return `Rename the active window to ${action.name}`;
+    case "kill-window":
+      return "Close the active tmux window";
+    case "zoom-pane":
+      return "Toggle focus on the active terminal pane";
+    case "swap-pane":
+      return "Swap the active pane with the next pane";
+    case "break-pane":
+      return "Move the active pane into its own window";
+    case "rotate-window":
+      return "Rotate panes through the current layout";
+    case "select-layout":
+      return `Apply the ${action.layout} tmux layout`;
+    case "sync-toggle":
+      return "Toggle synchronized input for this window";
+    case "select-text":
+      return "Temporarily capture text instead of app mouse input";
+    case "resize-window":
+      return "Reclaim the tmux window at this app's canvas size";
+    case "settings":
+      return "Configure tmux-ide";
+    case "quit":
+      return "Close this app without sending Ctrl-C to a pane";
+  }
+}
+
+function isCurrent(action: PaletteAction, context: PaletteSurfaceAdapterContext): boolean {
+  if (action.kind === "tab") return action.tab === context.currentTab;
+  if (action.kind === "view") return action.viewId === context.currentViewId;
+  if (action.kind === "attach") return action.session === context.currentSession;
+  if (action.kind === "sync-toggle") return context.syncOn === true;
+  return false;
+}
+
+function statusForAction(
+  action: PaletteAction,
+  context: PaletteSurfaceAdapterContext,
+): string | null {
+  if (action.kind === "sync-toggle") return context.syncOn ? "on" : "off";
+  if (action.kind === "jump-agent") return action.session;
+  if (action.kind === "attach" && action.session === context.currentSession) return "current";
+  return null;
+}
+
+function disabledReason(
+  action: PaletteAction,
+  context: PaletteSurfaceAdapterContext,
+): string | null {
+  const explicit = context.disabledReason?.(action)?.trim();
+  if (explicit) return explicit;
+  if (action.kind === "save" && context.editorAvailable === false) return "No file is open";
+  return null;
+}
+
+/** Adapt the ranked legacy action rows without changing their order or execution identity. */
+export function adaptPaletteRowsToCommands(
+  rows: readonly PaletteRow[],
+  context: PaletteSurfaceAdapterContext = {},
+): PaletteSurfaceEntry[] {
+  const hasExplicitGroups = rows.some((row) => row.type === "header");
+  let group = context.fallbackGroup?.trim() || "Commands";
+  let candidateIndex = 0;
+  const seenGroups = new Set<string>();
+  const entries: PaletteSurfaceEntry[] = [];
+
+  for (const row of rows) {
+    if (row.type === "header") {
+      group = row.label;
+      continue;
+    }
+    const normalizedGroup = hasExplicitGroups ? group : context.fallbackGroup?.trim() || "Commands";
+    if (!seenGroups.has(normalizedGroup)) {
+      seenGroups.add(normalizedGroup);
+      candidateIndex += 1;
+    }
+    const id = paletteCommandId(row.action);
+    const current = isCurrent(row.action, context);
+    const descriptor: CommandPaletteDescriptor = {
+      id,
+      icon: iconForAction(row.action),
+      label: row.action.label,
+      detail: detailForAction(row.action),
+      category: categoryForAction(row.action),
+      group: normalizedGroup,
+      shortcut: row.shortcut,
+      status: statusForAction(row.action, context),
+      disabledReason: disabledReason(row.action, context),
+      current,
+    };
+    entries.push({ id, action: row.action, descriptor, candidateIndex });
+    candidateIndex += 1;
+  }
+  return entries;
+}
+
+export function firstEnabledPaletteCommandId(
+  entries: readonly PaletteSurfaceEntry[],
+): string | null {
+  return entries.find((entry) => !entry.descriptor.disabledReason)?.id ?? null;
+}
+
+export function stepEnabledPaletteCommandId(
+  entries: readonly PaletteSurfaceEntry[],
+  selectedId: string | null,
+  direction: 1 | -1,
+): string | null {
+  const current = entries.findIndex((entry) => entry.id === selectedId);
+  const start = current < 0 ? (direction === 1 ? -1 : entries.length) : current;
+  for (let index = start + direction; index >= 0 && index < entries.length; index += direction) {
+    if (!entries[index]!.descriptor.disabledReason) return entries[index]!.id;
+  }
+  return current >= 0 ? selectedId : firstEnabledPaletteCommandId(entries);
+}
+
+export function paletteActionForCommand(
+  entries: readonly PaletteSurfaceEntry[],
+  commandId: string | null,
+): PaletteAction | null {
+  const entry = entries.find((candidate) => candidate.id === commandId);
+  return entry && !entry.descriptor.disabledReason ? entry.action : null;
+}
+
+export function ensurePaletteSelectionVisible(
+  projection: CommandPaletteProjection,
+  entries: readonly PaletteSurfaceEntry[],
+  commandId: string | null,
+): number {
+  if (!commandId) return projection.scrollTop;
+  if (projection.rows.some((row) => row.kind === "command" && row.commandId === commandId)) {
+    return projection.scrollTop;
+  }
+  const entry = entries.find((candidate) => candidate.id === commandId);
+  if (!entry) return projection.scrollTop;
+  return Math.max(0, Math.min(entry.candidateIndex, Math.max(0, projection.contentRowCount - 1)));
+}
+
+export function appendPalettePaste(query: string, text: string): string {
+  // Palette queries are a single terminal row; collapse pasted control runs so
+  // they can never leak escape sequences or create invisible command text.
+  // eslint-disable-next-line no-control-regex
+  return query + text.replace(/[\x00-\x1f\x7f]+/g, " ");
+}

--- a/packages/daemon/src/tui/mirror/palette-surface-adapter.ts
+++ b/packages/daemon/src/tui/mirror/palette-surface-adapter.ts
@@ -11,10 +11,49 @@ export interface PaletteSurfaceAdapterContext {
   currentViewId?: string | null;
   currentSession?: string | null;
   syncOn?: boolean;
-  editorAvailable?: boolean;
+  saveState?: PaletteSaveState;
   /** Return a reason to disable an otherwise offered action. */
   disabledReason?: (action: PaletteAction) => string | null | undefined;
   fallbackGroup?: string;
+}
+
+export interface PaletteSaveState {
+  hasBuffer: boolean;
+  hasPath: boolean;
+  readOnlyReason: string | null;
+}
+
+export interface PaletteActionLevelRestore {
+  selectedCommandId: string | null;
+  scrollTop: number;
+}
+
+/**
+ * Single-writer authority for the asynchronous tmux paste-buffer picker.
+ * Leaving/reopening the palette invalidates all prior request generations, and
+ * starting a newer request prevents an older completion from winning.
+ */
+export class PaletteBufferLoadGate {
+  #generation = 0;
+
+  begin(): number {
+    this.#generation += 1;
+    return this.#generation;
+  }
+
+  invalidate(): void {
+    this.#generation += 1;
+  }
+
+  isCurrent(generation: number): boolean {
+    return generation === this.#generation;
+  }
+
+  commit(generation: number, effect: () => void): boolean {
+    if (!this.isCurrent(generation)) return false;
+    effect();
+    return true;
+  }
 }
 
 export interface PaletteSurfaceEntry {
@@ -240,7 +279,10 @@ function disabledReason(
 ): string | null {
   const explicit = context.disabledReason?.(action)?.trim();
   if (explicit) return explicit;
-  if (action.kind === "save" && context.editorAvailable === false) return "No file is open";
+  if (action.kind === "save" && context.saveState) {
+    if (!context.saveState.hasBuffer || !context.saveState.hasPath) return "No file is open";
+    if (context.saveState.readOnlyReason) return "File is read-only";
+  }
   return null;
 }
 
@@ -312,6 +354,18 @@ export function paletteActionForCommand(
   return entry && !entry.descriptor.disabledReason ? entry.action : null;
 }
 
+/** The only action-level activation gate; disabled/missing rows never reach app effects. */
+export function dispatchPaletteCommand(
+  entries: readonly PaletteSurfaceEntry[],
+  commandId: string | null,
+  execute: (action: PaletteAction) => void,
+): boolean {
+  const action = paletteActionForCommand(entries, commandId);
+  if (!action) return false;
+  execute(action);
+  return true;
+}
+
 export function ensurePaletteSelectionVisible(
   projection: CommandPaletteProjection,
   entries: readonly PaletteSurfaceEntry[],
@@ -324,6 +378,21 @@ export function ensurePaletteSelectionVisible(
   const entry = entries.find((candidate) => candidate.id === commandId);
   if (!entry) return projection.scrollTop;
   return Math.max(0, Math.min(entry.candidateIndex, Math.max(0, projection.contentRowCount - 1)));
+}
+
+/** Return from the tmux buffer picker to its visible, selected parent action. */
+export function restorePaletteActionLevelFromBuffers(
+  projection: CommandPaletteProjection,
+  entries: readonly PaletteSurfaceEntry[],
+): PaletteActionLevelRestore {
+  const parent = entries.find(
+    (entry) => entry.action.kind === "paste-buffer" && !entry.descriptor.disabledReason,
+  );
+  const selectedCommandId = parent?.id ?? firstEnabledPaletteCommandId(entries);
+  return {
+    selectedCommandId,
+    scrollTop: ensurePaletteSelectionVisible(projection, entries, selectedCommandId),
+  };
 }
 
 export function appendPalettePaste(query: string, text: string): string {

--- a/packages/daemon/src/tui/mirror/workspace/command-palette-surface.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/command-palette-surface.test.ts
@@ -181,6 +181,26 @@ describe("command palette surface projection", () => {
     }
   });
 
+  it("keeps presentation groups separate from semantic command categories", () => {
+    const projection = projectCommandPalette({
+      width: 120,
+      height: 40,
+      query: "",
+      commands: [
+        { ...commands[0]!, group: "Recent" },
+        { ...commands[2]!, group: "Suggested" },
+      ],
+    });
+    expect(
+      projection.rows.filter((row) => row.kind === "group").map((row) => row.category),
+    ).toEqual(["Recent", "Suggested"]);
+    expect(
+      projection.rows
+        .filter((row) => row.kind === "command")
+        .map((row) => (row.kind === "command" ? row.category : "")),
+    ).toEqual(["Navigation", "Files"]);
+  });
+
   it("keeps semantic row ids stable across fresh descriptors and transient selection", () => {
     const first = projectCommandPalette({
       width: 120,

--- a/packages/daemon/src/tui/mirror/workspace/command-palette-surface.ts
+++ b/packages/daemon/src/tui/mirror/workspace/command-palette-surface.ts
@@ -17,6 +17,12 @@ export interface CommandPaletteDescriptor {
   label: string;
   description?: string;
   detail?: string;
+  /**
+   * Optional presentation group. `category` remains the command's semantic
+   * category (Files, Window, …), while adapters can preserve ranked sections
+   * such as Recent/Suggested without lying about command semantics.
+   */
+  group?: string;
   category: string;
   shortcut?: string | null;
   status?: string | null;
@@ -241,7 +247,7 @@ function uniqueCommands(commands: readonly CommandPaletteDescriptor[]): CommandP
 function commandCandidates(commands: readonly CommandPaletteDescriptor[]): CandidateRow[] {
   const categories = new Map<string, CommandPaletteDescriptor[]>();
   for (const command of commands) {
-    const category = command.category.trim() || "Commands";
+    const category = command.group?.trim() || command.category.trim() || "Commands";
     const group = categories.get(category);
     if (group) group.push(command);
     else categories.set(category, [command]);

--- a/packages/daemon/src/tui/mirror/workspace/command-palette-surface.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/command-palette-surface.tsx
@@ -259,7 +259,9 @@ export function CommandPaletteSurface(props: CommandPaletteSurfaceProps) {
     <box
       width={props.projection.width}
       height={props.projection.height}
-      position="relative"
+      position="absolute"
+      left={0}
+      top={0}
       overflow="hidden"
     >
       <box


### PR DESCRIPTION
## Summary
- replace the live inline text palette with the native adaptive CommandPaletteSurface
- adapt the existing fuzzy/usage-ranked action model into semantic icon/detail/category/current/disabled descriptors
- preserve Recent/Suggested grouping, sessions/files/agents/settings actions, and the paste-buffer second level
- keep app.tsx as sole keyboard, paste, pointer, lifecycle, and executor owner
- route hover/click/wheel/outside/retry through projection-derived hit geometry

## Production invariants
- F5, Ctrl-P, and host-aware Cmd-K share canonical opening behavior
- paste into an open palette edits the query and cannot leak to the terminal
- disabled commands cannot execute, record usage, or close the palette
- Save availability exactly matches the editor executor preconditions
- paste-buffer back restores a visible semantic parent selection
- generation guards reject stale/overlapping async buffer responses on back/close/reopen/unmount
- hosted quit/detach lifecycle remains unchanged

## Validation
- focused palette/input suites: 117 passed
- palette renderer: 10 passed, 8 snapshots
- full daemon: 2,119 tests passed
- full renderer: 87 tests, 62 snapshots, 3,748 assertions
- full pnpm check and build:tui passed
- independent adversarial re-review + manual race/restore permutations: clean