### PR TITLE
feat(onboarding): add bounded project readiness probing

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -49,6 +49,7 @@ export {
   type ProjectReadinessIssueCode,
   type ProjectReadinessIssueSeverity,
   type ProjectReadinessPlatformProbe,
+  type ProjectPathKind,
   type ProjectReadinessProbe,
   type ProjectReadinessProjectProbe,
   type ProjectReadinessResult,
@@ -66,5 +67,6 @@ export {
   type ReadinessCommandOptions,
   type ReadinessCommandResult,
   type ReadinessCommandStatus,
+  type ReadinessExecutableKind,
   type ReadinessPathKind,
 } from "./lib/project-readiness-probe.ts";

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -57,3 +57,14 @@ export {
   type ProjectRecoveryActionKind,
   type ProjectRegistrationState,
 } from "./lib/project-readiness.ts";
+export {
+  assessProjectReadiness,
+  probeProjectReadiness,
+  type CustomReadinessHarnessProfile,
+  type ProjectReadinessProbeIo,
+  type ProjectReadinessProbeOptions,
+  type ReadinessCommandOptions,
+  type ReadinessCommandResult,
+  type ReadinessCommandStatus,
+  type ReadinessPathKind,
+} from "./lib/project-readiness-probe.ts";

--- a/packages/daemon/src/lib/__tests__/project-readiness-probe.test.ts
+++ b/packages/daemon/src/lib/__tests__/project-readiness-probe.test.ts
@@ -9,6 +9,7 @@ import {
   type ProjectReadinessProbeIo,
   type ReadinessCommandOptions,
   type ReadinessCommandResult,
+  type ReadinessExecutableKind,
   type ReadinessPathKind,
 } from "../project-readiness-probe.ts";
 import type { Availability } from "../project-readiness.ts";
@@ -26,6 +27,7 @@ interface FakeIoOptions {
   inspectPath?: (path: string) => ReadinessPathKind;
   exists?: (path: string) => boolean;
   realpath?: (path: string) => string;
+  inspectExecutable?: (path: string) => ReadinessExecutableKind;
   isExecutable?: (path: string) => Availability;
   runCommand?: (call: CommandCall) => Promise<ReadinessCommandResult>;
 }
@@ -57,6 +59,7 @@ function createFakeIo(options: FakeIoOptions = {}): {
     "/opt/bin/codex",
     "/opt/bin/claude",
     "/opt/bin/opencode",
+    "/opt/bin/acme-agent",
     "/bin/zsh",
     "/bin/sh",
   ]);
@@ -67,6 +70,8 @@ function createFakeIo(options: FakeIoOptions = {}): {
     inspectPath: options.inspectPath ?? (() => "directory"),
     exists: options.exists ?? (() => false),
     realpath: options.realpath ?? ((path) => path),
+    inspectExecutable:
+      options.inspectExecutable ?? ((path) => (executables.has(path) ? "file" : "missing")),
     isExecutable:
       options.isExecutable ?? ((path) => (executables.has(path) ? "available" : "missing")),
     runCommand: async (executable, argv, commandOptions) => {
@@ -134,6 +139,7 @@ describe("project readiness probe adapter", () => {
       root: "/actual/project",
       name: "project",
       identitySource: "canonical-realpath",
+      pathKind: "directory",
       exists: true,
       isDirectory: true,
     });
@@ -244,7 +250,7 @@ describe("project readiness probe adapter", () => {
 
     const custom = result.harnesses.find((harness) => harness.id === "acme");
     expect(custom).toMatchObject({
-      command: ["acme-agent", "run", "--interactive"],
+      command: ["/opt/bin/acme-agent", "run", "--interactive"],
       version: "4.2.0",
       usable: true,
     });
@@ -293,5 +299,95 @@ describe("project readiness probe adapter", () => {
     expect(probe.project.registration).toBe("stale");
     expect(probe.project.root).toBeNull();
     expect(calls.some((call) => call.argv.includes("--is-inside-work-tree"))).toBe(false);
+  });
+
+  it.each([
+    ["failed", { status: "failure", stdout: "tmux error", exitCode: 1 }],
+    ["timed out", { status: "timeout" }],
+    ["returned no version", { status: "success", stdout: "\n\0\t" }],
+  ] as const)("blocks tmux when its bounded version probe %s", async (_label, tmuxResult) => {
+    const { io } = createFakeIo({
+      runCommand: async (call) =>
+        call.executable === "/usr/bin/tmux" ? tmuxResult : defaultCommand(call),
+    });
+
+    const result = await assessProjectReadiness("/project", { io });
+
+    expect(result.capabilities.tmux).toBe("unverified");
+    expect(result.blockingIssues.map((issue) => issue.code)).toContain("TMUX_UNVERIFIED");
+    expect(result.recommendedLaunchPlan.mode).toBe("unavailable");
+  });
+
+  it("does not treat an executable directory as an installed tool", async () => {
+    const { io, calls } = createFakeIo({
+      inspectExecutable: (path) => (path === "/usr/bin/tmux" ? "other" : "file"),
+    });
+
+    const result = await assessProjectReadiness("/project", { io });
+
+    expect(result.capabilities.tmux).toBe("missing");
+    expect(result.blockingIssues.map((issue) => issue.code)).toContain("TMUX_MISSING");
+    expect(calls.some((call) => call.executable === "/usr/bin/tmux")).toBe(false);
+  });
+
+  it("rejects padded executable tokens instead of checking and launching different identities", async () => {
+    const { io } = createFakeIo();
+
+    const result = await assessProjectReadiness("/project", {
+      io,
+      preferredHarnessId: "padded",
+      shellCommand: [" /bin/zsh"],
+      customHarnesses: [
+        {
+          id: "padded",
+          label: "Padded Agent",
+          command: [" codex ", "--yolo"],
+          authentication: "not-required",
+          commandReadiness: "ready",
+        },
+      ],
+    });
+
+    expect(result.harnesses.find((harness) => harness.id === "padded")?.state).toBe(
+      "command-invalid",
+    );
+    expect(result.blockingIssues.map((issue) => issue.code)).toContain("SHELL_COMMAND_INVALID");
+    expect(result.recommendedLaunchPlan.panes).toEqual([]);
+  });
+
+  it("resolves relative PATH entries against the project cwd and skips empty entries", async () => {
+    const inspected: string[] = [];
+    const { io, calls } = createFakeIo({
+      environment: { PATH: ":tools", SHELL: "/bin/zsh" },
+      inspectExecutable: (path) => {
+        inspected.push(path);
+        return path === "/project/tools/codex" || path === "/bin/zsh" ? "file" : "missing";
+      },
+      isExecutable: (path) =>
+        path === "/project/tools/codex" || path === "/bin/zsh" ? "available" : "missing",
+    });
+
+    const probe = await probeProjectReadiness("/project", { io });
+    const codex = probe.harnesses.find((harness) => harness.id === "codex");
+
+    expect(codex?.command).toEqual(["/project/tools/codex"]);
+    expect(calls).toContainEqual(
+      expect.objectContaining({ executable: "/project/tools/codex", argv: ["--version"] }),
+    );
+    expect(inspected).not.toContain("/project/codex");
+    expect(inspected).not.toContain("/cwd/tools/codex");
+  });
+
+  it("preserves an uninspectable path as an explicit blocking project fact", async () => {
+    const { io } = createFakeIo({ inspectPath: () => "unknown" });
+
+    const result = await assessProjectReadiness("/protected", { io, registration: "current" });
+
+    expect(result.project).toMatchObject({ pathKind: "unknown", registration: "current" });
+    expect(result.blockingIssues.map((issue) => issue.code)).toContain("PROJECT_PATH_UNVERIFIED");
+    expect(result.blockingIssues.map((issue) => issue.code)).not.toContain("PROJECT_NOT_FOUND");
+    expect(result.recoveryActions).toContainEqual(
+      expect.objectContaining({ kind: "refresh-project", label: "Check project path again" }),
+    );
   });
 });

--- a/packages/daemon/src/lib/__tests__/project-readiness-probe.test.ts
+++ b/packages/daemon/src/lib/__tests__/project-readiness-probe.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+import {
+  assessProjectReadiness as publicAssessProjectReadiness,
+  probeProjectReadiness as publicProbeProjectReadiness,
+} from "../../index.ts";
+import {
+  assessProjectReadiness,
+  probeProjectReadiness,
+  type ProjectReadinessProbeIo,
+  type ReadinessCommandOptions,
+  type ReadinessCommandResult,
+  type ReadinessPathKind,
+} from "../project-readiness-probe.ts";
+import type { Availability } from "../project-readiness.ts";
+
+interface CommandCall {
+  executable: string;
+  argv: readonly string[];
+  options: ReadinessCommandOptions;
+}
+
+interface FakeIoOptions {
+  cwd?: string;
+  environment?: NodeJS.ProcessEnv;
+  platform?: { os: NodeJS.Platform; arch: string };
+  inspectPath?: (path: string) => ReadinessPathKind;
+  exists?: (path: string) => boolean;
+  realpath?: (path: string) => string;
+  isExecutable?: (path: string) => Availability;
+  runCommand?: (call: CommandCall) => Promise<ReadinessCommandResult>;
+}
+
+function defaultCommand(call: CommandCall): ReadinessCommandResult {
+  const binary = call.executable.split("/").at(-1) ?? call.executable;
+  if (binary === "git" && call.argv.includes("--show-toplevel")) {
+    return { status: "failure", stderr: "fatal: not a git repository", exitCode: 128 };
+  }
+  if (binary === "git" && call.argv.includes("--git-common-dir")) {
+    return { status: "failure", stderr: "fatal: not a git repository", exitCode: 128 };
+  }
+  if (binary === "git" && call.argv.includes("--is-inside-work-tree")) {
+    return { status: "failure", stderr: "fatal: not a git repository", exitCode: 128 };
+  }
+  const version =
+    binary === "tmux" ? "tmux 3.5a" : binary === "git" ? "git version 2.50.0" : `${binary} 1.0.0`;
+  return { status: "success", stdout: `${version}\n`, exitCode: 0 };
+}
+
+function createFakeIo(options: FakeIoOptions = {}): {
+  io: ProjectReadinessProbeIo;
+  calls: CommandCall[];
+} {
+  const calls: CommandCall[] = [];
+  const executables = new Set([
+    "/usr/bin/git",
+    "/usr/bin/tmux",
+    "/opt/bin/codex",
+    "/opt/bin/claude",
+    "/opt/bin/opencode",
+    "/bin/zsh",
+    "/bin/sh",
+  ]);
+  const io: ProjectReadinessProbeIo = {
+    cwd: () => options.cwd ?? "/cwd",
+    environment: () => options.environment ?? { PATH: "/usr/bin:/opt/bin:/bin", SHELL: "/bin/zsh" },
+    platform: () => options.platform ?? { os: "darwin", arch: "arm64" },
+    inspectPath: options.inspectPath ?? (() => "directory"),
+    exists: options.exists ?? (() => false),
+    realpath: options.realpath ?? ((path) => path),
+    isExecutable:
+      options.isExecutable ?? ((path) => (executables.has(path) ? "available" : "missing")),
+    runCommand: async (executable, argv, commandOptions) => {
+      const call = { executable, argv: [...argv], options: commandOptions };
+      calls.push(call);
+      return options.runCommand ? options.runCommand(call) : defaultCommand(call);
+    },
+  };
+  return { io, calls };
+}
+
+function gitWorktreeCommand(call: CommandCall): ReadinessCommandResult {
+  if (call.argv.includes("--show-toplevel")) {
+    return {
+      status: "success",
+      stdout: call.argv[1]!.startsWith("/worktrees/feature") ? "/worktrees/feature\n" : "/repo\n",
+    };
+  }
+  if (call.argv.includes("--git-common-dir")) {
+    return { status: "success", stdout: "/repo/.git\n" };
+  }
+  if (call.argv.includes("--is-inside-work-tree")) {
+    return { status: "success", stdout: "true\n" };
+  }
+  return defaultCommand(call);
+}
+
+describe("project readiness probe adapter", () => {
+  it("is exported through the public daemon entry point", () => {
+    expect(publicProbeProjectReadiness).toBe(probeProjectReadiness);
+    expect(publicAssessProjectReadiness).toBe(assessProjectReadiness);
+  });
+
+  it("shares Git common-dir identity across a main checkout and linked worktree", async () => {
+    const { io, calls } = createFakeIo({ runCommand: async (call) => gitWorktreeCommand(call) });
+
+    const main = await probeProjectReadiness("/repo", { io });
+    const linked = await probeProjectReadiness("/worktrees/feature/src", { io });
+
+    expect(main.project.root).toBe("/repo");
+    expect(linked.project.root).toBe("/worktrees/feature");
+    expect(main.project.identitySource).toBe("git-common-dir");
+    expect(linked.project.identitySource).toBe("git-common-dir");
+    expect(linked.project.identityKey).toBe(main.project.identityKey);
+    expect(main.git.repository).toBe(true);
+    expect(linked.git.repository).toBe(true);
+    expect(calls).toContainEqual(
+      expect.objectContaining({
+        executable: "/usr/bin/git",
+        argv: ["-C", "/repo", "rev-parse", "--show-toplevel"],
+      }),
+    );
+    expect(calls.every((call) => Array.isArray(call.argv))).toBe(true);
+  });
+
+  it("uses canonical realpath identity without Git or a config file", async () => {
+    const { io } = createFakeIo({
+      realpath: (path) => (path === "/alias/project" ? "/actual/project" : path),
+      isExecutable: (path) => (path === "/bin/zsh" ? "available" : "missing"),
+    });
+
+    const probe = await probeProjectReadiness("/alias/project", { io });
+
+    expect(probe.project).toMatchObject({
+      root: "/actual/project",
+      name: "project",
+      identitySource: "canonical-realpath",
+      exists: true,
+      isDirectory: true,
+    });
+    expect(probe.project.identityKey).toMatch(/^path-[a-f0-9]{64}$/u);
+    expect(probe.harnesses.map((harness) => harness.installation)).toEqual([
+      "missing",
+      "missing",
+      "missing",
+    ]);
+  });
+
+  it("gives symlink aliases one canonical non-Git identity", async () => {
+    const { io } = createFakeIo({
+      realpath: (path) => (path === "/alias-a" || path === "/alias-b" ? "/actual/project" : path),
+      isExecutable: (path) => (path === "/bin/zsh" ? "available" : "missing"),
+    });
+
+    const left = await probeProjectReadiness("/alias-a", { io });
+    const right = await probeProjectReadiness("/alias-b", { io });
+
+    expect(left.project.root).toBe("/actual/project");
+    expect(right.project.root).toBe("/actual/project");
+    expect(left.project.identityKey).toBe(right.project.identityKey);
+  });
+
+  it("blocks missing and malformed canonical paths without fabricating identity", async () => {
+    const missingIo = createFakeIo({ inspectPath: () => "missing" }).io;
+    const malformedIo = createFakeIo({ realpath: () => "/bad\npath" }).io;
+
+    const missing = await assessProjectReadiness("/missing", { io: missingIo });
+    const malformed = await assessProjectReadiness("/malformed", { io: malformedIo });
+
+    expect(missing.project).toMatchObject({ root: null, identityKey: null });
+    expect(missing.blockingIssues.map((issue) => issue.code)).toContain("PROJECT_NOT_FOUND");
+    expect(malformed.project).toMatchObject({ root: null, identityKey: null });
+    expect(malformed.blockingIssues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(["PROJECT_ROOT_UNRESOLVED", "PROJECT_IDENTITY_UNRESOLVED"]),
+    );
+    expect(malformed.recommendedLaunchPlan.configRequired).toBe(false);
+  });
+
+  it("reports PATH-dependent tools as unknown while retaining an absolute shell fallback", async () => {
+    const { io, calls } = createFakeIo({
+      environment: {},
+      isExecutable: (path) => (path === "/bin/sh" ? "available" : "unknown"),
+    });
+
+    const probe = await probeProjectReadiness("/project", { io });
+
+    expect(probe.git.availability).toBe("unknown");
+    expect(probe.tmux.availability).toBe("unknown");
+    expect(probe.shell).toMatchObject({ availability: "available", command: ["/bin/sh"] });
+    expect(probe.harnesses.map((harness) => harness.installation)).toEqual([
+      "unknown",
+      "unknown",
+      "unknown",
+    ]);
+    expect(calls).toEqual([]);
+  });
+
+  it("keeps built-in harnesses in Codex, Claude Code, OpenCode order", async () => {
+    const { io } = createFakeIo();
+    const result = await assessProjectReadiness("/project", {
+      io,
+      authentication: { codex: "ready", claude: "ready", opencode: "ready" },
+    });
+
+    expect(result.harnesses.map(({ id, version }) => [id, version])).toEqual([
+      ["shell", null],
+      ["codex", "codex 1.0.0"],
+      ["claude", "claude 1.0.0"],
+      ["opencode", "opencode 1.0.0"],
+    ]);
+    expect(result.recommendedLaunchPlan.selectedHarnessId).toBe("codex");
+    expect(result.recommendedLaunchPlan.configRequired).toBe(false);
+  });
+
+  it("preserves custom argv and never executes the custom launch command", async () => {
+    const { io, calls } = createFakeIo({
+      isExecutable: (path) =>
+        path === "/opt/bin/acme-agent" ||
+        [
+          "/usr/bin/git",
+          "/usr/bin/tmux",
+          "/opt/bin/codex",
+          "/opt/bin/claude",
+          "/opt/bin/opencode",
+          "/bin/zsh",
+        ].includes(path)
+          ? "available"
+          : "missing",
+    });
+
+    const result = await assessProjectReadiness("/project", {
+      io,
+      preferredHarnessId: "acme",
+      customHarnesses: [
+        {
+          id: "acme",
+          label: "Acme Agent",
+          command: ["acme-agent", "run", "--interactive"],
+          authentication: "not-required",
+          commandReadiness: "ready",
+          version: "4.2.0",
+        },
+      ],
+    });
+
+    const custom = result.harnesses.find((harness) => harness.id === "acme");
+    expect(custom).toMatchObject({
+      command: ["acme-agent", "run", "--interactive"],
+      version: "4.2.0",
+      usable: true,
+    });
+    expect(result.recommendedLaunchPlan.selectedHarnessId).toBe("acme");
+    expect(calls.some((call) => call.executable.endsWith("/acme-agent"))).toBe(false);
+    expect(calls.every((call) => !call.argv.includes("login"))).toBe(true);
+  });
+
+  it("times out hanging probes and treats failures/authentication conservatively", async () => {
+    const { io, calls } = createFakeIo({
+      runCommand: async (call) => {
+        if (call.executable.endsWith("/codex")) {
+          return new Promise<ReadinessCommandResult>(() => {});
+        }
+        if (call.executable.endsWith("/claude")) {
+          return { status: "failure", stderr: "version unavailable", exitCode: 1 };
+        }
+        return defaultCommand(call);
+      },
+    });
+
+    const started = Date.now();
+    const probe = await probeProjectReadiness("/project", { io, timeoutMs: 10 });
+
+    expect(Date.now() - started).toBeLessThan(1_000);
+    expect(
+      probe.harnesses.map(({ id, commandReadiness, authentication }) => ({
+        id,
+        commandReadiness,
+        authentication,
+      })),
+    ).toEqual([
+      { id: "codex", commandReadiness: "unknown", authentication: "unknown" },
+      { id: "claude", commandReadiness: "unknown", authentication: "unknown" },
+      { id: "opencode", commandReadiness: "ready", authentication: "unknown" },
+    ]);
+    expect(calls.every((call) => !call.argv.some((arg) => /auth|login/iu.test(arg)))).toBe(true);
+    expect(calls.every((call) => call.options.timeoutMs === 10)).toBe(true);
+  });
+
+  it("normalizes a missing registered folder to stale without running project commands", async () => {
+    const { io, calls } = createFakeIo({ inspectPath: () => "missing" });
+
+    const probe = await probeProjectReadiness("/moved", { io, registration: "current" });
+
+    expect(probe.project.registration).toBe("stale");
+    expect(probe.project.root).toBeNull();
+    expect(calls.some((call) => call.argv.includes("--is-inside-work-tree"))).toBe(false);
+  });
+});

--- a/packages/daemon/src/lib/__tests__/project-readiness.test.ts
+++ b/packages/daemon/src/lib/__tests__/project-readiness.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { classifyProjectReadiness as publicClassifyProjectReadiness } from "../../index.ts";
+import {
+  classifyProjectReadiness as publicClassifyProjectReadiness,
+  type ProjectReadinessProbe as PublicProjectReadinessProbe,
+} from "../../index.ts";
 import {
   classifyProjectReadiness,
   type ProjectReadinessHarnessProbe,
@@ -48,9 +51,66 @@ function issueCodes(result: ReturnType<typeof classifyProjectReadiness>): string
   return result.issues.map((issue) => issue.code);
 }
 
+function legacyPublicProbe(
+  projectOverrides: Partial<PublicProjectReadinessProbe["project"]> = {},
+): PublicProjectReadinessProbe {
+  return {
+    project: {
+      requestedPath: "/work/legacy",
+      root: "/work/legacy",
+      name: "legacy",
+      identityKey: "legacy-identity",
+      identitySource: "canonical-realpath",
+      exists: true,
+      isDirectory: true,
+      registration: "unregistered",
+      ...projectOverrides,
+    },
+    platform: { os: "darwin", arch: "arm64" },
+    git: { availability: "available", version: "2.50.0", repository: true },
+    tmux: { availability: "available", version: "3.5a" },
+    shell: { availability: "available", command: ["/bin/zsh"] },
+    harnesses: [harness()],
+  };
+}
+
 describe("classifyProjectReadiness", () => {
   it("is exported through the public daemon package entry point", () => {
     expect(publicClassifyProjectReadiness).toBe(classifyProjectReadiness);
+  });
+
+  it("normalizes pre-pathKind public probe shapes without changing legacy readiness", () => {
+    const ready = publicClassifyProjectReadiness(legacyPublicProbe());
+    const missing = publicClassifyProjectReadiness(
+      legacyPublicProbe({
+        root: null,
+        name: null,
+        identityKey: null,
+        identitySource: null,
+        exists: false,
+        isDirectory: false,
+      }),
+    );
+    const file = publicClassifyProjectReadiness(
+      legacyPublicProbe({
+        root: null,
+        identityKey: null,
+        identitySource: null,
+        exists: true,
+        isDirectory: false,
+      }),
+    );
+
+    expect(ready).toMatchObject({
+      status: "ready",
+      canLaunch: true,
+      project: { pathKind: "directory" },
+      recommendedLaunchPlan: { mode: "agent-workbench" },
+    });
+    expect(missing.project.pathKind).toBe("missing");
+    expect(issueCodes(missing)).toContain("PROJECT_NOT_FOUND");
+    expect(file.project.pathKind).toBe("other");
+    expect(issueCodes(file)).toContain("PROJECT_NOT_DIRECTORY");
   });
 
   it("classifies a clean project and recommends a config-free agent workbench", () => {

--- a/packages/daemon/src/lib/__tests__/project-readiness.test.ts
+++ b/packages/daemon/src/lib/__tests__/project-readiness.test.ts
@@ -30,6 +30,7 @@ function cleanProbe(overrides: Partial<ProjectReadinessProbe> = {}): ProjectRead
       name: "tmux-ide",
       identityKey: "git-a1b2c3",
       identitySource: "git-common-dir",
+      pathKind: "directory",
       exists: true,
       isDirectory: true,
       registration: "current",
@@ -63,6 +64,7 @@ describe("classifyProjectReadiness", () => {
       name: "tmux-ide",
       identityKey: "git-a1b2c3",
       identitySource: "git-common-dir",
+      pathKind: "directory",
       registration: "current",
     });
     expect(result.capabilities).toEqual({
@@ -347,6 +349,7 @@ describe("classifyProjectReadiness", () => {
         project: {
           ...cleanProbe().project,
           root: null,
+          pathKind: "missing",
           exists: false,
           isDirectory: false,
           registration: "stale",
@@ -361,6 +364,7 @@ describe("classifyProjectReadiness", () => {
           name: null,
           identityKey: null,
           identitySource: null,
+          pathKind: "missing",
           exists: false,
           isDirectory: false,
           registration: "unregistered",
@@ -390,7 +394,9 @@ describe("classifyProjectReadiness", () => {
 
   it("blocks a file path and supplies a directory recovery action", () => {
     const result = classifyProjectReadiness(
-      cleanProbe({ project: { ...cleanProbe().project, isDirectory: false } }),
+      cleanProbe({
+        project: { ...cleanProbe().project, pathKind: "other", isDirectory: false },
+      }),
     );
 
     expect(result.canLaunch).toBe(false);
@@ -424,6 +430,7 @@ describe("classifyProjectReadiness", () => {
       cleanProbe({
         project: {
           ...cleanProbe().project,
+          pathKind: "missing",
           exists: false,
           isDirectory: false,
           registration: "stale",

--- a/packages/daemon/src/lib/project-readiness-probe.ts
+++ b/packages/daemon/src/lib/project-readiness-probe.ts
@@ -17,6 +17,7 @@ import {
   type ProjectReadinessHarnessProbe,
   type ProjectReadinessProbe,
   type ProjectReadinessResult,
+  type ProjectPathKind,
   type ProjectRegistrationState,
 } from "./project-readiness.ts";
 import { sanitizeName } from "./project-probe.ts";
@@ -26,7 +27,8 @@ const DEFAULT_TIMEOUT_MS = 2_000;
 const MAX_TIMEOUT_MS = 30_000;
 const MAX_OUTPUT_BYTES = 64 * 1024;
 
-export type ReadinessPathKind = "directory" | "other" | "missing" | "unknown";
+export type ReadinessPathKind = ProjectPathKind;
+export type ReadinessExecutableKind = "file" | "other" | "missing" | "unknown";
 
 export type ReadinessCommandStatus = "success" | "failure" | "timeout" | "not-found" | "unknown";
 
@@ -50,6 +52,7 @@ export interface ProjectReadinessProbeIo {
   inspectPath(path: string): ReadinessPathKind;
   exists(path: string): boolean;
   realpath(path: string): string;
+  inspectExecutable(path: string): ReadinessExecutableKind;
   isExecutable(path: string): Availability;
   runCommand(
     executable: string,
@@ -61,7 +64,7 @@ export interface ProjectReadinessProbeIo {
 export interface CustomReadinessHarnessProfile {
   id: string;
   label: string;
-  /** Launch argv is preserved for the plan but never executed by this probe. */
+  /** Args are preserved; a verified executable is canonicalized and never launched by this probe. */
   command: readonly string[];
   source?: "workspace" | "user";
   authentication?: AuthenticationReadiness;
@@ -148,6 +151,14 @@ const defaultIo: ProjectReadinessProbeIo = {
   },
   exists: existsSync,
   realpath: realpathSync,
+  inspectExecutable: (path) => {
+    try {
+      return statSync(path).isFile() ? "file" : "other";
+    } catch (error) {
+      const code = errorCode(error);
+      return code === "ENOENT" || code === "ENOTDIR" ? "missing" : "unknown";
+    }
+  },
   isExecutable: (path) => {
     try {
       accessSync(path, constants.X_OK);
@@ -267,20 +278,40 @@ function canonicalExecutable(path: string, io: ProjectReadinessProbeIo): string 
   return isValidAbsolutePath(canonical) ? canonical : path;
 }
 
+function hasValidExecutableToken(executable: string): boolean {
+  return (
+    executable.length > 0 &&
+    executable === executable.trim() &&
+    !executable.includes("\0") &&
+    !/[\r\n]/u.test(executable)
+  );
+}
+
+function inspectExecutableCandidate(path: string, io: ProjectReadinessProbeIo): Availability {
+  const kind = safeCall(() => io.inspectExecutable(path), "unknown" as const);
+  if (kind === "missing" || kind === "other") return "missing";
+  if (kind === "unknown") return "unknown";
+  return safeCall(() => io.isExecutable(path), "unknown" as Availability);
+}
+
 function locateExecutable(
   executable: string,
   cwd: string,
   environment: Readonly<NodeJS.ProcessEnv>,
   io: ProjectReadinessProbeIo,
 ): LocatedExecutable {
-  const clean = executable.trim();
-  if (clean.length === 0 || clean.includes("\0") || /[\r\n]/u.test(clean)) {
+  if (!hasValidExecutableToken(executable)) {
     return { availability: "missing", path: null };
   }
 
-  if (isAbsolute(clean) || clean.includes(sep) || clean.includes("/") || clean.includes("\\")) {
-    const candidate = isAbsolute(clean) ? clean : resolve(cwd, clean);
-    const availability = safeCall(() => io.isExecutable(candidate), "unknown" as Availability);
+  if (
+    isAbsolute(executable) ||
+    executable.includes(sep) ||
+    executable.includes("/") ||
+    executable.includes("\\")
+  ) {
+    const candidate = isAbsolute(executable) ? executable : resolve(cwd, executable);
+    const availability = inspectExecutableCandidate(candidate, io);
     return {
       availability,
       path: availability === "available" ? canonicalExecutable(candidate, io) : null,
@@ -291,9 +322,11 @@ function locateExecutable(
   if (pathValue === null) return { availability: "unknown", path: null };
   let sawUnknown = false;
   for (const entry of pathValue.split(delimiter)) {
-    if (entry.trim().length === 0) continue;
-    const candidate = resolve(entry, clean);
-    const availability = safeCall(() => io.isExecutable(candidate), "unknown" as Availability);
+    // Empty PATH entries are intentionally ignored instead of meaning cwd.
+    if (entry.length === 0) continue;
+    const directory = isAbsolute(entry) ? entry : resolve(cwd, entry);
+    const candidate = resolve(directory, executable);
+    const availability = inspectExecutableCandidate(candidate, io);
     if (availability === "available") {
       return { availability, path: canonicalExecutable(candidate, io) };
     }
@@ -305,9 +338,17 @@ function locateExecutable(
 function versionFrom(result: ReadinessCommandResult): string | null {
   if (result.status !== "success") return null;
   const line = (result.stdout ?? "")
-    .replaceAll("\0", "")
     .split(/\r?\n/u)
-    .map((part) => part.trim())
+    .map((part) =>
+      [...part]
+        .map((character) => {
+          const code = character.codePointAt(0) ?? 0;
+          return code <= 31 || code === 127 ? " " : character;
+        })
+        .join("")
+        .replace(/\s+/gu, " ")
+        .trim(),
+    )
     .find((part) => part.length > 0);
   return line ? line.slice(0, 256) : null;
 }
@@ -350,22 +391,24 @@ async function probeHarness(
   environment: Readonly<NodeJS.ProcessEnv>,
   commandOptions: ReadinessCommandOptions,
 ): Promise<ProjectReadinessHarnessProbe> {
-  const executable = spec.command[0]?.trim() ?? "";
+  const executable = spec.command[0] ?? "";
+  const executableValid = hasValidExecutableToken(executable);
   const located = locateExecutable(executable, cwd, environment, io);
   const versionProbe =
     spec.versionArgv === null
       ? { version: spec.declaredVersion ?? null, commandReadiness: "unknown" as const }
       : await probeVersion(io, located, spec.versionArgv, commandOptions);
-  const commandReadiness =
-    executable.length === 0
-      ? "invalid"
-      : (spec.declaredCommandReadiness ?? versionProbe.commandReadiness);
+  const commandReadiness = !executableValid
+    ? "invalid"
+    : (spec.declaredCommandReadiness ?? versionProbe.commandReadiness);
+  const command = [...spec.command];
+  if (located.availability === "available" && located.path !== null) command[0] = located.path;
 
   return {
     id: spec.id,
     kind: spec.kind,
     label: spec.label,
-    command: [...spec.command],
+    command,
     installation: located.availability,
     commandReadiness,
     authentication: spec.authentication,
@@ -416,8 +459,15 @@ export async function probeProjectReadiness(
   const shellCommand =
     options.shellCommand && options.shellCommand.length > 0
       ? [...options.shellCommand]
-      : [environment.SHELL?.trim() || "/bin/sh"];
+      : [
+          typeof environment.SHELL === "string" && environment.SHELL.length > 0
+            ? environment.SHELL
+            : "/bin/sh",
+        ];
   const shellLocated = locateExecutable(shellCommand[0] ?? "", commandCwd, environment, io);
+  if (shellLocated.availability === "available" && shellLocated.path !== null) {
+    shellCommand[0] = shellLocated.path;
+  }
 
   const gitRun = async (argv: readonly string[], cwd: string): Promise<ReadinessCommandResult> => {
     if (gitLocated.availability !== "available" || gitLocated.path === null) {
@@ -482,6 +532,10 @@ export async function probeProjectReadiness(
   const requestedRegistration = options.registration ?? "unregistered";
   const registration =
     pathKind === "missing" && requestedRegistration === "current" ? "stale" : requestedRegistration;
+  const tmuxAvailability =
+    tmuxLocated.availability === "available" && tmuxVersion.commandReadiness !== "ready"
+      ? "unknown"
+      : tmuxLocated.availability;
 
   return {
     project: {
@@ -490,6 +544,7 @@ export async function probeProjectReadiness(
       name: sanitizedName || "project",
       identityKey,
       identitySource,
+      pathKind,
       exists,
       isDirectory,
       registration,
@@ -501,7 +556,7 @@ export async function probeProjectReadiness(
       repository,
     },
     tmux: {
-      availability: tmuxLocated.availability,
+      availability: tmuxAvailability,
       version: tmuxVersion.version,
     },
     shell: {

--- a/packages/daemon/src/lib/project-readiness-probe.ts
+++ b/packages/daemon/src/lib/project-readiness-probe.ts
@@ -1,0 +1,523 @@
+/**
+ * Read-only, bounded adapter for the pure project-readiness classifier.
+ *
+ * Every effect is injectable. Built-in commands are probed only with known
+ * version/read-only argv; custom harness launch argv are never executed.
+ */
+
+import { execFile } from "node:child_process";
+import { accessSync, constants, existsSync, realpathSync, statSync } from "node:fs";
+import { delimiter, isAbsolute, basename, resolve, sep } from "node:path";
+import {
+  classifyProjectReadiness,
+  type AuthenticationReadiness,
+  type Availability,
+  type CommandReadiness,
+  type HarnessKind,
+  type ProjectReadinessHarnessProbe,
+  type ProjectReadinessProbe,
+  type ProjectReadinessResult,
+  type ProjectRegistrationState,
+} from "./project-readiness.ts";
+import { sanitizeName } from "./project-probe.ts";
+import { resolveProject } from "./project-resolver.ts";
+
+const DEFAULT_TIMEOUT_MS = 2_000;
+const MAX_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_BYTES = 64 * 1024;
+
+export type ReadinessPathKind = "directory" | "other" | "missing" | "unknown";
+
+export type ReadinessCommandStatus = "success" | "failure" | "timeout" | "not-found" | "unknown";
+
+export interface ReadinessCommandResult {
+  status: ReadinessCommandStatus;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+}
+
+export interface ReadinessCommandOptions {
+  cwd: string;
+  env: Readonly<NodeJS.ProcessEnv>;
+  timeoutMs: number;
+}
+
+export interface ProjectReadinessProbeIo {
+  cwd(): string;
+  environment(): Readonly<NodeJS.ProcessEnv>;
+  platform(): { os: NodeJS.Platform; arch: string };
+  inspectPath(path: string): ReadinessPathKind;
+  exists(path: string): boolean;
+  realpath(path: string): string;
+  isExecutable(path: string): Availability;
+  runCommand(
+    executable: string,
+    argv: readonly string[],
+    options: ReadinessCommandOptions,
+  ): Promise<ReadinessCommandResult>;
+}
+
+export interface CustomReadinessHarnessProfile {
+  id: string;
+  label: string;
+  /** Launch argv is preserved for the plan but never executed by this probe. */
+  command: readonly string[];
+  source?: "workspace" | "user";
+  authentication?: AuthenticationReadiness;
+  commandReadiness?: CommandReadiness;
+  version?: string | null;
+}
+
+export interface ProjectReadinessProbeOptions {
+  io?: Partial<ProjectReadinessProbeIo>;
+  timeoutMs?: number;
+  registration?: ProjectRegistrationState;
+  projectRootHint?: string | null;
+  shellCommand?: readonly string[];
+  customHarnesses?: readonly CustomReadinessHarnessProfile[];
+  preferredHarnessId?: string | null;
+  /** Trusted facts from a separate, non-interactive credential surface. */
+  authentication?: Readonly<Record<string, AuthenticationReadiness | undefined>>;
+}
+
+interface LocatedExecutable {
+  availability: Availability;
+  path: string | null;
+}
+
+interface HarnessSpec {
+  id: string;
+  kind: HarnessKind;
+  label: string;
+  command: readonly string[];
+  source: "detected" | "workspace" | "user";
+  versionArgv: readonly string[] | null;
+  authentication: AuthenticationReadiness;
+  declaredCommandReadiness?: CommandReadiness;
+  declaredVersion?: string | null;
+}
+
+const BUILTIN_HARNESSES: readonly Omit<
+  HarnessSpec,
+  "authentication" | "declaredCommandReadiness" | "declaredVersion"
+>[] = [
+  {
+    id: "codex",
+    kind: "codex",
+    label: "Codex",
+    command: ["codex"],
+    source: "detected",
+    versionArgv: ["--version"],
+  },
+  {
+    id: "claude",
+    kind: "claude",
+    label: "Claude Code",
+    command: ["claude"],
+    source: "detected",
+    versionArgv: ["--version"],
+  },
+  {
+    id: "opencode",
+    kind: "opencode",
+    label: "OpenCode",
+    command: ["opencode"],
+    source: "detected",
+    versionArgv: ["--version"],
+  },
+];
+
+function errorCode(error: unknown): string | number | undefined {
+  if (!error || typeof error !== "object" || !("code" in error)) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" || typeof code === "number" ? code : undefined;
+}
+
+const defaultIo: ProjectReadinessProbeIo = {
+  cwd: () => process.cwd(),
+  environment: () => process.env,
+  platform: () => ({ os: process.platform, arch: process.arch }),
+  inspectPath: (path) => {
+    try {
+      return statSync(path).isDirectory() ? "directory" : "other";
+    } catch (error) {
+      const code = errorCode(error);
+      return code === "ENOENT" || code === "ENOTDIR" ? "missing" : "unknown";
+    }
+  },
+  exists: existsSync,
+  realpath: realpathSync,
+  isExecutable: (path) => {
+    try {
+      accessSync(path, constants.X_OK);
+      return "available";
+    } catch (error) {
+      const code = errorCode(error);
+      return code === "ENOENT" || code === "ENOTDIR" || code === "EACCES" ? "missing" : "unknown";
+    }
+  },
+  runCommand: (executable, argv, options) =>
+    new Promise((resolveResult) => {
+      execFile(
+        executable,
+        [...argv],
+        {
+          cwd: options.cwd,
+          env: { ...options.env },
+          encoding: "utf-8",
+          maxBuffer: MAX_OUTPUT_BYTES,
+          timeout: options.timeoutMs,
+          windowsHide: true,
+        },
+        (error, stdout, stderr) => {
+          if (!error) {
+            resolveResult({ status: "success", stdout, stderr, exitCode: 0 });
+            return;
+          }
+          const code = errorCode(error);
+          if (code === "ENOENT") {
+            resolveResult({ status: "not-found", stdout, stderr, exitCode: null });
+            return;
+          }
+          if (code === "ETIMEDOUT" || ("killed" in error && error.killed)) {
+            resolveResult({ status: "timeout", stdout, stderr, exitCode: null });
+            return;
+          }
+          resolveResult({
+            status: "failure",
+            stdout,
+            stderr,
+            exitCode: typeof code === "number" ? code : null,
+          });
+        },
+      );
+    }),
+};
+
+function normalizeTimeout(timeoutMs: number | undefined): number {
+  if (timeoutMs === undefined || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  return Math.min(Math.floor(timeoutMs), MAX_TIMEOUT_MS);
+}
+
+function safeCall<T>(operation: () => T, fallback: T): T {
+  try {
+    return operation();
+  } catch {
+    return fallback;
+  }
+}
+
+function isValidAbsolutePath(path: string): boolean {
+  return (
+    isAbsolute(path) && path.trim().length > 0 && !path.includes("\0") && !/[\r\n]/u.test(path)
+  );
+}
+
+function normalizeCommandResult(value: unknown): ReadinessCommandResult {
+  if (!value || typeof value !== "object" || !("status" in value)) {
+    return { status: "unknown" };
+  }
+  const candidate = value as ReadinessCommandResult;
+  if (!["success", "failure", "timeout", "not-found", "unknown"].includes(candidate.status)) {
+    return { status: "unknown" };
+  }
+  return {
+    status: candidate.status,
+    stdout: typeof candidate.stdout === "string" ? candidate.stdout : undefined,
+    stderr: typeof candidate.stderr === "string" ? candidate.stderr : undefined,
+    exitCode:
+      typeof candidate.exitCode === "number" || candidate.exitCode === null
+        ? candidate.exitCode
+        : undefined,
+  };
+}
+
+async function runBounded(
+  io: ProjectReadinessProbeIo,
+  executable: string,
+  argv: readonly string[],
+  options: ReadinessCommandOptions,
+): Promise<ReadinessCommandResult> {
+  return new Promise((resolveResult) => {
+    let settled = false;
+    const settle = (result: ReadinessCommandResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveResult(result);
+    };
+    const timer = setTimeout(() => settle({ status: "timeout" }), options.timeoutMs);
+    void Promise.resolve()
+      .then(() => io.runCommand(executable, [...argv], options))
+      .then((result) => settle(normalizeCommandResult(result)))
+      .catch(() => settle({ status: "unknown" }));
+  });
+}
+
+function environmentPath(environment: Readonly<NodeJS.ProcessEnv>): string | null {
+  const value = environment.PATH ?? environment.Path ?? environment.path;
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function canonicalExecutable(path: string, io: ProjectReadinessProbeIo): string {
+  const canonical = safeCall(() => io.realpath(path), path);
+  return isValidAbsolutePath(canonical) ? canonical : path;
+}
+
+function locateExecutable(
+  executable: string,
+  cwd: string,
+  environment: Readonly<NodeJS.ProcessEnv>,
+  io: ProjectReadinessProbeIo,
+): LocatedExecutable {
+  const clean = executable.trim();
+  if (clean.length === 0 || clean.includes("\0") || /[\r\n]/u.test(clean)) {
+    return { availability: "missing", path: null };
+  }
+
+  if (isAbsolute(clean) || clean.includes(sep) || clean.includes("/") || clean.includes("\\")) {
+    const candidate = isAbsolute(clean) ? clean : resolve(cwd, clean);
+    const availability = safeCall(() => io.isExecutable(candidate), "unknown" as Availability);
+    return {
+      availability,
+      path: availability === "available" ? canonicalExecutable(candidate, io) : null,
+    };
+  }
+
+  const pathValue = environmentPath(environment);
+  if (pathValue === null) return { availability: "unknown", path: null };
+  let sawUnknown = false;
+  for (const entry of pathValue.split(delimiter)) {
+    if (entry.trim().length === 0) continue;
+    const candidate = resolve(entry, clean);
+    const availability = safeCall(() => io.isExecutable(candidate), "unknown" as Availability);
+    if (availability === "available") {
+      return { availability, path: canonicalExecutable(candidate, io) };
+    }
+    if (availability === "unknown") sawUnknown = true;
+  }
+  return { availability: sawUnknown ? "unknown" : "missing", path: null };
+}
+
+function versionFrom(result: ReadinessCommandResult): string | null {
+  if (result.status !== "success") return null;
+  const line = (result.stdout ?? "")
+    .replaceAll("\0", "")
+    .split(/\r?\n/u)
+    .map((part) => part.trim())
+    .find((part) => part.length > 0);
+  return line ? line.slice(0, 256) : null;
+}
+
+async function probeVersion(
+  io: ProjectReadinessProbeIo,
+  located: LocatedExecutable,
+  argv: readonly string[],
+  commandOptions: ReadinessCommandOptions,
+): Promise<{ version: string | null; commandReadiness: CommandReadiness }> {
+  if (located.availability !== "available" || located.path === null) {
+    return { version: null, commandReadiness: "unknown" };
+  }
+  const result = await runBounded(io, located.path, argv, commandOptions);
+  const version = versionFrom(result);
+  return {
+    version,
+    commandReadiness: result.status === "success" && version !== null ? "ready" : "unknown",
+  };
+}
+
+function customHarnessSpecs(profiles: readonly CustomReadinessHarnessProfile[]): HarnessSpec[] {
+  return profiles.map((profile) => ({
+    id: profile.id,
+    kind: "custom",
+    label: profile.label,
+    command: [...profile.command],
+    source: profile.source ?? "user",
+    versionArgv: null,
+    authentication: profile.authentication ?? "unknown",
+    declaredCommandReadiness: profile.commandReadiness,
+    declaredVersion: profile.version,
+  }));
+}
+
+async function probeHarness(
+  spec: HarnessSpec,
+  io: ProjectReadinessProbeIo,
+  cwd: string,
+  environment: Readonly<NodeJS.ProcessEnv>,
+  commandOptions: ReadinessCommandOptions,
+): Promise<ProjectReadinessHarnessProbe> {
+  const executable = spec.command[0]?.trim() ?? "";
+  const located = locateExecutable(executable, cwd, environment, io);
+  const versionProbe =
+    spec.versionArgv === null
+      ? { version: spec.declaredVersion ?? null, commandReadiness: "unknown" as const }
+      : await probeVersion(io, located, spec.versionArgv, commandOptions);
+  const commandReadiness =
+    executable.length === 0
+      ? "invalid"
+      : (spec.declaredCommandReadiness ?? versionProbe.commandReadiness);
+
+  return {
+    id: spec.id,
+    kind: spec.kind,
+    label: spec.label,
+    command: [...spec.command],
+    installation: located.availability,
+    commandReadiness,
+    authentication: spec.authentication,
+    source: spec.source,
+    version: located.availability === "available" ? versionProbe.version : null,
+  };
+}
+
+function nonRepositoryFailure(result: ReadinessCommandResult): boolean {
+  if (result.status !== "failure") return false;
+  const output = `${result.stderr ?? ""}\n${result.stdout ?? ""}`.toLowerCase();
+  return output.includes("not a git repository") || output.includes("not a work tree");
+}
+
+/** Build normalized, conservative facts for the pure readiness classifier. */
+export async function probeProjectReadiness(
+  requestedPath: string,
+  options: ProjectReadinessProbeOptions = {},
+): Promise<ProjectReadinessProbe> {
+  const io: ProjectReadinessProbeIo = { ...defaultIo, ...options.io };
+  const timeoutMs = normalizeTimeout(options.timeoutMs);
+  const environment = safeCall(() => io.environment(), {} as Readonly<NodeJS.ProcessEnv>);
+  const platform = safeCall(() => io.platform(), {
+    os: process.platform,
+    arch: process.arch,
+  } as const);
+  const baseCwd = safeCall(() => io.cwd(), process.cwd());
+  const absoluteRequestedPath = isAbsolute(requestedPath)
+    ? requestedPath
+    : resolve(baseCwd, requestedPath);
+  const pathKind = safeCall(() => io.inspectPath(absoluteRequestedPath), "unknown" as const);
+  const exists = pathKind === "directory" || pathKind === "other";
+  const isDirectory = pathKind === "directory";
+  const canonicalInput = isDirectory
+    ? safeCall(() => io.realpath(absoluteRequestedPath), null as string | null)
+    : null;
+  const validCanonicalInput =
+    canonicalInput !== null && isValidAbsolutePath(canonicalInput) ? canonicalInput : null;
+  const commandCwd = validCanonicalInput ?? baseCwd;
+  const commandOptions: ReadinessCommandOptions = {
+    cwd: commandCwd,
+    env: environment,
+    timeoutMs,
+  };
+
+  const gitLocated = locateExecutable("git", commandCwd, environment, io);
+  const tmuxLocated = locateExecutable("tmux", commandCwd, environment, io);
+  const shellCommand =
+    options.shellCommand && options.shellCommand.length > 0
+      ? [...options.shellCommand]
+      : [environment.SHELL?.trim() || "/bin/sh"];
+  const shellLocated = locateExecutable(shellCommand[0] ?? "", commandCwd, environment, io);
+
+  const gitRun = async (argv: readonly string[], cwd: string): Promise<ReadinessCommandResult> => {
+    if (gitLocated.availability !== "available" || gitLocated.path === null) {
+      return { status: gitLocated.availability === "missing" ? "not-found" : "unknown" };
+    }
+    return runBounded(io, gitLocated.path, ["-C", cwd, ...argv], {
+      ...commandOptions,
+      cwd,
+    });
+  };
+
+  let resolution: Awaited<ReturnType<typeof resolveProject>> | null = null;
+  if (validCanonicalInput !== null) {
+    try {
+      resolution = await resolveProject(validCanonicalInput, {
+        projectRootHint: options.projectRootHint,
+        io: {
+          exists: (path) => safeCall(() => io.exists(path), false),
+          realpath: (path) => io.realpath(path),
+          runGit: async (args, cwd) => {
+            const result = await gitRun(args, cwd);
+            return result.status === "success" ? (result.stdout ?? "").trim() || null : null;
+          },
+        },
+      });
+    } catch {
+      resolution = null;
+    }
+  }
+
+  const validResolution =
+    resolution !== null && isValidAbsolutePath(resolution.projectRoot) ? resolution : null;
+  const projectRoot = validResolution?.projectRoot ?? null;
+  const identityKey = validResolution?.identityKey ?? null;
+  const identitySource = validResolution?.identitySource ?? null;
+  const projectNameSource = projectRoot ?? validCanonicalInput ?? absoluteRequestedPath;
+  const sanitizedName = sanitizeName(basename(projectNameSource));
+
+  const [gitVersion, tmuxVersion, repositoryResult, ...harnesses] = await Promise.all([
+    probeVersion(io, gitLocated, ["--version"], commandOptions),
+    probeVersion(io, tmuxLocated, ["-V"], commandOptions),
+    validCanonicalInput === null
+      ? Promise.resolve({ status: "unknown" } as ReadinessCommandResult)
+      : gitRun(["rev-parse", "--is-inside-work-tree"], validCanonicalInput),
+    ...[
+      ...BUILTIN_HARNESSES.map((spec) => ({
+        ...spec,
+        authentication: options.authentication?.[spec.id] ?? "unknown",
+      })),
+      ...customHarnessSpecs(options.customHarnesses ?? []),
+    ].map((spec) => probeHarness(spec, io, commandCwd, environment, commandOptions)),
+  ]);
+
+  let repository: boolean | null = null;
+  if (repositoryResult.status === "success") {
+    const output = (repositoryResult.stdout ?? "").trim().toLowerCase();
+    repository = output === "true" ? true : output === "false" ? false : null;
+  } else if (nonRepositoryFailure(repositoryResult)) {
+    repository = false;
+  }
+
+  const requestedRegistration = options.registration ?? "unregistered";
+  const registration =
+    pathKind === "missing" && requestedRegistration === "current" ? "stale" : requestedRegistration;
+
+  return {
+    project: {
+      requestedPath: absoluteRequestedPath,
+      root: projectRoot,
+      name: sanitizedName || "project",
+      identityKey,
+      identitySource,
+      exists,
+      isDirectory,
+      registration,
+    },
+    platform,
+    git: {
+      availability: gitLocated.availability,
+      version: gitVersion.version,
+      repository,
+    },
+    tmux: {
+      availability: tmuxLocated.availability,
+      version: tmuxVersion.version,
+    },
+    shell: {
+      availability: shellLocated.availability,
+      command: shellCommand,
+      version: null,
+    },
+    harnesses: harnesses as ProjectReadinessHarnessProbe[],
+    preferredHarnessId: options.preferredHarnessId,
+  };
+}
+
+/** Probe and classify in one public, read-only call. */
+export async function assessProjectReadiness(
+  requestedPath: string,
+  options: ProjectReadinessProbeOptions = {},
+): Promise<ProjectReadinessResult> {
+  return classifyProjectReadiness(await probeProjectReadiness(requestedPath, options));
+}

--- a/packages/daemon/src/lib/project-readiness.ts
+++ b/packages/daemon/src/lib/project-readiness.ts
@@ -60,6 +60,8 @@ export interface ProjectReadinessHarnessProbe {
   commandReadiness: CommandReadiness;
   authentication: AuthenticationReadiness;
   source: "detected" | "workspace" | "user";
+  /** Version reported by a read-only probe, when one completed successfully. */
+  version?: string | null;
   /** Optional recovery commands supplied by the effectful probe adapter. */
   installCommand?: readonly string[] | null;
   authCommand?: readonly string[] | null;
@@ -155,6 +157,7 @@ export interface ProjectHarnessReadiness {
   label: string;
   command: readonly string[];
   source: ProjectReadinessHarnessProbe["source"];
+  version: string | null;
   state: HarnessReadinessState;
   usable: boolean;
   agentCapable: boolean;
@@ -269,6 +272,7 @@ function classifyHarness(probe: ProjectReadinessHarnessProbe): ProjectHarnessRea
     label: probe.label,
     command: [...probe.command],
     source: probe.source,
+    version: probe.version ?? null,
     state,
     usable: state === "ready",
     agentCapable: probe.kind !== "shell",

--- a/packages/daemon/src/lib/project-readiness.ts
+++ b/packages/daemon/src/lib/project-readiness.ts
@@ -30,8 +30,8 @@ export interface ProjectReadinessProjectProbe {
    */
   identityKey: string | null;
   identitySource: "git-common-dir" | "canonical-realpath" | null;
-  /** Result of inspecting the requested path; `unknown` must never mean missing. */
-  pathKind: ProjectPathKind;
+  /** Result of inspecting the requested path; omitted by pre-pathKind callers. */
+  pathKind?: ProjectPathKind;
   exists: boolean;
   isDirectory: boolean;
   registration: ProjectRegistrationState;
@@ -502,14 +502,17 @@ function createLaunchPlan(
 export function classifyProjectReadiness(probe: ProjectReadinessProbe): ProjectReadinessResult {
   const state: MutableClassification = { issues: [], actions: [] };
   const platformSupported = SUPPORTED_PLATFORMS.has(probe.platform.os);
+  const projectPathKind: ProjectPathKind =
+    probe.project.pathKind ??
+    (probe.project.exists ? (probe.project.isDirectory ? "directory" : "other") : "missing");
   const projectDirectoryPresent =
-    probe.project.pathKind === "directory" && probe.project.exists && probe.project.isDirectory;
+    projectPathKind === "directory" && probe.project.exists && probe.project.isDirectory;
   const hasProjectRoot = probe.project.root !== null && probe.project.root.trim().length > 0;
   const hasIdentityKey =
     probe.project.identityKey !== null && probe.project.identityKey.trim().length > 0;
   const hasIdentitySource = probe.project.identitySource !== null;
 
-  if (probe.project.pathKind === "unknown") {
+  if (projectPathKind === "unknown") {
     addIssue(
       state,
       {
@@ -535,7 +538,7 @@ export function classifyProjectReadiness(probe: ProjectReadinessProbe): ProjectR
         },
       ],
     );
-  } else if (probe.project.pathKind === "missing") {
+  } else if (projectPathKind === "missing") {
     if (probe.project.registration === "stale") {
       addIssue(
         state,
@@ -582,7 +585,7 @@ export function classifyProjectReadiness(probe: ProjectReadinessProbe): ProjectR
         ],
       );
     }
-  } else if (probe.project.pathKind === "other") {
+  } else if (projectPathKind === "other") {
     addIssue(
       state,
       {
@@ -992,7 +995,7 @@ export function classifyProjectReadiness(probe: ProjectReadinessProbe): ProjectR
       name: probe.project.name,
       identityKey: probe.project.identityKey,
       identitySource: probe.project.identitySource,
-      pathKind: probe.project.pathKind,
+      pathKind: projectPathKind,
       registration: probe.project.registration,
     },
     capabilities: {

--- a/packages/daemon/src/lib/project-readiness.ts
+++ b/packages/daemon/src/lib/project-readiness.ts
@@ -12,6 +12,7 @@ export type Availability = "available" | "missing" | "unknown";
 export type CommandReadiness = "ready" | "invalid" | "unknown";
 export type AuthenticationReadiness = "ready" | "required" | "not-required" | "unknown";
 export type ProjectRegistrationState = "unregistered" | "current" | "stale";
+export type ProjectPathKind = "directory" | "other" | "missing" | "unknown";
 export type HarnessKind = "codex" | "claude" | "opencode" | "shell" | "custom";
 
 export interface ProjectReadinessProjectProbe {
@@ -29,6 +30,8 @@ export interface ProjectReadinessProjectProbe {
    */
   identityKey: string | null;
   identitySource: "git-common-dir" | "canonical-realpath" | null;
+  /** Result of inspecting the requested path; `unknown` must never mean missing. */
+  pathKind: ProjectPathKind;
   exists: boolean;
   isDirectory: boolean;
   registration: ProjectRegistrationState;
@@ -82,6 +85,7 @@ export type ProjectReadinessIssueSeverity = "blocking" | "recoverable";
 
 export type ProjectReadinessIssueCode =
   | "PROJECT_NOT_FOUND"
+  | "PROJECT_PATH_UNVERIFIED"
   | "PROJECT_NOT_DIRECTORY"
   | "PROJECT_REGISTRATION_STALE"
   | "PROJECT_ROOT_UNRESOLVED"
@@ -191,6 +195,7 @@ export interface ProjectReadinessResult {
     name: string | null;
     identityKey: string | null;
     identitySource: ProjectReadinessProjectProbe["identitySource"];
+    pathKind: ProjectPathKind;
     registration: ProjectRegistrationState;
   };
   capabilities: {
@@ -248,9 +253,20 @@ function commandOrNull(command: readonly string[] | null | undefined): readonly 
   return command && command.length > 0 ? [...command] : null;
 }
 
+function hasValidExecutableToken(command: readonly string[]): boolean {
+  const executable = command[0];
+  return (
+    executable !== undefined &&
+    executable.length > 0 &&
+    executable === executable.trim() &&
+    !executable.includes("\0") &&
+    !/[\r\n]/u.test(executable)
+  );
+}
+
 function classifyHarness(probe: ProjectReadinessHarnessProbe): ProjectHarnessReadiness {
   let state: HarnessReadinessState;
-  if (probe.command.length === 0 || probe.commandReadiness === "invalid") {
+  if (!hasValidExecutableToken(probe.command) || probe.commandReadiness === "invalid") {
     state = "command-invalid";
   } else if (probe.installation === "missing") {
     state = "install-required";
@@ -486,13 +502,40 @@ function createLaunchPlan(
 export function classifyProjectReadiness(probe: ProjectReadinessProbe): ProjectReadinessResult {
   const state: MutableClassification = { issues: [], actions: [] };
   const platformSupported = SUPPORTED_PLATFORMS.has(probe.platform.os);
-  const projectDirectoryPresent = probe.project.exists && probe.project.isDirectory;
+  const projectDirectoryPresent =
+    probe.project.pathKind === "directory" && probe.project.exists && probe.project.isDirectory;
   const hasProjectRoot = probe.project.root !== null && probe.project.root.trim().length > 0;
   const hasIdentityKey =
     probe.project.identityKey !== null && probe.project.identityKey.trim().length > 0;
   const hasIdentitySource = probe.project.identitySource !== null;
 
-  if (!probe.project.exists) {
+  if (probe.project.pathKind === "unknown") {
+    addIssue(
+      state,
+      {
+        code: "PROJECT_PATH_UNVERIFIED",
+        severity: "blocking",
+        message: `Project path could not be inspected: ${probe.project.requestedPath}`,
+        harnessId: null,
+      },
+      [
+        {
+          kind: "refresh-project",
+          label: "Check project path again",
+          target: "project",
+          harnessId: null,
+          command: null,
+        },
+        {
+          kind: "choose-project",
+          label: "Choose another project",
+          target: "project",
+          harnessId: null,
+          command: null,
+        },
+      ],
+    );
+  } else if (probe.project.pathKind === "missing") {
     if (probe.project.registration === "stale") {
       addIssue(
         state,
@@ -539,7 +582,7 @@ export function classifyProjectReadiness(probe: ProjectReadinessProbe): ProjectR
         ],
       );
     }
-  } else if (!probe.project.isDirectory) {
+  } else if (probe.project.pathKind === "other") {
     addIssue(
       state,
       {
@@ -715,7 +758,7 @@ export function classifyProjectReadiness(probe: ProjectReadinessProbe): ProjectR
     );
   }
 
-  const shellCommandInvalid = probe.shell.command.length === 0;
+  const shellCommandInvalid = !hasValidExecutableToken(probe.shell.command);
   if (shellCommandInvalid) {
     addIssue(
       state,
@@ -949,6 +992,7 @@ export function classifyProjectReadiness(probe: ProjectReadinessProbe): ProjectR
       name: probe.project.name,
       identityKey: probe.project.identityKey,
       identitySource: probe.project.identitySource,
+      pathKind: probe.project.pathKind,
       registration: probe.project.registration,
     },
     capabilities: {


### PR DESCRIPTION
## Summary
- add public probeProjectReadiness and assessProjectReadiness APIs over injected, bounded IO
- resolve real/canonical project paths and stable Git-common-dir or realpath identity
- probe Git, tmux, shell, Codex, Claude Code, OpenCode, and custom harness facts without launch/install/auth/config side effects
- preserve config-free agent-workbench or shell-only planning

## Production invariants
- only argv arrays are executed; shell/custom launch commands are never probed by running them
- tmux is ready only after a bounded, successful, non-empty `tmux -V` from a regular executable file
- checked executable identity exactly matches the launch-plan argv; padded executable tokens are rejected
- relative PATH entries resolve from the probed project cwd; empty entries are deliberately skipped
- missing, file, directory, and uninspectable/permission path states remain distinct
- auth defaults unknown unless trusted facts are supplied
- hanging injected runners time out without late state writes or unhandled rejection
- pre-existing public classifier callers may omit pathKind; result output is always normalized

## Validation
- focused readiness/probe suites: 36 passed
- full daemon: 2,124 tests passed
- full renderer: 87 tests, 62 snapshots
- full pnpm check passed
- repeated adversarial review with hostile injected IO: clean