### PR TITLE
feat(desktop): add the canonical DOM experience adapter

### DIFF
--- a/apps/desktop-renderer/package.json
+++ b/apps/desktop-renderer/package.json
@@ -15,6 +15,7 @@
     "solid-js": "1.9.12"
   },
   "devDependencies": {
+    "happy-dom": "^20.8.4",
     "typescript": "^5.9.3",
     "vite": "^7.2.2",
     "vite-plugin-solid": "^2.11.10",

--- a/apps/desktop-renderer/src/App.test.tsx
+++ b/apps/desktop-renderer/src/App.test.tsx
@@ -1,0 +1,131 @@
+/* @vitest-environment happy-dom */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "solid-js/web";
+import {
+  DESKTOP_HOST_API_VERSION,
+  type DesktopHostBootstrap,
+  type DesktopThemeState,
+  type DesktopWindowState,
+  type HostCapabilities,
+} from "@tmux-ide/contracts";
+
+import { App } from "./App.tsx";
+import styles from "./styles.css?raw";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value) {
+      resolvePromise?.(value);
+    },
+  };
+}
+
+function installLightMediaPreference(): void {
+  vi.spyOn(window, "matchMedia").mockImplementation(
+    (query) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(() => true),
+      }) satisfies MediaQueryList,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.replaceChildren();
+});
+
+describe("desktop App host lifecycle", () => {
+  it("paints the synchronous light seed, reacts to deferred bootstrap/events, and unsubscribes", async () => {
+    installLightMediaPreference();
+    const pendingBootstrap = deferred<DesktopHostBootstrap>();
+    const stopTheme = vi.fn();
+    const stopWindow = vi.fn();
+    let publishTheme: ((state: DesktopThemeState) => void) | undefined;
+    let publishWindow: ((state: DesktopWindowState) => void) | undefined;
+    const initialWindow: DesktopWindowState = {
+      maximized: false,
+      fullscreen: false,
+      focused: true,
+    };
+    const host: HostCapabilities = {
+      apiVersion: DESKTOP_HOST_API_VERSION,
+      bootstrap: () => pendingBootstrap.promise,
+      lifecycle: { requestQuit: async () => undefined },
+      window: {
+        getState: async () => initialWindow,
+        minimize: async () => initialWindow,
+        toggleMaximized: async () => initialWindow,
+        close: async () => undefined,
+        onStateChanged(listener) {
+          publishWindow = listener;
+          return stopWindow;
+        },
+      },
+      menu: { showApplicationMenu: async () => ({ status: "unavailable" }) },
+      dialog: { selectProjectDirectory: async () => null },
+      theme: {
+        getState: async () => ({ mode: "light", highContrast: false, reducedMotion: false }),
+        onChanged(listener) {
+          publishTheme = listener;
+          return stopTheme;
+        },
+      },
+    };
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(() => <App host={host} />, root);
+    const app = root.querySelector<HTMLElement>(".app")!;
+
+    expect(app.dataset.theme).toBe("light");
+    expect(app.style.getPropertyValue("--tmux-ide-surface-canvas")).toBe("rgb(245 245 247)");
+    expect(app.dataset.increasedContrast).toBe("false");
+    expect(root.querySelector(".window-controls")).toBeNull();
+
+    pendingBootstrap.resolve({
+      apiVersion: DESKTOP_HOST_API_VERSION,
+      runtime: "electron",
+      platform: "linux",
+      appVersion: "test",
+      theme: { mode: "light", highContrast: true, reducedMotion: false },
+      window: initialWindow,
+      daemon: { status: "deferred", reason: "test boundary" },
+    });
+    await vi.waitFor(() => {
+      expect(app.dataset.increasedContrast).toBe("true");
+      expect(app.dataset.reducedMotion).toBe("false");
+      expect(root.querySelector(".window-controls")).not.toBeNull();
+    });
+    expect(styles).toMatch(
+      /\.window-controls button \{[\s\S]*?transition:\s*color var\(--tmux-ide-motion-fast\) linear,\s*background-color var\(--tmux-ide-motion-fast\) linear;/u,
+    );
+
+    publishTheme?.({ mode: "dark", highContrast: false, reducedMotion: false });
+    publishWindow?.({ ...initialWindow, maximized: true });
+    await vi.waitFor(() => {
+      expect(app.dataset.theme).toBe("dark");
+      expect(app.style.getPropertyValue("--tmux-ide-surface-canvas")).toBe("rgb(14 14 18)");
+      expect(root.querySelector('[aria-label="Restore"]')).not.toBeNull();
+    });
+
+    dispose();
+    expect(stopTheme).toHaveBeenCalledOnce();
+    expect(stopWindow).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop-renderer/src/App.tsx
+++ b/apps/desktop-renderer/src/App.tsx
@@ -1,15 +1,14 @@
 import { Show, createMemo, createResource, createSignal, onCleanup, onMount } from "solid-js";
-import type { DesktopThemeState, DesktopWindowState } from "@tmux-ide/contracts";
+import type { DesktopThemeState, DesktopWindowState, HostCapabilities } from "@tmux-ide/contracts";
 
 import {
   parseThemeState,
   parseWindowState,
   readHostBootstrap,
+  readInitialThemeState,
   resolveHostCapabilities,
 } from "./host-capabilities.ts";
 import { createDomExperience } from "./experience/index.ts";
-
-const host = resolveHostCapabilities();
 
 function daemonLabel(status: string): string {
   if (status === "ready") return "Daemon ready";
@@ -18,7 +17,14 @@ function daemonLabel(status: string): string {
   return "Daemon integration deferred";
 }
 
-export function App() {
+export interface AppProps {
+  readonly host?: HostCapabilities;
+  readonly initialTheme?: DesktopThemeState;
+}
+
+export function App(props: AppProps = {}) {
+  const host = props.host ?? resolveHostCapabilities();
+  const initialTheme = props.initialTheme ?? readInitialThemeState();
   const [bootstrap] = createResource(() => readHostBootstrap(host));
   const [theme, setTheme] = createSignal<DesktopThemeState | null>(null);
   const [windowState, setWindowState] = createSignal<DesktopWindowState | null>(null);
@@ -32,7 +38,7 @@ export function App() {
     });
   });
 
-  const effectiveTheme = () => theme() ?? bootstrap()?.theme ?? null;
+  const effectiveTheme = () => theme() ?? bootstrap()?.theme ?? initialTheme;
   const effectiveWindow = () => windowState() ?? bootstrap()?.window ?? null;
   const experience = createMemo(() => createDomExperience({ hostTheme: effectiveTheme() }));
 

--- a/apps/desktop-renderer/src/App.tsx
+++ b/apps/desktop-renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { Show, createResource, createSignal, onCleanup, onMount } from "solid-js";
+import { Show, createMemo, createResource, createSignal, onCleanup, onMount } from "solid-js";
 import type { DesktopThemeState, DesktopWindowState } from "@tmux-ide/contracts";
 
 import {
@@ -7,6 +7,7 @@ import {
   readHostBootstrap,
   resolveHostCapabilities,
 } from "./host-capabilities.ts";
+import { createDomExperience } from "./experience/index.ts";
 
 const host = resolveHostCapabilities();
 
@@ -33,9 +34,17 @@ export function App() {
 
   const effectiveTheme = () => theme() ?? bootstrap()?.theme ?? null;
   const effectiveWindow = () => windowState() ?? bootstrap()?.window ?? null;
+  const experience = createMemo(() => createDomExperience({ hostTheme: effectiveTheme() }));
 
   return (
-    <main class="app" data-theme={effectiveTheme()?.mode ?? "dark"}>
+    <main
+      class="app"
+      data-theme={experience().appearance}
+      data-reduced-motion={String(experience().accessibility.reducedMotion)}
+      data-increased-contrast={String(experience().accessibility.increasedContrast)}
+      data-accessibility-conflicts={experience().accessibility.conflicts.join(" ") || undefined}
+      style={experience().variables}
+    >
       <header class="titlebar">
         <div class="titlebar__drag">
           <span class="brand-mark" aria-hidden="true">

--- a/apps/desktop-renderer/src/experience/dom-experience.test.ts
+++ b/apps/desktop-renderer/src/experience/dom-experience.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  COHESION_FIXTURE_V1,
+  SEMANTIC_ICON_IDS,
+  type RendererNeutralColor,
+} from "@tmux-ide/contracts";
+
+import { DOM_EXPERIENCE_VARIABLE, createDomExperience } from "./dom-experience.ts";
+import { resolveDomIcon } from "./dom-icons.ts";
+
+function color(red: number, green: number, blue: number): RendererNeutralColor {
+  return { space: "srgb", red, green, blue, alpha: 255 };
+}
+
+describe("DOM experience adapter", () => {
+  it("projects complete canonical dark and light themes into stable CSS variables", () => {
+    const dark = createDomExperience({ hostTheme: { mode: "dark" } });
+    const light = createDomExperience({ hostTheme: { mode: "light" } });
+
+    expect(dark.appearance).toBe("dark");
+    expect(dark.variables[DOM_EXPERIENCE_VARIABLE.surface.canvas]).toBe("rgb(14 14 18)");
+    expect(dark.variables[DOM_EXPERIENCE_VARIABLE.text.primary]).toBe("rgb(222 222 230)");
+    expect(light.appearance).toBe("light");
+    expect(light.variables[DOM_EXPERIENCE_VARIABLE.surface.canvas]).toBe("rgb(245 245 247)");
+    expect(light.variables[DOM_EXPERIENCE_VARIABLE.text.primary]).toBe("rgb(32 32 39)");
+    expect(Object.keys(dark.variables).length).toBeGreaterThanOrEqual(80);
+    expect(Object.values(dark.variables).every((value) => value.length > 0)).toBe(true);
+    expect({
+      panel: DOM_EXPERIENCE_VARIABLE.surface.panel,
+      raised: DOM_EXPERIENCE_VARIABLE.surface.panelRaised,
+      focus: DOM_EXPERIENCE_VARIABLE.border.focused,
+      attention: DOM_EXPERIENCE_VARIABLE.border.attention,
+      selected: DOM_EXPERIENCE_VARIABLE.selection.selection,
+      disabled: DOM_EXPERIENCE_VARIABLE.selection.disabled,
+    }).toEqual({
+      panel: "--tmux-ide-surface-panel",
+      raised: "--tmux-ide-surface-panel-raised",
+      focus: "--tmux-ide-border-focused",
+      attention: "--tmux-ide-border-attention",
+      selected: "--tmux-ide-selection-selection",
+      disabled: "--tmux-ide-selection-disabled",
+    });
+  });
+
+  it("applies high contrast and reduced motion before producing host values", () => {
+    const experience = createDomExperience({
+      hostTheme: { mode: "dark", highContrast: true, reducedMotion: true },
+    });
+
+    expect(experience.variables[DOM_EXPERIENCE_VARIABLE.border.focused]).toBe("rgb(255 255 255)");
+    expect(experience.variables[DOM_EXPERIENCE_VARIABLE.border.selected]).toBe("rgb(255 255 255)");
+    expect(experience.variables[DOM_EXPERIENCE_VARIABLE.focus.focusContrast]).toBe("7");
+    expect(experience.variables[DOM_EXPERIENCE_VARIABLE.motion.fast]).toBe("0ms");
+    expect(experience.variables[DOM_EXPERIENCE_VARIABLE.motion.easingStandard]).toBe("linear");
+    expect(experience.variables["--tmux-ide-window-activity-inactive-opacity"]).toBe("1");
+  });
+
+  it("fills missing optional theme tokens from the canonical appearance fallback", () => {
+    const experience = createDomExperience({
+      userTheme: {
+        version: 1,
+        id: "partial-light",
+        name: "Partial light",
+        appearance: "light",
+        overrides: { text: { link: color(12, 34, 56) } },
+      },
+    });
+
+    expect(experience.appearance).toBe("light");
+    expect(experience.variables[DOM_EXPERIENCE_VARIABLE.text.link]).toBe("rgb(12 34 56)");
+    expect(experience.variables[DOM_EXPERIENCE_VARIABLE.surface.panel]).toBe("rgb(255 255 255)");
+    expect(experience.diagnostics).toEqual([]);
+  });
+
+  it("surfaces host/product accessibility disagreement and chooses the safer preference", () => {
+    const experience = createDomExperience({
+      hostTheme: { mode: "dark", highContrast: false, reducedMotion: true },
+      productAccessibility: COHESION_FIXTURE_V1.theme.accessibility,
+      userTheme: COHESION_FIXTURE_V1.theme.user,
+      projectTheme: COHESION_FIXTURE_V1.theme.project ?? undefined,
+    });
+
+    expect(COHESION_FIXTURE_V1.theme.accessibility.reducedMotion).toBe(false);
+    expect(experience.accessibility).toEqual({
+      reducedMotion: true,
+      increasedContrast: false,
+      conflicts: ["reduced-motion"],
+    });
+    expect(experience.variables[DOM_EXPERIENCE_VARIABLE.motion.emphasized]).toBe("0ms");
+  });
+
+  it("provides vector metadata for every canonical semantic icon", () => {
+    expect(Object.keys(createDomExperience().icons)).toEqual([...SEMANTIC_ICON_IDS]);
+    for (const id of SEMANTIC_ICON_IDS) {
+      expect(resolveDomIcon(id)).toMatchObject({
+        id,
+        viewBox: "0 0 16 16",
+        fill: "none",
+        stroke: "currentColor",
+      });
+      expect(resolveDomIcon(id).label.length).toBeGreaterThan(0);
+      expect(resolveDomIcon(id).paths.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/desktop-renderer/src/experience/dom-experience.test.ts
+++ b/apps/desktop-renderer/src/experience/dom-experience.test.ts
@@ -8,6 +8,94 @@ import {
 import { DOM_EXPERIENCE_VARIABLE, createDomExperience } from "./dom-experience.ts";
 import { resolveDomIcon } from "./dom-icons.ts";
 
+const EXPECTED_DOM_EXPERIENCE_VARIABLE_NAMES = [
+  "--tmux-ide-border-attention",
+  "--tmux-ide-border-danger",
+  "--tmux-ide-border-default",
+  "--tmux-ide-border-focused",
+  "--tmux-ide-border-selected",
+  "--tmux-ide-border-subtle",
+  "--tmux-ide-control-disabled-background",
+  "--tmux-ide-control-disabled-foreground",
+  "--tmux-ide-control-disabled-foreground-high-contrast",
+  "--tmux-ide-density-cell-height",
+  "--tmux-ide-density-control-padding",
+  "--tmux-ide-density-header-height",
+  "--tmux-ide-density-inline-gap",
+  "--tmux-ide-density-section-gap",
+  "--tmux-ide-density-status-height",
+  "--tmux-ide-elevation-floating-intent",
+  "--tmux-ide-elevation-floating-level",
+  "--tmux-ide-elevation-floating-shadow",
+  "--tmux-ide-elevation-palette-intent",
+  "--tmux-ide-elevation-palette-level",
+  "--tmux-ide-elevation-palette-shadow",
+  "--tmux-ide-elevation-window-mode-intent",
+  "--tmux-ide-elevation-window-mode-level",
+  "--tmux-ide-elevation-window-mode-shadow",
+  "--tmux-ide-focus-focus-contrast",
+  "--tmux-ide-focus-high-contrast-outline",
+  "--tmux-ide-focus-outline",
+  "--tmux-ide-focus-outline-offset",
+  "--tmux-ide-motion-easing-emphasized",
+  "--tmux-ide-motion-easing-standard",
+  "--tmux-ide-motion-emphasized",
+  "--tmux-ide-motion-fast",
+  "--tmux-ide-motion-instant",
+  "--tmux-ide-motion-standard",
+  "--tmux-ide-selection-disabled",
+  "--tmux-ide-selection-hover",
+  "--tmux-ide-selection-pressed",
+  "--tmux-ide-selection-selection",
+  "--tmux-ide-selection-selection-text",
+  "--tmux-ide-shape-control-radius",
+  "--tmux-ide-shape-docked-radius",
+  "--tmux-ide-shape-floating-radius",
+  "--tmux-ide-shape-status-radius",
+  "--tmux-ide-status-danger",
+  "--tmux-ide-status-info",
+  "--tmux-ide-status-neutral",
+  "--tmux-ide-status-success",
+  "--tmux-ide-status-warning",
+  "--tmux-ide-surface-canvas",
+  "--tmux-ide-surface-command",
+  "--tmux-ide-surface-header",
+  "--tmux-ide-surface-header-active",
+  "--tmux-ide-surface-panel",
+  "--tmux-ide-surface-panel-raised",
+  "--tmux-ide-surface-terminal",
+  "--tmux-ide-text-bright",
+  "--tmux-ide-text-inverse",
+  "--tmux-ide-text-link",
+  "--tmux-ide-text-muted",
+  "--tmux-ide-text-primary",
+  "--tmux-ide-text-secondary",
+  "--tmux-ide-typography-code-family",
+  "--tmux-ide-typography-code-line-height",
+  "--tmux-ide-typography-code-truncation",
+  "--tmux-ide-typography-code-weight",
+  "--tmux-ide-typography-label-family",
+  "--tmux-ide-typography-label-line-height",
+  "--tmux-ide-typography-label-truncation",
+  "--tmux-ide-typography-label-weight",
+  "--tmux-ide-typography-metadata-family",
+  "--tmux-ide-typography-metadata-line-height",
+  "--tmux-ide-typography-metadata-truncation",
+  "--tmux-ide-typography-metadata-weight",
+  "--tmux-ide-typography-title-family",
+  "--tmux-ide-typography-title-line-height",
+  "--tmux-ide-typography-title-truncation",
+  "--tmux-ide-typography-title-weight",
+  "--tmux-ide-typography-workspace-family",
+  "--tmux-ide-typography-workspace-line-height",
+  "--tmux-ide-typography-workspace-truncation",
+  "--tmux-ide-typography-workspace-weight",
+  "--tmux-ide-window-activity-active-contrast",
+  "--tmux-ide-window-activity-active-opacity",
+  "--tmux-ide-window-activity-inactive-contrast",
+  "--tmux-ide-window-activity-inactive-opacity",
+] as const;
+
 function color(red: number, green: number, blue: number): RendererNeutralColor {
   return { space: "srgb", red, green, blue, alpha: 255 };
 }
@@ -23,7 +111,7 @@ describe("DOM experience adapter", () => {
     expect(light.appearance).toBe("light");
     expect(light.variables[DOM_EXPERIENCE_VARIABLE.surface.canvas]).toBe("rgb(245 245 247)");
     expect(light.variables[DOM_EXPERIENCE_VARIABLE.text.primary]).toBe("rgb(32 32 39)");
-    expect(Object.keys(dark.variables).length).toBeGreaterThanOrEqual(80);
+    expect(Object.keys(dark.variables).sort()).toEqual(EXPECTED_DOM_EXPERIENCE_VARIABLE_NAMES);
     expect(Object.values(dark.variables).every((value) => value.length > 0)).toBe(true);
     expect({
       panel: DOM_EXPERIENCE_VARIABLE.surface.panel,
@@ -40,6 +128,28 @@ describe("DOM experience adapter", () => {
       selected: "--tmux-ide-selection-selection",
       disabled: "--tmux-ide-selection-disabled",
     });
+    expect(dark.variables["--tmux-ide-elevation-floating-shadow"]).toBe(
+      "0 18px 38px rgb(14 14 18 / 0.46)",
+    );
+    expect(dark.variables["--tmux-ide-elevation-palette-shadow"]).toBe(
+      "0 10px 18px rgb(14 14 18 / 0.34)",
+    );
+    expect(dark.variables["--tmux-ide-elevation-window-mode-shadow"]).toBe(
+      "0 18px 40px rgb(14 14 18 / 0.5)",
+    );
+    expect(light.variables["--tmux-ide-elevation-floating-shadow"]).toBe(
+      "0 18px 38px rgb(245 245 247 / 0.46)",
+    );
+    expect(dark.variables[DOM_EXPERIENCE_VARIABLE.control.disabledBackground]).toBe(
+      "rgb(19 19 26)",
+    );
+    expect(dark.variables[DOM_EXPERIENCE_VARIABLE.control.disabledForeground]).toBe(
+      "rgb(123 123 138 / 0.55)",
+    );
+    expect(dark.variables[DOM_EXPERIENCE_VARIABLE.control.disabledForegroundHighContrast]).toBe(
+      "rgb(123 123 138)",
+    );
+    expect(dark.variables[DOM_EXPERIENCE_VARIABLE.motion.fast]).toBe("90ms");
   });
 
   it("applies high contrast and reduced motion before producing host values", () => {
@@ -95,11 +205,19 @@ describe("DOM experience adapter", () => {
       expect(resolveDomIcon(id)).toMatchObject({
         id,
         viewBox: "0 0 16 16",
+        size: 12,
+        usage: "action",
+        usageSizes: { pane: 12, tab: 12, rail: 12, action: 12, nativeWindow: 10 },
+        strokeWidth: 1.5,
+        strokeLinecap: "round",
+        strokeLinejoin: "round",
         fill: "none",
         stroke: "currentColor",
       });
       expect(resolveDomIcon(id).label.length).toBeGreaterThan(0);
       expect(resolveDomIcon(id).paths.length).toBeGreaterThan(0);
     }
+    expect(resolveDomIcon("close", "nativeWindow").size).toBe(10);
+    expect(resolveDomIcon("more").paths).toEqual(["M2.75 8h.5M7.75 8h.5M12.75 8h.5"]);
   });
 });

--- a/apps/desktop-renderer/src/experience/dom-experience.ts
+++ b/apps/desktop-renderer/src/experience/dom-experience.ts
@@ -48,6 +48,11 @@ export const DOM_EXPERIENCE_VARIABLE = Object.freeze({
   selection: Object.fromEntries(
     SELECTION_TOKEN_ROLES.map((role) => [role, `--tmux-ide-selection-${toKebabCase(role)}`]),
   ) as Record<(typeof SELECTION_TOKEN_ROLES)[number], `--tmux-ide-selection-${string}`>,
+  control: {
+    disabledBackground: "--tmux-ide-control-disabled-background",
+    disabledForeground: "--tmux-ide-control-disabled-foreground",
+    disabledForegroundHighContrast: "--tmux-ide-control-disabled-foreground-high-contrast",
+  } as const,
   density: Object.fromEntries(
     DENSITY_TOKEN_ROLES.map((role) => [role, `--tmux-ide-density-${toKebabCase(role)}`]),
   ) as Record<(typeof DENSITY_TOKEN_ROLES)[number], `--tmux-ide-density-${string}`>,
@@ -113,6 +118,10 @@ function colorToCss(value: RendererNeutralColor): string {
   return `rgb(${value.red} ${value.green} ${value.blue} / ${formatNumber(value.alpha / 255)})`;
 }
 
+function colorToCssWithAlpha(value: RendererNeutralColor, alpha: number): string {
+  return `rgb(${value.red} ${value.green} ${value.blue} / ${formatNumber(alpha)})`;
+}
+
 function formatNumber(value: number): string {
   return String(Math.round(value * 1_000) / 1_000);
 }
@@ -127,12 +136,23 @@ function easingToCss(value: "linear" | "standard" | "decelerate"): string {
   return "cubic-bezier(0.2, 0, 0, 1)";
 }
 
-function elevationToCss(value: ElevationValue): string {
+const BENCHMARK_ELEVATION = Object.freeze({
+  floating: { y: 18, blur: 38, alpha: 0.46 },
+  palette: { y: 10, blur: 18, alpha: 0.34 },
+  windowMode: { y: 18, blur: 40, alpha: 0.5 },
+} satisfies Record<
+  (typeof ELEVATION_TOKEN_ROLES)[number],
+  { readonly y: number; readonly blur: number; readonly alpha: number }
+>);
+
+function elevationToCss(
+  role: (typeof ELEVATION_TOKEN_ROLES)[number],
+  value: ElevationValue,
+  canvas: RendererNeutralColor,
+): string {
   if (value.level === 0 || value.intent === "flat") return "none";
-  const y = value.level * 4 + 4;
-  const blur = value.level * 12 + 12;
-  const alpha = value.intent === "overlay" ? 0.34 : 0.22;
-  return `0 ${y}px ${blur}px rgb(0 0 0 / ${alpha})`;
+  const benchmark = BENCHMARK_ELEVATION[role];
+  return `0 ${benchmark.y}px ${benchmark.blur}px ${colorToCssWithAlpha(canvas, benchmark.alpha)}`;
 }
 
 function typographyFamily(value: TypographyValue["family"]): string {
@@ -189,6 +209,14 @@ function createVariables(input: ReturnType<typeof resolveVisualTheme>): DomExper
   for (const role of SELECTION_TOKEN_ROLES) {
     variables[DOM_EXPERIENCE_VARIABLE.selection[role]] = colorToCss(tokens.selection[role]);
   }
+  variables[DOM_EXPERIENCE_VARIABLE.control.disabledBackground] = colorToCss(tokens.surfaces.panel);
+  variables[DOM_EXPERIENCE_VARIABLE.control.disabledForeground] = colorToCssWithAlpha(
+    tokens.text.muted,
+    0.55,
+  );
+  variables[DOM_EXPERIENCE_VARIABLE.control.disabledForegroundHighContrast] = colorToCss(
+    tokens.text.muted,
+  );
   for (const role of DENSITY_TOKEN_ROLES) {
     variables[DOM_EXPERIENCE_VARIABLE.density[role]] = rhythmToCss(tokens.density[role].value);
   }
@@ -197,7 +225,11 @@ function createVariables(input: ReturnType<typeof resolveVisualTheme>): DomExper
   }
   for (const role of ELEVATION_TOKEN_ROLES) {
     const name = DOM_EXPERIENCE_VARIABLE.elevation[role];
-    variables[`${name}-shadow`] = elevationToCss(tokens.elevation[role]);
+    variables[`${name}-shadow`] = elevationToCss(
+      role,
+      tokens.elevation[role],
+      tokens.surfaces.canvas,
+    );
     variables[`${name}-level`] = String(tokens.elevation[role].level);
     variables[`${name}-intent`] = tokens.elevation[role].intent;
   }

--- a/apps/desktop-renderer/src/experience/dom-experience.ts
+++ b/apps/desktop-renderer/src/experience/dom-experience.ts
@@ -1,0 +1,255 @@
+import {
+  BORDER_TOKEN_ROLES,
+  DENSITY_TOKEN_ROLES,
+  ELEVATION_TOKEN_ROLES,
+  FOCUS_TOKEN_ROLES,
+  MOTION_DURATION_ROLES,
+  SELECTION_TOKEN_ROLES,
+  SHAPE_TOKEN_ROLES,
+  STATUS_TONE_ROLES,
+  SURFACE_TOKEN_ROLES,
+  TEXT_TOKEN_ROLES,
+  TYPOGRAPHY_TOKEN_ROLES,
+  WINDOW_ACTIVITY_TOKEN_ROLES,
+  resolveVisualTheme,
+  type DesktopThemeState,
+  type ElevationValue,
+  type RendererNeutralColor,
+  type SemanticIconId,
+  type ThemeAccessibilityPreferences,
+  type ThemeAppearance,
+  type ThemeDiagnostic,
+  type TypographyValue,
+} from "@tmux-ide/contracts";
+
+import { DOM_ICON_METADATA, type DomIconMetadata } from "./dom-icons.ts";
+
+const DOM_RHYTHM_PX = 18;
+
+export const DOM_EXPERIENCE_VARIABLE = Object.freeze({
+  surface: {
+    canvas: "--tmux-ide-surface-canvas",
+    panel: "--tmux-ide-surface-panel",
+    panelRaised: "--tmux-ide-surface-panel-raised",
+    terminal: "--tmux-ide-surface-terminal",
+    header: "--tmux-ide-surface-header",
+    headerActive: "--tmux-ide-surface-header-active",
+    command: "--tmux-ide-surface-command",
+  } as const,
+  text: Object.fromEntries(
+    TEXT_TOKEN_ROLES.map((role) => [role, `--tmux-ide-text-${toKebabCase(role)}`]),
+  ) as Record<(typeof TEXT_TOKEN_ROLES)[number], `--tmux-ide-text-${string}`>,
+  border: Object.fromEntries(
+    BORDER_TOKEN_ROLES.map((role) => [role, `--tmux-ide-border-${toKebabCase(role)}`]),
+  ) as Record<(typeof BORDER_TOKEN_ROLES)[number], `--tmux-ide-border-${string}`>,
+  status: Object.fromEntries(
+    STATUS_TONE_ROLES.map((role) => [role, `--tmux-ide-status-${toKebabCase(role)}`]),
+  ) as Record<(typeof STATUS_TONE_ROLES)[number], `--tmux-ide-status-${string}`>,
+  selection: Object.fromEntries(
+    SELECTION_TOKEN_ROLES.map((role) => [role, `--tmux-ide-selection-${toKebabCase(role)}`]),
+  ) as Record<(typeof SELECTION_TOKEN_ROLES)[number], `--tmux-ide-selection-${string}`>,
+  density: Object.fromEntries(
+    DENSITY_TOKEN_ROLES.map((role) => [role, `--tmux-ide-density-${toKebabCase(role)}`]),
+  ) as Record<(typeof DENSITY_TOKEN_ROLES)[number], `--tmux-ide-density-${string}`>,
+  shape: Object.fromEntries(
+    SHAPE_TOKEN_ROLES.map((role) => [role, `--tmux-ide-shape-${toKebabCase(role)}`]),
+  ) as Record<(typeof SHAPE_TOKEN_ROLES)[number], `--tmux-ide-shape-${string}`>,
+  elevation: Object.fromEntries(
+    ELEVATION_TOKEN_ROLES.map((role) => [role, `--tmux-ide-elevation-${toKebabCase(role)}`]),
+  ) as Record<(typeof ELEVATION_TOKEN_ROLES)[number], `--tmux-ide-elevation-${string}`>,
+  motion: {
+    instant: "--tmux-ide-motion-instant",
+    fast: "--tmux-ide-motion-fast",
+    standard: "--tmux-ide-motion-standard",
+    emphasized: "--tmux-ide-motion-emphasized",
+    easingStandard: "--tmux-ide-motion-easing-standard",
+    easingEmphasized: "--tmux-ide-motion-easing-emphasized",
+  } as const,
+  typography: Object.fromEntries(
+    TYPOGRAPHY_TOKEN_ROLES.map((role) => [role, `--tmux-ide-typography-${toKebabCase(role)}`]),
+  ) as Record<(typeof TYPOGRAPHY_TOKEN_ROLES)[number], `--tmux-ide-typography-${string}`>,
+  focus: Object.fromEntries(
+    FOCUS_TOKEN_ROLES.map((role) => [role, `--tmux-ide-focus-${toKebabCase(role)}`]),
+  ) as Record<(typeof FOCUS_TOKEN_ROLES)[number], `--tmux-ide-focus-${string}`>,
+  windowActivity: Object.fromEntries(
+    WINDOW_ACTIVITY_TOKEN_ROLES.map((role) => [
+      role,
+      `--tmux-ide-window-activity-${toKebabCase(role)}`,
+    ]),
+  ) as Record<(typeof WINDOW_ACTIVITY_TOKEN_ROLES)[number], `--tmux-ide-window-activity-${string}`>,
+});
+
+export type DomExperienceVariableName = `--tmux-ide-${string}`;
+export type DomExperienceVariables = Record<DomExperienceVariableName, string>;
+export type AccessibilityPreferenceConflict = "reduced-motion" | "increased-contrast";
+
+export interface DomExperienceAccessibility {
+  readonly reducedMotion: boolean;
+  readonly increasedContrast: boolean;
+  readonly conflicts: readonly AccessibilityPreferenceConflict[];
+}
+
+export interface DomExperienceInput {
+  readonly hostTheme?: Partial<DesktopThemeState> | null;
+  readonly productAccessibility?: Partial<ThemeAccessibilityPreferences> | null;
+  readonly userTheme?: unknown;
+  readonly projectTheme?: unknown;
+}
+
+export interface DomExperience {
+  readonly appearance: ThemeAppearance;
+  readonly accessibility: DomExperienceAccessibility;
+  readonly variables: DomExperienceVariables;
+  readonly icons: Readonly<Record<SemanticIconId, DomIconMetadata>>;
+  readonly diagnostics: readonly ThemeDiagnostic[];
+}
+
+function toKebabCase(value: string): string {
+  return value.replace(/[A-Z]/gu, (character) => `-${character.toLowerCase()}`);
+}
+
+function colorToCss(value: RendererNeutralColor): string {
+  if (value.alpha === 255) return `rgb(${value.red} ${value.green} ${value.blue})`;
+  return `rgb(${value.red} ${value.green} ${value.blue} / ${formatNumber(value.alpha / 255)})`;
+}
+
+function formatNumber(value: number): string {
+  return String(Math.round(value * 1_000) / 1_000);
+}
+
+function rhythmToCss(value: number): string {
+  return `${formatNumber(value * DOM_RHYTHM_PX)}px`;
+}
+
+function easingToCss(value: "linear" | "standard" | "decelerate"): string {
+  if (value === "linear") return "linear";
+  if (value === "decelerate") return "cubic-bezier(0, 0, 0.2, 1)";
+  return "cubic-bezier(0.2, 0, 0, 1)";
+}
+
+function elevationToCss(value: ElevationValue): string {
+  if (value.level === 0 || value.intent === "flat") return "none";
+  const y = value.level * 4 + 4;
+  const blur = value.level * 12 + 12;
+  const alpha = value.intent === "overlay" ? 0.34 : 0.22;
+  return `0 ${y}px ${blur}px rgb(0 0 0 / ${alpha})`;
+}
+
+function typographyFamily(value: TypographyValue["family"]): string {
+  return value === "monospace"
+    ? 'ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, monospace'
+    : 'Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+}
+
+function typographyWeight(value: TypographyValue["weight"]): string {
+  return String({ regular: 400, medium: 500, semibold: 600, bold: 700 }[value]);
+}
+
+function reconcileAccessibility(
+  host: Partial<DesktopThemeState> | null | undefined,
+  product: Partial<ThemeAccessibilityPreferences> | null | undefined,
+): DomExperienceAccessibility {
+  const conflicts: AccessibilityPreferenceConflict[] = [];
+  if (
+    host?.reducedMotion !== undefined &&
+    product?.reducedMotion !== undefined &&
+    host.reducedMotion !== product.reducedMotion
+  ) {
+    conflicts.push("reduced-motion");
+  }
+  if (
+    host?.highContrast !== undefined &&
+    product?.increasedContrast !== undefined &&
+    host.highContrast !== product.increasedContrast
+  ) {
+    conflicts.push("increased-contrast");
+  }
+  return Object.freeze({
+    reducedMotion: Boolean(host?.reducedMotion || product?.reducedMotion),
+    increasedContrast: Boolean(host?.highContrast || product?.increasedContrast),
+    conflicts: Object.freeze(conflicts),
+  });
+}
+
+function createVariables(input: ReturnType<typeof resolveVisualTheme>): DomExperienceVariables {
+  const variables = {} as DomExperienceVariables;
+  const { tokens } = input;
+  for (const role of SURFACE_TOKEN_ROLES) {
+    variables[DOM_EXPERIENCE_VARIABLE.surface[role]] = colorToCss(tokens.surfaces[role]);
+  }
+  for (const role of TEXT_TOKEN_ROLES) {
+    variables[DOM_EXPERIENCE_VARIABLE.text[role]] = colorToCss(tokens.text[role]);
+  }
+  for (const role of BORDER_TOKEN_ROLES) {
+    variables[DOM_EXPERIENCE_VARIABLE.border[role]] = colorToCss(tokens.borders[role]);
+  }
+  for (const role of STATUS_TONE_ROLES) {
+    variables[DOM_EXPERIENCE_VARIABLE.status[role]] = colorToCss(tokens.statusTone[role]);
+  }
+  for (const role of SELECTION_TOKEN_ROLES) {
+    variables[DOM_EXPERIENCE_VARIABLE.selection[role]] = colorToCss(tokens.selection[role]);
+  }
+  for (const role of DENSITY_TOKEN_ROLES) {
+    variables[DOM_EXPERIENCE_VARIABLE.density[role]] = rhythmToCss(tokens.density[role].value);
+  }
+  for (const role of SHAPE_TOKEN_ROLES) {
+    variables[DOM_EXPERIENCE_VARIABLE.shape[role]] = rhythmToCss(tokens.shape[role].value);
+  }
+  for (const role of ELEVATION_TOKEN_ROLES) {
+    const name = DOM_EXPERIENCE_VARIABLE.elevation[role];
+    variables[`${name}-shadow`] = elevationToCss(tokens.elevation[role]);
+    variables[`${name}-level`] = String(tokens.elevation[role].level);
+    variables[`${name}-intent`] = tokens.elevation[role].intent;
+  }
+  for (const role of MOTION_DURATION_ROLES) {
+    variables[DOM_EXPERIENCE_VARIABLE.motion[role]] = `${tokens.motion[role].value}ms`;
+  }
+  variables[DOM_EXPERIENCE_VARIABLE.motion.easingStandard] = easingToCss(
+    tokens.motion.easing.standard,
+  );
+  variables[DOM_EXPERIENCE_VARIABLE.motion.easingEmphasized] = easingToCss(
+    tokens.motion.easing.emphasized,
+  );
+  for (const role of TYPOGRAPHY_TOKEN_ROLES) {
+    const name = DOM_EXPERIENCE_VARIABLE.typography[role];
+    const typography = tokens.typography[role];
+    variables[`${name}-family`] = typographyFamily(typography.family);
+    variables[`${name}-weight`] = typographyWeight(typography.weight);
+    variables[`${name}-line-height`] = formatNumber(typography.lineHeight.value);
+    variables[`${name}-truncation`] = typography.truncation;
+  }
+  variables[DOM_EXPERIENCE_VARIABLE.focus.outline] = rhythmToCss(tokens.focus.outline.value);
+  variables[DOM_EXPERIENCE_VARIABLE.focus.outlineOffset] = rhythmToCss(
+    tokens.focus.outlineOffset.value,
+  );
+  variables[DOM_EXPERIENCE_VARIABLE.focus.focusContrast] = formatNumber(
+    tokens.focus.focusContrast.value,
+  );
+  variables[DOM_EXPERIENCE_VARIABLE.focus.highContrastOutline] = colorToCss(
+    tokens.focus.highContrastOutline,
+  );
+  for (const role of WINDOW_ACTIVITY_TOKEN_ROLES) {
+    const name = DOM_EXPERIENCE_VARIABLE.windowActivity[role];
+    variables[`${name}-opacity`] = formatNumber(tokens.windowActivity[role].opacity.value);
+    variables[`${name}-contrast`] = formatNumber(tokens.windowActivity[role].contrast.value);
+  }
+  return Object.freeze(variables);
+}
+
+/** Browser-safe projection of canonical experience contracts into DOM host primitives. */
+export function createDomExperience(input: DomExperienceInput = {}): DomExperience {
+  const accessibility = reconcileAccessibility(input.hostTheme, input.productAccessibility);
+  const resolved = resolveVisualTheme({
+    appearance: input.hostTheme?.mode,
+    userTheme: input.userTheme,
+    projectTheme: input.projectTheme,
+    accessibility,
+  });
+  return Object.freeze({
+    appearance: resolved.appearance,
+    accessibility,
+    variables: createVariables(resolved),
+    icons: DOM_ICON_METADATA,
+    diagnostics: resolved.diagnostics,
+  });
+}

--- a/apps/desktop-renderer/src/experience/dom-icons.ts
+++ b/apps/desktop-renderer/src/experience/dom-icons.ts
@@ -1,14 +1,33 @@
 import { SEMANTIC_ICON_IDS, type SemanticIconId } from "@tmux-ide/contracts";
 
+export const DOM_ICON_USAGE_SIZES = Object.freeze({
+  pane: 12,
+  tab: 12,
+  rail: 12,
+  action: 12,
+  nativeWindow: 10,
+} as const);
+
+export type DomIconUsage = keyof typeof DOM_ICON_USAGE_SIZES;
+export type DomIconSize = (typeof DOM_ICON_USAGE_SIZES)[DomIconUsage];
+
 export interface DomIconMetadata {
   readonly id: SemanticIconId;
   readonly label: string;
   readonly viewBox: "0 0 16 16";
-  readonly size: 16;
+  readonly size: 12;
+  readonly usageSizes: Readonly<Record<DomIconUsage, DomIconSize>>;
   readonly strokeWidth: 1.5;
+  readonly strokeLinecap: "round";
+  readonly strokeLinejoin: "round";
   readonly fill: "none";
   readonly stroke: "currentColor";
   readonly paths: readonly string[];
+}
+
+export interface ResolvedDomIconMetadata extends Omit<DomIconMetadata, "size"> {
+  readonly usage: DomIconUsage;
+  readonly size: DomIconSize;
 }
 
 type DomIconSpec = Pick<DomIconMetadata, "label" | "paths">;
@@ -46,7 +65,7 @@ const ICON_SPECS = {
     label: "Native window",
     paths: ["M2 3h12v10H2Z", "M2 5.5h12", "M4 4.25h.01", "M5.5 4.25h.01"],
   },
-  more: { label: "More", paths: ["M3 8h.01M8 8h.01M13 8h.01"] },
+  more: { label: "More", paths: ["M2.75 8h.5M7.75 8h.5M12.75 8h.5"] },
   close: { label: "Close", paths: ["m3.5 3.5 9 9", "m12.5 3.5-9 9"] },
   minimize: { label: "Minimize", paths: ["M3 11.5h10"] },
   maximize: { label: "Maximize", paths: ["M3 3h10v10H3Z"] },
@@ -118,8 +137,11 @@ export const DOM_ICON_METADATA: Readonly<Record<SemanticIconId, DomIconMetadata>
           id,
           label: spec.label,
           viewBox: "0 0 16 16" as const,
-          size: 16 as const,
+          size: 12 as const,
+          usageSizes: DOM_ICON_USAGE_SIZES,
           strokeWidth: 1.5 as const,
+          strokeLinecap: "round" as const,
+          strokeLinejoin: "round" as const,
           fill: "none" as const,
           stroke: "currentColor" as const,
           paths: Object.freeze([...spec.paths]),
@@ -129,6 +151,10 @@ export const DOM_ICON_METADATA: Readonly<Record<SemanticIconId, DomIconMetadata>
   ) as Record<SemanticIconId, DomIconMetadata>,
 );
 
-export function resolveDomIcon(id: SemanticIconId): DomIconMetadata {
-  return DOM_ICON_METADATA[id];
+export function resolveDomIcon(
+  id: SemanticIconId,
+  usage: DomIconUsage = "action",
+): ResolvedDomIconMetadata {
+  const metadata = DOM_ICON_METADATA[id];
+  return Object.freeze({ ...metadata, usage, size: metadata.usageSizes[usage] });
 }

--- a/apps/desktop-renderer/src/experience/dom-icons.ts
+++ b/apps/desktop-renderer/src/experience/dom-icons.ts
@@ -1,0 +1,134 @@
+import { SEMANTIC_ICON_IDS, type SemanticIconId } from "@tmux-ide/contracts";
+
+export interface DomIconMetadata {
+  readonly id: SemanticIconId;
+  readonly label: string;
+  readonly viewBox: "0 0 16 16";
+  readonly size: 16;
+  readonly strokeWidth: 1.5;
+  readonly fill: "none";
+  readonly stroke: "currentColor";
+  readonly paths: readonly string[];
+}
+
+type DomIconSpec = Pick<DomIconMetadata, "label" | "paths">;
+
+const ICON_SPECS = {
+  home: { label: "Home", paths: ["M2.5 7 8 2.5 13.5 7v6.5h-4v-4h-3v4h-4Z"] },
+  terminals: {
+    label: "Terminals",
+    paths: ["M2 3.25h12v9.5H2Z", "m4.25 6 2 2-2 2", "M8.25 10.25h3.5"],
+  },
+  files: {
+    label: "Files",
+    paths: ["M2.5 3.25h4l1.25 1.5h5.75v8H2.5Z"],
+  },
+  changes: {
+    label: "Changes",
+    paths: ["M5 2.5v11", "m3-8 2-2 2 2", "m4 6 2 2-2 2", "M10 4.5v3", "M6 8.5v3"],
+  },
+  missions: {
+    label: "Missions",
+    paths: ["M8 2.25 13.75 8 8 13.75 2.25 8Z", "M8 5.5v5", "M5.5 8h5"],
+  },
+  activity: {
+    label: "Activity",
+    paths: ["M1.75 8h2.5l1.5-4 3 8 1.5-4h4"],
+  },
+  preview: {
+    label: "Preview",
+    paths: [
+      "M1.5 8s2.25-3.75 6.5-3.75S14.5 8 14.5 8 12.25 11.75 8 11.75 1.5 8 1.5 8Z",
+      "M8 6.25a1.75 1.75 0 1 1 0 3.5 1.75 1.75 0 0 1 0-3.5Z",
+    ],
+  },
+  native: {
+    label: "Native window",
+    paths: ["M2 3h12v10H2Z", "M2 5.5h12", "M4 4.25h.01", "M5.5 4.25h.01"],
+  },
+  more: { label: "More", paths: ["M3 8h.01M8 8h.01M13 8h.01"] },
+  close: { label: "Close", paths: ["m3.5 3.5 9 9", "m12.5 3.5-9 9"] },
+  minimize: { label: "Minimize", paths: ["M3 11.5h10"] },
+  maximize: { label: "Maximize", paths: ["M3 3h10v10H3Z"] },
+  restore: {
+    label: "Restore",
+    paths: ["M5 3h8v8h-2", "M3 5h8v8H3Z"],
+  },
+  "split-right": {
+    label: "Split right",
+    paths: ["M2.5 3h11v10h-11Z", "M8 3v10", "m10.5 6 2 2-2 2"],
+  },
+  "split-down": {
+    label: "Split down",
+    paths: ["M2.5 3h11v10h-11Z", "M2.5 8h11", "m6 10.5 2 2 2-2"],
+  },
+  duplicate: {
+    label: "Duplicate",
+    paths: ["M5 5h8v8H5Z", "M3 11H2.5V3H10v.5"],
+  },
+  dock: {
+    label: "Dock",
+    paths: ["M2.5 3h11v10h-11Z", "M2.5 9.5h11", "m6 5.5 2 2 2-2"],
+  },
+  float: {
+    label: "Float",
+    paths: ["M4.5 5h8v7.5h-8Z", "M2.5 10V3.5H10", "m9 3.5 3.5 0V7"],
+  },
+  move: {
+    label: "Move",
+    paths: [
+      "M8 1.75v12.5M1.75 8h12.5",
+      "m5.75 4.25 2.25-2.5 2.25 2.5",
+      "m5.75 11.75 2.25 2.5 2.25-2.5",
+      "m4.25 5.75-2.5 2.25 2.5 2.25",
+      "m11.75 5.75 2.5 2.25-2.5 2.25",
+    ],
+  },
+  resize: {
+    label: "Resize",
+    paths: ["M3 6V3h3", "M10 3h3v3", "M13 10v3h-3", "M6 13H3v-3"],
+  },
+  "pop-out": {
+    label: "Pop out",
+    paths: ["M7 3H3v10h10V9", "M9 3h4v4", "m7 9 6-6"],
+  },
+  search: {
+    label: "Search",
+    paths: ["M7 2.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z", "m10.5 10.5 3 3"],
+  },
+  refresh: {
+    label: "Refresh",
+    paths: ["M13 5.5V2.75l-1.5 1.5A5.25 5.25 0 1 0 13 10", "M13 2.75h-2.75"],
+  },
+  command: {
+    label: "Command palette",
+    paths: [
+      "M5 5.25A2.25 2.25 0 1 1 2.75 3 2.25 2.25 0 0 1 5 5.25v5.5A2.25 2.25 0 1 1 2.75 13 2.25 2.25 0 0 1 5 10.75h6A2.25 2.25 0 1 1 13.25 13 2.25 2.25 0 0 1 11 10.75v-5.5A2.25 2.25 0 1 1 13.25 3 2.25 2.25 0 0 1 11 5.25Z",
+    ],
+  },
+} satisfies Record<SemanticIconId, DomIconSpec>;
+
+export const DOM_ICON_METADATA: Readonly<Record<SemanticIconId, DomIconMetadata>> = Object.freeze(
+  Object.fromEntries(
+    SEMANTIC_ICON_IDS.map((id) => {
+      const spec = ICON_SPECS[id];
+      return [
+        id,
+        Object.freeze({
+          id,
+          label: spec.label,
+          viewBox: "0 0 16 16" as const,
+          size: 16 as const,
+          strokeWidth: 1.5 as const,
+          fill: "none" as const,
+          stroke: "currentColor" as const,
+          paths: Object.freeze([...spec.paths]),
+        }),
+      ];
+    }),
+  ) as Record<SemanticIconId, DomIconMetadata>,
+);
+
+export function resolveDomIcon(id: SemanticIconId): DomIconMetadata {
+  return DOM_ICON_METADATA[id];
+}

--- a/apps/desktop-renderer/src/experience/index.ts
+++ b/apps/desktop-renderer/src/experience/index.ts
@@ -1,0 +1,2 @@
+export * from "./dom-experience.ts";
+export * from "./dom-icons.ts";

--- a/apps/desktop-renderer/src/host-capabilities.ts
+++ b/apps/desktop-renderer/src/host-capabilities.ts
@@ -31,6 +31,20 @@ function browserTheme(): DesktopThemeState {
   };
 }
 
+const FALLBACK_INITIAL_THEME: DesktopThemeState = Object.freeze({
+  mode: "dark",
+  highContrast: false,
+  reducedMotion: false,
+});
+
+/** Synchronous paint seed; async host bootstrap remains the authoritative state. */
+export function readInitialThemeState(): DesktopThemeState {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return FALLBACK_INITIAL_THEME;
+  }
+  return browserTheme();
+}
+
 function browserWindowState(): DesktopWindowState {
   return {
     maximized: false,
@@ -110,7 +124,9 @@ function hasNarrowFacade(value: unknown): value is HostCapabilities {
   );
 }
 
-export function resolveHostCapabilities(candidate: unknown = window.tmuxIdeHost): HostCapabilities {
+export function resolveHostCapabilities(
+  candidate: unknown = typeof window === "undefined" ? undefined : window.tmuxIdeHost,
+): HostCapabilities {
   return hasNarrowFacade(candidate) ? candidate : createBrowserHostCapabilities();
 }
 

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -6,8 +6,8 @@
     BlinkMacSystemFont,
     "Segoe UI",
     sans-serif;
-  color: #e8e9f2;
-  background: #0d0e14;
+  color: CanvasText;
+  background: Canvas;
   font-synthesis: none;
   text-rendering: geometricPrecision;
 }
@@ -30,25 +30,23 @@ button {
 }
 
 .app {
-  --surface: #11121a;
-  --surface-raised: #171923;
-  --border: #282a37;
-  --muted: #8a8d9e;
-  --accent: #62b7bf;
-  --accent-soft: #1b353a;
   display: grid;
   grid-template-rows: 42px 1fr 30px;
   width: 100%;
   height: 100%;
-  color: #e8e9f2;
-  background: radial-gradient(circle at 45% -15%, #1c2730 0, #0d0e14 36%);
+  color: var(--tmux-ide-text-primary);
+  background: radial-gradient(
+    circle at 45% -15%,
+    color-mix(in srgb, var(--tmux-ide-surface-header-active) 62%, var(--tmux-ide-surface-canvas)) 0,
+    var(--tmux-ide-surface-canvas) 36%
+  );
 }
 
 .titlebar {
   display: flex;
   align-items: stretch;
-  border-bottom: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  border-bottom: 1px solid var(--tmux-ide-border-subtle);
+  background: color-mix(in srgb, var(--tmux-ide-surface-header) 92%, transparent);
   user-select: none;
 }
 .titlebar__drag {
@@ -61,11 +59,11 @@ button {
   letter-spacing: -0.01em;
 }
 .brand-mark {
-  color: var(--accent);
+  color: var(--tmux-ide-text-link);
   font-size: 17px;
 }
 .titlebar__context {
-  color: var(--muted);
+  color: var(--tmux-ide-text-muted);
   font-size: 12px;
   font-weight: 500;
 }
@@ -76,16 +74,20 @@ button {
 .window-controls button {
   width: 46px;
   border: 0;
-  color: #b8bac7;
+  color: var(--tmux-ide-text-secondary);
   background: transparent;
   cursor: default;
+  transition:
+    color var(--tmux-ide-motion-fast) var(--tmux-ide-motion-easing-standard),
+    background-color var(--tmux-ide-motion-fast) var(--tmux-ide-motion-easing-standard);
 }
 .window-controls button:hover {
-  color: white;
-  background: #272936;
+  color: var(--tmux-ide-text-bright);
+  background: var(--tmux-ide-selection-hover);
 }
 .window-controls button:last-child:hover {
-  background: #c8424e;
+  color: var(--tmux-ide-text-bright);
+  background: var(--tmux-ide-status-danger);
 }
 
 .workbench {
@@ -95,11 +97,11 @@ button {
 }
 .rail,
 .inspector {
-  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  background: color-mix(in srgb, var(--tmux-ide-surface-panel) 88%, transparent);
 }
 .rail {
   padding: 14px 10px;
-  border-right: 1px solid var(--border);
+  border-right: 1px solid var(--tmux-ide-border-subtle);
 }
 .rail__item {
   display: flex;
@@ -110,21 +112,21 @@ button {
   padding: 9px 10px;
   border: 0;
   border-radius: 7px;
-  color: var(--muted);
+  color: var(--tmux-ide-text-muted);
   background: transparent;
   text-align: left;
 }
 .rail__item span {
   width: 18px;
-  color: #6f7282;
+  color: var(--tmux-ide-status-neutral);
   text-align: center;
 }
 .rail__item--active {
-  color: #f4f5fa;
-  background: #232531;
+  color: var(--tmux-ide-text-bright);
+  background: var(--tmux-ide-selection-hover);
 }
 .rail__item--active span {
-  color: var(--accent);
+  color: var(--tmux-ide-text-link);
 }
 
 .canvas {
@@ -133,7 +135,7 @@ button {
 }
 .canvas__eyebrow {
   margin-bottom: 12px;
-  color: var(--accent);
+  color: var(--tmux-ide-text-link);
   font:
     600 11px/1.2 ui-monospace,
     SFMono-Regular,
@@ -152,7 +154,7 @@ h1 {
 .canvas__lead {
   max-width: 660px;
   margin: 26px 0 38px;
-  color: #a3a6b4;
+  color: var(--tmux-ide-text-secondary);
   font-size: 16px;
   line-height: 1.65;
 }
@@ -167,14 +169,18 @@ h1 {
   min-height: 210px;
   padding: 24px;
   overflow: hidden;
-  border: 1px solid var(--border);
+  border: 1px solid var(--tmux-ide-border-subtle);
   border-radius: 12px;
-  background: linear-gradient(145deg, #181a24, #12131b);
-  box-shadow: 0 20px 60px #0005;
+  background: linear-gradient(
+    145deg,
+    var(--tmux-ide-surface-panel-raised),
+    var(--tmux-ide-surface-panel)
+  );
+  box-shadow: var(--tmux-ide-elevation-floating-shadow);
 }
 .card__icon {
   margin-bottom: 30px;
-  color: var(--accent);
+  color: var(--tmux-ide-text-link);
   font:
     600 12px ui-monospace,
     monospace;
@@ -185,21 +191,21 @@ h1 {
 }
 .card p {
   margin: 0 0 22px;
-  color: var(--muted);
+  color: var(--tmux-ide-text-muted);
   font-size: 13px;
   line-height: 1.55;
 }
 .primary-action {
   padding: 9px 13px;
-  border: 1px solid #39737a;
+  border: 1px solid var(--tmux-ide-border-focused);
   border-radius: 7px;
-  color: #dff8fa;
-  background: var(--accent-soft);
+  color: var(--tmux-ide-selection-selection-text);
+  background: var(--tmux-ide-selection-selection);
 }
 .card--terminal {
   display: flex;
   align-items: center;
-  background: #0b0d12;
+  background: var(--tmux-ide-surface-terminal);
 }
 .terminal-dots {
   position: absolute;
@@ -212,11 +218,11 @@ h1 {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #343743;
+  background: var(--tmux-ide-border-default);
 }
 .card pre {
   margin: 0;
-  color: #c5c8d4;
+  color: var(--tmux-ide-text-secondary);
   font:
     13px/1.8 ui-monospace,
     SFMono-Regular,
@@ -224,16 +230,16 @@ h1 {
     monospace;
 }
 .card pre span {
-  color: var(--accent);
+  color: var(--tmux-ide-text-link);
 }
 .card pre b {
-  color: #747889;
+  color: var(--tmux-ide-text-muted);
   font-weight: 400;
 }
 
 .inspector {
   padding: 18px;
-  border-left: 1px solid var(--border);
+  border-left: 1px solid var(--tmux-ide-border-subtle);
 }
 .inspector h2 {
   margin: 4px 0 20px;
@@ -249,31 +255,31 @@ h1 {
   justify-content: space-between;
   gap: 10px;
   padding: 9px 0;
-  border-bottom: 1px solid #232531;
+  border-bottom: 1px solid var(--tmux-ide-border-subtle);
   font-size: 12px;
 }
 .inspector dt {
-  color: var(--muted);
+  color: var(--tmux-ide-text-muted);
 }
 .inspector dd {
   margin: 0;
-  color: #d3d5de;
+  color: var(--tmux-ide-text-primary);
   text-align: right;
 }
 .boundary-note {
   margin-top: 22px;
   padding: 12px;
-  border: 1px solid #254449;
+  border: 1px solid var(--tmux-ide-status-info);
   border-radius: 8px;
-  color: #8caeb1;
-  background: #142328;
+  color: var(--tmux-ide-text-secondary);
+  background: color-mix(in srgb, var(--tmux-ide-surface-panel) 80%, var(--tmux-ide-status-info));
   font-size: 11px;
   line-height: 1.5;
 }
 .boundary-note span {
   display: block;
   margin-bottom: 4px;
-  color: #b9e6e9;
+  color: var(--tmux-ide-text-link);
   font-weight: 700;
   text-transform: uppercase;
 }
@@ -283,9 +289,9 @@ h1 {
   align-items: center;
   justify-content: space-between;
   padding: 0 10px;
-  border-top: 1px solid var(--border);
-  color: #777a89;
-  background: #101119;
+  border-top: 1px solid var(--tmux-ide-border-subtle);
+  color: var(--tmux-ide-text-muted);
+  background: var(--tmux-ide-surface-header);
   font:
     11px ui-monospace,
     SFMono-Regular,
@@ -298,8 +304,8 @@ h1 {
   height: 6px;
   margin-right: 6px;
   border-radius: 50%;
-  background: #65bd86;
-  box-shadow: 0 0 8px #65bd8688;
+  background: var(--tmux-ide-status-success);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--tmux-ide-status-success) 54%, transparent);
 }
 
 @media (max-width: 980px) {
@@ -332,4 +338,12 @@ h1 {
     transition: none !important;
     animation: none !important;
   }
+}
+
+.app[data-reduced-motion="true"] *,
+.app[data-reduced-motion="true"] *::before,
+.app[data-reduced-motion="true"] *::after {
+  scroll-behavior: auto !important;
+  transition: none !important;
+  animation: none !important;
 }

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -78,8 +78,8 @@ button {
   background: transparent;
   cursor: default;
   transition:
-    color var(--tmux-ide-motion-fast) var(--tmux-ide-motion-easing-standard),
-    background-color var(--tmux-ide-motion-fast) var(--tmux-ide-motion-easing-standard);
+    color var(--tmux-ide-motion-fast) linear,
+    background-color var(--tmux-ide-motion-fast) linear;
 }
 .window-controls button:hover {
   color: var(--tmux-ide-text-bright);

--- a/apps/desktop-renderer/vitest.config.ts
+++ b/apps/desktop-renderer/vitest.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from "vitest/config";
+import solid from "vite-plugin-solid";
 
 export default defineConfig({
+  plugins: [solid()],
   test: {
+    css: true,
     environment: "node",
   },
 });

--- a/packages/daemon/src/ui/workbench-dock/web-host.css
+++ b/packages/daemon/src/ui/workbench-dock/web-host.css
@@ -89,9 +89,18 @@
 
 .workbench-dock__tab:disabled {
   cursor: not-allowed;
-  color: var(--dock-muted);
-  background: var(--tmux-ide-selection-disabled);
-  opacity: var(--tmux-ide-window-activity-inactive-opacity);
+  color: var(--tmux-ide-control-disabled-foreground);
+  background: var(--tmux-ide-control-disabled-background);
+  opacity: 1;
+}
+
+.workbench-dock__tab:disabled .workbench-dock__shortcut,
+.workbench-dock__tab:disabled .workbench-dock__attention {
+  color: inherit;
+}
+
+[data-increased-contrast="true"] .workbench-dock__tab:disabled {
+  color: var(--tmux-ide-control-disabled-foreground-high-contrast);
 }
 
 .workbench-dock__shortcut {

--- a/packages/daemon/src/ui/workbench-dock/web-host.css
+++ b/packages/daemon/src/ui/workbench-dock/web-host.css
@@ -1,12 +1,12 @@
 .workbench-dock {
-  --dock-bg: #111219;
-  --dock-raised: #191b25;
-  --dock-border: #303443;
-  --dock-fg: #e8eaf0;
-  --dock-muted: #8d93a5;
-  --dock-accent: #77a8ff;
-  --dock-selection: #243b61;
-  --dock-hover: #222633;
+  --dock-bg: var(--tmux-ide-surface-panel);
+  --dock-raised: var(--tmux-ide-surface-panel-raised);
+  --dock-border: var(--tmux-ide-border-subtle);
+  --dock-fg: var(--tmux-ide-text-primary);
+  --dock-muted: var(--tmux-ide-text-muted);
+  --dock-accent: var(--tmux-ide-border-focused);
+  --dock-selection: var(--tmux-ide-selection-selection);
+  --dock-hover: var(--tmux-ide-selection-hover);
   display: flex;
   min-width: 0;
   min-height: 0;
@@ -78,17 +78,20 @@
 }
 
 .workbench-dock__tab:focus-visible,
+.workbench-dock__tab[data-focused="true"],
 .workbench-dock__action:focus-visible,
 .workbench-dock__body:focus-visible {
   position: relative;
   z-index: 1;
-  outline: 2px solid var(--dock-accent);
-  outline-offset: -2px;
+  outline: var(--tmux-ide-focus-outline) solid var(--dock-accent);
+  outline-offset: calc(-1 * var(--tmux-ide-focus-outline-offset));
 }
 
 .workbench-dock__tab:disabled {
   cursor: not-allowed;
-  opacity: 0.42;
+  color: var(--dock-muted);
+  background: var(--tmux-ide-selection-disabled);
+  opacity: var(--tmux-ide-window-activity-inactive-opacity);
 }
 
 .workbench-dock__shortcut {
@@ -98,7 +101,7 @@
 
 .workbench-dock__attention {
   min-width: 0.55em;
-  color: #efbd56;
+  color: var(--tmux-ide-border-attention);
   font-size: 0.65em;
 }
 

--- a/packages/daemon/src/ui/workbench-dock/web-host.test.tsx
+++ b/packages/daemon/src/ui/workbench-dock/web-host.test.tsx
@@ -1,7 +1,12 @@
 /* @vitest-environment happy-dom */
 import { afterEach, describe, expect, it } from "vitest";
 import { render } from "solid-js/web";
-import { COHESION_FIXTURE_V1, resolveVisualTheme } from "@tmux-ide/contracts";
+import { COHESION_FIXTURE_V1 } from "@tmux-ide/contracts";
+import {
+  DOM_EXPERIENCE_VARIABLE,
+  createDomExperience,
+  type DomExperienceInput,
+} from "../../../../../apps/desktop-renderer/src/experience/dom-experience.ts";
 import {
   createWorkbenchDockHostFixture,
   createWorkbenchDockHostTrace,
@@ -12,42 +17,21 @@ import { WebWorkbenchDock } from "./web-host.tsx";
 
 const disposers: Array<() => void> = [];
 
-function colorToCss(value: { red: number; green: number; blue: number }): string {
-  return `rgb(${value.red} ${value.green} ${value.blue})`;
-}
-
 function installCanonicalFixtureVariables(
   root: HTMLElement,
-): ReturnType<typeof resolveVisualTheme> {
-  const theme = resolveVisualTheme({
+  overrides: DomExperienceInput = {},
+): ReturnType<typeof createDomExperience> {
+  const experience = createDomExperience({
     userTheme: COHESION_FIXTURE_V1.theme.user,
     projectTheme: COHESION_FIXTURE_V1.theme.project ?? undefined,
-    accessibility: COHESION_FIXTURE_V1.theme.accessibility,
+    productAccessibility: COHESION_FIXTURE_V1.theme.accessibility,
+    ...overrides,
   });
-  const { tokens } = theme;
-  root.style.setProperty("--tmux-ide-surface-panel", colorToCss(tokens.surfaces.panel));
-  root.style.setProperty(
-    "--tmux-ide-surface-panel-raised",
-    colorToCss(tokens.surfaces.panelRaised),
-  );
-  root.style.setProperty("--tmux-ide-border-subtle", colorToCss(tokens.borders.subtle));
-  root.style.setProperty("--tmux-ide-border-focused", colorToCss(tokens.borders.focused));
-  root.style.setProperty("--tmux-ide-border-attention", colorToCss(tokens.borders.attention));
-  root.style.setProperty("--tmux-ide-text-primary", colorToCss(tokens.text.primary));
-  root.style.setProperty("--tmux-ide-text-muted", colorToCss(tokens.text.muted));
-  root.style.setProperty("--tmux-ide-selection-selection", colorToCss(tokens.selection.selection));
-  root.style.setProperty("--tmux-ide-selection-hover", colorToCss(tokens.selection.hover));
-  root.style.setProperty("--tmux-ide-selection-disabled", colorToCss(tokens.selection.disabled));
-  root.style.setProperty("--tmux-ide-focus-outline", `${tokens.focus.outline.value * 18}px`);
-  root.style.setProperty(
-    "--tmux-ide-focus-outline-offset",
-    `${tokens.focus.outlineOffset.value * 18}px`,
-  );
-  root.style.setProperty(
-    "--tmux-ide-window-activity-inactive-opacity",
-    String(tokens.windowActivity.inactive.opacity.value),
-  );
-  return theme;
+  for (const [name, value] of Object.entries(experience.variables)) {
+    root.style.setProperty(name, value);
+  }
+  root.dataset.increasedContrast = String(experience.accessibility.increasedContrast);
+  return experience;
 }
 
 afterEach(() => {
@@ -55,10 +39,13 @@ afterEach(() => {
   document.body.replaceChildren();
 });
 
-function renderDock(projection = createWorkbenchDockHostFixture()) {
+function renderDock(
+  projection = createWorkbenchDockHostFixture(),
+  experienceOverrides: DomExperienceInput = {},
+) {
   const trace = createWorkbenchDockHostTrace();
   const root = document.createElement("div");
-  const theme = installCanonicalFixtureVariables(root);
+  const experience = installCanonicalFixtureVariables(root, experienceOverrides);
   document.body.append(root);
   disposers.push(
     render(
@@ -74,7 +61,7 @@ function renderDock(projection = createWorkbenchDockHostFixture()) {
       root,
     ),
   );
-  return { root, theme, trace };
+  return { experience, root, trace };
 }
 
 function tab(root: HTMLElement, id: string): HTMLButtonElement {
@@ -154,7 +141,7 @@ describe("shared WorkbenchDockPresenter DOM host", () => {
   });
 
   it("computes selected, focused, attention, and disabled styles from canonical variables", () => {
-    const { root, theme } = renderDock();
+    const { experience, root } = renderDock();
     expect(document.styleSheets[0]?.cssRules.length).toBeGreaterThan(0);
     const missions = tab(root, "missions");
     const changes = tab(root, "changes");
@@ -162,17 +149,41 @@ describe("shared WorkbenchDockPresenter DOM host", () => {
       ".workbench-dock__attention",
     )!;
 
+    expect(Array.from(root.style).sort()).toEqual(Object.keys(experience.variables).sort());
     expect(getComputedStyle(missions).backgroundColor).toBe(
-      colorToCss(theme.tokens.selection.selection),
+      experience.variables[DOM_EXPERIENCE_VARIABLE.selection.selection],
     );
-    expect(getComputedStyle(missions).outlineColor).toBe(colorToCss(theme.tokens.borders.focused));
-    expect(getComputedStyle(attention).color).toBe(colorToCss(theme.tokens.borders.attention));
+    expect(getComputedStyle(missions).outlineColor).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.border.focused],
+    );
+    expect(getComputedStyle(attention).color).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.border.attention],
+    );
     expect(getComputedStyle(changes).backgroundColor).toBe(
-      colorToCss(theme.tokens.selection.disabled),
+      experience.variables[DOM_EXPERIENCE_VARIABLE.control.disabledBackground],
     );
-    expect(getComputedStyle(changes).opacity).toBe(
-      String(theme.tokens.windowActivity.inactive.opacity.value),
+    expect(getComputedStyle(changes).color).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.control.disabledForeground],
     );
+    expect(
+      getComputedStyle(changes.querySelector<HTMLElement>(".workbench-dock__shortcut")!).color,
+    ).toBe("inherit");
+    expect(getComputedStyle(changes).opacity).toBe("1");
+  });
+
+  it("uses the opaque high-contrast disabled foreground without changing the base surface", () => {
+    const { experience, root } = renderDock(createWorkbenchDockHostFixture(), {
+      hostTheme: { mode: "dark", highContrast: true },
+    });
+    const changes = tab(root, "changes");
+
+    expect(getComputedStyle(changes).backgroundColor).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.control.disabledBackground],
+    );
+    expect(getComputedStyle(changes).color).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.control.disabledForegroundHighContrast],
+    );
+    expect(getComputedStyle(changes).opacity).toBe("1");
   });
 
   it("keeps every surface and dock control discoverable in a narrow collapsed layout", () => {

--- a/packages/daemon/src/ui/workbench-dock/web-host.test.tsx
+++ b/packages/daemon/src/ui/workbench-dock/web-host.test.tsx
@@ -1,6 +1,7 @@
 /* @vitest-environment happy-dom */
 import { afterEach, describe, expect, it } from "vitest";
 import { render } from "solid-js/web";
+import { COHESION_FIXTURE_V1, resolveVisualTheme } from "@tmux-ide/contracts";
 import {
   createWorkbenchDockHostFixture,
   createWorkbenchDockHostTrace,
@@ -11,6 +12,44 @@ import { WebWorkbenchDock } from "./web-host.tsx";
 
 const disposers: Array<() => void> = [];
 
+function colorToCss(value: { red: number; green: number; blue: number }): string {
+  return `rgb(${value.red} ${value.green} ${value.blue})`;
+}
+
+function installCanonicalFixtureVariables(
+  root: HTMLElement,
+): ReturnType<typeof resolveVisualTheme> {
+  const theme = resolveVisualTheme({
+    userTheme: COHESION_FIXTURE_V1.theme.user,
+    projectTheme: COHESION_FIXTURE_V1.theme.project ?? undefined,
+    accessibility: COHESION_FIXTURE_V1.theme.accessibility,
+  });
+  const { tokens } = theme;
+  root.style.setProperty("--tmux-ide-surface-panel", colorToCss(tokens.surfaces.panel));
+  root.style.setProperty(
+    "--tmux-ide-surface-panel-raised",
+    colorToCss(tokens.surfaces.panelRaised),
+  );
+  root.style.setProperty("--tmux-ide-border-subtle", colorToCss(tokens.borders.subtle));
+  root.style.setProperty("--tmux-ide-border-focused", colorToCss(tokens.borders.focused));
+  root.style.setProperty("--tmux-ide-border-attention", colorToCss(tokens.borders.attention));
+  root.style.setProperty("--tmux-ide-text-primary", colorToCss(tokens.text.primary));
+  root.style.setProperty("--tmux-ide-text-muted", colorToCss(tokens.text.muted));
+  root.style.setProperty("--tmux-ide-selection-selection", colorToCss(tokens.selection.selection));
+  root.style.setProperty("--tmux-ide-selection-hover", colorToCss(tokens.selection.hover));
+  root.style.setProperty("--tmux-ide-selection-disabled", colorToCss(tokens.selection.disabled));
+  root.style.setProperty("--tmux-ide-focus-outline", `${tokens.focus.outline.value * 18}px`);
+  root.style.setProperty(
+    "--tmux-ide-focus-outline-offset",
+    `${tokens.focus.outlineOffset.value * 18}px`,
+  );
+  root.style.setProperty(
+    "--tmux-ide-window-activity-inactive-opacity",
+    String(tokens.windowActivity.inactive.opacity.value),
+  );
+  return theme;
+}
+
 afterEach(() => {
   for (const dispose of disposers.splice(0)) dispose();
   document.body.replaceChildren();
@@ -19,6 +58,7 @@ afterEach(() => {
 function renderDock(projection = createWorkbenchDockHostFixture()) {
   const trace = createWorkbenchDockHostTrace();
   const root = document.createElement("div");
+  const theme = installCanonicalFixtureVariables(root);
   document.body.append(root);
   disposers.push(
     render(
@@ -34,7 +74,7 @@ function renderDock(projection = createWorkbenchDockHostFixture()) {
       root,
     ),
   );
-  return { root, trace };
+  return { root, theme, trace };
 }
 
 function tab(root: HTMLElement, id: string): HTMLButtonElement {
@@ -111,6 +151,28 @@ describe("shared WorkbenchDockPresenter DOM host", () => {
       "tab:activity",
       "tab:files",
     ]);
+  });
+
+  it("computes selected, focused, attention, and disabled styles from canonical variables", () => {
+    const { root, theme } = renderDock();
+    expect(document.styleSheets[0]?.cssRules.length).toBeGreaterThan(0);
+    const missions = tab(root, "missions");
+    const changes = tab(root, "changes");
+    const attention = tab(root, "activity").querySelector<HTMLElement>(
+      ".workbench-dock__attention",
+    )!;
+
+    expect(getComputedStyle(missions).backgroundColor).toBe(
+      colorToCss(theme.tokens.selection.selection),
+    );
+    expect(getComputedStyle(missions).outlineColor).toBe(colorToCss(theme.tokens.borders.focused));
+    expect(getComputedStyle(attention).color).toBe(colorToCss(theme.tokens.borders.attention));
+    expect(getComputedStyle(changes).backgroundColor).toBe(
+      colorToCss(theme.tokens.selection.disabled),
+    );
+    expect(getComputedStyle(changes).opacity).toBe(
+      String(theme.tokens.windowActivity.inactive.opacity.value),
+    );
   });
 
   it("keeps every surface and dock control discoverable in a narrow collapsed layout", () => {

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     alias: [{ find: /^ws$/, replacement: fileURLToPath(import.meta.resolve("ws")) }],
   },
   test: {
+    css: true,
     environment: "node",
     include: [
       "src/restore.test.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
         specifier: 1.9.12
         version: 1.9.12
     devDependencies:
+      happy-dom:
+        specifier: ^20.8.4
+        version: 20.8.4
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary
- project all canonical visual roles into an exact, browser-safe CSS variable contract
- add complete semantic SVG icon metadata with benchmark usage sizes and round stroke semantics
- move desktop and shared dock states onto canonical selected/focused/attention/disabled styling
- seed first paint synchronously, then react to authoritative host bootstrap/theme/window events with cleanup
- retain the temporary dashboard only as the Card 22.3 replacement boundary

## Review repairs
Adversarial review caught approximate shadows, incomplete icon semantics, incorrect disabled styling, a light-host dark flash, duplicated computed-style fixtures, and non-pinned motion. The repair now matches the visual benchmark exactly and tests the production adapter/CSS path.

## Verification
- full `pnpm check` after rebasing onto current main
- desktop renderer: 3 files / 9 tests, typecheck, lint, production build
- shared dock DOM: 5 tests plus package consumer proof
- Electron: 7 files / 21 tests, typecheck/lint, hidden smoke (`tmux-ide desktop smoke ready`)
- 131 daemon files / 2,192 tests and 89 OpenTUI renderer tests / 62 snapshots
- formatting and diff checks
