### PR TITLE
feat(contracts): add the canonical application shell seam

### DIFF
--- a/packages/contracts/src/__tests__/application-shell.test.ts
+++ b/packages/contracts/src/__tests__/application-shell.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
+  APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS,
+  APPLICATION_SHELL_COMMAND_DEFINITIONS,
   APPLICATION_SHELL_COMMAND_DESCRIPTORS,
+  ApplicationShellActionTraceV1SchemaZ,
+  ApplicationShellCommandInvocationSchemaZ,
+  ApplicationShellProjectionV1SchemaZ,
+  applyApplicationShellInvocationV1,
   applicationShellActionTraceV1,
+  applicationShellCommandInvocation,
   applicationShellCommandDescriptor,
   projectApplicationShellV1,
+  replayApplicationShellActionTraceV1,
 } from "../application-shell.ts";
 import { COHESION_FIXTURE_V1 } from "../cohesion-fixture.ts";
 import {
@@ -12,9 +20,34 @@ import {
   CommandDescriptorSchemaZ,
   CommandInvocationSchemaZ,
 } from "../commands.ts";
-import { CANONICAL_SURFACE_REGISTRY } from "../experience-shell.ts";
+import {
+  CANONICAL_SHELL_AREAS,
+  CANONICAL_SURFACE_REGISTRY,
+  commandsToOpenSurface,
+} from "../experience-shell.ts";
 
 const serialized = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+function mutableDataPaths(value: unknown, path = "value", findings: string[] = []): string[] {
+  if (!value || typeof value !== "object") return findings;
+  const prototype = Object.getPrototypeOf(value);
+  if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null)
+    return findings;
+  if (!Object.isFrozen(value)) findings.push(path);
+  if (Array.isArray(value)) {
+    value.forEach((child, index) => mutableDataPaths(child, `${path}.${index}`, findings));
+  } else {
+    for (const [key, child] of Object.entries(value)) {
+      mutableDataPaths(child, `${path}.${key}`, findings);
+    }
+  }
+  return findings;
+}
+
+const closedOverlayFixture = {
+  ...COHESION_FIXTURE_V1,
+  focus: { ...COHESION_FIXTURE_V1.focus, overlays: [] },
+};
 
 describe("semantic application shell", () => {
   it("projects navigation and dock identity only from the canonical surface registry", () => {
@@ -68,6 +101,7 @@ describe("semantic application shell", () => {
   it("round-trips and freezes the host-neutral projection without geometry", () => {
     const projection = projectApplicationShellV1(COHESION_FIXTURE_V1);
     expect(serialized(projection)).toEqual(projection);
+    expect(ApplicationShellProjectionV1SchemaZ.parse(serialized(projection))).toEqual(projection);
 
     const forbiddenKeys = new Set([
       "x",
@@ -122,54 +156,143 @@ describe("semantic application shell", () => {
       expect(Object.isFrozen(descriptor)).toBe(true);
       expect(Object.isFrozen(descriptor.schemas)).toBe(true);
     }
+    expect(APPLICATION_SHELL_COMMAND_DEFINITIONS.map(({ descriptor }) => descriptor)).toEqual(
+      APPLICATION_SHELL_COMMAND_DESCRIPTORS,
+    );
+    for (const definition of APPLICATION_SHELL_COMMAND_DEFINITIONS) {
+      expect(definition.inputSchema).toBe(
+        APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS[
+          ApplicationShellCommandIdSchemaZ.parse(definition.descriptor.id)
+        ],
+      );
+    }
+  });
+
+  it("deep-freezes every exported and returned shell data source", () => {
+    const invocation = applicationShellCommandInvocation(
+      APPLICATION_SHELL_COMMAND_IDS.moveFocus,
+      { target: { kind: "zone", zone: "dock-tabs" } },
+      { kind: "keyboard", surface: "workbench" },
+    );
+    const sources = {
+      commandIds: APPLICATION_SHELL_COMMAND_IDS,
+      commandSchemas: APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS,
+      commandDefinitions: APPLICATION_SHELL_COMMAND_DEFINITIONS,
+      shellAreas: CANONICAL_SHELL_AREAS,
+      surfaces: CANONICAL_SURFACE_REGISTRY,
+      openSurfaceCommands: commandsToOpenSurface({
+        surface: "missions",
+        resourceId: "mission.m31",
+      }),
+      descriptors: APPLICATION_SHELL_COMMAND_DESCRIPTORS,
+      invocation,
+    };
+    for (const [name, source] of Object.entries(sources)) {
+      expect(mutableDataPaths(source, name), name).toEqual([]);
+    }
+  });
+
+  it("validates each command's arguments by semantic id", () => {
+    const source = { kind: "program", surface: "test" } as const;
+    const valid = [
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.activateMode,
+        { mode: "home" },
+        source,
+      ),
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.activateDockTool,
+        { tool: "files" },
+        source,
+      ),
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.setDockMode,
+        { mode: "open" },
+        source,
+      ),
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.moveFocus,
+        { target: { kind: "zone", zone: "canvas" } },
+        source,
+      ),
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.openPalette,
+        {
+          overlayId: "overlay.palette.test",
+          focusReturnTarget: { kind: "zone", zone: "canvas" },
+        },
+        source,
+      ),
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.closePalette,
+        { overlayId: "overlay.palette.test" },
+        source,
+      ),
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.selectResource,
+        { surface: "files", resourceId: "file.readme" },
+        source,
+      ),
+    ];
+    for (const invocation of valid) {
+      expect(ApplicationShellCommandInvocationSchemaZ.parse(serialized(invocation))).toEqual(
+        invocation,
+      );
+    }
+    expect(() =>
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.activateDockTool,
+        { tool: "unknown" } as never,
+        source,
+      ),
+    ).toThrow();
+    expect(
+      ApplicationShellCommandInvocationSchemaZ.safeParse({
+        ...valid[0],
+        args: { tool: "files" },
+      }).success,
+    ).toBe(false);
   });
 
   it("turns the shared cohesion fixture into one exact cross-host command trace", () => {
-    const trace = applicationShellActionTraceV1(COHESION_FIXTURE_V1);
+    const trace = applicationShellActionTraceV1(closedOverlayFixture);
     expect(trace.invocations.map(({ id, args }) => ({ id, args }))).toEqual([
-      { id: "workspace.mode.activate", args: { mode: "home" } },
-      { id: "workspace.mode.activate", args: { mode: "terminals" } },
-      { id: "workspace.mode.activate", args: { mode: "terminals" } },
-      { id: "workspace.dock.mode.set", args: { mode: "open" } },
-      { id: "workspace.dock.activate", args: { tool: "files" } },
-      { id: "workspace.mode.activate", args: { mode: "terminals" } },
-      { id: "workspace.dock.mode.set", args: { mode: "open" } },
-      { id: "workspace.dock.activate", args: { tool: "changes" } },
-      { id: "workspace.mode.activate", args: { mode: "terminals" } },
-      { id: "workspace.dock.mode.set", args: { mode: "open" } },
-      { id: "workspace.dock.activate", args: { tool: "missions" } },
-      { id: "workspace.mode.activate", args: { mode: "terminals" } },
-      { id: "workspace.dock.mode.set", args: { mode: "open" } },
-      { id: "workspace.dock.activate", args: { tool: "activity" } },
-      { id: "workspace.dock.mode.set", args: { mode: "collapsed" } },
-      { id: "workspace.dock.mode.set", args: { mode: "open" } },
-      { id: "workspace.dock.mode.set", args: { mode: "maximized" } },
+      { id: "application.shell.mode.activate", args: { mode: "home" } },
+      { id: "application.shell.mode.activate", args: { mode: "terminals" } },
+      { id: "application.shell.mode.activate", args: { mode: "terminals" } },
+      { id: "application.shell.dock.mode.set", args: { mode: "open" } },
+      { id: "application.shell.dock.activate", args: { tool: "files" } },
+      { id: "application.shell.mode.activate", args: { mode: "terminals" } },
+      { id: "application.shell.dock.mode.set", args: { mode: "open" } },
+      { id: "application.shell.dock.activate", args: { tool: "changes" } },
+      { id: "application.shell.mode.activate", args: { mode: "terminals" } },
+      { id: "application.shell.dock.mode.set", args: { mode: "open" } },
+      { id: "application.shell.dock.activate", args: { tool: "missions" } },
+      { id: "application.shell.mode.activate", args: { mode: "terminals" } },
+      { id: "application.shell.dock.mode.set", args: { mode: "open" } },
+      { id: "application.shell.dock.activate", args: { tool: "activity" } },
+      { id: "application.shell.dock.mode.set", args: { mode: "collapsed" } },
+      { id: "application.shell.dock.mode.set", args: { mode: "open" } },
+      { id: "application.shell.dock.mode.set", args: { mode: "maximized" } },
       {
-        id: "workspace.focus.move",
+        id: "application.shell.focus.move",
         args: { target: { kind: "zone", zone: "dock-tabs" } },
       },
       {
-        id: "app.palette.open",
+        id: "application.shell.palette.open",
         args: {
-          overlayId: "overlay.palette",
-          focusReturnTarget: {
-            kind: "pane",
-            paneId: "pane.implementer",
-            input: "terminal",
-          },
+          overlayId: "overlay.palette.trace",
+          focusReturnTarget: { kind: "zone", zone: "dock-tabs" },
         },
       },
-      { id: "app.palette.close", args: { overlayId: "overlay.palette" } },
       {
-        id: "workspace.focus.move",
-        args: {
-          target: { kind: "pane", paneId: "pane.implementer", input: "terminal" },
-        },
+        id: "application.shell.palette.close",
+        args: { overlayId: "overlay.palette.trace" },
       },
     ]);
     expect(serialized(trace)).toEqual(trace);
-    expect(Object.isFrozen(trace)).toBe(true);
-    expect(Object.isFrozen(trace.invocations)).toBe(true);
+    expect(ApplicationShellActionTraceV1SchemaZ.parse(serialized(trace))).toEqual(trace);
+    expect(mutableDataPaths(trace, "trace")).toEqual([]);
     for (const invocation of trace.invocations) {
       expect(CommandInvocationSchemaZ.parse(serialized(invocation))).toEqual(invocation);
       expect(
@@ -177,5 +300,45 @@ describe("semantic application shell", () => {
       ).toBeDefined();
       expect(invocation.source).toEqual({ kind: "program", surface: "application-shell" });
     }
+    expect(replayApplicationShellActionTraceV1(trace)).toEqual(trace.finalState);
+    expect(trace.finalState.focus).toMatchObject({
+      focusZone: "dock-tabs",
+      terminalInputPaneId: null,
+      overlays: [],
+    });
+  });
+
+  it("replays palette ownership sequentially and restores the pre-overlay focus", () => {
+    const trace = applicationShellActionTraceV1(closedOverlayFixture);
+    const openIndex = trace.invocations.findIndex(
+      ({ id }) => id === APPLICATION_SHELL_COMMAND_IDS.openPalette,
+    );
+    const beforeOpen = trace.invocations
+      .slice(0, openIndex)
+      .reduce(
+        (state, invocation) => applyApplicationShellInvocationV1(state, invocation),
+        trace.initialState,
+      );
+    const opened = applyApplicationShellInvocationV1(beforeOpen, trace.invocations[openIndex]!);
+    expect(opened.focus.overlays).toHaveLength(1);
+    expect(() =>
+      applyApplicationShellInvocationV1(
+        opened,
+        applicationShellCommandInvocation(
+          APPLICATION_SHELL_COMMAND_IDS.activateMode,
+          { mode: "home" },
+          { kind: "program" },
+        ),
+      ),
+    ).toThrow("semantic input is owned by overlay");
+    const closed = applyApplicationShellInvocationV1(opened, trace.invocations[openIndex + 1]!);
+    expect(closed.focus).toEqual(beforeOpen.focus);
+    expect(() => applicationShellActionTraceV1(COHESION_FIXTURE_V1)).toThrow(
+      "closed-overlay initial state",
+    );
+
+    const tampered = serialized(trace);
+    tampered.finalState.activeMode = "home";
+    expect(ApplicationShellActionTraceV1SchemaZ.safeParse(tampered).success).toBe(false);
   });
 });

--- a/packages/contracts/src/__tests__/application-shell.test.ts
+++ b/packages/contracts/src/__tests__/application-shell.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  APPLICATION_SHELL_COMMAND_DESCRIPTORS,
+  applicationShellActionTraceV1,
+  applicationShellCommandDescriptor,
+  projectApplicationShellV1,
+} from "../application-shell.ts";
+import { COHESION_FIXTURE_V1 } from "../cohesion-fixture.ts";
+import {
+  APPLICATION_SHELL_COMMAND_IDS,
+  ApplicationShellCommandIdSchemaZ,
+  CommandDescriptorSchemaZ,
+  CommandInvocationSchemaZ,
+} from "../commands.ts";
+import { CANONICAL_SURFACE_REGISTRY } from "../experience-shell.ts";
+
+const serialized = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+describe("semantic application shell", () => {
+  it("projects navigation and dock identity only from the canonical surface registry", () => {
+    const projection = projectApplicationShellV1(COHESION_FIXTURE_V1);
+    const projectedSurfaces = [
+      ...projection.primaryNavigation.items,
+      ...projection.bottomDock.tools,
+    ];
+
+    expect(
+      projectedSurfaces.map(
+        ({ id, icon, label, kind, area, order, owningMode, shortcut, activation }) => ({
+          id,
+          icon,
+          label,
+          kind,
+          area,
+          order,
+          owningMode,
+          shortcut,
+          activation,
+        }),
+      ),
+    ).toEqual(CANONICAL_SURFACE_REGISTRY);
+    expect(projection.primaryNavigation.items.map(({ id }) => id)).toEqual(["home", "terminals"]);
+    expect(projection.bottomDock.tools.map(({ id }) => id)).toEqual([
+      "files",
+      "changes",
+      "missions",
+      "activity",
+    ]);
+    expect(
+      projection.primaryNavigation.items.every(({ area }) => area === "workspace-canvas"),
+    ).toBe(true);
+    expect(projection.bottomDock.tools.every(({ area }) => area === "bottom-dock")).toBe(true);
+    expect(projection.primaryNavigation.activeMode).toBe("terminals");
+    expect(projection.bottomDock).toEqual(
+      expect.objectContaining({ mode: "open", activeTool: "missions" }),
+    );
+    expect(projection.focus.palette).toEqual({
+      open: true,
+      overlayId: "overlay.palette",
+      focusReturnTarget: {
+        kind: "pane",
+        paneId: "pane.implementer",
+        input: "terminal",
+      },
+    });
+  });
+
+  it("round-trips and freezes the host-neutral projection without geometry", () => {
+    const projection = projectApplicationShellV1(COHESION_FIXTURE_V1);
+    expect(serialized(projection)).toEqual(projection);
+
+    const forbiddenKeys = new Set([
+      "x",
+      "y",
+      "width",
+      "height",
+      "rect",
+      "bounds",
+      "cell",
+      "cells",
+      "column",
+      "columns",
+      "row",
+      "rows",
+      "pixel",
+      "pixels",
+      "px",
+      "geometry",
+      "tmuxPaneId",
+      "ptyId",
+      "nativeHandle",
+    ]);
+    const findings: string[] = [];
+    const mutable: string[] = [];
+    const walk = (value: unknown, path = "projection"): void => {
+      if (!value || typeof value !== "object") return;
+      if (!Object.isFrozen(value)) mutable.push(path);
+      if (Array.isArray(value)) {
+        value.forEach((child, index) => walk(child, `${path}.${index}`));
+        return;
+      }
+      for (const [key, child] of Object.entries(value)) {
+        if (forbiddenKeys.has(key)) findings.push(`${path}.${key}`);
+        walk(child, `${path}.${key}`);
+      }
+    };
+    walk(projection);
+
+    expect(findings).toEqual([]);
+    expect(mutable).toEqual([]);
+  });
+
+  it("exports serializable descriptors for every semantic shell command", () => {
+    expect(APPLICATION_SHELL_COMMAND_DESCRIPTORS.map(({ id }) => id)).toEqual(
+      Object.values(APPLICATION_SHELL_COMMAND_IDS),
+    );
+    for (const descriptor of APPLICATION_SHELL_COMMAND_DESCRIPTORS) {
+      expect(CommandDescriptorSchemaZ.parse(serialized(descriptor))).toEqual(descriptor);
+      expect(
+        applicationShellCommandDescriptor(ApplicationShellCommandIdSchemaZ.parse(descriptor.id)),
+      ).toBe(descriptor);
+      expect(Object.isFrozen(descriptor)).toBe(true);
+      expect(Object.isFrozen(descriptor.schemas)).toBe(true);
+    }
+  });
+
+  it("turns the shared cohesion fixture into one exact cross-host command trace", () => {
+    const trace = applicationShellActionTraceV1(COHESION_FIXTURE_V1);
+    expect(trace.invocations.map(({ id, args }) => ({ id, args }))).toEqual([
+      { id: "workspace.mode.activate", args: { mode: "home" } },
+      { id: "workspace.mode.activate", args: { mode: "terminals" } },
+      { id: "workspace.mode.activate", args: { mode: "terminals" } },
+      { id: "workspace.dock.mode.set", args: { mode: "open" } },
+      { id: "workspace.dock.activate", args: { tool: "files" } },
+      { id: "workspace.mode.activate", args: { mode: "terminals" } },
+      { id: "workspace.dock.mode.set", args: { mode: "open" } },
+      { id: "workspace.dock.activate", args: { tool: "changes" } },
+      { id: "workspace.mode.activate", args: { mode: "terminals" } },
+      { id: "workspace.dock.mode.set", args: { mode: "open" } },
+      { id: "workspace.dock.activate", args: { tool: "missions" } },
+      { id: "workspace.mode.activate", args: { mode: "terminals" } },
+      { id: "workspace.dock.mode.set", args: { mode: "open" } },
+      { id: "workspace.dock.activate", args: { tool: "activity" } },
+      { id: "workspace.dock.mode.set", args: { mode: "collapsed" } },
+      { id: "workspace.dock.mode.set", args: { mode: "open" } },
+      { id: "workspace.dock.mode.set", args: { mode: "maximized" } },
+      {
+        id: "workspace.focus.move",
+        args: { target: { kind: "zone", zone: "dock-tabs" } },
+      },
+      {
+        id: "app.palette.open",
+        args: {
+          overlayId: "overlay.palette",
+          focusReturnTarget: {
+            kind: "pane",
+            paneId: "pane.implementer",
+            input: "terminal",
+          },
+        },
+      },
+      { id: "app.palette.close", args: { overlayId: "overlay.palette" } },
+      {
+        id: "workspace.focus.move",
+        args: {
+          target: { kind: "pane", paneId: "pane.implementer", input: "terminal" },
+        },
+      },
+    ]);
+    expect(serialized(trace)).toEqual(trace);
+    expect(Object.isFrozen(trace)).toBe(true);
+    expect(Object.isFrozen(trace.invocations)).toBe(true);
+    for (const invocation of trace.invocations) {
+      expect(CommandInvocationSchemaZ.parse(serialized(invocation))).toEqual(invocation);
+      expect(
+        applicationShellCommandDescriptor(ApplicationShellCommandIdSchemaZ.parse(invocation.id)),
+      ).toBeDefined();
+      expect(invocation.source).toEqual({ kind: "program", surface: "application-shell" });
+    }
+  });
+});

--- a/packages/contracts/src/__tests__/commands.test.ts
+++ b/packages/contracts/src/__tests__/commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  APPLICATION_SHELL_COMMAND_IDS,
   COMMAND_PROTOCOL_VERSION,
   CommandAvailabilitySchemaZ,
   CommandDescriptorSchemaZ,
@@ -75,5 +76,11 @@ describe("command protocol", () => {
     for (const id of WORKSPACE_WINDOW_MODE_COMMAND_IDS) {
       expect(CommandDescriptorSchemaZ.safeParse({ ...descriptor, id }).success).toBe(true);
     }
+  });
+
+  it("keeps application-shell ids immutable and isolated from live renderer ids", () => {
+    expect(Object.isFrozen(APPLICATION_SHELL_COMMAND_IDS)).toBe(true);
+    expect(Object.values(APPLICATION_SHELL_COMMAND_IDS)).not.toContain("app.palette.open");
+    expect(Object.values(APPLICATION_SHELL_COMMAND_IDS)).not.toContain("workspace.dock.activate");
   });
 });

--- a/packages/contracts/src/__tests__/experience-kernel-boundary.test.ts
+++ b/packages/contracts/src/__tests__/experience-kernel-boundary.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 
 const SOURCE_ROOT = fileURLToPath(new URL("../", import.meta.url));
 const KERNEL_ENTRY_FILES = [
+  "application-shell.ts",
   "experience-identifiers.ts",
   "experience-shell.ts",
   "visual-recipes.ts",
@@ -18,7 +19,7 @@ const KERNEL_ENTRY_FILES = [
 const ALLOWED_EXTERNAL_IMPORTS = new Set(["zod"]);
 const NODE_IMPORTS = new Set(builtinModules.flatMap((name) => [name, name.replace(/^node:/u, "")]));
 const FORBIDDEN_LOCAL_SEGMENT =
-  /(?:^|[/._-])(?:dom|electron|opentui|solid|react|xterm|string-width|tmux|pty)(?=$|[/._-])/iu;
+  /(?:^|[/._-])(?:cell|cells|dom|electron|geometry|opentui|pixel|pixels|pty|react|rect|solid|string-width|tmux|xterm)(?=$|[/._-])/iu;
 
 function resolveLocalImport(importer: string, specifier: string): string | null {
   const candidate = resolve(dirname(importer), specifier);
@@ -86,6 +87,7 @@ describe("experience-kernel import boundary", () => {
 
     expect(findings).toEqual([]);
     expect([...visited].map(displayPath).sort()).toEqual([
+      "application-shell.ts",
       "cohesion-fixture.ts",
       "commands.ts",
       "experience-identifiers.ts",

--- a/packages/contracts/src/__tests__/experience-shell.test.ts
+++ b/packages/contracts/src/__tests__/experience-shell.test.ts
@@ -45,7 +45,7 @@ describe("experience shell", () => {
     ]);
     expect(commandsToOpenSurface({ surface: "missions", resourceId: "mission.m31" })).toEqual([
       { id: "workspace.mode.activate", args: { mode: "terminals" } },
-      { id: "workspace.dock.expand", args: {} },
+      { id: "workspace.dock.mode.set", args: { mode: "open" } },
       { id: "workspace.dock.activate", args: { tool: "missions" } },
       {
         id: "workspace.resource.select",

--- a/packages/contracts/src/__tests__/experience-shell.test.ts
+++ b/packages/contracts/src/__tests__/experience-shell.test.ts
@@ -41,18 +41,19 @@ describe("experience shell", () => {
 
   it("converges direct, keyboard, and deep-link opening on semantic commands", () => {
     expect(commandsToOpenSurface({ surface: "terminals" })).toEqual([
-      { id: "workspace.mode.activate", args: { mode: "terminals" } },
+      { id: "application.shell.mode.activate", args: { mode: "terminals" } },
     ]);
     expect(commandsToOpenSurface({ surface: "missions", resourceId: "mission.m31" })).toEqual([
-      { id: "workspace.mode.activate", args: { mode: "terminals" } },
-      { id: "workspace.dock.mode.set", args: { mode: "open" } },
-      { id: "workspace.dock.activate", args: { tool: "missions" } },
+      { id: "application.shell.mode.activate", args: { mode: "terminals" } },
+      { id: "application.shell.dock.mode.set", args: { mode: "open" } },
+      { id: "application.shell.dock.activate", args: { tool: "missions" } },
       {
-        id: "workspace.resource.select",
+        id: "application.shell.resource.select",
         args: { surface: "missions", resourceId: "mission.m31" },
       },
     ]);
     expect(canonicalSurface("files").area).toBe("bottom-dock");
+    expect(Object.isFrozen(commandsToOpenSurface({ surface: "missions" }))).toBe(true);
   });
 
   it("keeps flat and elevated presentation intent explicit", () => {

--- a/packages/contracts/src/application-shell.ts
+++ b/packages/contracts/src/application-shell.ts
@@ -1,0 +1,357 @@
+import { z } from "zod";
+import type { CohesionFixtureV1 } from "./cohesion-fixture.ts";
+import {
+  APPLICATION_SHELL_COMMAND_IDS,
+  COMMAND_PROTOCOL_VERSION,
+  ApplicationShellCommandIdSchemaZ,
+  CommandArgumentsSchemaZ,
+  CommandDescriptorSchemaZ,
+  CommandInvocationSchemaZ,
+  type ApplicationShellCommandId,
+  type CommandDescriptor,
+  type CommandInvocation,
+  type CommandSource,
+} from "./commands.ts";
+import {
+  CANONICAL_SURFACE_REGISTRY,
+  commandsToOpenSurface,
+  type DockToolId,
+  type PrimaryWorkspaceModeId,
+  type ProductSurfaceDefinition,
+  type ProductSurfaceId,
+  type SurfaceCommandTemplate,
+} from "./experience-shell.ts";
+import type { SemanticIconId } from "./experience-identifiers.ts";
+import type {
+  FocusOverlayStateV1,
+  FocusZone,
+  SemanticFocusTarget,
+  SemanticOverlay,
+} from "./focus-overlay.ts";
+
+export const APPLICATION_SHELL_PROJECTION_VERSION = 1 as const;
+export const APPLICATION_SHELL_TRACE_VERSION = 1 as const;
+
+export const ApplicationShellDockModeSchemaZ = z.enum(["collapsed", "open", "maximized"]);
+export type ApplicationShellDockMode = z.infer<typeof ApplicationShellDockModeSchemaZ>;
+
+export type ApplicationShellProjectionInputV1 = Pick<
+  CohesionFixtureV1,
+  "project" | "workspace" | "dock" | "focus" | "connection"
+>;
+
+type SidebarSession = CohesionFixtureV1["workspace"]["sidebar"]["sessions"][number];
+type SidebarAgent = CohesionFixtureV1["workspace"]["sidebar"]["agents"][number];
+type Readiness = CohesionFixtureV1["project"]["readiness"];
+type Connection = CohesionFixtureV1["connection"];
+
+export interface ApplicationShellSurfaceProjection {
+  readonly id: ProductSurfaceId;
+  readonly icon: SemanticIconId;
+  readonly label: string;
+  readonly kind: ProductSurfaceDefinition["kind"];
+  readonly area: ProductSurfaceDefinition["area"];
+  readonly order: number;
+  readonly owningMode: PrimaryWorkspaceModeId;
+  readonly shortcut: string;
+  readonly activation: SurfaceCommandTemplate;
+  readonly active: boolean;
+  readonly attention: boolean;
+  readonly disabledReason: string | null;
+}
+
+export interface ApplicationShellProjectionV1 {
+  readonly version: typeof APPLICATION_SHELL_PROJECTION_VERSION;
+  readonly project: {
+    readonly id: string;
+    readonly name: string;
+    readonly rootLabel: string;
+    readonly readiness: Readiness;
+  };
+  readonly workspace: { readonly id: string; readonly name: string };
+  readonly sidebar: {
+    readonly activeSessionId: string;
+    readonly sessions: readonly SidebarSession[];
+    readonly agents: readonly SidebarAgent[];
+  };
+  readonly primaryNavigation: {
+    readonly activeMode: PrimaryWorkspaceModeId;
+    readonly items: readonly ApplicationShellSurfaceProjection[];
+  };
+  readonly workspaceCanvas: { readonly activeMode: PrimaryWorkspaceModeId };
+  readonly bottomDock: {
+    readonly mode: ApplicationShellDockMode;
+    readonly activeTool: DockToolId;
+    readonly tools: readonly ApplicationShellSurfaceProjection[];
+  };
+  readonly statusStrip: Connection;
+  readonly focus: {
+    readonly windowActivity: FocusOverlayStateV1["windowActivity"];
+    readonly zone: FocusZone;
+    readonly appFocusedPaneId: string | null;
+    readonly terminalInputPaneId: string | null;
+    readonly layoutSelectedPaneId: string | null;
+    readonly overlays: readonly SemanticOverlay[];
+    readonly palette: {
+      readonly open: boolean;
+      readonly overlayId: string | null;
+      readonly focusReturnTarget: SemanticFocusTarget | null;
+    };
+  };
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) deepFreeze(child);
+  return Object.freeze(value);
+}
+
+function cloneFocusTarget(target: SemanticFocusTarget): SemanticFocusTarget {
+  return { ...target };
+}
+
+function cloneOverlay(overlay: SemanticOverlay): SemanticOverlay {
+  return { ...overlay, focusReturnTarget: cloneFocusTarget(overlay.focusReturnTarget) };
+}
+
+function paletteOverlay(focus: FocusOverlayStateV1): SemanticOverlay | null {
+  for (let index = focus.overlays.length - 1; index >= 0; index -= 1) {
+    const overlay = focus.overlays[index]!;
+    if (overlay.kind === "command-palette") return overlay;
+  }
+  return null;
+}
+
+function projectedSurface(
+  definition: ProductSurfaceDefinition,
+  input: ApplicationShellProjectionInputV1,
+): ApplicationShellSurfaceProjection {
+  const dockState =
+    definition.kind === "dock-tool"
+      ? input.dock.tools.find((tool) => tool.id === definition.id)
+      : undefined;
+  return {
+    ...definition,
+    activation: { ...definition.activation, args: { ...definition.activation.args } },
+    active:
+      definition.kind === "primary-mode"
+        ? definition.id === input.workspace.activeMode
+        : definition.id === input.dock.activeTool,
+    attention: dockState !== undefined && dockState.unreadCount > 0,
+    disabledReason: dockState?.disabledReason ?? null,
+  };
+}
+
+/**
+ * Renderer-neutral product shell. Hosts add layout and event plumbing around
+ * this projection; they never create another product surface registry.
+ */
+export function projectApplicationShellV1(
+  input: ApplicationShellProjectionInputV1,
+): ApplicationShellProjectionV1 {
+  const surfaces = CANONICAL_SURFACE_REGISTRY.map((surface) => projectedSurface(surface, input));
+  const palette = paletteOverlay(input.focus);
+  return deepFreeze({
+    version: APPLICATION_SHELL_PROJECTION_VERSION,
+    project: {
+      id: input.project.id,
+      name: input.project.name,
+      rootLabel: input.project.rootLabel,
+      readiness: {
+        ...input.project.readiness,
+        facts: [...input.project.readiness.facts],
+        warnings: [...input.project.readiness.warnings],
+      },
+    },
+    workspace: { id: input.workspace.id, name: input.workspace.name },
+    sidebar: {
+      activeSessionId: input.workspace.session.id,
+      sessions: input.workspace.sidebar.sessions.map((session) => ({ ...session })),
+      agents: input.workspace.sidebar.agents.map((agent) => ({ ...agent })),
+    },
+    primaryNavigation: {
+      activeMode: input.workspace.activeMode,
+      items: surfaces.filter((surface) => surface.kind === "primary-mode"),
+    },
+    workspaceCanvas: { activeMode: input.workspace.activeMode },
+    bottomDock: {
+      mode: ApplicationShellDockModeSchemaZ.parse(input.dock.mode),
+      activeTool: input.dock.activeTool,
+      tools: surfaces.filter((surface) => surface.kind === "dock-tool"),
+    },
+    statusStrip: { ...input.connection },
+    focus: {
+      windowActivity: input.focus.windowActivity,
+      zone: input.focus.focusZone,
+      appFocusedPaneId: input.focus.appFocusedPaneId,
+      terminalInputPaneId: input.focus.terminalInputPaneId,
+      layoutSelectedPaneId: input.focus.layoutSelectedPaneId,
+      overlays: input.focus.overlays.map(cloneOverlay),
+      palette: {
+        open: palette !== null,
+        overlayId: palette?.id ?? null,
+        focusReturnTarget: palette ? cloneFocusTarget(palette.focusReturnTarget) : null,
+      },
+    },
+  });
+}
+
+interface ApplicationShellCommandArgumentsById {
+  [APPLICATION_SHELL_COMMAND_IDS.activateMode]: { readonly mode: PrimaryWorkspaceModeId };
+  [APPLICATION_SHELL_COMMAND_IDS.activateDockTool]: { readonly tool: DockToolId };
+  [APPLICATION_SHELL_COMMAND_IDS.setDockMode]: { readonly mode: ApplicationShellDockMode };
+  [APPLICATION_SHELL_COMMAND_IDS.moveFocus]: { readonly target: SemanticFocusTarget };
+  [APPLICATION_SHELL_COMMAND_IDS.openPalette]: {
+    readonly overlayId: string;
+    readonly focusReturnTarget: SemanticFocusTarget;
+  };
+  [APPLICATION_SHELL_COMMAND_IDS.closePalette]: { readonly overlayId: string };
+  [APPLICATION_SHELL_COMMAND_IDS.selectResource]: {
+    readonly surface: ProductSurfaceId;
+    readonly resourceId: string;
+  };
+}
+
+const descriptor = (
+  id: ApplicationShellCommandId,
+  label: string,
+  category: "application" | "workspace",
+): CommandDescriptor =>
+  deepFreeze(
+    CommandDescriptorSchemaZ.parse({
+      version: COMMAND_PROTOCOL_VERSION,
+      id,
+      owner: "renderer",
+      label,
+      category,
+      schemas: { input: `${id}.input.v1` },
+      dangerous: false,
+      confirmation: "none",
+    }),
+  );
+
+export const APPLICATION_SHELL_COMMAND_DESCRIPTORS: readonly CommandDescriptor[] = deepFreeze([
+  descriptor(APPLICATION_SHELL_COMMAND_IDS.activateMode, "Activate workspace mode", "workspace"),
+  descriptor(APPLICATION_SHELL_COMMAND_IDS.activateDockTool, "Activate dock tool", "workspace"),
+  descriptor(APPLICATION_SHELL_COMMAND_IDS.setDockMode, "Set dock mode", "workspace"),
+  descriptor(APPLICATION_SHELL_COMMAND_IDS.moveFocus, "Move workspace focus", "workspace"),
+  descriptor(APPLICATION_SHELL_COMMAND_IDS.openPalette, "Open command palette", "application"),
+  descriptor(APPLICATION_SHELL_COMMAND_IDS.closePalette, "Close command palette", "application"),
+  descriptor(
+    APPLICATION_SHELL_COMMAND_IDS.selectResource,
+    "Select workspace resource",
+    "workspace",
+  ),
+]);
+
+const descriptorById = new Map(
+  APPLICATION_SHELL_COMMAND_DESCRIPTORS.map((item) => [item.id, item]),
+);
+
+export function applicationShellCommandDescriptor(
+  id: ApplicationShellCommandId,
+): CommandDescriptor {
+  return descriptorById.get(id)!;
+}
+
+function validatedInvocation(
+  id: ApplicationShellCommandId,
+  args: unknown,
+  source: CommandSource,
+): CommandInvocation {
+  return CommandInvocationSchemaZ.parse({
+    version: COMMAND_PROTOCOL_VERSION,
+    id,
+    source,
+    args: CommandArgumentsSchemaZ.parse(args),
+  });
+}
+
+export function applicationShellCommandInvocation<Id extends ApplicationShellCommandId>(
+  id: Id,
+  args: ApplicationShellCommandArgumentsById[Id],
+  source: CommandSource,
+): CommandInvocation {
+  return validatedInvocation(id, args, source);
+}
+
+function invocationFromTemplate(
+  template: SurfaceCommandTemplate,
+  source: CommandSource,
+): CommandInvocation {
+  return validatedInvocation(
+    ApplicationShellCommandIdSchemaZ.parse(template.id),
+    template.args,
+    source,
+  );
+}
+
+function fallbackFocusReturnTarget(focus: FocusOverlayStateV1): SemanticFocusTarget {
+  if (focus.terminalInputPaneId !== null) {
+    return { kind: "pane", paneId: focus.terminalInputPaneId, input: "terminal" };
+  }
+  if (focus.appFocusedPaneId !== null) {
+    return { kind: "pane", paneId: focus.appFocusedPaneId, input: "chrome" };
+  }
+  return { kind: "zone", zone: focus.focusZone };
+}
+
+export interface ApplicationShellActionTraceV1 {
+  readonly version: typeof APPLICATION_SHELL_TRACE_VERSION;
+  readonly invocations: readonly CommandInvocation[];
+}
+
+/**
+ * One deterministic fixture trace for paired OpenTUI/DOM host conformance.
+ * It describes semantic intent only; neither command execution nor host focus
+ * handles enter the shared kernel.
+ */
+export function applicationShellActionTraceV1(
+  input: ApplicationShellProjectionInputV1,
+  source: CommandSource = { kind: "program", surface: "application-shell" },
+): ApplicationShellActionTraceV1 {
+  const focusPalette = paletteOverlay(input.focus);
+  const overlayId = focusPalette?.id ?? "overlay.palette";
+  const focusReturnTarget =
+    focusPalette?.focusReturnTarget ?? fallbackFocusReturnTarget(input.focus);
+  const invocations: CommandInvocation[] = [];
+
+  for (const surface of CANONICAL_SURFACE_REGISTRY) {
+    for (const template of commandsToOpenSurface({ surface: surface.id })) {
+      invocations.push(invocationFromTemplate(template, source));
+    }
+  }
+  for (const mode of ApplicationShellDockModeSchemaZ.options) {
+    invocations.push(
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.setDockMode,
+        { mode },
+        source,
+      ),
+    );
+  }
+  invocations.push(
+    applicationShellCommandInvocation(
+      APPLICATION_SHELL_COMMAND_IDS.moveFocus,
+      { target: { kind: "zone", zone: "dock-tabs" } },
+      source,
+    ),
+    applicationShellCommandInvocation(
+      APPLICATION_SHELL_COMMAND_IDS.openPalette,
+      { overlayId, focusReturnTarget },
+      source,
+    ),
+    applicationShellCommandInvocation(
+      APPLICATION_SHELL_COMMAND_IDS.closePalette,
+      { overlayId },
+      source,
+    ),
+    applicationShellCommandInvocation(
+      APPLICATION_SHELL_COMMAND_IDS.moveFocus,
+      { target: focusReturnTarget },
+      source,
+    ),
+  );
+
+  return deepFreeze({ version: APPLICATION_SHELL_TRACE_VERSION, invocations });
+}

--- a/packages/contracts/src/application-shell.ts
+++ b/packages/contracts/src/application-shell.ts
@@ -1,44 +1,61 @@
 import { z } from "zod";
-import type { CohesionFixtureV1 } from "./cohesion-fixture.ts";
+import { CohesionFixtureV1SchemaZ, type CohesionFixtureV1 } from "./cohesion-fixture.ts";
 import {
   APPLICATION_SHELL_COMMAND_IDS,
   COMMAND_PROTOCOL_VERSION,
   ApplicationShellCommandIdSchemaZ,
-  CommandArgumentsSchemaZ,
   CommandDescriptorSchemaZ,
-  CommandInvocationSchemaZ,
+  CommandSourceSchemaZ,
   type ApplicationShellCommandId,
   type CommandDescriptor,
-  type CommandInvocation,
   type CommandSource,
 } from "./commands.ts";
 import {
+  ApplicationShellDockModeSchemaZ,
   CANONICAL_SURFACE_REGISTRY,
+  DockToolIdSchemaZ,
+  PrimaryWorkspaceModeIdSchemaZ,
+  ProductSurfaceIdSchemaZ,
+  SurfaceCommandTemplateSchemaZ,
   commandsToOpenSurface,
+  type ApplicationShellDockMode,
   type DockToolId,
   type PrimaryWorkspaceModeId,
   type ProductSurfaceDefinition,
   type ProductSurfaceId,
   type SurfaceCommandTemplate,
 } from "./experience-shell.ts";
-import type { SemanticIconId } from "./experience-identifiers.ts";
-import type {
-  FocusOverlayStateV1,
-  FocusZone,
-  SemanticFocusTarget,
-  SemanticOverlay,
+import { SemanticIconIdSchemaZ, type SemanticIconId } from "./experience-identifiers.ts";
+import {
+  FocusOverlayStateV1SchemaZ,
+  FocusZoneSchemaZ,
+  SemanticFocusTargetSchemaZ,
+  SemanticOverlaySchemaZ,
+  resolveSemanticInputLayer,
+  type FocusOverlayStateV1,
+  type FocusZone,
+  type SemanticFocusTarget,
+  type SemanticOverlay,
 } from "./focus-overlay.ts";
+import { SemanticProductIdSchemaZ } from "./pane-appearance.ts";
 
 export const APPLICATION_SHELL_PROJECTION_VERSION = 1 as const;
 export const APPLICATION_SHELL_TRACE_VERSION = 1 as const;
-
-export const ApplicationShellDockModeSchemaZ = z.enum(["collapsed", "open", "maximized"]);
-export type ApplicationShellDockMode = z.infer<typeof ApplicationShellDockModeSchemaZ>;
 
 export type ApplicationShellProjectionInputV1 = Pick<
   CohesionFixtureV1,
   "project" | "workspace" | "dock" | "focus" | "connection"
 >;
+
+export const ApplicationShellProjectionInputV1SchemaZ = z
+  .object({
+    project: CohesionFixtureV1SchemaZ.shape.project,
+    workspace: CohesionFixtureV1SchemaZ.shape.workspace,
+    dock: CohesionFixtureV1SchemaZ.shape.dock,
+    focus: FocusOverlayStateV1SchemaZ,
+    connection: CohesionFixtureV1SchemaZ.shape.connection,
+  })
+  .strict();
 
 type SidebarSession = CohesionFixtureV1["workspace"]["sidebar"]["sessions"][number];
 type SidebarAgent = CohesionFixtureV1["workspace"]["sidebar"]["agents"][number];
@@ -100,6 +117,77 @@ export interface ApplicationShellProjectionV1 {
   };
 }
 
+const WorkspaceFixtureSchemaZ = CohesionFixtureV1SchemaZ.shape.workspace;
+
+export const ApplicationShellSurfaceProjectionSchemaZ = z
+  .object({
+    id: ProductSurfaceIdSchemaZ,
+    icon: SemanticIconIdSchemaZ,
+    label: z.string().min(1).max(160),
+    kind: z.enum(["primary-mode", "dock-tool"]),
+    area: z.enum(["workspace-canvas", "bottom-dock"]),
+    order: z.number().int().nonnegative(),
+    owningMode: PrimaryWorkspaceModeIdSchemaZ,
+    shortcut: z.string().min(1).max(32),
+    activation: SurfaceCommandTemplateSchemaZ,
+    active: z.boolean(),
+    attention: z.boolean(),
+    disabledReason: z.string().min(1).max(240).nullable(),
+  })
+  .strict();
+
+export const ApplicationShellProjectionV1SchemaZ = z
+  .object({
+    version: z.literal(APPLICATION_SHELL_PROJECTION_VERSION),
+    project: CohesionFixtureV1SchemaZ.shape.project,
+    workspace: z
+      .object({
+        id: SemanticProductIdSchemaZ,
+        name: z.string().min(1).max(160),
+      })
+      .strict(),
+    sidebar: z
+      .object({
+        activeSessionId: SemanticProductIdSchemaZ,
+        sessions: WorkspaceFixtureSchemaZ.shape.sidebar.shape.sessions,
+        agents: WorkspaceFixtureSchemaZ.shape.sidebar.shape.agents,
+      })
+      .strict(),
+    primaryNavigation: z
+      .object({
+        activeMode: PrimaryWorkspaceModeIdSchemaZ,
+        items: z.array(ApplicationShellSurfaceProjectionSchemaZ),
+      })
+      .strict(),
+    workspaceCanvas: z.object({ activeMode: PrimaryWorkspaceModeIdSchemaZ }).strict(),
+    bottomDock: z
+      .object({
+        mode: ApplicationShellDockModeSchemaZ,
+        activeTool: DockToolIdSchemaZ,
+        tools: z.array(ApplicationShellSurfaceProjectionSchemaZ),
+      })
+      .strict(),
+    statusStrip: CohesionFixtureV1SchemaZ.shape.connection,
+    focus: z
+      .object({
+        windowActivity: z.enum(["active", "inactive"]),
+        zone: FocusZoneSchemaZ,
+        appFocusedPaneId: SemanticProductIdSchemaZ.nullable(),
+        terminalInputPaneId: SemanticProductIdSchemaZ.nullable(),
+        layoutSelectedPaneId: SemanticProductIdSchemaZ.nullable(),
+        overlays: z.array(SemanticOverlaySchemaZ).max(16),
+        palette: z
+          .object({
+            open: z.boolean(),
+            overlayId: SemanticProductIdSchemaZ.nullable(),
+            focusReturnTarget: SemanticFocusTargetSchemaZ.nullable(),
+          })
+          .strict(),
+      })
+      .strict(),
+  })
+  .strict();
+
 function deepFreeze<T>(value: T): T {
   if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
   for (const child of Object.values(value)) deepFreeze(child);
@@ -132,7 +220,7 @@ function projectedSurface(
       : undefined;
   return {
     ...definition,
-    activation: { ...definition.activation, args: { ...definition.activation.args } },
+    activation: SurfaceCommandTemplateSchemaZ.parse(definition.activation),
     active:
       definition.kind === "primary-mode"
         ? definition.id === input.workspace.activeMode
@@ -149,68 +237,168 @@ function projectedSurface(
 export function projectApplicationShellV1(
   input: ApplicationShellProjectionInputV1,
 ): ApplicationShellProjectionV1 {
-  const surfaces = CANONICAL_SURFACE_REGISTRY.map((surface) => projectedSurface(surface, input));
-  const palette = paletteOverlay(input.focus);
-  return deepFreeze({
-    version: APPLICATION_SHELL_PROJECTION_VERSION,
-    project: {
-      id: input.project.id,
-      name: input.project.name,
-      rootLabel: input.project.rootLabel,
-      readiness: {
-        ...input.project.readiness,
-        facts: [...input.project.readiness.facts],
-        warnings: [...input.project.readiness.warnings],
-      },
-    },
-    workspace: { id: input.workspace.id, name: input.workspace.name },
-    sidebar: {
-      activeSessionId: input.workspace.session.id,
-      sessions: input.workspace.sidebar.sessions.map((session) => ({ ...session })),
-      agents: input.workspace.sidebar.agents.map((agent) => ({ ...agent })),
-    },
-    primaryNavigation: {
-      activeMode: input.workspace.activeMode,
-      items: surfaces.filter((surface) => surface.kind === "primary-mode"),
-    },
-    workspaceCanvas: { activeMode: input.workspace.activeMode },
-    bottomDock: {
-      mode: ApplicationShellDockModeSchemaZ.parse(input.dock.mode),
-      activeTool: input.dock.activeTool,
-      tools: surfaces.filter((surface) => surface.kind === "dock-tool"),
-    },
-    statusStrip: { ...input.connection },
-    focus: {
-      windowActivity: input.focus.windowActivity,
-      zone: input.focus.focusZone,
-      appFocusedPaneId: input.focus.appFocusedPaneId,
-      terminalInputPaneId: input.focus.terminalInputPaneId,
-      layoutSelectedPaneId: input.focus.layoutSelectedPaneId,
-      overlays: input.focus.overlays.map(cloneOverlay),
-      palette: {
-        open: palette !== null,
-        overlayId: palette?.id ?? null,
-        focusReturnTarget: palette ? cloneFocusTarget(palette.focusReturnTarget) : null,
-      },
-    },
+  const parsed = ApplicationShellProjectionInputV1SchemaZ.parse({
+    project: input.project,
+    workspace: input.workspace,
+    dock: input.dock,
+    focus: input.focus,
+    connection: input.connection,
   });
+  const surfaces = CANONICAL_SURFACE_REGISTRY.map((surface) => projectedSurface(surface, parsed));
+  const palette = paletteOverlay(parsed.focus);
+  return deepFreeze(
+    ApplicationShellProjectionV1SchemaZ.parse({
+      version: APPLICATION_SHELL_PROJECTION_VERSION,
+      project: {
+        id: parsed.project.id,
+        name: parsed.project.name,
+        rootLabel: parsed.project.rootLabel,
+        readiness: {
+          ...parsed.project.readiness,
+          facts: [...parsed.project.readiness.facts],
+          warnings: [...parsed.project.readiness.warnings],
+        },
+      },
+      workspace: { id: parsed.workspace.id, name: parsed.workspace.name },
+      sidebar: {
+        activeSessionId: parsed.workspace.session.id,
+        sessions: parsed.workspace.sidebar.sessions.map((session) => ({ ...session })),
+        agents: parsed.workspace.sidebar.agents.map((agent) => ({ ...agent })),
+      },
+      primaryNavigation: {
+        activeMode: parsed.workspace.activeMode,
+        items: surfaces.filter((surface) => surface.kind === "primary-mode"),
+      },
+      workspaceCanvas: { activeMode: parsed.workspace.activeMode },
+      bottomDock: {
+        mode: ApplicationShellDockModeSchemaZ.parse(parsed.dock.mode),
+        activeTool: parsed.dock.activeTool,
+        tools: surfaces.filter((surface) => surface.kind === "dock-tool"),
+      },
+      statusStrip: { ...parsed.connection },
+      focus: {
+        windowActivity: parsed.focus.windowActivity,
+        zone: parsed.focus.focusZone,
+        appFocusedPaneId: parsed.focus.appFocusedPaneId,
+        terminalInputPaneId: parsed.focus.terminalInputPaneId,
+        layoutSelectedPaneId: parsed.focus.layoutSelectedPaneId,
+        overlays: parsed.focus.overlays.map(cloneOverlay),
+        palette: {
+          open: palette !== null,
+          overlayId: palette?.id ?? null,
+          focusReturnTarget: palette ? cloneFocusTarget(palette.focusReturnTarget) : null,
+        },
+      },
+    }),
+  );
 }
 
-interface ApplicationShellCommandArgumentsById {
-  [APPLICATION_SHELL_COMMAND_IDS.activateMode]: { readonly mode: PrimaryWorkspaceModeId };
-  [APPLICATION_SHELL_COMMAND_IDS.activateDockTool]: { readonly tool: DockToolId };
-  [APPLICATION_SHELL_COMMAND_IDS.setDockMode]: { readonly mode: ApplicationShellDockMode };
-  [APPLICATION_SHELL_COMMAND_IDS.moveFocus]: { readonly target: SemanticFocusTarget };
-  [APPLICATION_SHELL_COMMAND_IDS.openPalette]: {
-    readonly overlayId: string;
-    readonly focusReturnTarget: SemanticFocusTarget;
-  };
-  [APPLICATION_SHELL_COMMAND_IDS.closePalette]: { readonly overlayId: string };
-  [APPLICATION_SHELL_COMMAND_IDS.selectResource]: {
-    readonly surface: ProductSurfaceId;
-    readonly resourceId: string;
-  };
-}
+export const ApplicationShellActivateModeArgumentsSchemaZ = z
+  .object({ mode: PrimaryWorkspaceModeIdSchemaZ })
+  .strict();
+export const ApplicationShellActivateDockToolArgumentsSchemaZ = z
+  .object({ tool: DockToolIdSchemaZ })
+  .strict();
+export const ApplicationShellSetDockModeArgumentsSchemaZ = z
+  .object({ mode: ApplicationShellDockModeSchemaZ })
+  .strict();
+export const ApplicationShellMoveFocusArgumentsSchemaZ = z
+  .object({ target: SemanticFocusTargetSchemaZ })
+  .strict();
+export const ApplicationShellOpenPaletteArgumentsSchemaZ = z
+  .object({
+    overlayId: SemanticProductIdSchemaZ,
+    focusReturnTarget: SemanticFocusTargetSchemaZ,
+  })
+  .strict();
+export const ApplicationShellClosePaletteArgumentsSchemaZ = z
+  .object({ overlayId: SemanticProductIdSchemaZ })
+  .strict();
+export const ApplicationShellSelectResourceArgumentsSchemaZ = z
+  .object({
+    surface: ProductSurfaceIdSchemaZ,
+    resourceId: SemanticProductIdSchemaZ,
+  })
+  .strict();
+
+export const APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS = Object.freeze({
+  [APPLICATION_SHELL_COMMAND_IDS.activateMode]: ApplicationShellActivateModeArgumentsSchemaZ,
+  [APPLICATION_SHELL_COMMAND_IDS.activateDockTool]:
+    ApplicationShellActivateDockToolArgumentsSchemaZ,
+  [APPLICATION_SHELL_COMMAND_IDS.setDockMode]: ApplicationShellSetDockModeArgumentsSchemaZ,
+  [APPLICATION_SHELL_COMMAND_IDS.moveFocus]: ApplicationShellMoveFocusArgumentsSchemaZ,
+  [APPLICATION_SHELL_COMMAND_IDS.openPalette]: ApplicationShellOpenPaletteArgumentsSchemaZ,
+  [APPLICATION_SHELL_COMMAND_IDS.closePalette]: ApplicationShellClosePaletteArgumentsSchemaZ,
+  [APPLICATION_SHELL_COMMAND_IDS.selectResource]: ApplicationShellSelectResourceArgumentsSchemaZ,
+} as const);
+
+export type ApplicationShellCommandArgumentsById = {
+  [Id in ApplicationShellCommandId]: z.infer<
+    (typeof APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS)[Id]
+  >;
+};
+
+export const ApplicationShellCommandInvocationSchemaZ = z.discriminatedUnion("id", [
+  z
+    .object({
+      version: z.literal(COMMAND_PROTOCOL_VERSION),
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
+      source: CommandSourceSchemaZ,
+      args: ApplicationShellActivateModeArgumentsSchemaZ,
+    })
+    .strict(),
+  z
+    .object({
+      version: z.literal(COMMAND_PROTOCOL_VERSION),
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
+      source: CommandSourceSchemaZ,
+      args: ApplicationShellActivateDockToolArgumentsSchemaZ,
+    })
+    .strict(),
+  z
+    .object({
+      version: z.literal(COMMAND_PROTOCOL_VERSION),
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
+      source: CommandSourceSchemaZ,
+      args: ApplicationShellSetDockModeArgumentsSchemaZ,
+    })
+    .strict(),
+  z
+    .object({
+      version: z.literal(COMMAND_PROTOCOL_VERSION),
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.moveFocus),
+      source: CommandSourceSchemaZ,
+      args: ApplicationShellMoveFocusArgumentsSchemaZ,
+    })
+    .strict(),
+  z
+    .object({
+      version: z.literal(COMMAND_PROTOCOL_VERSION),
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.openPalette),
+      source: CommandSourceSchemaZ,
+      args: ApplicationShellOpenPaletteArgumentsSchemaZ,
+    })
+    .strict(),
+  z
+    .object({
+      version: z.literal(COMMAND_PROTOCOL_VERSION),
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.closePalette),
+      source: CommandSourceSchemaZ,
+      args: ApplicationShellClosePaletteArgumentsSchemaZ,
+    })
+    .strict(),
+  z
+    .object({
+      version: z.literal(COMMAND_PROTOCOL_VERSION),
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
+      source: CommandSourceSchemaZ,
+      args: ApplicationShellSelectResourceArgumentsSchemaZ,
+    })
+    .strict(),
+]);
+export type ApplicationShellCommandInvocation = z.infer<
+  typeof ApplicationShellCommandInvocationSchemaZ
+>;
 
 const descriptor = (
   id: ApplicationShellCommandId,
@@ -248,37 +436,65 @@ const descriptorById = new Map(
   APPLICATION_SHELL_COMMAND_DESCRIPTORS.map((item) => [item.id, item]),
 );
 
+export interface ApplicationShellCommandDefinition {
+  readonly descriptor: CommandDescriptor;
+  readonly inputSchema: z.ZodType;
+}
+
+export const APPLICATION_SHELL_COMMAND_DEFINITIONS: readonly ApplicationShellCommandDefinition[] =
+  Object.freeze(
+    APPLICATION_SHELL_COMMAND_DESCRIPTORS.map((item) =>
+      Object.freeze({
+        descriptor: item,
+        inputSchema:
+          APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS[item.id as ApplicationShellCommandId],
+      }),
+    ),
+  );
+
 export function applicationShellCommandDescriptor(
   id: ApplicationShellCommandId,
 ): CommandDescriptor {
   return descriptorById.get(id)!;
 }
 
+export function applicationShellCommandArgumentSchema<Id extends ApplicationShellCommandId>(
+  id: Id,
+): (typeof APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS)[Id] {
+  return APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS[id];
+}
+
 function validatedInvocation(
   id: ApplicationShellCommandId,
   args: unknown,
   source: CommandSource,
-): CommandInvocation {
-  return CommandInvocationSchemaZ.parse({
-    version: COMMAND_PROTOCOL_VERSION,
-    id,
-    source,
-    args: CommandArgumentsSchemaZ.parse(args),
-  });
+): ApplicationShellCommandInvocation {
+  const parsedArgs = applicationShellCommandArgumentSchema(id).parse(args);
+  return deepFreeze(
+    ApplicationShellCommandInvocationSchemaZ.parse({
+      version: COMMAND_PROTOCOL_VERSION,
+      id,
+      source,
+      args: parsedArgs,
+    }),
+  );
 }
 
 export function applicationShellCommandInvocation<Id extends ApplicationShellCommandId>(
   id: Id,
   args: ApplicationShellCommandArgumentsById[Id],
   source: CommandSource,
-): CommandInvocation {
-  return validatedInvocation(id, args, source);
+): Extract<ApplicationShellCommandInvocation, { id: Id }> {
+  return validatedInvocation(id, args, source) as Extract<
+    ApplicationShellCommandInvocation,
+    { id: Id }
+  >;
 }
 
 function invocationFromTemplate(
   template: SurfaceCommandTemplate,
   source: CommandSource,
-): CommandInvocation {
+): ApplicationShellCommandInvocation {
   return validatedInvocation(
     ApplicationShellCommandIdSchemaZ.parse(template.id),
     template.args,
@@ -286,19 +502,181 @@ function invocationFromTemplate(
   );
 }
 
-function fallbackFocusReturnTarget(focus: FocusOverlayStateV1): SemanticFocusTarget {
-  if (focus.terminalInputPaneId !== null) {
-    return { kind: "pane", paneId: focus.terminalInputPaneId, input: "terminal" };
+export const ApplicationShellResourceSelectionSchemaZ = z
+  .object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ })
+  .strict();
+
+export const ApplicationShellReplayStateV1SchemaZ = z
+  .object({
+    activeMode: PrimaryWorkspaceModeIdSchemaZ,
+    dockMode: ApplicationShellDockModeSchemaZ,
+    activeDockTool: DockToolIdSchemaZ,
+    focus: FocusOverlayStateV1SchemaZ,
+    selectedResources: z.array(ApplicationShellResourceSelectionSchemaZ),
+  })
+  .strict()
+  .superRefine((state, ctx) => {
+    const surfaces = state.selectedResources.map(({ surface }) => surface);
+    if (new Set(surfaces).size !== surfaces.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "selected resources must be unique by surface",
+        path: ["selectedResources"],
+      });
+    }
+  });
+export type ApplicationShellReplayStateV1 = z.infer<typeof ApplicationShellReplayStateV1SchemaZ>;
+
+function applyFocusTarget(
+  focus: FocusOverlayStateV1,
+  target: SemanticFocusTarget,
+): FocusOverlayStateV1 {
+  if (target.kind === "pane") {
+    return {
+      ...focus,
+      focusZone: target.input === "terminal" ? "terminal" : "canvas",
+      appFocusedPaneId: target.paneId,
+      terminalInputPaneId: target.input === "terminal" ? target.paneId : null,
+    };
   }
-  if (focus.appFocusedPaneId !== null) {
-    return { kind: "pane", paneId: focus.appFocusedPaneId, input: "chrome" };
+  if (target.kind === "dock-tool") {
+    return { ...focus, focusZone: "dock-tabs", terminalInputPaneId: null };
   }
-  return { kind: "zone", zone: focus.focusZone };
+  return {
+    ...focus,
+    focusZone: target.zone,
+    terminalInputPaneId: null,
+  };
 }
 
-export interface ApplicationShellActionTraceV1 {
-  readonly version: typeof APPLICATION_SHELL_TRACE_VERSION;
-  readonly invocations: readonly CommandInvocation[];
+function replaceResourceSelection(
+  selections: readonly z.infer<typeof ApplicationShellResourceSelectionSchemaZ>[],
+  next: z.infer<typeof ApplicationShellResourceSelectionSchemaZ>,
+): z.infer<typeof ApplicationShellResourceSelectionSchemaZ>[] {
+  const order = new Map(CANONICAL_SURFACE_REGISTRY.map((surface, index) => [surface.id, index]));
+  return [...selections.filter(({ surface }) => surface !== next.surface), next].sort(
+    (left, right) => order.get(left.surface)! - order.get(right.surface)!,
+  );
+}
+
+/** Apply one semantic command while enforcing overlay input ownership. */
+export function applyApplicationShellInvocationV1(
+  state: ApplicationShellReplayStateV1,
+  rawInvocation: ApplicationShellCommandInvocation,
+): ApplicationShellReplayStateV1 {
+  const current = ApplicationShellReplayStateV1SchemaZ.parse(state);
+  const invocation = ApplicationShellCommandInvocationSchemaZ.parse(rawInvocation);
+  const inputLayer = resolveSemanticInputLayer(current.focus);
+  const overlayOwnsInput =
+    inputLayer.kind === "modal-dialog" ||
+    inputLayer.kind === "command-palette" ||
+    inputLayer.kind === "context-menu";
+
+  if (overlayOwnsInput) {
+    if (
+      invocation.id !== APPLICATION_SHELL_COMMAND_IDS.closePalette ||
+      inputLayer.kind !== "command-palette" ||
+      inputLayer.overlayId !== invocation.args.overlayId
+    ) {
+      throw new Error(`semantic input is owned by overlay: ${inputLayer.overlayId}`);
+    }
+  } else if (invocation.id === APPLICATION_SHELL_COMMAND_IDS.closePalette) {
+    throw new Error(`cannot close absent command palette: ${invocation.args.overlayId}`);
+  }
+
+  let next: ApplicationShellReplayStateV1;
+  switch (invocation.id) {
+    case APPLICATION_SHELL_COMMAND_IDS.activateMode:
+      next = { ...current, activeMode: invocation.args.mode };
+      break;
+    case APPLICATION_SHELL_COMMAND_IDS.activateDockTool:
+      next = { ...current, activeDockTool: invocation.args.tool };
+      break;
+    case APPLICATION_SHELL_COMMAND_IDS.setDockMode:
+      next = { ...current, dockMode: invocation.args.mode };
+      break;
+    case APPLICATION_SHELL_COMMAND_IDS.moveFocus:
+      next = { ...current, focus: applyFocusTarget(current.focus, invocation.args.target) };
+      break;
+    case APPLICATION_SHELL_COMMAND_IDS.openPalette: {
+      const overlay: SemanticOverlay = {
+        id: invocation.args.overlayId,
+        kind: "command-palette",
+        focusReturnTarget: invocation.args.focusReturnTarget,
+      };
+      next = {
+        ...current,
+        focus: { ...current.focus, overlays: [...current.focus.overlays, overlay] },
+      };
+      break;
+    }
+    case APPLICATION_SHELL_COMMAND_IDS.closePalette: {
+      const overlay = current.focus.overlays.find(({ id }) => id === invocation.args.overlayId);
+      if (!overlay || overlay.kind !== "command-palette") {
+        throw new Error(`command palette overlay is not open: ${invocation.args.overlayId}`);
+      }
+      const withoutClosed = {
+        ...current.focus,
+        overlays: current.focus.overlays.filter(({ id }) => id !== overlay.id),
+      };
+      next = { ...current, focus: applyFocusTarget(withoutClosed, overlay.focusReturnTarget) };
+      break;
+    }
+    case APPLICATION_SHELL_COMMAND_IDS.selectResource:
+      next = {
+        ...current,
+        selectedResources: replaceResourceSelection(current.selectedResources, invocation.args),
+      };
+      break;
+  }
+  return deepFreeze(ApplicationShellReplayStateV1SchemaZ.parse(next));
+}
+
+const ApplicationShellActionTraceV1BaseSchemaZ = z
+  .object({
+    version: z.literal(APPLICATION_SHELL_TRACE_VERSION),
+    initialState: ApplicationShellReplayStateV1SchemaZ,
+    invocations: z.array(ApplicationShellCommandInvocationSchemaZ),
+    finalState: ApplicationShellReplayStateV1SchemaZ,
+  })
+  .strict();
+
+function replayInvocations(
+  initialState: ApplicationShellReplayStateV1,
+  invocations: readonly ApplicationShellCommandInvocation[],
+): ApplicationShellReplayStateV1 {
+  return invocations.reduce(
+    (state, invocation) => applyApplicationShellInvocationV1(state, invocation),
+    deepFreeze(ApplicationShellReplayStateV1SchemaZ.parse(initialState)),
+  );
+}
+
+export const ApplicationShellActionTraceV1SchemaZ =
+  ApplicationShellActionTraceV1BaseSchemaZ.superRefine((trace, ctx) => {
+    try {
+      const replayed = replayInvocations(trace.initialState, trace.invocations);
+      if (JSON.stringify(replayed) !== JSON.stringify(trace.finalState)) {
+        ctx.addIssue({
+          code: "custom",
+          message: "final state does not match sequential command replay",
+          path: ["finalState"],
+        });
+      }
+    } catch (error) {
+      ctx.addIssue({
+        code: "custom",
+        message: error instanceof Error ? error.message : "command replay failed",
+        path: ["invocations"],
+      });
+    }
+  });
+export type ApplicationShellActionTraceV1 = z.infer<typeof ApplicationShellActionTraceV1SchemaZ>;
+
+export function replayApplicationShellActionTraceV1(
+  trace: ApplicationShellActionTraceV1,
+): ApplicationShellReplayStateV1 {
+  const parsed = ApplicationShellActionTraceV1SchemaZ.parse(trace);
+  return replayInvocations(parsed.initialState, parsed.invocations);
 }
 
 /**
@@ -310,19 +688,39 @@ export function applicationShellActionTraceV1(
   input: ApplicationShellProjectionInputV1,
   source: CommandSource = { kind: "program", surface: "application-shell" },
 ): ApplicationShellActionTraceV1 {
-  const focusPalette = paletteOverlay(input.focus);
-  const overlayId = focusPalette?.id ?? "overlay.palette";
-  const focusReturnTarget =
-    focusPalette?.focusReturnTarget ?? fallbackFocusReturnTarget(input.focus);
-  const invocations: CommandInvocation[] = [];
+  const parsedInput = ApplicationShellProjectionInputV1SchemaZ.parse({
+    project: input.project,
+    workspace: input.workspace,
+    dock: input.dock,
+    focus: input.focus,
+    connection: input.connection,
+  });
+  if (parsedInput.focus.overlays.length > 0) {
+    throw new Error("application shell action traces require a closed-overlay initial state");
+  }
+  const initialState = deepFreeze(
+    ApplicationShellReplayStateV1SchemaZ.parse({
+      activeMode: parsedInput.workspace.activeMode,
+      dockMode: parsedInput.dock.mode,
+      activeDockTool: parsedInput.dock.activeTool,
+      focus: parsedInput.focus,
+      selectedResources: [],
+    }),
+  );
+  let currentState = initialState;
+  const invocations: ApplicationShellCommandInvocation[] = [];
+  const append = (invocation: ApplicationShellCommandInvocation): void => {
+    currentState = applyApplicationShellInvocationV1(currentState, invocation);
+    invocations.push(invocation);
+  };
 
   for (const surface of CANONICAL_SURFACE_REGISTRY) {
     for (const template of commandsToOpenSurface({ surface: surface.id })) {
-      invocations.push(invocationFromTemplate(template, source));
+      append(invocationFromTemplate(template, source));
     }
   }
   for (const mode of ApplicationShellDockModeSchemaZ.options) {
-    invocations.push(
+    append(
       applicationShellCommandInvocation(
         APPLICATION_SHELL_COMMAND_IDS.setDockMode,
         { mode },
@@ -330,28 +728,36 @@ export function applicationShellActionTraceV1(
       ),
     );
   }
-  invocations.push(
-    applicationShellCommandInvocation(
-      APPLICATION_SHELL_COMMAND_IDS.moveFocus,
-      { target: { kind: "zone", zone: "dock-tabs" } },
-      source,
-    ),
-    applicationShellCommandInvocation(
-      APPLICATION_SHELL_COMMAND_IDS.openPalette,
-      { overlayId, focusReturnTarget },
-      source,
-    ),
-    applicationShellCommandInvocation(
-      APPLICATION_SHELL_COMMAND_IDS.closePalette,
-      { overlayId },
-      source,
-    ),
+  const focusReturnTarget = { kind: "zone", zone: "dock-tabs" } as const;
+  const overlayId = "overlay.palette.trace";
+  append(
     applicationShellCommandInvocation(
       APPLICATION_SHELL_COMMAND_IDS.moveFocus,
       { target: focusReturnTarget },
       source,
     ),
   );
+  append(
+    applicationShellCommandInvocation(
+      APPLICATION_SHELL_COMMAND_IDS.openPalette,
+      { overlayId, focusReturnTarget },
+      source,
+    ),
+  );
+  append(
+    applicationShellCommandInvocation(
+      APPLICATION_SHELL_COMMAND_IDS.closePalette,
+      { overlayId },
+      source,
+    ),
+  );
 
-  return deepFreeze({ version: APPLICATION_SHELL_TRACE_VERSION, invocations });
+  return deepFreeze(
+    ApplicationShellActionTraceV1SchemaZ.parse({
+      version: APPLICATION_SHELL_TRACE_VERSION,
+      initialState,
+      invocations,
+      finalState: currentState,
+    }),
+  );
 }

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -114,15 +114,15 @@ export type CommandResolutionError = z.infer<typeof CommandResolutionErrorSchema
  * Stable semantic shell commands consumed by both OpenTUI and DOM hosts.
  * Host input events translate to these IDs; effects remain in the host root.
  */
-export const APPLICATION_SHELL_COMMAND_IDS = {
-  activateMode: "workspace.mode.activate",
-  activateDockTool: "workspace.dock.activate",
-  setDockMode: "workspace.dock.mode.set",
-  moveFocus: "workspace.focus.move",
-  openPalette: "app.palette.open",
-  closePalette: "app.palette.close",
-  selectResource: "workspace.resource.select",
-} as const satisfies Readonly<Record<string, CommandId>>;
+export const APPLICATION_SHELL_COMMAND_IDS = Object.freeze({
+  activateMode: "application.shell.mode.activate",
+  activateDockTool: "application.shell.dock.activate",
+  setDockMode: "application.shell.dock.mode.set",
+  moveFocus: "application.shell.focus.move",
+  openPalette: "application.shell.palette.open",
+  closePalette: "application.shell.palette.close",
+  selectResource: "application.shell.resource.select",
+} as const satisfies Readonly<Record<string, CommandId>>);
 
 export type ApplicationShellCommandId =
   (typeof APPLICATION_SHELL_COMMAND_IDS)[keyof typeof APPLICATION_SHELL_COMMAND_IDS];

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -111,6 +111,30 @@ export type CommandResolutionErrorCode = z.infer<typeof CommandResolutionErrorCo
 export type CommandResolutionError = z.infer<typeof CommandResolutionErrorSchemaZ>;
 
 /**
+ * Stable semantic shell commands consumed by both OpenTUI and DOM hosts.
+ * Host input events translate to these IDs; effects remain in the host root.
+ */
+export const APPLICATION_SHELL_COMMAND_IDS = {
+  activateMode: "workspace.mode.activate",
+  activateDockTool: "workspace.dock.activate",
+  setDockMode: "workspace.dock.mode.set",
+  moveFocus: "workspace.focus.move",
+  openPalette: "app.palette.open",
+  closePalette: "app.palette.close",
+  selectResource: "workspace.resource.select",
+} as const satisfies Readonly<Record<string, CommandId>>;
+
+export type ApplicationShellCommandId =
+  (typeof APPLICATION_SHELL_COMMAND_IDS)[keyof typeof APPLICATION_SHELL_COMMAND_IDS];
+
+export const ApplicationShellCommandIdSchemaZ = z.enum(
+  Object.values(APPLICATION_SHELL_COMMAND_IDS) as [
+    ApplicationShellCommandId,
+    ...ApplicationShellCommandId[],
+  ],
+);
+
+/**
  * Names reserved for the Gloomberb-inspired window-control work. They are not
  * command registrations yet and therefore cannot be invoked by Card07.
  */

--- a/packages/contracts/src/experience-shell.ts
+++ b/packages/contracts/src/experience-shell.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { CommandIdSchemaZ, type CommandArguments, type CommandId } from "./commands.ts";
+import {
+  APPLICATION_SHELL_COMMAND_IDS,
+  CommandIdSchemaZ,
+  type CommandArguments,
+  type CommandId,
+} from "./commands.ts";
 import { SemanticIconIdSchemaZ, type SemanticIconId } from "./experience-identifiers.ts";
 
 /** Canonical product information architecture. Hosts may change placement, never identity/order. */
@@ -65,12 +70,12 @@ export interface ProductSurfaceDefinition {
 }
 
 const modeCommand = (mode: PrimaryWorkspaceModeId): SurfaceCommandTemplate => ({
-  id: "workspace.mode.activate",
+  id: APPLICATION_SHELL_COMMAND_IDS.activateMode,
   args: { mode },
 });
 
 const dockCommand = (tool: DockToolId): SurfaceCommandTemplate => ({
-  id: "workspace.dock.activate",
+  id: APPLICATION_SHELL_COMMAND_IDS.activateDockTool,
   args: { tool },
 });
 
@@ -165,12 +170,12 @@ export function commandsToOpenSurface(
   if (surface.kind === "primary-mode") return [surface.activation];
   const commands: SurfaceCommandTemplate[] = [
     modeCommand(surface.owningMode),
-    { id: "workspace.dock.expand", args: {} },
+    { id: APPLICATION_SHELL_COMMAND_IDS.setDockMode, args: { mode: "open" } },
     surface.activation,
   ];
   if (intent.resourceId) {
     commands.push({
-      id: "workspace.resource.select",
+      id: APPLICATION_SHELL_COMMAND_IDS.selectResource,
       args: { surface: surface.id, resourceId: intent.resourceId },
     });
   }

--- a/packages/contracts/src/experience-shell.ts
+++ b/packages/contracts/src/experience-shell.ts
@@ -1,11 +1,7 @@
 import { z } from "zod";
-import {
-  APPLICATION_SHELL_COMMAND_IDS,
-  CommandIdSchemaZ,
-  type CommandArguments,
-  type CommandId,
-} from "./commands.ts";
-import { SemanticIconIdSchemaZ, type SemanticIconId } from "./experience-identifiers.ts";
+import { APPLICATION_SHELL_COMMAND_IDS } from "./commands.ts";
+import { SemanticIconIdSchemaZ } from "./experience-identifiers.ts";
+import { SemanticProductIdSchemaZ } from "./pane-appearance.ts";
 
 /** Canonical product information architecture. Hosts may change placement, never identity/order. */
 export const EXPERIENCE_KERNEL_VERSION = 1 as const;
@@ -21,15 +17,18 @@ export const ShellAreaIdSchemaZ = z.enum([
 ]);
 export type ShellAreaId = z.infer<typeof ShellAreaIdSchemaZ>;
 
-export const PRIMARY_WORKSPACE_MODE_IDS = ["home", "terminals"] as const;
+export const PRIMARY_WORKSPACE_MODE_IDS = Object.freeze(["home", "terminals"] as const);
 export const PrimaryWorkspaceModeIdSchemaZ = z.enum(PRIMARY_WORKSPACE_MODE_IDS);
 export type PrimaryWorkspaceModeId = z.infer<typeof PrimaryWorkspaceModeIdSchemaZ>;
 
-export const DOCK_TOOL_IDS = ["files", "changes", "missions", "activity"] as const;
+export const DOCK_TOOL_IDS = Object.freeze(["files", "changes", "missions", "activity"] as const);
 export const DockToolIdSchemaZ = z.enum(DOCK_TOOL_IDS);
 export type DockToolId = z.infer<typeof DockToolIdSchemaZ>;
 
-export const PRODUCT_SURFACE_IDS = [...PRIMARY_WORKSPACE_MODE_IDS, ...DOCK_TOOL_IDS] as const;
+export const PRODUCT_SURFACE_IDS = Object.freeze([
+  ...PRIMARY_WORKSPACE_MODE_IDS,
+  ...DOCK_TOOL_IDS,
+] as const);
 export const ProductSurfaceIdSchemaZ = z.enum(PRODUCT_SURFACE_IDS);
 export type ProductSurfaceId = z.infer<typeof ProductSurfaceIdSchemaZ>;
 
@@ -39,7 +38,13 @@ export interface ShellAreaDefinition {
   readonly order: number;
 }
 
-export const CANONICAL_SHELL_AREAS: readonly ShellAreaDefinition[] = Object.freeze([
+function deepFreezeData<T>(value: T): T {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) deepFreezeData(child);
+  return Object.freeze(value);
+}
+
+export const CANONICAL_SHELL_AREAS: readonly ShellAreaDefinition[] = deepFreezeData([
   { id: "application-bar", label: "Application bar", order: 0 },
   { id: "sidebar", label: "Workspace sidebar", order: 1 },
   { id: "primary-navigation", label: "Workspace modes", order: 2 },
@@ -52,101 +57,158 @@ export const CANONICAL_SHELL_AREAS: readonly ShellAreaDefinition[] = Object.free
 export const SurfaceKindSchemaZ = z.enum(["primary-mode", "dock-tool"]);
 export type SurfaceKind = z.infer<typeof SurfaceKindSchemaZ>;
 
-export interface SurfaceCommandTemplate {
-  readonly id: CommandId;
-  readonly args: Readonly<CommandArguments>;
-}
+export const ApplicationShellDockModeSchemaZ = z.enum(["collapsed", "open", "maximized"]);
+export type ApplicationShellDockMode = z.infer<typeof ApplicationShellDockModeSchemaZ>;
 
-export interface ProductSurfaceDefinition {
-  readonly id: ProductSurfaceId;
-  readonly icon: SemanticIconId;
-  readonly label: string;
-  readonly kind: SurfaceKind;
-  readonly area: "workspace-canvas" | "bottom-dock";
-  readonly order: number;
-  readonly owningMode: PrimaryWorkspaceModeId;
-  readonly shortcut: string;
-  readonly activation: SurfaceCommandTemplate;
-}
-
-const modeCommand = (mode: PrimaryWorkspaceModeId): SurfaceCommandTemplate => ({
-  id: APPLICATION_SHELL_COMMAND_IDS.activateMode,
-  args: { mode },
-});
-
-const dockCommand = (tool: DockToolId): SurfaceCommandTemplate => ({
-  id: APPLICATION_SHELL_COMMAND_IDS.activateDockTool,
-  args: { tool },
-});
-
-export const CANONICAL_SURFACE_REGISTRY: readonly ProductSurfaceDefinition[] = Object.freeze([
-  {
-    id: "home",
-    icon: "home",
-    label: "Home",
-    kind: "primary-mode",
-    area: "workspace-canvas",
-    order: 0,
-    owningMode: "home",
-    shortcut: "F1",
-    activation: modeCommand("home"),
-  },
-  {
-    id: "terminals",
-    icon: "terminals",
-    label: "Terminals",
-    kind: "primary-mode",
-    area: "workspace-canvas",
-    order: 1,
-    owningMode: "terminals",
-    shortcut: "F2",
-    activation: modeCommand("terminals"),
-  },
-  {
-    id: "files",
-    icon: "files",
-    label: "Files",
-    kind: "dock-tool",
-    area: "bottom-dock",
-    order: 0,
-    owningMode: "terminals",
-    shortcut: "F3",
-    activation: dockCommand("files"),
-  },
-  {
-    id: "changes",
-    icon: "changes",
-    label: "Changes",
-    kind: "dock-tool",
-    area: "bottom-dock",
-    order: 1,
-    owningMode: "terminals",
-    shortcut: "F4",
-    activation: dockCommand("changes"),
-  },
-  {
-    id: "missions",
-    icon: "missions",
-    label: "Missions",
-    kind: "dock-tool",
-    area: "bottom-dock",
-    order: 2,
-    owningMode: "terminals",
-    shortcut: "F6",
-    activation: dockCommand("missions"),
-  },
-  {
-    id: "activity",
-    icon: "activity",
-    label: "Activity",
-    kind: "dock-tool",
-    area: "bottom-dock",
-    order: 3,
-    owningMode: "terminals",
-    shortcut: "F9",
-    activation: dockCommand("activity"),
-  },
+export const SurfaceCommandTemplateSchemaZ = z.discriminatedUnion("id", [
+  z
+    .object({
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
+      args: z.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict(),
+    })
+    .strict(),
+  z
+    .object({
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
+      args: z.object({ tool: DockToolIdSchemaZ }).strict(),
+    })
+    .strict(),
+  z
+    .object({
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
+      args: z.object({ mode: ApplicationShellDockModeSchemaZ }).strict(),
+    })
+    .strict(),
+  z
+    .object({
+      id: z.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
+      args: z
+        .object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ })
+        .strict(),
+    })
+    .strict(),
 ]);
+export type SurfaceCommandTemplate = z.infer<typeof SurfaceCommandTemplateSchemaZ>;
+
+export const ProductSurfaceDefinitionSchemaZ = z
+  .object({
+    id: ProductSurfaceIdSchemaZ,
+    icon: SemanticIconIdSchemaZ,
+    label: z.string().min(1).max(160),
+    kind: SurfaceKindSchemaZ,
+    area: z.enum(["workspace-canvas", "bottom-dock"]),
+    order: z.number().int().nonnegative(),
+    owningMode: PrimaryWorkspaceModeIdSchemaZ,
+    shortcut: z.string().min(1).max(32),
+    activation: SurfaceCommandTemplateSchemaZ,
+  })
+  .strict()
+  .superRefine((surface, ctx) => {
+    if (
+      surface.kind === "primary-mode" &&
+      surface.activation.id !== APPLICATION_SHELL_COMMAND_IDS.activateMode
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "primary modes require a mode activation command",
+        path: ["activation", "id"],
+      });
+    }
+    if (
+      surface.kind === "dock-tool" &&
+      surface.activation.id !== APPLICATION_SHELL_COMMAND_IDS.activateDockTool
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "dock tools require a dock activation command",
+        path: ["activation", "id"],
+      });
+    }
+  });
+export type ProductSurfaceDefinition = z.infer<typeof ProductSurfaceDefinitionSchemaZ>;
+
+const modeCommand = (mode: PrimaryWorkspaceModeId): SurfaceCommandTemplate =>
+  deepFreezeData({
+    id: APPLICATION_SHELL_COMMAND_IDS.activateMode,
+    args: { mode },
+  });
+
+const dockCommand = (tool: DockToolId): SurfaceCommandTemplate =>
+  deepFreezeData({
+    id: APPLICATION_SHELL_COMMAND_IDS.activateDockTool,
+    args: { tool },
+  });
+
+export const CANONICAL_SURFACE_REGISTRY: readonly ProductSurfaceDefinition[] = deepFreezeData(
+  ProductSurfaceDefinitionSchemaZ.array().parse([
+    {
+      id: "home",
+      icon: "home",
+      label: "Home",
+      kind: "primary-mode",
+      area: "workspace-canvas",
+      order: 0,
+      owningMode: "home",
+      shortcut: "F1",
+      activation: modeCommand("home"),
+    },
+    {
+      id: "terminals",
+      icon: "terminals",
+      label: "Terminals",
+      kind: "primary-mode",
+      area: "workspace-canvas",
+      order: 1,
+      owningMode: "terminals",
+      shortcut: "F2",
+      activation: modeCommand("terminals"),
+    },
+    {
+      id: "files",
+      icon: "files",
+      label: "Files",
+      kind: "dock-tool",
+      area: "bottom-dock",
+      order: 0,
+      owningMode: "terminals",
+      shortcut: "F3",
+      activation: dockCommand("files"),
+    },
+    {
+      id: "changes",
+      icon: "changes",
+      label: "Changes",
+      kind: "dock-tool",
+      area: "bottom-dock",
+      order: 1,
+      owningMode: "terminals",
+      shortcut: "F4",
+      activation: dockCommand("changes"),
+    },
+    {
+      id: "missions",
+      icon: "missions",
+      label: "Missions",
+      kind: "dock-tool",
+      area: "bottom-dock",
+      order: 2,
+      owningMode: "terminals",
+      shortcut: "F6",
+      activation: dockCommand("missions"),
+    },
+    {
+      id: "activity",
+      icon: "activity",
+      label: "Activity",
+      kind: "dock-tool",
+      area: "bottom-dock",
+      order: 3,
+      owningMode: "terminals",
+      shortcut: "F9",
+      activation: dockCommand("activity"),
+    },
+  ]),
+);
 
 const surfaceById = new Map(CANONICAL_SURFACE_REGISTRY.map((surface) => [surface.id, surface]));
 
@@ -167,7 +229,7 @@ export function commandsToOpenSurface(
   intent: SurfaceOpenIntent,
 ): readonly SurfaceCommandTemplate[] {
   const surface = canonicalSurface(intent.surface);
-  if (surface.kind === "primary-mode") return [surface.activation];
+  if (surface.kind === "primary-mode") return deepFreezeData([surface.activation]);
   const commands: SurfaceCommandTemplate[] = [
     modeCommand(surface.owningMode),
     { id: APPLICATION_SHELL_COMMAND_IDS.setDockMode, args: { mode: "open" } },
@@ -179,10 +241,9 @@ export function commandsToOpenSurface(
       args: { surface: surface.id, resourceId: intent.resourceId },
     });
   }
-  return commands;
+  return deepFreezeData(SurfaceCommandTemplateSchemaZ.array().parse(commands));
 }
 
 for (const surface of CANONICAL_SURFACE_REGISTRY) {
-  CommandIdSchemaZ.parse(surface.activation.id);
   SemanticIconIdSchemaZ.parse(surface.icon);
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -31,6 +31,7 @@ export * from "./commands.ts";
 export * from "./desktop-host.ts";
 export * from "./experience-identifiers.ts";
 export * from "./experience-shell.ts";
+export * from "./application-shell.ts";
 export * from "./visual-tokens.ts";
 export * from "./visual-recipes.ts";
 export * from "./pane-appearance.ts";

--- a/packages/daemon/src/tui/mirror/renderer-commands.test.ts
+++ b/packages/daemon/src/tui/mirror/renderer-commands.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { COMMAND_PROTOCOL_VERSION, type CommandInvocation } from "@tmux-ide/contracts";
+import {
+  APPLICATION_SHELL_COMMAND_DEFINITIONS,
+  APPLICATION_SHELL_COMMAND_IDS,
+  COMMAND_PROTOCOL_VERSION,
+  applicationShellCommandInvocation,
+  type CommandInvocation,
+} from "@tmux-ide/contracts";
 import { z } from "zod";
 import { CommandRegistry } from "../../lib/command-registry.ts";
 import {
@@ -75,6 +81,57 @@ describe("renderer command boundary", () => {
       id: "workspace.view.activate",
       args: { viewId: "my-view" },
     });
+  });
+
+  it("composes the live renderer and canonical shell catalogs without id or input collisions", () => {
+    const rendererIds = new Set(
+      RENDERER_COMMAND_DEFINITIONS.map(({ descriptor }) => descriptor.id),
+    );
+    const shellIds = APPLICATION_SHELL_COMMAND_DEFINITIONS.map(({ descriptor }) => descriptor.id);
+    expect(shellIds.filter((id) => rendererIds.has(id))).toEqual([]);
+
+    const registry = new CommandRegistry<RendererCommandContext>([
+      ...RENDERER_COMMAND_DEFINITIONS,
+      ...APPLICATION_SHELL_COMMAND_DEFINITIONS,
+    ]);
+    expect(registry.descriptors()).toHaveLength(
+      RENDERER_COMMAND_DEFINITIONS.length + APPLICATION_SHELL_COMMAND_DEFINITIONS.length,
+    );
+
+    const source = { kind: "program", surface: "compatibility-test" } as const;
+    expect(
+      registry.resolve(
+        rendererCommandInvocation(RENDERER_COMMAND_IDS.openPalette, {}, source),
+        available,
+      ),
+    ).toMatchObject({ ok: true, command: { input: {} } });
+    expect(
+      registry.resolve(
+        rendererCommandInvocation(RENDERER_COMMAND_IDS.activateDock, { tab: "missions" }, source),
+        available,
+      ),
+    ).toMatchObject({ ok: true, command: { input: { tab: "missions" } } });
+    expect(
+      registry.resolve(
+        applicationShellCommandInvocation(
+          APPLICATION_SHELL_COMMAND_IDS.activateDockTool,
+          { tool: "missions" },
+          source,
+        ),
+        available,
+      ),
+    ).toMatchObject({ ok: true, command: { input: { tool: "missions" } } });
+    expect(
+      registry.resolve(
+        {
+          version: COMMAND_PROTOCOL_VERSION,
+          id: APPLICATION_SHELL_COMMAND_IDS.activateDockTool,
+          source,
+          args: { tab: "missions" },
+        },
+        available,
+      ),
+    ).toMatchObject({ ok: false, error: { code: "invalid-input" } });
   });
 
   it("executes every converted effect through one injected seam", () => {


### PR DESCRIPTION
## Summary
- add a renderer-neutral, schema-validated application-shell projection and command seam
- source Home/Terminals and bottom-dock Files/Changes/Missions/Activity exclusively from the canonical surface registry
- add a replayed semantic action trace for dock, palette, overlay ownership, and exact focus return
- keep existing renderer command IDs/payloads backward compatible through a noncolliding `application.shell.*` namespace
- deeply freeze registries, definitions, invocations, projections, replay states, and traces

## Review repairs
Adversarial review caught command collisions, unenforced advertised schemas, shallow immutability, and a non-sequential trace. This branch now exports strict per-ID Zod definitions, composes safely with the live renderer registry, mutation-tests all public data, and applies every trace step through a pure reducer.

## Verification
- contracts: 18 files, 95 tests
- renderer command + registry: 2 files, 17 tests
- contracts and daemon typechecks (including OpenTUI/web dock configs)
- contracts/targeted renderer lint
- formatting and diff checks
