### PR TITLE
feat(ui): add shared pane frame presenter

### DIFF
--- a/packages/daemon/src/ui/pane-frame/fixture.ts
+++ b/packages/daemon/src/ui/pane-frame/fixture.ts
@@ -1,0 +1,81 @@
+import { COHESION_FIXTURE_V1, resolvePaneAppearance } from "@tmux-ide/contracts";
+import type { PaneFrameActionIntent, PaneFrameGripIntent, PaneFrameModel } from "./presenter.js";
+
+const fixturePane = COHESION_FIXTURE_V1.panes.find((pane) => pane.id === "pane.implementer");
+if (!fixturePane) throw new Error("The cohesion fixture must include the implementer pane");
+
+const appearance = resolvePaneAppearance(fixturePane.state);
+
+/** Canonical semantic input shared by every PaneFrame host acceptance suite. */
+export const PANE_FRAME_FIXTURE_MODEL: PaneFrameModel = Object.freeze({
+  pane: Object.freeze({ id: fixturePane.id, kind: fixturePane.role }),
+  appearance,
+  title: fixturePane.title,
+  subtitle: fixturePane.subtitle,
+  status: Object.freeze({
+    id: "status.domain",
+    label: fixturePane.state.domainStatus,
+    description: appearance.accessibility.description,
+    tone: appearance.status.tone,
+    busy: appearance.accessibility.busy,
+  }),
+  chips: Object.freeze([
+    Object.freeze({
+      id: "chip.agent",
+      kind: "agent" as const,
+      label: `${fixturePane.subtitle ?? "Agent"}: ${fixturePane.state.agentActivity}`,
+      tone: appearance.status.domainTone,
+    }),
+    Object.freeze({
+      id: "chip.attention",
+      kind: "attention" as const,
+      label: fixturePane.state.attention,
+      tone: appearance.status.attentionTone,
+    }),
+  ]),
+  actions: Object.freeze(
+    fixturePane.actions.map((action) =>
+      Object.freeze({
+        id: action.id,
+        commandId: action.commandId,
+        icon: action.icon,
+        label: action.label,
+        description: action.disabledReason ?? action.label,
+        available: action.available,
+        disabledReason: action.disabledReason,
+        pressed:
+          (action.id === "maximize-toggle" && appearance.structure === "maximized") ||
+          (action.id === "float-toggle" && appearance.structure === "floating"),
+        busy: false,
+      }),
+    ),
+  ),
+});
+
+export type PaneFrameFixtureTraceEntry = PaneFrameActionIntent | PaneFrameGripIntent;
+
+export const PANE_FRAME_FIXTURE_EXPECTED_TRACE: readonly PaneFrameFixtureTraceEntry[] =
+  Object.freeze([
+    Object.freeze({ kind: "grip", paneId: fixturePane.id }),
+    Object.freeze({
+      kind: "action",
+      paneId: fixturePane.id,
+      actionId: "split",
+      commandId: "pane.split",
+    }),
+  ]);
+
+export interface PaneFrameFixtureTraceRecorder {
+  readonly trace: PaneFrameFixtureTraceEntry[];
+  readonly onActionActivate: (intent: PaneFrameActionIntent) => void;
+  readonly onGripActivate: (intent: PaneFrameGripIntent) => void;
+}
+
+export function createPaneFrameFixtureTraceRecorder(): PaneFrameFixtureTraceRecorder {
+  const trace: PaneFrameFixtureTraceEntry[] = [];
+  return {
+    trace,
+    onActionActivate: (intent) => trace.push(intent),
+    onGripActivate: (intent) => trace.push(intent),
+  };
+}

--- a/packages/daemon/src/ui/pane-frame/import-dag.test.ts
+++ b/packages/daemon/src/ui/pane-frame/import-dag.test.ts
@@ -1,0 +1,126 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "../../../../..");
+
+interface ImportGraph {
+  readonly files: ReadonlyMap<string, string>;
+  readonly externalSpecifiers: ReadonlySet<string>;
+}
+
+function runtimeImports(source: string): string[] {
+  const withoutTypeImports = source.replace(
+    /^\s*import\s+type\s+[\s\S]*?\s+from\s+["'][^"']+["'];?\s*$/gmu,
+    "",
+  );
+  return [
+    ...withoutTypeImports.matchAll(/\b(?:from\s+|import\s*\(\s*)["']([^"']+)["']/gu),
+    ...withoutTypeImports.matchAll(/^\s*import\s*["']([^"']+)["']/gmu),
+  ].map((match) => match[1]!);
+}
+
+function resolveLocalImport(importer: string, specifier: string): string | null {
+  if (!specifier.startsWith(".")) return null;
+  const candidate = resolve(dirname(importer), specifier);
+  const extension = extname(candidate);
+  const candidates =
+    extension === ".js" || extension === ".jsx"
+      ? [
+          candidate.slice(0, -extension.length) + ".ts",
+          candidate.slice(0, -extension.length) + ".tsx",
+        ]
+      : extension
+        ? [candidate]
+        : [candidate + ".ts", candidate + ".tsx"];
+  for (const sourceCandidate of candidates) {
+    try {
+      readFileSync(sourceCandidate, "utf8");
+      return sourceCandidate;
+    } catch {
+      // Continue with the next source representation.
+    }
+  }
+  return candidate;
+}
+
+function importGraph(entry: string): ImportGraph {
+  const files = new Map<string, string>();
+  const externalSpecifiers = new Set<string>();
+  const pending = [entry];
+  while (pending.length > 0) {
+    const file = pending.pop()!;
+    if (files.has(file) || ![".ts", ".tsx"].includes(extname(file))) continue;
+    const source = readFileSync(file, "utf8");
+    files.set(file, source);
+    for (const specifier of runtimeImports(source)) {
+      const local = resolveLocalImport(file, specifier);
+      if (local) pending.push(local);
+      else externalSpecifiers.add(specifier);
+    }
+  }
+  return { files, externalSpecifiers };
+}
+
+function relativeFiles(graph: ImportGraph): string[] {
+  return [...graph.files.keys()].map((file) => file.slice(REPO_ROOT.length + 1)).sort();
+}
+
+function intrinsicJsxNames(source: string): string[] {
+  const file = ts.createSourceFile(
+    "presenter.tsx",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const names: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const name = node.tagName.getText(file);
+      if (/^[a-z]/u.test(name)) names.push(name);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return names;
+}
+
+describe("shared PaneFrame presenter import DAG", () => {
+  it("keeps every transitive runtime dependency intrinsic-free and on solid-js alone", () => {
+    const graph = importGraph(resolve(HERE, "presenter.tsx"));
+    expect([...graph.externalSpecifiers].sort()).toEqual(["solid-js"]);
+    expect(relativeFiles(graph)).toEqual(["packages/daemon/src/ui/pane-frame/presenter.tsx"]);
+
+    const source = [...graph.files.values()].join("\n");
+    expect(intrinsicJsxNames(source)).toEqual([]);
+    expect(source).not.toMatch(
+      /\b(?:document|window|HTMLElement|KeyboardEvent|MouseEvent|PointerEvent|WheelEvent|process|Buffer)\b/u,
+    );
+    expect(source).not.toMatch(
+      /\b(?:cell|cells|pixel|pixels|rectangle|rectangles|geometry|transport|rgba|glyph|glyphs)\b/iu,
+    );
+    expect(source).not.toMatch(/%pane_id|electron|xterm|\bpty\b|@opentui|solid-js\/web/iu);
+  });
+
+  it("follows emitted local specifiers before evaluating downstream dependencies", () => {
+    const root = mkdtempSync(resolve(tmpdir(), "tmux-ide-pane-frame-dag-"));
+    try {
+      const entry = resolve(root, "entry.ts");
+      writeFileSync(entry, 'import "./downstream.js";\n');
+      writeFileSync(resolve(root, "downstream.ts"), 'import "node:fs";\n');
+
+      const graph = importGraph(entry);
+      expect([...graph.files.keys()].sort()).toEqual(
+        [entry, resolve(root, "downstream.ts")].sort(),
+      );
+      expect([...graph.externalSpecifiers]).toContain("node:fs");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/daemon/src/ui/pane-frame/presenter.test.tsx
+++ b/packages/daemon/src/ui/pane-frame/presenter.test.tsx
@@ -1,0 +1,270 @@
+/* @vitest-environment happy-dom */
+import { afterEach, describe, expect, it } from "vitest";
+import { createSignal } from "solid-js";
+import { render } from "solid-js/web";
+import {
+  PANE_FRAME_FIXTURE_EXPECTED_TRACE,
+  PANE_FRAME_FIXTURE_MODEL,
+  createPaneFrameFixtureTraceRecorder,
+} from "./fixture.js";
+import {
+  PaneFramePresenter,
+  type PaneFrameHostLeaves,
+  type PaneFrameModel,
+  type PaneFrameStatusItem,
+} from "./presenter.js";
+
+const disposers: Array<() => void> = [];
+
+function statusLabel(item: PaneFrameStatusItem): string {
+  return item.kind === "status" ? item.status.label : item.chip.label;
+}
+
+const TEST_HOST: PaneFrameHostLeaves = {
+  Root: (props) => (
+    <section data-leaf="root" data-pane={props.pane.id}>
+      {props.children}
+    </section>
+  ),
+  Header: (props) => <header data-leaf="header">{props.children}</header>,
+  Grip: (props) => (
+    <button data-leaf="grip" type="button" onClick={() => props.onActivate?.()}>
+      Move {props.pane.id}
+    </button>
+  ),
+  Title: (props) => (
+    <h2 data-leaf="title">
+      {props.title}
+      {props.subtitle ? <small>{props.subtitle}</small> : null}
+    </h2>
+  ),
+  Status: (props) => (
+    <span
+      data-leaf="status"
+      data-item={`${props.item.kind}:${props.item.id}`}
+      data-pane={props.pane.id}
+    >
+      {statusLabel(props.item)}
+    </span>
+  ),
+  ActionList: (props) => (
+    <nav data-leaf="actions" data-actions={props.actions.map((action) => action.id).join(",")}>
+      {props.children}
+    </nav>
+  ),
+  Action: (props) => (
+    <button
+      data-leaf="action"
+      data-action={props.action.id}
+      type="button"
+      disabled={!props.interactive}
+      onClick={() => props.onActivate?.()}
+    >
+      {props.action.label}
+    </button>
+  ),
+  Body: (props) => (
+    <main data-leaf="body" data-pane={props.pane.id}>
+      {props.children}
+    </main>
+  ),
+};
+
+function freshModel(): PaneFrameModel {
+  return {
+    ...PANE_FRAME_FIXTURE_MODEL,
+    pane: { ...PANE_FRAME_FIXTURE_MODEL.pane },
+    status: PANE_FRAME_FIXTURE_MODEL.status ? { ...PANE_FRAME_FIXTURE_MODEL.status } : null,
+    chips: PANE_FRAME_FIXTURE_MODEL.chips.map((chip) => ({ ...chip })),
+    actions: PANE_FRAME_FIXTURE_MODEL.actions.map((action) => ({ ...action })),
+  };
+}
+
+function renderPresenter(initial: PaneFrameModel = freshModel()) {
+  const root = document.createElement("div");
+  document.body.append(root);
+  const [model, setModel] = createSignal(initial);
+  const trace = createPaneFrameFixtureTraceRecorder();
+  disposers.push(
+    render(
+      () => (
+        <PaneFramePresenter
+          model={model()}
+          host={TEST_HOST}
+          body={<p data-body-content="shared">Shared body</p>}
+          onActionActivate={trace.onActionActivate}
+          onGripActivate={trace.onGripActivate}
+        />
+      ),
+      root,
+    ),
+  );
+  return { model, root, setModel, trace };
+}
+
+function byData(root: HTMLElement, attribute: string, id: string): HTMLElement {
+  return root.querySelector<HTMLElement>(`[data-${attribute}="${id}"]`)!;
+}
+
+afterEach(() => {
+  for (const dispose of disposers.splice(0)) dispose();
+  document.body.replaceChildren();
+});
+
+describe("PaneFramePresenter", () => {
+  it("emits only the shared semantic fixture trace", () => {
+    const { root, trace } = renderPresenter();
+
+    byData(root, "leaf", "grip").click();
+    byData(root, "action", "split").click();
+
+    expect(trace.trace).toEqual(PANE_FRAME_FIXTURE_EXPECTED_TRACE);
+  });
+
+  it("keeps body, action, and chip leaves keyed by semantic identity", () => {
+    const { root, setModel } = renderPresenter();
+    const body = byData(root, "leaf", "body");
+    const split = byData(root, "action", "split");
+    const agent = byData(root, "item", "chip:chip.agent");
+    const attention = byData(root, "item", "chip:chip.attention");
+
+    const next = freshModel();
+    const [nextAgent, nextAttention] = next.chips;
+    const splitIndex = next.actions.findIndex((action) => action.id === "split");
+    const splitAction = next.actions[splitIndex]!;
+    const otherActions = next.actions.filter((action) => action.id !== "split").reverse();
+    setModel({
+      ...next,
+      title: "Updated implementer",
+      chips: [
+        { ...nextAttention!, label: "Attention updated" },
+        { ...nextAgent!, label: "Agent updated" },
+      ],
+      actions: [{ ...splitAction, label: "Split updated" }, ...otherActions],
+    });
+
+    expect(byData(root, "leaf", "body")).toBe(body);
+    expect(byData(root, "action", "split")).toBe(split);
+    expect(byData(root, "item", "chip:chip.agent")).toBe(agent);
+    expect(byData(root, "item", "chip:chip.attention")).toBe(attention);
+    expect(split.textContent).toBe("Split updated");
+    expect(byData(root, "leaf", "actions").dataset.actions?.split(",")[0]).toBe("split");
+    expect(root.querySelector('[data-leaf="title"]')?.textContent).toContain("Updated implementer");
+  });
+
+  it("disposes removed identities and creates a fresh leaf when they return", () => {
+    const { root, setModel } = renderPresenter();
+    const original = byData(root, "action", "split");
+    const withoutSplit = freshModel();
+    setModel({
+      ...withoutSplit,
+      actions: withoutSplit.actions.filter((action) => action.id !== "split"),
+    });
+    expect(root.querySelector('[data-action="split"]')).toBeNull();
+
+    const restored = freshModel();
+    const split = restored.actions.find((action) => action.id === "split")!;
+    setModel({
+      ...restored,
+      actions: [split, ...restored.actions.filter((item) => item !== split)],
+    });
+    const replacement = byData(root, "action", "split");
+    expect(replacement).not.toBe(original);
+
+    const updated = freshModel();
+    setModel({
+      ...updated,
+      actions: updated.actions.map((action) =>
+        action.id === "split" ? { ...action, label: "Restored and updated" } : action,
+      ),
+    });
+    expect(byData(root, "action", "split")).toBe(replacement);
+    expect(replacement.textContent).toBe("Restored and updated");
+  });
+
+  it("remounts the body leaf when its semantic pane identity changes", () => {
+    const { root, setModel } = renderPresenter();
+    const body = byData(root, "leaf", "body");
+    const next = freshModel();
+
+    setModel({ ...next, pane: { ...next.pane, id: "pane.follow-up" } });
+
+    expect(byData(root, "leaf", "body")).not.toBe(body);
+    expect(byData(root, "leaf", "body").dataset.pane).toBe("pane.follow-up");
+  });
+
+  it("withholds callbacks for unavailable, busy, and globally disabled actions", () => {
+    const fixture = freshModel();
+    const unavailable: PaneFrameModel = {
+      ...fixture,
+      actions: fixture.actions.map((action) =>
+        action.id === "split"
+          ? { ...action, available: false, disabledReason: "Unavailable" }
+          : action,
+      ),
+    };
+    const { root, setModel, trace } = renderPresenter(unavailable);
+
+    expect((byData(root, "action", "split") as HTMLButtonElement).disabled).toBe(true);
+    byData(root, "action", "split").click();
+
+    const busy = freshModel();
+    setModel({
+      ...busy,
+      actions: busy.actions.map((action) =>
+        action.id === "split" ? { ...action, busy: true } : action,
+      ),
+    });
+    expect((byData(root, "action", "split") as HTMLButtonElement).disabled).toBe(true);
+    byData(root, "action", "split").click();
+
+    const globallyDisabled = freshModel();
+    setModel({
+      ...globallyDisabled,
+      appearance: {
+        ...globallyDisabled.appearance,
+        action: {
+          ...globallyDisabled.appearance.action,
+          disabled: true,
+          interactive: false,
+        },
+      },
+    });
+    expect((byData(root, "action", "split") as HTMLButtonElement).disabled).toBe(true);
+    byData(root, "action", "split").click();
+    expect(trace.trace).toEqual([]);
+  });
+
+  it("rejects duplicate pane, status, chip, and action identities deterministically", () => {
+    const pane = freshModel();
+    const status = freshModel();
+    const chips = freshModel();
+    const actions = freshModel();
+    const cases: readonly PaneFrameModel[] = [
+      {
+        ...pane,
+        actions: [{ ...pane.actions[0]!, id: pane.pane.id }, ...pane.actions.slice(1)],
+      },
+      {
+        ...status,
+        chips: [{ ...status.chips[0]!, id: status.status!.id }, ...status.chips.slice(1)],
+      },
+      {
+        ...chips,
+        chips: [chips.chips[0]!, { ...chips.chips[1]!, id: chips.chips[0]!.id }],
+      },
+      {
+        ...actions,
+        actions: [
+          actions.actions[0]!,
+          { ...actions.actions[1]!, id: actions.actions[0]!.id },
+          ...actions.actions.slice(2),
+        ],
+      },
+    ];
+
+    for (const model of cases) {
+      expect(() => renderPresenter(model)).toThrow(/semantic identity must be unique/u);
+    }
+  });
+});

--- a/packages/daemon/src/ui/pane-frame/presenter.tsx
+++ b/packages/daemon/src/ui/pane-frame/presenter.tsx
@@ -1,0 +1,317 @@
+import {
+  For,
+  createComputed,
+  createSignal,
+  onCleanup,
+  type Accessor,
+  type Component,
+  type JSX,
+  type ParentProps,
+} from "solid-js";
+import type {
+  CommandId,
+  PaneAppearance,
+  PaneRoleId,
+  SemanticIconId,
+  SemanticProductId,
+} from "@tmux-ide/contracts";
+
+export interface PaneFramePane {
+  readonly id: SemanticProductId;
+  readonly kind: PaneRoleId;
+}
+
+export interface PaneFrameStatus {
+  readonly id: SemanticProductId;
+  readonly label: string;
+  readonly description?: string;
+  readonly tone: PaneAppearance["status"]["tone"];
+  readonly busy: boolean;
+}
+
+export type PaneFrameChipKind = "agent" | "attention" | "context" | "mode" | "state";
+
+export interface PaneFrameChip {
+  readonly id: SemanticProductId;
+  readonly kind: PaneFrameChipKind;
+  readonly label: string;
+  readonly description?: string;
+  readonly tone: PaneAppearance["status"]["tone"] | null;
+}
+
+export interface PaneFrameAction {
+  readonly id: SemanticProductId;
+  readonly commandId: CommandId;
+  readonly icon: SemanticIconId;
+  readonly label: string;
+  readonly description?: string;
+  readonly available: boolean;
+  readonly disabledReason: string | null;
+  readonly pressed: boolean;
+  readonly busy: boolean;
+}
+
+export interface PaneFrameModel {
+  readonly pane: PaneFramePane;
+  readonly appearance: PaneAppearance;
+  readonly title: string;
+  readonly subtitle: string | null;
+  readonly status: PaneFrameStatus | null;
+  readonly chips: readonly PaneFrameChip[];
+  readonly actions: readonly PaneFrameAction[];
+}
+
+export type PaneFrameStatusItem =
+  | {
+      readonly kind: "status";
+      readonly id: SemanticProductId;
+      readonly status: PaneFrameStatus;
+    }
+  | {
+      readonly kind: "chip";
+      readonly id: SemanticProductId;
+      readonly chip: PaneFrameChip;
+    };
+
+export interface PaneFrameActionIntent {
+  readonly kind: "action";
+  readonly paneId: SemanticProductId;
+  readonly actionId: SemanticProductId;
+  readonly commandId: CommandId;
+}
+
+export interface PaneFrameGripIntent {
+  readonly kind: "grip";
+  readonly paneId: SemanticProductId;
+}
+
+export interface PaneFrameLeafContext {
+  readonly pane: PaneFramePane;
+  readonly appearance: PaneAppearance;
+}
+
+export type PaneFrameRootLeafProps = ParentProps<PaneFrameLeafContext>;
+export type PaneFrameHeaderLeafProps = ParentProps<PaneFrameLeafContext>;
+
+export interface PaneFrameGripLeafProps extends PaneFrameLeafContext {
+  readonly onActivate?: () => void;
+}
+
+export interface PaneFrameTitleLeafProps extends PaneFrameLeafContext {
+  readonly title: string;
+  readonly subtitle: string | null;
+}
+
+export interface PaneFrameStatusLeafProps extends PaneFrameLeafContext {
+  readonly item: PaneFrameStatusItem;
+}
+
+export type PaneFrameActionListLeafProps = ParentProps<
+  PaneFrameLeafContext & {
+    readonly actions: readonly PaneFrameAction[];
+  }
+>;
+
+export interface PaneFrameActionLeafProps extends PaneFrameLeafContext {
+  readonly action: PaneFrameAction;
+  readonly interactive: boolean;
+  readonly onActivate?: () => void;
+}
+
+export type PaneFrameBodyLeafProps = ParentProps<PaneFrameLeafContext>;
+
+/** Every rendered primitive is supplied by the owning host. */
+export interface PaneFrameHostLeaves {
+  readonly Root: Component<PaneFrameRootLeafProps>;
+  readonly Header: Component<PaneFrameHeaderLeafProps>;
+  readonly Grip: Component<PaneFrameGripLeafProps>;
+  readonly Title: Component<PaneFrameTitleLeafProps>;
+  readonly Status: Component<PaneFrameStatusLeafProps>;
+  readonly ActionList: Component<PaneFrameActionListLeafProps>;
+  readonly Action: Component<PaneFrameActionLeafProps>;
+  readonly Body: Component<PaneFrameBodyLeafProps>;
+}
+
+export interface PaneFramePresenterProps {
+  readonly model: PaneFrameModel;
+  readonly host: PaneFrameHostLeaves;
+  readonly body?: JSX.Element;
+  readonly onActionActivate?: (intent: PaneFrameActionIntent) => void;
+  readonly onGripActivate?: (intent: PaneFrameGripIntent) => void;
+}
+
+interface KeyedRecord<T> {
+  readonly key: string;
+  readonly value: Accessor<T>;
+  readonly update: (next: T) => void;
+}
+
+function createKeyedRecords<T>(
+  source: Accessor<readonly T[]>,
+  keyOf: (item: T) => string,
+): Accessor<readonly KeyedRecord<T>[]> {
+  const [records, setRecords] = createSignal<readonly KeyedRecord<T>[]>([]);
+  let available = new Map<string, KeyedRecord<T>>();
+
+  createComputed(() => {
+    const seen = new Set<string>();
+    const ordered: KeyedRecord<T>[] = [];
+
+    for (const item of source()) {
+      const key = keyOf(item);
+      if (seen.has(key)) throw new Error(`PaneFrame semantic identity must be unique: ${key}`);
+      seen.add(key);
+
+      const current = available.get(key);
+      if (current) {
+        current.update(item);
+        ordered.push(current);
+        continue;
+      }
+
+      const [value, setValue] = createSignal(item, { equals: false });
+      ordered.push({
+        key,
+        value,
+        update: (next) => setValue(() => next),
+      });
+    }
+
+    available = new Map(ordered.map((record) => [record.key, record]));
+    setRecords(ordered);
+  });
+  onCleanup(() => available.clear());
+  return records;
+}
+
+function statusItems(model: PaneFrameModel): readonly PaneFrameStatusItem[] {
+  const items: PaneFrameStatusItem[] = [];
+  if (model.status) {
+    items.push({ kind: "status", id: model.status.id, status: model.status });
+  }
+  for (const chip of model.chips) items.push({ kind: "chip", id: chip.id, chip });
+  return items;
+}
+
+function assertUniqueSemanticIdentities(model: PaneFrameModel): void {
+  const identities: Array<readonly [string, SemanticProductId]> = [["pane", model.pane.id]];
+  if (model.status) identities.push(["status", model.status.id]);
+  for (const chip of model.chips) identities.push(["chip", chip.id]);
+  for (const action of model.actions) identities.push(["action", action.id]);
+
+  const owners = new Map<SemanticProductId, string>();
+  for (const [owner, id] of identities) {
+    const previous = owners.get(id);
+    if (previous) {
+      throw new Error(
+        `PaneFrame semantic identity must be unique: ${id} is used by ${previous} and ${owner}`,
+      );
+    }
+    owners.set(id, owner);
+  }
+}
+
+/** Shared Solid control flow for a semantic pane frame. */
+export function PaneFramePresenter(props: PaneFramePresenterProps) {
+  const Root = props.host.Root;
+  const Header = props.host.Header;
+  const Grip = props.host.Grip;
+  const Title = props.host.Title;
+  const Status = props.host.Status;
+  const ActionList = props.host.ActionList;
+  const Action = props.host.Action;
+  const Body = props.host.Body;
+  const frames = createKeyedRecords(
+    () => {
+      assertUniqueSemanticIdentities(props.model);
+      return [props.model];
+    },
+    (model) => model.pane.id,
+  );
+
+  return (
+    <For each={frames()}>
+      {(frame) => {
+        const model = frame.value;
+        const statuses = createKeyedRecords(
+          () => statusItems(model()),
+          (item) => `${item.kind}:${item.id}`,
+        );
+        const actions = createKeyedRecords(
+          () => model().actions,
+          (action) => action.id,
+        );
+        const currentActions = () => actions().map((action) => action.value());
+
+        return (
+          <Root pane={model().pane} appearance={model().appearance}>
+            <Header pane={model().pane} appearance={model().appearance}>
+              <Grip
+                pane={model().pane}
+                appearance={model().appearance}
+                onActivate={
+                  props.onGripActivate
+                    ? () => props.onGripActivate?.({ kind: "grip", paneId: model().pane.id })
+                    : undefined
+                }
+              />
+              <Title
+                pane={model().pane}
+                appearance={model().appearance}
+                title={model().title}
+                subtitle={model().subtitle}
+              />
+              <For each={statuses()}>
+                {(status) => (
+                  <Status
+                    pane={model().pane}
+                    appearance={model().appearance}
+                    item={status.value()}
+                  />
+                )}
+              </For>
+              <ActionList
+                pane={model().pane}
+                appearance={model().appearance}
+                actions={currentActions()}
+              >
+                <For each={actions()}>
+                  {(entry) => {
+                    const interactive = () =>
+                      entry.value().available &&
+                      !entry.value().busy &&
+                      model().appearance.action.interactive;
+                    return (
+                      <Action
+                        pane={model().pane}
+                        appearance={model().appearance}
+                        action={entry.value()}
+                        interactive={interactive()}
+                        onActivate={
+                          interactive() && props.onActionActivate
+                            ? () => {
+                                const action = entry.value();
+                                props.onActionActivate?.({
+                                  kind: "action",
+                                  paneId: model().pane.id,
+                                  actionId: action.id,
+                                  commandId: action.commandId,
+                                });
+                              }
+                            : undefined
+                        }
+                      />
+                    );
+                  }}
+                </For>
+              </ActionList>
+            </Header>
+            <Body pane={model().pane} appearance={model().appearance}>
+              {props.body}
+            </Body>
+          </Root>
+        );
+      }}
+    </For>
+  );
+}

--- a/packages/daemon/tsconfig.workbench-dock-opentui.json
+++ b/packages/daemon/tsconfig.workbench-dock-opentui.json
@@ -7,6 +7,7 @@
   },
   "files": [
     "src/js-yaml.d.ts",
+    "src/ui/pane-frame/presenter.tsx",
     "src/ui/workbench-dock/presenter.tsx",
     "src/tui/mirror/workspace/workbench-dock-opentui.tsx",
     "src/tui/mirror/workspace/workbench-shell.tsx"

--- a/packages/daemon/tsconfig.workbench-dock-web.json
+++ b/packages/daemon/tsconfig.workbench-dock-web.json
@@ -4,6 +4,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "rewriteRelativeImportExtensions": true,
     "noEmit": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,
@@ -13,6 +14,7 @@
     "types": []
   },
   "include": [
+    "src/ui/pane-frame/presenter.tsx",
     "src/ui/workbench-dock/presenter.tsx",
     "src/ui/workbench-dock/navigation.ts",
     "src/ui/workbench-dock/web-host.tsx",

--- a/packages/daemon/tsconfig.workbench-dock-web.types.json
+++ b/packages/daemon/tsconfig.workbench-dock-web.types.json
@@ -6,5 +6,11 @@
     "emitDeclarationOnly": true,
     "rootDir": "src/ui/workbench-dock",
     "declarationDir": "dist/ui/workbench-dock"
-  }
+  },
+  "include": [
+    "src/ui/workbench-dock/presenter.tsx",
+    "src/ui/workbench-dock/navigation.ts",
+    "src/ui/workbench-dock/web-host.tsx",
+    "src/ui/workbench-dock/web-entry.tsx"
+  ]
 }

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -33,6 +33,8 @@ export default defineConfig({
       "src/tui/chrome/*.test.ts",
       "src/tui/integrations/*.test.ts",
       "src/widgets/lib/grammar.test.ts",
+      "src/ui/pane-frame/**/*.test.ts",
+      "src/ui/pane-frame/**/*.test.tsx",
       "src/ui/workbench-dock/**/*.test.ts",
       "src/ui/workbench-dock/**/*.test.tsx",
     ],


### PR DESCRIPTION
## Summary
- add a renderer-neutral Solid PaneFrame presenter with eight injected host leaves
- model pane appearance, title, status, chips, actions, body, and semantic grip/action intents without geometry or runtime IDs
- preserve DOM/OpenTUI leaf identity across fresh projections using semantic keyed reconciliation
- add a shared cohesion fixture/trace and transitive import-DAG enforcement

## Review repairs
- replaced signal creation/writes inside memo evaluation with a Solid-safe computed reconciliation list
- added removal/re-add identity coverage and deterministic duplicate-ID failures across pane/status/chips/actions
- explicitly cover unavailable, busy, and globally disabled action semantics
- keep ActionList synchronized with reconciled action records

## Verification
- full `pnpm check` passed on the implementation branch
- post-rebase focused PaneFrame tests: 8/8
- post-rebase daemon and both DOM/OpenTUI Solid typechecks passed
- daemon suite: 137 files / 2231 tests
- OpenTUI renderer: 89 tests / 62 snapshots
- docs, package install, and native dependency gates passed
- `git diff --check` passed