### PR TITLE
feat(tui): adapt OpenTUI to the canonical experience

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2309,7 +2309,7 @@ var init_control = __esm({
 
 // packages/contracts/src/commands.ts
 import { z as z14 } from "zod";
-var COMMAND_PROTOCOL_VERSION, CommandIdSchemaZ, CommandOwnerSchemaZ, CommandSourceKindSchemaZ, CommandSourceSchemaZ, CommandSchemaReferencesSchemaZ, CommandConfirmationSchemaZ, CommandDescriptorSchemaZ, CommandArgumentsSchemaZ, CommandInvocationSchemaZ, CommandAvailabilitySchemaZ, CommandResolutionErrorCodeSchemaZ, CommandResolutionErrorSchemaZ;
+var COMMAND_PROTOCOL_VERSION, CommandIdSchemaZ, CommandOwnerSchemaZ, CommandSourceKindSchemaZ, CommandSourceSchemaZ, CommandSchemaReferencesSchemaZ, CommandConfirmationSchemaZ, CommandDescriptorSchemaZ, CommandArgumentsSchemaZ, CommandInvocationSchemaZ, CommandAvailabilitySchemaZ, CommandResolutionErrorCodeSchemaZ, CommandResolutionErrorSchemaZ, APPLICATION_SHELL_COMMAND_IDS, ApplicationShellCommandIdSchemaZ;
 var init_commands = __esm({
   "packages/contracts/src/commands.ts"() {
     "use strict";
@@ -2376,6 +2376,18 @@ var init_commands = __esm({
       commandId: CommandIdSchemaZ.optional(),
       details: z14.json().optional()
     }).strict();
+    APPLICATION_SHELL_COMMAND_IDS = Object.freeze({
+      activateMode: "application.shell.mode.activate",
+      activateDockTool: "application.shell.dock.activate",
+      setDockMode: "application.shell.dock.mode.set",
+      moveFocus: "application.shell.focus.move",
+      openPalette: "application.shell.palette.open",
+      closePalette: "application.shell.palette.close",
+      selectResource: "application.shell.resource.select"
+    });
+    ApplicationShellCommandIdSchemaZ = z14.enum(
+      Object.values(APPLICATION_SHELL_COMMAND_IDS)
+    );
   }
 });
 
@@ -2466,15 +2478,91 @@ var init_experience_identifiers = __esm({
   }
 });
 
-// packages/contracts/src/experience-shell.ts
+// packages/contracts/src/pane-appearance.ts
 import { z as z17 } from "zod";
-var ShellAreaIdSchemaZ, PRIMARY_WORKSPACE_MODE_IDS, PrimaryWorkspaceModeIdSchemaZ, DOCK_TOOL_IDS, DockToolIdSchemaZ, PRODUCT_SURFACE_IDS, ProductSurfaceIdSchemaZ, CANONICAL_SHELL_AREAS, SurfaceKindSchemaZ, modeCommand, dockCommand, CANONICAL_SURFACE_REGISTRY, surfaceById;
+var SemanticProductIdSchemaZ, PANE_STRUCTURE_IDS, PaneStructureSchemaZ, AGENT_ACTIVITY_IDS, AgentActivitySchemaZ, CANONICAL_DOMAIN_STATUS_IDS, CanonicalDomainStatusSchemaZ, PANE_ATTENTION_IDS, PaneAttentionSchemaZ, PaneVisualStateV1SchemaZ, DOMAIN_STATUS_TONES;
+var init_pane_appearance = __esm({
+  "packages/contracts/src/pane-appearance.ts"() {
+    "use strict";
+    SemanticProductIdSchemaZ = z17.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u, "semantic id contains a transport-only character");
+    PANE_STRUCTURE_IDS = ["docked", "floating", "maximized"];
+    PaneStructureSchemaZ = z17.enum(PANE_STRUCTURE_IDS);
+    AGENT_ACTIVITY_IDS = [
+      "idle",
+      "running",
+      "waiting",
+      "complete",
+      "failed",
+      "disconnected"
+    ];
+    AgentActivitySchemaZ = z17.enum(AGENT_ACTIVITY_IDS);
+    CANONICAL_DOMAIN_STATUS_IDS = [
+      "idle",
+      "running",
+      "blocked",
+      "review",
+      "done",
+      "disconnected",
+      "recovering"
+    ];
+    CanonicalDomainStatusSchemaZ = z17.enum(CANONICAL_DOMAIN_STATUS_IDS);
+    PANE_ATTENTION_IDS = [
+      "none",
+      "unread",
+      "requested",
+      "warning",
+      "destructive",
+      "recovery"
+    ];
+    PaneAttentionSchemaZ = z17.enum(PANE_ATTENTION_IDS);
+    PaneVisualStateV1SchemaZ = z17.object({
+      structure: PaneStructureSchemaZ,
+      applicationFocus: z17.object({ pane: z17.boolean(), terminalInput: z17.boolean(), windowActive: z17.boolean() }).strict(),
+      agentActivity: AgentActivitySchemaZ,
+      domainStatus: CanonicalDomainStatusSchemaZ,
+      attention: PaneAttentionSchemaZ,
+      layoutInteraction: z17.object({
+        editable: z17.boolean(),
+        selected: z17.boolean(),
+        dragging: z17.boolean(),
+        resizing: z17.boolean(),
+        previewing: z17.boolean()
+      }).strict(),
+      controlInteraction: z17.object({
+        hover: z17.boolean(),
+        focusVisible: z17.boolean(),
+        pressed: z17.boolean(),
+        disabled: z17.boolean(),
+        loading: z17.boolean()
+      }).strict()
+    }).strict();
+    DOMAIN_STATUS_TONES = Object.freeze({
+      idle: "neutral",
+      running: "info",
+      blocked: "warning",
+      review: "info",
+      done: "success",
+      disconnected: "danger",
+      recovering: "danger"
+    });
+  }
+});
+
+// packages/contracts/src/experience-shell.ts
+import { z as z18 } from "zod";
+function deepFreezeData(value) {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) deepFreezeData(child);
+  return Object.freeze(value);
+}
+var ShellAreaIdSchemaZ, PRIMARY_WORKSPACE_MODE_IDS, PrimaryWorkspaceModeIdSchemaZ, DOCK_TOOL_IDS, DockToolIdSchemaZ, PRODUCT_SURFACE_IDS, ProductSurfaceIdSchemaZ, CANONICAL_SHELL_AREAS, SurfaceKindSchemaZ, ApplicationShellDockModeSchemaZ, SurfaceCommandTemplateSchemaZ, ProductSurfaceDefinitionSchemaZ, modeCommand, dockCommand, CANONICAL_SURFACE_REGISTRY, surfaceById;
 var init_experience_shell = __esm({
   "packages/contracts/src/experience-shell.ts"() {
     "use strict";
     init_commands();
     init_experience_identifiers();
-    ShellAreaIdSchemaZ = z17.enum([
+    init_pane_appearance();
+    ShellAreaIdSchemaZ = z18.enum([
       "application-bar",
       "sidebar",
       "primary-navigation",
@@ -2483,13 +2571,16 @@ var init_experience_shell = __esm({
       "bottom-dock",
       "status-strip"
     ]);
-    PRIMARY_WORKSPACE_MODE_IDS = ["home", "terminals"];
-    PrimaryWorkspaceModeIdSchemaZ = z17.enum(PRIMARY_WORKSPACE_MODE_IDS);
-    DOCK_TOOL_IDS = ["files", "changes", "missions", "activity"];
-    DockToolIdSchemaZ = z17.enum(DOCK_TOOL_IDS);
-    PRODUCT_SURFACE_IDS = [...PRIMARY_WORKSPACE_MODE_IDS, ...DOCK_TOOL_IDS];
-    ProductSurfaceIdSchemaZ = z17.enum(PRODUCT_SURFACE_IDS);
-    CANONICAL_SHELL_AREAS = Object.freeze([
+    PRIMARY_WORKSPACE_MODE_IDS = Object.freeze(["home", "terminals"]);
+    PrimaryWorkspaceModeIdSchemaZ = z18.enum(PRIMARY_WORKSPACE_MODE_IDS);
+    DOCK_TOOL_IDS = Object.freeze(["files", "changes", "missions", "activity"]);
+    DockToolIdSchemaZ = z18.enum(DOCK_TOOL_IDS);
+    PRODUCT_SURFACE_IDS = Object.freeze([
+      ...PRIMARY_WORKSPACE_MODE_IDS,
+      ...DOCK_TOOL_IDS
+    ]);
+    ProductSurfaceIdSchemaZ = z18.enum(PRODUCT_SURFACE_IDS);
+    CANONICAL_SHELL_AREAS = deepFreezeData([
       { id: "application-bar", label: "Application bar", order: 0 },
       { id: "sidebar", label: "Workspace sidebar", order: 1 },
       { id: "primary-navigation", label: "Workspace modes", order: 2 },
@@ -2498,93 +2589,221 @@ var init_experience_shell = __esm({
       { id: "bottom-dock", label: "Bottom dock", order: 5 },
       { id: "status-strip", label: "Status and recovery", order: 6 }
     ]);
-    SurfaceKindSchemaZ = z17.enum(["primary-mode", "dock-tool"]);
-    modeCommand = (mode) => ({
-      id: "workspace.mode.activate",
+    SurfaceKindSchemaZ = z18.enum(["primary-mode", "dock-tool"]);
+    ApplicationShellDockModeSchemaZ = z18.enum(["collapsed", "open", "maximized"]);
+    SurfaceCommandTemplateSchemaZ = z18.discriminatedUnion("id", [
+      z18.object({
+        id: z18.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
+        args: z18.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict()
+      }).strict(),
+      z18.object({
+        id: z18.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
+        args: z18.object({ tool: DockToolIdSchemaZ }).strict()
+      }).strict(),
+      z18.object({
+        id: z18.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
+        args: z18.object({ mode: ApplicationShellDockModeSchemaZ }).strict()
+      }).strict(),
+      z18.object({
+        id: z18.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
+        args: z18.object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ }).strict()
+      }).strict()
+    ]);
+    ProductSurfaceDefinitionSchemaZ = z18.object({
+      id: ProductSurfaceIdSchemaZ,
+      icon: SemanticIconIdSchemaZ,
+      label: z18.string().min(1).max(160),
+      kind: SurfaceKindSchemaZ,
+      area: z18.enum(["workspace-canvas", "bottom-dock"]),
+      order: z18.number().int().nonnegative(),
+      owningMode: PrimaryWorkspaceModeIdSchemaZ,
+      shortcut: z18.string().min(1).max(32),
+      activation: SurfaceCommandTemplateSchemaZ
+    }).strict().superRefine((surface, ctx) => {
+      if (surface.kind === "primary-mode" && surface.activation.id !== APPLICATION_SHELL_COMMAND_IDS.activateMode) {
+        ctx.addIssue({
+          code: "custom",
+          message: "primary modes require a mode activation command",
+          path: ["activation", "id"]
+        });
+      }
+      if (surface.kind === "dock-tool" && surface.activation.id !== APPLICATION_SHELL_COMMAND_IDS.activateDockTool) {
+        ctx.addIssue({
+          code: "custom",
+          message: "dock tools require a dock activation command",
+          path: ["activation", "id"]
+        });
+      }
+    });
+    modeCommand = (mode) => deepFreezeData({
+      id: APPLICATION_SHELL_COMMAND_IDS.activateMode,
       args: { mode }
     });
-    dockCommand = (tool) => ({
-      id: "workspace.dock.activate",
+    dockCommand = (tool) => deepFreezeData({
+      id: APPLICATION_SHELL_COMMAND_IDS.activateDockTool,
       args: { tool }
     });
-    CANONICAL_SURFACE_REGISTRY = Object.freeze([
-      {
-        id: "home",
-        icon: "home",
-        label: "Home",
-        kind: "primary-mode",
-        area: "workspace-canvas",
-        order: 0,
-        owningMode: "home",
-        shortcut: "F1",
-        activation: modeCommand("home")
-      },
-      {
-        id: "terminals",
-        icon: "terminals",
-        label: "Terminals",
-        kind: "primary-mode",
-        area: "workspace-canvas",
-        order: 1,
-        owningMode: "terminals",
-        shortcut: "F2",
-        activation: modeCommand("terminals")
-      },
-      {
-        id: "files",
-        icon: "files",
-        label: "Files",
-        kind: "dock-tool",
-        area: "bottom-dock",
-        order: 0,
-        owningMode: "terminals",
-        shortcut: "F3",
-        activation: dockCommand("files")
-      },
-      {
-        id: "changes",
-        icon: "changes",
-        label: "Changes",
-        kind: "dock-tool",
-        area: "bottom-dock",
-        order: 1,
-        owningMode: "terminals",
-        shortcut: "F4",
-        activation: dockCommand("changes")
-      },
-      {
-        id: "missions",
-        icon: "missions",
-        label: "Missions",
-        kind: "dock-tool",
-        area: "bottom-dock",
-        order: 2,
-        owningMode: "terminals",
-        shortcut: "F6",
-        activation: dockCommand("missions")
-      },
-      {
-        id: "activity",
-        icon: "activity",
-        label: "Activity",
-        kind: "dock-tool",
-        area: "bottom-dock",
-        order: 3,
-        owningMode: "terminals",
-        shortcut: "F9",
-        activation: dockCommand("activity")
-      }
-    ]);
+    CANONICAL_SURFACE_REGISTRY = deepFreezeData(
+      ProductSurfaceDefinitionSchemaZ.array().parse([
+        {
+          id: "home",
+          icon: "home",
+          label: "Home",
+          kind: "primary-mode",
+          area: "workspace-canvas",
+          order: 0,
+          owningMode: "home",
+          shortcut: "F1",
+          activation: modeCommand("home")
+        },
+        {
+          id: "terminals",
+          icon: "terminals",
+          label: "Terminals",
+          kind: "primary-mode",
+          area: "workspace-canvas",
+          order: 1,
+          owningMode: "terminals",
+          shortcut: "F2",
+          activation: modeCommand("terminals")
+        },
+        {
+          id: "files",
+          icon: "files",
+          label: "Files",
+          kind: "dock-tool",
+          area: "bottom-dock",
+          order: 0,
+          owningMode: "terminals",
+          shortcut: "F3",
+          activation: dockCommand("files")
+        },
+        {
+          id: "changes",
+          icon: "changes",
+          label: "Changes",
+          kind: "dock-tool",
+          area: "bottom-dock",
+          order: 1,
+          owningMode: "terminals",
+          shortcut: "F4",
+          activation: dockCommand("changes")
+        },
+        {
+          id: "missions",
+          icon: "missions",
+          label: "Missions",
+          kind: "dock-tool",
+          area: "bottom-dock",
+          order: 2,
+          owningMode: "terminals",
+          shortcut: "F6",
+          activation: dockCommand("missions")
+        },
+        {
+          id: "activity",
+          icon: "activity",
+          label: "Activity",
+          kind: "dock-tool",
+          area: "bottom-dock",
+          order: 3,
+          owningMode: "terminals",
+          shortcut: "F9",
+          activation: dockCommand("activity")
+        }
+      ])
+    );
     surfaceById = new Map(CANONICAL_SURFACE_REGISTRY.map((surface) => [surface.id, surface]));
     for (const surface of CANONICAL_SURFACE_REGISTRY) {
-      CommandIdSchemaZ.parse(surface.activation.id);
       SemanticIconIdSchemaZ.parse(surface.icon);
     }
   }
 });
 
+// packages/contracts/src/focus-overlay.ts
+import { z as z19 } from "zod";
+function resolveSemanticInputLayer(state) {
+  const parsed = FocusOverlayStateV1SchemaZ.parse(state);
+  let winner = null;
+  for (const overlay of parsed.overlays) {
+    if (!winner || overlayPriority[overlay.kind] >= overlayPriority[winner.kind]) winner = overlay;
+  }
+  if (winner) return { kind: winner.kind, overlayId: winner.id };
+  if (parsed.terminalInputPaneId !== null && parsed.focusZone === "terminal") {
+    return { kind: "terminal", paneId: parsed.terminalInputPaneId };
+  }
+  return { kind: "app", zone: parsed.focusZone };
+}
+var FocusZoneSchemaZ, SemanticFocusTargetSchemaZ, OverlayKindSchemaZ, SemanticOverlaySchemaZ, FocusOverlayStateV1SchemaZ, overlayPriority;
+var init_focus_overlay = __esm({
+  "packages/contracts/src/focus-overlay.ts"() {
+    "use strict";
+    init_experience_shell();
+    init_pane_appearance();
+    FocusZoneSchemaZ = z19.enum([
+      "application-bar",
+      "sidebar",
+      "primary-navigation",
+      "canvas",
+      "dock-tabs",
+      "dock-body",
+      "status-strip",
+      "terminal"
+    ]);
+    SemanticFocusTargetSchemaZ = z19.discriminatedUnion("kind", [
+      z19.object({ kind: z19.literal("zone"), zone: FocusZoneSchemaZ }).strict(),
+      z19.object({
+        kind: z19.literal("pane"),
+        paneId: SemanticProductIdSchemaZ,
+        input: z19.enum(["chrome", "terminal"])
+      }).strict(),
+      z19.object({ kind: z19.literal("dock-tool"), tool: DockToolIdSchemaZ }).strict(),
+      z19.object({
+        kind: z19.literal("control"),
+        controlId: SemanticProductIdSchemaZ,
+        zone: FocusZoneSchemaZ
+      }).strict()
+    ]);
+    OverlayKindSchemaZ = z19.enum(["modal-dialog", "command-palette", "context-menu"]);
+    SemanticOverlaySchemaZ = z19.object({
+      id: SemanticProductIdSchemaZ,
+      kind: OverlayKindSchemaZ,
+      focusReturnTarget: SemanticFocusTargetSchemaZ
+    }).strict();
+    FocusOverlayStateV1SchemaZ = z19.object({
+      windowActivity: z19.enum(["active", "inactive"]),
+      focusZone: FocusZoneSchemaZ,
+      appFocusedPaneId: SemanticProductIdSchemaZ.nullable(),
+      terminalInputPaneId: SemanticProductIdSchemaZ.nullable(),
+      layoutSelectedPaneId: SemanticProductIdSchemaZ.nullable(),
+      overlays: z19.array(SemanticOverlaySchemaZ).max(16)
+    }).strict().superRefine((state, ctx) => {
+      const ids = state.overlays.map((overlay) => overlay.id);
+      if (new Set(ids).size !== ids.length) {
+        ctx.addIssue({
+          code: z19.ZodIssueCode.custom,
+          message: "overlay ids must be unique",
+          path: ["overlays"]
+        });
+      }
+      if (state.terminalInputPaneId !== null && state.appFocusedPaneId !== state.terminalInputPaneId) {
+        ctx.addIssue({
+          code: z19.ZodIssueCode.custom,
+          message: "terminal input owner must also be the app-focused pane",
+          path: ["terminalInputPaneId"]
+        });
+      }
+    });
+    overlayPriority = {
+      "context-menu": 1,
+      "command-palette": 2,
+      "modal-dialog": 3
+    };
+  }
+});
+
 // packages/contracts/src/visual-tokens.ts
-import { z as z18 } from "zod";
+import { z as z20 } from "zod";
 function color(hex) {
   const normalized = hex.replace(/^#/u, "");
   return {
@@ -2746,32 +2965,32 @@ var init_visual_tokens = __esm({
     MOTION_DURATION_ROLES = ["instant", "fast", "standard", "emphasized"];
     TYPOGRAPHY_TOKEN_ROLES = ["workspace", "label", "title", "metadata", "code"];
     WINDOW_ACTIVITY_TOKEN_ROLES = ["active", "inactive"];
-    RendererNeutralColorSchemaZ = z18.object({
-      space: z18.literal("srgb"),
-      red: z18.number().int().min(0).max(255),
-      green: z18.number().int().min(0).max(255),
-      blue: z18.number().int().min(0).max(255),
-      alpha: z18.number().int().min(0).max(255)
+    RendererNeutralColorSchemaZ = z20.object({
+      space: z20.literal("srgb"),
+      red: z20.number().int().min(0).max(255),
+      green: z20.number().int().min(0).max(255),
+      blue: z20.number().int().min(0).max(255),
+      alpha: z20.number().int().min(0).max(255)
     }).strict();
-    RhythmValueSchemaZ = z18.object({ unit: z18.literal("rhythm"), value: z18.number().finite().min(0).max(16) }).strict();
-    RatioValueSchemaZ = z18.object({ unit: z18.literal("ratio"), value: z18.number().finite().min(0).max(20) }).strict();
-    DurationValueSchemaZ = z18.object({ unit: z18.literal("ms"), value: z18.number().finite().min(0).max(1e4) }).strict();
-    ElevationValueSchemaZ = z18.object({
-      level: z18.number().int().min(0).max(4),
-      intent: z18.enum(["flat", "raised", "overlay"])
+    RhythmValueSchemaZ = z20.object({ unit: z20.literal("rhythm"), value: z20.number().finite().min(0).max(16) }).strict();
+    RatioValueSchemaZ = z20.object({ unit: z20.literal("ratio"), value: z20.number().finite().min(0).max(20) }).strict();
+    DurationValueSchemaZ = z20.object({ unit: z20.literal("ms"), value: z20.number().finite().min(0).max(1e4) }).strict();
+    ElevationValueSchemaZ = z20.object({
+      level: z20.number().int().min(0).max(4),
+      intent: z20.enum(["flat", "raised", "overlay"])
     }).strict();
-    TypographyValueSchemaZ = z18.object({
-      family: z18.enum(["monospace", "system"]),
-      weight: z18.enum(["regular", "medium", "semibold", "bold"]),
+    TypographyValueSchemaZ = z20.object({
+      family: z20.enum(["monospace", "system"]),
+      weight: z20.enum(["regular", "medium", "semibold", "bold"]),
       lineHeight: RatioValueSchemaZ,
-      truncation: z18.enum(["ellipsis", "clip", "wrap"])
+      truncation: z20.enum(["ellipsis", "clip", "wrap"])
     }).strict();
-    MotionEasingSchemaZ = z18.object({
-      standard: z18.enum(["linear", "standard", "decelerate"]),
-      emphasized: z18.enum(["linear", "standard", "decelerate"])
+    MotionEasingSchemaZ = z20.object({
+      standard: z20.enum(["linear", "standard", "decelerate"]),
+      emphasized: z20.enum(["linear", "standard", "decelerate"])
     }).strict();
-    WindowActivityValueSchemaZ = z18.object({ opacity: RatioValueSchemaZ, contrast: RatioValueSchemaZ }).strict();
-    SurfacesSchemaZ = z18.object({
+    WindowActivityValueSchemaZ = z20.object({ opacity: RatioValueSchemaZ, contrast: RatioValueSchemaZ }).strict();
+    SurfacesSchemaZ = z20.object({
       canvas: RendererNeutralColorSchemaZ,
       panel: RendererNeutralColorSchemaZ,
       panelRaised: RendererNeutralColorSchemaZ,
@@ -2780,7 +2999,7 @@ var init_visual_tokens = __esm({
       headerActive: RendererNeutralColorSchemaZ,
       command: RendererNeutralColorSchemaZ
     }).strict();
-    TextSchemaZ = z18.object({
+    TextSchemaZ = z20.object({
       primary: RendererNeutralColorSchemaZ,
       secondary: RendererNeutralColorSchemaZ,
       muted: RendererNeutralColorSchemaZ,
@@ -2788,7 +3007,7 @@ var init_visual_tokens = __esm({
       inverse: RendererNeutralColorSchemaZ,
       link: RendererNeutralColorSchemaZ
     }).strict();
-    BordersSchemaZ = z18.object({
+    BordersSchemaZ = z20.object({
       subtle: RendererNeutralColorSchemaZ,
       default: RendererNeutralColorSchemaZ,
       focused: RendererNeutralColorSchemaZ,
@@ -2796,21 +3015,21 @@ var init_visual_tokens = __esm({
       attention: RendererNeutralColorSchemaZ,
       danger: RendererNeutralColorSchemaZ
     }).strict();
-    StatusToneSchemaZ = z18.object({
+    StatusToneSchemaZ = z20.object({
       neutral: RendererNeutralColorSchemaZ,
       info: RendererNeutralColorSchemaZ,
       warning: RendererNeutralColorSchemaZ,
       danger: RendererNeutralColorSchemaZ,
       success: RendererNeutralColorSchemaZ
     }).strict();
-    SelectionSchemaZ = z18.object({
+    SelectionSchemaZ = z20.object({
       selection: RendererNeutralColorSchemaZ,
       selectionText: RendererNeutralColorSchemaZ,
       hover: RendererNeutralColorSchemaZ,
       pressed: RendererNeutralColorSchemaZ,
       disabled: RendererNeutralColorSchemaZ
     }).strict();
-    DensitySchemaZ = z18.object({
+    DensitySchemaZ = z20.object({
       cellHeight: RhythmValueSchemaZ,
       headerHeight: RhythmValueSchemaZ,
       statusHeight: RhythmValueSchemaZ,
@@ -2818,39 +3037,39 @@ var init_visual_tokens = __esm({
       sectionGap: RhythmValueSchemaZ,
       controlPadding: RhythmValueSchemaZ
     }).strict();
-    ShapeSchemaZ = z18.object({
+    ShapeSchemaZ = z20.object({
       dockedRadius: RhythmValueSchemaZ,
       floatingRadius: RhythmValueSchemaZ,
       controlRadius: RhythmValueSchemaZ,
       statusRadius: RhythmValueSchemaZ
     }).strict();
-    ElevationSchemaZ = z18.object({
+    ElevationSchemaZ = z20.object({
       floating: ElevationValueSchemaZ,
       palette: ElevationValueSchemaZ,
       windowMode: ElevationValueSchemaZ
     }).strict();
-    MotionSchemaZ = z18.object({
+    MotionSchemaZ = z20.object({
       instant: DurationValueSchemaZ,
       fast: DurationValueSchemaZ,
       standard: DurationValueSchemaZ,
       emphasized: DurationValueSchemaZ,
       easing: MotionEasingSchemaZ
     }).strict();
-    TypographySchemaZ = z18.object({
+    TypographySchemaZ = z20.object({
       workspace: TypographyValueSchemaZ,
       label: TypographyValueSchemaZ,
       title: TypographyValueSchemaZ,
       metadata: TypographyValueSchemaZ,
       code: TypographyValueSchemaZ
     }).strict();
-    FocusSchemaZ = z18.object({
+    FocusSchemaZ = z20.object({
       outline: RhythmValueSchemaZ,
       outlineOffset: RhythmValueSchemaZ,
       focusContrast: RatioValueSchemaZ,
       highContrastOutline: RendererNeutralColorSchemaZ
     }).strict();
-    WindowActivitySchemaZ = z18.object({ active: WindowActivityValueSchemaZ, inactive: WindowActivityValueSchemaZ }).strict();
-    VisualTokensV1SchemaZ = z18.object({
+    WindowActivitySchemaZ = z20.object({ active: WindowActivityValueSchemaZ, inactive: WindowActivityValueSchemaZ }).strict();
+    VisualTokensV1SchemaZ = z20.object({
       surfaces: SurfacesSchemaZ,
       text: TextSchemaZ,
       borders: BordersSchemaZ,
@@ -2864,7 +3083,7 @@ var init_visual_tokens = __esm({
       focus: FocusSchemaZ,
       windowActivity: WindowActivitySchemaZ
     }).strict();
-    VisualTokenOverridesV1SchemaZ = z18.object({
+    VisualTokenOverridesV1SchemaZ = z20.object({
       surfaces: SurfacesSchemaZ.partial().optional(),
       text: TextSchemaZ.partial().optional(),
       borders: BordersSchemaZ.partial().optional(),
@@ -2878,24 +3097,24 @@ var init_visual_tokens = __esm({
       focus: FocusSchemaZ.partial().optional(),
       windowActivity: WindowActivitySchemaZ.partial().optional()
     }).strict();
-    ThemeIdSchemaZ = z18.string().min(1).max(80).regex(/^[a-z0-9][a-z0-9._-]*$/u);
-    ThemeNameSchemaZ = z18.string().min(1).max(120);
-    ThemeAppearanceSchemaZ = z18.enum(["dark", "light"]);
-    VisualThemeDocumentV1SchemaZ = z18.object({
-      version: z18.literal(VISUAL_THEME_VERSION),
+    ThemeIdSchemaZ = z20.string().min(1).max(80).regex(/^[a-z0-9][a-z0-9._-]*$/u);
+    ThemeNameSchemaZ = z20.string().min(1).max(120);
+    ThemeAppearanceSchemaZ = z20.enum(["dark", "light"]);
+    VisualThemeDocumentV1SchemaZ = z20.object({
+      version: z20.literal(VISUAL_THEME_VERSION),
       id: ThemeIdSchemaZ,
       name: ThemeNameSchemaZ,
       appearance: ThemeAppearanceSchemaZ.optional(),
       overrides: VisualTokenOverridesV1SchemaZ
     }).strict();
-    VisualThemeDocumentV0SchemaZ = z18.object({
-      version: z18.literal(0),
+    VisualThemeDocumentV0SchemaZ = z20.object({
+      version: z20.literal(0),
       id: ThemeIdSchemaZ,
       name: ThemeNameSchemaZ,
       appearance: ThemeAppearanceSchemaZ.optional(),
       tokens: VisualTokenOverridesV1SchemaZ
     }).strict();
-    ThemeAccessibilityPreferencesSchemaZ = z18.object({ reducedMotion: z18.boolean(), increasedContrast: z18.boolean() }).strict();
+    ThemeAccessibilityPreferencesSchemaZ = z20.object({ reducedMotion: z20.boolean(), increasedContrast: z20.boolean() }).strict();
     groupSchemas = {
       surfaces: {
         canvas: RendererNeutralColorSchemaZ,
@@ -2960,243 +3179,6 @@ var init_visual_tokens = __esm({
     ratio = (value) => ({ unit: "ratio", value });
     duration = (value) => ({ unit: "ms", value });
     BUILTIN_VISUAL_THEMES = Object.freeze({ dark: baseTokens("dark"), light: baseTokens("light") });
-  }
-});
-
-// packages/contracts/src/visual-recipes.ts
-var VISUAL_RECIPE_REGISTRY;
-var init_visual_recipes = __esm({
-  "packages/contracts/src/visual-recipes.ts"() {
-    "use strict";
-    VISUAL_RECIPE_REGISTRY = Object.freeze(
-      {
-        "application-bar": {
-          id: "application-bar",
-          surface: "header",
-          text: "bright",
-          border: "subtle",
-          typography: "label",
-          shape: "dockedRadius",
-          elevation: null
-        },
-        sidebar: {
-          id: "sidebar",
-          surface: "panel",
-          text: "secondary",
-          border: "subtle",
-          typography: "metadata",
-          shape: "dockedRadius",
-          elevation: null
-        },
-        "primary-navigation": {
-          id: "primary-navigation",
-          surface: "header",
-          text: "primary",
-          border: "subtle",
-          typography: "label",
-          shape: "controlRadius",
-          elevation: null
-        },
-        "context-actions": {
-          id: "context-actions",
-          surface: "header",
-          text: "secondary",
-          border: "subtle",
-          typography: "label",
-          shape: "controlRadius",
-          elevation: null
-        },
-        "workspace-canvas": {
-          id: "workspace-canvas",
-          surface: "canvas",
-          text: "primary",
-          border: "subtle",
-          typography: "workspace",
-          shape: "dockedRadius",
-          elevation: null
-        },
-        "bottom-dock": {
-          id: "bottom-dock",
-          surface: "panel",
-          text: "primary",
-          border: "default",
-          typography: "workspace",
-          shape: "dockedRadius",
-          elevation: null
-        },
-        "status-strip": {
-          id: "status-strip",
-          surface: "header",
-          text: "muted",
-          border: "subtle",
-          typography: "metadata",
-          shape: "statusRadius",
-          elevation: null
-        },
-        "pane-docked": {
-          id: "pane-docked",
-          surface: "terminal",
-          text: "primary",
-          border: "default",
-          typography: "workspace",
-          shape: "dockedRadius",
-          elevation: null
-        },
-        "pane-floating": {
-          id: "pane-floating",
-          surface: "panelRaised",
-          text: "primary",
-          border: "default",
-          typography: "workspace",
-          shape: "floatingRadius",
-          elevation: "floating"
-        },
-        "command-palette": {
-          id: "command-palette",
-          surface: "command",
-          text: "primary",
-          border: "focused",
-          typography: "workspace",
-          shape: "floatingRadius",
-          elevation: "palette"
-        }
-      }
-    );
-  }
-});
-
-// packages/contracts/src/pane-appearance.ts
-import { z as z19 } from "zod";
-var SemanticProductIdSchemaZ, PANE_STRUCTURE_IDS, PaneStructureSchemaZ, AGENT_ACTIVITY_IDS, AgentActivitySchemaZ, CANONICAL_DOMAIN_STATUS_IDS, CanonicalDomainStatusSchemaZ, PANE_ATTENTION_IDS, PaneAttentionSchemaZ, PaneVisualStateV1SchemaZ, DOMAIN_STATUS_TONES;
-var init_pane_appearance = __esm({
-  "packages/contracts/src/pane-appearance.ts"() {
-    "use strict";
-    SemanticProductIdSchemaZ = z19.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u, "semantic id contains a transport-only character");
-    PANE_STRUCTURE_IDS = ["docked", "floating", "maximized"];
-    PaneStructureSchemaZ = z19.enum(PANE_STRUCTURE_IDS);
-    AGENT_ACTIVITY_IDS = [
-      "idle",
-      "running",
-      "waiting",
-      "complete",
-      "failed",
-      "disconnected"
-    ];
-    AgentActivitySchemaZ = z19.enum(AGENT_ACTIVITY_IDS);
-    CANONICAL_DOMAIN_STATUS_IDS = [
-      "idle",
-      "running",
-      "blocked",
-      "review",
-      "done",
-      "disconnected",
-      "recovering"
-    ];
-    CanonicalDomainStatusSchemaZ = z19.enum(CANONICAL_DOMAIN_STATUS_IDS);
-    PANE_ATTENTION_IDS = [
-      "none",
-      "unread",
-      "requested",
-      "warning",
-      "destructive",
-      "recovery"
-    ];
-    PaneAttentionSchemaZ = z19.enum(PANE_ATTENTION_IDS);
-    PaneVisualStateV1SchemaZ = z19.object({
-      structure: PaneStructureSchemaZ,
-      applicationFocus: z19.object({ pane: z19.boolean(), terminalInput: z19.boolean(), windowActive: z19.boolean() }).strict(),
-      agentActivity: AgentActivitySchemaZ,
-      domainStatus: CanonicalDomainStatusSchemaZ,
-      attention: PaneAttentionSchemaZ,
-      layoutInteraction: z19.object({
-        editable: z19.boolean(),
-        selected: z19.boolean(),
-        dragging: z19.boolean(),
-        resizing: z19.boolean(),
-        previewing: z19.boolean()
-      }).strict(),
-      controlInteraction: z19.object({
-        hover: z19.boolean(),
-        focusVisible: z19.boolean(),
-        pressed: z19.boolean(),
-        disabled: z19.boolean(),
-        loading: z19.boolean()
-      }).strict()
-    }).strict();
-    DOMAIN_STATUS_TONES = Object.freeze({
-      idle: "neutral",
-      running: "info",
-      blocked: "warning",
-      review: "info",
-      done: "success",
-      disconnected: "danger",
-      recovering: "danger"
-    });
-  }
-});
-
-// packages/contracts/src/focus-overlay.ts
-import { z as z20 } from "zod";
-var FocusZoneSchemaZ, SemanticFocusTargetSchemaZ, OverlayKindSchemaZ, SemanticOverlaySchemaZ, FocusOverlayStateV1SchemaZ;
-var init_focus_overlay = __esm({
-  "packages/contracts/src/focus-overlay.ts"() {
-    "use strict";
-    init_experience_shell();
-    init_pane_appearance();
-    FocusZoneSchemaZ = z20.enum([
-      "application-bar",
-      "sidebar",
-      "primary-navigation",
-      "canvas",
-      "dock-tabs",
-      "dock-body",
-      "status-strip",
-      "terminal"
-    ]);
-    SemanticFocusTargetSchemaZ = z20.discriminatedUnion("kind", [
-      z20.object({ kind: z20.literal("zone"), zone: FocusZoneSchemaZ }).strict(),
-      z20.object({
-        kind: z20.literal("pane"),
-        paneId: SemanticProductIdSchemaZ,
-        input: z20.enum(["chrome", "terminal"])
-      }).strict(),
-      z20.object({ kind: z20.literal("dock-tool"), tool: DockToolIdSchemaZ }).strict(),
-      z20.object({
-        kind: z20.literal("control"),
-        controlId: SemanticProductIdSchemaZ,
-        zone: FocusZoneSchemaZ
-      }).strict()
-    ]);
-    OverlayKindSchemaZ = z20.enum(["modal-dialog", "command-palette", "context-menu"]);
-    SemanticOverlaySchemaZ = z20.object({
-      id: SemanticProductIdSchemaZ,
-      kind: OverlayKindSchemaZ,
-      focusReturnTarget: SemanticFocusTargetSchemaZ
-    }).strict();
-    FocusOverlayStateV1SchemaZ = z20.object({
-      windowActivity: z20.enum(["active", "inactive"]),
-      focusZone: FocusZoneSchemaZ,
-      appFocusedPaneId: SemanticProductIdSchemaZ.nullable(),
-      terminalInputPaneId: SemanticProductIdSchemaZ.nullable(),
-      layoutSelectedPaneId: SemanticProductIdSchemaZ.nullable(),
-      overlays: z20.array(SemanticOverlaySchemaZ).max(16)
-    }).strict().superRefine((state, ctx) => {
-      const ids = state.overlays.map((overlay) => overlay.id);
-      if (new Set(ids).size !== ids.length) {
-        ctx.addIssue({
-          code: z20.ZodIssueCode.custom,
-          message: "overlay ids must be unique",
-          path: ["overlays"]
-        });
-      }
-      if (state.terminalInputPaneId !== null && state.appFocusedPaneId !== state.terminalInputPaneId) {
-        ctx.addIssue({
-          code: z20.ZodIssueCode.custom,
-          message: "terminal input owner must also be the app-focused pane",
-          path: ["terminalInputPaneId"]
-        });
-      }
-    });
   }
 });
 
@@ -3779,8 +3761,423 @@ var init_cohesion_fixture = __esm({
   }
 });
 
-// packages/contracts/src/daemon-wire.ts
+// packages/contracts/src/application-shell.ts
 import { z as z22 } from "zod";
+function deepFreeze2(value) {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) deepFreeze2(child);
+  return Object.freeze(value);
+}
+function applyFocusTarget(focus, target) {
+  if (target.kind === "pane") {
+    return {
+      ...focus,
+      focusZone: target.input === "terminal" ? "terminal" : "canvas",
+      appFocusedPaneId: target.paneId,
+      terminalInputPaneId: target.input === "terminal" ? target.paneId : null
+    };
+  }
+  if (target.kind === "dock-tool") {
+    return { ...focus, focusZone: "dock-tabs", terminalInputPaneId: null };
+  }
+  return {
+    ...focus,
+    focusZone: target.zone,
+    terminalInputPaneId: null
+  };
+}
+function replaceResourceSelection(selections, next) {
+  const order = new Map(CANONICAL_SURFACE_REGISTRY.map((surface, index) => [surface.id, index]));
+  return [...selections.filter(({ surface }) => surface !== next.surface), next].sort(
+    (left, right) => order.get(left.surface) - order.get(right.surface)
+  );
+}
+function applyApplicationShellInvocationV1(state, rawInvocation) {
+  const current = ApplicationShellReplayStateV1SchemaZ.parse(state);
+  const invocation = ApplicationShellCommandInvocationSchemaZ.parse(rawInvocation);
+  const inputLayer = resolveSemanticInputLayer(current.focus);
+  const overlayOwnsInput = inputLayer.kind === "modal-dialog" || inputLayer.kind === "command-palette" || inputLayer.kind === "context-menu";
+  if (overlayOwnsInput) {
+    if (invocation.id !== APPLICATION_SHELL_COMMAND_IDS.closePalette || inputLayer.kind !== "command-palette" || inputLayer.overlayId !== invocation.args.overlayId) {
+      throw new Error(`semantic input is owned by overlay: ${inputLayer.overlayId}`);
+    }
+  } else if (invocation.id === APPLICATION_SHELL_COMMAND_IDS.closePalette) {
+    throw new Error(`cannot close absent command palette: ${invocation.args.overlayId}`);
+  }
+  let next;
+  switch (invocation.id) {
+    case APPLICATION_SHELL_COMMAND_IDS.activateMode:
+      next = { ...current, activeMode: invocation.args.mode };
+      break;
+    case APPLICATION_SHELL_COMMAND_IDS.activateDockTool:
+      next = { ...current, activeDockTool: invocation.args.tool };
+      break;
+    case APPLICATION_SHELL_COMMAND_IDS.setDockMode:
+      next = { ...current, dockMode: invocation.args.mode };
+      break;
+    case APPLICATION_SHELL_COMMAND_IDS.moveFocus:
+      next = { ...current, focus: applyFocusTarget(current.focus, invocation.args.target) };
+      break;
+    case APPLICATION_SHELL_COMMAND_IDS.openPalette: {
+      const overlay = {
+        id: invocation.args.overlayId,
+        kind: "command-palette",
+        focusReturnTarget: invocation.args.focusReturnTarget
+      };
+      next = {
+        ...current,
+        focus: { ...current.focus, overlays: [...current.focus.overlays, overlay] }
+      };
+      break;
+    }
+    case APPLICATION_SHELL_COMMAND_IDS.closePalette: {
+      const overlay = current.focus.overlays.find(({ id }) => id === invocation.args.overlayId);
+      if (!overlay || overlay.kind !== "command-palette") {
+        throw new Error(`command palette overlay is not open: ${invocation.args.overlayId}`);
+      }
+      const withoutClosed = {
+        ...current.focus,
+        overlays: current.focus.overlays.filter(({ id }) => id !== overlay.id)
+      };
+      next = { ...current, focus: applyFocusTarget(withoutClosed, overlay.focusReturnTarget) };
+      break;
+    }
+    case APPLICATION_SHELL_COMMAND_IDS.selectResource:
+      next = {
+        ...current,
+        selectedResources: replaceResourceSelection(current.selectedResources, invocation.args)
+      };
+      break;
+  }
+  return deepFreeze2(ApplicationShellReplayStateV1SchemaZ.parse(next));
+}
+function replayInvocations(initialState, invocations) {
+  return invocations.reduce(
+    (state, invocation) => applyApplicationShellInvocationV1(state, invocation),
+    deepFreeze2(ApplicationShellReplayStateV1SchemaZ.parse(initialState))
+  );
+}
+var APPLICATION_SHELL_PROJECTION_VERSION, APPLICATION_SHELL_TRACE_VERSION, ApplicationShellProjectionInputV1SchemaZ, WorkspaceFixtureSchemaZ, ApplicationShellSurfaceProjectionSchemaZ, ApplicationShellProjectionV1SchemaZ, ApplicationShellActivateModeArgumentsSchemaZ, ApplicationShellActivateDockToolArgumentsSchemaZ, ApplicationShellSetDockModeArgumentsSchemaZ, ApplicationShellMoveFocusArgumentsSchemaZ, ApplicationShellOpenPaletteArgumentsSchemaZ, ApplicationShellClosePaletteArgumentsSchemaZ, ApplicationShellSelectResourceArgumentsSchemaZ, APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS, ApplicationShellCommandInvocationSchemaZ, descriptor, APPLICATION_SHELL_COMMAND_DESCRIPTORS, descriptorById, APPLICATION_SHELL_COMMAND_DEFINITIONS, ApplicationShellResourceSelectionSchemaZ, ApplicationShellReplayStateV1SchemaZ, ApplicationShellActionTraceV1BaseSchemaZ, ApplicationShellActionTraceV1SchemaZ;
+var init_application_shell = __esm({
+  "packages/contracts/src/application-shell.ts"() {
+    "use strict";
+    init_cohesion_fixture();
+    init_commands();
+    init_experience_shell();
+    init_experience_identifiers();
+    init_focus_overlay();
+    init_pane_appearance();
+    APPLICATION_SHELL_PROJECTION_VERSION = 1;
+    APPLICATION_SHELL_TRACE_VERSION = 1;
+    ApplicationShellProjectionInputV1SchemaZ = z22.object({
+      project: CohesionFixtureV1SchemaZ.shape.project,
+      workspace: CohesionFixtureV1SchemaZ.shape.workspace,
+      dock: CohesionFixtureV1SchemaZ.shape.dock,
+      focus: FocusOverlayStateV1SchemaZ,
+      connection: CohesionFixtureV1SchemaZ.shape.connection
+    }).strict();
+    WorkspaceFixtureSchemaZ = CohesionFixtureV1SchemaZ.shape.workspace;
+    ApplicationShellSurfaceProjectionSchemaZ = z22.object({
+      id: ProductSurfaceIdSchemaZ,
+      icon: SemanticIconIdSchemaZ,
+      label: z22.string().min(1).max(160),
+      kind: z22.enum(["primary-mode", "dock-tool"]),
+      area: z22.enum(["workspace-canvas", "bottom-dock"]),
+      order: z22.number().int().nonnegative(),
+      owningMode: PrimaryWorkspaceModeIdSchemaZ,
+      shortcut: z22.string().min(1).max(32),
+      activation: SurfaceCommandTemplateSchemaZ,
+      active: z22.boolean(),
+      attention: z22.boolean(),
+      disabledReason: z22.string().min(1).max(240).nullable()
+    }).strict();
+    ApplicationShellProjectionV1SchemaZ = z22.object({
+      version: z22.literal(APPLICATION_SHELL_PROJECTION_VERSION),
+      project: CohesionFixtureV1SchemaZ.shape.project,
+      workspace: z22.object({
+        id: SemanticProductIdSchemaZ,
+        name: z22.string().min(1).max(160)
+      }).strict(),
+      sidebar: z22.object({
+        activeSessionId: SemanticProductIdSchemaZ,
+        sessions: WorkspaceFixtureSchemaZ.shape.sidebar.shape.sessions,
+        agents: WorkspaceFixtureSchemaZ.shape.sidebar.shape.agents
+      }).strict(),
+      primaryNavigation: z22.object({
+        activeMode: PrimaryWorkspaceModeIdSchemaZ,
+        items: z22.array(ApplicationShellSurfaceProjectionSchemaZ)
+      }).strict(),
+      workspaceCanvas: z22.object({ activeMode: PrimaryWorkspaceModeIdSchemaZ }).strict(),
+      bottomDock: z22.object({
+        mode: ApplicationShellDockModeSchemaZ,
+        activeTool: DockToolIdSchemaZ,
+        tools: z22.array(ApplicationShellSurfaceProjectionSchemaZ)
+      }).strict(),
+      statusStrip: CohesionFixtureV1SchemaZ.shape.connection,
+      focus: z22.object({
+        windowActivity: z22.enum(["active", "inactive"]),
+        zone: FocusZoneSchemaZ,
+        appFocusedPaneId: SemanticProductIdSchemaZ.nullable(),
+        terminalInputPaneId: SemanticProductIdSchemaZ.nullable(),
+        layoutSelectedPaneId: SemanticProductIdSchemaZ.nullable(),
+        overlays: z22.array(SemanticOverlaySchemaZ).max(16),
+        palette: z22.object({
+          open: z22.boolean(),
+          overlayId: SemanticProductIdSchemaZ.nullable(),
+          focusReturnTarget: SemanticFocusTargetSchemaZ.nullable()
+        }).strict()
+      }).strict()
+    }).strict();
+    ApplicationShellActivateModeArgumentsSchemaZ = z22.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict();
+    ApplicationShellActivateDockToolArgumentsSchemaZ = z22.object({ tool: DockToolIdSchemaZ }).strict();
+    ApplicationShellSetDockModeArgumentsSchemaZ = z22.object({ mode: ApplicationShellDockModeSchemaZ }).strict();
+    ApplicationShellMoveFocusArgumentsSchemaZ = z22.object({ target: SemanticFocusTargetSchemaZ }).strict();
+    ApplicationShellOpenPaletteArgumentsSchemaZ = z22.object({
+      overlayId: SemanticProductIdSchemaZ,
+      focusReturnTarget: SemanticFocusTargetSchemaZ
+    }).strict();
+    ApplicationShellClosePaletteArgumentsSchemaZ = z22.object({ overlayId: SemanticProductIdSchemaZ }).strict();
+    ApplicationShellSelectResourceArgumentsSchemaZ = z22.object({
+      surface: ProductSurfaceIdSchemaZ,
+      resourceId: SemanticProductIdSchemaZ
+    }).strict();
+    APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS = Object.freeze({
+      [APPLICATION_SHELL_COMMAND_IDS.activateMode]: ApplicationShellActivateModeArgumentsSchemaZ,
+      [APPLICATION_SHELL_COMMAND_IDS.activateDockTool]: ApplicationShellActivateDockToolArgumentsSchemaZ,
+      [APPLICATION_SHELL_COMMAND_IDS.setDockMode]: ApplicationShellSetDockModeArgumentsSchemaZ,
+      [APPLICATION_SHELL_COMMAND_IDS.moveFocus]: ApplicationShellMoveFocusArgumentsSchemaZ,
+      [APPLICATION_SHELL_COMMAND_IDS.openPalette]: ApplicationShellOpenPaletteArgumentsSchemaZ,
+      [APPLICATION_SHELL_COMMAND_IDS.closePalette]: ApplicationShellClosePaletteArgumentsSchemaZ,
+      [APPLICATION_SHELL_COMMAND_IDS.selectResource]: ApplicationShellSelectResourceArgumentsSchemaZ
+    });
+    ApplicationShellCommandInvocationSchemaZ = z22.discriminatedUnion("id", [
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
+        source: CommandSourceSchemaZ,
+        args: ApplicationShellActivateModeArgumentsSchemaZ
+      }).strict(),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
+        source: CommandSourceSchemaZ,
+        args: ApplicationShellActivateDockToolArgumentsSchemaZ
+      }).strict(),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
+        source: CommandSourceSchemaZ,
+        args: ApplicationShellSetDockModeArgumentsSchemaZ
+      }).strict(),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.moveFocus),
+        source: CommandSourceSchemaZ,
+        args: ApplicationShellMoveFocusArgumentsSchemaZ
+      }).strict(),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.openPalette),
+        source: CommandSourceSchemaZ,
+        args: ApplicationShellOpenPaletteArgumentsSchemaZ
+      }).strict(),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.closePalette),
+        source: CommandSourceSchemaZ,
+        args: ApplicationShellClosePaletteArgumentsSchemaZ
+      }).strict(),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
+        source: CommandSourceSchemaZ,
+        args: ApplicationShellSelectResourceArgumentsSchemaZ
+      }).strict()
+    ]);
+    descriptor = (id, label, category) => deepFreeze2(
+      CommandDescriptorSchemaZ.parse({
+        version: COMMAND_PROTOCOL_VERSION,
+        id,
+        owner: "renderer",
+        label,
+        category,
+        schemas: { input: `${id}.input.v1` },
+        dangerous: false,
+        confirmation: "none"
+      })
+    );
+    APPLICATION_SHELL_COMMAND_DESCRIPTORS = deepFreeze2([
+      descriptor(APPLICATION_SHELL_COMMAND_IDS.activateMode, "Activate workspace mode", "workspace"),
+      descriptor(APPLICATION_SHELL_COMMAND_IDS.activateDockTool, "Activate dock tool", "workspace"),
+      descriptor(APPLICATION_SHELL_COMMAND_IDS.setDockMode, "Set dock mode", "workspace"),
+      descriptor(APPLICATION_SHELL_COMMAND_IDS.moveFocus, "Move workspace focus", "workspace"),
+      descriptor(APPLICATION_SHELL_COMMAND_IDS.openPalette, "Open command palette", "application"),
+      descriptor(APPLICATION_SHELL_COMMAND_IDS.closePalette, "Close command palette", "application"),
+      descriptor(
+        APPLICATION_SHELL_COMMAND_IDS.selectResource,
+        "Select workspace resource",
+        "workspace"
+      )
+    ]);
+    descriptorById = new Map(
+      APPLICATION_SHELL_COMMAND_DESCRIPTORS.map((item) => [item.id, item])
+    );
+    APPLICATION_SHELL_COMMAND_DEFINITIONS = Object.freeze(
+      APPLICATION_SHELL_COMMAND_DESCRIPTORS.map(
+        (item) => Object.freeze({
+          descriptor: item,
+          inputSchema: APPLICATION_SHELL_COMMAND_ARGUMENT_SCHEMAS[item.id]
+        })
+      )
+    );
+    ApplicationShellResourceSelectionSchemaZ = z22.object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ }).strict();
+    ApplicationShellReplayStateV1SchemaZ = z22.object({
+      activeMode: PrimaryWorkspaceModeIdSchemaZ,
+      dockMode: ApplicationShellDockModeSchemaZ,
+      activeDockTool: DockToolIdSchemaZ,
+      focus: FocusOverlayStateV1SchemaZ,
+      selectedResources: z22.array(ApplicationShellResourceSelectionSchemaZ)
+    }).strict().superRefine((state, ctx) => {
+      const surfaces = state.selectedResources.map(({ surface }) => surface);
+      if (new Set(surfaces).size !== surfaces.length) {
+        ctx.addIssue({
+          code: "custom",
+          message: "selected resources must be unique by surface",
+          path: ["selectedResources"]
+        });
+      }
+    });
+    ApplicationShellActionTraceV1BaseSchemaZ = z22.object({
+      version: z22.literal(APPLICATION_SHELL_TRACE_VERSION),
+      initialState: ApplicationShellReplayStateV1SchemaZ,
+      invocations: z22.array(ApplicationShellCommandInvocationSchemaZ),
+      finalState: ApplicationShellReplayStateV1SchemaZ
+    }).strict();
+    ApplicationShellActionTraceV1SchemaZ = ApplicationShellActionTraceV1BaseSchemaZ.superRefine((trace, ctx) => {
+      try {
+        const replayed = replayInvocations(trace.initialState, trace.invocations);
+        if (JSON.stringify(replayed) !== JSON.stringify(trace.finalState)) {
+          ctx.addIssue({
+            code: "custom",
+            message: "final state does not match sequential command replay",
+            path: ["finalState"]
+          });
+        }
+      } catch (error) {
+        ctx.addIssue({
+          code: "custom",
+          message: error instanceof Error ? error.message : "command replay failed",
+          path: ["invocations"]
+        });
+      }
+    });
+  }
+});
+
+// packages/contracts/src/visual-recipes.ts
+var VISUAL_RECIPE_REGISTRY;
+var init_visual_recipes = __esm({
+  "packages/contracts/src/visual-recipes.ts"() {
+    "use strict";
+    VISUAL_RECIPE_REGISTRY = Object.freeze(
+      {
+        "application-bar": {
+          id: "application-bar",
+          surface: "header",
+          text: "bright",
+          border: "subtle",
+          typography: "label",
+          shape: "dockedRadius",
+          elevation: null
+        },
+        sidebar: {
+          id: "sidebar",
+          surface: "panel",
+          text: "secondary",
+          border: "subtle",
+          typography: "metadata",
+          shape: "dockedRadius",
+          elevation: null
+        },
+        "primary-navigation": {
+          id: "primary-navigation",
+          surface: "header",
+          text: "primary",
+          border: "subtle",
+          typography: "label",
+          shape: "controlRadius",
+          elevation: null
+        },
+        "context-actions": {
+          id: "context-actions",
+          surface: "header",
+          text: "secondary",
+          border: "subtle",
+          typography: "label",
+          shape: "controlRadius",
+          elevation: null
+        },
+        "workspace-canvas": {
+          id: "workspace-canvas",
+          surface: "canvas",
+          text: "primary",
+          border: "subtle",
+          typography: "workspace",
+          shape: "dockedRadius",
+          elevation: null
+        },
+        "bottom-dock": {
+          id: "bottom-dock",
+          surface: "panel",
+          text: "primary",
+          border: "default",
+          typography: "workspace",
+          shape: "dockedRadius",
+          elevation: null
+        },
+        "status-strip": {
+          id: "status-strip",
+          surface: "header",
+          text: "muted",
+          border: "subtle",
+          typography: "metadata",
+          shape: "statusRadius",
+          elevation: null
+        },
+        "pane-docked": {
+          id: "pane-docked",
+          surface: "terminal",
+          text: "primary",
+          border: "default",
+          typography: "workspace",
+          shape: "dockedRadius",
+          elevation: null
+        },
+        "pane-floating": {
+          id: "pane-floating",
+          surface: "panelRaised",
+          text: "primary",
+          border: "default",
+          typography: "workspace",
+          shape: "floatingRadius",
+          elevation: "floating"
+        },
+        "command-palette": {
+          id: "command-palette",
+          surface: "command",
+          text: "primary",
+          border: "focused",
+          typography: "workspace",
+          shape: "floatingRadius",
+          elevation: "palette"
+        }
+      }
+    );
+  }
+});
+
+// packages/contracts/src/daemon-wire.ts
+import { z as z23 } from "zod";
 function isDaemonWireProtocolCompatible(protocolVersion) {
   return protocolVersion === DAEMON_WIRE_PROTOCOL_VERSION;
 }
@@ -3789,37 +4186,37 @@ var init_daemon_wire = __esm({
   "packages/contracts/src/daemon-wire.ts"() {
     "use strict";
     DAEMON_WIRE_PROTOCOL_VERSION = 1;
-    DaemonWireProtocolVersionSchema = z22.number().int().positive();
-    DaemonInstanceIdSchema = z22.uuid();
-    CanonicalDaemonInfoSchema = z22.object({
-      pid: z22.number().int().positive(),
-      port: z22.number().int().min(1).max(65535),
+    DaemonWireProtocolVersionSchema = z23.number().int().positive();
+    DaemonInstanceIdSchema = z23.uuid();
+    CanonicalDaemonInfoSchema = z23.object({
+      pid: z23.number().int().positive(),
+      port: z23.number().int().min(1).max(65535),
       protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z22.string().trim().min(1),
+      productVersion: z23.string().trim().min(1),
       instanceId: DaemonInstanceIdSchema,
-      startedAt: z22.iso.datetime({ offset: true }),
-      bindHostname: z22.string().trim().min(1),
-      authToken: z22.string().min(1).nullable()
+      startedAt: z23.iso.datetime({ offset: true }),
+      bindHostname: z23.string().trim().min(1),
+      authToken: z23.string().min(1).nullable()
     });
-    DaemonHealthSchema = z22.object({
-      ok: z22.literal(true),
+    DaemonHealthSchema = z23.object({
+      ok: z23.literal(true),
       protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z22.string().trim().min(1),
-      uptime: z22.number().nonnegative()
+      productVersion: z23.string().trim().min(1),
+      uptime: z23.number().nonnegative()
     });
-    DaemonHealthzSchema = z22.object({
-      ok: z22.literal(true),
+    DaemonHealthzSchema = z23.object({
+      ok: z23.literal(true),
       protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z22.string().trim().min(1),
-      uptimeMs: z22.number().nonnegative()
+      productVersion: z23.string().trim().min(1),
+      uptimeMs: z23.number().nonnegative()
     });
-    DaemonIdentitySchema = z22.object({
-      ok: z22.literal(true),
-      pid: z22.number().int().positive(),
+    DaemonIdentitySchema = z23.object({
+      ok: z23.literal(true),
+      pid: z23.number().int().positive(),
       protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z22.string().trim().min(1),
+      productVersion: z23.string().trim().min(1),
       instanceId: DaemonInstanceIdSchema,
-      startedAt: z22.iso.datetime({ offset: true })
+      startedAt: z23.iso.datetime({ offset: true })
     });
   }
 });
@@ -3846,6 +4243,7 @@ var init_src = __esm({
     init_desktop_host();
     init_experience_identifiers();
     init_experience_shell();
+    init_application_shell();
     init_visual_tokens();
     init_visual_recipes();
     init_pane_appearance();
@@ -7123,6 +7521,34 @@ var init_sessions2 = __esm({
   }
 });
 
+// packages/daemon/src/lib/legacy-theme-compat.ts
+function legacyThemeOverrideProvenance(explicitIds = /* @__PURE__ */ new Set()) {
+  return Object.freeze(
+    Object.fromEntries(LEGACY_THEME_OVERRIDE_IDS.map((id) => [id, explicitIds.has(id)]))
+  );
+}
+var LEGACY_THEME_OVERRIDE_IDS, LEGACY_THEME_OVERRIDE_PROVENANCE;
+var init_legacy_theme_compat = __esm({
+  "packages/daemon/src/lib/legacy-theme-compat.ts"() {
+    "use strict";
+    LEGACY_THEME_OVERRIDE_IDS = [
+      "accent",
+      "muted",
+      "fg",
+      "status.blocked",
+      "status.working",
+      "status.done",
+      "status.idle",
+      "status.unknown",
+      "glyphs.active",
+      "glyphs.inactive"
+    ];
+    LEGACY_THEME_OVERRIDE_PROVENANCE = /* @__PURE__ */ Symbol.for(
+      "tmux-ide.legacy-theme-override-provenance"
+    );
+  }
+});
+
 // packages/daemon/src/lib/app-config.ts
 var app_config_exports = {};
 __export(app_config_exports, {
@@ -7158,6 +7584,22 @@ function pickNonNegInt(value, fallback) {
 }
 function pickChoice(value, allowed, fallback) {
   return typeof value === "string" && allowed.includes(value) ? value : fallback;
+}
+function isExplicitString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function appThemeOverrideProvenance(theme, status2, glyphs) {
+  const explicit = /* @__PURE__ */ new Set();
+  if (isExplicitString(theme.accent)) explicit.add("accent");
+  if (isExplicitString(theme.muted)) explicit.add("muted");
+  if (isExplicitString(theme.fg)) explicit.add("fg");
+  for (const id of ["blocked", "working", "done", "idle", "unknown"]) {
+    if (isExplicitString(status2[id])) explicit.add(`status.${id}`);
+  }
+  for (const id of ["active", "inactive"]) {
+    if (isExplicitString(glyphs[id])) explicit.add(`glyphs.${id}`);
+  }
+  return legacyThemeOverrideProvenance(explicit);
 }
 function parseAppConfig(input) {
   const D = DEFAULT_APP_CONFIG;
@@ -7203,7 +7645,8 @@ function parseAppConfig(input) {
       glyphs: {
         active: pickString(glyphs.active, D.theme.glyphs.active),
         inactive: pickString(glyphs.inactive, D.theme.glyphs.inactive)
-      }
+      },
+      [LEGACY_THEME_OVERRIDE_PROVENANCE]: appThemeOverrideProvenance(theme, status2, glyphs)
     },
     updater: {
       tickMs: pickPosInt(updater.tickMs, D.updater.tickMs),
@@ -7295,6 +7738,7 @@ var DEFAULT_APP_CONFIG, DEFAULT_THEME, DEFAULT_KEYS, cached;
 var init_app_config = __esm({
   "packages/daemon/src/lib/app-config.ts"() {
     "use strict";
+    init_legacy_theme_compat();
     DEFAULT_APP_CONFIG = {
       keys: {
         popup: "M-p",
@@ -7316,7 +7760,8 @@ var init_app_config = __esm({
           idle: "colour114",
           unknown: "colour244"
         },
-        glyphs: { active: "\u25CF", inactive: "\u25CB" }
+        glyphs: { active: "\u25CF", inactive: "\u25CB" },
+        [LEGACY_THEME_OVERRIDE_PROVENANCE]: legacyThemeOverrideProvenance()
       },
       updater: { tickMs: 2e3, snapshotEvery: 15 },
       notifications: { toast: true, macos: false, terminal: true, delaySeconds: 2, sound: "blocked" },
@@ -9004,45 +9449,45 @@ var init_session_id = __esm({
 });
 
 // packages/daemon/src/schemas/registry.ts
-import { z as z23 } from "zod";
+import { z as z24 } from "zod";
 var RegisteredProjectSchemaZ, RegisterProjectRequestSchemaZ, InitProjectRequestSchemaZ, ProjectTemplateSchemaZ;
 var init_registry = __esm({
   "packages/daemon/src/schemas/registry.ts"() {
     "use strict";
-    RegisteredProjectSchemaZ = z23.object({
+    RegisteredProjectSchemaZ = z24.object({
       /** Unique registry key. Defaults to `basename(dir)`; collisions resolved by appending `-2`, `-3`, … */
-      name: z23.string(),
+      name: z24.string(),
       /** Absolute path to the project directory. */
-      dir: z23.string(),
+      dir: z24.string(),
       /** Whether `<dir>/ide.yml` exists; refreshed on register and on `probe()`. */
-      hasIdeYml: z23.boolean(),
+      hasIdeYml: z24.boolean(),
       /** Whether `.tmux-ide/workspace.yml` exists or wins discovery. */
-      hasWorkspaceConfig: z23.boolean().optional(),
+      hasWorkspaceConfig: z24.boolean().optional(),
       /** Generalized winning config kind. Added without replacing `hasIdeYml`. */
-      configKind: z23.enum(["workspace", "legacy", "none"]).optional(),
+      configKind: z24.enum(["workspace", "legacy", "none"]).optional(),
       /** Generalized winning config path. */
-      configPath: z23.string().nullable().optional(),
+      configPath: z24.string().nullable().optional(),
       /** Legacy config path when an `ide.yml` is present. */
-      ideConfigPath: z23.string().nullable().optional(),
+      ideConfigPath: z24.string().nullable().optional(),
       /** Git remote origin URL, or `null` if not a git repo / no origin / probe failed. */
-      gitOrigin: z23.string().nullable(),
+      gitOrigin: z24.string().nullable(),
       /** Current git branch, or `null` if not a git repo / detached HEAD / probe failed. */
-      gitBranch: z23.string().nullable(),
+      gitBranch: z24.string().nullable(),
       /** ISO-8601 timestamp the project was first registered. */
-      registeredAt: z23.string()
+      registeredAt: z24.string()
     });
-    RegisterProjectRequestSchemaZ = z23.object({
-      dir: z23.string().min(1),
-      name: z23.string().min(1).optional()
+    RegisterProjectRequestSchemaZ = z24.object({
+      dir: z24.string().min(1),
+      name: z24.string().min(1).optional()
     });
-    InitProjectRequestSchemaZ = z23.object({
-      dir: z23.string().min(1),
-      template: z23.string().min(1).optional()
+    InitProjectRequestSchemaZ = z24.object({
+      dir: z24.string().min(1),
+      template: z24.string().min(1).optional()
     });
-    ProjectTemplateSchemaZ = z23.object({
-      id: z23.string(),
-      label: z23.string(),
-      description: z23.string()
+    ProjectTemplateSchemaZ = z24.object({
+      id: z24.string(),
+      label: z24.string(),
+      description: z24.string()
     });
   }
 });
@@ -9104,7 +9549,7 @@ import { EventEmitter } from "node:events";
 import { existsSync as existsSync15, mkdirSync as mkdirSync9, readFileSync as readFileSync11, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir10 } from "node:os";
 import { dirname as dirname15, isAbsolute as isAbsolute3, join as join14, resolve as resolve11 } from "node:path";
-import { z as z24 } from "zod";
+import { z as z25 } from "zod";
 function applyAction(state, action) {
   switch (action.type) {
     case "register":
@@ -9243,9 +9688,9 @@ var init_project_registry = __esm({
     init_registry();
     init_project_probe();
     REGISTRY_DIR_ENV = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ = z24.object({
-      version: z24.literal(1),
-      projects: z24.array(RegisteredProjectSchemaZ)
+    RegistryFileSchemaZ = z25.object({
+      version: z25.literal(1),
+      projects: z25.array(RegisteredProjectSchemaZ)
     });
     ProjectRegistryError = class extends Error {
       code;
@@ -10017,7 +10462,7 @@ var init_notify_state = __esm({
 import { existsSync as existsSync19, mkdirSync as mkdirSync12, readFileSync as readFileSync14, renameSync as renameSync7, writeFileSync as writeFileSync11 } from "node:fs";
 import { homedir as homedir12 } from "node:os";
 import { dirname as dirname17, join as join18 } from "node:path";
-import { z as z25 } from "zod";
+import { z as z26 } from "zod";
 function isBareShell(cmd) {
   return /^-?(zsh|bash|sh|fish|dash|ksh|tcsh|csh|nu)$/.test(cmd.trim());
 }
@@ -10189,32 +10634,32 @@ var init_snapshot2 = __esm({
     init_src2();
     init_process_tree();
     init_sessions2();
-    PaneSnapshotSchemaZ = z25.object({
-      index: z25.number(),
-      cwd: z25.string(),
-      command: z25.string().nullable(),
-      agent: z25.string().nullable(),
-      agentSessionId: z25.string().nullable(),
-      agentState: z25.string().nullable(),
-      title: z25.string()
+    PaneSnapshotSchemaZ = z26.object({
+      index: z26.number(),
+      cwd: z26.string(),
+      command: z26.string().nullable(),
+      agent: z26.string().nullable(),
+      agentSessionId: z26.string().nullable(),
+      agentState: z26.string().nullable(),
+      title: z26.string()
     });
-    WindowSnapshotSchemaZ = z25.object({
-      index: z25.number(),
-      name: z25.string(),
-      active: z25.boolean(),
-      layout: z25.string(),
-      panes: z25.array(PaneSnapshotSchemaZ)
+    WindowSnapshotSchemaZ = z26.object({
+      index: z26.number(),
+      name: z26.string(),
+      active: z26.boolean(),
+      layout: z26.string(),
+      panes: z26.array(PaneSnapshotSchemaZ)
     });
-    SessionSnapshotSchemaZ = z25.object({
-      name: z25.string(),
-      cwd: z25.string(),
-      adopted: z25.boolean(),
-      windows: z25.array(WindowSnapshotSchemaZ)
+    SessionSnapshotSchemaZ = z26.object({
+      name: z26.string(),
+      cwd: z26.string(),
+      adopted: z26.boolean(),
+      windows: z26.array(WindowSnapshotSchemaZ)
     });
-    FleetSnapshotSchemaZ = z25.object({
-      version: z25.literal(1),
-      savedAt: z25.string(),
-      sessions: z25.array(SessionSnapshotSchemaZ)
+    FleetSnapshotSchemaZ = z26.object({
+      version: z26.literal(1),
+      savedAt: z26.string(),
+      sessions: z26.array(SessionSnapshotSchemaZ)
     });
     SNAPSHOT_PANE_FORMAT = [
       "#{session_name}",
@@ -10933,7 +11378,7 @@ function ownerPidFromRaw(raw) {
   return typeof pid === "number" && Number.isInteger(pid) && pid > 0 ? pid : null;
 }
 function inspectCanonicalDaemonInfoPath(path2) {
-  let descriptor;
+  let descriptor2;
   try {
     const pathStat = lstatSync(path2);
     const pathObservation = observation(pathStat);
@@ -10972,8 +11417,8 @@ function inspectCanonicalDaemonInfoPath(path2) {
         pathObservation
       );
     }
-    descriptor = openSync2(path2, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
-    const openedStat = fstatSync(descriptor);
+    descriptor2 = openSync2(path2, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    const openedStat = fstatSync(descriptor2);
     const openedObservation = observation(openedStat);
     if (!openedStat.isFile() || !sameObservation(pathObservation, openedObservation) || typeof process.getuid === "function" && openedStat.uid !== process.getuid() || (openedStat.mode & 63) !== 0) {
       return invalidState(
@@ -10985,7 +11430,7 @@ function inspectCanonicalDaemonInfoPath(path2) {
     }
     let raw;
     try {
-      raw = JSON.parse(readFileSync15(descriptor, "utf-8"));
+      raw = JSON.parse(readFileSync15(descriptor2, "utf-8"));
     } catch (error) {
       return invalidState(
         "malformed-json",
@@ -11011,11 +11456,11 @@ function inspectCanonicalDaemonInfoPath(path2) {
       error instanceof Error ? error.message : "daemon.json could not be read"
     );
   } finally {
-    if (descriptor !== void 0) closeSync2(descriptor);
+    if (descriptor2 !== void 0) closeSync2(descriptor2);
   }
 }
 function inspectCanonicalDaemonClaimPath(path2) {
-  let descriptor;
+  let descriptor2;
   try {
     const claimStat = lstatSync(path2);
     if (claimStat.isSymbolicLink() || !claimStat.isDirectory()) {
@@ -11041,12 +11486,12 @@ function inspectCanonicalDaemonClaimPath(path2) {
     if ((ownerStat.mode & 63) !== 0) {
       return { status: "invalid", detail: "daemon claim owner is not owner-only" };
     }
-    descriptor = openSync2(ownerPath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
-    const openedStat = fstatSync(descriptor);
+    descriptor2 = openSync2(ownerPath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    const openedStat = fstatSync(descriptor2);
     if (!openedStat.isFile() || openedStat.dev !== ownerStat.dev || openedStat.ino !== ownerStat.ino || openedStat.size !== ownerStat.size) {
       return { status: "invalid", detail: "daemon claim changed while it was opened" };
     }
-    const raw = JSON.parse(readFileSync15(descriptor, "utf-8"));
+    const raw = JSON.parse(readFileSync15(descriptor2, "utf-8"));
     if (typeof raw.claimId !== "string" || !/^[0-9a-f-]{36}$/iu.test(raw.claimId) || typeof raw.pid !== "number" || !Number.isInteger(raw.pid) || raw.pid <= 0 || typeof raw.acquiredAt !== "string" || !Number.isFinite(Date.parse(raw.acquiredAt))) {
       return { status: "invalid", detail: "daemon claim owner has invalid metadata" };
     }
@@ -11061,7 +11506,7 @@ function inspectCanonicalDaemonClaimPath(path2) {
       detail: error instanceof Error ? error.message : "daemon claim could not be read"
     };
   } finally {
-    if (descriptor !== void 0) closeSync2(descriptor);
+    if (descriptor2 !== void 0) closeSync2(descriptor2);
   }
 }
 function restoreCapturedFile(capturedPath, canonicalPath) {
@@ -13163,7 +13608,7 @@ import { EventEmitter as EventEmitter3 } from "node:events";
 import { existsSync as existsSync26, mkdirSync as mkdirSync17, readFileSync as readFileSync20, renameSync as renameSync9, writeFileSync as writeFileSync16 } from "node:fs";
 import { homedir as homedir16 } from "node:os";
 import { dirname as dirname24, join as join24 } from "node:path";
-import { z as z26 } from "zod";
+import { z as z27 } from "zod";
 function getDefaultWorkspaceRegistry() {
   if (!_default) _default = new WorkspaceRegistry();
   return _default;
@@ -13186,9 +13631,9 @@ var init_workspace_registry = __esm({
     "use strict";
     init_src();
     REGISTRY_DIR_ENV3 = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ2 = z26.object({
-      version: z26.literal(1),
-      workspaces: z26.array(WorkspaceSchemaZ)
+    RegistryFileSchemaZ2 = z27.object({
+      version: z27.literal(1),
+      workspaces: z27.array(WorkspaceSchemaZ)
     });
     WorkspaceAlreadyExistsError = class extends Error {
       code = "ALREADY_EXISTS";
@@ -14000,74 +14445,74 @@ var init_log = __esm({
 });
 
 // packages/daemon/src/command-center/schemas.ts
-import { z as z27 } from "zod";
+import { z as z28 } from "zod";
 var updateTaskSchema, createTaskSchema, savePlanSchema, savePlanContentSchema, sendCommandSchema, createMilestoneSchema, updateMilestoneSchema, updateAssertionSchema, triggerResearchSchema, launchSchema, stopSchema, skillNameRegex, createSkillSchema, updateSkillSchema;
 var init_schemas = __esm({
   "packages/daemon/src/command-center/schemas.ts"() {
     "use strict";
-    updateTaskSchema = z27.object({
-      status: z27.enum(["todo", "in-progress", "review", "done"]).optional(),
-      assignee: z27.string().optional(),
-      title: z27.string().optional(),
-      description: z27.string().optional(),
-      priority: z27.number().optional()
+    updateTaskSchema = z28.object({
+      status: z28.enum(["todo", "in-progress", "review", "done"]).optional(),
+      assignee: z28.string().optional(),
+      title: z28.string().optional(),
+      description: z28.string().optional(),
+      priority: z28.number().optional()
     });
-    createTaskSchema = z27.object({
-      title: z27.string().trim().min(1, "Title is required"),
-      description: z27.string().optional(),
-      priority: z27.number().optional(),
-      goal: z27.string().optional(),
-      tags: z27.array(z27.string()).optional()
+    createTaskSchema = z28.object({
+      title: z28.string().trim().min(1, "Title is required"),
+      description: z28.string().optional(),
+      priority: z28.number().optional(),
+      goal: z28.string().optional(),
+      tags: z28.array(z28.string()).optional()
     });
-    savePlanSchema = z27.object({
-      content: z27.string().max(1e6, "Plan content is too large")
+    savePlanSchema = z28.object({
+      content: z28.string().max(1e6, "Plan content is too large")
     });
-    savePlanContentSchema = z27.object({
-      content: z27.string().max(1e6, "Plan content is too large")
+    savePlanContentSchema = z28.object({
+      content: z28.string().max(1e6, "Plan content is too large")
     });
-    sendCommandSchema = z27.object({
-      target: z27.string().min(1, "Target pane is required"),
-      message: z27.string().min(1, "Message is required"),
-      noEnter: z27.boolean().optional()
+    sendCommandSchema = z28.object({
+      target: z28.string().min(1, "Target pane is required"),
+      message: z28.string().min(1, "Message is required"),
+      noEnter: z28.boolean().optional()
     });
-    createMilestoneSchema = z27.object({
-      title: z27.string().trim().min(1, "Title is required"),
-      sequence: z27.number().int().positive(),
-      description: z27.string().optional()
+    createMilestoneSchema = z28.object({
+      title: z28.string().trim().min(1, "Title is required"),
+      sequence: z28.number().int().positive(),
+      description: z28.string().optional()
     });
-    updateMilestoneSchema = z27.object({
-      status: z27.enum(["locked", "active", "done", "validating"]).optional(),
-      title: z27.string().optional(),
-      description: z27.string().optional()
+    updateMilestoneSchema = z28.object({
+      status: z28.enum(["locked", "active", "done", "validating"]).optional(),
+      title: z28.string().optional(),
+      description: z28.string().optional()
     });
-    updateAssertionSchema = z27.object({
-      status: z27.enum(["pending", "passing", "failing", "blocked"]),
-      evidence: z27.string().optional(),
-      verifiedBy: z27.string().optional()
+    updateAssertionSchema = z28.object({
+      status: z28.enum(["pending", "passing", "failing", "blocked"]),
+      evidence: z28.string().optional(),
+      verifiedBy: z28.string().optional()
     });
-    triggerResearchSchema = z27.object({
-      type: z27.string().trim().min(1, "Research type is required")
+    triggerResearchSchema = z28.object({
+      type: z28.string().trim().min(1, "Research type is required")
     });
-    launchSchema = z27.object({
-      attach: z27.boolean().optional()
+    launchSchema = z28.object({
+      attach: z28.boolean().optional()
     }).optional();
-    stopSchema = z27.object({}).optional();
+    stopSchema = z28.object({}).optional();
     skillNameRegex = /^[A-Za-z0-9._ -]+$/;
-    createSkillSchema = z27.object({
-      name: z27.string().trim().min(1, "Skill name is required").regex(
+    createSkillSchema = z28.object({
+      name: z28.string().trim().min(1, "Skill name is required").regex(
         skillNameRegex,
         "Skill name may only contain letters, digits, dot, dash, underscore, or space"
       ),
-      role: z27.string().trim().optional(),
-      description: z27.string().optional(),
-      specialties: z27.array(z27.string()).optional(),
-      body: z27.string().optional()
+      role: z28.string().trim().optional(),
+      description: z28.string().optional(),
+      specialties: z28.array(z28.string()).optional(),
+      body: z28.string().optional()
     });
-    updateSkillSchema = z27.object({
-      role: z27.string().trim().optional(),
-      description: z27.string().optional(),
-      specialties: z27.array(z27.string()).optional(),
-      body: z27.string().optional()
+    updateSkillSchema = z28.object({
+      role: z28.string().trim().optional(),
+      description: z28.string().optional(),
+      specialties: z28.array(z28.string()).optional(),
+      body: z28.string().optional()
     });
   }
 });
@@ -14934,10 +15379,10 @@ function recoverCommandId(value) {
   return parsed.success ? parsed.data : void 0;
 }
 function immutableDescriptor(rawDescriptor) {
-  const descriptor = CommandDescriptorSchemaZ.parse(rawDescriptor);
+  const descriptor2 = CommandDescriptorSchemaZ.parse(rawDescriptor);
   return Object.freeze({
-    ...descriptor,
-    schemas: Object.freeze({ ...descriptor.schemas })
+    ...descriptor2,
+    schemas: Object.freeze({ ...descriptor2.schemas })
   });
 }
 var CommandRegistry;
@@ -14951,13 +15396,13 @@ var init_command_registry = __esm({
         for (const definition of definitions) this.register(definition);
       }
       register(definition) {
-        const descriptor = immutableDescriptor(definition.descriptor);
-        if (this.definitions.has(descriptor.id)) {
-          throw new Error(`duplicate command id: ${descriptor.id}`);
+        const descriptor2 = immutableDescriptor(definition.descriptor);
+        if (this.definitions.has(descriptor2.id)) {
+          throw new Error(`duplicate command id: ${descriptor2.id}`);
         }
-        this.definitions.set(descriptor.id, {
+        this.definitions.set(descriptor2.id, {
           ...definition,
-          descriptor: Object.freeze(descriptor)
+          descriptor: Object.freeze(descriptor2)
         });
       }
       has(id) {
@@ -15312,64 +15757,64 @@ var init_project_init_runner = __esm({
 });
 
 // packages/daemon/src/schemas/inspect.ts
-import { z as z28 } from "zod";
+import { z as z29 } from "zod";
 var ProjectInspectDetectedSchemaZ, ProjectInspectSchemaZ, InspectFilesystemRequestSchemaZ, OnboardProjectRequestSchemaZ;
 var init_inspect = __esm({
   "packages/daemon/src/schemas/inspect.ts"() {
     "use strict";
-    ProjectInspectDetectedSchemaZ = z28.object({
+    ProjectInspectDetectedSchemaZ = z29.object({
       /** Detected package manager from lockfile, or `null`. */
-      packageManager: z28.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
+      packageManager: z29.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
       /** Detected frameworks (e.g. `["next", "convex"]`). Empty array when none. */
-      frameworks: z28.array(z28.string()),
+      frameworks: z29.array(z29.string()),
       /** Suggested dev command (e.g. `pnpm dev`). `null` if no dev script found. */
-      devCommand: z28.string().nullable(),
+      devCommand: z29.string().nullable(),
       /** Suggested test command (e.g. `pnpm test`). `null` if no test script found. */
-      testCommand: z28.string().nullable()
+      testCommand: z29.string().nullable()
     });
-    ProjectInspectSchemaZ = z28.object({
+    ProjectInspectSchemaZ = z29.object({
       /** Sanitized basename of the directory — safe to use as a tmux session name. */
-      name: z28.string(),
+      name: z29.string(),
       /** Absolute, canonical path to the directory. */
-      dir: z28.string(),
+      dir: z29.string(),
       /** Whether `<dir>/ide.yml` exists. Legacy compatibility fact. */
-      hasIdeYml: z28.boolean(),
+      hasIdeYml: z29.boolean(),
       /** Whether `.tmux-ide/workspace.yml` exists or wins discovery. */
-      hasWorkspaceConfig: z28.boolean().optional(),
+      hasWorkspaceConfig: z29.boolean().optional(),
       /** Generalized winning config kind. Added without replacing `hasIdeYml`. */
-      configKind: z28.enum(["workspace", "legacy", "none"]).optional(),
+      configKind: z29.enum(["workspace", "legacy", "none"]).optional(),
       /** Generalized winning config path. Added without replacing legacy path facts. */
-      configPath: z28.string().nullable().optional(),
+      configPath: z29.string().nullable().optional(),
       /** Legacy config path when an `ide.yml` is present. */
-      ideConfigPath: z28.string().nullable().optional(),
+      ideConfigPath: z29.string().nullable().optional(),
       /** Git remote origin URL, or `null` if not a git repo / no origin / probe failed. */
-      gitOrigin: z28.string().nullable(),
+      gitOrigin: z29.string().nullable(),
       /** Current git branch, or `null` if not a git repo / detached HEAD / probe failed. */
-      gitBranch: z28.string().nullable(),
+      gitBranch: z29.string().nullable(),
       /** Detected stack signals (reuses `tmux-ide detect` logic). */
       detected: ProjectInspectDetectedSchemaZ
     });
-    InspectFilesystemRequestSchemaZ = z28.object({
-      dir: z28.string().min(1)
+    InspectFilesystemRequestSchemaZ = z29.object({
+      dir: z29.string().min(1)
     });
-    OnboardProjectRequestSchemaZ = z28.object({
-      dir: z28.string().min(1),
+    OnboardProjectRequestSchemaZ = z29.object({
+      dir: z29.string().min(1),
       /** Optional override for the project name — defaults to inspect.name. */
-      name: z28.string().min(1).optional(),
+      name: z29.string().min(1).optional(),
       /** 1, 2, or 3 — how many Claude panes to scaffold in the top row. */
-      agents: z28.number().int().min(1).max(3),
+      agents: z29.number().int().min(1).max(3),
       /**
        * Optional per-agent pane titles. When provided, length must equal
        * `agents`; the server uses these as `title:` for the Claude panes
        * instead of the canonical `Lead`/`Teammate N`/`Claude N` defaults.
        */
-      agentNames: z28.array(z28.string().min(1)).optional(),
+      agentNames: z29.array(z29.string().min(1)).optional(),
       /** Dev server command (e.g. `pnpm dev`). Omit / null to skip the dev pane. */
-      devCommand: z28.string().min(1).nullable().optional(),
+      devCommand: z29.string().min(1).nullable().optional(),
       /** Test command (e.g. `pnpm test`). Currently informational; stored for later. */
-      testCommand: z28.string().min(1).nullable().optional(),
+      testCommand: z29.string().min(1).nullable().optional(),
       /** Lint command (e.g. `pnpm lint`). Currently informational; stored for later. */
-      lintCommand: z28.string().min(1).nullable().optional()
+      lintCommand: z29.string().min(1).nullable().optional()
     });
   }
 });
@@ -17309,7 +17754,7 @@ var init_daemon_embed = __esm({
 
 // packages/daemon/src/lib/cli-action-bridge.ts
 import { createRequire as createRequire3 } from "node:module";
-import { z as z29 } from "zod";
+import { z as z30 } from "zod";
 function timeoutSignal3(ms) {
   const controller = new AbortController();
   setTimeout(() => controller.abort(), ms).unref?.();
@@ -17408,7 +17853,7 @@ async function tryDispatchAction(name, input, options = {}) {
       details: failure.data.error.details
     });
   }
-  const success = z29.object({ ok: z29.literal(true), result: contract.result }).safeParse(body);
+  const success = z30.object({ ok: z30.literal(true), result: contract.result }).safeParse(body);
   if (!success.success) return null;
   return success.data.result;
 }
@@ -17419,12 +17864,12 @@ var init_cli_action_bridge = __esm({
     init_contract();
     init_canonical_daemon();
     init_daemon_embed();
-    FailureEnvelopeZ = z29.object({
-      ok: z29.literal(false),
-      error: z29.object({
-        code: z29.string(),
-        message: z29.string(),
-        details: z29.unknown().optional()
+    FailureEnvelopeZ = z30.object({
+      ok: z30.literal(false),
+      error: z30.object({
+        code: z30.string(),
+        message: z30.string(),
+        details: z30.unknown().optional()
       })
     });
     deps = {

--- a/packages/daemon/src/lib/app-config.test.ts
+++ b/packages/daemon/src/lib/app-config.test.ts
@@ -15,6 +15,10 @@ import {
   parseAppConfig,
   updateAppConfig,
 } from "./app-config.ts";
+import {
+  LEGACY_THEME_OVERRIDE_IDS,
+  LEGACY_THEME_OVERRIDE_PROVENANCE,
+} from "./legacy-theme-compat.ts";
 
 describe("parseAppConfig — defaults", () => {
   it("returns the full defaults for undefined / null / non-objects / arrays", () => {
@@ -29,6 +33,33 @@ describe("parseAppConfig — defaults", () => {
   it("never throws on hostile input", () => {
     expect(() => parseAppConfig({ theme: 5, keys: "x", updater: [] })).not.toThrow();
     expect(parseAppConfig({ theme: 5, keys: "x", updater: [] })).toEqual(DEFAULT_APP_CONFIG);
+  });
+
+  it("records legacy theme provenance without serializing internal metadata", () => {
+    const defaults = parseAppConfig(undefined).theme[LEGACY_THEME_OVERRIDE_PROVENANCE]!;
+    expect(Object.keys(defaults)).toEqual([...LEGACY_THEME_OVERRIDE_IDS]);
+    expect(Object.values(defaults).every((explicit) => !explicit)).toBe(true);
+
+    const custom = parseAppConfig({
+      theme: {
+        accent: "colour75",
+        fg: "#123456",
+        muted: "",
+        status: { blocked: "colour99", working: 42 },
+        glyphs: { active: "◆" },
+      },
+    }).theme[LEGACY_THEME_OVERRIDE_PROVENANCE]!;
+    expect(custom.accent).toBe(true);
+    expect(custom.fg).toBe(true);
+    expect(custom.muted).toBe(false);
+    expect(custom["status.blocked"]).toBe(true);
+    expect(custom["status.working"]).toBe(false);
+    expect(custom["glyphs.active"]).toBe(true);
+    expect(custom["glyphs.inactive"]).toBe(false);
+
+    expect(JSON.stringify(parseAppConfig(undefined))).not.toContain(
+      "legacy-theme-override-provenance",
+    );
   });
 });
 

--- a/packages/daemon/src/lib/app-config.ts
+++ b/packages/daemon/src/lib/app-config.ts
@@ -25,6 +25,12 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { AgentStatus } from "../tui/detect/classify.ts";
 import type { ThemeModeSetting } from "../tui/mirror/theme.ts";
+import {
+  LEGACY_THEME_OVERRIDE_PROVENANCE,
+  legacyThemeOverrideProvenance,
+  type LegacyThemeOverrideId,
+  type LegacyThemeOverrideProvenance,
+} from "./legacy-theme-compat.ts";
 
 // ---------------------------------------------------------------------------
 // Shape
@@ -89,6 +95,8 @@ export interface AppTheme {
   status: AppThemeStatus;
   /** The filled/hollow state glyphs. */
   glyphs: AppThemeGlyphs;
+  /** Internal, non-serializing record of legacy leaves genuinely present in the raw config. */
+  [LEGACY_THEME_OVERRIDE_PROVENANCE]?: LegacyThemeOverrideProvenance;
 }
 
 /** Chrome updater cadence. */
@@ -266,6 +274,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
       unknown: "colour244",
     },
     glyphs: { active: "●", inactive: "○" },
+    [LEGACY_THEME_OVERRIDE_PROVENANCE]: legacyThemeOverrideProvenance(),
   },
   updater: { tickMs: 2000, snapshotEvery: 15 },
   notifications: { toast: true, macos: false, terminal: true, delaySeconds: 2, sound: "blocked" },
@@ -327,6 +336,28 @@ function pickChoice<T extends string>(value: unknown, allowed: readonly T[], fal
     : fallback;
 }
 
+function isExplicitString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function appThemeOverrideProvenance(
+  theme: Record<string, unknown>,
+  status: Record<string, unknown>,
+  glyphs: Record<string, unknown>,
+): LegacyThemeOverrideProvenance {
+  const explicit = new Set<LegacyThemeOverrideId>();
+  if (isExplicitString(theme.accent)) explicit.add("accent");
+  if (isExplicitString(theme.muted)) explicit.add("muted");
+  if (isExplicitString(theme.fg)) explicit.add("fg");
+  for (const id of ["blocked", "working", "done", "idle", "unknown"] as const) {
+    if (isExplicitString(status[id])) explicit.add(`status.${id}`);
+  }
+  for (const id of ["active", "inactive"] as const) {
+    if (isExplicitString(glyphs[id])) explicit.add(`glyphs.${id}`);
+  }
+  return legacyThemeOverrideProvenance(explicit);
+}
+
 /**
  * PURE — merge an unknown (typically parsed JSON) over {@link DEFAULT_APP_CONFIG}.
  * Every block/leaf is validated independently: a missing or mistyped field falls
@@ -378,6 +409,7 @@ export function parseAppConfig(input: unknown): AppConfig {
         active: pickString(glyphs.active, D.theme.glyphs.active),
         inactive: pickString(glyphs.inactive, D.theme.glyphs.inactive),
       },
+      [LEGACY_THEME_OVERRIDE_PROVENANCE]: appThemeOverrideProvenance(theme, status, glyphs),
     },
     updater: {
       tickMs: pickPosInt(updater.tickMs, D.updater.tickMs),

--- a/packages/daemon/src/lib/legacy-theme-compat.ts
+++ b/packages/daemon/src/lib/legacy-theme-compat.ts
@@ -1,0 +1,40 @@
+/**
+ * Compatibility metadata for the pre-canonical app theme fields.
+ *
+ * `parseAppConfig` must still resolve a complete legacy palette for tmux chrome,
+ * while the native app must only project values the user actually wrote over
+ * the canonical visual theme. A symbol keeps that provenance on the in-memory
+ * object (including through object spread) without serializing implementation
+ * metadata into `~/.tmux-ide/config.json`.
+ */
+
+export const LEGACY_THEME_OVERRIDE_IDS = [
+  "accent",
+  "muted",
+  "fg",
+  "status.blocked",
+  "status.working",
+  "status.done",
+  "status.idle",
+  "status.unknown",
+  "glyphs.active",
+  "glyphs.inactive",
+] as const;
+
+export type LegacyThemeOverrideId = (typeof LEGACY_THEME_OVERRIDE_IDS)[number];
+export type LegacyThemeOverrideProvenance = Readonly<Record<LegacyThemeOverrideId, boolean>>;
+
+export const LEGACY_THEME_OVERRIDE_PROVENANCE = Symbol.for(
+  "tmux-ide.legacy-theme-override-provenance",
+);
+
+export function legacyThemeOverrideProvenance(
+  explicitIds: ReadonlySet<LegacyThemeOverrideId> = new Set(),
+): LegacyThemeOverrideProvenance {
+  return Object.freeze(
+    Object.fromEntries(LEGACY_THEME_OVERRIDE_IDS.map((id) => [id, explicitIds.has(id)])) as Record<
+      LegacyThemeOverrideId,
+      boolean
+    >,
+  );
+}

--- a/packages/daemon/src/tui/mirror/activity-surface.tsx
+++ b/packages/daemon/src/tui/mirror/activity-surface.tsx
@@ -21,7 +21,7 @@ export function ActivitySurface(props: ActivitySurfaceProps) {
       width={props.projection.width}
       height={props.projection.height}
       position="relative"
-      backgroundColor={props.theme.colors.surface}
+      backgroundColor={props.theme.roles.surfaces.panel}
       overflow="hidden"
     >
       <Show when={props.projection.header.height > 0}>
@@ -51,9 +51,7 @@ export function ActivitySurface(props: ActivitySurfaceProps) {
               width={props.projection.scrollbar.width}
               height={1}
             >
-              <text
-                fg={glyph === "█" ? props.theme.colors.accent : props.theme.colors.mutedForeground}
-              >
+              <text fg={glyph === "█" ? props.theme.roles.text.link : props.theme.roles.text.muted}>
                 {glyph}
               </text>
             </box>
@@ -69,10 +67,10 @@ export function ActivitySurface(props: ActivitySurfaceProps) {
           width={props.projection.footer.width}
           height={props.projection.footer.height}
           paddingLeft={1}
-          backgroundColor={props.theme.colors.background}
+          backgroundColor={props.theme.roles.surfaces.canvas}
           overflow="hidden"
         >
-          <text fg={props.theme.colors.mutedForeground}>{props.projection.footerText}</text>
+          <text fg={props.theme.roles.text.muted}>{props.projection.footerText}</text>
         </box>
       </Show>
     </box>
@@ -93,13 +91,13 @@ function ActivityHeader(props: {
       paddingLeft={1}
       flexDirection="row"
       gap={1}
-      backgroundColor={props.theme.colors.surfaceRaised}
+      backgroundColor={props.theme.roles.surfaces.panelRaised}
       overflow="hidden"
     >
-      <text fg={props.theme.colors.accent} attributes={1}>
+      <text fg={props.theme.roles.text.link} attributes={1}>
         {props.projection.title}
       </text>
-      <text fg={props.theme.colors.mutedForeground}>{`· ${props.projection.summary}`}</text>
+      <text fg={props.theme.roles.text.muted}>{`· ${props.projection.summary}`}</text>
     </box>
   );
 }
@@ -163,7 +161,7 @@ function ActivityStateMessage(props: {
           <text fg={palette().foreground}>{` ${title()}`}</text>
         </box>
         <Show when={props.projection.body.height > 1}>
-          <text fg={props.theme.colors.mutedForeground}>{`  ${props.message}`}</text>
+          <text fg={props.theme.roles.text.muted}>{`  ${props.message}`}</text>
         </Show>
       </box>
     </Show>

--- a/packages/daemon/src/tui/mirror/changes-surface.tsx
+++ b/packages/daemon/src/tui/mirror/changes-surface.tsx
@@ -28,7 +28,7 @@ export function ChangesSurface(props: ChangesSurfaceProps) {
       width={props.projection.width}
       height={props.projection.height}
       position="relative"
-      backgroundColor={props.theme.colors.background}
+      backgroundColor={props.theme.roles.surfaces.canvas}
       overflow="hidden"
     >
       <ChangesHeader theme={props.theme} projection={props.projection} />
@@ -44,8 +44,8 @@ export function ChangesSurface(props: ChangesSurfaceProps) {
         <text
           fg={
             props.projection.state === "error"
-              ? props.theme.colors.status.blocked
-              : props.theme.colors.mutedForeground
+              ? props.theme.roles.statusTone.danger
+              : props.theme.roles.text.muted
           }
         >
           {props.projection.message}
@@ -111,7 +111,7 @@ export function ChangesSurface(props: ChangesSurfaceProps) {
                 <box
                   height={1}
                   backgroundColor={
-                    props.colors.diffLineBg[line.kind] ?? props.theme.colors.background
+                    props.colors.diffLineBg[line.kind] ?? props.theme.roles.surfaces.canvas
                   }
                   overflow="hidden"
                 >
@@ -130,7 +130,7 @@ export function ChangesSurface(props: ChangesSurfaceProps) {
         height={props.projection.footer.height}
         overflow="hidden"
       >
-        <text fg={props.theme.colors.mutedForeground}>{` ${props.projection.footerHint}`}</text>
+        <text fg={props.theme.roles.text.muted}>{` ${props.projection.footerHint}`}</text>
         <For each={props.projection.footerActions}>
           {(action) => (
             <box position="absolute" left={action.start} top={0} width={action.width} height={1}>
@@ -172,10 +172,10 @@ function ChangesHeader(props: {
         gap={1}
         overflow="hidden"
       >
-        <text fg={props.theme.colors.accent} attributes={1}>
+        <text fg={props.theme.roles.text.link} attributes={1}>
           {props.projection.title}
         </text>
-        <text fg={props.theme.colors.mutedForeground}>{props.projection.totals}</text>
+        <text fg={props.theme.roles.text.muted}>{props.projection.totals}</text>
         <Show when={props.projection.filter.active}>
           <InputShell
             theme={props.theme}
@@ -224,7 +224,7 @@ function ChangesFileRow(props: {
     Math.max(1, props.row.width - countWidth() - (props.row.action?.width ?? 0));
   return (
     <box height={1} flexDirection="row" backgroundColor={palette().background} overflow="hidden">
-      <text fg={props.colors.statusLetterFg[props.row.status] ?? props.theme.colors.foreground}>
+      <text fg={props.colors.statusLetterFg[props.row.status] ?? props.theme.roles.text.primary}>
         {props.row.status}
       </text>
       <SelectableRow
@@ -236,7 +236,7 @@ function ChangesFileRow(props: {
         tone="neutral"
       />
       <Show when={props.row.countText}>
-        {(count) => <text fg={props.theme.colors.mutedForeground}>{` ${count()}`}</text>}
+        {(count) => <text fg={props.theme.roles.text.muted}>{` ${count()}`}</text>}
       </Show>
       <Show when={props.row.action}>
         {(action) => (

--- a/packages/daemon/src/tui/mirror/files-surface.tsx
+++ b/packages/daemon/src/tui/mirror/files-surface.tsx
@@ -31,7 +31,7 @@ export function FilesSurface(props: FilesSurfaceProps) {
       width={props.projection.width}
       height={props.projection.height}
       position="relative"
-      backgroundColor={props.theme.colors.background}
+      backgroundColor={props.theme.roles.surfaces.canvas}
       overflow="hidden"
     >
       <FilesHeader theme={props.theme} projection={props.projection} />
@@ -46,10 +46,10 @@ export function FilesSurface(props: FilesSurfaceProps) {
         <text
           fg={
             props.projection.state === "error"
-              ? props.theme.colors.status.blocked
+              ? props.theme.roles.statusTone.danger
               : props.projection.state === "success"
-                ? props.theme.colors.status.done
-                : props.theme.colors.mutedForeground
+                ? props.theme.roles.statusTone.success
+                : props.theme.roles.text.muted
           }
         >
           {props.projection.stateMessage}
@@ -117,15 +117,15 @@ export function FilesSurface(props: FilesSurfaceProps) {
                   </text>
                   <Show
                     when={line.cursorCol !== null}
-                    fallback={<text fg={props.theme.colors.foreground}>{line.text}</text>}
+                    fallback={<text fg={props.theme.roles.text.primary}>{line.text}</text>}
                   >
-                    <text fg={props.theme.colors.foreground}>
+                    <text fg={props.theme.roles.text.primary}>
                       {line.text.slice(0, line.cursorCol!)}
                     </text>
-                    <text fg={props.theme.colors.background} bg={props.colors.cursorBg}>
+                    <text fg={props.theme.roles.surfaces.canvas} bg={props.colors.cursorBg}>
                       {line.text[line.cursorCol!] ?? " "}
                     </text>
-                    <text fg={props.theme.colors.foreground}>
+                    <text fg={props.theme.roles.text.primary}>
                       {line.text.slice(line.cursorCol! + 1)}
                     </text>
                   </Show>
@@ -144,7 +144,7 @@ export function FilesSurface(props: FilesSurfaceProps) {
         paddingLeft={1}
         overflow="hidden"
       >
-        <text fg={props.theme.colors.mutedForeground}>{props.projection.footerHint}</text>
+        <text fg={props.theme.roles.text.muted}>{props.projection.footerHint}</text>
       </box>
     </box>
   );
@@ -169,11 +169,11 @@ function FilesHeader(props: { theme: SemanticThemeSnapshot; projection: FilesSur
         gap={1}
         overflow="hidden"
       >
-        <text fg={props.theme.colors.accent} attributes={1}>
+        <text fg={props.theme.roles.text.link} attributes={1}>
           {props.projection.title}
         </text>
         <For each={props.projection.headerMeta}>
-          {(meta) => <text fg={props.theme.colors.mutedForeground}>{meta}</text>}
+          {(meta) => <text fg={props.theme.roles.text.muted}>{meta}</text>}
         </For>
         <Show when={props.projection.filter.active}>
           <InputShell
@@ -230,7 +230,7 @@ function FileRow(props: {
       />
       <Show when={props.row.status}>
         {(status) => (
-          <text fg={props.colors.statusLetterFg[status()] ?? props.theme.colors.foreground}>
+          <text fg={props.colors.statusLetterFg[status()] ?? props.theme.roles.text.primary}>
             {` ${status()}`}
           </text>
         )}

--- a/packages/daemon/src/tui/mirror/missions-surface.tsx
+++ b/packages/daemon/src/tui/mirror/missions-surface.tsx
@@ -2,15 +2,7 @@
 import type { RGBA } from "@opentui/core";
 import { For, Show } from "solid-js";
 import type { MissionDashboardProjection } from "./missions-dashboard.ts";
-import {
-  ACCENT,
-  BADGE_BG,
-  BUTTON_HOVER_BG,
-  DEFAULT_BG,
-  DEFAULT_FG,
-  HOVER_BG,
-  MUTED,
-} from "./theme.ts";
+import { DARK_THEME, type SemanticThemeSnapshot } from "./theme.ts";
 import {
   clipTerminal,
   missionWorkspaceLayout,
@@ -44,7 +36,10 @@ export interface MissionSurfaceProps {
   errorMessage: string;
   resolveDeepLink: (kind: MissionDeepLinkKind) => MissionDeepLinkResolution;
   isHovered: (region: MissionSurfaceHoverRegion, index: number) => boolean;
+  /** @deprecated Card 22.3 removes this accepted-but-unread compatibility prop. */
   theme: MissionSurfaceTheme;
+  /** Canonical theme projection; optional until app.tsx adopts it in Card 22.3. */
+  semanticTheme?: SemanticThemeSnapshot;
 }
 
 interface MissionMainSurfaceProps {
@@ -56,7 +51,7 @@ interface MissionMainSurfaceProps {
   errorMessage: string;
   resolveDeepLink: (kind: MissionDeepLinkKind) => MissionDeepLinkResolution;
   isHovered: (region: MissionSurfaceHoverRegion, index: number) => boolean;
-  theme: MissionSurfaceTheme;
+  semanticTheme?: SemanticThemeSnapshot;
 }
 
 export function missionSurfaceLayout(
@@ -70,6 +65,7 @@ export function missionSurfaceLayout(
 }
 
 export function MissionsSurface(props: MissionSurfaceProps) {
+  const semantic = () => props.semanticTheme ?? DARK_THEME;
   return (
     <box width={props.width} height={props.dashboard.height} flexDirection="row" gap={1}>
       <box
@@ -87,7 +83,7 @@ export function MissionsSurface(props: MissionSurfaceProps) {
           errorMessage={props.errorMessage}
           resolveDeepLink={props.resolveDeepLink}
           isHovered={props.isHovered}
-          theme={props.theme}
+          semanticTheme={props.semanticTheme}
         />
       </box>
       <Show when={props.dashboard.inspector}>
@@ -97,21 +93,29 @@ export function MissionsSurface(props: MissionSurfaceProps) {
             height={inspector().height}
             flexDirection="column"
             border={inspector().width >= 2 && inspector().height >= 2}
-            borderColor={MUTED}
+            borderColor={semantic().roles.borders.default}
             overflow="hidden"
-            backgroundColor={DEFAULT_BG}
+            backgroundColor={semantic().roles.surfaces.canvas}
           >
             <Show when={inspector().titleRows > 0}>
-              <text fg={ACCENT}>
+              <text fg={semantic().roles.text.link}>
                 {clipTerminal(inspector().title, Math.max(0, inspector().width - 2))}
               </text>
             </Show>
             <For each={inspector().rows.slice(0, inspector().bodyRows)}>
               {(row) => (
                 <box height={1} flexDirection="row" overflow="hidden">
-                  <text fg={row.emphasis ? ACCENT : MUTED}>{row.label}</text>
-                  <text fg={MUTED}>{": "}</text>
-                  <text fg={row.emphasis ? DEFAULT_FG : MUTED}>{row.value}</text>
+                  <text
+                    fg={row.emphasis ? semantic().roles.text.link : semantic().roles.text.muted}
+                  >
+                    {row.label}
+                  </text>
+                  <text fg={semantic().roles.text.muted}>{": "}</text>
+                  <text
+                    fg={row.emphasis ? semantic().roles.text.primary : semantic().roles.text.muted}
+                  >
+                    {row.value}
+                  </text>
                 </box>
               )}
             </For>
@@ -123,6 +127,7 @@ export function MissionsSurface(props: MissionSurfaceProps) {
 }
 
 function MissionMainSurface(props: MissionMainSurfaceProps) {
+  const semantic = () => props.semanticTheme ?? DARK_THEME;
   const ready = () =>
     props.snapshot &&
     props.loadState.status !== "loading" &&
@@ -135,22 +140,22 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
         <For each={props.layout.header.rows[0] ?? []}>
           {(chip) => (
             <text
-              fg={DEFAULT_FG}
+              fg={semantic().roles.text.primary}
               bg={
                 chip.kind === "mode" && chip.mode === props.model.mode
-                  ? props.theme.buttonActiveBg
+                  ? semantic().roles.selection.selection
                   : chip.kind === "mode" &&
                       props.isHovered("missionmode", chip.mode === "board" ? 0 : 1)
-                    ? BUTTON_HOVER_BG
+                    ? semantic().roles.selection.hover
                     : chip.kind === "refresh" && props.isHovered("missionbutton", 0)
-                      ? BUTTON_HOVER_BG
+                      ? semantic().roles.selection.hover
                       : chip.kind === "density" && props.isHovered("missionbutton", 1)
-                        ? BUTTON_HOVER_BG
+                        ? semantic().roles.selection.hover
                         : chip.kind === "collapse" && props.isHovered("missionbutton", 4)
-                          ? BUTTON_HOVER_BG
+                          ? semantic().roles.selection.hover
                           : chip.kind === "zoom" && props.isHovered("missionbutton", 5)
-                            ? BUTTON_HOVER_BG
-                            : props.theme.buttonBg
+                            ? semantic().roles.selection.hover
+                            : semantic().roles.surfaces.header
               }
             >
               {chip.label}
@@ -160,18 +165,26 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
       </box>
       <box width={props.width} flexDirection="row">
         <text
-          fg={props.theme.buttonFg}
-          bg={props.isHovered("missionbutton", 2) ? BUTTON_HOVER_BG : props.theme.buttonBg}
+          fg={semantic().roles.text.secondary}
+          bg={
+            props.isHovered("missionbutton", 2)
+              ? semantic().roles.selection.hover
+              : semantic().roles.surfaces.header
+          }
         >
           {"<"}
         </text>
-        <text fg={MUTED}>
+        <text fg={semantic().roles.text.muted}>
           {clipTerminal(props.layout.header.labels[1].slice(1, -1), Math.max(0, props.width - 2))}
         </text>
         <Show when={props.width > 1}>
           <text
-            fg={props.theme.buttonFg}
-            bg={props.isHovered("missionbutton", 3) ? BUTTON_HOVER_BG : props.theme.buttonBg}
+            fg={semantic().roles.text.secondary}
+            bg={
+              props.isHovered("missionbutton", 3)
+                ? semantic().roles.selection.hover
+                : semantic().roles.surfaces.header
+            }
           >
             {">"}
           </text>
@@ -180,23 +193,29 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
       <Show when={props.loadState.status === "loading"}>
         <box flexDirection="column" flexGrow={1}>
           <box height={1} />
-          <text fg={DEFAULT_FG}>Loading missions…</text>
-          <text fg={MUTED}>Mission history is read from the active project runtime.</text>
+          <text fg={semantic().roles.text.primary}>Loading missions…</text>
+          <text fg={semantic().roles.text.muted}>
+            Mission history is read from the active project runtime.
+          </text>
         </box>
       </Show>
       <Show when={props.loadState.status === "error" && !props.snapshot}>
         <box flexDirection="column" flexGrow={1}>
           <box height={1} />
-          <text fg={props.theme.bannerFg}>Mission data could not be loaded.</text>
-          <text fg={MUTED}>{props.errorMessage}</text>
-          <text fg={MUTED}>Press r to retry. Other workspace views remain available.</text>
+          <text fg={semantic().roles.statusTone.danger}>Mission data could not be loaded.</text>
+          <text fg={semantic().roles.text.muted}>{props.errorMessage}</text>
+          <text fg={semantic().roles.text.muted}>
+            Press r to retry. Other workspace views remain available.
+          </text>
         </box>
       </Show>
       <Show when={props.loadState.status === "empty"}>
         <box flexDirection="column" flexGrow={1}>
           <box height={1} />
-          <text fg={DEFAULT_FG}>No missions yet.</text>
-          <text fg={MUTED}>This read-only board will populate from durable mission history.</text>
+          <text fg={semantic().roles.text.primary}>No missions yet.</text>
+          <text fg={semantic().roles.text.muted}>
+            This read-only board will populate from durable mission history.
+          </text>
         </box>
       </Show>
       <Show when={ready()}>
@@ -209,12 +228,18 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
                   width={column.width}
                   height={column.height}
                   border={column.width >= 2 && column.height >= 2}
-                  borderColor={column.active ? ACCENT : MUTED}
-                  backgroundColor={DEFAULT_BG}
+                  borderColor={
+                    column.active
+                      ? semantic().roles.borders.focused
+                      : semantic().roles.borders.default
+                  }
+                  backgroundColor={semantic().roles.surfaces.canvas}
                   overflow="hidden"
                 >
                   <Show when={column.showTitle}>
-                    <text fg={column.active ? ACCENT : MUTED}>
+                    <text
+                      fg={column.active ? semantic().roles.text.link : semantic().roles.text.muted}
+                    >
                       {clipTerminal(column.title, column.bodyWidth)}
                     </text>
                   </Show>
@@ -227,10 +252,10 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
                           height={cardLayout.height}
                           backgroundColor={
                             selected
-                              ? BADGE_BG
+                              ? semantic().roles.selection.selection
                               : props.isHovered("missioncard", cardLayout.hoverKey)
-                                ? HOVER_BG
-                                : DEFAULT_BG
+                                ? semantic().roles.selection.hover
+                                : semantic().roles.surfaces.canvas
                           }
                         >
                           <For each={cardLayout.lines}>
@@ -238,10 +263,10 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
                               <text
                                 fg={
                                   selected && lineIndex() === 0
-                                    ? ACCENT
+                                    ? semantic().roles.text.link
                                     : lineIndex() === 0
-                                      ? DEFAULT_FG
-                                      : MUTED
+                                      ? semantic().roles.text.primary
+                                      : semantic().roles.text.muted
                                 }
                               >
                                 {clipTerminal(line, cardLayout.width)}
@@ -268,15 +293,21 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
                     height={row.height}
                     backgroundColor={
                       selected
-                        ? BADGE_BG
+                        ? semantic().roles.selection.selection
                         : props.isHovered("missionhistory", row.hoverKey)
-                          ? HOVER_BG
-                          : DEFAULT_BG
+                          ? semantic().roles.selection.hover
+                          : semantic().roles.surfaces.canvas
                     }
                   >
                     <For each={row.lines}>
                       {(line, lineIndex) => (
-                        <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>
+                        <text
+                          fg={
+                            lineIndex() === 0
+                              ? semantic().roles.text.primary
+                              : semantic().roles.text.muted
+                          }
+                        >
                           {clipTerminal(line, row.width)}
                         </text>
                       )}
@@ -293,15 +324,15 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
               <For each={props.layout.detail.sections}>
                 {(chip) => (
                   <text
-                    fg={DEFAULT_FG}
+                    fg={semantic().roles.text.primary}
                     bg={
                       chip.section === props.model.detailSection ||
                       props.isHovered(
                         "missionbutton",
                         10 + props.layout.detail.sections.indexOf(chip),
                       )
-                        ? props.theme.buttonActiveBg
-                        : props.theme.buttonBg
+                        ? semantic().roles.selection.selection
+                        : semantic().roles.surfaces.header
                     }
                   >
                     {chip.label}
@@ -314,15 +345,19 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
                   const resolved = chip.link ? props.resolveDeepLink(chip.link) : null;
                   return (
                     <text
-                      fg={resolved?.available ? props.theme.buttonFg : MUTED}
+                      fg={
+                        resolved?.available
+                          ? semantic().roles.text.secondary
+                          : semantic().roles.text.muted
+                      }
                       bg={
                         chip.link &&
                         props.isHovered(
                           "missionbutton",
                           20 + props.layout.detail.links.indexOf(chip),
                         )
-                          ? BUTTON_HOVER_BG
-                          : props.theme.buttonBg
+                          ? semantic().roles.selection.hover
+                          : semantic().roles.surfaces.header
                       }
                     >
                       {chip.label}
@@ -335,8 +370,10 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
               when={props.snapshot?.detail}
               fallback={
                 <box flexDirection="column" flexGrow={1}>
-                  <text fg={DEFAULT_FG}>Loading mission detail…</text>
-                  <text fg={MUTED}>Press r to refresh if this does not resolve.</text>
+                  <text fg={semantic().roles.text.primary}>Loading mission detail…</text>
+                  <text fg={semantic().roles.text.muted}>
+                    Press r to refresh if this does not resolve.
+                  </text>
                 </box>
               }
             >
@@ -347,7 +384,15 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
                       {(row) => (
                         <For each={row.lines}>
                           {(line, lineIndex) => (
-                            <text fg={lineIndex() === 0 ? ACCENT : MUTED}>{line}</text>
+                            <text
+                              fg={
+                                lineIndex() === 0
+                                  ? semantic().roles.text.link
+                                  : semantic().roles.text.muted
+                              }
+                            >
+                              {line}
+                            </text>
                           )}
                         </For>
                       )}
@@ -365,15 +410,23 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
                           height={row.height}
                           backgroundColor={
                             selected
-                              ? BADGE_BG
+                              ? semantic().roles.selection.selection
                               : props.isHovered("missionhistory", row.hoverKey)
-                                ? HOVER_BG
-                                : DEFAULT_BG
+                                ? semantic().roles.selection.hover
+                                : semantic().roles.surfaces.canvas
                           }
                         >
                           <For each={row.lines}>
                             {(line, lineIndex) => (
-                              <text fg={lineIndex() === 0 ? DEFAULT_FG : MUTED}>{line}</text>
+                              <text
+                                fg={
+                                  lineIndex() === 0
+                                    ? semantic().roles.text.primary
+                                    : semantic().roles.text.muted
+                                }
+                              >
+                                {line}
+                              </text>
                             )}
                           </For>
                         </box>
@@ -386,7 +439,7 @@ function MissionMainSurface(props: MissionMainSurfaceProps) {
           </box>
         </Show>
       </Show>
-      <text fg={MUTED}>{props.layout.footer.label}</text>
+      <text fg={semantic().roles.text.muted}>{props.layout.footer.label}</text>
     </>
   );
 }

--- a/packages/daemon/src/tui/mirror/palette-surface-adapter.ts
+++ b/packages/daemon/src/tui/mirror/palette-surface-adapter.ts
@@ -106,7 +106,7 @@ function iconForAction(action: PaletteAction): WorkspaceIconId {
           ? "terminals"
           : action.tab === "files"
             ? "files"
-            : "diff";
+            : "changes";
     case "view":
       return "native";
     case "open-folder":
@@ -126,9 +126,9 @@ function iconForAction(action: PaletteAction): WorkspaceIconId {
     case "select-text":
       return "terminals";
     case "refresh-diff":
-      return "diff";
+      return "changes";
     case "new-window":
-      return "popOut";
+      return "pop-out";
     case "rename-window":
       return "command";
     case "kill-window":
@@ -140,7 +140,7 @@ function iconForAction(action: PaletteAction): WorkspaceIconId {
     case "rotate-window":
       return "move";
     case "break-pane":
-      return "splitRight";
+      return "split-right";
     case "select-layout":
     case "resize-window":
       return "resize";

--- a/packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx
@@ -72,8 +72,8 @@ function expectSemanticMarkerSpan(mode: "dark" | "light"): void {
   expect(blockedLine).toBeDefined();
   const marker = blockedLine!.spans.find((span) => span.text === theme.glyphs.active);
   expect(marker).toBeDefined();
-  expect(colorKey(marker!.fg)).toBe(colorKey(theme.colors.status.blocked));
-  expect(colorKey(marker!.bg)).toBe(colorKey(theme.colors.selection));
+  expect(colorKey(marker!.fg)).toBe(colorKey(theme.roles.statusTone.warning));
+  expect(colorKey(marker!.bg)).toBe(colorKey(theme.roles.selection.selection));
 }
 
 function expectInputPlaceholderSpan(mode: "dark" | "light"): void {
@@ -85,7 +85,7 @@ function expectInputPlaceholderSpan(mode: "dark" | "light"): void {
   expect(inputLine).toBeDefined();
   const placeholder = inputLine!.spans.find((span) => span.text.includes("Search…"));
   expect(placeholder).toBeDefined();
-  expect(colorKey(placeholder!.fg)).toBe(colorKey(theme.colors.mutedForeground));
+  expect(colorKey(placeholder!.fg)).toBe(colorKey(theme.roles.text.muted));
 }
 
 async function renderGallery(width: number, height: number, initial: RecipeGalleryModel) {

--- a/packages/daemon/src/tui/mirror/recipes.test.ts
+++ b/packages/daemon/src/tui/mirror/recipes.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
+  COHESION_FIXTURE_V1,
+  VISUAL_RECIPE_REGISTRY,
+  type VisualRecipeId,
+} from "@tmux-ide/contracts";
+import {
   applyRecipeGalleryCommand,
   createRecipeGalleryModel,
   recipeGalleryCommandForKey,
   recipeGalleryHitTest,
   recipeGalleryLayout,
   recipeGalleryTheme,
+  openTuiRecipeColors,
   recipePalette,
   resolveRecipeState,
   rowText,
@@ -49,9 +55,9 @@ describe("visual recipes", () => {
       status: "blocked",
     });
     expect(blockedSelected.state).toBe("selected");
-    expect(colorKey(blockedSelected.background)).toBe(colorKey(theme.colors.selection));
-    expect(colorKey(blockedSelected.border)).toBe(colorKey(theme.colors.focusBorder));
-    expect(colorKey(blockedSelected.accent)).toBe(colorKey(theme.colors.status.blocked));
+    expect(colorKey(blockedSelected.background)).toBe(colorKey(theme.roles.selection.selection));
+    expect(colorKey(blockedSelected.border)).toBe(colorKey(theme.roles.borders.selected));
+    expect(colorKey(blockedSelected.accent)).toBe(colorKey(theme.roles.statusTone.warning));
   });
 
   it("derives palettes from the semantic theme without a second hard-coded palette", () => {
@@ -60,10 +66,36 @@ describe("visual recipes", () => {
     const focused = recipePalette(theme, { focused: true });
     const blocked = recipePalette(theme, { status: "blocked" });
 
-    expect(colorKey(selected.background)).toBe(colorKey(theme.colors.selection));
-    expect(colorKey(selected.border)).toBe(colorKey(theme.colors.focusBorder));
-    expect(colorKey(focused.accent)).toBe(colorKey(theme.colors.focus));
-    expect(colorKey(blocked.accent)).toBe(colorKey(theme.colors.status.blocked));
+    expect(colorKey(selected.background)).toBe(colorKey(theme.roles.selection.selection));
+    expect(colorKey(selected.border)).toBe(colorKey(theme.roles.borders.selected));
+    expect(colorKey(focused.accent)).toBe(colorKey(theme.roles.borders.focused));
+    expect(colorKey(blocked.accent)).toBe(colorKey(theme.roles.statusTone.warning));
+  });
+
+  it("maps canonical recipes through the common fixture in dark, light, and high contrast", () => {
+    const fixtureTheme = createSemanticThemeSnapshot({
+      mode: "dark",
+      userTheme: COHESION_FIXTURE_V1.theme.user,
+      projectTheme: COHESION_FIXTURE_V1.theme.project ?? undefined,
+      accessibility: COHESION_FIXTURE_V1.theme.accessibility,
+    });
+    const themes = [
+      fixtureTheme,
+      createSemanticThemeSnapshot({ mode: "light" }),
+      createSemanticThemeSnapshot({
+        mode: "dark",
+        accessibility: { reducedMotion: false, increasedContrast: true },
+      }),
+    ];
+    for (const theme of themes) {
+      for (const recipeId of Object.keys(VISUAL_RECIPE_REGISTRY) as VisualRecipeId[]) {
+        const recipe = VISUAL_RECIPE_REGISTRY[recipeId];
+        const colors = openTuiRecipeColors(theme, recipeId);
+        expect(colorKey(colors.background)).toBe(colorKey(theme.roles.surfaces[recipe.surface]));
+        expect(colorKey(colors.foreground)).toBe(colorKey(theme.roles.text[recipe.text]));
+        expect(colorKey(colors.border)).toBe(colorKey(theme.roles.borders[recipe.border]));
+      }
+    }
   });
 
   it("pins row metadata within the requested terminal width", () => {

--- a/packages/daemon/src/tui/mirror/recipes.ts
+++ b/packages/daemon/src/tui/mirror/recipes.ts
@@ -1,5 +1,14 @@
 import type { RGBA } from "@opentui/core";
 import {
+  VISUAL_RECIPE_REGISTRY,
+  resolvePaneAppearance,
+  statusToneForDomainStatus,
+  type CanonicalDomainStatus,
+  type PaneVisualStateV1,
+  type StatusToneRole,
+  type VisualRecipeId,
+} from "@tmux-ide/contracts";
+import {
   createSemanticThemeSnapshot,
   type ResolvedThemeMode,
   type SemanticThemeSnapshot,
@@ -163,22 +172,58 @@ const STATE_ORDER: readonly RecipeResolvedState[] = [
 
 export const RECIPE_STATE_PRECEDENCE = STATE_ORDER;
 
+function domainStatusForRecipeTone(tone: RecipeTone | undefined): CanonicalDomainStatus {
+  if (tone === "blocked") return "blocked";
+  if (tone === "working") return "running";
+  if (tone === "done") return "done";
+  return "idle";
+}
+
+function statusToneForRecipeTone(tone: RecipeTone | undefined): StatusToneRole {
+  return statusToneForDomainStatus(domainStatusForRecipeTone(tone));
+}
+
 function statusColor(theme: SemanticThemeSnapshot, tone: RecipeTone | undefined): RGBA {
-  if (tone === "blocked") return theme.colors.status.blocked;
-  if (tone === "working") return theme.colors.status.working;
-  if (tone === "done") return theme.colors.status.done;
-  if (tone === "idle") return theme.colors.status.idle;
-  if (tone === "unknown") return theme.colors.status.unknown;
-  return theme.colors.mutedForeground;
+  return theme.roles.statusTone[statusToneForRecipeTone(tone)];
+}
+
+function interactionAppearance(state: RecipeInteractionState) {
+  const paneState: PaneVisualStateV1 = {
+    structure: "docked",
+    applicationFocus: {
+      pane: Boolean(state.focused),
+      terminalInput: false,
+      windowActive: true,
+    },
+    agentActivity: state.loading ? "running" : "idle",
+    domainStatus: domainStatusForRecipeTone(state.status),
+    attention: state.attention ? "requested" : "none",
+    layoutInteraction: {
+      editable: true,
+      selected: Boolean(state.selected),
+      dragging: false,
+      resizing: false,
+      previewing: false,
+    },
+    controlInteraction: {
+      hover: Boolean(state.hovered),
+      focusVisible: Boolean(state.focused),
+      pressed: Boolean(state.pressed),
+      disabled: Boolean(state.disabled),
+      loading: Boolean(state.loading),
+    },
+  };
+  return resolvePaneAppearance(paneState);
 }
 
 export function resolveRecipeState(state: RecipeInteractionState): RecipeResolvedState {
-  if (state.disabled) return "disabled";
-  if (state.pressed) return "pressed";
+  const interaction = interactionAppearance(state);
+  if (interaction.action.background === "disabled") return "disabled";
+  if (interaction.action.background === "pressed") return "pressed";
   if (state.selected) return "selected";
   if (state.focused) return "focused";
   if (state.attention) return "attention";
-  if (state.hovered) return "hovered";
+  if (interaction.action.background === "hover") return "hovered";
   if (state.loading) return "loading";
   if (state.empty) return "empty";
   if (state.status) return "status";
@@ -193,6 +238,15 @@ function stateAccent(
   return state.status ? statusColor(theme, state.status) : fallback;
 }
 
+export function openTuiRecipeColors(theme: SemanticThemeSnapshot, recipeId: VisualRecipeId) {
+  const recipe = VISUAL_RECIPE_REGISTRY[recipeId];
+  return {
+    foreground: theme.roles.text[recipe.text],
+    background: theme.roles.surfaces[recipe.surface],
+    border: theme.roles.borders[recipe.border],
+  } as const;
+}
+
 export function recipePalette(
   theme: SemanticThemeSnapshot,
   state: RecipeInteractionState = {},
@@ -202,80 +256,80 @@ export function recipePalette(
   if (resolved === "disabled") {
     return {
       state: resolved,
-      foreground: theme.colors.mutedForeground,
-      background: theme.colors.surface,
-      border: theme.colors.border,
-      accent: theme.colors.mutedForeground,
+      foreground: theme.roles.text.muted,
+      background: theme.roles.selection.disabled,
+      border: theme.roles.borders.subtle,
+      accent: theme.roles.statusTone.neutral,
       marker: "×",
     };
   }
   if (resolved === "pressed") {
     return {
       state: resolved,
-      foreground: theme.colors.selectionForeground,
-      background: theme.colors.buttonHover,
-      border: theme.colors.focusBorder,
-      accent: theme.colors.focus,
+      foreground: theme.roles.selection.selectionText,
+      background: theme.roles.selection.pressed,
+      border: theme.roles.borders.focused,
+      accent: theme.roles.borders.focused,
       marker: "◆",
     };
   }
   if (resolved === "selected") {
     return {
       state: resolved,
-      foreground: theme.colors.selectionForeground,
-      background: theme.colors.selection,
-      border: theme.colors.focusBorder,
-      accent: stateAccent(theme, state, theme.colors.focus),
+      foreground: theme.roles.selection.selectionText,
+      background: theme.roles.selection.selection,
+      border: theme.roles.borders.selected,
+      accent: stateAccent(theme, state, theme.roles.borders.focused),
       marker: theme.glyphs.active,
     };
   }
   if (resolved === "focused") {
     return {
       state: resolved,
-      foreground: theme.colors.foreground,
-      background: theme.colors.surfaceRaised,
-      border: theme.colors.focusBorder,
-      accent: stateAccent(theme, state, theme.colors.focus),
+      foreground: theme.roles.text.primary,
+      background: theme.roles.surfaces.panelRaised,
+      border: theme.roles.borders.focused,
+      accent: stateAccent(theme, state, theme.roles.borders.focused),
       marker: "›",
     };
   }
   if (resolved === "hovered") {
     return {
       state: resolved,
-      foreground: theme.colors.foreground,
-      background: theme.colors.hover,
-      border: theme.colors.border,
-      accent: stateAccent(theme, state, theme.colors.accent),
+      foreground: theme.roles.text.primary,
+      background: theme.roles.selection.hover,
+      border: theme.roles.borders.default,
+      accent: stateAccent(theme, state, theme.roles.text.link),
       marker: "·",
     };
   }
   if (resolved === "attention") {
     return {
       state: resolved,
-      foreground: theme.colors.foreground,
-      background: theme.colors.attention,
-      border: theme.colors.focusBorder,
-      accent: stateAccent(theme, state, theme.colors.focus),
+      foreground: theme.roles.text.primary,
+      background: theme.derived.attentionSurface,
+      border: theme.roles.borders.attention,
+      accent: stateAccent(theme, state, theme.roles.borders.attention),
       marker: "!",
     };
   }
   if (resolved === "loading") {
     return {
       state: resolved,
-      foreground: theme.colors.mutedForeground,
-      background: theme.colors.surface,
-      border: theme.colors.border,
-      accent: theme.colors.status.working,
+      foreground: theme.roles.text.muted,
+      background: theme.roles.surfaces.panel,
+      border: theme.roles.borders.default,
+      accent: theme.roles.statusTone.info,
       marker: "…",
     };
   }
   if (resolved === "empty") {
     return {
       state: resolved,
-      foreground: theme.colors.mutedForeground,
-      background: theme.colors.background,
-      border: theme.colors.border,
-      accent: theme.colors.mutedForeground,
+      foreground: theme.roles.text.muted,
+      background: theme.roles.surfaces.canvas,
+      border: theme.roles.borders.subtle,
+      accent: theme.roles.statusTone.neutral,
       marker: "○",
     };
   }
@@ -283,19 +337,19 @@ export function recipePalette(
     const accent = statusColor(theme, state.status);
     return {
       state: resolved,
-      foreground: theme.colors.foreground,
-      background: theme.colors.surface,
+      foreground: theme.roles.text.primary,
+      background: theme.roles.surfaces.panel,
       border: accent,
       accent,
       marker: theme.glyphs.active,
     };
   }
-  const accent = tone === "accent" ? theme.colors.accent : statusColor(theme, tone);
+  const accent = tone === "accent" ? theme.roles.text.link : statusColor(theme, tone);
   return {
     state: resolved,
-    foreground: theme.colors.foreground,
-    background: theme.colors.surface,
-    border: theme.colors.border,
+    foreground: theme.roles.text.primary,
+    background: theme.roles.surfaces.panel,
+    border: theme.roles.borders.default,
     accent,
     marker: theme.glyphs.inactive,
   };

--- a/packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx
@@ -281,11 +281,11 @@ describe("ShellChrome OpenTUI renderer", () => {
       .find((span) => span.text.includes("⧉ web"));
     expect(contextChip).toBeDefined();
     expect(colorKey(contextChip!.bg)).toBe(colorKey(contextPalette.bg));
-    expect(colorKey(contextChip!.bg)).not.toBe(colorKey(theme.colors.attention));
+    expect(colorKey(contextChip!.bg)).not.toBe(colorKey(theme.derived.attentionSurface));
 
     const tabAttentionMarker = spans.lines[0]!.spans.find((span) => span.text === "!");
     expect(tabAttentionMarker).toBeDefined();
-    expect(colorKey(tabAttentionMarker!.fg)).toBe(colorKey(theme.colors.status.blocked));
+    expect(colorKey(tabAttentionMarker!.fg)).toBe(colorKey(theme.roles.statusTone.warning));
     expect(colorKey(tabAttentionMarker!.bg)).toBe(colorKey(selectedAttention.bg));
 
     const attentionLine = spans.lines.find((line) =>

--- a/packages/daemon/src/tui/mirror/shell-chrome.test.ts
+++ b/packages/daemon/src/tui/mirror/shell-chrome.test.ts
@@ -102,16 +102,16 @@ describe("shell chrome responsive projection", () => {
     });
     const terminal = shellVisualPalette(theme, { terminalFocus: true });
 
-    expect(key(selected.bg)).toBe(key(theme.colors.selection));
-    expect(key(hovered.bg)).toBe(key(theme.colors.hover));
-    expect(key(context.bg)).not.toBe(key(theme.colors.attention));
-    expect(key(context.fg)).toBe(key(theme.colors.accent));
-    expect(key(attention.bg)).toBe(key(theme.colors.attention));
-    expect(key(attention.border)).toBe(key(theme.colors.status.blocked));
-    expect(key(selectedAttention.bg)).toBe(key(theme.colors.selection));
+    expect(key(selected.bg)).toBe(key(theme.roles.selection.selection));
+    expect(key(hovered.bg)).toBe(key(theme.roles.selection.hover));
+    expect(key(context.bg)).not.toBe(key(theme.derived.attentionSurface));
+    expect(key(context.fg)).toBe(key(theme.roles.text.link));
+    expect(key(attention.bg)).toBe(key(theme.derived.attentionSurface));
+    expect(key(attention.border)).toBe(key(theme.roles.statusTone.warning));
+    expect(key(selectedAttention.bg)).toBe(key(theme.roles.selection.selection));
     expect(selectedAttention.marker).toBe("!");
-    expect(key(selectedAttention.border)).toBe(key(theme.colors.status.blocked));
-    expect(key(terminal.bg)).toBe(key(theme.colors.focus));
+    expect(key(selectedAttention.border)).toBe(key(theme.roles.statusTone.warning));
+    expect(key(terminal.bg)).toBe(key(theme.roles.borders.focused));
     expect(
       new Set([selected.marker, hovered.marker, context.marker, attention.marker, terminal.marker])
         .size,

--- a/packages/daemon/src/tui/mirror/shell-chrome.ts
+++ b/packages/daemon/src/tui/mirror/shell-chrome.ts
@@ -222,62 +222,62 @@ export function shellVisualPalette(
   const attention = Boolean(state.attention);
   if (state.terminalFocus) {
     return {
-      fg: theme.colors.background,
-      bg: theme.colors.focus,
-      border: attention ? theme.colors.status.blocked : theme.colors.focusBorder,
+      fg: theme.roles.text.inverse,
+      bg: theme.roles.borders.focused,
+      border: attention ? theme.roles.statusTone.warning : theme.roles.borders.focused,
       marker: attention ? "!" : "▣",
       attributes: 1,
     };
   }
   if (state.selected) {
     return {
-      fg: theme.colors.selectionForeground,
-      bg: theme.colors.selection,
-      border: attention ? theme.colors.status.blocked : theme.colors.focusBorder,
+      fg: theme.roles.selection.selectionText,
+      bg: theme.roles.selection.selection,
+      border: attention ? theme.roles.statusTone.warning : theme.roles.borders.selected,
       marker: attention ? "!" : theme.glyphs.active,
       attributes: state.focused ? 1 : 0,
     };
   }
   if (attention) {
     return {
-      fg: theme.colors.foreground,
-      bg: theme.colors.attention,
-      border: theme.colors.status.blocked,
+      fg: theme.roles.text.primary,
+      bg: theme.derived.attentionSurface,
+      border: theme.roles.statusTone.warning,
       marker: "!",
       attributes: 1,
     };
   }
   if (state.context) {
     return {
-      fg: theme.colors.accent,
-      bg: theme.colors.surfaceRaised,
-      border: theme.colors.accentMuted,
+      fg: theme.roles.text.link,
+      bg: theme.roles.surfaces.panelRaised,
+      border: theme.roles.borders.subtle,
       marker: "⧉",
       attributes: 0,
     };
   }
   if (state.hovered) {
     return {
-      fg: theme.colors.foreground,
-      bg: theme.colors.hover,
-      border: theme.colors.border,
+      fg: theme.roles.text.primary,
+      bg: theme.roles.selection.hover,
+      border: theme.roles.borders.default,
       marker: "·",
       attributes: 0,
     };
   }
   if (state.focused) {
     return {
-      fg: theme.colors.foreground,
-      bg: theme.colors.surfaceRaised,
-      border: theme.colors.focusBorder,
+      fg: theme.roles.text.primary,
+      bg: theme.roles.surfaces.panelRaised,
+      border: theme.roles.borders.focused,
       marker: "›",
       attributes: 0,
     };
   }
   return {
-    fg: theme.colors.mutedForeground,
-    bg: theme.colors.surface,
-    border: theme.colors.border,
+    fg: theme.roles.text.muted,
+    bg: theme.roles.surfaces.panel,
+    border: theme.roles.borders.subtle,
     marker: theme.glyphs.inactive,
     attributes: 0,
   };

--- a/packages/daemon/src/tui/mirror/shell-chrome.tsx
+++ b/packages/daemon/src/tui/mirror/shell-chrome.tsx
@@ -44,7 +44,7 @@ export function ShellTabBar(props: ShellTabBarProps) {
       height={1}
       width={props.width}
       flexDirection="row"
-      backgroundColor={props.theme.colors.surface}
+      backgroundColor={props.theme.roles.surfaces.header}
       overflow="hidden"
     >
       <For each={tabs()}>
@@ -75,7 +75,7 @@ export function ShellTabBar(props: ShellTabBarProps) {
                       <text fg={palette().fg} attributes={palette().attributes}>
                         {before}
                       </text>
-                      <text fg={props.theme.colors.status.blocked} attributes={1}>
+                      <text fg={props.theme.roles.statusTone.warning} attributes={1}>
                         !
                       </text>
                       <text fg={palette().fg} attributes={palette().attributes}>
@@ -91,7 +91,7 @@ export function ShellTabBar(props: ShellTabBarProps) {
       </For>
       <box flexGrow={1} />
       <Show when={props.note}>
-        <text fg={props.theme.colors.focus} attributes={1}>
+        <text fg={props.theme.roles.text.link} attributes={1}>
           {clipTerminal(`${props.note} `, Math.max(0, Math.floor(props.width / 3)))}
         </text>
       </Show>
@@ -122,7 +122,11 @@ export function ShellTabBar(props: ShellTabBarProps) {
                       <text fg={palette().fg} bg={palette().bg} attributes={palette().attributes}>
                         {before}
                       </text>
-                      <text fg={props.theme.colors.status.blocked} bg={palette().bg} attributes={1}>
+                      <text
+                        fg={props.theme.roles.statusTone.warning}
+                        bg={palette().bg}
+                        attributes={1}
+                      >
                         !
                       </text>
                       <text fg={palette().fg} bg={palette().bg} attributes={palette().attributes}>
@@ -154,10 +158,10 @@ export function ShellStatusStrip(props: ShellStatusStripProps) {
     <box
       height={props.layout.status.height}
       width={props.layout.status.width}
-      backgroundColor={props.theme.colors.surface}
+      backgroundColor={props.theme.roles.surfaces.header}
       overflow="hidden"
     >
-      <text fg={props.theme.colors.mutedForeground}>
+      <text fg={props.theme.roles.text.muted}>
         {shellStatusLine(
           props.layout.variant,
           {
@@ -212,16 +216,26 @@ export interface ShellMiniSidebarProps {
   hint: ShellSidebarHint;
 }
 
+function shellSessionStatusColor(
+  theme: SemanticThemeSnapshot,
+  status: ShellMiniSidebarProps["sessions"][number]["status"],
+) {
+  if (status === "blocked") return theme.roles.statusTone.warning;
+  if (status === "working") return theme.roles.statusTone.info;
+  if (status === "done") return theme.roles.statusTone.success;
+  return theme.roles.statusTone.neutral;
+}
+
 export function ShellMiniSidebar(props: ShellMiniSidebarProps) {
   return (
     <box
       width={props.width}
       flexDirection="column"
-      backgroundColor={props.theme.colors.surface}
+      backgroundColor={props.theme.roles.surfaces.panel}
       paddingLeft={1}
       overflow="hidden"
     >
-      <text fg={props.theme.colors.focus} attributes={1}>
+      <text fg={props.theme.roles.text.link} attributes={1}>
         {props.variant === "compact" ? " tmux" : " tmux-ide"}
       </text>
       <For each={props.sessions}>
@@ -230,7 +244,9 @@ export function ShellMiniSidebar(props: ShellMiniSidebarProps) {
           const palette = () => shellVisualPalette(props.theme, { selected: selected() });
           return (
             <box height={1} flexDirection="row" backgroundColor={palette().bg}>
-              <text fg={props.theme.colors.status[session.status]}>{selected() ? "●" : "○"}</text>
+              <text fg={shellSessionStatusColor(props.theme, session.status)}>
+                {selected() ? "●" : "○"}
+              </text>
               <text fg={palette().fg}>
                 {clipTerminal(` ${session.name}`, Math.max(0, props.width - 1))}
               </text>
@@ -240,11 +256,11 @@ export function ShellMiniSidebar(props: ShellMiniSidebarProps) {
       </For>
       <box flexGrow={1} />
       <box height={1} width={props.width} flexDirection="row" overflow="hidden">
-        <text fg={props.theme.colors.mutedForeground}>{props.hint.pre}</text>
-        <text fg={props.theme.colors.foreground} bg={props.theme.colors.hover}>
+        <text fg={props.theme.roles.text.muted}>{props.hint.pre}</text>
+        <text fg={props.theme.roles.text.primary} bg={props.theme.roles.selection.hover}>
           {props.hint.btn}
         </text>
-        <text fg={props.theme.colors.mutedForeground}>{props.hint.post}</text>
+        <text fg={props.theme.roles.text.muted}>{props.hint.post}</text>
       </box>
     </box>
   );

--- a/packages/daemon/src/tui/mirror/sidebar.tsx
+++ b/packages/daemon/src/tui/mirror/sidebar.tsx
@@ -22,7 +22,7 @@
  * move together; that's why AGENTS_GAP_ROWS is shared rather than a literal here.
  */
 import { For, Show } from "solid-js";
-import { STATUS_COLOR, STATUS_GLYPH } from "./status-grammar.ts";
+import { STATUS_GLYPH } from "./status-grammar.ts";
 import {
   AGENTS_ADD_CHIP,
   AGENTS_EMPTY_LINE,
@@ -33,16 +33,7 @@ import {
   agentsHeaderLabel,
   type AgentRowInput,
 } from "./agent-rows.ts";
-import {
-  ACCENT,
-  BUTTON_HOVER_BG,
-  CHIP_ATTN_BG,
-  DEFAULT_FG,
-  HOVER_BG,
-  MUTED,
-  SIDEBAR_BG,
-  TAB_ACTIVE_BG,
-} from "./theme.ts";
+import { DARK_THEME, type SemanticThemeSnapshot } from "./theme.ts";
 import type { AgentStatus } from "../detect/classify.ts";
 import type { ShellChromeVariant } from "./shell-chrome.ts";
 
@@ -70,6 +61,8 @@ export interface SidebarMouseEvent {
 }
 
 export interface SidebarProps {
+  /** Card 22 adapter input. Optional until app.tsx switches in Card 22.3. */
+  theme?: SemanticThemeSnapshot;
   /** Column width in cells. */
   width: number;
   variant?: ShellChromeVariant;
@@ -92,19 +85,26 @@ export interface SidebarProps {
 }
 
 export function Sidebar(props: SidebarProps) {
+  const theme = () => props.theme ?? DARK_THEME;
+  const statusColor = (status: AgentStatus) => {
+    if (status === "blocked") return theme().roles.statusTone.warning;
+    if (status === "working") return theme().roles.statusTone.info;
+    if (status === "done") return theme().roles.statusTone.success;
+    return theme().roles.statusTone.neutral;
+  };
   return (
     <box
       width={props.width}
       flexDirection="column"
-      backgroundColor={SIDEBAR_BG}
+      backgroundColor={theme().roles.surfaces.panel}
       paddingLeft={1}
       overflow="hidden"
       onMouse={(e: SidebarMouseEvent) => props.onMouse?.(e)}
     >
-      <text fg={ACCENT} attributes={1}>
+      <text fg={theme().roles.text.link} attributes={1}>
         {props.variant === "compact" ? "tmux" : "tmux-ide"}
       </text>
-      <text fg={MUTED}>{"─".repeat(props.width - 2)}</text>
+      <text fg={theme().roles.text.muted}>{"─".repeat(props.width - 2)}</text>
       <box flexDirection="column">
         <For each={props.sessions}>
           {(s, i) => (
@@ -113,14 +113,18 @@ export function Sidebar(props: SidebarProps) {
               gap={1}
               backgroundColor={
                 s.name === props.current
-                  ? TAB_ACTIVE_BG
+                  ? theme().roles.selection.selection
                   : props.isHovered("sidebar", i())
-                    ? HOVER_BG
-                    : SIDEBAR_BG
+                    ? theme().roles.selection.hover
+                    : theme().roles.surfaces.panel
               }
             >
-              <text fg={STATUS_COLOR[s.status]}>{STATUS_GLYPH[s.status]}</text>
-              <text fg={s.name === props.current ? DEFAULT_FG : MUTED}>
+              <text fg={statusColor(s.status)}>{STATUS_GLYPH[s.status]}</text>
+              <text
+                fg={
+                  s.name === props.current ? theme().roles.text.primary : theme().roles.text.muted
+                }
+              >
                 {s.name.slice(0, Math.max(1, props.width - (props.variant === "compact" ? 3 : 5)))}
               </text>
             </box>
@@ -139,16 +143,27 @@ export function Sidebar(props: SidebarProps) {
           before any agent runs. */}
         <box
           flexDirection="row"
-          backgroundColor={props.isHovered("agentshdr", 0) ? HOVER_BG : SIDEBAR_BG}
+          backgroundColor={
+            props.isHovered("agentshdr", 0)
+              ? theme().roles.selection.hover
+              : theme().roles.surfaces.panel
+          }
         >
-          <text fg={MUTED} attributes={1}>
+          <text fg={theme().roles.text.muted} attributes={1}>
             {agentsHeaderLabel(
               props.agents.length,
               Math.max(1, props.width - AGENTS_ADD_CHIP.length - 2),
             )}
           </text>
           <box flexGrow={1} />
-          <text fg={MUTED} bg={props.isHovered("agentschip", 0) ? BUTTON_HOVER_BG : SIDEBAR_BG}>
+          <text
+            fg={theme().roles.text.muted}
+            bg={
+              props.isHovered("agentschip", 0)
+                ? theme().roles.selection.hover
+                : theme().roles.surfaces.panel
+            }
+          >
             {AGENTS_ADD_CHIP}
           </text>
         </box>
@@ -156,11 +171,18 @@ export function Sidebar(props: SidebarProps) {
           when={props.agents.length > 0}
           fallback={
             <box flexDirection="row">
-              <text fg={MUTED}>
+              <text fg={theme().roles.text.muted}>
                 {AGENTS_EMPTY_LINE.slice(0, Math.max(1, props.width - AGENTS_ADD_CHIP.length - 2))}
               </text>
               <box flexGrow={1} />
-              <text fg={MUTED} bg={props.isHovered("agentschip", 1) ? BUTTON_HOVER_BG : SIDEBAR_BG}>
+              <text
+                fg={theme().roles.text.muted}
+                bg={
+                  props.isHovered("agentschip", 1)
+                    ? theme().roles.selection.hover
+                    : theme().roles.surfaces.panel
+                }
+              >
                 {AGENTS_ADD_CHIP}
               </text>
             </box>
@@ -183,20 +205,30 @@ export function Sidebar(props: SidebarProps) {
                 <box
                   flexDirection="row"
                   gap={1}
-                  backgroundColor={flashed() ? CHIP_ATTN_BG : hovered() ? HOVER_BG : SIDEBAR_BG}
+                  backgroundColor={
+                    flashed()
+                      ? theme().derived.attentionSurface
+                      : hovered()
+                        ? theme().roles.selection.hover
+                        : theme().roles.surfaces.panel
+                  }
                 >
-                  <text fg={STATUS_COLOR[a.state]} attributes={attn()}>
+                  <text fg={statusColor(a.state)} attributes={attn()}>
                     {STATUS_GLYPH[a.state]}
                   </text>
                   <text
-                    fg={a.state === "blocked" ? STATUS_COLOR.blocked : MUTED}
+                    fg={
+                      a.state === "blocked"
+                        ? theme().roles.statusTone.warning
+                        : theme().roles.text.muted
+                    }
                     attributes={attn()}
                   >
                     {agentRowLabel(agentDisplayKind(a), a.session, labelBudget())}
                   </text>
                   <Show when={ageShown()}>
                     <box flexGrow={1} />
-                    <text fg={MUTED}>{ageShown()}</text>
+                    <text fg={theme().roles.text.muted}>{ageShown()}</text>
                   </Show>
                 </box>
               );
@@ -209,11 +241,18 @@ export function Sidebar(props: SidebarProps) {
         hit-tests SIDEBAR_HINT_SPAN on the last screen row, and these three runs
         render the exact same cells. */}
       <box width={props.width} flexDirection="row" overflow="hidden">
-        <text fg={MUTED}>{props.hint.pre}</text>
-        <text fg={MUTED} bg={props.isHovered("sidebtn", 0) ? BUTTON_HOVER_BG : SIDEBAR_BG}>
+        <text fg={theme().roles.text.muted}>{props.hint.pre}</text>
+        <text
+          fg={theme().roles.text.muted}
+          bg={
+            props.isHovered("sidebtn", 0)
+              ? theme().roles.selection.hover
+              : theme().roles.surfaces.panel
+          }
+        >
           {props.hint.btn}
         </text>
-        <text fg={MUTED}>{props.hint.post}</text>
+        <text fg={theme().roles.text.muted}>{props.hint.post}</text>
       </box>
     </box>
   );

--- a/packages/daemon/src/tui/mirror/theme.test.ts
+++ b/packages/daemon/src/tui/mirror/theme.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@tmux-ide/contracts";
 import {
   ACCENT,
+  CARD_22_3B_LIVE_THEME_WIRING_DEFERRALS,
   DARK_THEME,
   DEFAULT_BG,
   LIGHT_THEME,
@@ -20,6 +21,7 @@ import {
   type ThemeModeSource,
 } from "./theme.ts";
 import { THEME_PRESETS } from "./settings-model.ts";
+import { parseAppConfig } from "../../lib/app-config.ts";
 
 function rgbaKey(color: { r: number; g: number; b: number; a: number }): string {
   return colorToThemeBytes(color as Parameters<typeof colorToThemeBytes>[0]).join(",");
@@ -115,6 +117,57 @@ describe("semantic theme snapshots", () => {
       expectCanonicalColorProjection(createSemanticThemeSnapshot(config), expected);
     }
     expect(Object.isFrozen(COHESION_FIXTURE_V1)).toBe(true);
+  });
+
+  it("does not treat parser-filled legacy defaults as canonical theme overrides", () => {
+    const cases = [
+      { mode: "dark" as const, rendererMode: null, accessibility: undefined },
+      { mode: "light" as const, rendererMode: null, accessibility: undefined },
+      { mode: "system" as const, rendererMode: "light" as const, accessibility: undefined },
+      {
+        mode: "dark" as const,
+        rendererMode: null,
+        accessibility: { reducedMotion: true, increasedContrast: true },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const parsed = parseAppConfig({ theme: { mode: testCase.mode } }).theme;
+      const config = { ...parsed, accessibility: testCase.accessibility };
+      const expectedMode =
+        testCase.mode === "system" ? (testCase.rendererMode ?? "dark") : testCase.mode;
+      const expected = resolveVisualTheme({
+        appearance: expectedMode,
+        accessibility: testCase.accessibility,
+      });
+      const snapshot = createSemanticThemeSnapshot(config, testCase.rendererMode);
+      expectCanonicalColorProjection(snapshot, expected);
+      expect(snapshot.canonical).toEqual(expected.tokens);
+    }
+  });
+
+  it("preserves only legacy theme leaves explicitly present in parsed app config", () => {
+    const parsed = parseAppConfig({
+      theme: {
+        mode: "light",
+        accent: "#123456",
+        status: { blocked: "#654321" },
+        glyphs: { active: "◆" },
+      },
+    }).theme;
+    const snapshot = createSemanticThemeSnapshot(parsed);
+    const canonical = resolveVisualTheme({ appearance: "light" });
+
+    expect(rgbaKey(snapshot.colors.accent)).toBe("18,52,86,255");
+    expect(rgbaKey(snapshot.roles.statusTone.warning)).toBe("101,67,33,255");
+    expect(rgbaKey(snapshot.roles.text.primary)).toBe(
+      rendererNeutralKey(canonical.tokens.text.primary),
+    );
+    expect(rgbaKey(snapshot.roles.text.muted)).toBe(
+      rendererNeutralKey(canonical.tokens.text.muted),
+    );
+    expect(snapshot.glyphs.active).toBe("◆");
+    expect(snapshot.glyphs.inactive).toBe(DARK_THEME.glyphs.inactive);
   });
 
   it("keeps the explicit compatibility export list mapped to the canonical dark facade", () => {
@@ -237,6 +290,9 @@ describe("semantic theme snapshots", () => {
     expect(Object.isFrozen(first.density)).toBe(true);
     expect(Object.isFrozen(first.borders)).toBe(true);
     expect(Object.isFrozen(first.glyphs)).toBe(true);
+    expect(Object.isFrozen(first.canonical)).toBe(true);
+    expect(Object.isFrozen(first.canonical.motion)).toBe(true);
+    expect(Object.isFrozen(first.canonical.motion.fast)).toBe(true);
   });
 
   it("keeps compatibility focus signals distinct from semantic status colors", () => {
@@ -309,5 +365,44 @@ describe("semantic theme store", () => {
     expect(snapshots).toHaveLength(2);
     expect(rgbaKey(snapshots[0]!.colors.accent)).toBe("95,175,255,255");
     expect(rgbaKey(snapshots[1]!.colors.accent)).toBe("255,95,95,255");
+  });
+
+  it("retains and notifies on canonical non-color token changes", () => {
+    const projectTheme = (fast: number) => ({
+      version: 1 as const,
+      id: "motion-reactivity",
+      name: "Motion reactivity",
+      appearance: "dark" as const,
+      overrides: { motion: { fast: { unit: "ms" as const, value: fast } } },
+    });
+    const store = createSemanticThemeStore({ mode: "dark", projectTheme: projectTheme(10) });
+    const first = store.getSnapshot();
+    let notifications = 0;
+    store.subscribe(() => notifications++);
+
+    store.configure({ mode: "dark", projectTheme: projectTheme(20) });
+    expect(notifications).toBe(1);
+    expect(store.getSnapshot()).not.toBe(first);
+    expect(store.getSnapshot().canonical.motion.fast.value).toBe(20);
+
+    store.configure({ mode: "dark", projectTheme: projectTheme(20) });
+    expect(notifications).toBe(1);
+  });
+});
+
+describe("Card 22.3b live-theme wiring deferrals", () => {
+  it("keeps the two root-composition writes explicit until app.tsx owns them", () => {
+    expect(CARD_22_3B_LIVE_THEME_WIRING_DEFERRALS).toEqual([
+      { component: "Sidebar", prop: "theme", owner: "app.tsx" },
+      { component: "MissionsSurface", prop: "semanticTheme", owner: "app.tsx" },
+    ]);
+
+    const app = readFileSync(fileURLToPath(new URL("./app.tsx", import.meta.url)), "utf-8");
+    const sidebarCall = app.match(/<Sidebar[\s\S]*?\/>/u)?.[0];
+    const missionsCall = app.match(/<MissionsSurface[\s\S]*?\/>/u)?.[0];
+    expect(sidebarCall).toBeDefined();
+    expect(sidebarCall).not.toContain("theme={semanticTheme()}");
+    expect(missionsCall).toBeDefined();
+    expect(missionsCall).not.toContain("semanticTheme={semanticTheme()}");
   });
 });

--- a/packages/daemon/src/tui/mirror/theme.test.ts
+++ b/packages/daemon/src/tui/mirror/theme.test.ts
@@ -2,10 +2,17 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  COHESION_FIXTURE_V1,
+  deriveAttentionBlend,
+  resolveVisualTheme,
+  type RendererNeutralColor,
+} from "@tmux-ide/contracts";
+import {
   ACCENT,
   DARK_THEME,
   DEFAULT_BG,
   LIGHT_THEME,
+  LEGACY_THEME_ALIAS_IDS,
   colorToThemeBytes,
   createSemanticThemeSnapshot,
   createSemanticThemeStore,
@@ -16,6 +23,29 @@ import { THEME_PRESETS } from "./settings-model.ts";
 
 function rgbaKey(color: { r: number; g: number; b: number; a: number }): string {
   return colorToThemeBytes(color as Parameters<typeof colorToThemeBytes>[0]).join(",");
+}
+
+function rendererNeutralKey(color: RendererNeutralColor): string {
+  return [color.red, color.green, color.blue, color.alpha].join(",");
+}
+
+function expectCanonicalColorProjection(
+  snapshot: ReturnType<typeof createSemanticThemeSnapshot>,
+  resolved: ReturnType<typeof resolveVisualTheme>,
+): void {
+  for (const group of ["surfaces", "text", "borders", "statusTone", "selection"] as const) {
+    const actual = snapshot.roles[group] as Readonly<Record<string, Parameters<typeof rgbaKey>[0]>>;
+    const expected = resolved.tokens[group] as Readonly<Record<string, RendererNeutralColor>>;
+    expect(Object.keys(actual)).toEqual(Object.keys(expected));
+    for (const role of Object.keys(expected)) {
+      expect(rgbaKey(actual[role]!)).toBe(rendererNeutralKey(expected[role]!));
+    }
+  }
+  expect(rgbaKey(snapshot.derived.attentionSurface)).toBe(
+    rendererNeutralKey(
+      deriveAttentionBlend(resolved.tokens.surfaces.panel, resolved.tokens.borders.attention),
+    ),
+  );
 }
 
 class FakeThemeModeSource implements ThemeModeSource {
@@ -57,7 +87,50 @@ describe("semantic theme snapshots", () => {
     expect(createSemanticThemeSnapshot({ mode: "system" }, "light").setting).toBe("system");
   });
 
-  it("keeps dark compatibility exports mapped to the legacy dark palette", () => {
+  it("projects the common fixture and dark/light/high-contrast canonical roles exactly", () => {
+    const cases = [
+      {
+        config: {
+          mode: "dark" as const,
+          userTheme: COHESION_FIXTURE_V1.theme.user,
+          projectTheme: COHESION_FIXTURE_V1.theme.project ?? undefined,
+          accessibility: COHESION_FIXTURE_V1.theme.accessibility,
+        },
+      },
+      { config: { mode: "light" as const } },
+      {
+        config: {
+          mode: "dark" as const,
+          accessibility: { reducedMotion: true, increasedContrast: true },
+        },
+      },
+    ];
+    for (const { config } of cases) {
+      const expected = resolveVisualTheme({
+        appearance: config.mode,
+        userTheme: "userTheme" in config ? config.userTheme : undefined,
+        projectTheme: "projectTheme" in config ? config.projectTheme : undefined,
+        accessibility: "accessibility" in config ? config.accessibility : undefined,
+      });
+      expectCanonicalColorProjection(createSemanticThemeSnapshot(config), expected);
+    }
+    expect(Object.isFrozen(COHESION_FIXTURE_V1)).toBe(true);
+  });
+
+  it("keeps the explicit compatibility export list mapped to the canonical dark facade", () => {
+    expect(LEGACY_THEME_ALIAS_IDS).toEqual([
+      "DEFAULT_FG",
+      "DEFAULT_BG",
+      "SIDEBAR_BG",
+      "ACCENT",
+      "MUTED",
+      "BADGE_BG",
+      "FOCUS_BORDER_FG",
+      "TAB_ACTIVE_BG",
+      "HOVER_BG",
+      "BUTTON_HOVER_BG",
+      "CHIP_ATTN_BG",
+    ]);
     expect(rgbaKey(DEFAULT_BG)).toBe(rgbaKey(DARK_THEME.colors.background));
     expect(rgbaKey(ACCENT)).toBe(rgbaKey(DARK_THEME.colors.accent));
   });
@@ -74,14 +147,30 @@ describe("semantic theme snapshots", () => {
     expect(rgbaKey(snapshot.colors.accent)).toBe("255,0,170,255");
     expect(rgbaKey(snapshot.colors.focus)).toBe("255,0,170,255");
     expect(rgbaKey(snapshot.colors.focusBorder)).not.toBe(rgbaKey(snapshot.colors.focus));
+    expect(rgbaKey(snapshot.roles.text.link)).toBe("255,0,170,255");
+    expect(rgbaKey(snapshot.roles.borders.focused)).toBe("255,0,170,255");
+    expect(rgbaKey(snapshot.roles.selection.selection)).toBe(rgbaKey(snapshot.colors.selection));
     expect(rgbaKey(snapshot.colors.status.blocked)).toBe(rgbaKey(DARK_THEME.colors.status.blocked));
   });
 
+  it("keeps the canonical high-contrast focus outline above a legacy accent", () => {
+    const snapshot = createSemanticThemeSnapshot({
+      mode: "dark",
+      accent: "#ff00aa",
+      accessibility: { increasedContrast: true },
+    });
+    expect(rgbaKey(snapshot.roles.borders.focused)).toBe("255,255,255,255");
+    expect(rgbaKey(snapshot.roles.text.link)).toBe("255,0,170,255");
+  });
+
   it("preserves a saved accent that collides with status while deriving collision-safe focus", () => {
-    const snapshot = createSemanticThemeSnapshot({ mode: "dark", accent: "colour203" });
-    expect(rgbaKey(snapshot.colors.accent)).toBe("255,95,95,255");
+    const [r, g, b] = colorToThemeBytes(DARK_THEME.colors.status.blocked);
+    const statusAccent = `#${[r, g, b]
+      .map((channel) => channel.toString(16).padStart(2, "0"))
+      .join("")}`;
+    const snapshot = createSemanticThemeSnapshot({ mode: "dark", accent: statusAccent });
     expect(rgbaKey(snapshot.colors.accent)).toBe(rgbaKey(snapshot.colors.status.blocked));
-    expect(rgbaKey(snapshot.colors.focus)).toBe(rgbaKey(DARK_THEME.colors.focus));
+    expect(rgbaKey(snapshot.colors.focus)).toBe(rgbaKey(DARK_THEME.roles.borders.focused));
     expect(rgbaKey(snapshot.colors.focus)).not.toBe(rgbaKey(snapshot.colors.status.blocked));
     expect(rgbaKey(snapshot.colors.focusBorder)).not.toBe(rgbaKey(snapshot.colors.status.blocked));
   });
@@ -129,6 +218,7 @@ describe("semantic theme snapshots", () => {
     });
     expect(rgbaKey(snapshot.colors.accent)).toBe("95,175,255,255");
     expect(rgbaKey(snapshot.colors.status.idle)).toBe("0,255,0,255");
+    expect(rgbaKey(snapshot.roles.statusTone.neutral)).toBe("0,255,0,255");
     expect(snapshot.glyphs.active).toBe("◆");
     expect(snapshot.glyphs.inactive).toBe(DARK_THEME.glyphs.inactive);
   });
@@ -141,14 +231,20 @@ describe("semantic theme snapshots", () => {
     expect(Object.isFrozen(first)).toBe(true);
     expect(Object.isFrozen(first.colors)).toBe(true);
     expect(Object.isFrozen(first.colors.status)).toBe(true);
+    expect(Object.isFrozen(first.roles)).toBe(true);
+    expect(Object.isFrozen(first.roles.surfaces)).toBe(true);
+    expect(Object.isFrozen(first.derived)).toBe(true);
     expect(Object.isFrozen(first.density)).toBe(true);
     expect(Object.isFrozen(first.borders)).toBe(true);
     expect(Object.isFrozen(first.glyphs)).toBe(true);
   });
 
-  it("keeps focus/accent colors distinct from semantic status colors in both palettes", () => {
+  it("keeps compatibility focus signals distinct from semantic status colors", () => {
     for (const snapshot of [DARK_THEME, LIGHT_THEME]) {
-      const reserved = new Set([rgbaKey(snapshot.colors.accent), rgbaKey(snapshot.colors.focus)]);
+      const reserved = new Set([
+        rgbaKey(snapshot.colors.focus),
+        rgbaKey(snapshot.colors.focusBorder),
+      ]);
       expect(reserved.has(rgbaKey(snapshot.colors.status.blocked))).toBe(false);
       expect(reserved.has(rgbaKey(snapshot.colors.status.working))).toBe(false);
       expect(reserved.has(rgbaKey(snapshot.colors.status.done))).toBe(false);

--- a/packages/daemon/src/tui/mirror/theme.ts
+++ b/packages/daemon/src/tui/mirror/theme.ts
@@ -10,6 +10,18 @@
  * verbatim, aliasing @opentui/core to a browser shim that only exposes RGBA.
  */
 import { RGBA } from "@opentui/core";
+import {
+  deriveAttentionBlend,
+  resolveVisualTheme,
+  type BorderTokenRole,
+  type RendererNeutralColor,
+  type SelectionTokenRole,
+  type StatusToneRole,
+  type SurfaceTokenRole,
+  type TextTokenRole,
+  type ThemeAccessibilityPreferences,
+  type ThemeDiagnostic,
+} from "@tmux-ide/contracts";
 
 export type ResolvedThemeMode = "dark" | "light";
 export type ThemeModeSetting = ResolvedThemeMode | "system";
@@ -45,6 +57,20 @@ export interface SemanticThemeColors {
   };
 }
 
+/** OpenTUI's RGBA projection of the renderer-neutral product color vocabulary. */
+export interface OpenTuiSemanticColorRoles {
+  readonly surfaces: Readonly<Record<SurfaceTokenRole, RGBA>>;
+  readonly text: Readonly<Record<TextTokenRole, RGBA>>;
+  readonly borders: Readonly<Record<BorderTokenRole, RGBA>>;
+  readonly statusTone: Readonly<Record<StatusToneRole, RGBA>>;
+  readonly selection: Readonly<Record<SelectionTokenRole, RGBA>>;
+}
+
+export interface OpenTuiDerivedColors {
+  /** Terminal-cell background derived from canonical panel + attention tokens. */
+  readonly attentionSurface: RGBA;
+}
+
 export interface SemanticThemeTokens {
   readonly colors: SemanticThemeColors;
   readonly density: {
@@ -71,10 +97,18 @@ export interface SemanticThemeTokens {
 export interface SemanticThemeSnapshot extends SemanticThemeTokens {
   readonly mode: ResolvedThemeMode;
   readonly setting: ThemeModeSetting;
+  readonly roles: OpenTuiSemanticColorRoles;
+  readonly derived: OpenTuiDerivedColors;
+  readonly accessibility: ThemeAccessibilityPreferences;
+  readonly diagnostics: readonly ThemeDiagnostic[];
+  readonly futureSources: readonly ThemeDiagnostic["source"][];
 }
 
 export interface ThemeConfigInput {
   mode?: ThemeModeSetting;
+  userTheme?: unknown;
+  projectTheme?: unknown;
+  accessibility?: Partial<ThemeAccessibilityPreferences>;
   accent?: string;
   muted?: string;
   fg?: string;
@@ -122,6 +156,10 @@ type RgbaWithOptionalToInts = RGBA & { toInts?: () => [number, number, number, n
 
 function rgba(r: number, g: number, b: number, a = 255): RGBA {
   return RGBA.fromInts(r, g, b, a);
+}
+
+function rgbaFromRendererNeutral(color: RendererNeutralColor): RGBA {
+  return rgba(color.red, color.green, color.blue, color.alpha);
 }
 
 function byteChannel(channel: number): number {
@@ -255,45 +293,125 @@ function freezeSnapshot(snapshot: SemanticThemeSnapshot): SemanticThemeSnapshot 
   for (const colors of [
     snapshot.colors,
     snapshot.colors.status,
+    snapshot.roles,
+    snapshot.roles.surfaces,
+    snapshot.roles.text,
+    snapshot.roles.borders,
+    snapshot.roles.statusTone,
+    snapshot.roles.selection,
+    snapshot.derived,
     snapshot.density,
     snapshot.borders,
     snapshot.glyphs,
+    snapshot.accessibility,
+    snapshot.diagnostics,
+    snapshot.futureSources,
   ]) {
     Object.freeze(colors);
   }
   return Object.freeze(snapshot);
 }
 
-function darkPalette(): SemanticThemeSnapshot {
-  const accent = rgba(130, 170, 255);
-  return freezeSnapshot({
-    mode: "dark",
-    setting: "dark",
-    colors: {
-      background: rgba(16, 16, 22),
-      surface: rgba(22, 22, 30),
-      surfaceRaised: rgba(30, 30, 40),
-      foreground: rgba(212, 212, 216),
-      mutedForeground: rgba(110, 110, 130),
-      border: rgba(60, 60, 80),
-      accent,
-      accentMuted: rgba(60, 66, 92),
-      focus: rgba(130, 170, 255),
-      focusBorder: rgba(110, 145, 230),
-      selection: rgba(40, 46, 66),
-      selectionForeground: rgba(255, 255, 255),
-      hover: rgba(30, 34, 48),
-      buttonHover: rgba(52, 60, 86),
-      attention: rgba(92, 44, 48),
-      status: {
-        blocked: rgba(255, 95, 95),
-        working: rgba(255, 215, 95),
-        done: rgba(135, 175, 255),
-        idle: rgba(135, 215, 135),
-        unknown: rgba(128, 128, 128),
-      },
+const DEFAULT_ACCESSIBILITY: ThemeAccessibilityPreferences = Object.freeze({
+  reducedMotion: false,
+  increasedContrast: false,
+});
+
+function projectColorRoles(
+  tokens: ReturnType<typeof resolveVisualTheme>["tokens"],
+): OpenTuiSemanticColorRoles {
+  const surfaces: Record<SurfaceTokenRole, RGBA> = {
+    canvas: rgbaFromRendererNeutral(tokens.surfaces.canvas),
+    panel: rgbaFromRendererNeutral(tokens.surfaces.panel),
+    panelRaised: rgbaFromRendererNeutral(tokens.surfaces.panelRaised),
+    terminal: rgbaFromRendererNeutral(tokens.surfaces.terminal),
+    header: rgbaFromRendererNeutral(tokens.surfaces.header),
+    headerActive: rgbaFromRendererNeutral(tokens.surfaces.headerActive),
+    command: rgbaFromRendererNeutral(tokens.surfaces.command),
+  };
+  const text: Record<TextTokenRole, RGBA> = {
+    primary: rgbaFromRendererNeutral(tokens.text.primary),
+    secondary: rgbaFromRendererNeutral(tokens.text.secondary),
+    muted: rgbaFromRendererNeutral(tokens.text.muted),
+    bright: rgbaFromRendererNeutral(tokens.text.bright),
+    inverse: rgbaFromRendererNeutral(tokens.text.inverse),
+    link: rgbaFromRendererNeutral(tokens.text.link),
+  };
+  const borders: Record<BorderTokenRole, RGBA> = {
+    subtle: rgbaFromRendererNeutral(tokens.borders.subtle),
+    default: rgbaFromRendererNeutral(tokens.borders.default),
+    focused: rgbaFromRendererNeutral(tokens.borders.focused),
+    selected: rgbaFromRendererNeutral(tokens.borders.selected),
+    attention: rgbaFromRendererNeutral(tokens.borders.attention),
+    danger: rgbaFromRendererNeutral(tokens.borders.danger),
+  };
+  const statusTone: Record<StatusToneRole, RGBA> = {
+    neutral: rgbaFromRendererNeutral(tokens.statusTone.neutral),
+    info: rgbaFromRendererNeutral(tokens.statusTone.info),
+    warning: rgbaFromRendererNeutral(tokens.statusTone.warning),
+    danger: rgbaFromRendererNeutral(tokens.statusTone.danger),
+    success: rgbaFromRendererNeutral(tokens.statusTone.success),
+  };
+  const selection: Record<SelectionTokenRole, RGBA> = {
+    selection: rgbaFromRendererNeutral(tokens.selection.selection),
+    selectionText: rgbaFromRendererNeutral(tokens.selection.selectionText),
+    hover: rgbaFromRendererNeutral(tokens.selection.hover),
+    pressed: rgbaFromRendererNeutral(tokens.selection.pressed),
+    disabled: rgbaFromRendererNeutral(tokens.selection.disabled),
+  };
+  return { surfaces, text, borders, statusTone, selection };
+}
+
+function snapshotFromResolvedTheme(
+  resolved: ReturnType<typeof resolveVisualTheme>,
+  setting: ThemeModeSetting,
+  accessibility: ThemeAccessibilityPreferences,
+): SemanticThemeSnapshot {
+  const roles = projectColorRoles(resolved.tokens);
+  const derived = {
+    attentionSurface: rgbaFromRendererNeutral(
+      deriveAttentionBlend(resolved.tokens.surfaces.panel, resolved.tokens.borders.attention),
+    ),
+  };
+  const colors: SemanticThemeColors = {
+    background: roles.surfaces.canvas,
+    surface: roles.surfaces.panel,
+    surfaceRaised: roles.surfaces.panelRaised,
+    foreground: roles.text.primary,
+    mutedForeground: roles.text.muted,
+    border: roles.borders.default,
+    accent: roles.borders.focused,
+    accentMuted: roles.surfaces.headerActive,
+    focus: roles.borders.focused,
+    focusBorder: roles.borders.focused,
+    selection: roles.selection.selection,
+    selectionForeground: roles.selection.selectionText,
+    hover: roles.selection.hover,
+    buttonHover: roles.selection.pressed,
+    attention: derived.attentionSurface,
+    status: {
+      blocked: roles.statusTone.warning,
+      working: roles.statusTone.info,
+      done: roles.statusTone.success,
+      idle: roles.statusTone.neutral,
+      unknown: roles.statusTone.neutral,
     },
-    density: { compactGap: 0, comfortableGap: 1, detailedGap: 2, paddingX: 1 },
+  };
+  return freezeSnapshot({
+    mode: resolved.appearance,
+    setting,
+    roles,
+    derived,
+    colors,
+    accessibility: { ...accessibility },
+    diagnostics: [...resolved.diagnostics],
+    futureSources: [...resolved.futureSources],
+    density: {
+      compactGap: Math.floor(resolved.tokens.density.inlineGap.value),
+      comfortableGap: Math.max(1, Math.round(resolved.tokens.density.sectionGap.value)),
+      detailedGap: Math.max(2, Math.round(resolved.tokens.density.sectionGap.value) + 1),
+      paddingX: Math.max(0, Math.round(resolved.tokens.density.controlPadding.value)),
+    },
     borders: { style: "single", focusedStyle: "single" },
     glyphs: {
       active: "●",
@@ -305,56 +423,6 @@ function darkPalette(): SemanticThemeSnapshot {
       scrollTrack: "░",
     },
   });
-}
-
-function lightPalette(): SemanticThemeSnapshot {
-  const accent = rgba(45, 105, 220);
-  return freezeSnapshot({
-    mode: "light",
-    setting: "light",
-    colors: {
-      background: rgba(248, 248, 250),
-      surface: rgba(238, 240, 246),
-      surfaceRaised: rgba(255, 255, 255),
-      foreground: rgba(28, 32, 42),
-      mutedForeground: rgba(92, 99, 118),
-      border: rgba(188, 196, 214),
-      accent,
-      accentMuted: rgba(212, 224, 255),
-      focus: rgba(45, 105, 220),
-      focusBorder: rgba(20, 80, 190),
-      selection: rgba(218, 228, 252),
-      selectionForeground: rgba(15, 25, 45),
-      hover: rgba(228, 234, 246),
-      buttonHover: rgba(208, 220, 246),
-      attention: rgba(255, 224, 224),
-      status: {
-        blocked: rgba(210, 52, 72),
-        working: rgba(176, 120, 0),
-        done: rgba(66, 92, 210),
-        idle: rgba(38, 135, 82),
-        unknown: rgba(112, 118, 130),
-      },
-    },
-    density: { compactGap: 0, comfortableGap: 1, detailedGap: 2, paddingX: 1 },
-    borders: { style: "single", focusedStyle: "single" },
-    glyphs: {
-      active: "●",
-      inactive: "○",
-      focusHorizontal: "─",
-      focusVertical: "│",
-      check: "✓",
-      scrollThumb: "█",
-      scrollTrack: "░",
-    },
-  });
-}
-
-export const DARK_THEME = darkPalette();
-export const LIGHT_THEME = lightPalette();
-
-function baseFor(mode: ResolvedThemeMode): SemanticThemeSnapshot {
-  return mode === "dark" ? DARK_THEME : LIGHT_THEME;
 }
 
 function resolvedMode(
@@ -389,9 +457,45 @@ function withAppThemeConfig(
     ? base.colors.focusBorder
     : mix(accent, contrast, base.mode === "dark" ? 0.18 : 0.14);
   const focusBorder = safeFocusBorderColor(focus, preferredFocusBorder, base, statusColors);
+  const accentMuted = mix(base.colors.surface, accent, base.mode === "dark" ? 0.34 : 0.18);
+  const selection = mix(base.colors.background, accent, base.mode === "dark" ? 0.22 : 0.16);
+  const hover = mix(base.colors.background, accent, base.mode === "dark" ? 0.08 : 0.06);
+  const pressed = mix(base.colors.background, accent, base.mode === "dark" ? 0.24 : 0.16);
+  const roles: OpenTuiSemanticColorRoles = {
+    surfaces: {
+      ...base.roles.surfaces,
+      ...(config?.accent ? { headerActive: accentMuted } : {}),
+    },
+    text: {
+      ...base.roles.text,
+      ...(config?.fg ? { primary: foreground } : {}),
+      ...(config?.muted ? { secondary: muted, muted } : {}),
+      ...(config?.accent ? { link: accent } : {}),
+    },
+    borders: {
+      ...base.roles.borders,
+      ...(config?.accent && !base.accessibility.increasedContrast ? { focused: focus } : {}),
+    },
+    statusTone: {
+      ...base.roles.statusTone,
+      ...(config?.status?.blocked ? { warning: status.blocked } : {}),
+      ...(config?.status?.working ? { info: status.working } : {}),
+      ...(config?.status?.done ? { success: status.done } : {}),
+      ...(config?.status?.idle ? { neutral: status.idle } : {}),
+    },
+    selection: {
+      ...base.roles.selection,
+      ...(config?.accent ? { selection, hover, pressed } : {}),
+    },
+  };
   return freezeSnapshot({
     mode: base.mode,
     setting,
+    roles,
+    derived: base.derived,
+    accessibility: base.accessibility,
+    diagnostics: base.diagnostics,
+    futureSources: base.futureSources,
     colors: {
       background: cloneColor(base.colors.background),
       surface: cloneColor(base.colors.surface),
@@ -400,13 +504,13 @@ function withAppThemeConfig(
       mutedForeground: muted,
       border: cloneColor(base.colors.border),
       accent,
-      accentMuted: mix(base.colors.surface, accent, base.mode === "dark" ? 0.34 : 0.18),
+      accentMuted,
       focus,
       focusBorder,
-      selection: mix(base.colors.background, accent, base.mode === "dark" ? 0.22 : 0.16),
+      selection,
       selectionForeground: cloneColor(base.colors.selectionForeground),
-      hover: mix(base.colors.background, accent, base.mode === "dark" ? 0.08 : 0.06),
-      buttonHover: mix(base.colors.background, accent, base.mode === "dark" ? 0.24 : 0.16),
+      hover,
+      buttonHover: pressed,
       attention: cloneColor(base.colors.attention),
       status,
     },
@@ -425,8 +529,26 @@ export function createSemanticThemeSnapshot(
   rendererMode: ResolvedThemeMode | null = null,
 ): SemanticThemeSnapshot {
   const setting = config?.mode ?? "dark";
-  return withAppThemeConfig(baseFor(resolvedMode(setting, rendererMode)), setting, config);
+  const accessibility = {
+    reducedMotion: config?.accessibility?.reducedMotion ?? DEFAULT_ACCESSIBILITY.reducedMotion,
+    increasedContrast:
+      config?.accessibility?.increasedContrast ?? DEFAULT_ACCESSIBILITY.increasedContrast,
+  };
+  const resolved = resolveVisualTheme({
+    appearance: resolvedMode(setting, rendererMode),
+    userTheme: config?.userTheme,
+    projectTheme: config?.projectTheme,
+    accessibility,
+  });
+  return withAppThemeConfig(
+    snapshotFromResolvedTheme(resolved, setting, accessibility),
+    setting,
+    config,
+  );
 }
+
+export const DARK_THEME = createSemanticThemeSnapshot({ mode: "dark" });
+export const LIGHT_THEME = createSemanticThemeSnapshot({ mode: "light" });
 
 export function createSemanticThemeStore(
   config: ThemeConfigInput | undefined = undefined,
@@ -487,23 +609,67 @@ export function createSemanticThemeStore(
 }
 
 function sameSnapshot(a: SemanticThemeSnapshot, b: SemanticThemeSnapshot): boolean {
-  return (
-    a.mode === b.mode &&
-    a.setting === b.setting &&
-    rgbaKey(a.colors.accent) === rgbaKey(b.colors.accent) &&
-    rgbaKey(a.colors.foreground) === rgbaKey(b.colors.foreground) &&
-    rgbaKey(a.colors.mutedForeground) === rgbaKey(b.colors.mutedForeground) &&
-    rgbaKey(a.colors.status.blocked) === rgbaKey(b.colors.status.blocked) &&
-    rgbaKey(a.colors.status.working) === rgbaKey(b.colors.status.working) &&
-    rgbaKey(a.colors.status.done) === rgbaKey(b.colors.status.done) &&
-    rgbaKey(a.colors.status.idle) === rgbaKey(b.colors.status.idle) &&
-    rgbaKey(a.colors.status.unknown) === rgbaKey(b.colors.status.unknown) &&
-    a.glyphs.active === b.glyphs.active &&
-    a.glyphs.inactive === b.glyphs.inactive
-  );
+  const colorGroup = (group: Readonly<Record<string, RGBA>>) =>
+    Object.entries(group).map(([role, color]) => [role, rgbaKey(color)] as const);
+  const key = (snapshot: SemanticThemeSnapshot) =>
+    JSON.stringify({
+      mode: snapshot.mode,
+      setting: snapshot.setting,
+      colors: {
+        background: rgbaKey(snapshot.colors.background),
+        surface: rgbaKey(snapshot.colors.surface),
+        surfaceRaised: rgbaKey(snapshot.colors.surfaceRaised),
+        foreground: rgbaKey(snapshot.colors.foreground),
+        mutedForeground: rgbaKey(snapshot.colors.mutedForeground),
+        border: rgbaKey(snapshot.colors.border),
+        accent: rgbaKey(snapshot.colors.accent),
+        accentMuted: rgbaKey(snapshot.colors.accentMuted),
+        focus: rgbaKey(snapshot.colors.focus),
+        focusBorder: rgbaKey(snapshot.colors.focusBorder),
+        selection: rgbaKey(snapshot.colors.selection),
+        selectionForeground: rgbaKey(snapshot.colors.selectionForeground),
+        hover: rgbaKey(snapshot.colors.hover),
+        buttonHover: rgbaKey(snapshot.colors.buttonHover),
+        attention: rgbaKey(snapshot.colors.attention),
+        status: colorGroup(snapshot.colors.status),
+      },
+      roles: {
+        surfaces: colorGroup(snapshot.roles.surfaces),
+        text: colorGroup(snapshot.roles.text),
+        borders: colorGroup(snapshot.roles.borders),
+        statusTone: colorGroup(snapshot.roles.statusTone),
+        selection: colorGroup(snapshot.roles.selection),
+      },
+      derived: { attentionSurface: rgbaKey(snapshot.derived.attentionSurface) },
+      accessibility: snapshot.accessibility,
+      diagnostics: snapshot.diagnostics,
+      futureSources: snapshot.futureSources,
+      density: snapshot.density,
+      borders: snapshot.borders,
+      glyphs: snapshot.glyphs,
+    });
+  return key(a) === key(b);
 }
 
 const compatibilityTheme = DARK_THEME;
+
+/**
+ * Temporary names retained for app.tsx and pre-Card-22 leaves. Card 22.3 owns
+ * their removal after every consumer receives a live SemanticThemeSnapshot.
+ */
+export const LEGACY_THEME_ALIAS_IDS = [
+  "DEFAULT_FG",
+  "DEFAULT_BG",
+  "SIDEBAR_BG",
+  "ACCENT",
+  "MUTED",
+  "BADGE_BG",
+  "FOCUS_BORDER_FG",
+  "TAB_ACTIVE_BG",
+  "HOVER_BG",
+  "BUTTON_HOVER_BG",
+  "CHIP_ATTN_BG",
+] as const;
 
 export const DEFAULT_FG = compatibilityTheme.colors.foreground;
 export const DEFAULT_BG = compatibilityTheme.colors.background;

--- a/packages/daemon/src/tui/mirror/theme.ts
+++ b/packages/daemon/src/tui/mirror/theme.ts
@@ -21,7 +21,13 @@ import {
   type TextTokenRole,
   type ThemeAccessibilityPreferences,
   type ThemeDiagnostic,
+  type VisualTokensV1,
 } from "@tmux-ide/contracts";
+import {
+  LEGACY_THEME_OVERRIDE_PROVENANCE,
+  type LegacyThemeOverrideId,
+  type LegacyThemeOverrideProvenance,
+} from "../../lib/legacy-theme-compat.ts";
 
 export type ResolvedThemeMode = "dark" | "light";
 export type ThemeModeSetting = ResolvedThemeMode | "system";
@@ -97,6 +103,8 @@ export interface SemanticThemeTokens {
 export interface SemanticThemeSnapshot extends SemanticThemeTokens {
   readonly mode: ResolvedThemeMode;
   readonly setting: ThemeModeSetting;
+  /** Full renderer-neutral source tokens. Host projections may consume additional groups later. */
+  readonly canonical: VisualTokensV1;
   readonly roles: OpenTuiSemanticColorRoles;
   readonly derived: OpenTuiDerivedColors;
   readonly accessibility: ThemeAccessibilityPreferences;
@@ -114,6 +122,8 @@ export interface ThemeConfigInput {
   fg?: string;
   status?: Partial<Record<keyof SemanticThemeColors["status"], string>>;
   glyphs?: Partial<Pick<SemanticThemeTokens["glyphs"], "active" | "inactive">>;
+  /** Present on resolved app config; absent means direct callers supplied explicit legacy values. */
+  [LEGACY_THEME_OVERRIDE_PROVENANCE]?: LegacyThemeOverrideProvenance;
 }
 
 export interface ThemeStoreOptions {
@@ -309,7 +319,20 @@ function freezeSnapshot(snapshot: SemanticThemeSnapshot): SemanticThemeSnapshot 
   ]) {
     Object.freeze(colors);
   }
+  deepFreeze(snapshot.canonical);
   return Object.freeze(snapshot);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+  return Object.freeze(value);
+}
+
+function cloneCanonicalTokens(tokens: VisualTokensV1): VisualTokensV1 {
+  // The contract is JSON data by design. Clone before freezing so the facade
+  // never freezes the shared built-in token registry owned by contracts.
+  return JSON.parse(JSON.stringify(tokens)) as VisualTokensV1;
 }
 
 const DEFAULT_ACCESSIBILITY: ThemeAccessibilityPreferences = Object.freeze({
@@ -400,6 +423,7 @@ function snapshotFromResolvedTheme(
   return freezeSnapshot({
     mode: resolved.appearance,
     setting,
+    canonical: cloneCanonicalTokens(resolved.tokens),
     roles,
     derived,
     colors,
@@ -437,18 +461,34 @@ function withAppThemeConfig(
   setting: ThemeModeSetting,
   config: ThemeConfigInput | undefined,
 ): SemanticThemeSnapshot {
-  const accent = parseThemeColor(config?.accent, base.colors.accent);
-  const foreground = parseThemeColor(config?.fg, base.colors.foreground);
-  const muted = parseThemeColor(config?.muted, base.colors.mutedForeground);
+  const legacyValue = (id: LegacyThemeOverrideId, value: string | undefined) => {
+    const provenance = config?.[LEGACY_THEME_OVERRIDE_PROVENANCE];
+    return provenance === undefined || provenance[id] ? value : undefined;
+  };
+  const accentInput = legacyValue("accent", config?.accent);
+  const foregroundInput = legacyValue("fg", config?.fg);
+  const mutedInput = legacyValue("muted", config?.muted);
+  const statusInput = {
+    blocked: legacyValue("status.blocked", config?.status?.blocked),
+    working: legacyValue("status.working", config?.status?.working),
+    done: legacyValue("status.done", config?.status?.done),
+    idle: legacyValue("status.idle", config?.status?.idle),
+    unknown: legacyValue("status.unknown", config?.status?.unknown),
+  };
+  const activeGlyph = legacyValue("glyphs.active", config?.glyphs?.active);
+  const inactiveGlyph = legacyValue("glyphs.inactive", config?.glyphs?.inactive);
+  const accent = parseThemeColor(accentInput, base.colors.accent);
+  const foreground = parseThemeColor(foregroundInput, base.colors.foreground);
+  const muted = parseThemeColor(mutedInput, base.colors.mutedForeground);
   const white = rgba(255, 255, 255);
   const black = rgba(0, 0, 0);
   const contrast = base.mode === "dark" ? white : black;
   const status = {
-    blocked: parseThemeColor(config?.status?.blocked, base.colors.status.blocked),
-    working: parseThemeColor(config?.status?.working, base.colors.status.working),
-    done: parseThemeColor(config?.status?.done, base.colors.status.done),
-    idle: parseThemeColor(config?.status?.idle, base.colors.status.idle),
-    unknown: parseThemeColor(config?.status?.unknown, base.colors.status.unknown),
+    blocked: parseThemeColor(statusInput.blocked, base.colors.status.blocked),
+    working: parseThemeColor(statusInput.working, base.colors.status.working),
+    done: parseThemeColor(statusInput.done, base.colors.status.done),
+    idle: parseThemeColor(statusInput.idle, base.colors.status.idle),
+    unknown: parseThemeColor(statusInput.unknown, base.colors.status.unknown),
   };
   const statusColors = Object.values(status);
   const accentCollidesWithStatus = collidesWithAny(accent, statusColors);
@@ -464,33 +504,34 @@ function withAppThemeConfig(
   const roles: OpenTuiSemanticColorRoles = {
     surfaces: {
       ...base.roles.surfaces,
-      ...(config?.accent ? { headerActive: accentMuted } : {}),
+      ...(accentInput ? { headerActive: accentMuted } : {}),
     },
     text: {
       ...base.roles.text,
-      ...(config?.fg ? { primary: foreground } : {}),
-      ...(config?.muted ? { secondary: muted, muted } : {}),
-      ...(config?.accent ? { link: accent } : {}),
+      ...(foregroundInput ? { primary: foreground } : {}),
+      ...(mutedInput ? { secondary: muted, muted } : {}),
+      ...(accentInput ? { link: accent } : {}),
     },
     borders: {
       ...base.roles.borders,
-      ...(config?.accent && !base.accessibility.increasedContrast ? { focused: focus } : {}),
+      ...(accentInput && !base.accessibility.increasedContrast ? { focused: focus } : {}),
     },
     statusTone: {
       ...base.roles.statusTone,
-      ...(config?.status?.blocked ? { warning: status.blocked } : {}),
-      ...(config?.status?.working ? { info: status.working } : {}),
-      ...(config?.status?.done ? { success: status.done } : {}),
-      ...(config?.status?.idle ? { neutral: status.idle } : {}),
+      ...(statusInput.blocked ? { warning: status.blocked } : {}),
+      ...(statusInput.working ? { info: status.working } : {}),
+      ...(statusInput.done ? { success: status.done } : {}),
+      ...(statusInput.idle ? { neutral: status.idle } : {}),
     },
     selection: {
       ...base.roles.selection,
-      ...(config?.accent ? { selection, hover, pressed } : {}),
+      ...(accentInput ? { selection, hover, pressed } : {}),
     },
   };
   return freezeSnapshot({
     mode: base.mode,
     setting,
+    canonical: base.canonical,
     roles,
     derived: base.derived,
     accessibility: base.accessibility,
@@ -518,8 +559,8 @@ function withAppThemeConfig(
     borders: { ...base.borders },
     glyphs: {
       ...base.glyphs,
-      active: config?.glyphs?.active ?? base.glyphs.active,
-      inactive: config?.glyphs?.inactive ?? base.glyphs.inactive,
+      active: activeGlyph ?? base.glyphs.active,
+      inactive: inactiveGlyph ?? base.glyphs.inactive,
     },
   });
 }
@@ -615,6 +656,7 @@ function sameSnapshot(a: SemanticThemeSnapshot, b: SemanticThemeSnapshot): boole
     JSON.stringify({
       mode: snapshot.mode,
       setting: snapshot.setting,
+      canonical: snapshot.canonical,
       colors: {
         background: rgbaKey(snapshot.colors.background),
         surface: rgbaKey(snapshot.colors.surface),
@@ -652,6 +694,16 @@ function sameSnapshot(a: SemanticThemeSnapshot, b: SemanticThemeSnapshot): boole
 }
 
 const compatibilityTheme = DARK_THEME;
+
+/**
+ * Card 22.3b owns these root-composition writes. Keeping the list executable
+ * prevents optional DARK_THEME fallbacks from becoming an undocumented public
+ * contract while this adapter card deliberately leaves app.tsx untouched.
+ */
+export const CARD_22_3B_LIVE_THEME_WIRING_DEFERRALS = [
+  { component: "Sidebar", prop: "theme", owner: "app.tsx" },
+  { component: "MissionsSurface", prop: "semanticTheme", owner: "app.tsx" },
+] as const;
 
 /**
  * Temporary names retained for app.tsx and pre-Card-22 leaves. Card 22.3 owns

--- a/packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx
@@ -209,8 +209,8 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
         .captureSpans()
         .lines[projection.chrome.height - 1]!.spans.find((span) => span.text.includes("□"));
       expect(maximizeSpan).toBeDefined();
-      expect(colorKey(maximizeSpan!.bg)).toBe(colorKey(theme.colors.accentMuted));
-      expect(colorKey(maximizeSpan!.fg)).toBe(colorKey(theme.colors.mutedForeground));
+      expect(colorKey(maximizeSpan!.bg)).toBe(colorKey(theme.roles.surfaces.headerActive));
+      expect(colorKey(maximizeSpan!.fg)).toBe(colorKey(theme.roles.text.muted));
       setup.renderer.destroy();
     },
   );

--- a/packages/daemon/src/tui/mirror/workspace/command-palette-surface-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/command-palette-surface-renderer.test.tsx
@@ -54,7 +54,7 @@ const commands: readonly CommandPaletteDescriptor[] = [
   },
   {
     id: "workspace.diff.open",
-    icon: "diff",
+    icon: "changes",
     label: "Review Changes",
     description: "Open the native diff surface",
     category: "Files",
@@ -70,7 +70,7 @@ const commands: readonly CommandPaletteDescriptor[] = [
   },
   {
     id: "workspace.pane.split",
-    icon: "splitRight",
+    icon: "split-right",
     label: "Split Pane Right",
     description: "Create a terminal beside the active agent",
     category: "Window",

--- a/packages/daemon/src/tui/mirror/workspace/icons.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/icons.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from "vitest";
+import { COHESION_FIXTURE_V1, SEMANTIC_ICON_IDS } from "@tmux-ide/contracts";
 import { terminalDisplayWidth } from "../panel-host.ts";
 import { iconButtonText } from "../recipes.ts";
 import { WORKSPACE_ICONS, workspaceIcon, workspaceIconLabel } from "./icons.ts";
 
 describe("workspace icon grammar", () => {
+  it("implements every canonical icon and every icon referenced by the common fixture", () => {
+    expect(Object.keys(WORKSPACE_ICONS)).toEqual([...SEMANTIC_ICON_IDS]);
+    for (const pane of COHESION_FIXTURE_V1.panes) {
+      for (const action of pane.actions) {
+        expect(workspaceIcon(action.icon)).toBe(WORKSPACE_ICONS[action.icon].glyph);
+        expect(workspaceIconLabel(action.icon)).toBeTruthy();
+      }
+    }
+  });
+
   it("keeps every Unicode glyph and ASCII fallback to exactly one terminal cell", () => {
     for (const [id, icon] of Object.entries(WORKSPACE_ICONS)) {
       expect(terminalDisplayWidth(icon.glyph), `${id} Unicode glyph`).toBe(1);
@@ -17,6 +28,8 @@ describe("workspace icon grammar", () => {
     expect(workspaceIconLabel("maximize")).toBe("Maximize");
     expect(workspaceIcon("more")).toBe("⋯");
     expect(workspaceIcon("close")).toBe("×");
+    expect(workspaceIcon("split-right")).toBe("│");
+    expect(workspaceIcon("pop-out", "ascii")).toBe("^");
   });
 
   it("centers an icon without exceeding narrow hit geometry", () => {

--- a/packages/daemon/src/tui/mirror/workspace/icons.ts
+++ b/packages/daemon/src/tui/mirror/workspace/icons.ts
@@ -1,3 +1,5 @@
+import type { SemanticIconId } from "@tmux-ide/contracts";
+
 /**
  * A terminal-safe icon vocabulary shared by native workspace surfaces.
  *
@@ -9,7 +11,7 @@ export const WORKSPACE_ICONS = {
   home: { glyph: "⌂", fallback: "H", label: "Home" },
   terminals: { glyph: "❯", fallback: ">", label: "Terminals" },
   files: { glyph: "▤", fallback: "F", label: "Files" },
-  diff: { glyph: "±", fallback: "D", label: "Changes" },
+  changes: { glyph: "±", fallback: "D", label: "Changes" },
   missions: { glyph: "◆", fallback: "M", label: "Missions" },
   activity: { glyph: "◷", fallback: "A", label: "Activity" },
   preview: { glyph: "◫", fallback: "P", label: "Preview" },
@@ -19,19 +21,26 @@ export const WORKSPACE_ICONS = {
   minimize: { glyph: "−", fallback: "-", label: "Minimize" },
   maximize: { glyph: "□", fallback: "Z", label: "Maximize" },
   restore: { glyph: "▣", fallback: "R", label: "Restore" },
-  splitRight: { glyph: "│", fallback: "|", label: "Split side-by-side" },
-  splitDown: { glyph: "─", fallback: "-", label: "Split stacked" },
+  "split-right": { glyph: "│", fallback: "|", label: "Split side-by-side" },
+  "split-down": { glyph: "─", fallback: "-", label: "Split stacked" },
+  duplicate: { glyph: "▥", fallback: "+", label: "Duplicate" },
   dock: { glyph: "▤", fallback: "D", label: "Dock" },
   float: { glyph: "◇", fallback: "F", label: "Float" },
   move: { glyph: "⠿", fallback: "M", label: "Move" },
   resize: { glyph: "◲", fallback: "R", label: "Resize" },
-  popOut: { glyph: "⇱", fallback: "^", label: "Pop out" },
+  "pop-out": { glyph: "⇱", fallback: "^", label: "Pop out" },
   search: { glyph: "⌕", fallback: "/", label: "Search" },
   refresh: { glyph: "↻", fallback: "r", label: "Refresh" },
   command: { glyph: "›", fallback: ">", label: "Command" },
-} as const;
+} as const satisfies Readonly<Record<SemanticIconId, WorkspaceIconDefinition>>;
 
-export type WorkspaceIconId = keyof typeof WORKSPACE_ICONS;
+export interface WorkspaceIconDefinition {
+  readonly glyph: string;
+  readonly fallback: string;
+  readonly label: string;
+}
+
+export type WorkspaceIconId = SemanticIconId;
 export type WorkspaceIconMode = "unicode" | "ascii";
 
 export function workspaceIcon(id: WorkspaceIconId, mode: WorkspaceIconMode = "unicode"): string {

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
@@ -283,10 +283,10 @@ describe("PaneFrame OpenTUI renderer", () => {
       expect(titleSpan, label).toBeDefined();
       const nativeFocused = projection.focused || projection.terminalFocused;
       expect(colorKey(titleSpan!.fg), label).toBe(
-        colorKey(nativeFocused ? theme.colors.selectionForeground : theme.colors.mutedForeground),
+        colorKey(nativeFocused ? theme.roles.text.primary : theme.roles.text.muted),
       );
       expect(colorKey(titleSpan!.bg), label).toBe(
-        colorKey(nativeFocused ? theme.colors.accentMuted : palette.background),
+        colorKey(nativeFocused ? theme.roles.surfaces.headerActive : palette.background),
       );
       if (label === "edit-floating-maximized") {
         expect(stable).toContain("edit");
@@ -430,8 +430,8 @@ describe("PaneFrame OpenTUI renderer", () => {
     const hovered = spanContaining(setup, "⋯", projection.header.y)!;
     const disabled = spanContaining(setup, "×", projection.header.y)!;
     const pressed = spanContaining(setup, "◲", projection.header.y)!;
-    expect(colorKey(base.bg)).toBe(colorKey(theme.colors.accentMuted));
-    expect(colorKey(base.fg)).toBe(colorKey(theme.colors.mutedForeground));
+    expect(colorKey(base.bg)).toBe(colorKey(theme.roles.surfaces.headerActive));
+    expect(colorKey(base.fg)).toBe(colorKey(theme.roles.text.muted));
     expect(colorKey(hovered.bg)).toBe(colorKey(recipePalette(theme, { hovered: true }).background));
     expect(colorKey(disabled.fg)).toBe(
       colorKey(recipePalette(theme, { disabled: true }).foreground),

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
@@ -125,7 +125,7 @@ const KIND_ICONS: Readonly<Record<PaneFrameKind, WorkspaceIconId>> = {
   home: "home",
   terminals: "terminals",
   files: "files",
-  diff: "diff",
+  diff: "changes",
   missions: "missions",
   activity: "activity",
   preview: "preview",

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
@@ -113,9 +113,9 @@ export function PaneFrameHeader(props: PaneFrameHeaderProps) {
   const palette = () => framePalette(props.theme, props.projection);
   const nativeFocused = () => props.projection.focused || props.projection.terminalFocused;
   const background = () =>
-    nativeFocused() ? props.theme.colors.accentMuted : palette().background;
+    nativeFocused() ? props.theme.roles.surfaces.headerActive : palette().background;
   const titleForeground = () =>
-    nativeFocused() ? props.theme.colors.selectionForeground : props.theme.colors.mutedForeground;
+    nativeFocused() ? props.theme.roles.text.primary : props.theme.roles.text.muted;
   // PaneFrame projections are immutable, so chips are fresh value objects on
   // every state update. Preserve the renderable tree by semantic chip id and
   // resolve the current chip separately.
@@ -140,7 +140,13 @@ export function PaneFrameHeader(props: PaneFrameHeaderProps) {
           width={props.projection.grip!.width}
           height={1}
         >
-          <text fg={nativeFocused() ? props.theme.colors.focus : props.theme.colors.border}>
+          <text
+            fg={
+              nativeFocused()
+                ? props.theme.roles.borders.focused
+                : props.theme.roles.borders.default
+            }
+          >
             {props.projection.grip!.text}
           </text>
         </box>
@@ -165,9 +171,7 @@ export function PaneFrameHeader(props: PaneFrameHeaderProps) {
           height={1}
         >
           <text
-            fg={
-              nativeFocused() ? props.theme.colors.foreground : props.theme.colors.mutedForeground
-            }
+            fg={nativeFocused() ? props.theme.roles.text.primary : props.theme.roles.text.muted}
           >
             {props.projection.subtitleSpan!.text}
           </text>
@@ -205,7 +209,7 @@ export function PaneFrame(props: PaneFrameProps) {
       width={props.projection.width}
       height={props.projection.height}
       position="relative"
-      backgroundColor={props.theme.colors.background}
+      backgroundColor={props.theme.roles.surfaces.canvas}
       overflow="hidden"
     >
       <Show when={props.projection.borderStyle !== "none" && props.projection.width > 1}>
@@ -256,7 +260,7 @@ export function PaneFrame(props: PaneFrameProps) {
         width={props.projection.body.width}
         height={props.projection.body.height}
         flexDirection="column"
-        backgroundColor={props.theme.colors.background}
+        backgroundColor={props.theme.roles.surfaces.terminal}
         overflow="hidden"
       >
         {props.children}

--- a/packages/daemon/src/tui/mirror/workspace/workbench-dock-opentui.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/workbench-dock-opentui.tsx
@@ -34,7 +34,7 @@ export function createOpenTuiWorkbenchDockHost(
           width={props.projection.dockTabs.width}
           height={props.projection.dockTabs.height}
           position="relative"
-          backgroundColor={theme().colors.surfaceRaised}
+          backgroundColor={theme().roles.surfaces.panelRaised}
           overflow="hidden"
         >
           {props.children}
@@ -70,12 +70,12 @@ export function createOpenTuiWorkbenchDockHost(
       const palette = () =>
         props.action.active
           ? {
-              foreground: theme().colors.selectionForeground,
-              background: theme().colors.selection,
+              foreground: theme().roles.selection.selectionText,
+              background: theme().roles.selection.selection,
             }
           : {
-              foreground: theme().colors.foreground,
-              background: theme().colors.surface,
+              foreground: theme().roles.text.primary,
+              background: theme().roles.surfaces.panel,
             };
       return (
         <box
@@ -99,7 +99,7 @@ export function createOpenTuiWorkbenchDockHost(
             width={props.projection.dockBody.width}
             height={props.projection.dockBody.height}
             flexDirection="row"
-            backgroundColor={theme().colors.surface}
+            backgroundColor={theme().roles.surfaces.panel}
             overflow="hidden"
           >
             <DockFocusRail
@@ -126,31 +126,31 @@ export function createOpenTuiWorkbenchDockHost(
 function tabPalette(theme: SemanticThemeSnapshot, tab: WorkbenchDockHostTab) {
   if (tab.disabled) {
     return {
-      foreground: theme.colors.mutedForeground,
-      background: theme.colors.surface,
+      foreground: theme.roles.text.muted,
+      background: theme.roles.selection.disabled,
     };
   }
   if (tab.selected) {
     return {
-      foreground: theme.colors.selectionForeground,
-      background: theme.colors.selection,
+      foreground: theme.roles.selection.selectionText,
+      background: theme.roles.selection.selection,
     };
   }
   if (tab.attention) {
     return {
-      foreground: theme.colors.foreground,
-      background: theme.colors.attention,
+      foreground: theme.roles.text.primary,
+      background: theme.derived.attentionSurface,
     };
   }
   if (tab.hovered) {
     return {
-      foreground: theme.colors.foreground,
-      background: theme.colors.hover,
+      foreground: theme.roles.text.primary,
+      background: theme.roles.selection.hover,
     };
   }
   return {
-    foreground: theme.colors.foreground,
-    background: theme.colors.surface,
+    foreground: theme.roles.text.primary,
+    background: theme.roles.surfaces.panel,
   };
 }
 
@@ -164,10 +164,12 @@ function DockFocusRail(props: {
     <box
       width={props.width}
       height={props.height}
-      backgroundColor={props.theme.colors.background}
+      backgroundColor={props.theme.roles.surfaces.canvas}
       overflow="hidden"
     >
-      <text fg={props.focused ? props.theme.colors.focus : props.theme.colors.border}>
+      <text
+        fg={props.focused ? props.theme.roles.borders.focused : props.theme.roles.borders.subtle}
+      >
         {props.focused ? "▌" : "│"}
       </text>
     </box>


### PR DESCRIPTION
## Summary
- adapt canonical experience colors, typography, motion, elevation, and icons to OpenTUI values
- migrate shell, sidebar, pane, dock, and native surfaces away from direct product colors
- preserve genuinely user-authored legacy themes while preventing parser-filled defaults from overriding canonical dark/light/system/high-contrast themes
- retain the full canonical token snapshot so non-color token changes remain observable
- ship the regenerated CLI bundle

## Review repairs
- added raw-config provenance for legacy theme fields
- deep-froze the canonical semantic snapshot
- made snapshot equality include canonical token changes
- documented the two remaining live-wiring integration points for the production root slice

## Verification
- full `pnpm check` passed after rebase onto current main
- daemon: 135 files / 2232 tests
- contracts: 18 files / 95 tests
- desktop: 3 files / 9 tests
- Electron: 7 files / 21 tests
- OpenTUI renderer: 89 files / 62 snapshots
- native dependency check passed on darwin/arm64
- `git diff --check` passed