### PR TITLE
test(contracts): enforce cross-host experience conformance

### DIFF
--- a/packages/contracts/src/__tests__/cohesion-fixture.test.ts
+++ b/packages/contracts/src/__tests__/cohesion-fixture.test.ts
@@ -1,19 +1,8 @@
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { COHESION_FIXTURE_V1, CohesionFixtureV1SchemaZ } from "../cohesion-fixture.ts";
 import { resolvePaneAppearance } from "../pane-appearance.ts";
 import { resolveSemanticInputLayer } from "../focus-overlay.ts";
 import { resolveVisualTheme } from "../visual-tokens.ts";
-
-const KERNEL_FILES = [
-  "experience-shell.ts",
-  "visual-recipes.ts",
-  "visual-tokens.ts",
-  "pane-appearance.ts",
-  "focus-overlay.ts",
-  "cohesion-fixture.ts",
-] as const;
 
 describe("CohesionFixtureV1", () => {
   it("round-trips as strict serialized cross-host acceptance input", () => {
@@ -96,28 +85,22 @@ describe("CohesionFixtureV1", () => {
     walk(COHESION_FIXTURE_V1);
     expect(findings).toEqual([]);
   });
-});
 
-describe("experience-kernel boundaries", () => {
-  it("does not import renderer, runtime, DOM, or geometry packages", () => {
-    const forbidden = [
-      "node:",
-      "electron",
-      "@opentui",
-      "solid-js",
-      "react",
-      "xterm",
-      "dom",
-      "tmux",
-      "pty",
-    ];
-    for (const file of KERNEL_FILES) {
-      const source = readFileSync(fileURLToPath(new URL(`../${file}`, import.meta.url)), "utf8");
-      const imports = [...source.matchAll(/from\s+["']([^"']+)["']/gu)].map((match) => match[1]!);
-      expect(
-        imports.filter((specifier) => forbidden.some((name) => specifier.includes(name))),
-        file,
-      ).toEqual([]);
-    }
+  it("is deeply frozen so adapters cannot decorate shared input with host measurements", () => {
+    const mutableObjects: string[] = [];
+    const walk = (value: unknown, path = "fixture"): void => {
+      if (!value || typeof value !== "object") return;
+      if (!Object.isFrozen(value)) mutableObjects.push(path);
+      if (Array.isArray(value)) {
+        value.forEach((child, index) => walk(child, `${path}.${index}`));
+        return;
+      }
+      for (const [key, child] of Object.entries(value)) walk(child, `${path}.${key}`);
+    };
+
+    walk(COHESION_FIXTURE_V1);
+    expect(mutableObjects).toEqual([]);
+    expect(Reflect.set(COHESION_FIXTURE_V1.project, "name", "host-decorated")).toBe(false);
+    expect(COHESION_FIXTURE_V1.project.name).toBe("tmux-ide");
   });
 });

--- a/packages/contracts/src/__tests__/experience-conformance.test.ts
+++ b/packages/contracts/src/__tests__/experience-conformance.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+  PANE_ROLE_IDS,
+  PaneRoleIdSchemaZ,
+  SEMANTIC_ICON_IDS,
+  SemanticIconIdSchemaZ,
+} from "../experience-identifiers.ts";
+import {
+  CANONICAL_SURFACE_REGISTRY,
+  DOCK_TOOL_IDS,
+  DockToolIdSchemaZ,
+  PRIMARY_WORKSPACE_MODE_IDS,
+  PRODUCT_SURFACE_IDS,
+  PrimaryWorkspaceModeIdSchemaZ,
+  ProductSurfaceIdSchemaZ,
+} from "../experience-shell.ts";
+import {
+  AGENT_ACTIVITY_IDS,
+  AgentActivitySchemaZ,
+  CANONICAL_DOMAIN_STATUS_IDS,
+  CanonicalDomainStatusSchemaZ,
+  PANE_ATTENTION_IDS,
+  PaneAttentionSchemaZ,
+  statusToneForDomainStatus,
+} from "../pane-appearance.ts";
+import {
+  BORDER_TOKEN_ROLES,
+  BUILTIN_VISUAL_THEMES,
+  DENSITY_TOKEN_ROLES,
+  ELEVATION_TOKEN_ROLES,
+  FOCUS_TOKEN_ROLES,
+  MOTION_DURATION_ROLES,
+  SELECTION_TOKEN_ROLES,
+  SHAPE_TOKEN_ROLES,
+  STATUS_TONE_ROLES,
+  SURFACE_TOKEN_ROLES,
+  TEXT_TOKEN_ROLES,
+  TYPOGRAPHY_TOKEN_ROLES,
+  VisualTokensV1SchemaZ,
+  WINDOW_ACTIVITY_TOKEN_ROLES,
+  type VisualTokensV1,
+} from "../visual-tokens.ts";
+
+const TOKEN_ROLES_BY_GROUP = {
+  surfaces: SURFACE_TOKEN_ROLES,
+  text: TEXT_TOKEN_ROLES,
+  borders: BORDER_TOKEN_ROLES,
+  statusTone: STATUS_TONE_ROLES,
+  selection: SELECTION_TOKEN_ROLES,
+  density: DENSITY_TOKEN_ROLES,
+  shape: SHAPE_TOKEN_ROLES,
+  elevation: ELEVATION_TOKEN_ROLES,
+  motion: [...MOTION_DURATION_ROLES, "easing"],
+  typography: TYPOGRAPHY_TOKEN_ROLES,
+  focus: FOCUS_TOKEN_ROLES,
+  windowActivity: WINDOW_ACTIVITY_TOKEN_ROLES,
+} as const satisfies Readonly<{
+  [Group in keyof VisualTokensV1]: readonly (keyof VisualTokensV1[Group])[];
+}>;
+
+const jsonRoundTrip = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const TOKEN_IDS = Object.entries(TOKEN_ROLES_BY_GROUP).flatMap(([group, roles]) =>
+  roles.map((role) => `${group}.${String(role)}`),
+);
+
+/** One transport-shaped identity fixture proves the complete host adapter vocabulary. */
+const CONFORMANCE_ID_FIXTURE_V1 = Object.freeze({
+  version: 1 as const,
+  tokens: TOKEN_IDS,
+  icons: SEMANTIC_ICON_IDS,
+  statuses: {
+    agentActivity: AGENT_ACTIVITY_IDS,
+    domain: CANONICAL_DOMAIN_STATUS_IDS,
+    attention: PANE_ATTENTION_IDS,
+  },
+  surfaces: PRODUCT_SURFACE_IDS,
+  paneRoles: PANE_ROLE_IDS,
+});
+
+function expectUniqueSerializableIds(
+  ids: readonly string[],
+  parse: (value: unknown) => unknown,
+): void {
+  expect(new Set(ids).size).toBe(ids.length);
+  expect(jsonRoundTrip(ids)).toEqual(ids);
+  for (const id of ids) expect(parse(jsonRoundTrip(id))).toBe(id);
+}
+
+describe("experience-kernel identifier conformance", () => {
+  it("round-trips the complete adapter identity fixture", () => {
+    expect(jsonRoundTrip(CONFORMANCE_ID_FIXTURE_V1)).toEqual(CONFORMANCE_ID_FIXTURE_V1);
+  });
+
+  it("keeps every required visual token role exhaustive and serializable", () => {
+    expectUniqueSerializableIds(TOKEN_IDS, (id) => id);
+
+    for (const tokens of Object.values(BUILTIN_VISUAL_THEMES)) {
+      const roundTripped = VisualTokensV1SchemaZ.parse(jsonRoundTrip(tokens));
+      for (const [group, roles] of Object.entries(TOKEN_ROLES_BY_GROUP)) {
+        expect(Object.keys(roundTripped[group as keyof VisualTokensV1]).sort(), group).toEqual(
+          [...roles].sort(),
+        );
+      }
+    }
+  });
+
+  it("keeps every semantic icon ID exhaustive and serializable", () => {
+    expectUniqueSerializableIds(SEMANTIC_ICON_IDS, (id) => SemanticIconIdSchemaZ.parse(id));
+    expect(CANONICAL_SURFACE_REGISTRY.map(({ icon }) => icon)).toEqual([
+      "home",
+      "terminals",
+      "files",
+      "changes",
+      "missions",
+      "activity",
+    ]);
+  });
+
+  it("keeps every canonical status ID exhaustive and serializable", () => {
+    expectUniqueSerializableIds(AGENT_ACTIVITY_IDS, (id) => AgentActivitySchemaZ.parse(id));
+    expectUniqueSerializableIds(CANONICAL_DOMAIN_STATUS_IDS, (id) =>
+      CanonicalDomainStatusSchemaZ.parse(id),
+    );
+    expectUniqueSerializableIds(PANE_ATTENTION_IDS, (id) => PaneAttentionSchemaZ.parse(id));
+    expect(
+      Object.fromEntries(
+        CANONICAL_DOMAIN_STATUS_IDS.map((status) => [status, statusToneForDomainStatus(status)]),
+      ),
+    ).toEqual({
+      idle: "neutral",
+      running: "info",
+      blocked: "warning",
+      review: "info",
+      done: "success",
+      disconnected: "danger",
+      recovering: "danger",
+    });
+  });
+
+  it("keeps every product surface ID exhaustive and serializable", () => {
+    expectUniqueSerializableIds(PRIMARY_WORKSPACE_MODE_IDS, (id) =>
+      PrimaryWorkspaceModeIdSchemaZ.parse(id),
+    );
+    expectUniqueSerializableIds(DOCK_TOOL_IDS, (id) => DockToolIdSchemaZ.parse(id));
+    expectUniqueSerializableIds(PRODUCT_SURFACE_IDS, (id) => ProductSurfaceIdSchemaZ.parse(id));
+    expect(CANONICAL_SURFACE_REGISTRY.map(({ id }) => id)).toEqual(PRODUCT_SURFACE_IDS);
+  });
+
+  it("keeps every pane-role ID exhaustive and serializable", () => {
+    expectUniqueSerializableIds(PANE_ROLE_IDS, (id) => PaneRoleIdSchemaZ.parse(id));
+  });
+});

--- a/packages/contracts/src/__tests__/experience-kernel-boundary.test.ts
+++ b/packages/contracts/src/__tests__/experience-kernel-boundary.test.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync } from "node:fs";
+import { builtinModules } from "node:module";
+import { dirname, extname, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const SOURCE_ROOT = fileURLToPath(new URL("../", import.meta.url));
+const KERNEL_ENTRY_FILES = [
+  "experience-identifiers.ts",
+  "experience-shell.ts",
+  "visual-recipes.ts",
+  "visual-tokens.ts",
+  "pane-appearance.ts",
+  "focus-overlay.ts",
+  "cohesion-fixture.ts",
+] as const;
+const ALLOWED_EXTERNAL_IMPORTS = new Set(["zod"]);
+const NODE_IMPORTS = new Set(builtinModules.flatMap((name) => [name, name.replace(/^node:/u, "")]));
+const FORBIDDEN_LOCAL_SEGMENT =
+  /(?:^|[/._-])(?:dom|electron|opentui|solid|react|xterm|string-width|tmux|pty)(?=$|[/._-])/iu;
+
+function resolveLocalImport(importer: string, specifier: string): string | null {
+  const candidate = resolve(dirname(importer), specifier);
+  for (const path of [candidate, `${candidate}.ts`, resolve(candidate, "index.ts")]) {
+    if (existsSync(path)) return path;
+  }
+  return null;
+}
+
+function displayPath(path: string): string {
+  return relative(SOURCE_ROOT, path).split(sep).join("/");
+}
+
+describe("experience-kernel import boundary", () => {
+  it("keeps the complete shared graph free of host, runtime, and terminal dependencies", () => {
+    const pending = KERNEL_ENTRY_FILES.map((file) => resolve(SOURCE_ROOT, file));
+    const visited = new Set<string>();
+    const findings: string[] = [];
+
+    while (pending.length > 0) {
+      const file = pending.pop()!;
+      if (visited.has(file)) continue;
+      visited.add(file);
+      const source = readFileSync(file, "utf8");
+      const preprocessed = ts.preProcessFile(source, true, true);
+      const specifiers = [
+        ...preprocessed.importedFiles.map(({ fileName }) => fileName),
+        ...preprocessed.typeReferenceDirectives.map(({ fileName }) => fileName),
+        ...preprocessed.libReferenceDirectives.map(({ fileName }) => fileName),
+      ];
+
+      for (const specifier of specifiers) {
+        const evidence = `${displayPath(file)} -> ${specifier}`;
+        if (!specifier.startsWith(".")) {
+          const packageName = specifier
+            .replace(/^node:/u, "")
+            .split("/")
+            .slice(0, specifier.startsWith("@") ? 2 : 1)
+            .join("/");
+          if (
+            specifier.startsWith("node:") ||
+            NODE_IMPORTS.has(specifier) ||
+            NODE_IMPORTS.has(packageName) ||
+            !ALLOWED_EXTERNAL_IMPORTS.has(packageName)
+          ) {
+            findings.push(evidence);
+          }
+          continue;
+        }
+
+        if (FORBIDDEN_LOCAL_SEGMENT.test(specifier)) findings.push(evidence);
+        const dependency = resolveLocalImport(file, specifier);
+        if (dependency === null) {
+          findings.push(`${evidence} (unresolved)`);
+          continue;
+        }
+        const outsideSource = relative(SOURCE_ROOT, dependency).startsWith(`..${sep}`);
+        if (outsideSource || extname(dependency) !== ".ts") {
+          findings.push(`${evidence} (outside shared TypeScript graph)`);
+          continue;
+        }
+        pending.push(dependency);
+      }
+    }
+
+    expect(findings).toEqual([]);
+    expect([...visited].map(displayPath).sort()).toEqual([
+      "cohesion-fixture.ts",
+      "commands.ts",
+      "experience-identifiers.ts",
+      "experience-shell.ts",
+      "focus-overlay.ts",
+      "pane-appearance.ts",
+      "visual-recipes.ts",
+      "visual-tokens.ts",
+    ]);
+  });
+});

--- a/packages/contracts/src/cohesion-fixture.ts
+++ b/packages/contracts/src/cohesion-fixture.ts
@@ -5,6 +5,7 @@ import {
   PrimaryWorkspaceModeIdSchemaZ,
   CANONICAL_SURFACE_REGISTRY,
 } from "./experience-shell.ts";
+import { PaneRoleIdSchemaZ, SemanticIconIdSchemaZ } from "./experience-identifiers.ts";
 import { FocusOverlayStateV1SchemaZ } from "./focus-overlay.ts";
 import {
   AgentActivitySchemaZ,
@@ -60,6 +61,7 @@ const PaneActionSchemaZ = z
       "maximize-toggle",
       "detach",
     ]),
+    icon: SemanticIconIdSchemaZ,
     label: LabelSchemaZ,
     commandId: CommandIdSchemaZ,
     available: z.boolean(),
@@ -74,6 +76,7 @@ const PaneActionSchemaZ = z
 const PaneFixtureSchemaZ = z
   .object({
     id: SemanticProductIdSchemaZ,
+    role: PaneRoleIdSchemaZ,
     title: LabelSchemaZ,
     subtitle: OptionalLabelSchemaZ,
     terminalSourceId: SemanticProductIdSchemaZ.nullable(),
@@ -321,6 +324,7 @@ export type CohesionFixtureV1 = z.infer<typeof CohesionFixtureV1SchemaZ>;
 const paneActions = (canSplit: boolean) => [
   {
     id: "focus-terminal" as const,
+    icon: "terminals" as const,
     label: "Focus terminal",
     commandId: "pane.terminal.focus",
     available: true,
@@ -328,6 +332,7 @@ const paneActions = (canSplit: boolean) => [
   },
   {
     id: "split" as const,
+    icon: "split-right" as const,
     label: "Split pane",
     commandId: "pane.split",
     available: canSplit,
@@ -335,6 +340,7 @@ const paneActions = (canSplit: boolean) => [
   },
   {
     id: "duplicate" as const,
+    icon: "duplicate" as const,
     label: "Duplicate pane",
     commandId: "pane.duplicate",
     available: canSplit,
@@ -342,6 +348,7 @@ const paneActions = (canSplit: boolean) => [
   },
   {
     id: "float-toggle" as const,
+    icon: "float" as const,
     label: "Float or dock",
     commandId: "pane.float.toggle",
     available: true,
@@ -349,6 +356,7 @@ const paneActions = (canSplit: boolean) => [
   },
   {
     id: "maximize-toggle" as const,
+    icon: "maximize" as const,
     label: "Maximize or restore",
     commandId: "pane.maximize.toggle",
     available: true,
@@ -356,6 +364,7 @@ const paneActions = (canSplit: boolean) => [
   },
   {
     id: "detach" as const,
+    icon: "pop-out" as const,
     label: "Detach pane",
     commandId: "pane.detach",
     available: true,
@@ -363,8 +372,17 @@ const paneActions = (canSplit: boolean) => [
   },
 ];
 
-/** Canonical serialized cross-host acceptance input; contains no live transport or geometry. */
-export const COHESION_FIXTURE_V1: CohesionFixtureV1 = CohesionFixtureV1SchemaZ.parse({
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) deepFreeze(child);
+  return Object.freeze(value);
+}
+
+/**
+ * Canonical immutable cross-host acceptance input; contains no live transport or geometry.
+ * Card 22.2 host adapters consume this value but must never decorate or mutate it.
+ */
+const COHESION_FIXTURE_V1_INPUT: CohesionFixtureV1 = CohesionFixtureV1SchemaZ.parse({
   version: COHESION_FIXTURE_VERSION,
   project: {
     id: "project.tmux-ide",
@@ -425,6 +443,7 @@ export const COHESION_FIXTURE_V1: CohesionFixtureV1 = CohesionFixtureV1SchemaZ.p
   panes: [
     {
       id: "pane.pm",
+      role: "terminal",
       title: "Project manager",
       subtitle: "Fable",
       terminalSourceId: "terminal.pm",
@@ -454,6 +473,7 @@ export const COHESION_FIXTURE_V1: CohesionFixtureV1 = CohesionFixtureV1SchemaZ.p
     },
     {
       id: "pane.implementer",
+      role: "terminal",
       title: "Implementer",
       subtitle: "Codex",
       terminalSourceId: "terminal.implementer",
@@ -483,6 +503,7 @@ export const COHESION_FIXTURE_V1: CohesionFixtureV1 = CohesionFixtureV1SchemaZ.p
     },
     {
       id: "pane.reviewer",
+      role: "terminal",
       title: "Reviewer",
       subtitle: "Completed review",
       terminalSourceId: "terminal.reviewer",
@@ -512,6 +533,7 @@ export const COHESION_FIXTURE_V1: CohesionFixtureV1 = CohesionFixtureV1SchemaZ.p
     },
     {
       id: "pane.recovery",
+      role: "terminal",
       title: "Recovery",
       subtitle: "Connection lost",
       terminalSourceId: "terminal.recovery",
@@ -621,3 +643,5 @@ export const COHESION_FIXTURE_V1: CohesionFixtureV1 = CohesionFixtureV1SchemaZ.p
     nextAction: "Retry the attachment or open recovery details",
   },
 });
+
+export const COHESION_FIXTURE_V1: CohesionFixtureV1 = deepFreeze(COHESION_FIXTURE_V1_INPUT);

--- a/packages/contracts/src/experience-identifiers.ts
+++ b/packages/contracts/src/experience-identifiers.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+/**
+ * Renderer-neutral icon meanings shared by every product host.
+ *
+ * Host adapters own glyphs, vectors, measurements, and accessibility wiring.
+ * These IDs only preserve semantic identity across those adapters.
+ */
+export const SEMANTIC_ICON_IDS = [
+  "home",
+  "terminals",
+  "files",
+  "changes",
+  "missions",
+  "activity",
+  "preview",
+  "native",
+  "more",
+  "close",
+  "minimize",
+  "maximize",
+  "restore",
+  "split-right",
+  "split-down",
+  "duplicate",
+  "dock",
+  "float",
+  "move",
+  "resize",
+  "pop-out",
+  "search",
+  "refresh",
+  "command",
+] as const;
+export const SemanticIconIdSchemaZ = z.enum(SEMANTIC_ICON_IDS);
+export type SemanticIconId = z.infer<typeof SemanticIconIdSchemaZ>;
+
+/** Semantic content role of a framed pane; presentation remains host-owned. */
+export const PANE_ROLE_IDS = [
+  "home",
+  "terminal",
+  "files",
+  "changes",
+  "missions",
+  "activity",
+  "preview",
+  "native",
+] as const;
+export const PaneRoleIdSchemaZ = z.enum(PANE_ROLE_IDS);
+export type PaneRoleId = z.infer<typeof PaneRoleIdSchemaZ>;

--- a/packages/contracts/src/experience-shell.ts
+++ b/packages/contracts/src/experience-shell.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { CommandIdSchemaZ, type CommandArguments, type CommandId } from "./commands.ts";
+import { SemanticIconIdSchemaZ, type SemanticIconId } from "./experience-identifiers.ts";
 
 /** Canonical product information architecture. Hosts may change placement, never identity/order. */
 export const EXPERIENCE_KERNEL_VERSION = 1 as const;
@@ -15,13 +16,16 @@ export const ShellAreaIdSchemaZ = z.enum([
 ]);
 export type ShellAreaId = z.infer<typeof ShellAreaIdSchemaZ>;
 
-export const PrimaryWorkspaceModeIdSchemaZ = z.enum(["home", "terminals"]);
+export const PRIMARY_WORKSPACE_MODE_IDS = ["home", "terminals"] as const;
+export const PrimaryWorkspaceModeIdSchemaZ = z.enum(PRIMARY_WORKSPACE_MODE_IDS);
 export type PrimaryWorkspaceModeId = z.infer<typeof PrimaryWorkspaceModeIdSchemaZ>;
 
-export const DockToolIdSchemaZ = z.enum(["files", "changes", "missions", "activity"]);
+export const DOCK_TOOL_IDS = ["files", "changes", "missions", "activity"] as const;
+export const DockToolIdSchemaZ = z.enum(DOCK_TOOL_IDS);
 export type DockToolId = z.infer<typeof DockToolIdSchemaZ>;
 
-export const ProductSurfaceIdSchemaZ = z.union([PrimaryWorkspaceModeIdSchemaZ, DockToolIdSchemaZ]);
+export const PRODUCT_SURFACE_IDS = [...PRIMARY_WORKSPACE_MODE_IDS, ...DOCK_TOOL_IDS] as const;
+export const ProductSurfaceIdSchemaZ = z.enum(PRODUCT_SURFACE_IDS);
 export type ProductSurfaceId = z.infer<typeof ProductSurfaceIdSchemaZ>;
 
 export interface ShellAreaDefinition {
@@ -50,6 +54,7 @@ export interface SurfaceCommandTemplate {
 
 export interface ProductSurfaceDefinition {
   readonly id: ProductSurfaceId;
+  readonly icon: SemanticIconId;
   readonly label: string;
   readonly kind: SurfaceKind;
   readonly area: "workspace-canvas" | "bottom-dock";
@@ -72,6 +77,7 @@ const dockCommand = (tool: DockToolId): SurfaceCommandTemplate => ({
 export const CANONICAL_SURFACE_REGISTRY: readonly ProductSurfaceDefinition[] = Object.freeze([
   {
     id: "home",
+    icon: "home",
     label: "Home",
     kind: "primary-mode",
     area: "workspace-canvas",
@@ -82,6 +88,7 @@ export const CANONICAL_SURFACE_REGISTRY: readonly ProductSurfaceDefinition[] = O
   },
   {
     id: "terminals",
+    icon: "terminals",
     label: "Terminals",
     kind: "primary-mode",
     area: "workspace-canvas",
@@ -92,6 +99,7 @@ export const CANONICAL_SURFACE_REGISTRY: readonly ProductSurfaceDefinition[] = O
   },
   {
     id: "files",
+    icon: "files",
     label: "Files",
     kind: "dock-tool",
     area: "bottom-dock",
@@ -102,6 +110,7 @@ export const CANONICAL_SURFACE_REGISTRY: readonly ProductSurfaceDefinition[] = O
   },
   {
     id: "changes",
+    icon: "changes",
     label: "Changes",
     kind: "dock-tool",
     area: "bottom-dock",
@@ -112,6 +121,7 @@ export const CANONICAL_SURFACE_REGISTRY: readonly ProductSurfaceDefinition[] = O
   },
   {
     id: "missions",
+    icon: "missions",
     label: "Missions",
     kind: "dock-tool",
     area: "bottom-dock",
@@ -122,6 +132,7 @@ export const CANONICAL_SURFACE_REGISTRY: readonly ProductSurfaceDefinition[] = O
   },
   {
     id: "activity",
+    icon: "activity",
     label: "Activity",
     kind: "dock-tool",
     area: "bottom-dock",
@@ -168,4 +179,5 @@ export function commandsToOpenSurface(
 
 for (const surface of CANONICAL_SURFACE_REGISTRY) {
   CommandIdSchemaZ.parse(surface.activation.id);
+  SemanticIconIdSchemaZ.parse(surface.icon);
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -29,6 +29,7 @@ export * from "./terminals.ts";
 export * from "./control.ts";
 export * from "./commands.ts";
 export * from "./desktop-host.ts";
+export * from "./experience-identifiers.ts";
 export * from "./experience-shell.ts";
 export * from "./visual-tokens.ts";
 export * from "./visual-recipes.ts";

--- a/packages/contracts/src/pane-appearance.ts
+++ b/packages/contracts/src/pane-appearance.ts
@@ -14,16 +14,18 @@ export const SemanticProductIdSchemaZ = z
   .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u, "semantic id contains a transport-only character");
 export type SemanticProductId = z.infer<typeof SemanticProductIdSchemaZ>;
 
-export const PaneStructureSchemaZ = z.enum(["docked", "floating", "maximized"]);
-export const AgentActivitySchemaZ = z.enum([
+export const PANE_STRUCTURE_IDS = ["docked", "floating", "maximized"] as const;
+export const PaneStructureSchemaZ = z.enum(PANE_STRUCTURE_IDS);
+export const AGENT_ACTIVITY_IDS = [
   "idle",
   "running",
   "waiting",
   "complete",
   "failed",
   "disconnected",
-]);
-export const CanonicalDomainStatusSchemaZ = z.enum([
+] as const;
+export const AgentActivitySchemaZ = z.enum(AGENT_ACTIVITY_IDS);
+export const CANONICAL_DOMAIN_STATUS_IDS = [
   "idle",
   "running",
   "blocked",
@@ -31,15 +33,17 @@ export const CanonicalDomainStatusSchemaZ = z.enum([
   "done",
   "disconnected",
   "recovering",
-]);
-export const PaneAttentionSchemaZ = z.enum([
+] as const;
+export const CanonicalDomainStatusSchemaZ = z.enum(CANONICAL_DOMAIN_STATUS_IDS);
+export const PANE_ATTENTION_IDS = [
   "none",
   "unread",
   "requested",
   "warning",
   "destructive",
   "recovery",
-]);
+] as const;
+export const PaneAttentionSchemaZ = z.enum(PANE_ATTENTION_IDS);
 export type PaneStructure = z.infer<typeof PaneStructureSchemaZ>;
 export type AgentActivity = z.infer<typeof AgentActivitySchemaZ>;
 export type CanonicalDomainStatus = z.infer<typeof CanonicalDomainStatusSchemaZ>;


### PR DESCRIPTION
## Summary
- add exhaustive renderer-neutral icon, surface, status, token, and pane-role identifiers
- freeze the canonical cohesion fixture for both host adapter suites
- enforce the full shared experience-kernel import graph with a transitive TypeScript boundary test

## Stack
- depends on #163 (Card 22.1 experience kernel)
- unblocks parallel Card 22.2b OpenTUI and Card 22.2c DOM adapters

## Verification
- `pnpm --filter @tmux-ide/contracts test` (15 files, 84 tests)
- `pnpm --filter @tmux-ide/contracts typecheck`
- `pnpm --filter @tmux-ide/contracts lint`
- `pnpm exec prettier --check packages/contracts/src`
- `git diff 5d110727..HEAD --check`
