### PR TITLE
feat(app): add durable window repository and command kernel

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -39,6 +39,7 @@ export {
   AppWindowService,
   type AppWindowRepositoryDiagnostic,
   type AppWindowRepositoryErrorCode,
+  type AppWindowServiceMigrationOptions,
   type AppWindowServiceOptions,
   type AppWindowWriterLockOptions,
   type ExecuteAppWindowCommandOptions,
@@ -53,6 +54,25 @@ export {
   type AppWindowCommand,
   type AppWindowKernelErrorCode,
 } from "./lib/app-window-kernel.ts";
+export {
+  CorruptRuntimeDocumentError,
+  MissingRuntimeDocumentError,
+  ProjectRuntimeRepository,
+  ProjectRuntimeRepositoryError,
+  ProjectRuntimeWriterLockTimeoutError,
+  RevisionConflictError,
+  createProjectRuntimeRepository,
+  openProjectRuntimeRepository,
+  type OpenProjectRuntimeRepositoryOptions,
+  type ProjectRuntimeDocument,
+  type ProjectRuntimeMetadata,
+  type ProjectRuntimeRepositoryOptions,
+  type ProjectRuntimeWriterLockOptions,
+  type RecoverDocumentOptions,
+  type RecoverDocumentResult,
+  type WriteDocumentOptions,
+  type WriteDocumentResult,
+} from "./lib/project-runtime-repository.ts";
 export {
   classifyProjectReadiness,
   type AuthenticationReadiness,

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -34,6 +34,26 @@ export {
   type MissionProjectionOptions,
 } from "./lib/mission-projections.ts";
 export {
+  APP_WINDOW_DOCUMENT_PATH,
+  AppWindowRepositoryError,
+  AppWindowService,
+  type AppWindowRepositoryDiagnostic,
+  type AppWindowRepositoryErrorCode,
+  type AppWindowServiceOptions,
+  type AppWindowWriterLockOptions,
+  type ExecuteAppWindowCommandOptions,
+  type LoadedAppWindowDocument,
+  type ResetAppWindowDocumentRequest,
+  type ResetAppWindowDocumentResult,
+} from "./lib/app-window-repository.ts";
+export {
+  APP_WINDOW_FLOAT_MIN_HEIGHT,
+  APP_WINDOW_FLOAT_MIN_WIDTH,
+  AppWindowKernelError,
+  type AppWindowCommand,
+  type AppWindowKernelErrorCode,
+} from "./lib/app-window-kernel.ts";
+export {
   classifyProjectReadiness,
   type AuthenticationReadiness,
   type Availability,

--- a/packages/daemon/src/lib/__tests__/app-window-kernel.test.ts
+++ b/packages/daemon/src/lib/__tests__/app-window-kernel.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+
+import { AppWindowDocumentV1SchemaZ } from "@tmux-ide/contracts";
+
+import {
+  APP_WINDOW_FLOAT_MIN_HEIGHT,
+  APP_WINDOW_FLOAT_MIN_WIDTH,
+  AppWindowKernelError,
+  applyAppWindowCommand,
+} from "../app-window-kernel.ts";
+import { migrateWorkspaceUiStateV2ToAppWindowDocument } from "../../tui/mirror/app-window-state.ts";
+
+const NOW = "2026-07-20T12:00:00.000Z";
+const T1 = "2026-07-20T12:01:00.000Z";
+const T2 = "2026-07-20T12:02:00.000Z";
+const T3 = "2026-07-20T12:03:00.000Z";
+const T4 = "2026-07-20T12:04:00.000Z";
+
+function timestamp(minute: number): string {
+  return `2026-07-20T12:${String(minute).padStart(2, "0")}:00.000Z`;
+}
+
+function document() {
+  return migrateWorkspaceUiStateV2ToAppWindowDocument(
+    {
+      version: 2,
+      active: { viewId: "terminals", panel: "terminals" },
+      dock: {
+        activeTab: "files",
+        mode: "open",
+        preferredHeight: 12,
+        focusZone: "canvas",
+      },
+      views: {
+        files: { panel: "files" },
+        missions: { panel: "missions" },
+      },
+      surfaces: {},
+    },
+    {
+      migratedAt: NOW,
+      terminalSourceIds: ["agent-lead", "agent-worker"],
+      focusedTerminalSourceId: "agent-lead",
+    },
+  ).document;
+}
+
+function terminalId(state: ReturnType<typeof document>, sourceId: string): string {
+  return Object.values(state.windows).find(
+    (window) => window.source.kind === "terminal" && window.source.terminalSourceId === sourceId,
+  )!.id;
+}
+
+function canvasStack(state: ReturnType<typeof document>) {
+  const root = state.dockRoot!;
+  if (root.type !== "split" || root.children[0]?.type !== "stack") throw new Error("fixture");
+  return root.children[0];
+}
+
+describe("app window manipulation kernel", () => {
+  it("floats, bounds, moves, resizes, and docks while preserving both placement memories", () => {
+    const initial = document();
+    const id = terminalId(initial, "agent-worker");
+    const dockMemory = initial.windows[id]!.placement.docked;
+    const floated = applyAppWindowCommand(
+      initial,
+      { type: "window.float", windowId: id, rect: { x: 4, y: 3, width: 2, height: 1 } },
+      T1,
+    );
+    const moved = applyAppWindowCommand(
+      floated,
+      { type: "window.move", windowId: id, x: 2_000_000, y: -2_000_000 },
+      T2,
+    );
+    expect(() =>
+      applyAppWindowCommand(
+        floated,
+        { type: "window.dock", windowId: id, stackId: "missing-stack" },
+        T2,
+      ),
+    ).toThrowError(expect.objectContaining({ code: "STACK_NOT_FOUND" }));
+    const resized = applyAppWindowCommand(
+      moved,
+      { type: "window.resize", windowId: id, width: 1, height: 2 },
+      T3,
+    );
+    const docked = applyAppWindowCommand(resized, { type: "window.dock", windowId: id }, T4);
+
+    expect(floated.windows[id]?.placement).toEqual({
+      mode: "floating",
+      docked: dockMemory,
+      floating: {
+        x: 4,
+        y: 3,
+        width: APP_WINDOW_FLOAT_MIN_WIDTH,
+        height: APP_WINDOW_FLOAT_MIN_HEIGHT,
+      },
+    });
+    expect(moved.windows[id]?.placement.floating).toMatchObject({
+      x: 1_000_000,
+      y: -1_000_000,
+    });
+    expect(resized.windows[id]?.placement.floating).toMatchObject({
+      width: APP_WINDOW_FLOAT_MIN_WIDTH,
+      height: APP_WINDOW_FLOAT_MIN_HEIGHT,
+    });
+    expect(docked.windows[id]?.placement).toMatchObject({
+      mode: "docked",
+      floating: resized.windows[id]?.placement.floating,
+    });
+    expect(docked.windows[id]?.placement.docked?.stackId).toBe(dockMemory?.stackId);
+    expect(docked.focusedWindowId).toBe(id);
+    expect(canvasStack(docked).activeWindowId).toBe(id);
+    expect(AppWindowDocumentV1SchemaZ.safeParse(docked).success).toBe(true);
+    expect(docked.revision).toBe(initial.revision + 4);
+  });
+
+  it("raises focused floats and activates/reorders stack tabs through invariant-safe commands", () => {
+    const initial = document();
+    const lead = terminalId(initial, "agent-lead");
+    const worker = terminalId(initial, "agent-worker");
+    const firstFloat = applyAppWindowCommand(initial, { type: "window.float", windowId: lead }, T1);
+    const secondFloat = applyAppWindowCommand(
+      firstFloat,
+      { type: "window.float", windowId: worker },
+      T2,
+    );
+    const raised = applyAppWindowCommand(secondFloat, { type: "window.focus", windowId: lead }, T3);
+    const redocked = applyAppWindowCommand(
+      raised,
+      { type: "window.dock", windowId: worker, stackId: "stack-canvas", index: 0 },
+      T4,
+    );
+    const filesId = canvasStack(redocked).windowIds.find(
+      (id) => redocked.windows[id]?.source.kind === "native",
+    )!;
+    const activated = applyAppWindowCommand(
+      redocked,
+      { type: "stack.activate", stackId: "stack-canvas", windowId: filesId },
+      "2026-07-20T12:05:00.000Z",
+    );
+    const reordered = applyAppWindowCommand(
+      activated,
+      { type: "stack.reorder", stackId: "stack-canvas", windowId: worker, index: 99 },
+      "2026-07-20T12:06:00.000Z",
+    );
+
+    expect(raised.floatingOrder.at(-1)).toBe(lead);
+    expect(activated.focusedWindowId).toBe(filesId);
+    expect(canvasStack(activated).activeWindowId).toBe(filesId);
+    expect(canvasStack(reordered).windowIds.at(-1)).toBe(worker);
+    expect(reordered.windows[worker]?.placement.docked?.index).toBe(
+      canvasStack(reordered).windowIds.length - 1,
+    );
+    expect(AppWindowDocumentV1SchemaZ.safeParse(reordered).success).toBe(true);
+  });
+
+  it("saves, renames, restores, and deletes named layouts deterministically", () => {
+    const initial = document();
+    const saved = applyAppWindowCommand(
+      initial,
+      { type: "layout.save", layoutId: "review", name: "Review" },
+      T1,
+    );
+    const renamed = applyAppWindowCommand(
+      saved,
+      { type: "layout.rename", layoutId: "review", name: "Review two" },
+      T2,
+    );
+    const lead = terminalId(renamed, "agent-lead");
+    const floated = applyAppWindowCommand(renamed, { type: "window.float", windowId: lead }, T3);
+    const restored = applyAppWindowCommand(
+      floated,
+      { type: "layout.restore", layoutId: "review" },
+      T4,
+    );
+    const deleted = applyAppWindowCommand(
+      restored,
+      { type: "layout.delete", layoutId: "review" },
+      "2026-07-20T12:05:00.000Z",
+    );
+
+    expect(renamed.layouts.review).toMatchObject({ name: "Review two", revision: 2 });
+    expect(restored.windows[lead]?.placement.mode).toBe("docked");
+    expect(deleted.layouts.review).toBeUndefined();
+    expect(deleted.activeLayoutId).toBeNull();
+    expect(() =>
+      applyAppWindowCommand(
+        deleted,
+        { type: "layout.restore", layoutId: "review" },
+        "2026-07-20T12:06:00.000Z",
+      ),
+    ).toThrow(AppWindowKernelError);
+  });
+
+  it("rejects missing resources, invalid placement, and backwards timestamps with typed errors", () => {
+    const initial = document();
+    const lead = terminalId(initial, "agent-lead");
+
+    expect(() =>
+      applyAppWindowCommand(initial, { type: "window.move", windowId: lead, x: 1, y: 1 }, T1),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_PLACEMENT" }));
+    expect(() =>
+      applyAppWindowCommand(initial, { type: "window.focus", windowId: "missing" }, T1),
+    ).toThrowError(expect.objectContaining({ code: "WINDOW_NOT_FOUND" }));
+    expect(() =>
+      applyAppWindowCommand(initial, { type: "window.focus", windowId: "invalid id" }, T1),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_INPUT", path: "$.windowId" }));
+    const floated = applyAppWindowCommand(initial, { type: "window.float", windowId: lead }, T1);
+    expect(() =>
+      applyAppWindowCommand(floated, { type: "window.dock", windowId: lead, stackId: "" }, T2),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_INPUT", path: "$.stackId" }));
+    expect(() =>
+      applyAppWindowCommand(initial, { type: "window.focus", windowId: lead }, "not-a-time"),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_INPUT", path: "$.timestamp" }));
+    expect(() =>
+      applyAppWindowCommand(
+        initial,
+        { type: "window.focus", windowId: lead },
+        "2020-01-01T00:00:00.000Z",
+      ),
+    ).toThrowError(expect.objectContaining({ code: "TIMESTAMP_REGRESSION" }));
+  });
+
+  it("collapses an emptied dock tree and deterministically recreates a root stack", () => {
+    let state = document();
+    const dockedIds = Object.values(state.windows)
+      .filter((window) => window.placement.mode === "docked")
+      .map((window) => window.id);
+
+    for (const [index, windowId] of dockedIds.entries()) {
+      state = applyAppWindowCommand(
+        state,
+        { type: "window.float", windowId },
+        timestamp(index + 1),
+      );
+    }
+
+    expect(state.dockRoot).toBeNull();
+    expect(state.floatingOrder).toHaveLength(dockedIds.length);
+    const restoredId = dockedIds.at(-1)!;
+    const restored = applyAppWindowCommand(
+      state,
+      { type: "window.dock", windowId: restoredId },
+      timestamp(dockedIds.length + 1),
+    );
+
+    expect(restored.dockRoot).toEqual({
+      type: "stack",
+      id: "stack-root",
+      windowIds: [restoredId],
+      activeWindowId: restoredId,
+    });
+    expect(restored.windows[restoredId]?.placement.docked).toEqual({
+      stackId: "stack-root",
+      index: 0,
+    });
+    expect(AppWindowDocumentV1SchemaZ.safeParse(restored).success).toBe(true);
+  });
+
+  it("does not turn the legacy bottom-dock mode into durable window maximize state", () => {
+    const initial = AppWindowDocumentV1SchemaZ.parse({
+      ...document(),
+      dockState: { mode: "maximized", preferredHeight: 30, focusZone: "dock-body" },
+    });
+    const worker = terminalId(initial, "agent-worker");
+    const floated = applyAppWindowCommand(initial, { type: "window.float", windowId: worker }, T1);
+    const moved = applyAppWindowCommand(
+      floated,
+      { type: "window.move", windowId: worker, x: 10, y: 5 },
+      T2,
+    );
+    const resized = applyAppWindowCommand(
+      moved,
+      { type: "window.resize", windowId: worker, width: 60, height: 20 },
+      T3,
+    );
+    const docked = applyAppWindowCommand(resized, { type: "window.dock", windowId: worker }, T4);
+
+    for (const state of [floated, moved, resized, docked]) {
+      expect(state.dockState).toEqual(initial.dockState);
+      expect(Object.keys(state.windows[worker]!)).not.toContain("maximized");
+    }
+  });
+
+  it("rejects non-finite geometry before it can enter durable state", () => {
+    const initial = document();
+    const worker = terminalId(initial, "agent-worker");
+
+    expect(() =>
+      applyAppWindowCommand(
+        initial,
+        {
+          type: "window.float",
+          windowId: worker,
+          rect: { x: Number.NaN, y: 0, width: 40, height: 12 },
+        },
+        T1,
+      ),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_INPUT", path: "$.rect.x" }));
+    const floated = applyAppWindowCommand(initial, { type: "window.float", windowId: worker }, T1);
+    expect(() =>
+      applyAppWindowCommand(
+        floated,
+        { type: "window.resize", windowId: worker, width: Number.POSITIVE_INFINITY, height: 10 },
+        T2,
+      ),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_INPUT", path: "$.width" }));
+  });
+});

--- a/packages/daemon/src/lib/__tests__/app-window-repository.test.ts
+++ b/packages/daemon/src/lib/__tests__/app-window-repository.test.ts
@@ -13,7 +13,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ProjectResolution } from "../project-resolver.ts";
 import { createProjectRuntimeRepository } from "../project-runtime-repository.ts";
-import { applyAppWindowCommand } from "../app-window-kernel.ts";
 import {
   APP_WINDOW_DOCUMENT_PATH,
   AppWindowService,
@@ -132,46 +131,42 @@ describe("app window repository migration and CAS", () => {
     expect(a.load().document.layouts.external?.name).toBe("External");
   });
 
-  it("re-reads and reapplies a semantic command after a bounded write race", () => {
+  it("reconciles repeated semantic commands without advancing revisions", () => {
     const { first } = repositoryPair();
     writeAppWindowDocument(first, null, emptyAppWindowDocument(NOW));
-    const current = loadAppWindowDocument(first, { loadedAt: NOW });
-    const external = applyAppWindowCommand(
-      current.document,
-      { type: "layout.save", layoutId: "external", name: "External" },
-      LATER,
-    );
-    const externalPayload = JSON.parse(serializeAppWindowDocument(external));
-    const originalWrite = first.writeDocument.bind(first);
-    vi.spyOn(first, "writeDocument").mockImplementationOnce(((path, payload, options) => {
-      originalWrite(path, externalPayload, { expectedRevision: current.revision });
-      return originalWrite(path, payload, options);
-    }) as typeof first.writeDocument);
     const service = new AppWindowService(first, { now: () => LATER });
+    const command = { type: "layout.save", layoutId: "local", name: "Local" } as const;
+    const saved = service.execute(command, { maxRetries: 2 });
+    const repeated = service.execute(command, { maxRetries: 2 });
 
-    const saved = service.execute(
-      { type: "layout.save", layoutId: "local", name: "Local" },
-      { maxRetries: 2 },
-    );
-
-    expect(saved.revision).toBe(3);
-    expect(Object.keys(saved.document.layouts)).toEqual(["external", "local"]);
-    expect(saved.document.revision).toBe(2);
+    expect(saved.revision).toBe(2);
+    expect(repeated).toEqual(saved);
+    expect(Object.keys(saved.document.layouts)).toEqual(["local"]);
   });
 
   it("keeps the winner of a concurrent first-migration create race", () => {
-    const { first, second } = repositoryPair();
-    first.writeDocument("ui/workspace.json", legacyWorkspaceUiState(), {
+    const { home, first, second } = repositoryPair();
+    second.writeDocument("ui/workspace.json", legacyWorkspaceUiState(), {
       expectedRevision: null,
     });
     const winner = emptyAppWindowDocument(NOW);
-    const originalWrite = first.writeDocument.bind(first);
-    vi.spyOn(first, "writeDocument").mockImplementationOnce(((path, payload, options) => {
-      writeAppWindowDocument(second, null, winner);
-      return originalWrite(path, payload, options);
-    }) as typeof first.writeDocument);
+    const target = join(first.runtimeRoot, APP_WINDOW_DOCUMENT_PATH);
+    let staleReadInjected = false;
+    const racing = createProjectRuntimeRepository(first.resolution, {
+      home,
+      io: {
+        readBytes: (path) => {
+          if (path === target && !staleReadInjected) {
+            staleReadInjected = true;
+            writeAppWindowDocument(second, null, winner);
+            throw Object.assign(new Error("stale initial absence"), { code: "ENOENT" });
+          }
+          return readFileSync(path);
+        },
+      },
+    });
 
-    const loaded = new AppWindowService(first, {
+    const loaded = new AppWindowService(racing, {
       now: () => NOW,
       migration: { terminalSourceIds: ["agent-lead"] },
     }).load();
@@ -181,38 +176,56 @@ describe("app window repository migration and CAS", () => {
     expect(loaded.diagnostics).toEqual([]);
   });
 
-  it("stops after the configured retry budget without partially applying the losing command", () => {
-    const { first } = repositoryPair();
+  it("treats an already-deleted layout as a reconciled command result", () => {
+    const { first, second } = repositoryPair();
     writeAppWindowDocument(first, null, emptyAppWindowDocument(NOW));
-    const originalWrite = first.writeDocument.bind(first);
-    let races = 0;
-    vi.spyOn(first, "writeDocument").mockImplementation(((path, payload, options) => {
-      if (path !== APP_WINDOW_DOCUMENT_PATH) return originalWrite(path, payload, options);
-      const current = loadAppWindowDocument(first, { loadedAt: LATER, migrateLegacy: false });
-      races += 1;
-      const external = applyAppWindowCommand(
-        current.document,
-        { type: "layout.save", layoutId: `external-${races}`, name: `External ${races}` },
-        LATER,
-      );
-      originalWrite(path, JSON.parse(serializeAppWindowDocument(external)), {
-        expectedRevision: current.revision,
-      });
-      return originalWrite(path, payload, options);
-    }) as typeof first.writeDocument);
+    const external = new AppWindowService(second, { now: () => LATER });
+    external.execute({ type: "layout.save", layoutId: "shared", name: "Shared" });
+    const deleted = external.execute({ type: "layout.delete", layoutId: "shared" });
 
+    const reconciled = new AppWindowService(first, { now: () => LATER }).execute(
+      { type: "layout.delete", layoutId: "shared" },
+      { maxRetries: 2 },
+    );
+
+    expect(reconciled).toEqual(deleted);
+    expect(reconciled.document.layouts.shared).toBeUndefined();
+  });
+
+  it("write-protects failed legacy migration unless an explicit reason opts out", () => {
+    const { first } = repositoryPair();
+    first.writeDocument("ui/workspace.json", { version: 99 }, { expectedRevision: null });
+    const service = new AppWindowService(first, { now: () => NOW });
+
+    const protectedLoad = service.load();
+    expect(protectedLoad).toMatchObject({ writeProtected: true, revision: null });
+    expect(protectedLoad.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "MIGRATION_FAILED" }),
+    );
     expect(() =>
-      new AppWindowService(first, { now: () => LATER }).execute(
-        { type: "layout.save", layoutId: "local", name: "Local" },
-        { maxRetries: 2 },
-      ),
-    ).toThrowError(expect.objectContaining({ code: "REVISION_CONFLICT" }));
+      service.execute({ type: "layout.save", layoutId: "unsafe", name: "Unsafe" }),
+    ).toThrowError(expect.objectContaining({ code: "WRITE_PROTECTED" }));
+    expect(first.readDocument(APP_WINDOW_DOCUMENT_PATH).found).toBe(false);
 
-    const final = loadAppWindowDocument(first, { loadedAt: LATER, migrateLegacy: false });
-    expect(races).toBe(3);
-    expect(final.document.revision).toBe(3);
-    expect(final.document.layouts.local).toBeUndefined();
-    expect(Object.keys(final.document.layouts)).toEqual(["external-1", "external-2", "external-3"]);
+    const attemptedBooleanBypass = new AppWindowService(first, {
+      now: () => NOW,
+      migration: { migrateLegacy: false } as never,
+    });
+    expect(attemptedBooleanBypass.load()).toMatchObject({ writeProtected: true, revision: null });
+    expect(() =>
+      attemptedBooleanBypass.execute({
+        type: "layout.save",
+        layoutId: "still-unsafe",
+        name: "Still unsafe",
+      }),
+    ).toThrowError(expect.objectContaining({ code: "WRITE_PROTECTED" }));
+    expect(first.readDocument(APP_WINDOW_DOCUMENT_PATH).found).toBe(false);
+
+    const optedOut = new AppWindowService(first, {
+      now: () => NOW,
+      migration: { migrationFailureOptOut: { reason: "legacy state intentionally discarded" } },
+    }).execute({ type: "layout.save", layoutId: "fresh", name: "Fresh" });
+    expect(optedOut.document.layouts.fresh?.name).toBe("Fresh");
   });
 
   it("rejects skipped domain revisions and backwards timestamps even with a matching envelope CAS", () => {
@@ -306,6 +319,7 @@ describe("app window write protection and recovery", () => {
     const metadata = JSON.parse(readFileSync(join(first.runtimeRoot, reset.metadataPath), "utf-8"));
     expect(metadata).toMatchObject({
       version: 1,
+      status: "completed",
       path: APP_WINDOW_DOCUMENT_PATH,
       previousRawSha256: loaded.recoveryToken,
       reason: "future test payload requires explicit downgrade",
@@ -394,14 +408,14 @@ describe("app window write protection and recovery", () => {
     const racing = createProjectRuntimeRepository(first.resolution, {
       home,
       io: {
-        readFile: (path) => {
+        readBytes: (path) => {
           if (path === target) {
             targetReads += 1;
             if (targetReads === 4) {
               writeFileSync(target, "{ concurrent corrupt value\n", "utf-8");
             }
           }
-          return readFileSync(path, "utf-8");
+          return readFileSync(path);
         },
       },
     });
@@ -509,10 +523,15 @@ describe("app window atomic failure", () => {
       }),
     ).toThrowError(expect.objectContaining({ code: "WRITE_FAILED" }));
     expect(readFileSync(target, "utf-8")).toBe(before);
-    const backups = readdirSync(join(first.runtimeRoot, "recovery")).filter((name) =>
-      name.endsWith(".bak"),
-    );
-    expect(backups).toHaveLength(1);
-    expect(readFileSync(join(first.runtimeRoot, "recovery", backups[0]!), "utf-8")).toBe(before);
+    const operations = readdirSync(join(first.runtimeRoot, "recovery"));
+    expect(operations).toHaveLength(1);
+    expect(
+      readFileSync(join(first.runtimeRoot, "recovery", operations[0]!, "previous.bak"), "utf-8"),
+    ).toBe(before);
+    expect(
+      JSON.parse(
+        readFileSync(join(first.runtimeRoot, "recovery", operations[0]!, "audit.json"), "utf-8"),
+      ),
+    ).toMatchObject({ status: "prepared" });
   });
 });

--- a/packages/daemon/src/lib/__tests__/app-window-repository.test.ts
+++ b/packages/daemon/src/lib/__tests__/app-window-repository.test.ts
@@ -1,0 +1,518 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ProjectResolution } from "../project-resolver.ts";
+import { createProjectRuntimeRepository } from "../project-runtime-repository.ts";
+import { applyAppWindowCommand } from "../app-window-kernel.ts";
+import {
+  APP_WINDOW_DOCUMENT_PATH,
+  AppWindowService,
+  loadAppWindowDocument,
+  resetAppWindowDocument,
+  writeAppWindowDocument,
+} from "../app-window-repository.ts";
+import {
+  emptyAppWindowDocument,
+  serializeAppWindowDocument,
+} from "../../tui/mirror/app-window-state.ts";
+
+const roots: string[] = [];
+const IDENTITY_KEY = `git-${"f".repeat(64)}`;
+const NOW = "2026-07-20T12:00:00.000Z";
+const LATER = "2026-07-20T12:01:00.000Z";
+
+function temporaryRoot(prefix = "app-window-repository-"): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function resolution(projectRoot: string): ProjectResolution {
+  return {
+    inputDir: projectRoot,
+    projectRoot,
+    identityKey: IDENTITY_KEY,
+    identitySource: "git-common-dir",
+    identityAnchor: join(projectRoot, ".git"),
+    config: { kind: "none", path: null, explicit: false },
+    workspaceConfigPath: null,
+    legacyConfigPath: null,
+    hasLegacyConfigAtInput: false,
+  };
+}
+
+function legacyWorkspaceUiState() {
+  return {
+    version: 2,
+    active: { viewId: "terminals", panel: "terminals" },
+    dock: {
+      activeTab: "changes",
+      mode: "open",
+      preferredHeight: 11,
+      focusZone: "canvas",
+    },
+    surfaces: {},
+    views: { files: { panel: "files" }, diff: { panel: "diff" } },
+  };
+}
+
+function repositoryPair() {
+  const home = temporaryRoot("app-window-home-");
+  const project = temporaryRoot("app-window-project-");
+  return {
+    home,
+    first: createProjectRuntimeRepository(resolution(project), { home }),
+    second: createProjectRuntimeRepository(resolution(project), { home }),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("app window repository migration and CAS", () => {
+  it("atomically creates its own document by first-load migration only when absent", () => {
+    const { first } = repositoryPair();
+    first.writeDocument("ui/workspace.json", legacyWorkspaceUiState(), {
+      expectedRevision: null,
+    });
+    const service = new AppWindowService(first, {
+      now: () => NOW,
+      migration: {
+        terminalSourceIds: ["agent-lead", "agent-worker"],
+        focusedTerminalSourceId: "agent-worker",
+      },
+    });
+
+    const migrated = service.load();
+    const persisted = first.readRequiredDocument<unknown>(APP_WINDOW_DOCUMENT_PATH);
+    first.writeDocument("ui/workspace.json", { version: 2, active: null }, { expectedRevision: 1 });
+    const reopened = service.load();
+
+    expect(migrated.revision).toBe(1);
+    expect(persisted.payload).toEqual(JSON.parse(serializeAppWindowDocument(migrated.document)));
+    expect(migrated.document.windows[migrated.document.focusedWindowId!]?.source).toEqual({
+      kind: "terminal",
+      terminalSourceId: "agent-worker",
+    });
+    expect(JSON.stringify(persisted.payload)).not.toContain("%pane");
+    expect(reopened.document).toEqual(migrated.document);
+    expect(reopened.revision).toBe(1);
+  });
+
+  it("enforces explicit revision CAS and observes external updates", () => {
+    const { first, second } = repositoryPair();
+    writeAppWindowDocument(first, null, emptyAppWindowDocument(NOW));
+    const a = new AppWindowService(first, { now: () => LATER });
+    const b = new AppWindowService(second, { now: () => LATER });
+    const base = a.load();
+    const external = b.execute(
+      { type: "layout.save", layoutId: "external", name: "External" },
+      { expectedRevision: base.revision },
+    );
+
+    expect(() =>
+      a.execute(
+        { type: "layout.save", layoutId: "stale", name: "Stale" },
+        { expectedRevision: base.revision },
+      ),
+    ).toThrowError(expect.objectContaining({ code: "REVISION_CONFLICT" }));
+    expect(a.load()).toMatchObject({ revision: external.revision });
+    expect(a.load().document.layouts.external?.name).toBe("External");
+  });
+
+  it("re-reads and reapplies a semantic command after a bounded write race", () => {
+    const { first } = repositoryPair();
+    writeAppWindowDocument(first, null, emptyAppWindowDocument(NOW));
+    const current = loadAppWindowDocument(first, { loadedAt: NOW });
+    const external = applyAppWindowCommand(
+      current.document,
+      { type: "layout.save", layoutId: "external", name: "External" },
+      LATER,
+    );
+    const externalPayload = JSON.parse(serializeAppWindowDocument(external));
+    const originalWrite = first.writeDocument.bind(first);
+    vi.spyOn(first, "writeDocument").mockImplementationOnce(((path, payload, options) => {
+      originalWrite(path, externalPayload, { expectedRevision: current.revision });
+      return originalWrite(path, payload, options);
+    }) as typeof first.writeDocument);
+    const service = new AppWindowService(first, { now: () => LATER });
+
+    const saved = service.execute(
+      { type: "layout.save", layoutId: "local", name: "Local" },
+      { maxRetries: 2 },
+    );
+
+    expect(saved.revision).toBe(3);
+    expect(Object.keys(saved.document.layouts)).toEqual(["external", "local"]);
+    expect(saved.document.revision).toBe(2);
+  });
+
+  it("keeps the winner of a concurrent first-migration create race", () => {
+    const { first, second } = repositoryPair();
+    first.writeDocument("ui/workspace.json", legacyWorkspaceUiState(), {
+      expectedRevision: null,
+    });
+    const winner = emptyAppWindowDocument(NOW);
+    const originalWrite = first.writeDocument.bind(first);
+    vi.spyOn(first, "writeDocument").mockImplementationOnce(((path, payload, options) => {
+      writeAppWindowDocument(second, null, winner);
+      return originalWrite(path, payload, options);
+    }) as typeof first.writeDocument);
+
+    const loaded = new AppWindowService(first, {
+      now: () => NOW,
+      migration: { terminalSourceIds: ["agent-lead"] },
+    }).load();
+
+    expect(loaded.document).toEqual(winner);
+    expect(loaded.revision).toBe(1);
+    expect(loaded.diagnostics).toEqual([]);
+  });
+
+  it("stops after the configured retry budget without partially applying the losing command", () => {
+    const { first } = repositoryPair();
+    writeAppWindowDocument(first, null, emptyAppWindowDocument(NOW));
+    const originalWrite = first.writeDocument.bind(first);
+    let races = 0;
+    vi.spyOn(first, "writeDocument").mockImplementation(((path, payload, options) => {
+      if (path !== APP_WINDOW_DOCUMENT_PATH) return originalWrite(path, payload, options);
+      const current = loadAppWindowDocument(first, { loadedAt: LATER, migrateLegacy: false });
+      races += 1;
+      const external = applyAppWindowCommand(
+        current.document,
+        { type: "layout.save", layoutId: `external-${races}`, name: `External ${races}` },
+        LATER,
+      );
+      originalWrite(path, JSON.parse(serializeAppWindowDocument(external)), {
+        expectedRevision: current.revision,
+      });
+      return originalWrite(path, payload, options);
+    }) as typeof first.writeDocument);
+
+    expect(() =>
+      new AppWindowService(first, { now: () => LATER }).execute(
+        { type: "layout.save", layoutId: "local", name: "Local" },
+        { maxRetries: 2 },
+      ),
+    ).toThrowError(expect.objectContaining({ code: "REVISION_CONFLICT" }));
+
+    const final = loadAppWindowDocument(first, { loadedAt: LATER, migrateLegacy: false });
+    expect(races).toBe(3);
+    expect(final.document.revision).toBe(3);
+    expect(final.document.layouts.local).toBeUndefined();
+    expect(Object.keys(final.document.layouts)).toEqual(["external-1", "external-2", "external-3"]);
+  });
+
+  it("rejects skipped domain revisions and backwards timestamps even with a matching envelope CAS", () => {
+    const { first } = repositoryPair();
+    const written = writeAppWindowDocument(first, null, emptyAppWindowDocument(NOW));
+
+    expect(() =>
+      writeAppWindowDocument(first, written.revision, {
+        ...written.document,
+        revision: 2,
+        updatedAt: LATER,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_DOCUMENT" }));
+    expect(() =>
+      writeAppWindowDocument(first, written.revision, {
+        ...written.document,
+        revision: 1,
+        updatedAt: "2026-07-20T11:59:00.000Z",
+      }),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_DOCUMENT" }));
+    expect(first.readRequiredDocument(APP_WINDOW_DOCUMENT_PATH).revision).toBe(1);
+  });
+
+  it("rejects invalid CAS and retry controls with repository errors", () => {
+    const { first } = repositoryPair();
+    writeAppWindowDocument(first, null, emptyAppWindowDocument(NOW));
+    const service = new AppWindowService(first, { now: () => LATER });
+
+    expect(() =>
+      service.execute(
+        { type: "layout.save", layoutId: "review", name: "Review" },
+        { expectedRevision: Number.NaN },
+      ),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_DOCUMENT" }));
+    expect(() =>
+      service.execute(
+        { type: "layout.save", layoutId: "review", name: "Review" },
+        { maxRetries: 9 },
+      ),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_DOCUMENT" }));
+  });
+
+  it("uses the shared project writer lock and preserves state on lock contention", () => {
+    const { first } = repositoryPair();
+    writeAppWindowDocument(first, null, emptyAppWindowDocument(NOW));
+    const target = join(first.runtimeRoot, APP_WINDOW_DOCUMENT_PATH);
+    const before = readFileSync(target, "utf-8");
+    const lockPath = join(first.runtimeRoot, "workspace", ".state.lock");
+    mkdirSync(dirname(lockPath), { recursive: true });
+    writeFileSync(lockPath, "occupied by another writer\n", "utf-8");
+
+    expect(() =>
+      new AppWindowService(first, {
+        now: () => LATER,
+        writerLock: { timeoutMs: 1, pollMs: 1 },
+      }).execute({ type: "layout.save", layoutId: "blocked", name: "Blocked" }),
+    ).toThrowError(expect.objectContaining({ code: "WRITE_FAILED" }));
+    expect(readFileSync(target, "utf-8")).toBe(before);
+    expect(readFileSync(lockPath, "utf-8")).toBe("occupied by another writer\n");
+  });
+});
+
+describe("app window write protection and recovery", () => {
+  it("preserves future payloads until typed reset and backs up exact prior bytes", () => {
+    const { first } = repositoryPair();
+    first.writeDocument(
+      APP_WINDOW_DOCUMENT_PATH,
+      { version: 99, future: "keep-me" },
+      {
+        expectedRevision: null,
+      },
+    );
+    const target = join(first.runtimeRoot, APP_WINDOW_DOCUMENT_PATH);
+    const before = readFileSync(target, "utf-8");
+    const loaded = loadAppWindowDocument(first, { loadedAt: NOW });
+
+    expect(loaded.writeProtected).toBe(true);
+    expect(loaded.preservedPayload).toEqual({ version: 99, future: "keep-me" });
+    expect(() =>
+      writeAppWindowDocument(first, loaded.revision, emptyAppWindowDocument(NOW)),
+    ).toThrowError(expect.objectContaining({ code: "WRITE_PROTECTED" }));
+    expect(readFileSync(target, "utf-8")).toBe(before);
+
+    const reset = resetAppWindowDocument(first, {
+      expectedRecoveryToken: loaded.recoveryToken!,
+      reason: "future test payload requires explicit downgrade",
+      resetAt: LATER,
+    });
+    expect(reset.writeProtected).toBe(false);
+    expect(readFileSync(join(first.runtimeRoot, reset.backupPath), "utf-8")).toBe(before);
+    const metadata = JSON.parse(readFileSync(join(first.runtimeRoot, reset.metadataPath), "utf-8"));
+    expect(metadata).toMatchObject({
+      version: 1,
+      path: APP_WINDOW_DOCUMENT_PATH,
+      previousRawSha256: loaded.recoveryToken,
+      reason: "future test payload requires explicit downgrade",
+      details: {
+        diagnostics: [expect.objectContaining({ code: "UNSUPPORTED_VERSION" })],
+      },
+    });
+    expect(loadAppWindowDocument(first, { loadedAt: LATER }).document).toEqual(reset.document);
+  });
+
+  it("write-protects a malformed current-version payload and preserves it for inspection", () => {
+    const { first } = repositoryPair();
+    const malformed = { version: 1, revision: 7, updatedAt: NOW, windows: "not-a-record" };
+    first.writeDocument(APP_WINDOW_DOCUMENT_PATH, malformed, { expectedRevision: null });
+    const target = join(first.runtimeRoot, APP_WINDOW_DOCUMENT_PATH);
+    const before = readFileSync(target, "utf-8");
+
+    const loaded = loadAppWindowDocument(first, { loadedAt: NOW });
+
+    expect(loaded.writeProtected).toBe(true);
+    expect(loaded.preservedPayload).toEqual(malformed);
+    expect(loaded.diagnostics.some((entry) => entry.code === "INVALID_FIELD")).toBe(true);
+    expect(() =>
+      new AppWindowService(first, { now: () => LATER }).execute({
+        type: "layout.save",
+        layoutId: "unsafe",
+        name: "Unsafe",
+      }),
+    ).toThrowError(expect.objectContaining({ code: "WRITE_PROTECTED" }));
+    expect(readFileSync(target, "utf-8")).toBe(before);
+  });
+
+  it("recovers corrupt envelope bytes only with the exact inspected token", () => {
+    const { first } = repositoryPair();
+    const target = join(first.runtimeRoot, APP_WINDOW_DOCUMENT_PATH);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, "{ definitely not json\n", "utf-8");
+    const loaded = loadAppWindowDocument(first, { loadedAt: NOW });
+
+    expect(loaded.writeProtected).toBe(true);
+    expect(loaded.diagnostics[0]?.code).toBe("READ_FAILED");
+    expect(() =>
+      resetAppWindowDocument(first, {
+        expectedRecoveryToken: "0".repeat(64),
+        reason: "wrong token",
+        resetAt: LATER,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "RECOVERY_CONFLICT" }));
+
+    const reset = resetAppWindowDocument(first, {
+      expectedRecoveryToken: loaded.recoveryToken!,
+      reason: "corrupt envelope confirmed by operator",
+      resetAt: LATER,
+    });
+    expect(readFileSync(join(first.runtimeRoot, reset.backupPath), "utf-8")).toBe(
+      "{ definitely not json\n",
+    );
+    expect(reset.revision).toBe(1);
+  });
+
+  it("rejects recovery when corrupt bytes change after inspection", () => {
+    const { first } = repositoryPair();
+    const target = join(first.runtimeRoot, APP_WINDOW_DOCUMENT_PATH);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, "{ first corrupt value\n", "utf-8");
+    const loaded = loadAppWindowDocument(first, { loadedAt: NOW });
+    writeFileSync(target, "{ newer corrupt value\n", "utf-8");
+
+    expect(() =>
+      resetAppWindowDocument(first, {
+        expectedRecoveryToken: loaded.recoveryToken!,
+        reason: "stale operator inspection",
+        resetAt: LATER,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "RECOVERY_CONFLICT" }));
+    expect(readFileSync(target, "utf-8")).toBe("{ newer corrupt value\n");
+  });
+
+  it("rechecks the byte token after backup and leaves a racing writer intact", () => {
+    const { home, first } = repositoryPair();
+    const target = join(first.runtimeRoot, APP_WINDOW_DOCUMENT_PATH);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, "{ inspected corrupt value\n", "utf-8");
+    const inspected = loadAppWindowDocument(first, { loadedAt: NOW });
+    let targetReads = 0;
+    const racing = createProjectRuntimeRepository(first.resolution, {
+      home,
+      io: {
+        readFile: (path) => {
+          if (path === target) {
+            targetReads += 1;
+            if (targetReads === 4) {
+              writeFileSync(target, "{ concurrent corrupt value\n", "utf-8");
+            }
+          }
+          return readFileSync(path, "utf-8");
+        },
+      },
+    });
+
+    expect(() =>
+      resetAppWindowDocument(racing, {
+        expectedRecoveryToken: inspected.recoveryToken!,
+        reason: "recovery recheck race test",
+        resetAt: LATER,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "RECOVERY_CONFLICT" }));
+    expect(targetReads).toBe(4);
+    expect(readFileSync(target, "utf-8")).toBe("{ concurrent corrupt value\n");
+  });
+
+  it("never permits recovery of a valid writable document", () => {
+    const { first } = repositoryPair();
+    const written = writeAppWindowDocument(first, null, emptyAppWindowDocument(NOW));
+
+    expect(() =>
+      resetAppWindowDocument(first, {
+        expectedRecoveryToken: written.recoveryToken!,
+        reason: "should use normal CAS",
+        resetAt: LATER,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "RECOVERY_NOT_REQUIRED" }));
+  });
+});
+
+describe("app window atomic failure", () => {
+  it("leaves the prior document intact and cleans temp files after rename failure", () => {
+    const { home, first } = repositoryPair();
+    writeAppWindowDocument(first, null, emptyAppWindowDocument(NOW));
+    const target = join(first.runtimeRoot, APP_WINDOW_DOCUMENT_PATH);
+    const before = readFileSync(target, "utf-8");
+    const failing = createProjectRuntimeRepository(first.resolution, {
+      home,
+      io: {
+        rename: (from, to) => {
+          if (to === target) throw new Error("simulated rename crash");
+          renameSync(from, to);
+        },
+      },
+    });
+    const service = new AppWindowService(failing, { now: () => LATER });
+
+    expect(() =>
+      service.execute({ type: "layout.save", layoutId: "review", name: "Review" }),
+    ).toThrowError(expect.objectContaining({ code: "WRITE_FAILED" }));
+    expect(readFileSync(target, "utf-8")).toBe(before);
+    expect(readdirSync(dirname(target)).filter((name) => name.startsWith(".tmp-"))).toEqual([]);
+  });
+
+  it("does not touch the protected target when the exact-byte recovery backup fails", () => {
+    const { home, first } = repositoryPair();
+    const target = join(first.runtimeRoot, APP_WINDOW_DOCUMENT_PATH);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, "{ protected bytes\n", "utf-8");
+    const failing = createProjectRuntimeRepository(first.resolution, {
+      home,
+      io: {
+        rename: (from, to) => {
+          if (to.includes(join(first.runtimeRoot, "recovery")) && to.endsWith(".bak")) {
+            throw new Error("simulated backup crash");
+          }
+          renameSync(from, to);
+        },
+      },
+    });
+    const loaded = loadAppWindowDocument(failing, { loadedAt: NOW });
+
+    expect(() =>
+      resetAppWindowDocument(failing, {
+        expectedRecoveryToken: loaded.recoveryToken!,
+        reason: "recovery backup failure test",
+        resetAt: LATER,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "WRITE_FAILED" }));
+    expect(readFileSync(target, "utf-8")).toBe("{ protected bytes\n");
+    expect(readdirSync(join(first.runtimeRoot, "recovery"))).toEqual([]);
+  });
+
+  it("retains the exact backup and protected target when final recovery replacement fails", () => {
+    const { home, first } = repositoryPair();
+    const target = join(first.runtimeRoot, APP_WINDOW_DOCUMENT_PATH);
+    const before = "{ protected final bytes\n";
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, before, "utf-8");
+    const failing = createProjectRuntimeRepository(first.resolution, {
+      home,
+      io: {
+        rename: (from, to) => {
+          if (to === target) throw new Error("simulated recovery replacement crash");
+          renameSync(from, to);
+        },
+      },
+    });
+    const loaded = loadAppWindowDocument(failing, { loadedAt: NOW });
+
+    expect(() =>
+      resetAppWindowDocument(failing, {
+        expectedRecoveryToken: loaded.recoveryToken!,
+        reason: "recovery replacement failure test",
+        resetAt: LATER,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "WRITE_FAILED" }));
+    expect(readFileSync(target, "utf-8")).toBe(before);
+    const backups = readdirSync(join(first.runtimeRoot, "recovery")).filter((name) =>
+      name.endsWith(".bak"),
+    );
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(first.runtimeRoot, "recovery", backups[0]!), "utf-8")).toBe(before);
+  });
+});

--- a/packages/daemon/src/lib/__tests__/project-runtime-repository.test.ts
+++ b/packages/daemon/src/lib/__tests__/project-runtime-repository.test.ts
@@ -191,7 +191,8 @@ describe("ProjectRuntimeRepository documents", () => {
       ),
     ).toMatchObject({ code: "IO_ERROR", path: "bindings.json" });
     const directory = join(home, "projects", IDENTITY_KEY);
-    expect(readdirSync(directory)).toEqual([]);
+    expect(readdirSync(directory)).toEqual(["workspace"]);
+    expect(readdirSync(join(directory, "workspace"))).toEqual([]);
     expect(operations[0]).toContain("write:");
     expect(operations[0]).toContain(".tmp-");
     expect(operations[1]).toContain("rename:");
@@ -277,7 +278,7 @@ describe("ProjectRuntimeRepository documents", () => {
     const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), {
       home: temporaryRoot(),
       io: {
-        readFile: () => {
+        readBytes: () => {
           throw Object.assign(new Error("permission denied"), { code: "EACCES" });
         },
       },
@@ -313,6 +314,63 @@ describe("ProjectRuntimeRepository documents", () => {
       code: "DOCUMENT_CORRUPT",
       path: "bad-revision.json",
     });
+  });
+
+  it("hashes and preserves invalid UTF-8 as exact recovery bytes", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const target = join(repository.runtimeRoot, "invalid-utf8.json");
+    mkdirSync(dirname(target), { recursive: true });
+    const firstRaw = Buffer.from([0xff, 0x0a]);
+    const secondRaw = Buffer.from([0xfe, 0x0a]);
+    writeFileSync(target, firstRaw);
+    const firstToken = repository.documentRecoveryToken("invalid-utf8.json");
+    writeFileSync(target, secondRaw);
+    const secondToken = repository.documentRecoveryToken("invalid-utf8.json");
+
+    expect(firstToken).not.toBe(secondToken);
+    expect(caughtError(() => repository.readDocument("invalid-utf8.json"))).toMatchObject({
+      code: "DOCUMENT_CORRUPT",
+      path: "invalid-utf8.json",
+    });
+
+    const recovered = repository.recoverDocument(
+      "invalid-utf8.json",
+      { recovered: true },
+      {
+        expectedRawSha256: secondToken!,
+        reason: "operator confirmed invalid UTF-8 test fixture",
+      },
+    );
+    expect(readFileSync(join(repository.runtimeRoot, recovered.backupPath))).toEqual(secondRaw);
+    expect(
+      JSON.parse(readFileSync(join(repository.runtimeRoot, recovered.metadataPath), "utf-8")),
+    ).toMatchObject({ status: "completed", previousRawSha256: secondToken });
+  });
+
+  it("preserves distinct audits when identical corrupt bytes are recovered twice", () => {
+    const home = temporaryRoot("tmux-ide-home-");
+    const repository = createProjectRuntimeRepository(resolution(temporaryRoot()), { home });
+    const target = join(repository.runtimeRoot, "repeat-corrupt.json");
+    const corrupt = Buffer.from([0xff, 0x7b, 0x0a]);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, corrupt);
+    const token = repository.documentRecoveryToken("repeat-corrupt.json")!;
+    const first = repository.recoverDocument(
+      "repeat-corrupt.json",
+      { attempt: 1 },
+      { expectedRawSha256: token, reason: "first recovery" },
+    );
+    writeFileSync(target, corrupt);
+    const second = repository.recoverDocument(
+      "repeat-corrupt.json",
+      { attempt: 2 },
+      { expectedRawSha256: token, reason: "second recovery" },
+    );
+
+    expect(second.backupPath).not.toBe(first.backupPath);
+    expect(readFileSync(join(repository.runtimeRoot, first.backupPath))).toEqual(corrupt);
+    expect(readFileSync(join(repository.runtimeRoot, second.backupPath))).toEqual(corrupt);
   });
 
   it.each([

--- a/packages/daemon/src/lib/app-window-kernel.ts
+++ b/packages/daemon/src/lib/app-window-kernel.ts
@@ -1,0 +1,612 @@
+import {
+  AppWindowDocumentV1SchemaZ,
+  AppWindowIdSchemaZ,
+  AppWindowTimestampSchemaZ,
+  type AppWindowDockNodeShape,
+  type AppWindowDocumentV1,
+  type AppWindowInstance,
+  type AppWindowRect,
+} from "@tmux-ide/contracts";
+
+import {
+  focusAppWindow,
+  restoreAppWindowNamedLayout,
+  saveAppWindowNamedLayout,
+} from "../tui/mirror/app-window-state.ts";
+
+export const APP_WINDOW_FLOAT_MIN_WIDTH = 20;
+export const APP_WINDOW_FLOAT_MIN_HEIGHT = 6;
+const APP_WINDOW_COORDINATE_LIMIT = 1_000_000;
+
+export type AppWindowKernelErrorCode =
+  | "WINDOW_NOT_FOUND"
+  | "STACK_NOT_FOUND"
+  | "WINDOW_NOT_IN_STACK"
+  | "INVALID_PLACEMENT"
+  | "LAYOUT_NOT_FOUND"
+  | "INVALID_INPUT"
+  | "TIMESTAMP_REGRESSION";
+
+export class AppWindowKernelError extends Error {
+  readonly code: AppWindowKernelErrorCode;
+  readonly path: string;
+
+  constructor(code: AppWindowKernelErrorCode, path: string, message: string) {
+    super(message);
+    this.name = "AppWindowKernelError";
+    this.code = code;
+    this.path = path;
+  }
+}
+
+export type AppWindowCommand =
+  | { type: "window.focus"; windowId: string | null }
+  | { type: "window.float"; windowId: string; rect?: AppWindowRect }
+  | { type: "window.dock"; windowId: string; stackId?: string; index?: number }
+  | { type: "window.move"; windowId: string; x: number; y: number }
+  | { type: "window.resize"; windowId: string; width: number; height: number }
+  | { type: "stack.activate"; stackId: string; windowId: string }
+  | { type: "stack.reorder"; stackId: string; windowId: string; index: number }
+  | {
+      type: "layout.save";
+      layoutId: string;
+      name: string;
+      description?: string | null;
+    }
+  | { type: "layout.restore"; layoutId: string }
+  | { type: "layout.rename"; layoutId: string; name: string }
+  | { type: "layout.delete"; layoutId: string };
+
+export function applyAppWindowCommand(
+  document: AppWindowDocumentV1,
+  command: AppWindowCommand,
+  timestamp: string,
+): AppWindowDocumentV1 {
+  const current = requireDocument(document);
+  const at = requireTimestamp(current.updatedAt, timestamp);
+  switch (command.type) {
+    case "window.focus":
+      if (command.windowId !== null) requireWindowId(current, command.windowId);
+      try {
+        return focusAppWindow(current, command.windowId, at);
+      } catch (error) {
+        throw translateStateError(error, command.windowId ? `$.windows.${command.windowId}` : "$");
+      }
+    case "window.float":
+      return floatWindow(current, command, at);
+    case "window.dock":
+      return dockWindow(current, command, at);
+    case "window.move":
+      return moveFloatingWindow(current, command, at);
+    case "window.resize":
+      return resizeFloatingWindow(current, command, at);
+    case "stack.activate":
+      return activateStackWindow(current, command, at);
+    case "stack.reorder":
+      return reorderStackWindow(current, command, at);
+    case "layout.save":
+      try {
+        return saveAppWindowNamedLayout(current, {
+          id: command.layoutId,
+          name: command.name,
+          description: command.description,
+          updatedAt: at,
+        });
+      } catch (error) {
+        throw translateStateError(error, `$.layouts.${command.layoutId}`);
+      }
+    case "layout.restore":
+      try {
+        return restoreAppWindowNamedLayout(current, command.layoutId, at);
+      } catch (error) {
+        if ((error as Error).message.includes("unknown app window layout")) {
+          throw new AppWindowKernelError(
+            "LAYOUT_NOT_FOUND",
+            `$.layouts.${command.layoutId}`,
+            (error as Error).message,
+          );
+        }
+        throw translateStateError(error, `$.layouts.${command.layoutId}`);
+      }
+    case "layout.rename":
+      return renameLayout(current, command.layoutId, command.name, at);
+    case "layout.delete":
+      return deleteLayout(current, command.layoutId, at);
+  }
+}
+
+function floatWindow(
+  current: AppWindowDocumentV1,
+  command: Extract<AppWindowCommand, { type: "window.float" }>,
+  timestamp: string,
+): AppWindowDocumentV1 {
+  const id = requireWindowId(current, command.windowId);
+  const window = current.windows[id]!;
+  if (window.placement.mode !== "docked") {
+    throw new AppWindowKernelError(
+      "INVALID_PLACEMENT",
+      `$.windows.${id}.placement`,
+      `window "${id}" is already floating`,
+    );
+  }
+  const rect = normalizeRect(
+    command.rect ?? window.placement.floating ?? { x: 2, y: 2, width: 80, height: 24 },
+  );
+  const windows = structuredClone(current.windows);
+  windows[id] = {
+    ...window,
+    placement: {
+      mode: "floating",
+      docked: window.placement.docked,
+      floating: rect,
+    },
+  };
+  const dockRoot = removeDockWindow(current.dockRoot, id);
+  syncDockMemories(windows, dockRoot);
+  return finalize(current, timestamp, {
+    windows,
+    dockRoot,
+    floatingOrder: [...current.floatingOrder.filter((candidate) => candidate !== id), id],
+    focusedWindowId: id,
+  });
+}
+
+function dockWindow(
+  current: AppWindowDocumentV1,
+  command: Extract<AppWindowCommand, { type: "window.dock" }>,
+  timestamp: string,
+): AppWindowDocumentV1 {
+  const id = requireWindowId(current, command.windowId);
+  const window = current.windows[id]!;
+  if (window.placement.mode !== "floating") {
+    throw new AppWindowKernelError(
+      "INVALID_PLACEMENT",
+      `$.windows.${id}.placement`,
+      `window "${id}" is already docked`,
+    );
+  }
+  const requestedStackId =
+    command.stackId !== undefined
+      ? requireId(command.stackId, "$.stackId")
+      : window.placement.docked?.stackId;
+  if (command.stackId !== undefined && !findStack(current.dockRoot, requestedStackId!)) {
+    throw new AppWindowKernelError(
+      "STACK_NOT_FOUND",
+      `$.dockRoot.${requestedStackId}`,
+      `unknown app window stack "${requestedStackId}"`,
+    );
+  }
+  const existingFallback = firstStackId(current.dockRoot);
+  const targetStackId =
+    (requestedStackId && findStack(current.dockRoot, requestedStackId)
+      ? requestedStackId
+      : existingFallback) ?? uniqueRootStackId(current.dockRoot);
+  const rememberedIndex =
+    command.index ?? window.placement.docked?.index ?? Number.MAX_SAFE_INTEGER;
+  if (!Number.isInteger(rememberedIndex) || rememberedIndex < 0) {
+    throw new AppWindowKernelError(
+      "INVALID_INPUT",
+      "$.index",
+      "dock index must be a nonnegative integer",
+    );
+  }
+  const windows = structuredClone(current.windows);
+  windows[id] = {
+    ...window,
+    placement: {
+      mode: "docked",
+      docked: { stackId: targetStackId, index: 0 },
+      floating: window.placement.floating,
+    },
+  };
+  let dockRoot = current.dockRoot
+    ? insertDockWindow(current.dockRoot, targetStackId, id, rememberedIndex)
+    : {
+        type: "stack" as const,
+        id: targetStackId,
+        windowIds: [id],
+        activeWindowId: id,
+      };
+  dockRoot = activateDockWindow(dockRoot, targetStackId, id);
+  syncDockMemories(windows, dockRoot);
+  return finalize(current, timestamp, {
+    windows,
+    dockRoot,
+    floatingOrder: current.floatingOrder.filter((candidate) => candidate !== id),
+    focusedWindowId: id,
+  });
+}
+
+function moveFloatingWindow(
+  current: AppWindowDocumentV1,
+  command: Extract<AppWindowCommand, { type: "window.move" }>,
+  timestamp: string,
+): AppWindowDocumentV1 {
+  const [id, window, rect] = requireFloatingWindow(current, command.windowId);
+  return updateFloatingRect(
+    current,
+    id,
+    window,
+    {
+      ...rect,
+      x: boundedCoordinate(command.x, "$.x"),
+      y: boundedCoordinate(command.y, "$.y"),
+    },
+    timestamp,
+  );
+}
+
+function resizeFloatingWindow(
+  current: AppWindowDocumentV1,
+  command: Extract<AppWindowCommand, { type: "window.resize" }>,
+  timestamp: string,
+): AppWindowDocumentV1 {
+  const [id, window, rect] = requireFloatingWindow(current, command.windowId);
+  return updateFloatingRect(
+    current,
+    id,
+    window,
+    {
+      ...rect,
+      width: boundedExtent(command.width, APP_WINDOW_FLOAT_MIN_WIDTH, "$.width"),
+      height: boundedExtent(command.height, APP_WINDOW_FLOAT_MIN_HEIGHT, "$.height"),
+    },
+    timestamp,
+  );
+}
+
+function activateStackWindow(
+  current: AppWindowDocumentV1,
+  command: Extract<AppWindowCommand, { type: "stack.activate" }>,
+  timestamp: string,
+): AppWindowDocumentV1 {
+  const stackId = requireId(command.stackId, "$.stackId");
+  const windowId = requireWindowId(current, command.windowId);
+  const stack = requireStack(current.dockRoot, stackId);
+  if (!stack.windowIds.includes(windowId)) {
+    throw new AppWindowKernelError(
+      "WINDOW_NOT_IN_STACK",
+      `$.dockRoot.${stackId}`,
+      `window "${windowId}" is not in stack "${stackId}"`,
+    );
+  }
+  return finalize(current, timestamp, {
+    dockRoot: activateDockWindow(current.dockRoot!, stackId, windowId),
+    focusedWindowId: windowId,
+  });
+}
+
+function reorderStackWindow(
+  current: AppWindowDocumentV1,
+  command: Extract<AppWindowCommand, { type: "stack.reorder" }>,
+  timestamp: string,
+): AppWindowDocumentV1 {
+  const stackId = requireId(command.stackId, "$.stackId");
+  const windowId = requireWindowId(current, command.windowId);
+  const stack = requireStack(current.dockRoot, stackId);
+  if (!stack.windowIds.includes(windowId)) {
+    throw new AppWindowKernelError(
+      "WINDOW_NOT_IN_STACK",
+      `$.dockRoot.${stackId}`,
+      `window "${windowId}" is not in stack "${stackId}"`,
+    );
+  }
+  if (!Number.isInteger(command.index) || command.index < 0) {
+    throw new AppWindowKernelError("INVALID_INPUT", "$.index", "index must be nonnegative");
+  }
+  const ids = stack.windowIds.filter((candidate) => candidate !== windowId);
+  ids.splice(Math.min(command.index, ids.length), 0, windowId);
+  const dockRoot = replaceStack(current.dockRoot!, stackId, { ...stack, windowIds: ids });
+  const windows = structuredClone(current.windows);
+  syncDockMemories(windows, dockRoot);
+  return finalize(current, timestamp, { windows, dockRoot });
+}
+
+function renameLayout(
+  current: AppWindowDocumentV1,
+  layoutId: string,
+  name: string,
+  timestamp: string,
+): AppWindowDocumentV1 {
+  const id = requireId(layoutId, "$.layoutId");
+  const layout = Object.hasOwn(current.layouts, id) ? current.layouts[id] : null;
+  if (!layout) {
+    throw new AppWindowKernelError(
+      "LAYOUT_NOT_FOUND",
+      `$.layouts.${id}`,
+      `unknown app window layout "${id}"`,
+    );
+  }
+  return finalize(current, timestamp, {
+    layouts: {
+      ...current.layouts,
+      [id]: { ...layout, name, revision: layout.revision + 1, updatedAt: timestamp },
+    },
+  });
+}
+
+function deleteLayout(
+  current: AppWindowDocumentV1,
+  layoutId: string,
+  timestamp: string,
+): AppWindowDocumentV1 {
+  const id = requireId(layoutId, "$.layoutId");
+  if (!Object.hasOwn(current.layouts, id)) {
+    throw new AppWindowKernelError(
+      "LAYOUT_NOT_FOUND",
+      `$.layouts.${id}`,
+      `unknown app window layout "${id}"`,
+    );
+  }
+  const layouts = { ...current.layouts };
+  delete layouts[id];
+  return finalize(current, timestamp, {
+    layouts,
+    activeLayoutId: current.activeLayoutId === id ? null : current.activeLayoutId,
+  });
+}
+
+function updateFloatingRect(
+  current: AppWindowDocumentV1,
+  id: string,
+  window: AppWindowInstance,
+  rect: AppWindowRect,
+  timestamp: string,
+): AppWindowDocumentV1 {
+  return finalize(current, timestamp, {
+    windows: {
+      ...current.windows,
+      [id]: { ...window, placement: { ...window.placement, floating: rect } },
+    },
+  });
+}
+
+function requireWindowId(current: AppWindowDocumentV1, value: string): string {
+  const id = requireId(value, "$.windowId");
+  if (!Object.hasOwn(current.windows, id)) {
+    throw new AppWindowKernelError(
+      "WINDOW_NOT_FOUND",
+      `$.windows.${id}`,
+      `unknown app window "${id}"`,
+    );
+  }
+  return id;
+}
+
+function requireFloatingWindow(
+  current: AppWindowDocumentV1,
+  value: string,
+): [string, AppWindowInstance, AppWindowRect] {
+  const id = requireWindowId(current, value);
+  const window = current.windows[id]!;
+  if (window.placement.mode !== "floating" || !window.placement.floating) {
+    throw new AppWindowKernelError(
+      "INVALID_PLACEMENT",
+      `$.windows.${id}.placement`,
+      `window "${id}" is not floating`,
+    );
+  }
+  return [id, window, window.placement.floating];
+}
+
+function requireStack(
+  root: AppWindowDockNodeShape | null,
+  stackId: string,
+): Extract<AppWindowDockNodeShape, { type: "stack" }> {
+  const stack = findStack(root, stackId);
+  if (!stack) {
+    throw new AppWindowKernelError(
+      "STACK_NOT_FOUND",
+      `$.dockRoot.${stackId}`,
+      `unknown app window stack "${stackId}"`,
+    );
+  }
+  return stack;
+}
+
+function findStack(
+  node: AppWindowDockNodeShape | null,
+  stackId: string,
+): Extract<AppWindowDockNodeShape, { type: "stack" }> | null {
+  if (!node) return null;
+  if (node.type === "stack") return node.id === stackId ? node : null;
+  for (const child of node.children) {
+    const found = findStack(child, stackId);
+    if (found) return found;
+  }
+  return null;
+}
+
+function firstStackId(node: AppWindowDockNodeShape | null): string | null {
+  if (!node) return null;
+  if (node.type === "stack") return node.id;
+  return firstStackId(node.children[0] ?? null);
+}
+
+function removeDockWindow(
+  node: AppWindowDockNodeShape | null,
+  windowId: string,
+): AppWindowDockNodeShape | null {
+  if (!node) return null;
+  if (node.type === "stack") {
+    const index = node.windowIds.indexOf(windowId);
+    if (index < 0) return node;
+    const windowIds = node.windowIds.filter((candidate) => candidate !== windowId);
+    if (windowIds.length === 0) return null;
+    return {
+      ...node,
+      windowIds,
+      activeWindowId:
+        node.activeWindowId === windowId
+          ? windowIds[Math.min(index, windowIds.length - 1)]!
+          : node.activeWindowId,
+    };
+  }
+  const pairs = node.children
+    .map((child, index) => ({
+      child: removeDockWindow(child, windowId),
+      weight: node.weights[index]!,
+    }))
+    .filter(
+      (pair): pair is { child: AppWindowDockNodeShape; weight: number } => pair.child !== null,
+    );
+  if (pairs.length === 0) return null;
+  if (pairs.length === 1) return pairs[0]!.child;
+  return {
+    ...node,
+    children: pairs.map((pair) => pair.child),
+    weights: pairs.map((pair) => pair.weight),
+  };
+}
+
+function insertDockWindow(
+  node: AppWindowDockNodeShape,
+  stackId: string,
+  windowId: string,
+  index: number,
+): AppWindowDockNodeShape {
+  if (node.type === "stack") {
+    if (node.id !== stackId) return node;
+    const windowIds = [...node.windowIds];
+    windowIds.splice(Math.min(index, windowIds.length), 0, windowId);
+    return { ...node, windowIds };
+  }
+  return {
+    ...node,
+    children: node.children.map((child) => insertDockWindow(child, stackId, windowId, index)),
+  };
+}
+
+function activateDockWindow(
+  node: AppWindowDockNodeShape,
+  stackId: string,
+  windowId: string,
+): AppWindowDockNodeShape {
+  if (node.type === "stack") {
+    return node.id === stackId ? { ...node, activeWindowId: windowId } : node;
+  }
+  return {
+    ...node,
+    children: node.children.map((child) => activateDockWindow(child, stackId, windowId)),
+  };
+}
+
+function replaceStack(
+  node: AppWindowDockNodeShape,
+  stackId: string,
+  replacement: Extract<AppWindowDockNodeShape, { type: "stack" }>,
+): AppWindowDockNodeShape {
+  if (node.type === "stack") return node.id === stackId ? replacement : node;
+  return {
+    ...node,
+    children: node.children.map((child) => replaceStack(child, stackId, replacement)),
+  };
+}
+
+function syncDockMemories(
+  windows: Record<string, AppWindowInstance>,
+  node: AppWindowDockNodeShape | null,
+): void {
+  if (!node) return;
+  if (node.type === "split") {
+    for (const child of node.children) syncDockMemories(windows, child);
+    return;
+  }
+  for (const [index, id] of node.windowIds.entries()) {
+    const window = Object.hasOwn(windows, id) ? windows[id] : null;
+    if (!window || window.placement.mode !== "docked") continue;
+    windows[id] = {
+      ...window,
+      placement: { ...window.placement, docked: { stackId: node.id, index } },
+    };
+  }
+}
+
+function uniqueRootStackId(root: AppWindowDockNodeShape | null): string {
+  let ordinal = 0;
+  while (true) {
+    const candidate = ordinal === 0 ? "stack-root" : `stack-root-${ordinal}`;
+    if (!findStack(root, candidate)) return candidate;
+    ordinal += 1;
+  }
+}
+
+function normalizeRect(rect: AppWindowRect): AppWindowRect {
+  return {
+    x: boundedCoordinate(rect.x, "$.rect.x"),
+    y: boundedCoordinate(rect.y, "$.rect.y"),
+    width: boundedExtent(rect.width, APP_WINDOW_FLOAT_MIN_WIDTH, "$.rect.width"),
+    height: boundedExtent(rect.height, APP_WINDOW_FLOAT_MIN_HEIGHT, "$.rect.height"),
+  };
+}
+
+function boundedCoordinate(value: number, path: string): number {
+  if (!Number.isFinite(value)) {
+    throw new AppWindowKernelError("INVALID_INPUT", path, "coordinate must be finite");
+  }
+  return Math.max(-APP_WINDOW_COORDINATE_LIMIT, Math.min(APP_WINDOW_COORDINATE_LIMIT, value));
+}
+
+function boundedExtent(value: number, minimum: number, path: string): number {
+  if (!Number.isFinite(value)) {
+    throw new AppWindowKernelError("INVALID_INPUT", path, "extent must be finite");
+  }
+  return Math.max(minimum, Math.min(APP_WINDOW_COORDINATE_LIMIT, value));
+}
+
+function requireTimestamp(previous: string, value: string): string {
+  let timestamp: string;
+  try {
+    timestamp = AppWindowTimestampSchemaZ.parse(value);
+  } catch (error) {
+    throw translateStateError(error, "$.timestamp");
+  }
+  if (Date.parse(timestamp) < Date.parse(previous)) {
+    throw new AppWindowKernelError(
+      "TIMESTAMP_REGRESSION",
+      "$.updatedAt",
+      "app window mutation timestamp must not move backwards",
+    );
+  }
+  return timestamp;
+}
+
+function requireDocument(value: AppWindowDocumentV1): AppWindowDocumentV1 {
+  try {
+    return AppWindowDocumentV1SchemaZ.parse(value);
+  } catch (error) {
+    throw translateStateError(error, "$");
+  }
+}
+
+function requireId(value: string, path: string): string {
+  try {
+    return AppWindowIdSchemaZ.parse(value);
+  } catch (error) {
+    throw translateStateError(error, path);
+  }
+}
+
+function finalize(
+  current: AppWindowDocumentV1,
+  timestamp: string,
+  patch: Partial<AppWindowDocumentV1>,
+): AppWindowDocumentV1 {
+  try {
+    return AppWindowDocumentV1SchemaZ.parse({
+      ...current,
+      ...patch,
+      version: current.version,
+      revision: current.revision + 1,
+      updatedAt: timestamp,
+    });
+  } catch (error) {
+    throw translateStateError(error, "$");
+  }
+}
+
+function translateStateError(error: unknown, path: string): AppWindowKernelError {
+  if (error instanceof AppWindowKernelError) return error;
+  const message = (error as Error).message;
+  return new AppWindowKernelError("INVALID_INPUT", path, message);
+}

--- a/packages/daemon/src/lib/app-window-kernel.ts
+++ b/packages/daemon/src/lib/app-window-kernel.ts
@@ -115,6 +115,137 @@ export function applyAppWindowCommand(
   }
 }
 
+/**
+ * True when reapplying a semantic command would only repeat an outcome already
+ * visible in the durable document. This is used after a CAS retry so commands
+ * such as delete/dock do not fail merely because another writer completed the
+ * same intent first.
+ */
+export function isAppWindowCommandSatisfied(
+  document: AppWindowDocumentV1,
+  command: AppWindowCommand,
+): boolean {
+  const current = requireDocument(document);
+  switch (command.type) {
+    case "window.focus": {
+      if (command.windowId === null) return current.focusedWindowId === null;
+      const id = requireWindowId(current, command.windowId);
+      if (current.focusedWindowId !== id) return false;
+      const window = current.windows[id]!;
+      if (window.placement.mode === "floating") return current.floatingOrder.at(-1) === id;
+      const stack = window.placement.docked
+        ? findStack(current.dockRoot, window.placement.docked.stackId)
+        : null;
+      return stack?.activeWindowId === id;
+    }
+    case "window.float": {
+      const id = requireWindowId(current, command.windowId);
+      const window = current.windows[id]!;
+      if (
+        window.placement.mode !== "floating" ||
+        !window.placement.floating ||
+        current.focusedWindowId !== id ||
+        current.floatingOrder.at(-1) !== id
+      ) {
+        return false;
+      }
+      return command.rect === undefined
+        ? true
+        : sameRect(window.placement.floating, normalizeRect(command.rect));
+    }
+    case "window.dock": {
+      const id = requireWindowId(current, command.windowId);
+      const window = current.windows[id]!;
+      if (window.placement.mode !== "docked" || !window.placement.docked) return false;
+      if (command.stackId !== undefined) {
+        const stackId = requireId(command.stackId, "$.stackId");
+        if (!findStack(current.dockRoot, stackId)) {
+          throw new AppWindowKernelError(
+            "STACK_NOT_FOUND",
+            `$.dockRoot.${stackId}`,
+            `unknown app window stack "${stackId}"`,
+          );
+        }
+        if (window.placement.docked.stackId !== stackId) return false;
+      }
+      const stack = findStack(current.dockRoot, window.placement.docked.stackId);
+      if (!stack || stack.activeWindowId !== id || current.focusedWindowId !== id) return false;
+      if (command.index === undefined) return true;
+      requireNonnegativeIndex(command.index, "$.index", "dock index must be nonnegative");
+      return stack.windowIds.indexOf(id) === Math.min(command.index, stack.windowIds.length - 1);
+    }
+    case "window.move": {
+      const [, , rect] = requireFloatingWindow(current, command.windowId);
+      return (
+        rect.x === boundedCoordinate(command.x, "$.x") &&
+        rect.y === boundedCoordinate(command.y, "$.y")
+      );
+    }
+    case "window.resize": {
+      const [, , rect] = requireFloatingWindow(current, command.windowId);
+      return (
+        rect.width === boundedExtent(command.width, APP_WINDOW_FLOAT_MIN_WIDTH, "$.width") &&
+        rect.height === boundedExtent(command.height, APP_WINDOW_FLOAT_MIN_HEIGHT, "$.height")
+      );
+    }
+    case "stack.activate": {
+      const stackId = requireId(command.stackId, "$.stackId");
+      const windowId = requireWindowId(current, command.windowId);
+      const stack = requireStack(current.dockRoot, stackId);
+      if (!stack.windowIds.includes(windowId)) {
+        throw new AppWindowKernelError(
+          "WINDOW_NOT_IN_STACK",
+          `$.dockRoot.${stackId}`,
+          `window "${windowId}" is not in stack "${stackId}"`,
+        );
+      }
+      return stack.activeWindowId === windowId && current.focusedWindowId === windowId;
+    }
+    case "stack.reorder": {
+      const stackId = requireId(command.stackId, "$.stackId");
+      const windowId = requireWindowId(current, command.windowId);
+      const stack = requireStack(current.dockRoot, stackId);
+      if (!stack.windowIds.includes(windowId)) {
+        throw new AppWindowKernelError(
+          "WINDOW_NOT_IN_STACK",
+          `$.dockRoot.${stackId}`,
+          `window "${windowId}" is not in stack "${stackId}"`,
+        );
+      }
+      requireNonnegativeIndex(command.index, "$.index", "index must be nonnegative");
+      return (
+        stack.windowIds.indexOf(windowId) === Math.min(command.index, stack.windowIds.length - 1)
+      );
+    }
+    case "layout.save": {
+      const id = requireId(command.layoutId, "$.layoutId");
+      const layout = Object.hasOwn(current.layouts, id) ? current.layouts[id] : null;
+      return Boolean(
+        layout &&
+        layout.name === command.name &&
+        layout.description === (command.description ?? null) &&
+        current.activeLayoutId === id &&
+        sameScene(layout.scene, current),
+      );
+    }
+    case "layout.restore": {
+      const id = requireId(command.layoutId, "$.layoutId");
+      const layout = Object.hasOwn(current.layouts, id) ? current.layouts[id] : null;
+      if (!layout) return false;
+      return current.activeLayoutId === id && sameScene(layout.scene, current);
+    }
+    case "layout.rename": {
+      const id = requireId(command.layoutId, "$.layoutId");
+      const layout = Object.hasOwn(current.layouts, id) ? current.layouts[id] : null;
+      return layout?.name === command.name;
+    }
+    case "layout.delete": {
+      const id = requireId(command.layoutId, "$.layoutId");
+      return !Object.hasOwn(current.layouts, id);
+    }
+  }
+}
+
 function floatWindow(
   current: AppWindowDocumentV1,
   command: Extract<AppWindowCommand, { type: "window.float" }>,
@@ -122,13 +253,6 @@ function floatWindow(
 ): AppWindowDocumentV1 {
   const id = requireWindowId(current, command.windowId);
   const window = current.windows[id]!;
-  if (window.placement.mode !== "docked") {
-    throw new AppWindowKernelError(
-      "INVALID_PLACEMENT",
-      `$.windows.${id}.placement`,
-      `window "${id}" is already floating`,
-    );
-  }
   const rect = normalizeRect(
     command.rect ?? window.placement.floating ?? { x: 2, y: 2, width: 80, height: 24 },
   );
@@ -158,13 +282,6 @@ function dockWindow(
 ): AppWindowDocumentV1 {
   const id = requireWindowId(current, command.windowId);
   const window = current.windows[id]!;
-  if (window.placement.mode !== "floating") {
-    throw new AppWindowKernelError(
-      "INVALID_PLACEMENT",
-      `$.windows.${id}.placement`,
-      `window "${id}" is already docked`,
-    );
-  }
   const requestedStackId =
     command.stackId !== undefined
       ? requireId(command.stackId, "$.stackId")
@@ -176,11 +293,16 @@ function dockWindow(
       `unknown app window stack "${requestedStackId}"`,
     );
   }
-  const existingFallback = firstStackId(current.dockRoot);
+  const dockRootWithoutWindow = removeDockWindow(current.dockRoot, id);
+  const existingFallback = firstStackId(dockRootWithoutWindow);
+  const removedFromRequestedStack =
+    window.placement.mode === "docked" && window.placement.docked?.stackId === requestedStackId;
   const targetStackId =
-    (requestedStackId && findStack(current.dockRoot, requestedStackId)
+    (requestedStackId && findStack(dockRootWithoutWindow, requestedStackId)
       ? requestedStackId
-      : existingFallback) ?? uniqueRootStackId(current.dockRoot);
+      : removedFromRequestedStack
+        ? requestedStackId
+        : existingFallback) ?? uniqueRootStackId(dockRootWithoutWindow);
   const rememberedIndex =
     command.index ?? window.placement.docked?.index ?? Number.MAX_SAFE_INTEGER;
   if (!Number.isInteger(rememberedIndex) || rememberedIndex < 0) {
@@ -199,8 +321,8 @@ function dockWindow(
       floating: window.placement.floating,
     },
   };
-  let dockRoot = current.dockRoot
-    ? insertDockWindow(current.dockRoot, targetStackId, id, rememberedIndex)
+  let dockRoot = dockRootWithoutWindow
+    ? insertDockWindow(dockRootWithoutWindow, targetStackId, id, rememberedIndex)
     : {
         type: "stack" as const,
         id: targetStackId,
@@ -538,6 +660,49 @@ function normalizeRect(rect: AppWindowRect): AppWindowRect {
     width: boundedExtent(rect.width, APP_WINDOW_FLOAT_MIN_WIDTH, "$.rect.width"),
     height: boundedExtent(rect.height, APP_WINDOW_FLOAT_MIN_HEIGHT, "$.rect.height"),
   };
+}
+
+function sameRect(left: AppWindowRect, right: AppWindowRect): boolean {
+  return (
+    left.x === right.x &&
+    left.y === right.y &&
+    left.width === right.width &&
+    left.height === right.height
+  );
+}
+
+function sameScene(
+  left: {
+    windows: AppWindowDocumentV1["windows"];
+    dockRoot: AppWindowDocumentV1["dockRoot"];
+    dockState: AppWindowDocumentV1["dockState"];
+    floatingOrder: AppWindowDocumentV1["floatingOrder"];
+    focusedWindowId: AppWindowDocumentV1["focusedWindowId"];
+  },
+  right: AppWindowDocumentV1,
+): boolean {
+  return (
+    JSON.stringify({
+      windows: left.windows,
+      dockRoot: left.dockRoot,
+      dockState: left.dockState,
+      floatingOrder: left.floatingOrder,
+      focusedWindowId: left.focusedWindowId,
+    }) ===
+    JSON.stringify({
+      windows: right.windows,
+      dockRoot: right.dockRoot,
+      dockState: right.dockState,
+      floatingOrder: right.floatingOrder,
+      focusedWindowId: right.focusedWindowId,
+    })
+  );
+}
+
+function requireNonnegativeIndex(value: number, path: string, message: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new AppWindowKernelError("INVALID_INPUT", path, message);
+  }
 }
 
 function boundedCoordinate(value: number, path: string): number {

--- a/packages/daemon/src/lib/app-window-repository.ts
+++ b/packages/daemon/src/lib/app-window-repository.ts
@@ -1,0 +1,544 @@
+import { AppWindowDocumentV1SchemaZ, type AppWindowDocumentV1 } from "@tmux-ide/contracts";
+
+import {
+  RevisionConflictError,
+  type JsonValue,
+  type ProjectRuntimeRepository,
+} from "./project-runtime-repository.ts";
+import {
+  AppWindowKernelError,
+  applyAppWindowCommand,
+  type AppWindowCommand,
+} from "./app-window-kernel.ts";
+import { withWorkspaceStateLock } from "./workspace-state-repository.ts";
+import {
+  emptyAppWindowDocument,
+  migrateWorkspaceUiStateV2ToAppWindowDocument,
+  parseAppWindowDocument,
+  serializeAppWindowDocument,
+  type AppWindowStateDiagnostic,
+} from "../tui/mirror/app-window-state.ts";
+
+export const APP_WINDOW_DOCUMENT_PATH = "ui/app-windows.json";
+const LEGACY_WORKSPACE_UI_PATH = "ui/workspace.json";
+
+export type AppWindowRepositoryDiagnosticCode =
+  | AppWindowStateDiagnostic["code"]
+  | "MISSING"
+  | "READ_FAILED"
+  | "WRITE_FAILED"
+  | "WRITE_PROTECTED"
+  | "MIGRATION_FAILED"
+  | "REVISION_CONFLICT"
+  | "RECOVERED";
+
+export interface AppWindowRepositoryDiagnostic {
+  code: AppWindowRepositoryDiagnosticCode;
+  path: string;
+  message: string;
+}
+
+export interface LoadedAppWindowDocument {
+  document: AppWindowDocumentV1;
+  revision: number | null;
+  writeProtected: boolean;
+  diagnostics: AppWindowRepositoryDiagnostic[];
+  /** Exact parsed payload retained for inspection; never used as a write source. */
+  preservedPayload?: unknown;
+  /** Token required by explicit recovery. It identifies the exact on-disk bytes. */
+  recoveryToken: string | null;
+}
+
+export interface LoadAppWindowDocumentOptions {
+  loadedAt: string;
+  migrateLegacy?: boolean;
+  migratedAt?: string;
+  terminalSourceIds?: readonly string[];
+  focusedTerminalSourceId?: string | null;
+}
+
+export type AppWindowRepositoryErrorCode =
+  | "READ_FAILED"
+  | "WRITE_FAILED"
+  | "WRITE_PROTECTED"
+  | "REVISION_CONFLICT"
+  | "INVALID_DOCUMENT"
+  | "RECOVERY_NOT_REQUIRED"
+  | "RECOVERY_CONFLICT";
+
+export class AppWindowRepositoryError extends Error {
+  readonly code: AppWindowRepositoryErrorCode;
+  readonly diagnostics: AppWindowRepositoryDiagnostic[];
+  override readonly cause: unknown;
+
+  constructor(
+    code: AppWindowRepositoryErrorCode,
+    message: string,
+    diagnostics: AppWindowRepositoryDiagnostic[] = [],
+    cause?: unknown,
+  ) {
+    super(message);
+    this.name = "AppWindowRepositoryError";
+    this.code = code;
+    this.diagnostics = diagnostics;
+    this.cause = cause;
+  }
+}
+
+export interface ResetAppWindowDocumentRequest {
+  expectedRecoveryToken: string;
+  reason: string;
+  resetAt: string;
+  document?: AppWindowDocumentV1;
+}
+
+export interface ResetAppWindowDocumentResult extends LoadedAppWindowDocument {
+  backupPath: string;
+  metadataPath: string;
+  reason: string;
+}
+
+export interface AppWindowServiceOptions {
+  now?: () => string;
+  migration?: Omit<LoadAppWindowDocumentOptions, "loadedAt" | "migratedAt">;
+  writerLock?: AppWindowWriterLockOptions;
+}
+
+export interface AppWindowWriterLockOptions {
+  timeoutMs?: number;
+  pollMs?: number;
+}
+
+export interface ExecuteAppWindowCommandOptions {
+  /** When supplied, stale callers fail rather than rebasing the command. */
+  expectedRevision?: number | null;
+  maxRetries?: number;
+}
+
+export class AppWindowService {
+  readonly #runtime: ProjectRuntimeRepository;
+  readonly #now: () => string;
+  readonly #migration: AppWindowServiceOptions["migration"];
+  readonly #writerLock: AppWindowWriterLockOptions | undefined;
+
+  constructor(runtime: ProjectRuntimeRepository, options: AppWindowServiceOptions = {}) {
+    this.#runtime = runtime;
+    this.#now = options.now ?? (() => new Date().toISOString());
+    this.#migration = options.migration;
+    this.#writerLock = options.writerLock;
+  }
+
+  load(): LoadedAppWindowDocument {
+    const timestamp = this.#now();
+    return loadAppWindowDocument(this.#runtime, {
+      loadedAt: timestamp,
+      migratedAt: timestamp,
+      ...this.#migration,
+    });
+  }
+
+  execute(
+    command: AppWindowCommand,
+    options: ExecuteAppWindowCommandOptions = {},
+  ): LoadedAppWindowDocument {
+    const expectedRevision = validateExpectedRevision(options.expectedRevision);
+    return withAppWindowWriterLock(this.#runtime, this.#writerLock, () => {
+      const retries = boundedRetries(options.maxRetries);
+      for (let attempt = 0; attempt <= retries; attempt += 1) {
+        const loaded = this.load();
+        assertWritable(loaded);
+        if (expectedRevision !== undefined && expectedRevision !== loaded.revision) {
+          throw revisionError(expectedRevision, loaded.revision);
+        }
+        const clock = this.#now();
+        const timestamp =
+          Date.parse(clock) < Date.parse(loaded.document.updatedAt)
+            ? loaded.document.updatedAt
+            : clock;
+        const next = applyAppWindowCommand(loaded.document, command, timestamp);
+        try {
+          return writeAppWindowDocument(this.#runtime, loaded.revision, next);
+        } catch (error) {
+          if (
+            error instanceof AppWindowRepositoryError &&
+            error.code === "REVISION_CONFLICT" &&
+            expectedRevision === undefined &&
+            attempt < retries
+          ) {
+            continue;
+          }
+          throw error;
+        }
+      }
+      throw new Error("unreachable app-window retry exhaustion");
+    });
+  }
+
+  reset(request: ResetAppWindowDocumentRequest): ResetAppWindowDocumentResult {
+    return withAppWindowWriterLock(this.#runtime, this.#writerLock, () =>
+      resetAppWindowDocument(this.#runtime, request),
+    );
+  }
+}
+
+export function loadAppWindowDocument(
+  repository: ProjectRuntimeRepository,
+  options: LoadAppWindowDocumentOptions,
+): LoadedAppWindowDocument {
+  let runtimeDocument;
+  try {
+    runtimeDocument = repository.readDocument<unknown>(APP_WINDOW_DOCUMENT_PATH);
+  } catch (error) {
+    return protectedReadFailure(repository, options.loadedAt, error);
+  }
+  if (!runtimeDocument.found) {
+    if (options.migrateLegacy !== false) {
+      const migration = attemptFirstMigration(repository, options);
+      if (migration) return migration;
+    }
+    return {
+      document: emptyAppWindowDocument(options.loadedAt),
+      revision: null,
+      writeProtected: false,
+      diagnostics: [diagnostic("MISSING", APP_WINDOW_DOCUMENT_PATH, "app window state is absent")],
+      recoveryToken: null,
+    };
+  }
+  const parsed = parseAppWindowDocument(runtimeDocument.payload, options.loadedAt);
+  const diagnostics = parsed.diagnostics.map((entry) => ({ ...entry }));
+  const writeProtected = parsed.writeProtected || diagnostics.length > 0;
+  return {
+    document: parsed.document,
+    revision: runtimeDocument.revision,
+    writeProtected,
+    diagnostics,
+    ...(writeProtected ? { preservedPayload: structuredClone(runtimeDocument.payload) } : {}),
+    recoveryToken: safeRecoveryToken(repository),
+  };
+}
+
+export function writeAppWindowDocument(
+  repository: ProjectRuntimeRepository,
+  expectedRevision: number | null,
+  document: AppWindowDocumentV1,
+): LoadedAppWindowDocument {
+  const validation = AppWindowDocumentV1SchemaZ.safeParse(document);
+  if (!validation.success) {
+    throw new AppWindowRepositoryError(
+      "INVALID_DOCUMENT",
+      validation.error.issues.map((issue) => issue.message).join("; "),
+    );
+  }
+  const loaded = loadAppWindowDocument(repository, {
+    loadedAt: validation.data.updatedAt,
+    migrateLegacy: false,
+  });
+  assertWritable(loaded);
+  if (loaded.revision !== expectedRevision) throw revisionError(expectedRevision, loaded.revision);
+  assertNextDocumentRevision(loaded, validation.data);
+  try {
+    const payload = JSON.parse(serializeAppWindowDocument(validation.data)) as JsonValue;
+    const written = repository.writeDocument(APP_WINDOW_DOCUMENT_PATH, payload, {
+      expectedRevision,
+    });
+    return {
+      document: validation.data,
+      revision: written.revision,
+      writeProtected: false,
+      diagnostics: [],
+      recoveryToken: safeRecoveryToken(repository),
+    };
+  } catch (error) {
+    if (error instanceof RevisionConflictError) {
+      throw revisionError(error.expectedRevision, error.actualRevision, error);
+    }
+    throw new AppWindowRepositoryError(
+      "WRITE_FAILED",
+      `app window state could not be written: ${(error as Error).message}`,
+      [diagnostic("WRITE_FAILED", APP_WINDOW_DOCUMENT_PATH, (error as Error).message)],
+      error,
+    );
+  }
+}
+
+export function resetAppWindowDocument(
+  repository: ProjectRuntimeRepository,
+  request: ResetAppWindowDocumentRequest,
+): ResetAppWindowDocumentResult {
+  const loaded = loadAppWindowDocument(repository, {
+    loadedAt: request.resetAt,
+    migrateLegacy: false,
+  });
+  if (!loaded.writeProtected) {
+    throw new AppWindowRepositoryError(
+      "RECOVERY_NOT_REQUIRED",
+      "app window state is valid; normal revision CAS must be used",
+    );
+  }
+  if (!loaded.recoveryToken || loaded.recoveryToken !== request.expectedRecoveryToken) {
+    throw new AppWindowRepositoryError(
+      "RECOVERY_CONFLICT",
+      "app window recovery token no longer matches the preserved document",
+    );
+  }
+  let resetDocument: unknown = request.document;
+  if (resetDocument === undefined) {
+    try {
+      resetDocument = emptyAppWindowDocument(request.resetAt);
+    } catch (error) {
+      throw new AppWindowRepositoryError(
+        "INVALID_DOCUMENT",
+        `resetAt must be a valid app window timestamp: ${(error as Error).message}`,
+        [],
+        error,
+      );
+    }
+  }
+  const validation = AppWindowDocumentV1SchemaZ.safeParse(resetDocument);
+  if (!validation.success) {
+    throw new AppWindowRepositoryError(
+      "INVALID_DOCUMENT",
+      validation.error.issues.map((issue) => issue.message).join("; "),
+    );
+  }
+  const document = validation.data;
+  try {
+    const payload = JSON.parse(serializeAppWindowDocument(document)) as JsonValue;
+    const recovered = repository.recoverDocument(APP_WINDOW_DOCUMENT_PATH, payload, {
+      expectedRawSha256: request.expectedRecoveryToken,
+      reason: request.reason,
+      details: {
+        diagnostics: loaded.diagnostics.map((entry) => ({ ...entry })),
+      },
+    });
+    return {
+      document,
+      revision: recovered.revision,
+      writeProtected: false,
+      diagnostics: [
+        diagnostic(
+          "RECOVERED",
+          APP_WINDOW_DOCUMENT_PATH,
+          `app window state was explicitly reset; prior bytes preserved at ${recovered.backupPath}`,
+        ),
+      ],
+      recoveryToken: safeRecoveryToken(repository),
+      backupPath: recovered.backupPath,
+      metadataPath: recovered.metadataPath,
+      reason: recovered.reason,
+    };
+  } catch (error) {
+    if (error instanceof RevisionConflictError) {
+      throw new AppWindowRepositoryError(
+        "RECOVERY_CONFLICT",
+        "app window document changed before explicit recovery",
+        [],
+        error,
+      );
+    }
+    throw new AppWindowRepositoryError(
+      "WRITE_FAILED",
+      `app window recovery failed: ${(error as Error).message}`,
+      [],
+      error,
+    );
+  }
+}
+
+function assertNextDocumentRevision(
+  loaded: LoadedAppWindowDocument,
+  next: AppWindowDocumentV1,
+): void {
+  if (loaded.revision === null) {
+    if (next.revision === 0 || next.revision === 1) return;
+    throw new AppWindowRepositoryError(
+      "INVALID_DOCUMENT",
+      "a new app window document must start at domain revision 0 or 1",
+    );
+  }
+  if (next.revision !== loaded.document.revision + 1) {
+    throw new AppWindowRepositoryError(
+      "INVALID_DOCUMENT",
+      `app window domain revision must advance exactly once from ${loaded.document.revision}`,
+    );
+  }
+  if (Date.parse(next.updatedAt) < Date.parse(loaded.document.updatedAt)) {
+    throw new AppWindowRepositoryError(
+      "INVALID_DOCUMENT",
+      "app window updatedAt must not move backwards",
+    );
+  }
+}
+
+function withAppWindowWriterLock<T>(
+  repository: ProjectRuntimeRepository,
+  options: AppWindowWriterLockOptions | undefined,
+  action: () => T,
+): T {
+  try {
+    return withWorkspaceStateLock(repository, options, action);
+  } catch (error) {
+    if (error instanceof AppWindowRepositoryError || error instanceof AppWindowKernelError) {
+      throw error;
+    }
+    throw new AppWindowRepositoryError(
+      "WRITE_FAILED",
+      `app window writer lock failed: ${(error as Error).message}`,
+      [diagnostic("WRITE_FAILED", APP_WINDOW_DOCUMENT_PATH, (error as Error).message)],
+      error,
+    );
+  }
+}
+
+function attemptFirstMigration(
+  repository: ProjectRuntimeRepository,
+  options: LoadAppWindowDocumentOptions,
+): LoadedAppWindowDocument | null {
+  let legacy;
+  try {
+    legacy = repository.readDocument<unknown>(LEGACY_WORKSPACE_UI_PATH);
+  } catch (error) {
+    return {
+      document: emptyAppWindowDocument(options.loadedAt),
+      revision: null,
+      writeProtected: false,
+      diagnostics: [
+        diagnostic(
+          "MIGRATION_FAILED",
+          LEGACY_WORKSPACE_UI_PATH,
+          `legacy workspace UI state could not be read: ${(error as Error).message}`,
+        ),
+      ],
+      recoveryToken: null,
+    };
+  }
+  if (!legacy.found) return null;
+  try {
+    const migrated = migrateWorkspaceUiStateV2ToAppWindowDocument(legacy.payload, {
+      migratedAt: options.migratedAt ?? options.loadedAt,
+      terminalSourceIds: options.terminalSourceIds,
+      focusedTerminalSourceId: options.focusedTerminalSourceId,
+    });
+    const payload = JSON.parse(serializeAppWindowDocument(migrated.document)) as JsonValue;
+    const written = repository.writeDocument(APP_WINDOW_DOCUMENT_PATH, payload, {
+      expectedRevision: null,
+    });
+    return {
+      document: migrated.document,
+      revision: written.revision,
+      writeProtected: false,
+      diagnostics: migrated.diagnostics,
+      recoveryToken: safeRecoveryToken(repository),
+    };
+  } catch (error) {
+    if (error instanceof RevisionConflictError) {
+      return loadAppWindowDocument(repository, { ...options, migrateLegacy: false });
+    }
+    return {
+      document: emptyAppWindowDocument(options.loadedAt),
+      revision: null,
+      writeProtected: false,
+      diagnostics: [
+        diagnostic(
+          "MIGRATION_FAILED",
+          LEGACY_WORKSPACE_UI_PATH,
+          `legacy workspace UI state was not migrated: ${(error as Error).message}`,
+        ),
+      ],
+      recoveryToken: null,
+    };
+  }
+}
+
+function protectedReadFailure(
+  repository: ProjectRuntimeRepository,
+  loadedAt: string,
+  error: unknown,
+): LoadedAppWindowDocument {
+  return {
+    document: emptyAppWindowDocument(loadedAt),
+    revision: null,
+    writeProtected: true,
+    diagnostics: [
+      diagnostic(
+        "READ_FAILED",
+        APP_WINDOW_DOCUMENT_PATH,
+        `app window state could not be read safely: ${(error as Error).message}`,
+      ),
+    ],
+    recoveryToken: safeRecoveryToken(repository),
+  };
+}
+
+function assertWritable(loaded: LoadedAppWindowDocument): void {
+  if (!loaded.writeProtected) return;
+  throw new AppWindowRepositoryError(
+    "WRITE_PROTECTED",
+    "app window state is not safe to overwrite without explicit recovery",
+    [
+      ...loaded.diagnostics,
+      diagnostic(
+        "WRITE_PROTECTED",
+        APP_WINDOW_DOCUMENT_PATH,
+        "preserved current app window bytes without writing",
+      ),
+    ],
+  );
+}
+
+function safeRecoveryToken(repository: ProjectRuntimeRepository): string | null {
+  try {
+    return repository.documentRecoveryToken(APP_WINDOW_DOCUMENT_PATH);
+  } catch {
+    return null;
+  }
+}
+
+function revisionError(
+  expected: number | null,
+  actual: number | null,
+  cause?: unknown,
+): AppWindowRepositoryError {
+  return new AppWindowRepositoryError(
+    "REVISION_CONFLICT",
+    `app window revision conflict: expected ${String(expected)}, actual ${String(actual)}`,
+    [
+      diagnostic(
+        "REVISION_CONFLICT",
+        APP_WINDOW_DOCUMENT_PATH,
+        `expected ${String(expected)}, actual ${String(actual)}`,
+      ),
+    ],
+    cause,
+  );
+}
+
+function boundedRetries(value: number | undefined): number {
+  if (value === undefined) return 2;
+  if (!Number.isInteger(value) || value < 0 || value > 8) {
+    throw new AppWindowRepositoryError(
+      "INVALID_DOCUMENT",
+      "maxRetries must be an integer between 0 and 8",
+    );
+  }
+  return value;
+}
+
+function validateExpectedRevision(value: number | null | undefined): number | null | undefined {
+  if (value === undefined || value === null) return value;
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new AppWindowRepositoryError(
+      "INVALID_DOCUMENT",
+      "expectedRevision must be null or a nonnegative safe integer",
+    );
+  }
+  return value;
+}
+
+function diagnostic(
+  code: AppWindowRepositoryDiagnosticCode,
+  path: string,
+  message: string,
+): AppWindowRepositoryDiagnostic {
+  return { code, path, message };
+}

--- a/packages/daemon/src/lib/app-window-repository.ts
+++ b/packages/daemon/src/lib/app-window-repository.ts
@@ -3,14 +3,15 @@ import { AppWindowDocumentV1SchemaZ, type AppWindowDocumentV1 } from "@tmux-ide/
 import {
   RevisionConflictError,
   type JsonValue,
+  type ProjectRuntimeLockedWriter,
   type ProjectRuntimeRepository,
 } from "./project-runtime-repository.ts";
 import {
   AppWindowKernelError,
   applyAppWindowCommand,
+  isAppWindowCommandSatisfied,
   type AppWindowCommand,
 } from "./app-window-kernel.ts";
-import { withWorkspaceStateLock } from "./workspace-state-repository.ts";
 import {
   emptyAppWindowDocument,
   migrateWorkspaceUiStateV2ToAppWindowDocument,
@@ -55,6 +56,8 @@ export interface LoadAppWindowDocumentOptions {
   migratedAt?: string;
   terminalSourceIds?: readonly string[];
   focusedTerminalSourceId?: string | null;
+  /** Explicitly permits a fresh document after a failed legacy migration. */
+  migrationFailureOptOut?: { reason: string };
 }
 
 export type AppWindowRepositoryErrorCode =
@@ -100,8 +103,14 @@ export interface ResetAppWindowDocumentResult extends LoadedAppWindowDocument {
 
 export interface AppWindowServiceOptions {
   now?: () => string;
-  migration?: Omit<LoadAppWindowDocumentOptions, "loadedAt" | "migratedAt">;
+  migration?: AppWindowServiceMigrationOptions;
   writerLock?: AppWindowWriterLockOptions;
+}
+
+export interface AppWindowServiceMigrationOptions {
+  terminalSourceIds?: readonly string[];
+  focusedTerminalSourceId?: string | null;
+  migrationFailureOptOut?: { reason: string };
 }
 
 export interface AppWindowWriterLockOptions {
@@ -124,7 +133,13 @@ export class AppWindowService {
   constructor(runtime: ProjectRuntimeRepository, options: AppWindowServiceOptions = {}) {
     this.#runtime = runtime;
     this.#now = options.now ?? (() => new Date().toISOString());
-    this.#migration = options.migration;
+    this.#migration = options.migration
+      ? {
+          terminalSourceIds: options.migration.terminalSourceIds,
+          focusedTerminalSourceId: options.migration.focusedTerminalSourceId,
+          migrationFailureOptOut: options.migration.migrationFailureOptOut,
+        }
+      : undefined;
     this.#writerLock = options.writerLock;
   }
 
@@ -142,22 +157,32 @@ export class AppWindowService {
     options: ExecuteAppWindowCommandOptions = {},
   ): LoadedAppWindowDocument {
     const expectedRevision = validateExpectedRevision(options.expectedRevision);
-    return withAppWindowWriterLock(this.#runtime, this.#writerLock, () => {
+    return withAppWindowWriterLock(this.#runtime, this.#writerLock, (writer) => {
       const retries = boundedRetries(options.maxRetries);
       for (let attempt = 0; attempt <= retries; attempt += 1) {
-        const loaded = this.load();
+        const timestamp = this.#now();
+        const loaded = loadAppWindowDocumentInternal(
+          this.#runtime,
+          {
+            loadedAt: timestamp,
+            migratedAt: timestamp,
+            ...this.#migration,
+          },
+          writer,
+        );
         assertWritable(loaded);
         if (expectedRevision !== undefined && expectedRevision !== loaded.revision) {
           throw revisionError(expectedRevision, loaded.revision);
         }
+        if (isAppWindowCommandSatisfied(loaded.document, command)) return loaded;
         const clock = this.#now();
-        const timestamp =
+        const commandTimestamp =
           Date.parse(clock) < Date.parse(loaded.document.updatedAt)
             ? loaded.document.updatedAt
             : clock;
-        const next = applyAppWindowCommand(loaded.document, command, timestamp);
+        const next = applyAppWindowCommand(loaded.document, command, commandTimestamp);
         try {
-          return writeAppWindowDocument(this.#runtime, loaded.revision, next);
+          return writeAppWindowDocumentLocked(this.#runtime, writer, loaded.revision, next);
         } catch (error) {
           if (
             error instanceof AppWindowRepositoryError &&
@@ -175,8 +200,8 @@ export class AppWindowService {
   }
 
   reset(request: ResetAppWindowDocumentRequest): ResetAppWindowDocumentResult {
-    return withAppWindowWriterLock(this.#runtime, this.#writerLock, () =>
-      resetAppWindowDocument(this.#runtime, request),
+    return withAppWindowWriterLock(this.#runtime, this.#writerLock, (writer) =>
+      resetAppWindowDocumentLocked(this.#runtime, writer, request),
     );
   }
 }
@@ -184,6 +209,14 @@ export class AppWindowService {
 export function loadAppWindowDocument(
   repository: ProjectRuntimeRepository,
   options: LoadAppWindowDocumentOptions,
+): LoadedAppWindowDocument {
+  return loadAppWindowDocumentInternal(repository, options);
+}
+
+function loadAppWindowDocumentInternal(
+  repository: ProjectRuntimeRepository,
+  options: LoadAppWindowDocumentOptions,
+  writer?: ProjectRuntimeLockedWriter,
 ): LoadedAppWindowDocument {
   let runtimeDocument;
   try {
@@ -193,7 +226,9 @@ export function loadAppWindowDocument(
   }
   if (!runtimeDocument.found) {
     if (options.migrateLegacy !== false) {
-      const migration = attemptFirstMigration(repository, options);
+      const migration = writer
+        ? attemptFirstMigrationLocked(repository, writer, options)
+        : attemptFirstMigration(repository, options);
       if (migration) return migration;
     }
     return {
@@ -222,6 +257,17 @@ export function writeAppWindowDocument(
   expectedRevision: number | null,
   document: AppWindowDocumentV1,
 ): LoadedAppWindowDocument {
+  return withAppWindowWriterLock(repository, undefined, (writer) =>
+    writeAppWindowDocumentLocked(repository, writer, expectedRevision, document),
+  );
+}
+
+function writeAppWindowDocumentLocked(
+  repository: ProjectRuntimeRepository,
+  writer: ProjectRuntimeLockedWriter,
+  expectedRevision: number | null,
+  document: AppWindowDocumentV1,
+): LoadedAppWindowDocument {
   const validation = AppWindowDocumentV1SchemaZ.safeParse(document);
   if (!validation.success) {
     throw new AppWindowRepositoryError(
@@ -238,7 +284,7 @@ export function writeAppWindowDocument(
   assertNextDocumentRevision(loaded, validation.data);
   try {
     const payload = JSON.parse(serializeAppWindowDocument(validation.data)) as JsonValue;
-    const written = repository.writeDocument(APP_WINDOW_DOCUMENT_PATH, payload, {
+    const written = writer.writeDocument(APP_WINDOW_DOCUMENT_PATH, payload, {
       expectedRevision,
     });
     return {
@@ -263,6 +309,16 @@ export function writeAppWindowDocument(
 
 export function resetAppWindowDocument(
   repository: ProjectRuntimeRepository,
+  request: ResetAppWindowDocumentRequest,
+): ResetAppWindowDocumentResult {
+  return withAppWindowWriterLock(repository, undefined, (writer) =>
+    resetAppWindowDocumentLocked(repository, writer, request),
+  );
+}
+
+function resetAppWindowDocumentLocked(
+  repository: ProjectRuntimeRepository,
+  writer: ProjectRuntimeLockedWriter,
   request: ResetAppWindowDocumentRequest,
 ): ResetAppWindowDocumentResult {
   const loaded = loadAppWindowDocument(repository, {
@@ -304,7 +360,7 @@ export function resetAppWindowDocument(
   const document = validation.data;
   try {
     const payload = JSON.parse(serializeAppWindowDocument(document)) as JsonValue;
-    const recovered = repository.recoverDocument(APP_WINDOW_DOCUMENT_PATH, payload, {
+    const recovered = writer.recoverDocument(APP_WINDOW_DOCUMENT_PATH, payload, {
       expectedRawSha256: request.expectedRecoveryToken,
       reason: request.reason,
       details: {
@@ -373,10 +429,10 @@ function assertNextDocumentRevision(
 function withAppWindowWriterLock<T>(
   repository: ProjectRuntimeRepository,
   options: AppWindowWriterLockOptions | undefined,
-  action: () => T,
+  action: (writer: ProjectRuntimeLockedWriter) => T,
 ): T {
   try {
-    return withWorkspaceStateLock(repository, options, action);
+    return repository.withWriterLock(options, action);
   } catch (error) {
     if (error instanceof AppWindowRepositoryError || error instanceof AppWindowKernelError) {
       throw error;
@@ -394,23 +450,44 @@ function attemptFirstMigration(
   repository: ProjectRuntimeRepository,
   options: LoadAppWindowDocumentOptions,
 ): LoadedAppWindowDocument | null {
+  try {
+    return withAppWindowWriterLock(repository, undefined, (writer) =>
+      attemptFirstMigrationLocked(repository, writer, options),
+    );
+  } catch (error) {
+    return migrationFailure(
+      repository,
+      options,
+      error,
+      "legacy migration lock could not be acquired",
+    );
+  }
+}
+
+function attemptFirstMigrationLocked(
+  repository: ProjectRuntimeRepository,
+  writer: ProjectRuntimeLockedWriter,
+  options: LoadAppWindowDocumentOptions,
+): LoadedAppWindowDocument | null {
+  let current;
+  try {
+    current = repository.readDocument<unknown>(APP_WINDOW_DOCUMENT_PATH);
+  } catch (error) {
+    return protectedReadFailure(repository, options.loadedAt, error);
+  }
+  if (current.found) {
+    return loadAppWindowDocumentInternal(repository, { ...options, migrateLegacy: false }, writer);
+  }
   let legacy;
   try {
     legacy = repository.readDocument<unknown>(LEGACY_WORKSPACE_UI_PATH);
   } catch (error) {
-    return {
-      document: emptyAppWindowDocument(options.loadedAt),
-      revision: null,
-      writeProtected: false,
-      diagnostics: [
-        diagnostic(
-          "MIGRATION_FAILED",
-          LEGACY_WORKSPACE_UI_PATH,
-          `legacy workspace UI state could not be read: ${(error as Error).message}`,
-        ),
-      ],
-      recoveryToken: null,
-    };
+    return migrationFailure(
+      repository,
+      options,
+      error,
+      "legacy workspace UI state could not be read",
+    );
   }
   if (!legacy.found) return null;
   try {
@@ -420,7 +497,7 @@ function attemptFirstMigration(
       focusedTerminalSourceId: options.focusedTerminalSourceId,
     });
     const payload = JSON.parse(serializeAppWindowDocument(migrated.document)) as JsonValue;
-    const written = repository.writeDocument(APP_WINDOW_DOCUMENT_PATH, payload, {
+    const written = writer.writeDocument(APP_WINDOW_DOCUMENT_PATH, payload, {
       expectedRevision: null,
     });
     return {
@@ -432,22 +509,51 @@ function attemptFirstMigration(
     };
   } catch (error) {
     if (error instanceof RevisionConflictError) {
-      return loadAppWindowDocument(repository, { ...options, migrateLegacy: false });
+      return loadAppWindowDocumentInternal(
+        repository,
+        { ...options, migrateLegacy: false },
+        writer,
+      );
     }
-    return {
-      document: emptyAppWindowDocument(options.loadedAt),
-      revision: null,
-      writeProtected: false,
-      diagnostics: [
-        diagnostic(
-          "MIGRATION_FAILED",
-          LEGACY_WORKSPACE_UI_PATH,
-          `legacy workspace UI state was not migrated: ${(error as Error).message}`,
-        ),
-      ],
-      recoveryToken: null,
-    };
+    return migrationFailure(
+      repository,
+      options,
+      error,
+      "legacy workspace UI state was not migrated",
+    );
   }
+}
+
+function migrationFailure(
+  repository: ProjectRuntimeRepository,
+  options: LoadAppWindowDocumentOptions,
+  error: unknown,
+  context: string,
+): LoadedAppWindowDocument {
+  const optOut = validateMigrationFailureOptOut(options.migrationFailureOptOut);
+  const suffix = optOut
+    ? `; explicit migration opt-out accepted: ${optOut}`
+    : "; writes remain protected until an explicit migration opt-out reason is supplied";
+  return {
+    document: emptyAppWindowDocument(options.loadedAt),
+    revision: null,
+    writeProtected: optOut === null,
+    diagnostics: [
+      diagnostic(
+        "MIGRATION_FAILED",
+        LEGACY_WORKSPACE_UI_PATH,
+        `${context}: ${(error as Error).message}${suffix}`,
+      ),
+    ],
+    recoveryToken: safeRecoveryToken(repository),
+  };
+}
+
+function validateMigrationFailureOptOut(value: { reason: string } | undefined): string | null {
+  if (value === undefined) return null;
+  const reason = value.reason.trim();
+  if (reason.length === 0 || reason.length > 512 || reason.includes("\0")) return null;
+  return reason;
 }
 
 function protectedReadFailure(

--- a/packages/daemon/src/lib/project-runtime-repository.ts
+++ b/packages/daemon/src/lib/project-runtime-repository.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { lstatSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, relative, resolve, sep, win32 } from "node:path";
 
@@ -78,6 +78,22 @@ export interface WriteDocumentResult<T> {
   version: typeof DOCUMENT_ENVELOPE_VERSION;
   revision: number;
   payload: T;
+}
+
+export interface RecoverDocumentOptions {
+  /** Exact token returned by `documentRecoveryToken`; prevents stale recovery. */
+  expectedRawSha256: string;
+  /** Required operator-facing explanation for the destructive reset. */
+  reason: string;
+  /** Optional JSON audit context persisted beside the exact-byte backup. */
+  details?: JsonValue;
+}
+
+export interface RecoverDocumentResult<T> extends WriteDocumentResult<T> {
+  previousRawSha256: string;
+  backupPath: string;
+  metadataPath: string;
+  reason: string;
 }
 
 export interface RuntimeEvent<T> {
@@ -341,6 +357,94 @@ export class ProjectRuntimeRepository {
     };
   }
 
+  /**
+   * Token for explicit recovery of a document whose envelope or payload cannot
+   * be safely written through normal revision CAS. No bytes are exposed.
+   */
+  documentRecoveryToken(path: string): string | null {
+    const target = this.resolveRuntimePath(path);
+    const raw = this.readOptionalFile(target, path);
+    return raw === null ? null : sha256(raw);
+  }
+
+  /**
+   * Explicit destructive recovery. The exact prior bytes are atomically copied
+   * beneath `recovery/` before the target is replaced. Normal writes must never
+   * call this path.
+   */
+  recoverDocument<T>(
+    path: string,
+    payload: T,
+    options: RecoverDocumentOptions,
+  ): RecoverDocumentResult<T> {
+    const reason = options.reason.trim();
+    if (reason.length === 0 || reason.length > 512 || reason.includes("\0")) {
+      throw new InvalidJsonValueError(
+        "$.reason",
+        "recovery reason must contain 1-512 non-NUL characters",
+      );
+    }
+    if (!/^[a-f0-9]{64}$/u.test(options.expectedRawSha256)) {
+      throw new InvalidJsonValueError("$.expectedRawSha256", "recovery token must be SHA-256");
+    }
+    const target = this.resolveRuntimePath(path);
+    const raw = this.readOptionalFile(target, path);
+    if (raw === null) throw new MissingRuntimeDocumentError(path);
+    const actualToken = sha256(raw);
+    if (actualToken !== options.expectedRawSha256) {
+      throw new RevisionConflictError(path, null, null);
+    }
+    const serializedPayload = serializeJsonPayload(payload);
+    let priorRevision = 0;
+    try {
+      priorRevision = parseDocumentEnvelope(path, raw).revision;
+    } catch {
+      // Corrupt/unsupported envelopes restart at revision 1 after backup.
+    }
+    const recoveredAt = this.io.now();
+    if (!Number.isFinite(recoveredAt.getTime())) {
+      throw new InvalidJsonValueError("$.recoveredAt", "recovery timestamp must be valid");
+    }
+    const metadata = serializeJsonPayload({
+      version: 1,
+      path,
+      previousRawSha256: actualToken,
+      reason,
+      recoveredAt: recoveredAt.toISOString(),
+      details: options.details ?? null,
+    });
+    const safePath = sha256(path);
+    const backupPath = `recovery/${safePath}-${actualToken}.bak`;
+    const metadataPath = `recovery/${safePath}-${actualToken}.json`;
+    const backupTarget = this.resolveRuntimePath(backupPath);
+    this.atomicWrite(backupTarget, raw, backupPath);
+    this.atomicWrite(
+      this.resolveRuntimePath(metadataPath),
+      `${JSON.stringify(metadata, null, 2)}\n`,
+      metadataPath,
+    );
+    const recheckedRaw = this.readOptionalFile(target, path);
+    if (recheckedRaw === null || sha256(recheckedRaw) !== actualToken) {
+      throw new RevisionConflictError(path, null, null);
+    }
+    const envelope: DocumentEnvelope = {
+      version: DOCUMENT_ENVELOPE_VERSION,
+      revision: priorRevision + 1,
+      payload: serializedPayload,
+    };
+    this.atomicWrite(target, `${JSON.stringify(envelope, null, 2)}\n`, path);
+    return {
+      path,
+      version: DOCUMENT_ENVELOPE_VERSION,
+      revision: envelope.revision,
+      payload: cloneJson(serializedPayload) as T,
+      previousRawSha256: actualToken,
+      backupPath,
+      metadataPath,
+      reason,
+    };
+  }
+
   readEvents<T = JsonValue>(stream: string): RuntimeEvent<T>[] {
     const target = this.resolveEventPath(stream);
     const raw = this.readOptionalFile(target, `events/${stream}.jsonl`);
@@ -508,6 +612,10 @@ function parseDocumentEnvelope(path: string, raw: string): DocumentEnvelope {
     revision,
     payload: cloneJson(value.payload),
   };
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
 }
 
 function parseEventLog<T>(stream: string, raw: string): RuntimeEvent<T>[] {

--- a/packages/daemon/src/lib/project-runtime-repository.ts
+++ b/packages/daemon/src/lib/project-runtime-repository.ts
@@ -1,5 +1,16 @@
 import { createHash, randomUUID } from "node:crypto";
-import { lstatSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { isAbsolute, join, relative, resolve, sep, win32 } from "node:path";
 
 import type { ProjectResolution, ResolveProjectOptions } from "./project-resolver.js";
@@ -9,6 +20,8 @@ import { stateHome } from "./state-home.js";
 const DOCUMENT_ENVELOPE_VERSION = 1;
 const EVENT_ENVELOPE_VERSION = 1;
 const SAFE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const PROJECT_RUNTIME_WRITER_LOCK_FILENAME = "workspace/.state.lock";
+const PROJECT_RUNTIME_PROCESS_INSTANCE_ID = randomUUID();
 
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
@@ -22,11 +35,16 @@ export type ProjectRuntimeErrorCode =
   | "REVISION_CONFLICT"
   | "EVENT_SEQUENCE_CONFLICT"
   | "EVENT_LOG_CORRUPT"
+  | "WRITER_LOCK_TIMEOUT"
   | "IO_ERROR";
 
 export interface ProjectRuntimeRepositoryIo {
   readFile(path: string): string;
   writeFile(path: string, data: string): void;
+  readBytes(path: string): Uint8Array;
+  writeBytes(path: string, data: Uint8Array): void;
+  fsyncFile(path: string): void;
+  fsyncDirectory(path: string): void;
   mkdir(path: string): void;
   rename(from: string, to: string): void;
   unlink(path: string): void;
@@ -94,6 +112,27 @@ export interface RecoverDocumentResult<T> extends WriteDocumentResult<T> {
   backupPath: string;
   metadataPath: string;
   reason: string;
+}
+
+export interface ProjectRuntimeWriterLockOptions {
+  timeoutMs?: number;
+  pollMs?: number;
+}
+
+export interface ProjectRuntimeWriterLockOutcome<T> {
+  value: T;
+  releaseError: Error | null;
+}
+
+/** Short-lived capability valid only while the project writer lock is held. */
+export interface ProjectRuntimeLockedWriter {
+  writeDocument<T>(path: string, payload: T, options: WriteDocumentOptions): WriteDocumentResult<T>;
+  recoverDocument<T>(
+    path: string,
+    payload: T,
+    options: RecoverDocumentOptions,
+  ): RecoverDocumentResult<T>;
+  appendEvent<T>(stream: string, payload: T, options?: AppendEventOptions): RuntimeEvent<T>;
 }
 
 export interface RuntimeEvent<T> {
@@ -199,6 +238,21 @@ export class RevisionConflictError extends ProjectRuntimeRepositoryError {
   }
 }
 
+export class ProjectRuntimeWriterLockTimeoutError extends ProjectRuntimeRepositoryError {
+  readonly lockPath: string;
+  readonly timeoutMs: number;
+
+  constructor(lockPath: string, timeoutMs: number) {
+    super(
+      "WRITER_LOCK_TIMEOUT",
+      `Timed out after ${timeoutMs}ms waiting for project runtime writer lock`,
+    );
+    this.name = "ProjectRuntimeWriterLockTimeoutError";
+    this.lockPath = lockPath;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 export class EventSequenceConflictError extends ProjectRuntimeRepositoryError {
   readonly stream: string;
   readonly expectedPreviousSequence: number;
@@ -255,6 +309,24 @@ interface EventEnvelope {
 const defaultIo: ProjectRuntimeRepositoryIo = {
   readFile: (path) => readFileSync(path, "utf-8"),
   writeFile: (path, data) => writeFileSync(path, data, "utf-8"),
+  readBytes: (path) => readFileSync(path),
+  writeBytes: (path, data) => writeFileSync(path, data),
+  fsyncFile: (path) => {
+    const descriptor = openSync(path, "r");
+    try {
+      fsyncSync(descriptor);
+    } finally {
+      closeSync(descriptor);
+    }
+  },
+  fsyncDirectory: (path) => {
+    const descriptor = openSync(path, "r");
+    try {
+      fsyncSync(descriptor);
+    } finally {
+      closeSync(descriptor);
+    }
+  },
   mkdir: (path) => mkdirSync(path, { recursive: true }),
   rename: renameSync,
   unlink: unlinkSync,
@@ -299,7 +371,8 @@ export class ProjectRuntimeRepository {
 
   readDocument<T = JsonValue>(path: string): ProjectRuntimeDocument<T> {
     const target = this.resolveRuntimePath(path);
-    const raw = this.readOptionalFile(target, path);
+    const bytes = this.readOptionalBytes(target, path);
+    const raw = bytes === null ? null : decodeUtf8Strict(bytes, path);
     if (raw === null) return { found: false, path, revision: null };
     const envelope = parseDocumentEnvelope(path, raw);
     return {
@@ -327,6 +400,99 @@ export class ProjectRuntimeRepository {
     payload: T,
     options: WriteDocumentOptions,
   ): WriteDocumentResult<T> {
+    return this.withWriterLock(undefined, (writer) => writer.writeDocument(path, payload, options));
+  }
+
+  /**
+   * Serialize a compound read/check/write transaction with every other
+   * compliant project-runtime writer, including writers in other processes.
+   * The supplied capability expires as soon as the callback returns.
+   */
+  withWriterLock<T>(
+    options: ProjectRuntimeWriterLockOptions | undefined,
+    action: (writer: ProjectRuntimeLockedWriter) => T,
+  ): T {
+    const outcome = this.withWriterLockOutcome(options, action);
+    if (outcome.releaseError) throw outcome.releaseError;
+    return outcome.value;
+  }
+
+  withWriterLockOutcome<T>(
+    options: ProjectRuntimeWriterLockOptions | undefined,
+    action: (writer: ProjectRuntimeLockedWriter) => T,
+  ): ProjectRuntimeWriterLockOutcome<T> {
+    const release = this.acquireWriterLock(options);
+    let active = true;
+    const assertActive = (): void => {
+      if (!active) {
+        throw new ProjectRuntimeRepositoryError(
+          "IO_ERROR",
+          "Project runtime locked-writer capability is no longer active",
+        );
+      }
+    };
+    const writer: ProjectRuntimeLockedWriter = {
+      writeDocument: <TValue>(
+        path: string,
+        payload: TValue,
+        writeOptions: WriteDocumentOptions,
+      ): WriteDocumentResult<TValue> => {
+        assertActive();
+        return this.writeDocumentUnlocked(path, payload, writeOptions);
+      },
+      recoverDocument: <TValue>(
+        path: string,
+        payload: TValue,
+        recoverOptions: RecoverDocumentOptions,
+      ): RecoverDocumentResult<TValue> => {
+        assertActive();
+        return this.recoverDocumentUnlocked(path, payload, recoverOptions);
+      },
+      appendEvent: <TValue>(
+        stream: string,
+        payload: TValue,
+        appendOptions: AppendEventOptions = {},
+      ): RuntimeEvent<TValue> => {
+        assertActive();
+        return this.appendEventUnlocked(stream, payload, appendOptions);
+      },
+    };
+    let value: T;
+    try {
+      value = action(writer);
+      if (isPromiseLike(value)) {
+        throw new ProjectRuntimeRepositoryError(
+          "IO_ERROR",
+          "Project runtime writer transactions must be synchronous",
+        );
+      }
+    } catch (error) {
+      active = false;
+      try {
+        release();
+      } catch {
+        // Preserve the operation error; an abandoned lock is inspectable and
+        // must be recovered explicitly rather than hiding the original cause.
+      }
+      throw error;
+    }
+    active = false;
+    try {
+      release();
+      return { value, releaseError: null };
+    } catch (error) {
+      return {
+        value,
+        releaseError: error instanceof Error ? error : new Error(String(error)),
+      };
+    }
+  }
+
+  private writeDocumentUnlocked<T>(
+    path: string,
+    payload: T,
+    options: WriteDocumentOptions,
+  ): WriteDocumentResult<T> {
     if (
       options.expectedRevision !== null &&
       (!Number.isSafeInteger(options.expectedRevision) || options.expectedRevision < 1)
@@ -334,7 +500,8 @@ export class ProjectRuntimeRepository {
       throw new RevisionConflictError(path, options.expectedRevision, null);
     }
     const target = this.resolveRuntimePath(path);
-    const existing = this.readOptionalFile(target, path);
+    const existingBytes = this.readOptionalBytes(target, path);
+    const existing = existingBytes === null ? null : decodeUtf8Strict(existingBytes, path);
     const current = existing === null ? null : parseDocumentEnvelope(path, existing);
     const actualRevision = current?.revision ?? null;
 
@@ -363,7 +530,7 @@ export class ProjectRuntimeRepository {
    */
   documentRecoveryToken(path: string): string | null {
     const target = this.resolveRuntimePath(path);
-    const raw = this.readOptionalFile(target, path);
+    const raw = this.readOptionalBytes(target, path);
     return raw === null ? null : sha256(raw);
   }
 
@@ -373,6 +540,16 @@ export class ProjectRuntimeRepository {
    * call this path.
    */
   recoverDocument<T>(
+    path: string,
+    payload: T,
+    options: RecoverDocumentOptions,
+  ): RecoverDocumentResult<T> {
+    return this.withWriterLock(undefined, (writer) =>
+      writer.recoverDocument(path, payload, options),
+    );
+  }
+
+  private recoverDocumentUnlocked<T>(
     path: string,
     payload: T,
     options: RecoverDocumentOptions,
@@ -388,7 +565,7 @@ export class ProjectRuntimeRepository {
       throw new InvalidJsonValueError("$.expectedRawSha256", "recovery token must be SHA-256");
     }
     const target = this.resolveRuntimePath(path);
-    const raw = this.readOptionalFile(target, path);
+    const raw = this.readOptionalBytes(target, path);
     if (raw === null) throw new MissingRuntimeDocumentError(path);
     const actualToken = sha256(raw);
     if (actualToken !== options.expectedRawSha256) {
@@ -397,7 +574,7 @@ export class ProjectRuntimeRepository {
     const serializedPayload = serializeJsonPayload(payload);
     let priorRevision = 0;
     try {
-      priorRevision = parseDocumentEnvelope(path, raw).revision;
+      priorRevision = parseDocumentEnvelope(path, decodeUtf8(raw)).revision;
     } catch {
       // Corrupt/unsupported envelopes restart at revision 1 after backup.
     }
@@ -405,34 +582,62 @@ export class ProjectRuntimeRepository {
     if (!Number.isFinite(recoveredAt.getTime())) {
       throw new InvalidJsonValueError("$.recoveredAt", "recovery timestamp must be valid");
     }
-    const metadata = serializeJsonPayload({
-      version: 1,
-      path,
-      previousRawSha256: actualToken,
-      reason,
-      recoveredAt: recoveredAt.toISOString(),
-      details: options.details ?? null,
-    });
-    const safePath = sha256(path);
-    const backupPath = `recovery/${safePath}-${actualToken}.bak`;
-    const metadataPath = `recovery/${safePath}-${actualToken}.json`;
-    const backupTarget = this.resolveRuntimePath(backupPath);
-    this.atomicWrite(backupTarget, raw, backupPath);
-    this.atomicWrite(
-      this.resolveRuntimePath(metadataPath),
-      `${JSON.stringify(metadata, null, 2)}\n`,
-      metadataPath,
-    );
-    const recheckedRaw = this.readOptionalFile(target, path);
-    if (recheckedRaw === null || sha256(recheckedRaw) !== actualToken) {
-      throw new RevisionConflictError(path, null, null);
-    }
     const envelope: DocumentEnvelope = {
       version: DOCUMENT_ENVELOPE_VERSION,
       revision: priorRevision + 1,
       payload: serializedPayload,
     };
-    this.atomicWrite(target, `${JSON.stringify(envelope, null, 2)}\n`, path);
+    const replacement = encodeUtf8(`${JSON.stringify(envelope, null, 2)}\n`);
+    const recovery = this.reserveRecoveryOperation(path, actualToken);
+    const backupPath = `${recovery.relativePath}/previous.bak`;
+    const metadataPath = `${recovery.relativePath}/audit.json`;
+    const preparedMetadata = {
+      version: 1,
+      status: "prepared",
+      operationId: recovery.operationId,
+      path,
+      backupPath,
+      previousRawSha256: actualToken,
+      replacementRawSha256: sha256(replacement),
+      replacementRevision: envelope.revision,
+      reason,
+      recoveredAt: recoveredAt.toISOString(),
+      details: options.details ?? null,
+    } as const;
+    const backupTarget = this.resolveRuntimePath(backupPath);
+    try {
+      this.atomicWriteBytes(backupTarget, raw, backupPath, true);
+    } catch (error) {
+      try {
+        rmdirSync(recovery.target);
+        this.io.fsyncDirectory(resolve(recovery.target, ".."));
+      } catch {
+        // Preserve the backup failure; a non-empty artifact remains inspectable.
+      }
+      throw error;
+    }
+    this.atomicWriteBytes(
+      this.resolveRuntimePath(metadataPath),
+      encodeUtf8(`${JSON.stringify(serializeJsonPayload(preparedMetadata), null, 2)}\n`),
+      metadataPath,
+      true,
+    );
+    const recheckedRaw = this.readOptionalBytes(target, path);
+    if (recheckedRaw === null || sha256(recheckedRaw) !== actualToken) {
+      throw new RevisionConflictError(path, null, null);
+    }
+    this.atomicWriteBytes(target, replacement, path, true);
+    const completedMetadata = serializeJsonPayload({
+      ...preparedMetadata,
+      status: "completed",
+      completedAt: this.io.now().toISOString(),
+    });
+    this.atomicWriteBytes(
+      this.resolveRuntimePath(metadataPath),
+      encodeUtf8(`${JSON.stringify(completedMetadata, null, 2)}\n`),
+      metadataPath,
+      true,
+    );
     return {
       path,
       version: DOCUMENT_ENVELOPE_VERSION,
@@ -447,12 +652,21 @@ export class ProjectRuntimeRepository {
 
   readEvents<T = JsonValue>(stream: string): RuntimeEvent<T>[] {
     const target = this.resolveEventPath(stream);
-    const raw = this.readOptionalFile(target, `events/${stream}.jsonl`);
+    const bytes = this.readOptionalBytes(target, `events/${stream}.jsonl`);
+    const raw = bytes === null ? null : decodeUtf8Strict(bytes, `events/${stream}.jsonl`);
     if (raw === null) return [];
     return parseEventLog<T>(stream, raw);
   }
 
   appendEvent<T>(stream: string, payload: T, options: AppendEventOptions = {}): RuntimeEvent<T> {
+    return this.withWriterLock(undefined, (writer) => writer.appendEvent(stream, payload, options));
+  }
+
+  private appendEventUnlocked<T>(
+    stream: string,
+    payload: T,
+    options: AppendEventOptions = {},
+  ): RuntimeEvent<T> {
     if (
       options.expectedPreviousSequence !== undefined &&
       (!Number.isSafeInteger(options.expectedPreviousSequence) ||
@@ -461,7 +675,8 @@ export class ProjectRuntimeRepository {
       throw new EventSequenceConflictError(stream, options.expectedPreviousSequence, 0);
     }
     const target = this.resolveEventPath(stream);
-    const raw = this.readOptionalFile(target, `events/${stream}.jsonl`);
+    const bytes = this.readOptionalBytes(target, `events/${stream}.jsonl`);
+    const raw = bytes === null ? null : decodeUtf8Strict(bytes, `events/${stream}.jsonl`);
     const events = raw === null ? [] : parseEventLog<JsonValue>(stream, raw);
     const actualPreviousSequence = events.at(-1)?.sequence ?? 0;
 
@@ -538,12 +753,12 @@ export class ProjectRuntimeRepository {
     }
   }
 
-  private readOptionalFile(path: string, displayPath: string): string | null {
+  private readOptionalBytes(path: string, displayPath: string): Uint8Array | null {
     try {
-      return this.io.readFile(path);
+      return this.io.readBytes(path);
     } catch (error) {
       if (isNodeError(error) && error.code === "ENOENT") return null;
-      throw new ProjectRuntimeIoError(displayPath, "read", error);
+      throw new ProjectRuntimeIoError(displayPath, "read exact bytes from", error);
     }
   }
 
@@ -556,7 +771,9 @@ export class ProjectRuntimeRepository {
     );
     try {
       this.io.writeFile(tempPath, data);
+      this.io.fsyncFile(tempPath);
       this.io.rename(tempPath, target);
+      this.io.fsyncDirectory(destinationDir);
     } catch (error) {
       try {
         this.io.unlink(tempPath);
@@ -567,6 +784,165 @@ export class ProjectRuntimeRepository {
       }
       throw new ProjectRuntimeIoError(displayPath, "atomically write", error);
     }
+  }
+
+  private atomicWriteBytes(
+    target: string,
+    data: Uint8Array,
+    displayPath: string,
+    durable: boolean,
+  ): void {
+    const destinationDir = resolve(target, "..");
+    this.io.mkdir(destinationDir);
+    const tempPath = join(
+      destinationDir,
+      `.tmp-${process.pid}-${tempCounter++}-${safeTempId(this.io.randomId())}`,
+    );
+    try {
+      this.io.writeBytes(tempPath, data);
+      if (durable) this.io.fsyncFile(tempPath);
+      this.io.rename(tempPath, target);
+      if (durable) {
+        this.io.fsyncFile(target);
+        this.io.fsyncDirectory(destinationDir);
+      }
+    } catch (error) {
+      try {
+        this.io.unlink(tempPath);
+      } catch (cleanupError) {
+        if (!isNodeError(cleanupError) || cleanupError.code !== "ENOENT") {
+          // Preserve the write/rename/fsync failure; cleanup is best-effort.
+        }
+      }
+      throw new ProjectRuntimeIoError(displayPath, "durably atomically write", error);
+    }
+  }
+
+  private acquireWriterLock(options: ProjectRuntimeWriterLockOptions | undefined): () => void {
+    const timeoutMs = normalizeLockDuration(options?.timeoutMs, 2_000, 0, 60_000, "timeoutMs");
+    const pollMs = normalizeLockDuration(options?.pollMs, 10, 1, 250, "pollMs");
+    const lockPath = join(this.runtimeRoot, PROJECT_RUNTIME_WRITER_LOCK_FILENAME);
+    const lockDirectory = resolve(lockPath, "..");
+    this.io.mkdir(this.runtimeRoot);
+    assertLockDirectory(this.runtimeRoot);
+    this.io.mkdir(lockDirectory);
+    assertLockDirectory(lockDirectory);
+    const token = randomUUID();
+    const owner = `${JSON.stringify({
+      version: 1,
+      token,
+      processInstanceId: PROJECT_RUNTIME_PROCESS_INSTANCE_ID,
+      pid: process.pid,
+      createdAtMs: Date.now(),
+    })}\n`;
+    const startedAt = Date.now();
+    let installedIdentity: { device: number; inode: number } | null = null;
+
+    for (;;) {
+      let descriptor: number | null = null;
+      let created = false;
+      try {
+        descriptor = openSync(lockPath, "wx", 0o600);
+        created = true;
+        writeFileSync(descriptor, owner, "utf-8");
+        fsyncSync(descriptor);
+        closeSync(descriptor);
+        descriptor = null;
+        const installed = lstatSync(lockPath);
+        installedIdentity = { device: installed.dev, inode: installed.ino };
+        this.io.fsyncDirectory(lockDirectory);
+        break;
+      } catch (error) {
+        if (descriptor !== null) {
+          try {
+            closeSync(descriptor);
+          } catch {
+            // Preserve the acquisition failure.
+          }
+        }
+        if (created) {
+          try {
+            unlinkSync(lockPath);
+            this.io.fsyncDirectory(lockDirectory);
+          } catch {
+            // Cleanup is best effort; the lock remains visible for recovery.
+          }
+        }
+        if (!isNodeError(error) || error.code !== "EEXIST") {
+          throw new ProjectRuntimeIoError(PROJECT_RUNTIME_WRITER_LOCK_FILENAME, "acquire", error);
+        }
+        if (Date.now() - startedAt >= timeoutMs) {
+          throw new ProjectRuntimeWriterLockTimeoutError(lockPath, timeoutMs);
+        }
+        sleepSync(Math.min(pollMs, Math.max(1, timeoutMs - (Date.now() - startedAt))));
+      }
+    }
+
+    return () => {
+      try {
+        const before = lstatSync(lockPath);
+        if (
+          !installedIdentity ||
+          before.dev !== installedIdentity.device ||
+          before.ino !== installedIdentity.inode ||
+          !before.isFile() ||
+          before.isSymbolicLink()
+        ) {
+          throw new Error("writer lock filesystem identity changed before release");
+        }
+        const currentOwner = readFileSync(lockPath, "utf-8");
+        const afterRead = lstatSync(lockPath);
+        const parsed = JSON.parse(currentOwner) as {
+          token?: unknown;
+          processInstanceId?: unknown;
+        };
+        if (
+          afterRead.dev !== before.dev ||
+          afterRead.ino !== before.ino ||
+          parsed.token !== token ||
+          parsed.processInstanceId !== PROJECT_RUNTIME_PROCESS_INSTANCE_ID
+        ) {
+          throw new Error("writer lock ownership changed before release");
+        }
+        const releasedPath = `${lockPath}.released-${token}`;
+        renameSync(lockPath, releasedPath);
+        const moved = lstatSync(releasedPath);
+        if (moved.dev !== before.dev || moved.ino !== before.ino) {
+          throw new Error("writer lock filesystem identity changed while releasing");
+        }
+        unlinkSync(releasedPath);
+        this.io.fsyncDirectory(lockDirectory);
+      } catch (error) {
+        throw new ProjectRuntimeIoError(PROJECT_RUNTIME_WRITER_LOCK_FILENAME, "release", error);
+      }
+    };
+  }
+
+  private reserveRecoveryOperation(
+    path: string,
+    rawToken: string,
+  ): { operationId: string; relativePath: string; target: string } {
+    const recoveryRoot = this.resolveRuntimePath("recovery");
+    this.io.mkdir(recoveryRoot);
+    this.io.fsyncDirectory(resolve(recoveryRoot, ".."));
+    for (let attempt = 0; attempt < 16; attempt += 1) {
+      const operationId = safeTempId(this.io.randomId());
+      const relativePath = `recovery/${sha256(path)}-${rawToken}-${operationId}`;
+      const target = this.resolveRuntimePath(relativePath);
+      try {
+        mkdirSync(target, { mode: 0o700 });
+        this.io.fsyncDirectory(recoveryRoot);
+        return { operationId, relativePath, target };
+      } catch (error) {
+        if (isNodeError(error) && error.code === "EEXIST") continue;
+        throw new ProjectRuntimeIoError(relativePath, "reserve recovery operation", error);
+      }
+    }
+    throw new ProjectRuntimeIoError(
+      "recovery",
+      "reserve recovery operation",
+      new Error("recovery operation id collided too many times"),
+    );
   }
 }
 
@@ -614,8 +990,62 @@ function parseDocumentEnvelope(path: string, raw: string): DocumentEnvelope {
   };
 }
 
-function sha256(value: string): string {
+function sha256(value: string | Uint8Array): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function encodeUtf8(value: string): Uint8Array {
+  return Buffer.from(value, "utf-8");
+}
+
+function decodeUtf8(value: Uint8Array): string {
+  return Buffer.from(value).toString("utf-8");
+}
+
+function decodeUtf8Strict(value: Uint8Array, path: string): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(value);
+  } catch {
+    throw new CorruptRuntimeDocumentError(path, "document is not valid UTF-8");
+  }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === "object" || typeof value === "function") &&
+    value !== null &&
+    "then" in value &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
+function normalizeLockDuration(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  field: string,
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < minimum || resolved > maximum) {
+    throw new InvalidJsonValueError(
+      `$.${field}`,
+      `${field} must be an integer between ${minimum} and ${maximum}`,
+    );
+  }
+  return resolved;
+}
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function assertLockDirectory(path: string): void {
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink())
+    throw new InvalidRuntimePathError(path, "symbolic links are not allowed");
+  if (!stat.isDirectory())
+    throw new InvalidRuntimePathError(path, "writer lock parent must be a directory");
 }
 
 function parseEventLog<T>(stream: string, raw: string): RuntimeEvent<T>[] {

--- a/packages/daemon/src/lib/workspace-state-repository.ts
+++ b/packages/daemon/src/lib/workspace-state-repository.ts
@@ -23,6 +23,7 @@ import {
 } from "@tmux-ide/contracts";
 
 import {
+  ProjectRuntimeWriterLockTimeoutError,
   RevisionConflictError,
   type ProjectRuntimeRepository,
 } from "./project-runtime-repository.ts";
@@ -510,123 +511,119 @@ export function writeWorkspaceStateWithRetry(
   }
 
   try {
-    const outcome = withWorkspaceStateLockOutcome<WriteWorkspaceStateResult>(
-      request.repository,
-      request.lock,
-      () => {
-        const diagnostics: WorkspaceStateRepositoryDiagnostic[] = [];
-        const retries = boundedInteger(request.maxRevisionRetries, 2, 0, 8);
-        for (let attempt = 0; attempt <= retries; attempt += 1) {
-          const latest = loadWorkspaceState(request.repository);
-          if (latest.writeProtected) {
-            return {
-              ...latest,
-              saved: false,
-              diagnostics: [
-                ...latest.diagnostics,
-                diagnostic(
-                  "WRITE_PROTECTED",
-                  WORKSPACE_STATE_PATH,
-                  "workspace state was preserved because its current payload is not safe to overwrite",
-                ),
-              ],
-            };
-          }
-          if (
-            request.revision !== latest.revision &&
-            !diagnostics.some((entry) => entry.code === "STALE")
-          ) {
-            diagnostics.push(
+    const outcome = request.repository.withWriterLockOutcome(request.lock, (writer) => {
+      const diagnostics: WorkspaceStateRepositoryDiagnostic[] = [];
+      const retries = boundedInteger(request.maxRevisionRetries, 2, 0, 8);
+      for (let attempt = 0; attempt <= retries; attempt += 1) {
+        const latest = loadWorkspaceState(request.repository);
+        if (latest.writeProtected) {
+          return {
+            ...latest,
+            saved: false,
+            diagnostics: [
+              ...latest.diagnostics,
               diagnostic(
-                "STALE",
+                "WRITE_PROTECTED",
                 WORKSPACE_STATE_PATH,
-                `merged stale revision ${String(request.revision)} with current revision ${String(
-                  latest.revision,
-                )}`,
+                "workspace state was preserved because its current payload is not safe to overwrite",
               ),
-            );
-          }
-          let merged: WorkspaceStateV1;
-          try {
-            merged = mergeWorkspaceStateForSave(
-              latest.state,
-              validation.data,
-              request.touchedLayoutIds,
-              request.deletedLayoutIds,
-              request.touchedCheckoutKeys,
-              {
-                checkoutIntents: request.checkoutIntents,
-                deletedCheckoutKeys: request.deletedCheckoutKeys,
-                layoutBaseRevisions: request.layoutBaseRevisions,
-                documentIsStale: request.revision !== latest.revision,
-              },
-            );
-          } catch (error) {
-            if (error instanceof WorkspaceStateMergeConflictError) {
-              return {
-                ...latest,
-                saved: false,
-                diagnostics: [
-                  ...latest.diagnostics,
-                  ...diagnostics,
-                  diagnostic("CONFLICT", error.path, error.message),
-                ],
-              };
-            }
-            throw error;
-          }
-          const mergedValidation = WorkspaceStateV1SchemaZ.safeParse(merged);
-          if (!mergedValidation.success) {
-            return {
-              ...latest,
-              saved: false,
-              diagnostics: [
-                ...latest.diagnostics,
-                ...diagnostics,
-                diagnostic(
-                  "INVALID_STATE",
-                  WORKSPACE_STATE_PATH,
-                  mergedValidation.error.issues.map((issue) => issue.message).join("; "),
-                ),
-              ],
-            };
-          }
-          try {
-            const written = request.repository.writeDocument(
-              WORKSPACE_STATE_PATH,
-              JSON.parse(serializeWorkspaceState(mergedValidation.data)),
-              { expectedRevision: latest.revision },
-            );
-            return {
-              state: mergedValidation.data,
-              revision: written.revision,
-              writeProtected: false,
-              saved: true,
-              diagnostics: [
-                ...latest.diagnostics.filter((entry) => entry.code !== "MISSING"),
-                ...diagnostics,
-              ],
-            };
-          } catch (error) {
-            if (error instanceof RevisionConflictError && attempt < retries) continue;
-            return {
-              ...latest,
-              saved: false,
-              diagnostics: [
-                ...latest.diagnostics,
-                ...diagnostics,
-                diagnostic(
-                  "WRITE_FAILED",
-                  WORKSPACE_STATE_PATH,
-                  `workspace state could not be written: ${(error as Error).message}`,
-                ),
-              ],
-            };
-          }
+            ],
+          };
         }
-        throw new Error("unreachable workspace-state retry exhaustion");
-      },
-    );
+        if (
+          request.revision !== latest.revision &&
+          !diagnostics.some((entry) => entry.code === "STALE")
+        ) {
+          diagnostics.push(
+            diagnostic(
+              "STALE",
+              WORKSPACE_STATE_PATH,
+              `merged stale revision ${String(request.revision)} with current revision ${String(
+                latest.revision,
+              )}`,
+            ),
+          );
+        }
+        let merged: WorkspaceStateV1;
+        try {
+          merged = mergeWorkspaceStateForSave(
+            latest.state,
+            validation.data,
+            request.touchedLayoutIds,
+            request.deletedLayoutIds,
+            request.touchedCheckoutKeys,
+            {
+              checkoutIntents: request.checkoutIntents,
+              deletedCheckoutKeys: request.deletedCheckoutKeys,
+              layoutBaseRevisions: request.layoutBaseRevisions,
+              documentIsStale: request.revision !== latest.revision,
+            },
+          );
+        } catch (error) {
+          if (error instanceof WorkspaceStateMergeConflictError) {
+            return {
+              ...latest,
+              saved: false,
+              diagnostics: [
+                ...latest.diagnostics,
+                ...diagnostics,
+                diagnostic("CONFLICT", error.path, error.message),
+              ],
+            };
+          }
+          throw error;
+        }
+        const mergedValidation = WorkspaceStateV1SchemaZ.safeParse(merged);
+        if (!mergedValidation.success) {
+          return {
+            ...latest,
+            saved: false,
+            diagnostics: [
+              ...latest.diagnostics,
+              ...diagnostics,
+              diagnostic(
+                "INVALID_STATE",
+                WORKSPACE_STATE_PATH,
+                mergedValidation.error.issues.map((issue) => issue.message).join("; "),
+              ),
+            ],
+          };
+        }
+        try {
+          const written = writer.writeDocument(
+            WORKSPACE_STATE_PATH,
+            JSON.parse(serializeWorkspaceState(mergedValidation.data)),
+            { expectedRevision: latest.revision },
+          );
+          return {
+            state: mergedValidation.data,
+            revision: written.revision,
+            writeProtected: false,
+            saved: true,
+            diagnostics: [
+              ...latest.diagnostics.filter((entry) => entry.code !== "MISSING"),
+              ...diagnostics,
+            ],
+          };
+        } catch (error) {
+          if (error instanceof RevisionConflictError && attempt < retries) continue;
+          return {
+            ...latest,
+            saved: false,
+            diagnostics: [
+              ...latest.diagnostics,
+              ...diagnostics,
+              diagnostic(
+                "WRITE_FAILED",
+                WORKSPACE_STATE_PATH,
+                `workspace state could not be written: ${(error as Error).message}`,
+              ),
+            ],
+          };
+        }
+      }
+      throw new Error("unreachable workspace-state retry exhaustion");
+    });
     if (!outcome.releaseError) return outcome.value;
     return {
       ...outcome.value,
@@ -641,7 +638,11 @@ export function writeWorkspaceStateWithRetry(
     };
   } catch (error) {
     const loaded = loadWorkspaceState(request.repository);
-    const code = error instanceof WorkspaceStateLockTimeoutError ? "LOCK_TIMEOUT" : "WRITE_FAILED";
+    const code =
+      error instanceof WorkspaceStateLockTimeoutError ||
+      error instanceof ProjectRuntimeWriterLockTimeoutError
+        ? "LOCK_TIMEOUT"
+        : "WRITE_FAILED";
     return {
       ...loaded,
       saved: false,


### PR DESCRIPTION
## Summary
- add AppWindowService and typed pure window commands over the durable app-window document
- persist `ui/app-windows.json` through the project-runtime repository with strict CAS/retry semantics
- perform create-only WorkspaceUiStateV2 migration under one shared project writer lock
- support focus/raise, dock/float placement memory, bounded move/resize, stack activation/reorder, and named layout CRUD/restore

## Durability and recovery
- all compliant project-runtime document/event/recovery mutations share the existing cross-process `workspace/.state.lock`
- raw bytes are strict-UTF decoded only for JSON; recovery tokens and backups preserve exact corrupt bytes
- atomic durable writes fsync temp files and destination directories
- recovery reserves collision-safe operation directories and records prepared/completed audit phases
- token checks and replacement are serialized against every compliant generic/app writer
- failed/malformed/future legacy migration remains write-protected until explicit typed opt-out/recovery reason
- migration rechecks destination after lock acquisition and returns any concurrent winner
- semantic CAS retries reconcile already-achieved commands as idempotent success/no-op
- untyped `migrateLegacy:false` injection is stripped and cannot bypass protection

## Boundaries
- no app.tsx, renderer, tmux, process, config, mission, or topology ownership
- maximize remains transient and is not persisted
- public constructor dependencies are exported and typed

## Validation
- focused repository/kernel correction suites: 88 passed
- randomized 500-command invariant probe remained schema-valid
- full daemon: 2,152 tests passed
- contracts: 51 passed
- TUI renderer: 87 tests, 62 snapshots
- full pnpm check, post-rebase typecheck, and diff-check passed
- independent adversarial re-review: clean