### PR TITLE
docs(ui): freeze the Card 22 execution and visual benchmark

### DIFF
--- a/.tmux-ide/library/full-app/13-card22-implementation-readiness.md
+++ b/.tmux-ide/library/full-app/13-card22-implementation-readiness.md
@@ -1,0 +1,568 @@
+# Card 22 implementation-readiness audit
+
+Status: implementation map, no production changes
+
+Audit baseline: `origin/main` at `6932d541df47aa9dc5514ce7eee308aceeea0012`
+
+Headless prerequisite examined: `m31/task-16b-headless-frontdoor` through `1d3277be`
+
+Desktop prerequisite examined: `m31/task-19b-electron-shell` through `f8dc911f`
+
+Shared-dock prerequisite examined: `m31/task-19a-shared-solid-dock` through `fa85a405`
+
+Combined preview examined: `m31/integration-preview` at `5de0c589`
+
+## Result
+
+Cards 22.2–22.4 are ready to implement in small slices, but they must not begin on
+today's `origin/main` as though the headless front door, desktop packages, and
+shared dock were already there. The safe landing order is:
+
+1. Card 16b's canonical shipped `tmux-ide --headless` daemon owner;
+2. the corrected Card 19a shared dock and Card 19b Electron/Solid foundation,
+   rebased onto that daemon revision and then landed together;
+3. the completed Card 22.1 renderer-free experience kernel;
+4. Card 22 host adapters and integration.
+
+That dependency is real, not administrative. `origin/main` has the live
+Solid/OpenTUI application but no `apps/desktop-renderer`, no
+`apps/electron-shell`, and no `apps/*` workspace entry. Card 16b is also still a
+seven-commit branch above the same main SHA. It supplies the canonical headless
+daemon process and wire front door that the desktop host must discover rather
+than replace. The reviewed 19a and 19b work exists on separate branches. The
+combined preview proves that the corrected 19a/19b UI packages compose, but it
+does not contain Card 16b, and its desktop `App.tsx` still constructs a synthetic
+dock projection and keeps the foundation hero/rail/inspector. It is a visual
+preview, not the daemon-integrated Card 22 product shell.
+
+The implementation should preserve three existing strengths:
+
+- `app.tsx` remains the single OpenTUI keyboard, pointer, renderer-lifecycle, and
+  effect owner.
+- tmux remains the terminal framebuffer and process truth. App chrome and dock
+  geometry remain outside the framebuffer contract.
+- the Electron main process remains a thin, secure OS host; the browser-native
+  Solid renderer owns product UI and stays runnable without Electron.
+
+## Dependency graph
+
+```text
+16b canonical headless front door
+             │
+             ├─ 19a corrected shared dock ─┐
+             │                              ├─ shared landing revision
+             └─ 19b corrected desktop ─────┘              │
+                                                           ├─ 22.2 host adapters
+22.1 experience kernel ─────────────────────────────────────┤
+                                                           ├─ 22.3 shell/dock
+                                                           └─ 22.4 PaneFrame
+
+22.2 token adapters ────────────────┬─ 22.3 visual leaves
+                                    └─ 22.4 visual leaves
+
+22.3 shell geometry/slots ───────────── 22.4 terminal-pane composition
+
+Card 21 live xterm attachment ────────── independent body-slot supplier
+```
+
+22.2 can be split by host after 22.1 lands. The OpenTUI and DOM portions of 22.3
+can then proceed in parallel against one fixture and command trace. The shared
+PaneFrame presenter in 22.4 must land before its two host leaves, but live xterm
+transport is not a prerequisite for its chrome contract.
+
+### Exact current live-preview route
+
+The preview is branch-specific; it is not available from current `main`.
+
+```bash
+cd /Users/thijs/Developer/tmux-ide/.worktrees/m31-integration-preview
+pnpm install --frozen-lockfile
+pnpm dev:desktop-preview
+```
+
+`dev:desktop-preview` first builds `@tmux-ide/daemon`, then starts the Electron
+development host. That host starts Vite at exactly `http://127.0.0.1:5173/`, sets
+`TMUX_IDE_RENDERER_URL` to that URL, and opens the Electron window. For the same
+renderer without Electron:
+
+```bash
+cd /Users/thijs/Developer/tmux-ide/.worktrees/m31-integration-preview
+pnpm --filter @tmux-ide/daemon build
+pnpm --filter @tmux-ide/desktop-renderer dev
+# open http://127.0.0.1:5173/
+```
+
+The browser path intentionally uses the safe fallback in
+`apps/desktop-renderer/src/host-capabilities.ts`; native window actions and daemon
+lifecycle are unavailable there. Neither route previews Card 22 yet, and neither
+is the live Card 16b daemon integration path. After the dependency chain lands,
+keep the same user-facing preview command but replace Card 19b's deferred daemon
+preflight with discovery of the canonical 16b owner.
+
+## Verified ownership on current `origin/main`
+
+### OpenTUI root and navigation
+
+| File | Current owner | Card 22 treatment |
+| --- | --- | --- |
+| `packages/daemon/src/tui/mirror/app.tsx` | Production composition, signals, one `useKeyboard`, root pointer routing, renderer command executor, lifecycle, tmux effects, active canvas/dock/view state | Keep as the only input/effect owner. Replace direct shell JSX with the canonical shell projection/render boundary. Do not move tmux or lifecycle effects into presenters. |
+| `packages/daemon/src/tui/mirror/workspace/application-shell.ts` | Pure cell-layout projection and shell hit-test for top tabs, sidebar, content, and status | Keep as OpenTUI host geometry. Change its inputs from locally invented product labels/states to Card 22.1 semantic shell data. It must not become the shared renderer-free shell model because it exposes cell rectangles. |
+| `packages/daemon/src/tui/mirror/workspace/application-shell.tsx` | Tested presentational `ApplicationShell`, composing `ShellTabBar`, `ShellMiniSidebar`, `ShellStatusStrip`, and a child content slot | Make this the live OpenTUI shell boundary, after extending its sidebar slot/data so existing agent rows and actions are not lost. It is currently not imported or rendered by `app.tsx`. |
+| `packages/daemon/src/tui/mirror/shell-chrome.ts` | OpenTUI cell variants, tab spans, sidebar hint spans, status-line clipping, and RGBA visual palettes | Retain geometry/clipping in the TUI adapter. Replace product-law ownership (surface registry, token meaning, marker meaning) with imports from 22.1/22.2. |
+| `packages/daemon/src/tui/mirror/shell-chrome.tsx` | OpenTUI `ShellTabBar`, `ShellMiniSidebar`, `ShellStatusStrip`, and composite leaf chrome | Keep as OpenTUI leaves, fed through the 22.2 theme/icon facade. Do not expose these cell-native leaves to DOM. |
+| `packages/daemon/src/tui/mirror/sidebar.tsx` | The richer live fleet sidebar: sessions, agents, attention/age, add-agent affordance, and palette footer hint | Do not delete it before feature parity exists. Fold its agent rows/actions into the canonical OpenTUI sidebar leaf or make it the sidebar slot of `ApplicationShell`; then remove the redundant `ShellMiniSidebar` path. |
+| `packages/daemon/src/tui/mirror/workspace/workbench-controller.ts` | Renderer-local Home/Terminals and dock shortcut/focus policy | Keep renderer-local input interpretation, but use canonical surface and command IDs. The root still executes commands. |
+| `packages/daemon/src/tui/mirror/renderer-commands.ts` | Stable renderer command registry and executor for palette, lifecycle, surface, canvas, and dock actions | Preserve as the effect boundary. Rebase its surface IDs/descriptors onto 22.1 rather than creating a second desktop-only registry. |
+| `packages/daemon/src/tui/mirror/palette-surface-adapter.ts` | Converts current `PaletteAction` values into stable command-palette descriptors, icons, groups, details, shortcuts, and disabled reasons | Keep as a transitional OpenTUI adapter. Move shared command descriptor/ranking law to 22.1; retain tmux-specific actions and runtime availability here. |
+| `packages/daemon/src/tui/mirror/workspace/command-palette-surface.ts` and `.tsx` | OpenTUI palette geometry, stable row identities, hit zones, and terminal-native rendering | Retain as the OpenTUI Cmd-K host. It should consume the canonical descriptor ordering/state from 22.1. DOM needs its own semantic dialog/listbox host, not this cell projection. |
+
+The duplicate live composition is visible in `app.tsx`: it renders
+`ShellTabBar` directly, then `Sidebar`, then `WorkbenchShell`. The independently
+tested `ApplicationShell` is not part of production composition. Card 22.3 must
+remove that split ownership rather than adding a third shell.
+
+### OpenTUI dock and terminal canvas
+
+| File | Current owner | Card 22 treatment |
+| --- | --- | --- |
+| `packages/daemon/src/tui/mirror/workspace/workbench-shell.ts` | OpenTUI cell geometry for canvas, focus rails, three dock modes, four dock tabs, action spans, and hit tests | Keep cell geometry and hit tests host-specific. On the 19a prerequisite, retain the shared navigation policy import and renderer-neutral dock projection shape. |
+| `packages/daemon/src/tui/mirror/workspace/workbench-shell.tsx` | On main, manually renders canvas, dock tabs/actions, dock focus rail, and body | Start from corrected 19a, where the manual dock leaves are replaced by `OpenTuiWorkbenchDock`. Do not redo that extraction in 22.3. |
+| `packages/daemon/src/ui/workbench-dock/presenter.tsx` | On 19a, intrinsic-free Solid control flow and renderer-neutral dock projection contract | Keep as the one shared dock composition seam. It derives no geometry and owns no state. |
+| `packages/daemon/src/ui/workbench-dock/navigation.ts` | On 19a, shared automatic-activation policy for arrows/Home/End with disabled-tab skipping | Keep as shared command behavior. Both roots report the same semantic activation trace. |
+| `packages/daemon/src/tui/mirror/workspace/workbench-dock-opentui.tsx` | On 19a, OpenTUI host leaves for the shared presenter | Feed 22.2 tokens/icons into these leaves. Keep DOM and Node imports out. |
+| `packages/daemon/src/ui/workbench-dock/web-host.tsx` and `.css` | On 19a, DOM/ARIA leaves, keyboard roving/activation, and hard-coded dock CSS colors | Keep the DOM semantics. Replace the CSS literals with 22.2 variables. Do not move DOM keyboard events into the shared presenter. |
+| `packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas.ts` | Cell geometry separating app chrome/footer from the tmux framebuffer and its exact resize truth | Preserve. 22.3/22.4 may change shell space around it, but only this host adapter translates that into `tmuxSize`. |
+| `packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-view.tsx` | Passive OpenTUI slots for chrome, framebuffer, and footer | Preserve the slots. Chrome work must not remount or absorb the framebuffer body. |
+
+Files, Changes, Missions, and Activity already render as OpenTUI-native dock
+surfaces in `app.tsx`; they are not tmux panes. Card 22.3 should change their
+container and semantic data inputs, not replace them with terminal widgets.
+
+### OpenTUI pane chrome
+
+| File | Current owner | Card 22 treatment |
+| --- | --- | --- |
+| `packages/daemon/src/tui/mirror/workspace/pane-frame.ts` | Mixed host concerns: cell geometry/clipping/hit zones plus local pane-state precedence, markers, status glyphs, icon choice, chip priority, and action projection | Split the semantic composition from cell projection. Consume the 22.1 `PaneAppearance`; retain rectangles, cell fitting, Unicode display width, and hit tests here. |
+| `packages/daemon/src/tui/mirror/workspace/pane-frame.tsx` | OpenTUI header/full-frame rendering, border glyphs, token palette, and stable chip keys | Convert to the OpenTUI leaves/wrapper for the shared PaneFrame presenter. Preserve semantic chip keys and property updates. |
+| `packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts` | Adapts live tmux pane geometry/metadata to pane headers, chooses native/gutter placement, projects zoom/menu actions, and owns pointer intents | Keep as the tmux/OpenTUI bridge. Map pane metadata and orthogonal runtime flags into `PaneAppearance`; do not move `%pane_id` or cell geometry into the shared model. |
+| `packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome-view.tsx` | Renders native/framebuffer chrome layers and keys each pane by pane ID across fresh projections | Preserve keyed layer identity. Its current `sameIds`/`projectionsById` pattern is a regression guard against the prior `insertBefore`/anchor flicker. |
+| `packages/daemon/src/tui/mirror/workspace/icons.ts` | TUI Unicode glyph/fallback/label registry | Turn into the 22.2 OpenTUI icon adapter. Canonical icon meaning and ID come from 22.1; cell-safe glyph/fallback remains here. |
+| `packages/daemon/src/tui/mirror/theme.ts` and `recipes.ts` | OpenTUI `RGBA` semantic snapshot, interaction precedence, and cell-native recipe geometry | Keep a compatibility facade for current callers. Shared token/state meaning comes from 22.1; RGBA, cell dimensions, and OpenTUI palette conversion remain host-specific. |
+
+The existing pane state is already modeled as orthogonal booleans
+(`focused`, `terminalFocused`, `attention`, `windowEditSelected`, `floating`,
+`maximized`) but `paneFrameMarker` collapses those flags into one marker while
+other chips remain independent. Card 22.1 must become the authority for that
+composition; Card 22.4 must not re-create a different priority table in DOM.
+
+## Verified desktop ownership on the reviewed Card 19b foundation
+
+| File | Current owner | Card 22 treatment |
+| --- | --- | --- |
+| `apps/electron-shell/src/main.ts` | Single-instance lifecycle, BrowserWindow creation, native titlebar mode, macOS traffic-light placement, bounds persistence, theme publication, directory dialog, shutdown, and renderer loading | Keep all OS window controls and drag/window lifecycle capabilities here. Card 22.3 may adjust host-native titlebar parameters, but it must not move product UI into Electron main. |
+| `apps/electron-shell/src/window-security.ts` | Sandboxed/context-isolated preferences and navigation/popup/webview denial | No visual edits. Preserve this boundary while adding product UI. |
+| `apps/electron-shell/src/preload.ts`, `host-ipc.ts`, `ipc-channels.ts` | Finite validated `HostCapabilities` bridge for bootstrap, theme, window actions, quit, and folder selection | Reuse only the finite capabilities needed by the canonical shell. Do not add generic command/eval/raw IPC for UI parity. |
+| `apps/desktop-renderer/src/host-capabilities.ts` | Browser-safe fallback and validation of the preload bridge | Preserve browser-dev operation. Shell components depend on this interface, never on Electron imports. |
+| `apps/desktop-renderer/src/App.tsx` | Temporary foundation titlebar, static workspace rail, hero/cards, host-status inspector, statusbar; combined preview also fabricates dock state/projection | Replace its product composition in 22.3. Keep bootstrap/theme/window subscriptions and native capability calls, preferably moved into a small renderer controller/store. Delete the synthetic `DOCK_TABS`/`dockProjection` once real shared shell state drives the dock. |
+| `apps/desktop-renderer/src/styles.css` | Temporary foundation layout and hard-coded colors; combined preview imports shared dock CSS | Replace hero/rail/inspector/card rules with canonical shell CSS. Keep global reset, root sizing, reduced-motion handling, and titlebar drag/no-drag behavior as host concerns. Feed colors through 22.2 variables. |
+| `apps/desktop-renderer/src/main.tsx` | Solid DOM mount only | Keep minimal. |
+
+The Electron host already uses `titleBarStyle: "hiddenInset"` on macOS and
+`"hidden"` elsewhere; macOS traffic lights remain native, while the renderer
+shows finite minimize/maximize/close buttons only off macOS. That division is
+the correct Card 22.3 window-chrome boundary.
+
+## Card 22.2 — theme, typography, icon, and host adapters
+
+### 22.2a: shared token conformance (first)
+
+Dependency: landed 22.1 exports.
+
+1. Add fixture-level tests beside the 22.1 kernel proving all required token,
+   icon, status, surface, and pane-role IDs are exhaustive and serializable.
+2. Freeze one `CohesionFixtureV1` input for all adapter tests. Adapters may add
+   host measurements, never mutate or decorate the fixture with cells/pixels.
+3. Add an import-boundary test proving the 22.1 graph contains no DOM,
+   Electron, Node, OpenTUI, `string-width`, or terminal geometry imports.
+
+This slice changes kernel tests only after 22.1; it does not touch either
+renderer and can land before the two host adapters.
+
+### 22.2b: OpenTUI adapter
+
+Files to edit:
+
+- `packages/daemon/src/tui/mirror/theme.ts`: make
+  `createSemanticThemeSnapshot` a compatibility facade over canonical tokens;
+  keep `RGBA` conversion and resolved terminal theme mode here.
+- `packages/daemon/src/tui/mirror/recipes.ts`: consume canonical interaction
+  precedence and tone roles; keep `Rect`, cell widths, scrollbar glyphs, and
+  gallery geometry local.
+- `packages/daemon/src/tui/mirror/workspace/icons.ts`: map canonical icon IDs to
+  Unicode-safe primary/fallback glyphs and accessible text.
+- `packages/daemon/src/tui/mirror/shell-chrome.tsx`,
+  `workspace/workbench-dock-opentui.tsx`, and `workspace/pane-frame.tsx`: consume
+  only the facade/adapter, not raw shared color strings.
+- `packages/daemon/src/tui/mirror/sidebar.tsx` and the four native dock surface
+  renderers: remove direct product-color ownership as each is brought through
+  the facade. Temporary exported aliases are acceptable only with a removal
+  test/list.
+
+Tests/snapshots:
+
+- extend `theme.test.ts`, `recipes.test.ts`, and `workspace/icons.test.ts` with
+  the common fixture and light/dark/high-contrast mappings;
+- update renderer snapshots only after asserting semantic spans/colors, so an
+  all-dark blank snapshot cannot pass accidentally;
+- run the complete `test:tui-renderer` suite, because theme changes reach every
+  surface even when only shell snapshots visibly change.
+
+### 22.2c: DOM adapter
+
+Files to add/edit on the shared 19a/19b base:
+
+- add a desktop token adapter under `apps/desktop-renderer/src/experience/`
+  that emits CSS custom properties and returns canonical vector/icon metadata;
+- edit `apps/desktop-renderer/src/styles.css` to consume those variables;
+- edit `packages/daemon/src/ui/workbench-dock/web-host.css` to replace
+  `--dock-*` literals and the literal attention color with canonical variables;
+- edit `apps/desktop-renderer/src/App.tsx` only enough to install theme and
+  accessibility variables on the root. Full layout replacement belongs to
+  22.3.
+
+Tests:
+
+- pure adapter tests for light/dark/high-contrast and missing optional tokens;
+- DOM computed-style assertions for selected/focused/attention/disabled states;
+- keep `prefers-reduced-motion` behavior and add a fixture flag assertion so
+  host preference and product state cannot disagree silently.
+
+22.2b and 22.2c have disjoint host files and can run in parallel after 22.2a.
+
+## Card 22.3 — canonical application shell and dock
+
+### 22.3a: shared shell command/projection seam
+
+Dependency: 22.1 and 22.2a. No renderer JSX in this slice.
+
+- Use the 22.1 surface registry as the sole source for Home, Terminals, Files,
+  Changes, Missions, and Activity identity/order/labels/shortcuts.
+- Keep Files/Changes/Missions/Activity in the bottom dock; do not reintroduce
+  persistent top tabs or rail entries for those tools.
+- Define one semantic shell action trace covering surface activation, dock
+  collapse/open/maximize, focus-zone movement, palette open/close, and focus
+  return. Feed it through existing `CommandInvocation`/`CommandDescriptor`
+  shapes from `packages/contracts/src/commands.ts`.
+- Keep host geometry out. The OpenTUI `application-shell.ts` and
+  `workbench-shell.ts` continue to calculate cells; CSS calculates desktop
+  layout.
+
+Tests: one fixture-to-command trace test shared by both host harnesses and a
+forbidden-geometry/import test for the semantic projection.
+
+### 22.3b: OpenTUI shell integration
+
+Files to edit:
+
+- `packages/daemon/src/tui/mirror/app.tsx`: construct one
+  `ApplicationShellProjection`, render one `ApplicationShell`, and pass the
+  existing `WorkbenchShell` as its content. Route shell hits through
+  `applicationShellHitTest`; keep the existing root route and `useKeyboard`.
+- `packages/daemon/src/tui/mirror/workspace/application-shell.ts`: accept the
+  canonical shell semantic projection plus host dimensions, while retaining
+  cell rectangles and hit zones.
+- `packages/daemon/src/tui/mirror/workspace/application-shell.tsx`: expose a
+  sidebar slot or richer canonical sidebar props so sessions, agents,
+  attention, add-agent, and palette affordances survive migration.
+- `packages/daemon/src/tui/mirror/sidebar.tsx` and
+  `packages/daemon/src/tui/mirror/shell-chrome.tsx`: consolidate to one sidebar
+  leaf. Delete `ShellMiniSidebar` only after the production sidebar is covered
+  by the canonical shell renderer test.
+- `packages/daemon/src/tui/mirror/workspace/workbench-shell.tsx`: start from
+  corrected 19a and keep `OpenTuiWorkbenchDock`; no manual second tab bar.
+- `packages/daemon/src/tui/mirror/renderer-commands.ts` and
+  `workbench-controller.ts`: translate shortcuts/pointer hits to the shared
+  semantic command IDs and trace.
+
+Legacy JSX to delete from `app.tsx` after the replacement passes:
+
+- the outer direct `ShellTabBar` wrapper;
+- the direct side-by-side `Sidebar`/main composition;
+- local duplicate top-surface registry/order where 22.1 supplies it;
+- any old palette fallback overlay that bypasses `CommandPaletteSurface`, once
+  its asynchronous tmux paste-buffer subflow is represented inside the native
+  palette host.
+
+Do **not** delete the tmux window strip, framebuffer layers, search footer, pane
+chrome layers, or native dock tool bodies. They are content supplied to the new
+shell, not legacy shell ownership.
+
+Tests/snapshots to update:
+
+- `workspace/application-shell.test.ts` and
+  `workspace/application-shell-renderer.test.tsx`;
+- `workspace/workbench-shell.test.ts` and renderer snapshots from corrected
+  19a;
+- `shell-chrome.test.ts` and `shell-chrome-renderer.test.tsx`;
+- root input/lifecycle, renderer-command, pointer, paste, and workspace-state
+  tests affected by the new coordinate origin;
+- paired acceptance snapshots at exactly 80x24, 120x40, and 200x60.
+
+The existing `ApplicationShell` renderer test already covers those three sizes,
+pointer/keyboard routing, renderer destruction, and Solid disposal. Convert it
+from an isolated harness into the fixture baseline, then add one production-root
+smoke that proves `app.tsx` actually uses the boundary.
+
+### 22.3c: DOM shell integration
+
+Files to add/edit:
+
+- replace the composition in `apps/desktop-renderer/src/App.tsx` with canonical
+  titlebar, shared workspace/session/agent sidebar, Home/Terminals canvas,
+  `WebWorkbenchDock`, status/recovery strip, and overlay root;
+- add DOM components under `apps/desktop-renderer/src/experience/` for those
+  host leaves; use real landmarks, buttons, tabs, dialog/listbox semantics, and
+  focus restoration;
+- replace temporary `.rail`, `.canvas` hero, `.cards`, and `.inspector` rules in
+  `styles.css` with responsive shell rules at the three acceptance sizes;
+- keep `.titlebar__drag`, `.window-controls`, root sizing, and reduced-motion
+  rules, adapted to the canonical tokens;
+- keep `host-capabilities.ts` as the only native bridge;
+- use the corrected 19a `WebWorkbenchDock`; remove the combined preview's local
+  `DOCK_TABS` and fabricated one-pixel `dockProjection`.
+
+Tests/evidence:
+
+- DOM semantic tests for landmarks, sidebar selection, ARIA tab relationships,
+  dialog/listbox Cmd-K behavior, disabled reasons, Escape, and focus return;
+- keyboard/mouse tests that emit the same semantic command trace as OpenTUI;
+- screenshots at 720x480, 1280x820, and 1600x1000, in dark and light mode where
+  token differences matter;
+- browser-dev build plus Electron smoke. The shell must work in Vite without a
+  preload bridge, using the existing browser-safe fallback.
+
+22.3b and 22.3c can proceed in parallel after 22.3a and 22.2 host adapters.
+
+## Card 22.4 — cross-host PaneFrame
+
+### 22.4a: shared intrinsic-free presenter
+
+Dependency: 22.1 `PaneAppearance` and the shell body-slot contract from 22.3a.
+
+Add an intrinsic-free shared Solid presenter beside the dock precedent, for
+example under `packages/daemon/src/ui/pane-frame/`. It should accept:
+
+- stable semantic pane identity and kind;
+- composed `PaneAppearance` from 22.1;
+- semantic title/subtitle/status/chips/actions;
+- injected `Root`, `Header`, `Grip`, `Title`, `Status`, `ActionList`, `Action`,
+  and `Body` leaves;
+- semantic action callbacks only.
+
+It must not accept cell rectangles, CSS pixels, `%pane_id`, Electron window IDs,
+xterm IDs, PTY IDs, OpenTUI `RGBA`, DOM events, or transport handles. Like the
+shared dock presenter, it owns only Solid control flow and stable identity.
+
+Add import-DAG tests matching
+`packages/daemon/src/ui/workbench-dock/import-dag.test.ts`: presenter runtime
+imports are `solid-js` only; web leaves have no OpenTUI/Node imports; OpenTUI
+leaves have no DOM/Node imports.
+
+### 22.4b: OpenTUI PaneFrame leaves
+
+Files to edit:
+
+- `workspace/pane-frame.ts`: change `projectPaneFrame` to accept a semantic
+  appearance and host action descriptors; retain all cell fitting, spans,
+  clipping, border rectangles, and hit testing;
+- `workspace/pane-frame.tsx`: implement injected OpenTUI leaves or a thin
+  wrapper around them; retain `keyedChips` semantics;
+- `workspace/terminal-pane-chrome.ts`: map live pane metadata/state to
+  `PaneAppearance`, then map semantic actions to cell targets. Keep placement,
+  overlap proof, pointer intent, focus-before-action ordering, and zoom/menu
+  effects;
+- `workspace/terminal-pane-chrome-view.tsx`: retain pane-ID keyed renderables and
+  the native/framebuffer layer split;
+- `app.tsx`: only wire the new semantic input/callbacks. Do not restructure the
+  terminal body.
+
+Regression tests that must remain and be extended:
+
+- `pane-frame.test.ts`: tiny bounds, Unicode clipping, orthogonal state matrix,
+  action priority, and exact hit zones;
+- `pane-frame-renderer.test.tsx`: 80x24/120x40/200x60 snapshots, semantic
+  span/color assertions, disabled/hovered/pressed actions;
+- `terminal-pane-chrome.test.ts`: no body overlap, lower separator pass-through,
+  exact tmux sizing, focus-before-action, and lifecycle reconciliation;
+- `agent-terminal-canvas-renderer.test.tsx`: stable pane/action renderable
+  identity across fresh projections and no `insertBefore`/anchor warnings.
+
+### 22.4c: DOM PaneFrame leaves
+
+Add the DOM host next to the shared presenter and export it through a generated
+package entry consumed by `apps/desktop-renderer`. It must provide:
+
+- a semantic heading and status/chip text;
+- focus-visible and attention styling as separate channels;
+- actual buttons for actions, with labels/tooltips and disabled/pressed state;
+- a body slot whose keyed child is supplied by the terminal host.
+
+Add DOM tests for the complete `PaneAppearance` matrix, accessible action names,
+keyboard activation, focus/attention coexistence, and stable body node identity
+while appearance changes. Use a fake stable body sentinel until Card 21 supplies
+live xterm attachments; later replace the sentinel without changing PaneFrame.
+
+22.4b and 22.4c can run in parallel after 22.4a.
+
+## Package and build constraints
+
+These constraints come from the corrected 19a/19b code, not from the current
+main tree:
+
+1. Card 16b must land before the desktop host is wired to daemon lifecycle. Its
+   canonical `tmux-ide --headless` owner, lock/wire protocol, contention,
+   takeover, authentication, and shutdown behavior are the front door; Card 22
+   must consume them rather than start a second daemon implementation.
+2. `pnpm-workspace.yaml` must include `apps/*` before desktop packages can be
+   filtered or linked.
+3. `apps/desktop-renderer` is Solid/Vite, depends on `@tmux-ide/contracts`, and
+   may consume generated browser-safe daemon UI exports. It may not import
+   Electron, Node built-ins, or `@tmux-ide/electron-shell`.
+4. `apps/electron-shell` builds the renderer first, copies its dist, validates
+   CSP, bundles main/preload with esbuild, and requires Node >=22. Do not bypass
+   those scripts with a second renderer bundle path.
+5. The corrected shared-dock build deliberately separates:
+   - normal daemon `tsc` output;
+   - OpenTUI JSX typechecking;
+   - DOM JSX typechecking and declarations;
+   - Vite's DOM library output leaf.
+6. Vite must never clear the parent `dist/ui/workbench-dock` directory after
+   daemon `tsc`; corrected 19a writes the web bundle to a nested `web/` leaf.
+7. Any new exported PaneFrame DOM host needs the same pack-consumer proof as
+   `check-workbench-dock-package.mjs`: clean dist, pack, TypeScript consumer,
+   runtime import, and CSS export. A stale local dist must not make CI pass.
+8. Keep the intrinsic-free presenter on `solid-js` only. Do not import
+   `solid-js/web` into code used by OpenTUI, and do not import `@opentui/*` into
+   the DOM graph.
+9. Update root `test`, `test:unit`, `check`, and renderer-test lists when the
+   desktop/presenter tests land. The current main scripts do not include either
+   desktop package because those packages are not on main yet.
+
+Prefer one explicit browser UI build surface for additional shared components
+instead of accumulating unrelated Vite commands. If 22.4 extends the existing
+dock library build, rename/generalize its config and package check in the same
+commit; do not leave exports whose generated files depend on command order.
+
+## Legacy deletion checklist
+
+Delete only when the replacement has fixture and host coverage:
+
+- [ ] direct production `ShellTabBar`/`Sidebar` shell composition in OpenTUI
+- [ ] redundant `ShellMiniSidebar` after agent/session/action parity
+- [ ] local duplicate surface/tab registries superseded by 22.1
+- [ ] manual OpenTUI dock JSX from pre-19a `workbench-shell.tsx`
+- [ ] desktop foundation rail, hero/cards, and host-status inspector
+- [ ] combined preview's fabricated dock projection and placeholder dock body
+- [ ] hard-coded desktop and shared-dock product color literals
+- [ ] local pane marker/status/icon priority tables superseded by
+      `PaneAppearance`
+- [ ] old palette fallback overlay after tmux paste-buffer loading/error/retry is
+      represented in the canonical native palette host
+
+Keep:
+
+- [ ] OpenTUI root input/effect/lifecycle ownership
+- [ ] Electron native titlebar/window/security ownership
+- [ ] browser-safe renderer fallback
+- [ ] tmux framebuffer and exact resize truth
+- [ ] keyed OpenTUI pane renderables and keyed desktop terminal bodies
+- [ ] all native Files/Changes/Missions/Activity surfaces
+
+## Smallest safe parallel implementation slices after 22.1
+
+The following slices minimize overlapping files:
+
+1. **Prerequisite integration:** land Card 16b, then rebase/land corrected 19a
+   and 19b together on that revision; rerun Card 16b headless ownership/stress
+   tests, shared dock package proof, desktop tests/build/smoke, daemon typecheck,
+   and the OpenTUI renderer suite. This is serial.
+2. **22.2 shared conformance:** kernel fixture/exhaustiveness/import-boundary
+   tests. Serial and first.
+3. **22.2 OpenTUI adapter:** `theme.ts`, `recipes.ts`, `icons.ts`, OpenTUI leaves,
+   and renderer snapshots.
+4. **22.2 DOM adapter:** desktop CSS-variable/icon adapter and dock CSS. Runs in
+   parallel with slice 3.
+5. **22.3 shared command trace:** semantic shell actions and fixture trace. Serial
+   before host shell integration.
+6. **22.3 OpenTUI shell:** `app.tsx`, application-shell/sidebar/chrome, root
+   routing, and TUI acceptance snapshots.
+7. **22.3 DOM shell:** desktop `App.tsx`, experience components/CSS, ARIA tests,
+   and screenshots. Runs in parallel with slice 6.
+8. **22.4 shared PaneFrame presenter:** intrinsic-free composition, import DAG,
+   fixture trace, and package export skeleton. Serial before host leaves.
+9. **22.4 OpenTUI PaneFrame:** cell projection/leaves, terminal bridge, identity
+   and flicker tests.
+10. **22.4 DOM PaneFrame:** DOM leaves/CSS/ARIA/body-identity tests and generated
+    package proof. Runs in parallel with slice 9.
+11. **Cross-host qualification:** paired fixture traces, screenshots/snapshots,
+    theme/focus/attention stress, browser build, Electron smoke, TUI build, and
+    the full repository check. Serial final gate.
+
+No two parallel slices above need to edit `app.tsx`, desktop `App.tsx`, or the
+same host adapter. The shared semantic slices land first so host agents consume
+one contract instead of resolving drift during integration.
+
+## Verification commands for implementers
+
+Run the focused commands while iterating, then the full gate:
+
+```bash
+# OpenTUI
+pnpm --filter @tmux-ide/daemon typecheck
+pnpm test:tui-renderer
+pnpm build:tui
+
+# Shared browser UI package (names from corrected 19a; generalize if 22.4 does)
+pnpm build:workbench-dock-web
+pnpm test:workbench-dock-package
+
+# Desktop foundation after 19b lands
+pnpm --filter @tmux-ide/desktop-renderer test
+pnpm --filter @tmux-ide/desktop-renderer typecheck
+pnpm --filter @tmux-ide/desktop-renderer build
+pnpm --filter @tmux-ide/electron-shell test
+pnpm --filter @tmux-ide/electron-shell typecheck
+pnpm --filter @tmux-ide/electron-shell smoke
+
+# Final
+pnpm check
+git diff --check
+```
+
+Electron packaging smoke is a release-quality follow-up gate when platform and
+CI time permit; ordinary `smoke` plus the package-consumer proof should remain
+the per-card baseline.
+
+## Audit evidence index
+
+Every ownership claim above was checked against these concrete symbols or
+tests:
+
+- OpenTUI root: `app.tsx` imports/renders `ShellTabBar`, `Sidebar`,
+  `WorkbenchShell`, `AgentTerminalCanvas`, `TerminalPaneChromeLayer`, and
+  `CommandPaletteSurface`; its single `useKeyboard` owns global input.
+- Unwired shell: `projectApplicationShell`, `applicationShellHitTest`, and
+  `ApplicationShell`; no `ApplicationShell` reference exists in `app.tsx`.
+- Dock geometry: `projectWorkbenchShell`, `workbenchShellHitTest`, and corrected
+  19a's `WorkbenchDockPresenter`, `OpenTuiWorkbenchDock`, `WebWorkbenchDock`.
+- Terminal isolation: `projectAgentTerminalCanvas` and its `tmuxSize` contract;
+  `projectTerminalPaneChrome` and `terminalPaneChromeOverlapsBodies`.
+- Flicker guard: `TerminalPaneChromeLayer` keys by `paneId`; the renderer test
+  retains renderable identity and rejects anchor/`insertBefore` warnings.
+- Desktop boundary: `runDesktopApp`, `secureWebPreferences`, `denyRendererEscapes`,
+  `HostCapabilities`, and the package READMEs/import-boundary tests.
+- Build boundary: corrected 19a's daemon exports, separate OpenTUI/DOM
+  tsconfigs, nested Vite output, and `check-workbench-dock-package.mjs`.
+
+The audit intentionally made no production, package, config, tmux, or mission
+state changes.

--- a/.tmux-ide/library/full-app/card-22-visual-language-benchmark.md
+++ b/.tmux-ide/library/full-app/card-22-visual-language-benchmark.md
@@ -1,0 +1,734 @@
+# Card 22 — Cohesive product visual-language benchmark
+
+Status: normative implementation and acceptance benchmark
+
+Date: 2026-07-21
+
+Scope: OpenTUI application, Solid/Electron desktop application, and the shared
+Solid presentation boundary. This card changes no production code.
+
+## Pinned evidence
+
+The measurements in this document are pinned so later work can distinguish a
+deliberate product decision from source drift.
+
+| Input | Revision | What was inspected |
+| --- | --- | --- |
+| tmux-ide OpenTUI baseline | 6932d541 | Semantic theme, application shell, pane frame, terminal chrome, bottom dock, command palette, fixed-size renderer tests |
+| tmux-ide shared Solid dock delivery branch | fa85a405 | Shared presenter, OpenTUI leaves, DOM leaves, web-host CSS, package boundary |
+| tmux-ide Solid/Electron delivery branch | f8dc911f | Desktop app shell, host capabilities, titlebar, window controls, responsive CSS, reduced motion |
+| local Gloomberb reference | 1a44ddf | React host adapter, cell rhythm, pane chrome, tabs, command bar, themes, native window controls, scrollbars |
+| OpenTUI platform reference | local opentui skill, read 2026-07-21 | Integer-cell layout, Solid renderer behavior, keyboard/focus layering, animation constraints, deterministic rendering and span capture |
+
+Primary evidence locations:
+
+- Gloomberb: src/renderers/electrobun/view/input-host.tsx:23-24,
+  src/renderers/electrobun/view/host/style.ts,
+  src/renderers/electrobun/view/styles.css,
+  src/components/layout/pane/header.tsx,
+  src/components/layout/pane/footer/index.tsx,
+  src/components/layout/pane/sizing.ts,
+  src/renderers/electrobun/view/host/tabs.tsx,
+  src/components/command-bar/panel/layout.ts,
+  src/theme/themes.ts, and src/theme/colors.ts.
+- tmux-ide OpenTUI: packages/daemon/src/tui/mirror/theme.ts,
+  packages/daemon/src/tui/mirror/shell-chrome.ts,
+  packages/daemon/src/tui/mirror/workspace/application-shell.ts,
+  packages/daemon/src/tui/mirror/workspace/pane-frame.ts,
+  packages/daemon/src/tui/mirror/workspace/workbench-shell.ts, and
+  packages/daemon/src/tui/mirror/workspace/command-palette-surface.ts.
+- Shared Solid dock delivery branch:
+  packages/daemon/src/ui/workbench-dock/presenter.tsx,
+  packages/daemon/src/ui/workbench-dock/web-host.tsx, and
+  packages/daemon/src/ui/workbench-dock/web-host.css.
+- Electron delivery branch: apps/desktop-renderer/src/App.tsx and
+  apps/desktop-renderer/src/styles.css.
+
+## Decision
+
+tmux-ide should use a cell-first, host-refined visual system.
+
+The product shares semantic state, token names, component order, keyboard
+meaning, labels, and responsive intent. OpenTUI renders those decisions in
+integer character cells. The desktop host maps the base rhythm to pixels and
+adds native precision for hit targets, shadows, radii, scrollbars, drag regions,
+and window controls.
+
+The desktop application must feel like the same terminal-native product, not a
+generic web dashboard wrapped around terminals. That does not mean painting a
+terminal screenshot in HTML. It means preserving the same information density,
+one-row chrome, mono typography, focus hierarchy, state colors, command
+vocabulary, and bottom-dock behavior while using real DOM controls.
+
+The tmux panes remain the agent terminal substrate. Files, Changes, Missions,
+Activity, onboarding, and the command palette are native OpenTUI or DOM
+surfaces outside those tmux framebuffers.
+
+## What Gloomberb proves, and the tmux-ide response
+
+| Mechanic | Code-backed Gloomberb behavior | Current tmux-ide state at pinned revisions | Card 22 requirement |
+| --- | --- | --- | --- |
+| Cell rhythm | Web host defines an 8 by 18 px cell, reports viewport dimensions in cells, and translates numeric host layout values to pixels. | OpenTUI is naturally cell based. The Electron shell uses a loose sans dashboard scale. | Use 8 by 18 px as the desktop workspace rhythm and 1 by 1 terminal cells in OpenTUI. |
+| Typography | 12 px mono type on an 18 px line, anti-aliased with geometric precision. Status and pane footers use 11.5 px. | OpenTUI inherits terminal mono. Electron starts with Inter and large marketing typography. | Workspace UI is mono 12/18. Onboarding can reach 20/24, but cannot introduce a separate marketing visual language. |
+| Pane chrome | Header and footer are exactly one row. Focused terminal panes integrate borders into chrome; native panes use a stable one-pixel frame. | PaneFrame has a one-row header and rich state, but its border is painted by multiple absolute boxes and its density thresholds are global-size-like. | One stable owner paints header, border, footer, hit zones, and focus. Framebuffer content is clipped to body only. |
+| Focus hierarchy | Focus, terminal focus, window-edit selection, floating state, and attention are separate signals. Native selected windows get a stronger ring and halo. | The OpenTUI model already keeps these states orthogonal. Focus rails and pane borders can duplicate the signal. | Keep orthogonal state, define precedence, and never encode agent status as focus color. |
+| Tabs and dock | Underline tabs are 28 px, compact tabs are 18 px, active weight is stronger, overflow scrolls, and active tabs scroll into view. | OpenTUI bottom dock is one row and functional. DOM dock is 32 px with hard-coded colors and consumes terminal x/width fields. | One semantic dock model, host-owned geometry, 28 px desktop strip, one-row TUI strip, stable tab order and selected/hover distinction. |
+| Command palette | Width is derived from viewport cells and capped. Rows retain stable label and trailing columns. Keyboard selection clears pointer hover. | OpenTUI palette is feature-rich but substantially wider: 64/82/96 cells at the reference sizes. Electron only says that the palette is coming next. | Adopt the exact geometry in this benchmark and render the same command descriptors in both hosts. |
+| Window controls | 28 px titlebar overlay, three 28 px controls, 10 px icons, 90 ms color response, platform-specific native window style. | Electron uses a 42 px titlebar and 46 px controls. Host capabilities are secure and useful. | Preserve the secure host boundary, replace the dimensions and visual treatment with the shared dense chrome. |
+| Hover and press | Hover is subtle and selected state remains authoritative. Rows, tabs, and actions use small host-native feedback. | Recipe state coverage is strong in OpenTUI. DOM dock and Electron use independent values. | Share precedence and semantic variables; keep host-specific rendering and timing. |
+| Responsive behavior | Most geometry is continuous cell math rather than a collection of unrelated breakpoints. | OpenTUI has exact compact/standard/wide projections. Electron has one 980 px breakpoint. | Use the width and terminal matrices below. No surface may invent another unreviewed density breakpoint. |
+| Testing | Geometry and palettes are pure enough to test separately from hosts. | OpenTUI already uses 80x24, 120x40, and 200x60 char frames and span capture. Desktop lacks visual parity fixtures. | Make the 18 base host/theme/size combinations mandatory and add state sheets for chrome and palette. |
+
+Gloomberb is a behavior and mechanics reference, not a brand palette to copy.
+tmux-ide keeps the blue identity already established by its canonical OpenTUI
+semantic theme.
+
+## Parity boundary
+
+Full parity means parity of product-quality mechanics, not identical product
+content or a line-for-line port.
+
+### Parity-critical behavior
+
+These items are release blocking:
+
+| Area | Parity-critical behavior |
+| --- | --- |
+| Visual rhythm | Cell-derived desktop spacing, mono density, one-row chrome, stable label/trailing columns, and no generic dashboard scale |
+| Desktop shell | Compact native titlebar, coherent app tabs, platform-aware window controls, drag/no-drag regions, and real hover/close behavior |
+| Pane system | Per-pane header, grip, title, subtitle, status, actions, focus, attention, maximize/restore, floating treatment, resizing, and overflow degradation |
+| Focus | One visually unambiguous input location, atomic border paint, no layout shift, no flicker, and separate attention/status signals |
+| Bottom dock | Persistent tabbed tool surface, collapse/open/maximize, horizontal overflow, active-tab visibility, keyboard navigation, and native Files/Changes/Missions/Activity content |
+| Command palette | Centered capped geometry, stable columns, ranked groups, complete loading/empty/error/disabled states, keyboard/pointer agreement, and desktop overlay treatment |
+| Responsive behavior | Continuous cell-based density with explicit compact/standard/wide outcomes and no lost function at narrow widths |
+| Theme behavior | One semantic source for dark, light, and high contrast; compliant contrast; focused/selected/hovered/pressed/disabled states |
+| Terminal feel | Framebuffer clipped inside native pane chrome, correct cursor/input ownership, scroll behavior, and Ctrl-C passthrough |
+| Fit and finish | Coherent icons, subtle scrollbars, restrained motion, reduced-motion support, deterministic visual tests, and no temporary foundation UI in production |
+
+### Deliberate tmux-ide product differences
+
+These are not parity failures:
+
+| tmux-ide decision | Why it differs deliberately |
+| --- | --- |
+| Solid shared UI instead of React | Solid is the selected cross-surface product stack; renderer choice is not a visible parity requirement. |
+| Electron host instead of Electrobun | Secure host capability boundaries and platform behavior matter; the packaging runtime does not need to match. |
+| Canonical tmux-ide blue palette | Gloomberb supplies mechanics and contrast discipline, not tmux-ide branding. |
+| tmux as agent-terminal truth | Agent processes, PTYs, resizing, and terminal bytes remain tmux-owned. |
+| Native Files, Changes, Missions, Activity, onboarding, and palette | tmux panes are reserved for agents and shells; application tools are first-class OpenTUI/DOM surfaces. |
+| Mission-first information architecture | Projects, harness-neutral agents, mission history, and activity are tmux-ide concepts rather than Gloomberb plugins. |
+| Ctrl-Q quit/detach and Ctrl-C terminal passthrough | tmux-ide protects standard terminal interrupt behavior. |
+| Zero-config project discovery | Users should not need to author ide.yml or workspace.yml before seeing a useful application. |
+| Smaller initial theme catalog | Three complete modes are preferable to many partially integrated themes; more themes can be layered on the same semantic contract later. |
+| Product-specific labels and icons | Semantic meaning and metric coherence must match; Gloomberb names, marks, and copy must not be cloned. |
+
+Any claimed deliberate difference not listed here requires a benchmark update
+and review. “The host made it easier” is not sufficient justification.
+
+## Normative token contract
+
+All values in this section are exact. A host may only deviate where the table
+explicitly permits it.
+
+### Rhythm and typography
+
+| Token | Desktop Solid/Electron | OpenTUI |
+| --- | ---: | ---: |
+| workspace-cell-width | 8 px | 1 column |
+| workspace-cell-height | 18 px | 1 row |
+| workspace-font-family | ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace | terminal mono |
+| workspace-font-size | 12 px | terminal setting |
+| workspace-line-height | 18 px | 1 row |
+| chrome-font-size | 12 px | terminal setting |
+| status-font-size | 11.5 px | terminal setting |
+| onboarding-title | 20 px / 24 px, weight 700 | weight/bold attribute, at most two rows |
+| title weight, active | 700 | bold attribute |
+| title weight, inactive | 600 | normal unless contrast requires bold |
+| body weight | 400 | normal |
+| primary horizontal inset | 8 px | 1 column |
+| compact gap | 4 px | 0 columns |
+| regular inline gap | 8 px | 1 column |
+| regular vertical gap | 18 px | 1 row |
+
+Desktop text uses antialiasing and geometric precision. Workspace surfaces do
+not use oversized headings, wide card padding, decorative radial gradients, or
+proportional-font navigation. Selectable terminal output remains selectable;
+chrome remains non-selectable.
+
+### Chrome geometry
+
+| Token | Desktop Solid/Electron | OpenTUI |
+| --- | ---: | ---: |
+| native titlebar overlay | 28 px | not applicable |
+| window control | 28 by 28 px | host terminal owns OS controls |
+| window-control icon | 10 by 10 px, 1.5 px stroke | not applicable |
+| app tab strip | 28 px | 1 row |
+| pane header | 18 px | 1 row |
+| pane footer when visible | 18 px | 1 reserved row |
+| bottom dock tab strip | 28 px | 1 row |
+| global status strip | 18 px | 1 row |
+| docked pane border | 1 px | 1 cell line glyph |
+| floating pane border | 1 px | 1 cell line glyph |
+| window-edit selected border | 3 px inset plus 6 px at 22% focus halo | strong/double line glyph without changing rect |
+| divider hit gutter | 8 px with centered 1 px rule | 1 cell separator |
+| scrollbar gutter | 8 px | 1 column |
+| scrollbar minimum thumb | 24 px | 1 row or column |
+| docked radius | 0 px | none |
+| floating pane radius | 6 px | rounded line glyphs |
+| palette/dialog radius | 8 px | rounded line glyphs |
+| compact control radius | 4 px | none |
+| tab radius | 5 px underline, 6 px pill | none |
+| floating shadow | 0 18px 38px, canvas at 46% | none |
+| focused floating shadow | 0 18px 40px, canvas at 50% | none |
+
+Pane action targets inside the 18 px header are 20 by 18 px with a 12 px icon.
+Window and standalone controls use 28 by 28 px targets. Desktop dividers use a
+transparent 8 px resize target, so visual density does not reduce usability.
+In the primary desktop window, the native titlebar overlay and app-tab surface
+occupy the same 28 px row; they are not two stacked rows. Detached windows keep
+the same 28 px titlebar rhythm.
+
+### Pane density
+
+Pane density is based on the pane's own content budget, never the entire
+viewport.
+
+| Pane content width | Chrome variant | Required presentation |
+| ---: | --- | --- |
+| below 28 cells / 224 px | tiny | grip only when at least two cells fit; one-cell kind glyph; title consumes remaining space; one highest-priority action at most |
+| 28-43 cells / 224-351 px | compact | title, status glyph, icon actions; no subtitle or text action labels |
+| 44-79 cells / 352-639 px | standard | title, short subtitle when it fits, status text, icon actions |
+| 80 cells / 640 px and above | wide | title, subtitle, status text, state chips, icon actions; text action labels only when all title minimums still fit |
+
+The title minimum is 12 cells / 96 px after grip and kind glyph. Actions are
+removed from lowest priority first; the title is never covered or pushed under
+right-pinned controls. Below 8 by 4 cells, omit the border and preserve body
+content, matching the current safe fallback.
+
+### Semantic palettes
+
+These values replace per-surface hard-coded colors. The desktop host receives
+them as CSS variables from the same semantic theme snapshot used by OpenTUI.
+
+| Role | Dark | Light | High contrast |
+| --- | --- | --- | --- |
+| background | #101016 | #f8f8fa | #000000 |
+| surface | #16161e | #eef0f6 | #000000 |
+| surface-raised | #1e1e28 | #ffffff | #101010 |
+| foreground | #d4d4d8 | #1c202a | #ffffff |
+| muted-foreground | #6e6e82 | #5c6376 | #d0d0d0 |
+| border | #3c3c50 | #bcc4d6 | #a0a0a0 |
+| accent | #82aaff | #2d69dc | #8fc3ff |
+| accent-muted | #3c425c | #d4e0ff | #17324d |
+| focus | #82aaff | #2d69dc | #8fc3ff |
+| focus-border | #6e91e6 | #1450be | #ffffff |
+| selection | #282e42 | #dae4fc | #20547f |
+| selection-foreground | #ffffff | #0f192d | #ffffff |
+| hover | #1e2230 | #e4eaf6 | #10243a |
+| button-hover | #343c56 | #d0dcf6 | #1b3c5e |
+| attention surface | #5c2c30 | #ffe0e0 | #4a160f |
+| blocked | #ff5f5f | #d23448 | #ff7676 |
+| working | #ffd75f | #b07800 | #ffd75f |
+| done | #87afff | #425cd2 | #8fc3ff |
+| idle | #87d787 | #268752 | #79e09e |
+| unknown | #808080 | #707682 | #d0d0d0 |
+
+Required contrast:
+
+- foreground against background or surface: at least 4.5:1;
+- muted readable text: at least 3.6:1, never used for essential controls;
+- selected text against selection: at least 4.5:1;
+- keyboard focus indicator against adjacent surfaces: at least 3:1;
+- high-contrast foreground: at least 7:1;
+- high-contrast static boundaries: at least 3:1.
+
+The pinned dark and light values deliberately preserve the current tmux-ide
+OpenTUI palette. The current shared dock CSS and Electron teal palette are not
+additional themes and must be removed as independent sources of truth.
+
+### Derived surfaces
+
+Derived color math is shared, deterministic, and tested:
+
+- inactive pane body: background;
+- focused pane body: mix background toward focus by 6%;
+- inactive pane header: mix surface toward border by 15%;
+- focused pane header: mix background toward focus by 22%;
+- floating focused header: mix background toward focus by 25%;
+- pointer hover: the semantic hover token;
+- pressed action: button-hover;
+- disabled foreground: muted-foreground at 55% alpha on desktop, muted-foreground
+  without alpha plus a disabled glyph in OpenTUI;
+- inactive scrollbar: fully transparent;
+- active scrollbar thumb: foreground at 24% alpha;
+- hovered scrollbar thumb: foreground at 26% alpha.
+
+No component may derive focus from blocked, working, done, or idle status.
+
+## State and ownership matrix
+
+State precedence is exact, from highest to lowest:
+
+1. disabled;
+2. window-edit selected;
+3. terminal input focus;
+4. keyboard focus;
+5. selected/current;
+6. attention;
+7. pressed;
+8. pointer hover;
+9. base.
+
+Exceptions are additive and limited:
+
+- Attention may retain a one-cell or one-dot status marker when a pane is
+  focused, but may not replace the focus border.
+- Pressed may temporarily replace selected background only for the pressed
+  action, not its parent tab or pane.
+- Pointer hover is cleared when keyboard movement changes selection.
+- Selection and pointer-hover backgrounds never paint the same row.
+
+| State | Border | Header/body | Marker | Geometry |
+| --- | --- | --- | --- | --- |
+| inactive | border | inactive derived surfaces | hollow dot | unchanged |
+| keyboard focused | focus-border | focused header, normal body | solid dot | unchanged |
+| terminal focused | focus-border | focused header and 6% focused body | terminal square | unchanged |
+| attention, inactive | border | attention surface only in status/header marker region | exclamation in blocked/working tone | unchanged |
+| window-edit selected | strong focus border and halo | 24% focus header | diamond | unchanged |
+| floating | normal focus rules plus shadow/radius on desktop | floating derived surfaces | ring when otherwise inactive | unchanged |
+| maximized | normal focus rules | normal surfaces | max state chip | unchanged |
+| disabled action | no extra border | base surface | disabled glyph | unchanged |
+| hovered action | no extra border | hover | same icon | unchanged |
+| pressed action | no extra border | button-hover | same icon | unchanged |
+
+The pane frame is the only focus-border owner. The terminal framebuffer begins
+at the projected body origin and cannot paint header, footer, gutter, border, or
+halo cells. Workbench focus rails communicate canvas-versus-dock focus only;
+they do not repeat the focused pane's perimeter.
+
+On a focus change, old and new pane bounding rectangles, body origins, header
+positions, and action hit boxes must be bit-for-bit equal before and after.
+Only paint tokens and semantic attributes may change.
+
+## Responsive acceptance matrix
+
+### Desktop reference viewports
+
+Desktop golden captures use a 900 px viewport height. A separate 720 by 480
+minimum-window smoke test verifies clipping and scrolling but is not a golden
+composition.
+
+| Viewport | Variant | Session rail | Context inspector | Agent canvas | Open dock minimum | Expected pane density |
+| --- | --- | ---: | ---: | --- | ---: | --- |
+| 720 px | compact | 48 px, icons plus accessible names | hidden; represented by dock tab | one primary pane; two only if each remains at least 280 px | 126 px including strip | tiny or compact |
+| 1280 px | standard | 168 px | optional 240 px when explicitly open | two panes by default, three when each remains at least 280 px | 180 px including strip | compact or standard |
+| 1600 px | wide | 184 px | optional 280 px when explicitly open | three panes by default, four when each remains at least 280 px | 252 px including strip | standard or wide |
+
+Desktop workbench height excludes the 28 px titlebar and 18 px global status
+strip. Open dock height is round(workbench-height times 0.30), clamped to the
+minimum in the table and to preserve minimum canvas heights of 144, 216, and
+288 px for compact, standard, and wide. Collapsed dock height is exactly 28 px.
+Maximized dock consumes the workbench, but never the native titlebar or global
+status strip.
+
+At 720 px, no root horizontal scrollbar is allowed. The tab list may scroll
+horizontally with hidden chrome and must scroll the active tab into view.
+Inspector content moves into the bottom dock; it does not disappear from the
+product.
+
+### OpenTUI reference viewports
+
+The values below follow the current application-shell and workbench formulas
+at the fixed renderer-test sizes.
+
+| Terminal | Variant | Sidebar | Application content after top/status rows | Default open dock | Remaining canvas | Palette |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| 80 by 24 | compact | 20 columns | 60 by 22 cells | 7 rows | 15 rows | 54 by 22 cells |
+| 120 by 40 | standard | 28 columns | 92 by 38 cells | 11 rows | 27 rows | 72 by 23 cells |
+| 200 by 60 | wide | 28 columns | 172 by 58 cells | 17 rows | 41 rows | 72 by 23 cells |
+
+The top app tabs and bottom global status each consume one row. The bottom dock
+tab strip consumes one row inside the listed dock height. Collapsed dock height
+is one row. Minimum open dock heights remain 7, 10, and 14 rows; minimum canvas
+heights remain 8, 12, and 16 rows.
+
+When a sidebar plus pane grid cannot preserve a 28-column pane, pane chrome
+degrades according to the pane-density table. The app must not hide right-side
+pane actions by drawing them beyond the captured frame.
+
+## Command palette benchmark
+
+Palette width follows the measured Gloomberb cell formulas because they create
+a compact, repeatable command surface:
+
+- Desktop: max(46, min(78, viewport-cells minus 10, floor(viewport-cells times
+  0.64))).
+- OpenTUI: max(42, min(72, terminal-columns minus 8, floor(terminal-columns
+  times 0.68))).
+
+At the required viewports this resolves to:
+
+| Host size | Width | Ready-state height | Horizontal position |
+| --- | ---: | ---: | --- |
+| desktop 720 by 900 | 57 cells / 456 px | 20 cells / 360 px | centered, minimum 32 px edge |
+| desktop 1280 by 900 | 78 cells / 624 px | 20 cells / 360 px | centered |
+| desktop 1600 by 900 | 78 cells / 624 px | 20 cells / 360 px | centered |
+| OpenTUI 80 by 24 | 54 columns | 22 rows | centered, minimum 4 columns |
+| OpenTUI 120 by 40 | 72 columns | 23 rows | centered, minimum 4 columns |
+| OpenTUI 200 by 60 | 72 columns | 23 rows | centered, minimum 4 columns |
+
+The ready list body is at most 16 rows and at least 9. Desktop content padding
+is 1 cell / 8 px inline plus a 14 px panel inset; OpenTUI content padding is 3
+columns. Trailing command metadata is max(8, min(12, floor(inner-width times
+0.18))) cells. Query, group labels, command label, description, status, and
+shortcut columns may not change x position when the selected command changes.
+
+Desktop palette treatment is an 8 px radius, 14 px panel padding, and
+0 10px 18px canvas shadow at 34%. OpenTUI uses one rounded border. Backdrop
+click closes only on desktop. Escape closes on both. Loading, empty, no-match,
+error, retry, disabled, current, selected, and scrolled states are mandatory
+fixtures.
+
+## Icons
+
+Desktop uses one coherent line-icon family:
+
+- 12 by 12 px for pane, tab, rail, and compact action icons;
+- 10 by 10 px for native window controls;
+- 1.5 px stroke, round line caps and joins;
+- currentColor only;
+- no emoji and no mixed filled/outline metaphors in one control family.
+
+OpenTUI maps every semantic icon to a tested single-column Unicode fallback.
+Each fallback must pass the terminal display-width helper with width one.
+Labels remain the accessibility source of truth; icons are decorative where the
+label is already exposed.
+
+## Motion and feedback
+
+| Interaction | Desktop | OpenTUI |
+| --- | --- | --- |
+| window-control hover | 90 ms linear, color/background only | not applicable |
+| tab hover | 110 ms ease, color/background/underline only | next render, no animation |
+| action hover | 90 ms linear, color/background only | next render |
+| action press | 60 ms linear to button-hover; no translation | mouse-down state until release |
+| palette enter/exit | 120 ms ease-out, opacity plus at most 4 px vertical translation | immediate |
+| dock collapse/restore | 140 ms ease-out; content clips during transition | immediate |
+| pane focus | 0 ms; atomic paint update | one renderer frame |
+| resize drag | immediate; no easing | immediate integer cells |
+| attention pulse | no continuous pulse; one 140 ms arrival tint allowed | marker update only |
+
+No animation changes the cell grid, terminal body origin, pane header height, or
+hit geometry. With reduced motion, every duration is zero, scroll behavior is
+auto, and no looping spinner is required. TUI animation is limited to discrete
+glyph changes and must never repaint focus borders on a timer.
+
+## Shared-host architecture acceptance
+
+The shared Solid layer may own:
+
+- semantic IDs and ordering;
+- active, selected, focused, hovered, pressed, disabled, attention, and status
+  state;
+- labels, descriptions, keyboard commands, and accessibility intent;
+- responsive intent such as compact, standard, or wide;
+- command and mission descriptors.
+
+The OpenTUI host owns:
+
+- cell rectangles and integer layout;
+- terminal display-width clipping;
+- border glyphs, span colors, framebuffer clipping, and mouse cell hit tests.
+
+The desktop host owns:
+
+- CSS grid/flex and pixel rectangles;
+- DOM focus, ARIA, pointer hit targets, scrolling, shadows, radii, and motion;
+- titlebar drag regions and platform window controls.
+
+WorkbenchDockHostProjection on fa85a405 still exposes dock, dockTabs, dockBody,
+dockBodyRail, dockBodyContent, and per-tab x/width cell geometry to the DOM
+presenter. Card 22 must split this into a semantic dock presentation model plus
+OpenTUI and desktop geometry adapters. Structural TypeScript compatibility is
+not sufficient host independence.
+
+Likewise, hard-coded values in web-host.css and styles.css must become semantic
+CSS variables produced from the canonical theme. The renderer stays free of
+Node.js, Electron, tmux, and filesystem imports.
+
+## Required acceptance suite
+
+### Live preview review checklist
+
+Use this checklist on every candidate desktop and TUI preview. Record the
+candidate commit, host, size, theme, reduced-motion setting, and screenshot or
+terminal capture before checking a box. A preview passes only when every
+applicable item is yes; “not inspected” is not a pass.
+
+Setup for one review round:
+
+- [ ] Candidate revision and build artifact are recorded.
+- [ ] Desktop device scale is 100%; TUI font zoom is unchanged during the run.
+- [ ] Desktop is reviewed at 720 by 900, 1280 by 900, and 1600 by 900, then
+  smoke-tested at 720 by 480.
+- [ ] TUI is reviewed at 80 by 24, 120 by 40, and 200 by 60.
+- [ ] The same deterministic fixture is loaded: long pane title, two agent
+  statuses, Files attention, Missions selected, dirty changes, and enough
+  terminal output to scroll.
+- [ ] Dark, light, and high-contrast modes are each reviewed without restarting
+  into a different fixture.
+
+Shell and overall cohesion:
+
+- [ ] The first impression is one dense terminal-native application, not a web
+  landing page containing a terminal.
+- [ ] App tabs, session navigation, pane chrome, dock, palette, and status use
+  one mono rhythm and the same semantic colors.
+- [ ] Desktop titlebar is 28 px, status is 18 px, dock tabs are 28 px, and TUI
+  equivalents are one row.
+- [ ] On macOS, native traffic-light clearance aligns with the integrated app
+  tabs; on Windows/Linux, the three 28 px custom controls use 10 px icons.
+- [ ] Maximize and restore the desktop window from its control: state and icon
+  update together without moving app tabs. Verify minimize and close on a
+  disposable secondary window; close hover uses the danger treatment.
+- [ ] The current project/session, current surface, current input pane, and
+  current dock tab are each identifiable without competing accent signals.
+- [ ] No radial hero, oversized marketing heading, large dashboard card, or
+  host-local theme color remains in the workbench.
+
+Pane chrome and terminal ownership:
+
+- [ ] Every visible terminal pane has a header, grip, clipped title, kind icon,
+  status, and right-pinned actions appropriate to its local width.
+- [ ] Hover each pane action: its hit area is stable, icon is centered, and
+  title width does not change.
+- [ ] Press and release each pane action, including release outside: pressed
+  state always clears.
+- [ ] Maximize one pane and restore it: header/actions remain in the same visual
+  language and the previous grid returns without drift.
+- [ ] Resize across the 28, 44, and 80 cell density boundaries: controls degrade
+  in the specified order and never cover the title.
+- [ ] Scroll terminal content to all edges: bytes, cursor, selection, and
+  scrollbar stay inside the body and never overwrite chrome.
+- [ ] Focus transfers change paint only; body origin, border position, header,
+  footer, and actions do not move.
+
+Focus-flicker stress:
+
+- [ ] Switch focus across adjacent panes ten times with the keyboard.
+- [ ] Repeat ten switches with pointer clicks.
+- [ ] Hold a navigation key so focus advances rapidly where supported.
+- [ ] During all three checks there is exactly one focused pane, no detached
+  horizontal line, no old border residue, no double rail, and no terminal row
+  inserted into chrome.
+- [ ] A blocked or working state changes only status/attention treatment and
+  never impersonates focus.
+- [ ] Window-edit selection is visibly stronger than ordinary focus but does
+  not resize the pane.
+
+Bottom dock:
+
+- [ ] Files, Changes, Missions, and Activity appear in the same order on both
+  hosts with product-appropriate icons and shortcuts.
+- [ ] Arrow navigation, pointer activation, Enter/Space, disabled skipping, and
+  focus-visible behavior select the same semantic tab.
+- [ ] Pointer hover and keyboard selection never remain painted on two rows.
+- [ ] Collapse leaves exactly the tab strip; open restores the persisted size;
+  maximize consumes only the workbench and restores exactly.
+- [ ] Drag resize is immediate and respects the canvas/dock minimums.
+- [ ] At 720 px and 80 columns, overflow keeps all tools reachable and scrolls
+  the active tab into view.
+- [ ] Dock content is native UI, not a tmux pane pretending to be Files,
+  Changes, Missions, or Activity.
+
+Command palette:
+
+- [ ] Open from keyboard and pointer entry points; both land on the same query
+  and selected command.
+- [ ] Measured width and height match the command-palette benchmark at the
+  current viewport.
+- [ ] Query, group, icon, label, detail, status, and shortcut columns do not
+  jump while moving through results.
+- [ ] Keyboard movement clears stale pointer hover.
+- [ ] Selected, current, hovered, disabled, loading, empty, no-match, error, and
+  retry states are visually distinct without color-only meaning.
+- [ ] Long labels truncate before trailing shortcuts; the shortcut column
+  remains visible.
+- [ ] Escape closes the palette first. Ctrl-C is not consumed as app quit.
+- [ ] Desktop backdrop click closes the palette; clicks inside do not.
+
+Theme and state:
+
+- [ ] Switching dark to light to high contrast changes semantic variables, not
+  component geometry.
+- [ ] Foreground, muted text, selection, focus, and high-contrast boundaries
+  pass the ratios in this benchmark.
+- [ ] Essential status always has a glyph or label in addition to color.
+- [ ] Disabled controls remain readable but cannot be confused with inactive
+  enabled controls.
+- [ ] Hover is subtle, pressed is stronger, selected remains authoritative, and
+  focus-visible is reserved for keyboard focus.
+- [ ] High contrast contains no alpha-only essential border or focus cue.
+
+Responsive and narrow-window behavior:
+
+- [ ] 720 px shows a 48 px session rail, primary canvas, dock access, and status
+  with no root horizontal scrollbar.
+- [ ] Information removed from a side inspector at 720 px is reachable in the
+  bottom dock.
+- [ ] 1280 px supports the standard two-pane composition and optional context
+  inspector without violating 280 px pane minimums.
+- [ ] 1600 px supports the wide three-pane composition and coherent four-pane
+  degradation.
+- [ ] 80 columns retains quit/palette help, active surface, session identity,
+  one usable agent pane, dock tabs, and status.
+- [ ] 120 and 200 columns add detail rather than merely stretching blank space.
+
+Onboarding and empty state:
+
+- [ ] A project without .tmux-ide or ide.yml reaches a useful detected-project
+  screen without an error or blank canvas.
+- [ ] The primary action and its consequence are clear without documentation.
+- [ ] Onboarding uses the same mono type, chrome, palette, actions, and focus
+  behavior as the workbench.
+- [ ] Onboarding title stays within 20/24 desktop typography or two TUI rows.
+- [ ] Completing or skipping onboarding lands in the same shell; there is no
+  second visual system during the transition.
+
+Motion, icons, and accessibility:
+
+- [ ] Focus and resizing are immediate; hover, press, palette, and dock motion
+  match the timing table.
+- [ ] Reduced motion removes every nonessential transition and animation.
+- [ ] Desktop icons are one 12 px line family, window icons are 10 px, and no
+  emoji or font-dependent double-width icon appears.
+- [ ] TUI icon fallbacks occupy exactly one display cell.
+- [ ] Desktop controls expose correct roles, names, selected/expanded/pressed
+  state, and logical tab order.
+- [ ] Text selection works inside terminal output and text inputs but does not
+  accidentally select app chrome.
+
+Review closeout:
+
+- [ ] Required screenshots, char frames, span captures, and computed-token dumps
+  are attached to the card.
+- [ ] Every failure is classified as parity-critical, a listed deliberate
+  product difference, or a proposed benchmark change.
+- [ ] No proposed benchmark change is accepted only to make an existing
+  implementation pass.
+
+### Base visual matrix
+
+Every row below is required in dark, light, and high-contrast themes:
+
+| Host | Sizes | Capture |
+| --- | --- | --- |
+| Solid/Electron | 720 by 900, 1280 by 900, 1600 by 900 | deterministic screenshot and computed-token dump |
+| OpenTUI | 80 by 24, 120 by 40, 200 by 60 | captureCharFrame plus captureSpans |
+
+That is 18 base captures. Each base fixture contains:
+
+- agent canvas with one terminal-focused pane and one inactive attention pane
+  where the width permits;
+- bottom dock open on Missions;
+- Files tab carrying attention without stealing selection;
+- global status strip and session navigation;
+- enough terminal content to prove framebuffer clipping;
+- a long pane title and long tab label to prove truncation.
+
+For each of the 18 combinations, add these state captures:
+
+1. base workspace;
+2. command palette with selected, current, disabled, hovered, and trailing
+   shortcut rows;
+3. zero-config onboarding with detected project and one primary action.
+
+The resulting 54 captures are the release baseline for cohesive product
+experience.
+
+### Geometry assertions
+
+- Root width and height equal the requested viewport exactly; no root overflow.
+- Every desktop chrome value matches the normative table within 0.5 px.
+- Every OpenTUI chrome value matches the normative table exactly in cells.
+- Changing focus, terminal focus, attention, hover, press, theme, or selection
+  changes no bounding rectangle.
+- Pane body begins exactly after the owned header/border and ends before the
+  owned footer/border.
+- A pane framebuffer cannot produce a non-background span in chrome cells.
+- Ten rapid focus transfers produce no orphan border row, duplicate focus rail,
+  or single-frame geometry change.
+- Long titles truncate before the first right-pinned action with at least one
+  cell / 8 px gap.
+- Active tabs remain visible after overflow and keyboard navigation.
+- 720 by 480 keeps primary navigation, canvas, collapsed dock, and status
+  reachable without root horizontal scrolling.
+
+### State and input assertions
+
+- Keyboard selection clears stale pointer hover.
+- Hover cannot override selected, focused, disabled, or window-edit state.
+- Attention never changes focus color.
+- Pressed clears on pointer release outside the control and on blur.
+- Focus-visible appears for keyboard navigation and does not remain after a
+  pointer-only activation unless the platform requires it.
+- Escape closes palette first; it does not quit the app.
+- Ctrl-C remains terminal passthrough in a terminal body.
+- The product quit/detach command remains Ctrl-Q and is shown consistently.
+- Tab order, arrow-key behavior, Enter/Space activation, and disabled skipping
+  match across hosts.
+
+### Theme and accessibility assertions
+
+- Test computed contrast for every role pair listed in the palette section.
+- High-contrast mode uses no alpha-only essential boundary.
+- Essential status has text or glyph meaning in addition to color.
+- Desktop tablist, tabs, dock panels, pane actions, palette rows, window
+  controls, and onboarding actions have roles and accessible names.
+- TUI icon fallbacks are one display cell at all three terminal widths.
+- Reduced-motion captures contain no active transition or animation.
+
+## Definition of done
+
+Card 22 is complete only when:
+
+- the semantic token source drives OpenTUI, shared Solid surfaces, and the
+  Electron renderer;
+- high-contrast is a real theme mode rather than a CSS afterthought;
+- the shared dock no longer exports terminal rectangles to the DOM host;
+- the Electron foundation's sans dashboard, 42 px titlebar, 46 px controls,
+  independent teal palette, radial hero, and large cards are replaced by the
+  cohesive workbench language;
+- pane chrome has one owner and passes the rapid-focus anti-flicker assertion;
+- command palette geometry and behavior match the benchmark;
+- all 54 visual captures and the focused interaction tests pass;
+- no production surface has a local visual token without a documented semantic
+  role.
+
+## Highest-risk visual traps
+
+1. Sharing terminal geometry instead of semantics. Cell x/width fields in a DOM
+   contract will make desktop look like a stretched terminal and create
+   rounding bugs.
+2. Two chrome owners. A native PaneFrame plus framebuffer-drawn border/header is
+   the most likely cause of focus flicker, stray rows, and terminal content
+   overwriting chrome.
+3. Polishing the current Electron landing page. Its typography, density,
+   palette, titlebar, and card composition are intentionally only a foundation;
+   refining them would deepen the wrong visual language.
+4. Independent theme constants. OpenTUI, shared dock CSS, and Electron currently
+   have three similar but different palettes. Small drift is highly visible
+   when terminals and native panels touch.
+5. Global breakpoints applied to local panes. A 1600 px window can contain a
+   320 px pane; pane chrome must respond to its own budget.
+6. Focus encoded as status. Agent blocked/working/done colors must never move
+   the active border or users will lose input-location confidence.
+7. Animated focus geometry. Transitions on borders, width, inset, or body origin
+   turn ordinary focus changes into flicker. Focus is an atomic paint change.
+8. Mixed icon metrics. Emoji, double-width glyphs, and unrelated SVG families
+   break both alignment and product identity.
+9. Hiding functionality at 720 px. Inspector content may move into the dock but
+   cannot simply disappear at the desktop breakpoint.
+10. Golden frames without span/style checks. Character snapshots alone miss
+    focus, selection, hover, and contrast regressions; desktop pixels alone miss
+    semantic and computed-token drift.


### PR DESCRIPTION
## Summary
- add a verified file-level implementation map for Card 22.2 through 22.4
- pin the dependency chain and live desktop-preview route
- define exact terminal-native density, typography, pane, dock, palette, state, motion, and responsive targets
- add a 54-capture cross-host acceptance matrix and operational review checklist

## Scope
Documentation and implementation evidence only; no production, package, config, tmux, or mission state changes.

## Verification
- all file/ownership claims checked against current main and reviewed 19a/19b branches
- Prettier and diff checks pass
- preview command and package scripts verified