### PR TITLE
feat(desktop): add canonical Solid application shell

### DIFF
--- a/apps/desktop-renderer/src/App.test.tsx
+++ b/apps/desktop-renderer/src/App.test.tsx
@@ -96,6 +96,9 @@ describe("desktop App host lifecycle", () => {
     expect(app.dataset.theme).toBe("light");
     expect(app.style.getPropertyValue("--tmux-ide-surface-canvas")).toBe("rgb(245 245 247)");
     expect(app.dataset.increasedContrast).toBe("false");
+    expect(app.dataset.shellSource).toBe("preview");
+    expect(root.querySelector(".titlebar__preview-badge")?.textContent).toBe("Preview data");
+    expect(root.querySelector(".status-strip")?.getAttribute("data-shell-source")).toBe("preview");
     expect(root.querySelector(".window-controls")).toBeNull();
 
     pendingBootstrap.resolve({

--- a/apps/desktop-renderer/src/App.tsx
+++ b/apps/desktop-renderer/src/App.tsx
@@ -1,5 +1,11 @@
-import { Show, createMemo, createResource, createSignal, onCleanup, onMount } from "solid-js";
-import type { DesktopThemeState, DesktopWindowState, HostCapabilities } from "@tmux-ide/contracts";
+import { createMemo, createResource, createSignal, onCleanup, onMount } from "solid-js";
+import type {
+  ApplicationShellCommandInvocation,
+  ApplicationShellProjectionInputV1,
+  DesktopThemeState,
+  DesktopWindowState,
+  HostCapabilities,
+} from "@tmux-ide/contracts";
 
 import {
   parseThemeState,
@@ -8,18 +14,13 @@ import {
   readInitialThemeState,
   resolveHostCapabilities,
 } from "./host-capabilities.ts";
-import { createDomExperience } from "./experience/index.ts";
-
-function daemonLabel(status: string): string {
-  if (status === "ready") return "Daemon ready";
-  if (status === "absent") return "Daemon absent";
-  if (status === "unavailable") return "Daemon unavailable";
-  return "Daemon integration deferred";
-}
+import { DomApplicationShell, createDomExperience } from "./experience/index.ts";
 
 export interface AppProps {
   readonly host?: HostCapabilities;
   readonly initialTheme?: DesktopThemeState;
+  readonly shellInput?: ApplicationShellProjectionInputV1;
+  readonly onCommand?: (invocation: ApplicationShellCommandInvocation) => void;
 }
 
 export function App(props: AppProps = {}) {
@@ -43,131 +44,23 @@ export function App(props: AppProps = {}) {
   const experience = createMemo(() => createDomExperience({ hostTheme: effectiveTheme() }));
 
   return (
-    <main
+    <div
       class="app"
       data-theme={experience().appearance}
+      data-platform={bootstrap()?.platform}
       data-reduced-motion={String(experience().accessibility.reducedMotion)}
       data-increased-contrast={String(experience().accessibility.increasedContrast)}
       data-accessibility-conflicts={experience().accessibility.conflicts.join(" ") || undefined}
       style={experience().variables}
     >
-      <header class="titlebar">
-        <div class="titlebar__drag">
-          <span class="brand-mark" aria-hidden="true">
-            ▦
-          </span>
-          <strong>tmux-ide</strong>
-          <span class="titlebar__context">desktop foundation</span>
-        </div>
-        <Show when={bootstrap()?.runtime === "electron" && bootstrap()?.platform !== "darwin"}>
-          <nav class="window-controls" aria-label="Window controls">
-            <button type="button" aria-label="Minimize" onClick={() => void host.window.minimize()}>
-              −
-            </button>
-            <button
-              type="button"
-              aria-label={effectiveWindow()?.maximized ? "Restore" : "Maximize"}
-              onClick={() => void host.window.toggleMaximized()}
-            >
-              {effectiveWindow()?.maximized ? "❐" : "□"}
-            </button>
-            <button type="button" aria-label="Close" onClick={() => void host.window.close()}>
-              ×
-            </button>
-          </nav>
-        </Show>
-      </header>
-
-      <section class="workbench">
-        <aside class="rail" aria-label="Workspace navigation">
-          <button class="rail__item rail__item--active" type="button">
-            <span>⌂</span>Home
-          </button>
-          <button class="rail__item" type="button">
-            <span>▣</span>Sessions
-          </button>
-          <button class="rail__item" type="button">
-            <span>◇</span>Missions
-          </button>
-          <button class="rail__item" type="button">
-            <span>⌘</span>Commands
-          </button>
-        </aside>
-
-        <section class="canvas" aria-labelledby="welcome-title">
-          <div class="canvas__eyebrow">Host-neutral Solid workspace</div>
-          <h1 id="welcome-title">Your tmux sessions, ready for a real desktop.</h1>
-          <p class="canvas__lead">
-            This renderer is ordinary browser code. Electron owns only native lifecycle and window
-            capabilities; terminals and missions will arrive through shared daemon contracts.
-          </p>
-
-          <div class="cards">
-            <article class="card">
-              <div class="card__icon">01</div>
-              <h2>Open a project</h2>
-              <p>
-                Project onboarding will discover or create the workspace without hand-authored IDE
-                files.
-              </p>
-              <button
-                class="primary-action"
-                type="button"
-                onClick={() => void host.dialog.selectProjectDirectory()}
-              >
-                Choose folder
-              </button>
-            </article>
-            <article class="card card--terminal">
-              <div class="terminal-dots" aria-hidden="true">
-                <i />
-                <i />
-                <i />
-              </div>
-              <pre aria-label="Terminal placeholder">
-                <code>
-                  <span>$</span> tmux-ide --headless{"\n"}
-                  <b>future daemon preflight only</b>
-                </code>
-              </pre>
-            </article>
-          </div>
-        </section>
-
-        <aside class="inspector" aria-label="Desktop host status">
-          <h2>Foundation</h2>
-          <dl>
-            <div>
-              <dt>Runtime</dt>
-              <dd>{bootstrap()?.runtime ?? "loading"}</dd>
-            </div>
-            <div>
-              <dt>Platform</dt>
-              <dd>{bootstrap()?.platform ?? "—"}</dd>
-            </div>
-            <div>
-              <dt>Theme</dt>
-              <dd>{effectiveTheme()?.mode ?? "—"}</dd>
-            </div>
-            <div>
-              <dt>Daemon</dt>
-              <dd>{daemonLabel(bootstrap()?.daemon.status ?? "deferred")}</dd>
-            </div>
-          </dl>
-          <div class="boundary-note">
-            <span>Boundary</span>
-            No Node.js or Electron APIs are present in this renderer.
-          </div>
-        </aside>
-      </section>
-
-      <footer class="statusbar">
-        <span>
-          <i class="status-dot" />{" "}
-          {bootstrap.loading ? "Connecting to host" : "Desktop shell ready"}
-        </span>
-        <span>⌘K command palette · coming next</span>
-      </footer>
-    </main>
+      <DomApplicationShell
+        host={host}
+        runtime={bootstrap()?.runtime}
+        platform={bootstrap()?.platform}
+        windowState={effectiveWindow()}
+        input={props.shellInput}
+        onCommand={props.onCommand}
+      />
+    </div>
   );
 }

--- a/apps/desktop-renderer/src/App.tsx
+++ b/apps/desktop-renderer/src/App.tsx
@@ -51,6 +51,7 @@ export function App(props: AppProps = {}) {
       data-reduced-motion={String(experience().accessibility.reducedMotion)}
       data-increased-contrast={String(experience().accessibility.increasedContrast)}
       data-accessibility-conflicts={experience().accessibility.conflicts.join(" ") || undefined}
+      data-shell-source={props.shellInput === undefined ? "preview" : "runtime"}
       style={experience().variables}
     >
       <DomApplicationShell
@@ -59,6 +60,7 @@ export function App(props: AppProps = {}) {
         platform={bootstrap()?.platform}
         windowState={effectiveWindow()}
         input={props.shellInput}
+        dataMode={props.shellInput === undefined ? "preview" : "runtime"}
         onCommand={props.onCommand}
       />
     </div>

--- a/apps/desktop-renderer/src/experience/application-shell.test.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.test.tsx
@@ -150,6 +150,7 @@ function updatedSameWorkspace(
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const dispose of disposers.splice(0)) dispose();
   document.body.replaceChildren();
 });

--- a/apps/desktop-renderer/src/experience/application-shell.test.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.test.tsx
@@ -233,6 +233,23 @@ describe("visible DOM application shell", () => {
     expect(root.querySelector(".palette-trigger kbd")?.textContent).toBe("Ctrl K");
   });
 
+  it("keeps compact session identity and connection state accessible at 720px", () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(720);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(480);
+    const root = renderShell();
+
+    expect(root.querySelector(".workbench-dock")?.getAttribute("data-variant")).toBe("compact");
+    expect(
+      root.querySelector("#sidebar-session-session\\.product")?.getAttribute("aria-label"),
+    ).toBe("Product, reconnecting, selected");
+    expect(root.querySelector("#sidebar-session-session\\.docs")?.getAttribute("aria-label")).toBe(
+      "Documentation, connected",
+    );
+    expect(styles).toMatch(
+      /@media \(max-width: 999px\)[\s\S]*?\.sidebar-row span,[\s\S]*?display: none;/u,
+    );
+  });
+
   it("applies state tones to explicit indicators without recoloring their parent surfaces", () => {
     const root = renderShell();
     const experience = installApplicationStyles(root);
@@ -240,6 +257,8 @@ describe("visible DOM application shell", () => {
     const connectionIndicator = connection.querySelector<HTMLElement>("i")!;
     const runningPane = root.querySelector<HTMLElement>('.agent-pane[data-state="running"]')!;
     const runningIndicator = runningPane.querySelector<HTMLElement>("header i")!;
+    const recoveryPane = root.querySelector<HTMLElement>('.agent-pane[data-state="recovery"]')!;
+    const recoveryIndicator = recoveryPane.querySelector<HTMLElement>("header i")!;
 
     expect(getComputedStyle(connectionIndicator).backgroundColor).toBe(
       experience.variables[DOM_EXPERIENCE_VARIABLE.status.warning],
@@ -252,6 +271,18 @@ describe("visible DOM application shell", () => {
     );
     expect(getComputedStyle(runningPane).backgroundColor).toBe(
       experience.variables[DOM_EXPERIENCE_VARIABLE.surface.terminal],
+    );
+    expect(getComputedStyle(runningPane).borderColor).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.border.default],
+    );
+    expect(getComputedStyle(recoveryIndicator).backgroundColor).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.status.warning],
+    );
+    expect(getComputedStyle(recoveryPane).backgroundColor).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.surface.terminal],
+    );
+    expect(getComputedStyle(recoveryPane).borderColor).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.border.default],
     );
   });
 
@@ -343,6 +374,41 @@ describe("visible DOM application shell", () => {
       args: { mode: "home" },
       source: { kind: "keyboard", surface: "application-shell" },
     });
+  });
+
+  it("preserves keyboard and real-pointer provenance from the palette trigger", () => {
+    const invocations: ApplicationShellCommandInvocation[] = [];
+    const root = renderShell(createDefaultDomShellInput(), (invocation) =>
+      invocations.push(invocation),
+    );
+    const trigger = root.querySelector<HTMLButtonElement>("#application-command-palette-trigger")!;
+
+    trigger.click();
+    expect(invocations.slice(0, 2).map(({ id, source }) => ({ id, source }))).toEqual([
+      {
+        id: APPLICATION_SHELL_COMMAND_IDS.moveFocus,
+        source: { kind: "keyboard", surface: "application-bar" },
+      },
+      {
+        id: APPLICATION_SHELL_COMMAND_IDS.openPalette,
+        source: { kind: "keyboard", surface: "application-bar" },
+      },
+    ]);
+
+    root
+      .querySelector<HTMLInputElement>('[role="combobox"]')!
+      .dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    pointerClick(trigger);
+    expect(invocations.slice(-2).map(({ id, source }) => ({ id, source }))).toEqual([
+      {
+        id: APPLICATION_SHELL_COMMAND_IDS.moveFocus,
+        source: { kind: "mouse", surface: "application-bar" },
+      },
+      {
+        id: APPLICATION_SHELL_COMMAND_IDS.openPalette,
+        source: { kind: "mouse", surface: "application-bar" },
+      },
+    ]);
   });
 
   it("marks fallback data as preview-only and never claims fixture recovery is live", () => {

--- a/apps/desktop-renderer/src/experience/application-shell.test.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.test.tsx
@@ -1,0 +1,257 @@
+/* @vitest-environment happy-dom */
+import {
+  APPLICATION_SHELL_COMMAND_IDS,
+  ApplicationShellProjectionInputV1SchemaZ,
+  DESKTOP_HOST_API_VERSION,
+  applicationShellActionTraceV1,
+  type ApplicationShellCommandInvocation,
+  type ApplicationShellProjectionInputV1,
+  type DesktopWindowState,
+  type HostCapabilities,
+} from "@tmux-ide/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "solid-js/web";
+
+import { DomApplicationShell, PrimaryNavigation } from "./application-shell.tsx";
+import {
+  createDefaultDomShellInput,
+  createDomShellReplayState,
+  projectDomApplicationShell,
+} from "./dom-shell.ts";
+import styles from "../styles.css?raw";
+
+const disposers: Array<() => void> = [];
+
+const WINDOW_STATE: DesktopWindowState = {
+  maximized: false,
+  fullscreen: false,
+  focused: true,
+};
+
+function host(): HostCapabilities {
+  return {
+    apiVersion: DESKTOP_HOST_API_VERSION,
+    bootstrap: async () => ({
+      apiVersion: DESKTOP_HOST_API_VERSION,
+      runtime: "browser",
+      platform: "darwin",
+      appVersion: "test",
+      theme: { mode: "dark", highContrast: false, reducedMotion: false },
+      window: WINDOW_STATE,
+      daemon: { status: "deferred", reason: "fixture only" },
+    }),
+    lifecycle: { requestQuit: async () => undefined },
+    window: {
+      getState: async () => WINDOW_STATE,
+      minimize: async () => WINDOW_STATE,
+      toggleMaximized: async () => WINDOW_STATE,
+      close: async () => undefined,
+      onStateChanged: () => () => undefined,
+    },
+    menu: { showApplicationMenu: async () => ({ status: "unavailable" }) },
+    dialog: { selectProjectDirectory: async () => null },
+    theme: {
+      getState: async () => ({ mode: "dark", highContrast: false, reducedMotion: false }),
+      onChanged: () => () => undefined,
+    },
+  };
+}
+
+function withDisabledActivity(): ApplicationShellProjectionInputV1 {
+  const input = createDefaultDomShellInput();
+  return ApplicationShellProjectionInputV1SchemaZ.parse({
+    ...input,
+    dock: {
+      ...input.dock,
+      tools: input.dock.tools.map((tool) =>
+        tool.id === "activity"
+          ? { ...tool, disabledReason: "Activity requires a daemon connection" }
+          : tool,
+      ),
+    },
+  });
+}
+
+function renderShell(
+  input: ApplicationShellProjectionInputV1 = createDefaultDomShellInput(),
+  onCommand?: (invocation: ApplicationShellCommandInvocation) => void,
+  platform = "darwin",
+) {
+  const root = document.createElement("div");
+  document.body.append(root);
+  disposers.push(
+    render(
+      () => (
+        <DomApplicationShell
+          host={host()}
+          runtime="browser"
+          platform={platform}
+          windowState={WINDOW_STATE}
+          input={input}
+          onCommand={onCommand}
+        />
+      ),
+      root,
+    ),
+  );
+  return root;
+}
+
+function pointerClick(element: Element): void {
+  element.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+}
+
+afterEach(() => {
+  for (const dispose of disposers.splice(0)) dispose();
+  document.body.replaceChildren();
+});
+
+describe("visible DOM application shell", () => {
+  it("renders honest landmarks, canonical tabs, disabled reasons, and platform shortcuts", async () => {
+    const root = renderShell(withDisabledActivity());
+
+    expect(root.querySelector("header.titlebar")).not.toBeNull();
+    expect(root.querySelector('nav[aria-label="Workspace modes"]')).not.toBeNull();
+    expect(root.querySelector('aside[aria-label="Workspace overview"]')).not.toBeNull();
+    expect(root.querySelector("main.workspace-main")).not.toBeNull();
+    expect(root.querySelector('footer[role="status"]')).not.toBeNull();
+    expect(root.querySelectorAll('.primary-tabs [role="tab"]')).toHaveLength(2);
+    expect(root.querySelectorAll('.workbench-dock [role="tab"]')).toHaveLength(4);
+    expect(root.querySelectorAll('[role="tabpanel"]')).toHaveLength(6);
+    expect(root.textContent).toContain("Sessions");
+    expect(root.textContent).toContain("Agents");
+    expect(root.textContent).toContain("preview snapshot");
+    expect(root.textContent).not.toMatch(/\blive\b/u);
+    expect(root.querySelector(".status-strip button")).toBeNull();
+    expect(root.querySelector(".status-strip__guidance")?.textContent).toContain("Retry");
+    expect(root.querySelector(".status-strip__connection")?.getAttribute("title")).toContain(
+      "reconnecting",
+    );
+    expect(root.querySelector(".status-strip__guidance")?.getAttribute("title")).toContain("Retry");
+    expect(root.querySelector(".palette-trigger kbd")?.textContent).toBe("⌘K");
+    for (const tab of root.querySelectorAll<HTMLButtonElement>('.primary-tabs [role="tab"]')) {
+      expect(tab.getAttribute("aria-disabled")).toBe("false");
+    }
+
+    const disabledDockTab = root.querySelector<HTMLButtonElement>("#workbench-dock-tab-activity")!;
+    expect(disabledDockTab.disabled).toBe(true);
+    expect(disabledDockTab.getAttribute("aria-label")).toContain(
+      "Activity requires a daemon connection",
+    );
+    expect(disabledDockTab.title).toContain("Activity requires a daemon connection");
+
+    const returnTarget = root.querySelector<HTMLButtonElement>("#primary-tab-terminals")!;
+    returnTarget.focus();
+    expect(document.activeElement).toBe(returnTarget);
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }),
+    );
+    const input = root.querySelector<HTMLInputElement>('[role="combobox"]')!;
+    await vi.waitFor(() => expect(document.activeElement).toBe(input));
+    expect(input.getAttribute("aria-controls")).toBe("application-command-palette-list");
+    expect(root.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(root.querySelector('[role="listbox"]')).not.toBeNull();
+    const disabledOption = root.querySelector<HTMLElement>("#palette-option-activity")!;
+    expect(disabledOption.getAttribute("aria-disabled")).toBe("true");
+    expect(disabledOption.textContent).toContain("Activity requires a daemon connection");
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    expect(input.getAttribute("aria-activedescendant")).toBe("palette-option-missions");
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await vi.waitFor(() => expect(document.activeElement).toBe(returnTarget));
+
+    expect(styles).toContain("grid-template-rows: 28px minmax(0, 1fr) 18px");
+    expect(styles).toContain("grid-template-columns: 48px minmax(0, 1fr)");
+    expect(styles).toContain("width: 456px");
+    expect(styles).toMatch(
+      /@media \(max-width: 999px\)[\s\S]*?\.status-strip__safe \{\s*display: none;[\s\S]*?\.status-strip__guidance \{[\s\S]*?max-width: 184px;[\s\S]*?text-overflow: ellipsis;/u,
+    );
+    expect(styles).not.toMatch(
+      /\.command-palette(?:-overlay)?(?:--open)?\s*\{[^}]*(?:transition|transform)\s*:/gu,
+    );
+  });
+
+  it("uses Ctrl K outside Darwin", () => {
+    const root = renderShell(createDefaultDomShellInput(), undefined, "linux");
+    expect(root.querySelector(".palette-trigger kbd")?.textContent).toBe("Ctrl K");
+  });
+
+  it("makes an unavailable primary surface both explanatory and inert", () => {
+    const input = createDefaultDomShellInput();
+    const shell = projectDomApplicationShell(input, createDomShellReplayState(input));
+    const activate = vi.fn();
+    const root = document.createElement("div");
+    document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <PrimaryNavigation
+            items={shell.primaryNavigation.items.map((item) =>
+              item.id === "home"
+                ? { ...item, disabledReason: "Home is unavailable during recovery" }
+                : item,
+            )}
+            onActivate={activate}
+          />
+        ),
+        root,
+      ),
+    );
+
+    const home = root.querySelector<HTMLButtonElement>("#primary-tab-home")!;
+    expect(home.disabled).toBe(true);
+    expect(home.getAttribute("aria-disabled")).toBe("true");
+    expect(home.tabIndex).toBe(-1);
+    expect(root.querySelector<HTMLButtonElement>("#primary-tab-terminals")?.tabIndex).toBe(0);
+    expect(home.title).toBe("Home is unavailable during recovery");
+    pointerClick(home);
+    expect(activate).not.toHaveBeenCalled();
+  });
+
+  it("emits the canonical pointer and palette keyboard command trace", async () => {
+    const input = createDefaultDomShellInput();
+    const invocations: ApplicationShellCommandInvocation[] = [];
+    const root = renderShell(input, (invocation) => invocations.push(invocation));
+
+    for (const surface of ["home", "terminals"]) {
+      pointerClick(root.querySelector(`#primary-tab-${surface}`)!);
+    }
+    for (const surface of ["files", "changes", "missions", "activity"]) {
+      pointerClick(root.querySelector(`#workbench-dock-tab-${surface}`)!);
+    }
+    pointerClick(root.querySelector('[data-action="toggle-collapse"]')!);
+    pointerClick(root.querySelector('[data-action="toggle-collapse"]')!);
+    pointerClick(root.querySelector('[data-action="toggle-maximize"]')!);
+
+    const returnTarget = root.querySelector<HTMLButtonElement>("#workbench-dock-tab-activity")!;
+    returnTarget.focus();
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }),
+    );
+    const paletteInput = root.querySelector<HTMLInputElement>('[role="combobox"]')!;
+    await vi.waitFor(() => expect(document.activeElement).toBe(paletteInput));
+    paletteInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    const expected = applicationShellActionTraceV1(input).invocations;
+    expect(invocations.map(({ id, args }) => ({ id, args }))).toEqual(
+      expected.map(({ id, args }) => ({ id, args })),
+    );
+    expect(invocations[0]?.source.kind).toBe("mouse");
+    expect(invocations.at(-2)?.id).toBe(APPLICATION_SHELL_COMMAND_IDS.openPalette);
+    expect(invocations.at(-2)?.source.kind).toBe("keyboard");
+    expect(invocations.at(-1)?.id).toBe(APPLICATION_SHELL_COMMAND_IDS.closePalette);
+  });
+
+  it("routes function-key activation through the same canonical command", () => {
+    const invocations: ApplicationShellCommandInvocation[] = [];
+    renderShell(createDefaultDomShellInput(), (invocation) => invocations.push(invocation));
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "F1", bubbles: true }));
+
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]).toMatchObject({
+      id: APPLICATION_SHELL_COMMAND_IDS.activateMode,
+      args: { mode: "home" },
+      source: { kind: "keyboard", surface: "application-shell" },
+    });
+  });
+});

--- a/apps/desktop-renderer/src/experience/application-shell.test.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.test.tsx
@@ -10,9 +10,11 @@ import {
   type HostCapabilities,
 } from "@tmux-ide/contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSignal } from "solid-js";
 import { render } from "solid-js/web";
 
 import { DomApplicationShell, PrimaryNavigation } from "./application-shell.tsx";
+import { DOM_EXPERIENCE_VARIABLE, createDomExperience } from "./dom-experience.ts";
 import {
   createDefaultDomShellInput,
   createDomShellReplayState,
@@ -88,6 +90,7 @@ function renderShell(
           platform={platform}
           windowState={WINDOW_STATE}
           input={input}
+          dataMode="runtime"
           onCommand={onCommand}
         />
       ),
@@ -99,6 +102,51 @@ function renderShell(
 
 function pointerClick(element: Element): void {
   element.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+}
+
+function installApplicationStyles(root: HTMLElement) {
+  const experience = createDomExperience({ hostTheme: { mode: "dark" } });
+  for (const [name, value] of Object.entries(experience.variables)) {
+    root.style.setProperty(name, value);
+  }
+  const sheet = document.createElement("style");
+  sheet.textContent = styles;
+  document.head.append(sheet);
+  disposers.push(() => sheet.remove());
+  return experience;
+}
+
+function updatedSameWorkspace(
+  input: ApplicationShellProjectionInputV1,
+): ApplicationShellProjectionInputV1 {
+  return ApplicationShellProjectionInputV1SchemaZ.parse({
+    ...input,
+    project: { ...input.project, name: "tmux-ide reactive", rootLabel: "reactive/root" },
+    workspace: {
+      ...input.workspace,
+      name: "Reactive workspace",
+      sidebar: {
+        sessions: input.workspace.sidebar.sessions.map((session) =>
+          session.id === "session.docs" ? { ...session, label: "Fresh documentation" } : session,
+        ),
+        agents: input.workspace.sidebar.agents.map((agent) =>
+          agent.id === "agent.implementer" ? { ...agent, name: "Codex refreshed" } : agent,
+        ),
+      },
+    },
+    dock: {
+      ...input.dock,
+      tools: input.dock.tools.map((tool) =>
+        tool.data.kind === "files" ? { ...tool, data: { ...tool.data, fileCount: 999 } } : tool,
+      ),
+    },
+    connection: {
+      state: "connected",
+      message: "Connected from fresh host snapshot",
+      safeState: "Runtime workspace synchronized",
+      nextAction: "No action needed",
+    },
+  });
 }
 
 afterEach(() => {
@@ -120,7 +168,11 @@ describe("visible DOM application shell", () => {
     expect(root.querySelectorAll('[role="tabpanel"]')).toHaveLength(6);
     expect(root.textContent).toContain("Sessions");
     expect(root.textContent).toContain("Agents");
-    expect(root.textContent).toContain("preview snapshot");
+    expect(root.textContent).toContain("workspace snapshot");
+    expect(root.textContent).not.toContain("Preview data");
+    expect(root.querySelector(".shell-workbench")?.getAttribute("data-shell-source")).toBe(
+      "runtime",
+    );
     expect(root.textContent).not.toMatch(/\blive\b/u);
     expect(root.querySelector(".status-strip button")).toBeNull();
     expect(root.querySelector(".status-strip__guidance")?.textContent).toContain("Retry");
@@ -129,6 +181,9 @@ describe("visible DOM application shell", () => {
     );
     expect(root.querySelector(".status-strip__guidance")?.getAttribute("title")).toContain("Retry");
     expect(root.querySelector(".palette-trigger kbd")?.textContent).toBe("⌘K");
+    expect(root.querySelector("#sidebar-agent-agent\\.pm")?.getAttribute("aria-label")).toBe(
+      "Fable, waiting, needs attention",
+    );
     for (const tab of root.querySelectorAll<HTMLButtonElement>('.primary-tabs [role="tab"]')) {
       expect(tab.getAttribute("aria-disabled")).toBe("false");
     }
@@ -168,11 +223,36 @@ describe("visible DOM application shell", () => {
     expect(styles).not.toMatch(
       /\.command-palette(?:-overlay)?(?:--open)?\s*\{[^}]*(?:transition|transform)\s*:/gu,
     );
+    expect(styles).toContain('.status-strip__connection[data-state="recovering"] > i');
+    expect(styles).toContain('.agent-pane[data-state="running"] header i');
+    expect(styles).not.toMatch(/^\[data-state=/mu);
   });
 
   it("uses Ctrl K outside Darwin", () => {
     const root = renderShell(createDefaultDomShellInput(), undefined, "linux");
     expect(root.querySelector(".palette-trigger kbd")?.textContent).toBe("Ctrl K");
+  });
+
+  it("applies state tones to explicit indicators without recoloring their parent surfaces", () => {
+    const root = renderShell();
+    const experience = installApplicationStyles(root);
+    const connection = root.querySelector<HTMLElement>(".status-strip__connection")!;
+    const connectionIndicator = connection.querySelector<HTMLElement>("i")!;
+    const runningPane = root.querySelector<HTMLElement>('.agent-pane[data-state="running"]')!;
+    const runningIndicator = runningPane.querySelector<HTMLElement>("header i")!;
+
+    expect(getComputedStyle(connectionIndicator).backgroundColor).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.status.warning],
+    );
+    expect(getComputedStyle(connection).backgroundColor).not.toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.status.warning],
+    );
+    expect(getComputedStyle(runningIndicator).backgroundColor).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.status.info],
+    );
+    expect(getComputedStyle(runningPane).backgroundColor).toBe(
+      experience.variables[DOM_EXPERIENCE_VARIABLE.surface.terminal],
+    );
   });
 
   it("makes an unavailable primary surface both explanatory and inert", () => {
@@ -203,6 +283,7 @@ describe("visible DOM application shell", () => {
     expect(home.tabIndex).toBe(-1);
     expect(root.querySelector<HTMLButtonElement>("#primary-tab-terminals")?.tabIndex).toBe(0);
     expect(home.title).toBe("Home is unavailable during recovery");
+    expect(home.getAttribute("aria-label")).toContain("Home is unavailable during recovery");
     pointerClick(home);
     expect(activate).not.toHaveBeenCalled();
   });
@@ -231,11 +312,20 @@ describe("visible DOM application shell", () => {
     await vi.waitFor(() => expect(document.activeElement).toBe(paletteInput));
     paletteInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
 
-    const expected = applicationShellActionTraceV1(input).invocations;
-    expect(invocations.map(({ id, args }) => ({ id, args }))).toEqual(
-      expected.map(({ id, args }) => ({ id, args })),
+    const expected = applicationShellActionTraceV1(input).invocations.map(
+      (invocation, index): ApplicationShellCommandInvocation => ({
+        ...invocation,
+        source:
+          index < 2
+            ? { kind: "mouse", surface: "primary-navigation" }
+            : index < 17
+              ? { kind: "mouse", surface: "bottom-dock" }
+              : index < 19
+                ? { kind: "keyboard", surface: "application-shell" }
+                : { kind: "keyboard", surface: "command-palette" },
+      }),
     );
-    expect(invocations[0]?.source.kind).toBe("mouse");
+    expect(invocations).toEqual(expected);
     expect(invocations.at(-2)?.id).toBe(APPLICATION_SHELL_COMMAND_IDS.openPalette);
     expect(invocations.at(-2)?.source.kind).toBe("keyboard");
     expect(invocations.at(-1)?.id).toBe(APPLICATION_SHELL_COMMAND_IDS.closePalette);
@@ -253,5 +343,116 @@ describe("visible DOM application shell", () => {
       args: { mode: "home" },
       source: { kind: "keyboard", surface: "application-shell" },
     });
+  });
+
+  it("marks fallback data as preview-only and never claims fixture recovery is live", () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <DomApplicationShell
+            host={host()}
+            runtime="browser"
+            platform="darwin"
+            windowState={WINDOW_STATE}
+            dataMode="preview"
+          />
+        ),
+        root,
+      ),
+    );
+
+    expect(root.querySelector(".titlebar__preview-badge")?.textContent).toBe("Preview data");
+    expect(root.querySelector(".shell-workbench")?.getAttribute("data-shell-source")).toBe(
+      "preview",
+    );
+    expect(root.querySelector(".status-strip")?.getAttribute("data-shell-source")).toBe("preview");
+    expect(root.querySelector(".status-strip__connection")?.textContent).toContain(
+      "Preview workspace — no daemon connection",
+    );
+    expect(root.querySelector(".status-strip__safe")?.textContent).toBe("Illustrative data only");
+    expect(root.textContent).not.toContain("agent processes remain active");
+    expect(root.textContent).not.toContain("Retry the attachment");
+  });
+
+  it("reacts to replacement snapshots while preserving valid local state and stable leaves", async () => {
+    const initial = createDefaultDomShellInput();
+    const [input, setInput] = createSignal(initial);
+    const root = document.createElement("div");
+    document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <DomApplicationShell
+            host={host()}
+            runtime="browser"
+            platform="darwin"
+            windowState={WINDOW_STATE}
+            input={input()}
+            dataMode="runtime"
+          />
+        ),
+        root,
+      ),
+    );
+
+    pointerClick(root.querySelector("#workbench-dock-tab-files")!);
+    pointerClick(root.querySelector('[data-action="toggle-maximize"]')!);
+    pointerClick(root.querySelector("#sidebar-session-session\\.docs")!);
+    pointerClick(root.querySelector("#primary-tab-home")!);
+    const homeLeaf = root.querySelector("#primary-tab-home");
+    const filesLeaf = root.querySelector("#workbench-dock-tab-files");
+    const docsLeaf = root.querySelector("#sidebar-session-session\\.docs");
+
+    setInput(updatedSameWorkspace(initial));
+    await vi.waitFor(() =>
+      expect(root.querySelector(".titlebar__brand")?.textContent).toContain("tmux-ide reactive"),
+    );
+
+    expect(root.querySelector("#primary-tab-home")).toBe(homeLeaf);
+    expect(root.querySelector("#workbench-dock-tab-files")).toBe(filesLeaf);
+    expect(root.querySelector("#sidebar-session-session\\.docs")).toBe(docsLeaf);
+    expect(root.querySelector("#primary-tab-home")?.getAttribute("aria-selected")).toBe("true");
+    expect(root.querySelector("#workbench-dock-tab-files")?.getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(root.querySelector(".workspace-main")?.getAttribute("data-dock-mode")).toBe("maximized");
+    expect(docsLeaf?.getAttribute("aria-pressed")).toBe("true");
+    expect(root.textContent).toContain("Reactive workspace");
+    expect(root.textContent).toContain("Fresh documentation");
+    expect(root.textContent).toContain("Codex refreshed");
+    expect(root.textContent).toContain("999 indexed files");
+    expect(root.textContent).toContain("Connected from fresh host snapshot");
+  });
+
+  it("selects session and agent rows visibly while emitting canonical resource commands", () => {
+    const invocations: ApplicationShellCommandInvocation[] = [];
+    const root = renderShell(createDefaultDomShellInput(), (invocation) =>
+      invocations.push(invocation),
+    );
+    const product = root.querySelector<HTMLButtonElement>("#sidebar-session-session\\.product")!;
+    const docs = root.querySelector<HTMLButtonElement>("#sidebar-session-session\\.docs")!;
+    const reviewer = root.querySelector<HTMLButtonElement>("#sidebar-agent-agent\\.reviewer")!;
+
+    expect(product.getAttribute("aria-pressed")).toBe("true");
+    pointerClick(docs);
+    expect(product.getAttribute("aria-pressed")).toBe("false");
+    expect(docs.getAttribute("aria-pressed")).toBe("true");
+    pointerClick(reviewer);
+    expect(docs.getAttribute("aria-pressed")).toBe("false");
+    expect(reviewer.getAttribute("aria-pressed")).toBe("true");
+    expect(invocations).toEqual([
+      expect.objectContaining({
+        id: APPLICATION_SHELL_COMMAND_IDS.selectResource,
+        args: { surface: "terminals", resourceId: "session.docs" },
+        source: { kind: "mouse", surface: "sidebar" },
+      }),
+      expect.objectContaining({
+        id: APPLICATION_SHELL_COMMAND_IDS.selectResource,
+        args: { surface: "terminals", resourceId: "agent.reviewer" },
+        source: { kind: "mouse", surface: "sidebar" },
+      }),
+    ]);
   });
 });

--- a/apps/desktop-renderer/src/experience/application-shell.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.tsx
@@ -1,5 +1,6 @@
 import {
   APPLICATION_SHELL_COMMAND_IDS,
+  ApplicationShellProjectionInputV1SchemaZ,
   applyApplicationShellInvocationV1,
   applicationShellCommandInvocation,
   commandsToOpenSurface,
@@ -19,6 +20,7 @@ import {
   Match,
   Show,
   Switch,
+  createEffect,
   createMemo,
   createSignal,
   onCleanup,
@@ -41,6 +43,7 @@ import {
   invocationFromSurfaceCommand,
   projectDomApplicationShell,
   projectDomWorkbenchDock,
+  reconcileDomShellReplayState,
   type DomPaletteEntry,
   type DomViewport,
 } from "./dom-shell.ts";
@@ -53,6 +56,7 @@ export interface DomApplicationShellProps {
   readonly platform?: string;
   readonly windowState?: DesktopWindowState | null;
   readonly input?: ApplicationShellProjectionInputV1;
+  readonly dataMode?: "runtime" | "preview";
   readonly onCommand?: (invocation: ApplicationShellCommandInvocation) => void;
 }
 
@@ -104,6 +108,11 @@ export function PrimaryNavigation(props: PrimaryNavigationProps) {
             role="tab"
             aria-selected={item().active}
             aria-disabled={item().disabledReason !== null}
+            aria-label={
+              item().disabledReason
+                ? `${item().label}, unavailable: ${item().disabledReason}`
+                : undefined
+            }
             aria-controls={`workspace-panel-${item().id}`}
             disabled={item().disabledReason !== null}
             tabIndex={item().id === tabStopId() ? 0 : -1}
@@ -145,15 +154,48 @@ function activityTone(activity: string): string {
 }
 
 export function DomApplicationShell(props: DomApplicationShellProps) {
-  const input = props.input ?? createDefaultDomShellInput();
-  const [state, setState] = createSignal(createDomShellReplayState(input));
+  const fallbackInput = createDefaultDomShellInput();
+  const input = createMemo(() =>
+    ApplicationShellProjectionInputV1SchemaZ.parse(props.input ?? fallbackInput),
+  );
+  const dataMode = createMemo<"runtime" | "preview">(() =>
+    props.input === undefined ? "preview" : (props.dataMode ?? "runtime"),
+  );
+  const [state, setState] = createSignal(createDomShellReplayState(input()));
   const [viewport, setViewport] = createSignal(initialViewport());
+  let previousInput = input();
+  let previousDataMode = dataMode();
   let returnFocusElement: HTMLElement | null = null;
   let returnFocusId: string | null = null;
 
-  const shell = createMemo(() => projectDomApplicationShell(input, state()));
+  const shell = createMemo(() => projectDomApplicationShell(input(), state()));
   const dock = createMemo(() => projectDomWorkbenchDock(shell(), viewport()));
   const paletteEntries = createMemo(() => createDomPaletteEntries(shell()));
+  const statusStrip = createMemo(() =>
+    dataMode() === "preview"
+      ? {
+          state: "disconnected" as const,
+          message: "Preview workspace — no daemon connection",
+          safeState: "Illustrative data only",
+          nextAction: "Connect the desktop host to load a workspace",
+        }
+      : shell().statusStrip,
+  );
+
+  createEffect(() => {
+    const nextInput = input();
+    const nextDataMode = dataMode();
+    if (nextInput === previousInput && nextDataMode === previousDataMode) return;
+    const currentInput = previousInput;
+    const currentDataMode = previousDataMode;
+    previousInput = nextInput;
+    previousDataMode = nextDataMode;
+    setState((current) =>
+      currentDataMode === nextDataMode
+        ? reconcileDomShellReplayState(currentInput, nextInput, current)
+        : createDomShellReplayState(nextInput),
+    );
+  });
 
   const dispatch = (invocation: ApplicationShellCommandInvocation): void => {
     setState((current) => applyApplicationShellInvocationV1(current, invocation));
@@ -246,7 +288,7 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
   });
 
   const renderDockBody = () => {
-    const tool = input.dock.tools.find(
+    const tool = input().dock.tools.find(
       (candidate) => candidate.id === shell().bottomDock.activeTool,
     )!;
     return (
@@ -310,6 +352,9 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
           <strong>tmux-ide</strong>
           <span>{shell().project.name}</span>
         </div>
+        <Show when={dataMode() === "preview"}>
+          <span class="titlebar__preview-badge">Preview data</span>
+        </Show>
         <PrimaryNavigation
           items={shell().primaryNavigation.items}
           onActivate={(surface, kind) =>
@@ -354,7 +399,7 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
         </Show>
       </header>
 
-      <div class="shell-workbench">
+      <div class="shell-workbench" data-shell-source={dataMode()}>
         <aside class="workspace-sidebar" aria-label="Workspace overview" data-focus-zone="sidebar">
           <div class="workspace-sidebar__project">
             <span class="project-monogram" aria-hidden="true">
@@ -373,14 +418,24 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
                   id={`sidebar-session-${session().id}`}
                   type="button"
                   class="sidebar-row"
-                  classList={{ "sidebar-row--active": session().active }}
-                  aria-pressed={session().active}
-                  onClick={() =>
+                  classList={{
+                    "sidebar-row--active":
+                      (shell().sidebar.selectedResourceId ?? shell().sidebar.activeSessionId) ===
+                      session().id,
+                  }}
+                  aria-pressed={
+                    (shell().sidebar.selectedResourceId ?? shell().sidebar.activeSessionId) ===
+                    session().id
+                  }
+                  onClick={(event) =>
                     dispatch(
                       applicationShellCommandInvocation(
                         APPLICATION_SHELL_COMMAND_IDS.selectResource,
                         { surface: "terminals", resourceId: session().id },
-                        { kind: "mouse", surface: "sidebar" },
+                        {
+                          kind: event.detail === 0 ? "keyboard" : "mouse",
+                          surface: "sidebar",
+                        },
                       ),
                     )
                   }
@@ -401,13 +456,20 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
                   id={`sidebar-agent-${agent().id}`}
                   type="button"
                   class="sidebar-row sidebar-row--agent"
-                  aria-label={`${agent().name}, ${agent().activity}`}
-                  onClick={() =>
+                  classList={{
+                    "sidebar-row--active": shell().sidebar.selectedResourceId === agent().id,
+                  }}
+                  aria-label={`${agent().name}, ${agent().activity}${agent().attention ? ", needs attention" : ""}`}
+                  aria-pressed={shell().sidebar.selectedResourceId === agent().id}
+                  onClick={(event) =>
                     dispatch(
                       applicationShellCommandInvocation(
                         APPLICATION_SHELL_COMMAND_IDS.selectResource,
                         { surface: "terminals", resourceId: agent().id },
-                        { kind: "mouse", surface: "sidebar" },
+                        {
+                          kind: event.detail === 0 ? "keyboard" : "mouse",
+                          surface: "sidebar",
+                        },
                       ),
                     )
                   }
@@ -476,7 +538,8 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
           >
             <header class="canvas-toolbar">
               <span>
-                <strong>{shell().workspace.name}</strong> <small>preview snapshot</small>
+                <strong>{shell().workspace.name}</strong>{" "}
+                <small>{dataMode() === "preview" ? "preview data" : "workspace snapshot"}</small>
               </span>
               <span>{shell().sidebar.agents.length} agents</span>
             </header>
@@ -505,13 +568,14 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
           <div class="workspace-dock" data-focus-zone="dock-tabs">
             <WebWorkbenchDock
               projection={dock()}
-              onTabActivate={(tabId: WorkbenchDockHostTabId) =>
-                dispatchSurface(tabId, { kind: "mouse", surface: "bottom-dock" })
+              onTabActivate={(tabId: WorkbenchDockHostTabId, source) =>
+                dispatchSurface(tabId, { kind: source, surface: "bottom-dock" })
               }
               onActionActivate={(
                 _actionId: WorkbenchDockHostActionId,
                 nextMode: WorkbenchDockHostMode,
-              ) => setDockMode(nextMode, { kind: "mouse", surface: "bottom-dock" })}
+                source,
+              ) => setDockMode(nextMode, { kind: source, surface: "bottom-dock" })}
               renderTabIcon={(tab) => <DomIcon id={dockToolIcon(shell(), tab.id)} usage="tab" />}
               renderActionIcon={(action) => (
                 <DomIcon
@@ -532,20 +596,25 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
         </main>
       </div>
 
-      <footer class="status-strip" role="status" data-focus-zone="status-strip">
+      <footer
+        class="status-strip"
+        role="status"
+        data-focus-zone="status-strip"
+        data-shell-source={dataMode()}
+      >
         <span
           class="status-strip__connection"
-          data-state={shell().statusStrip.state}
-          title={shell().statusStrip.message}
+          data-state={statusStrip().state}
+          title={statusStrip().message}
         >
           <i />
-          <span>{shell().statusStrip.message}</span>
+          <span>{statusStrip().message}</span>
         </span>
-        <span class="status-strip__safe" title={shell().statusStrip.safeState}>
-          {shell().statusStrip.safeState}
+        <span class="status-strip__safe" title={statusStrip().safeState}>
+          {statusStrip().safeState}
         </span>
-        <span class="status-strip__guidance" title={shell().statusStrip.nextAction}>
-          {shell().statusStrip.nextAction}
+        <span class="status-strip__guidance" title={statusStrip().nextAction}>
+          {statusStrip().nextAction}
         </span>
       </footer>
 

--- a/apps/desktop-renderer/src/experience/application-shell.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.tsx
@@ -368,7 +368,12 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
           aria-label="Open command palette"
           id="application-command-palette-trigger"
           title="Open command palette (Cmd/Ctrl-K)"
-          onClick={() => openPalette({ kind: "mouse", surface: "application-bar" })}
+          onClick={(event) =>
+            openPalette({
+              kind: event.detail === 0 ? "keyboard" : "mouse",
+              surface: "application-bar",
+            })
+          }
         >
           <DomIcon id="command" usage="action" />
           <kbd>{props.platform === "darwin" ? "⌘K" : "Ctrl K"}</kbd>
@@ -413,37 +418,36 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
           <section aria-labelledby="sessions-heading">
             <h2 id="sessions-heading">Sessions</h2>
             <Index each={shell().sidebar.sessions}>
-              {(session) => (
-                <button
-                  id={`sidebar-session-${session().id}`}
-                  type="button"
-                  class="sidebar-row"
-                  classList={{
-                    "sidebar-row--active":
-                      (shell().sidebar.selectedResourceId ?? shell().sidebar.activeSessionId) ===
-                      session().id,
-                  }}
-                  aria-pressed={
-                    (shell().sidebar.selectedResourceId ?? shell().sidebar.activeSessionId) ===
-                    session().id
-                  }
-                  onClick={(event) =>
-                    dispatch(
-                      applicationShellCommandInvocation(
-                        APPLICATION_SHELL_COMMAND_IDS.selectResource,
-                        { surface: "terminals", resourceId: session().id },
-                        {
-                          kind: event.detail === 0 ? "keyboard" : "mouse",
-                          surface: "sidebar",
-                        },
-                      ),
-                    )
-                  }
-                >
-                  <i data-state={session().state} />
-                  <span>{session().label}</span>
-                </button>
-              )}
+              {(session) => {
+                const selected = () =>
+                  (shell().sidebar.selectedResourceId ?? shell().sidebar.activeSessionId) ===
+                  session().id;
+                return (
+                  <button
+                    id={`sidebar-session-${session().id}`}
+                    type="button"
+                    class="sidebar-row"
+                    classList={{ "sidebar-row--active": selected() }}
+                    aria-label={`${session().label}, ${session().state}${selected() ? ", selected" : ""}`}
+                    aria-pressed={selected()}
+                    onClick={(event) =>
+                      dispatch(
+                        applicationShellCommandInvocation(
+                          APPLICATION_SHELL_COMMAND_IDS.selectResource,
+                          { surface: "terminals", resourceId: session().id },
+                          {
+                            kind: event.detail === 0 ? "keyboard" : "mouse",
+                            surface: "sidebar",
+                          },
+                        ),
+                      )
+                    }
+                  >
+                    <i data-state={session().state} />
+                    <span>{session().label}</span>
+                  </button>
+                );
+              }}
             </Index>
           </section>
           <section aria-labelledby="agents-heading">

--- a/apps/desktop-renderer/src/experience/application-shell.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.tsx
@@ -1,0 +1,565 @@
+import {
+  APPLICATION_SHELL_COMMAND_IDS,
+  applyApplicationShellInvocationV1,
+  applicationShellCommandInvocation,
+  commandsToOpenSurface,
+  type ApplicationShellCommandInvocation,
+  type ApplicationShellProjectionInputV1,
+  type ApplicationShellProjectionV1,
+  type CommandSource,
+  type DesktopWindowState,
+  type FocusZone,
+  type HostCapabilities,
+  type ProductSurfaceId,
+  type SemanticFocusTarget,
+} from "@tmux-ide/contracts";
+import {
+  For,
+  Index,
+  Match,
+  Show,
+  Switch,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+} from "solid-js";
+
+import { WebWorkbenchDock } from "../../../../packages/daemon/src/ui/workbench-dock/web-host.tsx";
+import type {
+  WorkbenchDockHostActionId,
+  WorkbenchDockHostMode,
+  WorkbenchDockHostTabId,
+} from "../../../../packages/daemon/src/ui/workbench-dock/presenter.tsx";
+import { CommandPalette } from "./command-palette.tsx";
+import { DomIcon } from "./dom-icon.tsx";
+import {
+  createDefaultDomShellInput,
+  createDomPaletteEntries,
+  createDomShellReplayState,
+  dockToolIcon,
+  invocationFromSurfaceCommand,
+  projectDomApplicationShell,
+  projectDomWorkbenchDock,
+  type DomPaletteEntry,
+  type DomViewport,
+} from "./dom-shell.ts";
+
+const PALETTE_OVERLAY_ID = "overlay.palette.trace";
+
+export interface DomApplicationShellProps {
+  readonly host: HostCapabilities;
+  readonly runtime?: string;
+  readonly platform?: string;
+  readonly windowState?: DesktopWindowState | null;
+  readonly input?: ApplicationShellProjectionInputV1;
+  readonly onCommand?: (invocation: ApplicationShellCommandInvocation) => void;
+}
+
+export interface PrimaryNavigationProps {
+  readonly items: ApplicationShellProjectionV1["primaryNavigation"]["items"];
+  readonly onActivate: (surface: ProductSurfaceId, source: "keyboard" | "mouse") => void;
+}
+
+/** Stable, keyboard-complete DOM leaf for the canonical primary surfaces. */
+export function PrimaryNavigation(props: PrimaryNavigationProps) {
+  const tabStopId = createMemo(
+    () =>
+      props.items.find((item) => item.active && item.disabledReason === null)?.id ??
+      props.items.find((item) => item.disabledReason === null)?.id,
+  );
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+    const tabs = Array.from(
+      event.currentTarget instanceof HTMLElement
+        ? event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="tab"]:not(:disabled)')
+        : [],
+    );
+    const current = event.target instanceof HTMLButtonElement ? tabs.indexOf(event.target) : -1;
+    if (current < 0 || tabs.length === 0) return;
+    event.preventDefault();
+    const next =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? tabs.length - 1
+          : (current + (event.key === "ArrowRight" ? 1 : -1) + tabs.length) % tabs.length;
+    tabs[next]?.focus();
+    tabs[next]?.click();
+  };
+
+  return (
+    <nav
+      class="primary-tabs"
+      aria-label="Workspace modes"
+      role="tablist"
+      onKeyDown={handleKeyDown}
+      data-focus-zone="primary-navigation"
+    >
+      <Index each={props.items}>
+        {(item) => (
+          <button
+            id={`primary-tab-${item().id}`}
+            type="button"
+            role="tab"
+            aria-selected={item().active}
+            aria-disabled={item().disabledReason !== null}
+            aria-controls={`workspace-panel-${item().id}`}
+            disabled={item().disabledReason !== null}
+            tabIndex={item().id === tabStopId() ? 0 : -1}
+            title={item().disabledReason ?? `${item().label} (${item().shortcut})`}
+            classList={{ "primary-tabs__tab--active": item().active }}
+            onClick={(event) => {
+              if (!item().disabledReason) {
+                props.onActivate(item().id, event.detail === 0 ? "keyboard" : "mouse");
+              }
+            }}
+          >
+            <span>{item().shortcut}</span>
+            <DomIcon id={item().icon} usage="tab" />
+            {item().label}
+          </button>
+        )}
+      </Index>
+    </nav>
+  );
+}
+
+function initialViewport(): DomViewport {
+  return typeof window === "undefined"
+    ? { width: 1_280, height: 820 }
+    : { width: Math.max(720, window.innerWidth), height: Math.max(480, window.innerHeight) };
+}
+
+function semanticFocusTarget(element: Element | null): SemanticFocusTarget {
+  const host = element?.closest<HTMLElement>("[data-focus-zone]");
+  const zone = host?.dataset.focusZone as FocusZone | undefined;
+  return { kind: "zone", zone: zone ?? "primary-navigation" };
+}
+
+function activityTone(activity: string): string {
+  if (activity === "running") return "running";
+  if (activity === "complete") return "complete";
+  if (activity === "disconnected") return "recovery";
+  return "waiting";
+}
+
+export function DomApplicationShell(props: DomApplicationShellProps) {
+  const input = props.input ?? createDefaultDomShellInput();
+  const [state, setState] = createSignal(createDomShellReplayState(input));
+  const [viewport, setViewport] = createSignal(initialViewport());
+  let returnFocusElement: HTMLElement | null = null;
+  let returnFocusId: string | null = null;
+
+  const shell = createMemo(() => projectDomApplicationShell(input, state()));
+  const dock = createMemo(() => projectDomWorkbenchDock(shell(), viewport()));
+  const paletteEntries = createMemo(() => createDomPaletteEntries(shell()));
+
+  const dispatch = (invocation: ApplicationShellCommandInvocation): void => {
+    setState((current) => applyApplicationShellInvocationV1(current, invocation));
+    props.onCommand?.(invocation);
+  };
+
+  const dispatchSurface = (surface: ProductSurfaceId, source: CommandSource): void => {
+    for (const command of commandsToOpenSurface({ surface })) {
+      dispatch(invocationFromSurfaceCommand(command, source));
+    }
+  };
+
+  const setDockMode = (mode: WorkbenchDockHostMode, source: CommandSource): void => {
+    dispatch(
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.setDockMode,
+        { mode },
+        source,
+      ),
+    );
+  };
+
+  const openPalette = (source: CommandSource): void => {
+    if (shell().focus.palette.open) return;
+    const activeElement = document.activeElement;
+    returnFocusElement =
+      activeElement && "focus" in activeElement ? (activeElement as HTMLElement) : null;
+    returnFocusId = returnFocusElement?.id || null;
+    const focusReturnTarget = semanticFocusTarget(returnFocusElement);
+    dispatch(
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.moveFocus,
+        { target: focusReturnTarget },
+        source,
+      ),
+    );
+    dispatch(
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.openPalette,
+        { overlayId: PALETTE_OVERLAY_ID, focusReturnTarget },
+        source,
+      ),
+    );
+  };
+
+  const closePalette = (sourceKind: "keyboard" | "mouse"): void => {
+    const overlayId = shell().focus.palette.overlayId;
+    if (!overlayId) return;
+    dispatch(
+      applicationShellCommandInvocation(
+        APPLICATION_SHELL_COMMAND_IDS.closePalette,
+        { overlayId },
+        { kind: sourceKind, surface: "command-palette" },
+      ),
+    );
+  };
+
+  const activatePaletteEntry = (entry: DomPaletteEntry, sourceKind: "keyboard" | "mouse"): void => {
+    closePalette(sourceKind);
+    const source = { kind: "palette", surface: "command-palette" } as const;
+    for (const command of entry.commands) dispatch(invocationFromSurfaceCommand(command, source));
+  };
+
+  onMount(() => {
+    const resize = () =>
+      setViewport({
+        width: Math.max(720, window.innerWidth),
+        height: Math.max(480, window.innerHeight),
+      });
+    const keydown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || shell().focus.palette.open) return;
+      if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === "k") {
+        event.preventDefault();
+        openPalette({ kind: "keyboard", surface: "application-shell" });
+        return;
+      }
+      const surface = [...shell().primaryNavigation.items, ...shell().bottomDock.tools].find(
+        (item) => item.shortcut === event.key,
+      );
+      if (!surface || surface.disabledReason) return;
+      event.preventDefault();
+      dispatchSurface(surface.id, { kind: "keyboard", surface: "application-shell" });
+    };
+    window.addEventListener("resize", resize);
+    document.addEventListener("keydown", keydown);
+    onCleanup(() => {
+      window.removeEventListener("resize", resize);
+      document.removeEventListener("keydown", keydown);
+    });
+  });
+
+  const renderDockBody = () => {
+    const tool = input.dock.tools.find(
+      (candidate) => candidate.id === shell().bottomDock.activeTool,
+    )!;
+    return (
+      <div class="dock-surface" data-surface={tool.id}>
+        <div class="dock-surface__rail" aria-hidden="true">
+          <DomIcon id={dockToolIcon(shell(), tool.id)} usage="rail" />
+        </div>
+        <div class="dock-surface__content">
+          <header>
+            <strong>{tool.label}</strong>
+            <span>{tool.shortcut}</span>
+          </header>
+          <Switch>
+            <Match when={tool.data.kind === "files" && tool.data}>
+              {(data) => (
+                <div class="surface-summary">
+                  <span>{data().fileCount} indexed files</span>
+                  <code>{data().selectedResourceId}</code>
+                </div>
+              )}
+            </Match>
+            <Match when={tool.data.kind === "changes" && tool.data}>
+              {(data) => (
+                <div class="surface-summary">
+                  <span>{data().changeCount} working tree changes</span>
+                  <code>{data().selectedResourceId}</code>
+                </div>
+              )}
+            </Match>
+            <Match when={tool.data.kind === "missions" && tool.data}>
+              {(data) => (
+                <div class="mission-summary">
+                  <div>
+                    <small>{data().status}</small>
+                    <strong>{data().title}</strong>
+                  </div>
+                  <span>{data().goalCount} goals</span>
+                  <span>{data().taskCount} cards</span>
+                </div>
+              )}
+            </Match>
+            <Match when={tool.data.kind === "activity" && tool.data}>
+              {(data) => (
+                <div class="surface-summary">
+                  <span>{data().eventCount} recorded events</span>
+                  <code>{data().latestEventLabel}</code>
+                </div>
+              )}
+            </Match>
+          </Switch>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <header class="titlebar" data-focus-zone="application-bar">
+        <div class="titlebar__brand">
+          <DomIcon id="terminals" usage="tab" />
+          <strong>tmux-ide</strong>
+          <span>{shell().project.name}</span>
+        </div>
+        <PrimaryNavigation
+          items={shell().primaryNavigation.items}
+          onActivate={(surface, kind) =>
+            dispatchSurface(surface, { kind, surface: "primary-navigation" })
+          }
+        />
+        <div class="titlebar__drag titlebar__spacer" />
+        <button
+          class="palette-trigger"
+          type="button"
+          aria-label="Open command palette"
+          id="application-command-palette-trigger"
+          title="Open command palette (Cmd/Ctrl-K)"
+          onClick={() => openPalette({ kind: "mouse", surface: "application-bar" })}
+        >
+          <DomIcon id="command" usage="action" />
+          <kbd>{props.platform === "darwin" ? "⌘K" : "Ctrl K"}</kbd>
+        </button>
+        <Show when={props.runtime === "electron" && props.platform !== "darwin"}>
+          <nav class="window-controls" aria-label="Window controls">
+            <button
+              type="button"
+              aria-label="Minimize"
+              onClick={() => void props.host.window.minimize()}
+            >
+              <DomIcon id="minimize" usage="nativeWindow" />
+            </button>
+            <button
+              type="button"
+              aria-label={props.windowState?.maximized ? "Restore" : "Maximize"}
+              onClick={() => void props.host.window.toggleMaximized()}
+            >
+              <DomIcon
+                id={props.windowState?.maximized ? "restore" : "maximize"}
+                usage="nativeWindow"
+              />
+            </button>
+            <button type="button" aria-label="Close" onClick={() => void props.host.window.close()}>
+              <DomIcon id="close" usage="nativeWindow" />
+            </button>
+          </nav>
+        </Show>
+      </header>
+
+      <div class="shell-workbench">
+        <aside class="workspace-sidebar" aria-label="Workspace overview" data-focus-zone="sidebar">
+          <div class="workspace-sidebar__project">
+            <span class="project-monogram" aria-hidden="true">
+              {shell().project.name.slice(0, 2)}
+            </span>
+            <span>
+              <strong>{shell().project.name}</strong>
+              <small>{shell().project.rootLabel}</small>
+            </span>
+          </div>
+          <section aria-labelledby="sessions-heading">
+            <h2 id="sessions-heading">Sessions</h2>
+            <Index each={shell().sidebar.sessions}>
+              {(session) => (
+                <button
+                  id={`sidebar-session-${session().id}`}
+                  type="button"
+                  class="sidebar-row"
+                  classList={{ "sidebar-row--active": session().active }}
+                  aria-pressed={session().active}
+                  onClick={() =>
+                    dispatch(
+                      applicationShellCommandInvocation(
+                        APPLICATION_SHELL_COMMAND_IDS.selectResource,
+                        { surface: "terminals", resourceId: session().id },
+                        { kind: "mouse", surface: "sidebar" },
+                      ),
+                    )
+                  }
+                >
+                  <i data-state={session().state} />
+                  <span>{session().label}</span>
+                </button>
+              )}
+            </Index>
+          </section>
+          <section aria-labelledby="agents-heading">
+            <h2 id="agents-heading">
+              Agents <span>{shell().sidebar.agents.length}</span>
+            </h2>
+            <Index each={shell().sidebar.agents}>
+              {(agent) => (
+                <button
+                  id={`sidebar-agent-${agent().id}`}
+                  type="button"
+                  class="sidebar-row sidebar-row--agent"
+                  aria-label={`${agent().name}, ${agent().activity}`}
+                  onClick={() =>
+                    dispatch(
+                      applicationShellCommandInvocation(
+                        APPLICATION_SHELL_COMMAND_IDS.selectResource,
+                        { surface: "terminals", resourceId: agent().id },
+                        { kind: "mouse", surface: "sidebar" },
+                      ),
+                    )
+                  }
+                >
+                  <i data-state={activityTone(agent().activity)} />
+                  <span>{agent().name}</span>
+                  <Show when={agent().attention}>
+                    <b aria-label="Needs attention" />
+                  </Show>
+                </button>
+              )}
+            </Index>
+          </section>
+        </aside>
+
+        <main class="workspace-main" data-dock-mode={shell().bottomDock.mode}>
+          <section
+            id="workspace-panel-home"
+            class="workspace-canvas home-canvas"
+            role="tabpanel"
+            aria-labelledby="primary-tab-home"
+            hidden={shell().workspaceCanvas.activeMode !== "home"}
+            data-focus-zone="canvas"
+          >
+            <div class="home-canvas__intro">
+              <span class="eyebrow">Project workspace</span>
+              <h1>{shell().project.name}</h1>
+              <p>{shell().project.readiness.facts.join(" ")}</p>
+              <button type="button" onClick={() => void props.host.dialog.selectProjectDirectory()}>
+                Open another folder
+              </button>
+            </div>
+            <section class="readiness-card" aria-labelledby="readiness-heading">
+              <header>
+                <h2 id="readiness-heading">Workspace readiness</h2>
+                <span data-state={shell().project.readiness.state}>
+                  {shell().project.readiness.state}
+                </span>
+              </header>
+              <For each={shell().project.readiness.facts}>
+                {(fact) => (
+                  <p>
+                    <i />
+                    {fact}
+                  </p>
+                )}
+              </For>
+              <For each={shell().project.readiness.warnings}>
+                {(warning) => (
+                  <p class="warning">
+                    <i />
+                    {warning}
+                  </p>
+                )}
+              </For>
+            </section>
+          </section>
+
+          <section
+            id="workspace-panel-terminals"
+            class="workspace-canvas terminal-canvas"
+            role="tabpanel"
+            aria-labelledby="primary-tab-terminals"
+            hidden={shell().workspaceCanvas.activeMode !== "terminals"}
+            data-focus-zone="canvas"
+          >
+            <header class="canvas-toolbar">
+              <span>
+                <strong>{shell().workspace.name}</strong> <small>preview snapshot</small>
+              </span>
+              <span>{shell().sidebar.agents.length} agents</span>
+            </header>
+            <div class="agent-grid">
+              <Index each={shell().sidebar.agents}>
+                {(agent) => (
+                  <article class="agent-pane" data-state={activityTone(agent().activity)}>
+                    <header>
+                      <span>
+                        <i />
+                        <strong>{agent().name}</strong>
+                      </span>
+                      <span>{agent().activity}</span>
+                    </header>
+                    <div class="agent-pane__body">
+                      <span class="agent-prompt">{agent().harness}</span>
+                      <p>Activity: {agent().activity}</p>
+                    </div>
+                    <footer>{agent().paneId}</footer>
+                  </article>
+                )}
+              </Index>
+            </div>
+          </section>
+
+          <div class="workspace-dock" data-focus-zone="dock-tabs">
+            <WebWorkbenchDock
+              projection={dock()}
+              onTabActivate={(tabId: WorkbenchDockHostTabId) =>
+                dispatchSurface(tabId, { kind: "mouse", surface: "bottom-dock" })
+              }
+              onActionActivate={(
+                _actionId: WorkbenchDockHostActionId,
+                nextMode: WorkbenchDockHostMode,
+              ) => setDockMode(nextMode, { kind: "mouse", surface: "bottom-dock" })}
+              renderTabIcon={(tab) => <DomIcon id={dockToolIcon(shell(), tab.id)} usage="tab" />}
+              renderActionIcon={(action) => (
+                <DomIcon
+                  id={
+                    action.id === "toggle-collapse"
+                      ? "dock"
+                      : action.nextMode === "maximized"
+                        ? "maximize"
+                        : "restore"
+                  }
+                  usage="action"
+                />
+              )}
+            >
+              {renderDockBody()}
+            </WebWorkbenchDock>
+          </div>
+        </main>
+      </div>
+
+      <footer class="status-strip" role="status" data-focus-zone="status-strip">
+        <span
+          class="status-strip__connection"
+          data-state={shell().statusStrip.state}
+          title={shell().statusStrip.message}
+        >
+          <i />
+          <span>{shell().statusStrip.message}</span>
+        </span>
+        <span class="status-strip__safe" title={shell().statusStrip.safeState}>
+          {shell().statusStrip.safeState}
+        </span>
+        <span class="status-strip__guidance" title={shell().statusStrip.nextAction}>
+          {shell().statusStrip.nextAction}
+        </span>
+      </footer>
+
+      <CommandPalette
+        open={shell().focus.palette.open}
+        entries={paletteEntries()}
+        onClose={closePalette}
+        onClosed={() => {
+          const currentTarget = returnFocusId ? document.getElementById(returnFocusId) : null;
+          if (currentTarget && "focus" in currentTarget) currentTarget.focus();
+          else returnFocusElement?.focus();
+        }}
+        onActivate={activatePaletteEntry}
+      />
+    </>
+  );
+}

--- a/apps/desktop-renderer/src/experience/command-palette.tsx
+++ b/apps/desktop-renderer/src/experience/command-palette.tsx
@@ -1,0 +1,221 @@
+import { For, Show, createEffect, createMemo, createSignal, on } from "solid-js";
+
+import { DomIcon } from "./dom-icon.tsx";
+import type { DomPaletteEntry } from "./dom-shell.ts";
+
+export interface CommandPaletteProps {
+  readonly open: boolean;
+  readonly entries: readonly DomPaletteEntry[];
+  readonly onClose: (source: "keyboard" | "mouse") => void;
+  readonly onClosed?: () => void;
+  readonly onActivate: (entry: DomPaletteEntry, source: "keyboard" | "mouse") => void;
+}
+
+const PALETTE_INPUT_ID = "application-command-palette-input";
+const PALETTE_LIST_ID = "application-command-palette-list";
+
+function nextEnabledIndex(
+  entries: readonly DomPaletteEntry[],
+  current: number,
+  direction: 1 | -1,
+): number {
+  if (entries.length === 0) return -1;
+  for (let offset = 1; offset <= entries.length; offset += 1) {
+    const index = (current + direction * offset + entries.length) % entries.length;
+    if (!entries[index]?.disabledReason) return index;
+  }
+  return -1;
+}
+
+function edgeEnabledIndex(entries: readonly DomPaletteEntry[], fromEnd: boolean): number {
+  const indexes = entries.map((_, index) => index);
+  if (fromEnd) indexes.reverse();
+  return indexes.find((index) => !entries[index]?.disabledReason) ?? -1;
+}
+
+export function CommandPalette(props: CommandPaletteProps) {
+  const [query, setQuery] = createSignal("");
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+  const [hoveredIndex, setHoveredIndex] = createSignal<number | null>(null);
+  let overlay: HTMLDivElement | undefined;
+  let input: HTMLInputElement | undefined;
+  let previousFocus: HTMLElement | null = null;
+
+  const filteredEntries = createMemo(() => {
+    const needle = query().trim().toLocaleLowerCase();
+    return needle
+      ? props.entries.filter((entry) => entry.label.toLocaleLowerCase().includes(needle))
+      : props.entries;
+  });
+  const activeEntry = createMemo(() => filteredEntries()[selectedIndex()] ?? null);
+
+  createEffect(
+    on(
+      () => props.open,
+      (open, previousOpen) => {
+        if (!overlay) return;
+        overlay.inert = !open;
+        if (!open) {
+          if (previousOpen) {
+            queueMicrotask(() => {
+              previousFocus?.focus();
+              props.onClosed?.();
+            });
+          }
+          return;
+        }
+        const activeElement = document.activeElement;
+        previousFocus =
+          activeElement && "focus" in activeElement ? (activeElement as HTMLElement) : null;
+        setQuery("");
+        setSelectedIndex(edgeEnabledIndex(props.entries, false));
+        setHoveredIndex(null);
+        queueMicrotask(() => input?.focus());
+      },
+    ),
+  );
+
+  createEffect(
+    on(filteredEntries, (entries) => {
+      const current = selectedIndex();
+      if (current < entries.length && !entries[current]?.disabledReason) return;
+      setSelectedIndex(edgeEnabledIndex(entries, false));
+    }),
+  );
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    const entries = filteredEntries();
+    if (event.key === "Escape") {
+      event.preventDefault();
+      props.onClose("keyboard");
+      return;
+    }
+    if (event.key === "Tab") {
+      event.preventDefault();
+      input?.focus();
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      setHoveredIndex(null);
+      setSelectedIndex((current) =>
+        nextEnabledIndex(entries, current, event.key === "ArrowDown" ? 1 : -1),
+      );
+      return;
+    }
+    if (event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      setHoveredIndex(null);
+      setSelectedIndex(edgeEnabledIndex(entries, event.key === "End"));
+      return;
+    }
+    if (event.key === "Enter") {
+      const entry = activeEntry();
+      if (!entry || entry.disabledReason) return;
+      event.preventDefault();
+      props.onActivate(entry, "keyboard");
+    }
+  };
+
+  return (
+    <div
+      ref={(element) => {
+        overlay = element;
+      }}
+      class="command-palette-overlay"
+      classList={{ "command-palette-overlay--open": props.open }}
+      aria-hidden={props.open ? "false" : "true"}
+      data-overlay-root="true"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) props.onClose("mouse");
+      }}
+    >
+      <section
+        class="command-palette"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="application-command-palette-title"
+        onKeyDown={handleKeyDown}
+      >
+        <h2 id="application-command-palette-title" class="sr-only">
+          Command palette
+        </h2>
+        <div class="command-palette__query">
+          <DomIcon id="search" usage="action" />
+          <input
+            ref={(element) => {
+              input = element;
+            }}
+            id={PALETTE_INPUT_ID}
+            type="text"
+            role="combobox"
+            aria-label="Search commands"
+            aria-autocomplete="list"
+            aria-expanded={props.open}
+            aria-controls={PALETTE_LIST_ID}
+            aria-activedescendant={
+              activeEntry() ? `palette-option-${activeEntry()!.id}` : undefined
+            }
+            autocomplete="off"
+            placeholder="Type a command or surface…"
+            value={query()}
+            onInput={(event) => setQuery(event.currentTarget.value)}
+          />
+          <kbd>Esc</kbd>
+        </div>
+        <div class="command-palette__rule" />
+        <div
+          id={PALETTE_LIST_ID}
+          class="command-palette__list"
+          role="listbox"
+          aria-label="Available commands"
+        >
+          <For each={filteredEntries()}>
+            {(entry, index) => (
+              <div
+                id={`palette-option-${entry.id}`}
+                class="command-palette__option"
+                classList={{
+                  "command-palette__option--selected": selectedIndex() === index(),
+                  "command-palette__option--hovered": hoveredIndex() === index(),
+                }}
+                role="option"
+                aria-selected={selectedIndex() === index()}
+                aria-disabled={entry.disabledReason !== null}
+                title={entry.disabledReason ?? undefined}
+                data-surface={entry.id}
+                onMouseEnter={() => {
+                  setHoveredIndex(index());
+                  if (!entry.disabledReason) setSelectedIndex(index());
+                }}
+                onMouseLeave={() => setHoveredIndex(null)}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  if (!entry.disabledReason) props.onActivate(entry, "mouse");
+                }}
+              >
+                <DomIcon id={entry.icon} usage="action" />
+                <span class="command-palette__label">{entry.label}</span>
+                <Show when={entry.current}>
+                  <span class="command-palette__current">Current</span>
+                </Show>
+                <Show when={entry.disabledReason}>
+                  {(reason) => <span class="command-palette__reason">{reason()}</span>}
+                </Show>
+                <kbd>{entry.shortcut}</kbd>
+              </div>
+            )}
+          </For>
+          <Show when={filteredEntries().length === 0}>
+            <p class="command-palette__empty">No matching commands</p>
+          </Show>
+        </div>
+        <footer class="command-palette__footer">
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>Esc close</span>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop-renderer/src/experience/dom-icon.tsx
+++ b/apps/desktop-renderer/src/experience/dom-icon.tsx
@@ -1,0 +1,34 @@
+import { For } from "solid-js";
+import type { SemanticIconId } from "@tmux-ide/contracts";
+
+import { resolveDomIcon, type DomIconUsage } from "./dom-icons.ts";
+
+export interface DomIconProps {
+  readonly id: SemanticIconId;
+  readonly usage?: DomIconUsage;
+  readonly label?: string;
+  readonly class?: string;
+}
+
+/** Canonical, currentColor SVG leaf shared by every DOM shell surface. */
+export function DomIcon(props: DomIconProps) {
+  const icon = () => resolveDomIcon(props.id, props.usage);
+  return (
+    <svg
+      class={props.class}
+      width={icon().size}
+      height={icon().size}
+      viewBox={icon().viewBox}
+      fill={icon().fill}
+      stroke={icon().stroke}
+      stroke-width={icon().strokeWidth}
+      stroke-linecap={icon().strokeLinecap}
+      stroke-linejoin={icon().strokeLinejoin}
+      role={props.label ? "img" : undefined}
+      aria-label={props.label}
+      aria-hidden={props.label ? undefined : "true"}
+    >
+      <For each={icon().paths}>{(path) => <path d={path} />}</For>
+    </svg>
+  );
+}

--- a/apps/desktop-renderer/src/experience/dom-shell.test.ts
+++ b/apps/desktop-renderer/src/experience/dom-shell.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import { applicationShellActionTraceV1, type ApplicationShellDockMode } from "@tmux-ide/contracts";
+import {
+  ApplicationShellProjectionInputV1SchemaZ,
+  ApplicationShellReplayStateV1SchemaZ,
+  applicationShellActionTraceV1,
+  type ApplicationShellDockMode,
+} from "@tmux-ide/contracts";
 import {
   createDefaultDomShellInput,
   createDomShellReplayState,
   domShellVariant,
   projectDomApplicationShell,
   projectDomWorkbenchDock,
+  reconcileDomShellReplayState,
 } from "./dom-shell.ts";
 
 function projection(mode: ApplicationShellDockMode = "open") {
@@ -85,5 +91,93 @@ describe("DOM application-shell projection", () => {
       "activity",
     ]);
     expect(applicationShellActionTraceV1(input).invocations).toHaveLength(20);
+  });
+
+  it("preserves valid local state for fresh snapshots of the same project and workspace", () => {
+    const previous = createDefaultDomShellInput();
+    const current = ApplicationShellReplayStateV1SchemaZ.parse({
+      ...createDomShellReplayState(previous),
+      activeMode: "home",
+      dockMode: "maximized",
+      activeDockTool: "files",
+      focus: { ...previous.focus, focusZone: "dock-tabs", terminalInputPaneId: null },
+      selectedResources: [{ surface: "terminals", resourceId: "session.docs" }],
+    });
+    const next = ApplicationShellProjectionInputV1SchemaZ.parse({
+      ...previous,
+      project: { ...previous.project, name: "Fresh project data" },
+      workspace: { ...previous.workspace, name: "Fresh workspace data" },
+      connection: { ...previous.connection, message: "Fresh connection data" },
+    });
+
+    expect(reconcileDomShellReplayState(previous, next, current)).toEqual(current);
+  });
+
+  it("falls back from unavailable local targets and resets renderer state on identity change", () => {
+    const previous = createDefaultDomShellInput();
+    const current = ApplicationShellReplayStateV1SchemaZ.parse({
+      ...createDomShellReplayState(previous),
+      activeMode: "home",
+      dockMode: "maximized",
+      activeDockTool: "files",
+      focus: {
+        ...previous.focus,
+        focusZone: "canvas",
+        appFocusedPaneId: "pane.reviewer",
+        terminalInputPaneId: null,
+        layoutSelectedPaneId: "pane.reviewer",
+      },
+      selectedResources: [{ surface: "terminals", resourceId: "session.docs" }],
+    });
+    const next = ApplicationShellProjectionInputV1SchemaZ.parse({
+      ...previous,
+      workspace: {
+        ...previous.workspace,
+        sidebar: {
+          sessions: previous.workspace.sidebar.sessions.filter(
+            (session) => session.id !== "session.docs",
+          ),
+          agents: previous.workspace.sidebar.agents.filter(
+            (agent) => agent.id !== "agent.reviewer",
+          ),
+        },
+      },
+      dock: {
+        ...previous.dock,
+        activeTool: "activity",
+        tools: previous.dock.tools.map((tool) =>
+          tool.id === "files" ? { ...tool, disabledReason: "Files are unavailable" } : tool,
+        ),
+      },
+      focus: {
+        ...previous.focus,
+        appFocusedPaneId: "pane.implementer",
+        terminalInputPaneId: "pane.implementer",
+        layoutSelectedPaneId: "pane.implementer",
+      },
+    });
+    const reconciled = reconcileDomShellReplayState(previous, next, current);
+
+    expect(reconciled).toMatchObject({
+      activeMode: "home",
+      dockMode: "maximized",
+      activeDockTool: "activity",
+      focus: next.focus,
+      selectedResources: [],
+    });
+
+    const replacement = ApplicationShellProjectionInputV1SchemaZ.parse({
+      ...next,
+      project: { ...next.project, id: "project.replacement" },
+      workspace: {
+        ...next.workspace,
+        id: "workspace.replacement",
+        activeMode: "terminals",
+      },
+      dock: { ...next.dock, mode: "collapsed" },
+    });
+    expect(reconcileDomShellReplayState(next, replacement, reconciled)).toEqual(
+      createDomShellReplayState(replacement),
+    );
   });
 });

--- a/apps/desktop-renderer/src/experience/dom-shell.test.ts
+++ b/apps/desktop-renderer/src/experience/dom-shell.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { applicationShellActionTraceV1, type ApplicationShellDockMode } from "@tmux-ide/contracts";
+import {
+  createDefaultDomShellInput,
+  createDomShellReplayState,
+  domShellVariant,
+  projectDomApplicationShell,
+  projectDomWorkbenchDock,
+} from "./dom-shell.ts";
+
+function projection(mode: ApplicationShellDockMode = "open") {
+  const input = createDefaultDomShellInput();
+  const state = { ...createDomShellReplayState(input), dockMode: mode };
+  return projectDomApplicationShell(input, state);
+}
+
+describe("DOM application-shell projection", () => {
+  it.each([
+    {
+      viewport: { width: 720, height: 480 },
+      variant: "compact",
+      sidebar: 48,
+      workbench: 434,
+      canvas: 304,
+      dock: { x: 48, y: 332, width: 672, height: 130 },
+    },
+    {
+      viewport: { width: 1_280, height: 820 },
+      variant: "standard",
+      sidebar: 168,
+      workbench: 774,
+      canvas: 542,
+      dock: { x: 168, y: 570, width: 1_112, height: 232 },
+    },
+    {
+      viewport: { width: 1_600, height: 1_000 },
+      variant: "wide",
+      sidebar: 184,
+      workbench: 954,
+      canvas: 668,
+      dock: { x: 184, y: 696, width: 1_416, height: 286 },
+    },
+  ])("uses bottom-dock geometry at $viewport.width×$viewport.height", (fixture) => {
+    const dock = projectDomWorkbenchDock(projection(), fixture.viewport);
+
+    expect(domShellVariant(fixture.viewport)).toBe(fixture.variant);
+    expect(dock.variant).toBe(fixture.variant);
+    expect(dock.dock).toEqual(fixture.dock);
+    expect(dock.dock.x).toBe(fixture.sidebar);
+    expect(dock.dock.y - 28).toBe(fixture.canvas);
+    expect(dock.dock.y + dock.dock.height).toBe(fixture.viewport.height - 18);
+    expect(dock.dockTabs).toEqual({
+      x: fixture.sidebar,
+      y: fixture.dock.y,
+      width: fixture.dock.width,
+      height: 28,
+    });
+    expect(dock.dockBody.height).toBe(fixture.dock.height - 28);
+    expect(dock.dockBodyContent.width).toBe(fixture.dock.width - 28);
+    expect(dock.dock.width).toBe(fixture.viewport.width - fixture.sidebar);
+  });
+
+  it("projects collapsed and maximized modes on the vertical workbench axis", () => {
+    const viewport = { width: 1_280, height: 820 };
+    const collapsed = projectDomWorkbenchDock(projection("collapsed"), viewport);
+    const maximized = projectDomWorkbenchDock(projection("maximized"), viewport);
+
+    expect(collapsed.dock).toEqual({ x: 168, y: 774, width: 1_112, height: 28 });
+    expect(collapsed.dockBody.height).toBe(0);
+    expect(maximized.dock).toEqual({ x: 168, y: 28, width: 1_112, height: 774 });
+    expect(maximized.dockBody.height).toBe(746);
+  });
+
+  it("starts from the canonical closed-overlay fixture and trace", () => {
+    const input = createDefaultDomShellInput();
+    const shell = projectDomApplicationShell(input, createDomShellReplayState(input));
+
+    expect(shell.focus.palette.open).toBe(false);
+    expect(shell.primaryNavigation.items.map(({ id }) => id)).toEqual(["home", "terminals"]);
+    expect(shell.bottomDock.tools.map(({ id }) => id)).toEqual([
+      "files",
+      "changes",
+      "missions",
+      "activity",
+    ]);
+    expect(applicationShellActionTraceV1(input).invocations).toHaveLength(20);
+  });
+});

--- a/apps/desktop-renderer/src/experience/dom-shell.ts
+++ b/apps/desktop-renderer/src/experience/dom-shell.ts
@@ -38,6 +38,16 @@ export interface DomPaletteEntry {
   readonly commands: readonly SurfaceCommandTemplate[];
 }
 
+export interface DomApplicationShellProjection extends Omit<
+  ApplicationShellProjectionV1,
+  "sidebar"
+> {
+  readonly sidebar: ApplicationShellProjectionV1["sidebar"] & {
+    /** Canonical local selection, independent from the daemon's active tmux session. */
+    readonly selectedResourceId: string | null;
+  };
+}
+
 const TITLEBAR_HEIGHT = 28;
 const STATUS_HEIGHT = 18;
 const DOCK_STRIP_HEIGHT = 28;
@@ -64,15 +74,116 @@ export function createDomShellReplayState(
   });
 }
 
+function sameDomShellIdentity(
+  left: ApplicationShellProjectionInputV1,
+  right: ApplicationShellProjectionInputV1,
+): boolean {
+  return left.project.id === right.project.id && left.workspace.id === right.workspace.id;
+}
+
+function availablePaneIds(input: ApplicationShellProjectionInputV1): ReadonlySet<string> {
+  return new Set([
+    ...input.workspace.sidebar.agents.flatMap((agent) =>
+      agent.paneId === null ? [] : [agent.paneId],
+    ),
+    ...[
+      input.focus.appFocusedPaneId,
+      input.focus.terminalInputPaneId,
+      input.focus.layoutSelectedPaneId,
+    ].flatMap((paneId) => (paneId === null ? [] : [paneId])),
+  ]);
+}
+
+function focusTargetIsAvailable(
+  target: ApplicationShellReplayStateV1["focus"]["overlays"][number]["focusReturnTarget"],
+  paneIds: ReadonlySet<string>,
+): boolean {
+  return target.kind !== "pane" || paneIds.has(target.paneId);
+}
+
+function focusIsAvailable(
+  focus: ApplicationShellReplayStateV1["focus"],
+  input: ApplicationShellProjectionInputV1,
+): boolean {
+  const paneIds = availablePaneIds(input);
+  const referencedPaneIds = [
+    focus.appFocusedPaneId,
+    focus.terminalInputPaneId,
+    focus.layoutSelectedPaneId,
+  ];
+  return (
+    referencedPaneIds.every((paneId) => paneId === null || paneIds.has(paneId)) &&
+    focus.overlays.every((overlay) => focusTargetIsAvailable(overlay.focusReturnTarget, paneIds))
+  );
+}
+
+function availableDockTool(
+  preferred: DockToolId,
+  input: ApplicationShellProjectionInputV1,
+): DockToolId {
+  const preferredTool = input.dock.tools.find((tool) => tool.id === preferred);
+  if (preferredTool?.disabledReason === null) return preferred;
+  const snapshotTool = input.dock.tools.find((tool) => tool.id === input.dock.activeTool);
+  if (snapshotTool?.disabledReason === null) return input.dock.activeTool;
+  return input.dock.tools.find((tool) => tool.disabledReason === null)?.id ?? input.dock.activeTool;
+}
+
+function reconcileResourceSelections(
+  state: ApplicationShellReplayStateV1,
+  input: ApplicationShellProjectionInputV1,
+): ApplicationShellReplayStateV1["selectedResources"] {
+  const terminalResourceIds = new Set([
+    ...input.workspace.sidebar.sessions.map(({ id }) => id),
+    ...input.workspace.sidebar.agents.map(({ id }) => id),
+  ]);
+  return state.selectedResources.filter(
+    (selection) =>
+      selection.surface !== "terminals" || terminalResourceIds.has(selection.resourceId),
+  );
+}
+
+/**
+ * Reconcile a fresh immutable host snapshot with renderer-owned interaction
+ * state. Local mode, dock, focus, and selection survive only for the same
+ * project/workspace identity and only while their targets remain available.
+ */
+export function reconcileDomShellReplayState(
+  previousInput: ApplicationShellProjectionInputV1,
+  nextInput: ApplicationShellProjectionInputV1,
+  current: ApplicationShellReplayStateV1,
+): ApplicationShellReplayStateV1 {
+  const snapshotState = createDomShellReplayState(nextInput);
+  if (!sameDomShellIdentity(previousInput, nextInput)) {
+    return ApplicationShellReplayStateV1SchemaZ.parse({
+      ...snapshotState,
+      activeDockTool: availableDockTool(snapshotState.activeDockTool, nextInput),
+    });
+  }
+  return ApplicationShellReplayStateV1SchemaZ.parse({
+    ...current,
+    activeDockTool: availableDockTool(current.activeDockTool, nextInput),
+    focus: focusIsAvailable(current.focus, nextInput) ? current.focus : snapshotState.focus,
+    selectedResources: reconcileResourceSelections(current, nextInput),
+  });
+}
+
 export function projectDomApplicationShell(
   input: ApplicationShellProjectionInputV1,
   state: ApplicationShellReplayStateV1,
-): ApplicationShellProjectionV1 {
-  return projectApplicationShellV1({
+): DomApplicationShellProjection {
+  const shell = projectApplicationShellV1({
     ...input,
     workspace: { ...input.workspace, activeMode: state.activeMode },
     dock: { ...input.dock, mode: state.dockMode, activeTool: state.activeDockTool },
     focus: state.focus,
+  });
+  return Object.freeze({
+    ...shell,
+    sidebar: Object.freeze({
+      ...shell.sidebar,
+      selectedResourceId:
+        state.selectedResources.find(({ surface }) => surface === "terminals")?.resourceId ?? null,
+    }),
   });
 }
 

--- a/apps/desktop-renderer/src/experience/dom-shell.ts
+++ b/apps/desktop-renderer/src/experience/dom-shell.ts
@@ -1,0 +1,242 @@
+import {
+  APPLICATION_SHELL_COMMAND_IDS,
+  ApplicationShellProjectionInputV1SchemaZ,
+  ApplicationShellReplayStateV1SchemaZ,
+  COHESION_FIXTURE_V1,
+  applicationShellCommandInvocation,
+  commandsToOpenSurface,
+  projectApplicationShellV1,
+  type ApplicationShellCommandInvocation,
+  type ApplicationShellProjectionInputV1,
+  type ApplicationShellProjectionV1,
+  type ApplicationShellReplayStateV1,
+  type CommandSource,
+  type DockToolId,
+  type ProductSurfaceId,
+  type SemanticIconId,
+  type SurfaceCommandTemplate,
+} from "@tmux-ide/contracts";
+import type {
+  WorkbenchDockHostProjection,
+  WorkbenchDockHostTabId,
+} from "../../../../packages/daemon/src/ui/workbench-dock/presenter.tsx";
+
+export interface DomViewport {
+  readonly width: number;
+  readonly height: number;
+}
+
+export type DomShellVariant = "compact" | "standard" | "wide";
+
+export interface DomPaletteEntry {
+  readonly id: ProductSurfaceId;
+  readonly icon: SemanticIconId;
+  readonly label: string;
+  readonly shortcut: string;
+  readonly current: boolean;
+  readonly disabledReason: string | null;
+  readonly commands: readonly SurfaceCommandTemplate[];
+}
+
+const TITLEBAR_HEIGHT = 28;
+const STATUS_HEIGHT = 18;
+const DOCK_STRIP_HEIGHT = 28;
+
+export function createDefaultDomShellInput(): ApplicationShellProjectionInputV1 {
+  return ApplicationShellProjectionInputV1SchemaZ.parse({
+    project: COHESION_FIXTURE_V1.project,
+    workspace: COHESION_FIXTURE_V1.workspace,
+    dock: COHESION_FIXTURE_V1.dock,
+    focus: { ...COHESION_FIXTURE_V1.focus, overlays: [] },
+    connection: COHESION_FIXTURE_V1.connection,
+  });
+}
+
+export function createDomShellReplayState(
+  input: ApplicationShellProjectionInputV1,
+): ApplicationShellReplayStateV1 {
+  return ApplicationShellReplayStateV1SchemaZ.parse({
+    activeMode: input.workspace.activeMode,
+    dockMode: input.dock.mode,
+    activeDockTool: input.dock.activeTool,
+    focus: input.focus,
+    selectedResources: [],
+  });
+}
+
+export function projectDomApplicationShell(
+  input: ApplicationShellProjectionInputV1,
+  state: ApplicationShellReplayStateV1,
+): ApplicationShellProjectionV1 {
+  return projectApplicationShellV1({
+    ...input,
+    workspace: { ...input.workspace, activeMode: state.activeMode },
+    dock: { ...input.dock, mode: state.dockMode, activeTool: state.activeDockTool },
+    focus: state.focus,
+  });
+}
+
+export function domShellVariant(viewport: DomViewport): DomShellVariant {
+  if (viewport.width < 1_000) return "compact";
+  if (viewport.width < 1_440) return "standard";
+  return "wide";
+}
+
+function variantMetrics(variant: DomShellVariant): {
+  sidebar: number;
+  minimumDock: number;
+  minimumCanvas: number;
+} {
+  if (variant === "compact") return { sidebar: 48, minimumDock: 126, minimumCanvas: 144 };
+  if (variant === "standard") return { sidebar: 168, minimumDock: 180, minimumCanvas: 216 };
+  return { sidebar: 184, minimumDock: 252, minimumCanvas: 288 };
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(value, maximum));
+}
+
+/**
+ * Translate the canonical shell into the shared dock presenter's real desktop
+ * geometry. Geometry remains a DOM-host concern; surface identity never does.
+ */
+export function projectDomWorkbenchDock(
+  shell: ApplicationShellProjectionV1,
+  viewport: DomViewport,
+): WorkbenchDockHostProjection {
+  const variant = domShellVariant(viewport);
+  const metrics = variantMetrics(variant);
+  const workbenchHeight = Math.max(0, viewport.height - TITLEBAR_HEIGHT - STATUS_HEIGHT);
+  const workspaceWidth = Math.max(0, viewport.width - metrics.sidebar);
+  const maximumOpenDock = Math.max(metrics.minimumDock, workbenchHeight - metrics.minimumCanvas);
+  const openDockHeight = clamp(
+    Math.round(workbenchHeight * 0.3),
+    metrics.minimumDock,
+    maximumOpenDock,
+  );
+  const dockHeight =
+    shell.bottomDock.mode === "collapsed"
+      ? DOCK_STRIP_HEIGHT
+      : shell.bottomDock.mode === "maximized"
+        ? workbenchHeight
+        : openDockHeight;
+  const dockY = TITLEBAR_HEIGHT + workbenchHeight - dockHeight;
+  let cursor = metrics.sidebar;
+  const tabs = shell.bottomDock.tools.map((tool) => {
+    const width = Math.max(72, 28 + tool.label.length * 8 + tool.shortcut.length * 8);
+    const tab = {
+      id: tool.id as WorkbenchDockHostTabId,
+      title: tool.label,
+      label: tool.label,
+      shortcut: tool.shortcut,
+      selected: tool.active,
+      focused: shell.focus.zone === "dock-tabs" && tool.active,
+      hovered: false,
+      attention: tool.attention,
+      disabled: tool.disabledReason !== null,
+      disabledReason: tool.disabledReason,
+      x: cursor,
+      width,
+    };
+    cursor += width;
+    return tab;
+  });
+  const actions = [
+    {
+      id: "toggle-collapse" as const,
+      label: shell.bottomDock.mode === "collapsed" ? "Open" : "Collapse",
+      description:
+        shell.bottomDock.mode === "collapsed" ? "Open bottom dock" : "Collapse bottom dock",
+      nextMode: shell.bottomDock.mode === "collapsed" ? ("open" as const) : ("collapsed" as const),
+      active: shell.bottomDock.mode !== "collapsed",
+      x: viewport.width - 56,
+      width: 28,
+    },
+    {
+      id: "toggle-maximize" as const,
+      label: shell.bottomDock.mode === "maximized" ? "Restore" : "Maximize",
+      description:
+        shell.bottomDock.mode === "maximized" ? "Restore bottom dock" : "Maximize bottom dock",
+      nextMode: shell.bottomDock.mode === "maximized" ? ("open" as const) : ("maximized" as const),
+      active: shell.bottomDock.mode === "maximized",
+      x: viewport.width - 28,
+      width: 28,
+    },
+  ];
+  const bodyHeight = shell.bottomDock.mode === "collapsed" ? 0 : dockHeight - DOCK_STRIP_HEIGHT;
+
+  return {
+    variant,
+    dockMode: shell.bottomDock.mode,
+    focusZone:
+      shell.focus.zone === "dock-tabs" || shell.focus.zone === "dock-body"
+        ? shell.focus.zone
+        : "canvas",
+    activeDockTab: shell.bottomDock.activeTool,
+    dock: { x: metrics.sidebar, y: dockY, width: workspaceWidth, height: dockHeight },
+    dockTabs: {
+      x: metrics.sidebar,
+      y: dockY,
+      width: workspaceWidth,
+      height: DOCK_STRIP_HEIGHT,
+    },
+    dockBody: {
+      x: metrics.sidebar,
+      y: dockY + DOCK_STRIP_HEIGHT,
+      width: workspaceWidth,
+      height: bodyHeight,
+    },
+    dockBodyRail: {
+      x: metrics.sidebar,
+      y: dockY + DOCK_STRIP_HEIGHT,
+      width: DOCK_STRIP_HEIGHT,
+      height: bodyHeight,
+    },
+    dockBodyContent: {
+      x: metrics.sidebar + DOCK_STRIP_HEIGHT,
+      y: dockY + DOCK_STRIP_HEIGHT,
+      width: Math.max(0, workspaceWidth - DOCK_STRIP_HEIGHT),
+      height: bodyHeight,
+    },
+    tabs,
+    actions,
+  };
+}
+
+export function createDomPaletteEntries(
+  shell: ApplicationShellProjectionV1,
+): readonly DomPaletteEntry[] {
+  return [...shell.primaryNavigation.items, ...shell.bottomDock.tools]
+    .sort((left, right) =>
+      left.kind === right.kind ? left.order - right.order : left.kind === "primary-mode" ? -1 : 1,
+    )
+    .map((surface) => ({
+      id: surface.id,
+      icon: surface.icon,
+      label: surface.label,
+      shortcut: surface.shortcut,
+      current: surface.active,
+      disabledReason: surface.disabledReason,
+      commands: commandsToOpenSurface({ surface: surface.id }),
+    }));
+}
+
+export function invocationFromSurfaceCommand(
+  command: SurfaceCommandTemplate,
+  source: CommandSource,
+): ApplicationShellCommandInvocation {
+  switch (command.id) {
+    case APPLICATION_SHELL_COMMAND_IDS.activateMode:
+      return applicationShellCommandInvocation(command.id, command.args, source);
+    case APPLICATION_SHELL_COMMAND_IDS.activateDockTool:
+      return applicationShellCommandInvocation(command.id, command.args, source);
+    case APPLICATION_SHELL_COMMAND_IDS.setDockMode:
+      return applicationShellCommandInvocation(command.id, command.args, source);
+    case APPLICATION_SHELL_COMMAND_IDS.selectResource:
+      return applicationShellCommandInvocation(command.id, command.args, source);
+  }
+}
+
+export function dockToolIcon(shell: ApplicationShellProjectionV1, id: DockToolId): SemanticIconId {
+  return shell.bottomDock.tools.find((tool) => tool.id === id)!.icon;
+}

--- a/apps/desktop-renderer/src/experience/index.ts
+++ b/apps/desktop-renderer/src/experience/index.ts
@@ -1,2 +1,5 @@
 export * from "./dom-experience.ts";
 export * from "./dom-icons.ts";
+export * from "./dom-icon.tsx";
+export * from "./dom-shell.ts";
+export * from "./application-shell.tsx";

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -1,11 +1,5 @@
 :root {
-  font-family:
-    Inter,
-    ui-sans-serif,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    sans-serif;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
   color: CanvasText;
   background: Canvas;
   font-synthesis: none;
@@ -15,6 +9,7 @@
 * {
   box-sizing: border-box;
 }
+
 html,
 body,
 #root {
@@ -25,308 +20,886 @@ body,
   margin: 0;
   overflow: hidden;
 }
-button {
+
+button,
+input {
   font: inherit;
+}
+
+button:focus-visible,
+input:focus-visible,
+[tabindex]:focus-visible {
+  outline: var(--tmux-ide-focus-outline) solid var(--tmux-ide-border-focused);
+  outline-offset: calc(-1 * var(--tmux-ide-focus-outline-offset));
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .app {
   display: grid;
-  grid-template-rows: 42px 1fr 30px;
+  grid-template-rows: 28px minmax(0, 1fr) 18px;
   width: 100%;
   height: 100%;
+  overflow: hidden;
   color: var(--tmux-ide-text-primary);
-  background: radial-gradient(
-    circle at 45% -15%,
-    color-mix(in srgb, var(--tmux-ide-surface-header-active) 62%, var(--tmux-ide-surface-canvas)) 0,
-    var(--tmux-ide-surface-canvas) 36%
-  );
+  background: var(--tmux-ide-surface-canvas);
+  font-size: 12px;
+  line-height: 18px;
 }
 
 .titlebar {
+  -webkit-app-region: drag;
+  z-index: 10;
   display: flex;
+  min-width: 0;
+  height: 28px;
   align-items: stretch;
   border-bottom: 1px solid var(--tmux-ide-border-subtle);
-  background: color-mix(in srgb, var(--tmux-ide-surface-header) 92%, transparent);
+  background: var(--tmux-ide-surface-header);
   user-select: none;
 }
+
+.app[data-platform="darwin"] .titlebar {
+  padding-left: 78px;
+}
+
 .titlebar__drag {
   -webkit-app-region: drag;
+}
+
+.titlebar__brand {
   display: flex;
-  flex: 1;
+  flex: 0 0 168px;
+  min-width: 0;
   align-items: center;
-  gap: 10px;
-  padding: 0 16px 0 78px;
-  letter-spacing: -0.01em;
+  gap: 6px;
+  padding: 0 8px;
+  overflow: hidden;
+  color: var(--tmux-ide-text-secondary);
+  border-right: 1px solid var(--tmux-ide-border-subtle);
+  white-space: nowrap;
 }
-.brand-mark {
+
+.titlebar__brand svg {
+  flex: 0 0 auto;
   color: var(--tmux-ide-text-link);
-  font-size: 17px;
 }
-.titlebar__context {
+
+.titlebar__brand strong {
+  color: var(--tmux-ide-text-bright);
+}
+
+.titlebar__brand span {
+  overflow: hidden;
   color: var(--tmux-ide-text-muted);
-  font-size: 12px;
-  font-weight: 500;
+  text-overflow: ellipsis;
 }
+
+.primary-tabs {
+  -webkit-app-region: no-drag;
+  display: flex;
+  flex: 0 0 auto;
+}
+
+.primary-tabs button,
+.palette-trigger,
+.window-controls button {
+  border: 0;
+  border-radius: 0;
+  color: var(--tmux-ide-text-muted);
+  background: transparent;
+}
+
+.primary-tabs button {
+  display: inline-flex;
+  height: 28px;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  border-right: 1px solid var(--tmux-ide-border-subtle);
+  cursor: pointer;
+}
+
+.primary-tabs button > span {
+  color: var(--tmux-ide-text-muted);
+  font-size: 10px;
+}
+
+.primary-tabs button:hover,
+.primary-tabs__tab--active {
+  color: var(--tmux-ide-text-bright) !important;
+  background: var(--tmux-ide-surface-header-active) !important;
+}
+
+.primary-tabs button:disabled {
+  color: var(--tmux-ide-control-disabled-foreground);
+  background: var(--tmux-ide-control-disabled-background);
+  cursor: not-allowed;
+}
+
+.primary-tabs__tab--active {
+  box-shadow: inset 0 -2px 0 var(--tmux-ide-border-focused);
+}
+
+.titlebar__spacer {
+  flex: 1;
+  min-width: 10px;
+}
+
+.palette-trigger {
+  -webkit-app-region: no-drag;
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 28px;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  border-left: 1px solid var(--tmux-ide-border-subtle);
+  cursor: pointer;
+}
+
+.palette-trigger:hover {
+  color: var(--tmux-ide-text-bright);
+  background: var(--tmux-ide-selection-hover);
+}
+
+kbd {
+  color: var(--tmux-ide-text-muted);
+  font: inherit;
+}
+
 .window-controls {
   -webkit-app-region: no-drag;
   display: flex;
+  flex: 0 0 auto;
 }
+
 .window-controls button {
-  width: 46px;
-  border: 0;
-  color: var(--tmux-ide-text-secondary);
-  background: transparent;
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
   cursor: default;
   transition:
     color var(--tmux-ide-motion-fast) linear,
     background-color var(--tmux-ide-motion-fast) linear;
 }
+
 .window-controls button:hover {
   color: var(--tmux-ide-text-bright);
   background: var(--tmux-ide-selection-hover);
 }
+
 .window-controls button:last-child:hover {
   color: var(--tmux-ide-text-bright);
   background: var(--tmux-ide-status-danger);
 }
 
-.workbench {
+.shell-workbench {
   display: grid;
-  grid-template-columns: 170px minmax(420px, 1fr) 250px;
+  grid-template-columns: 168px minmax(0, 1fr);
+  min-width: 0;
   min-height: 0;
+  overflow: hidden;
 }
-.rail,
-.inspector {
-  background: color-mix(in srgb, var(--tmux-ide-surface-panel) 88%, transparent);
-}
-.rail {
-  padding: 14px 10px;
+
+.workspace-sidebar {
+  min-width: 0;
+  min-height: 0;
+  padding: 7px 6px;
+  overflow: hidden auto;
   border-right: 1px solid var(--tmux-ide-border-subtle);
+  background: var(--tmux-ide-surface-panel);
 }
-.rail__item {
+
+.workspace-sidebar__project {
   display: flex;
   align-items: center;
-  gap: 11px;
+  gap: 7px;
+  min-width: 0;
+  height: 38px;
+  margin-bottom: 6px;
+  padding: 4px;
+  border-bottom: 1px solid var(--tmux-ide-border-subtle);
+}
+
+.project-monogram {
+  display: grid;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  color: var(--tmux-ide-text-bright);
+  border: 1px solid var(--tmux-ide-border-default);
+  background: var(--tmux-ide-surface-panel-raised);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.workspace-sidebar__project > span:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  line-height: 14px;
+}
+
+.workspace-sidebar__project strong,
+.workspace-sidebar__project small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-sidebar__project small {
+  color: var(--tmux-ide-text-muted);
+  font-size: 10px;
+}
+
+.workspace-sidebar section {
+  margin: 0 0 12px;
+}
+
+.workspace-sidebar h2 {
+  display: flex;
+  justify-content: space-between;
+  margin: 0;
+  padding: 0 5px 3px;
+  color: var(--tmux-ide-text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 18px;
+  text-transform: uppercase;
+}
+
+.sidebar-row {
+  display: flex;
   width: 100%;
-  margin: 2px 0;
-  padding: 9px 10px;
+  min-width: 0;
+  height: 26px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 5px;
+  overflow: hidden;
   border: 0;
-  border-radius: 7px;
   color: var(--tmux-ide-text-muted);
   background: transparent;
   text-align: left;
-}
-.rail__item span {
-  width: 18px;
-  color: var(--tmux-ide-status-neutral);
-  text-align: center;
-}
-.rail__item--active {
-  color: var(--tmux-ide-text-bright);
-  background: var(--tmux-ide-selection-hover);
-}
-.rail__item--active span {
-  color: var(--tmux-ide-text-link);
+  white-space: nowrap;
+  cursor: pointer;
 }
 
-.canvas {
-  overflow: auto;
-  padding: clamp(40px, 7vw, 90px);
+.sidebar-row:hover,
+.sidebar-row--active {
+  color: var(--tmux-ide-text-primary);
+  background: var(--tmux-ide-selection-hover);
 }
-.canvas__eyebrow {
-  margin-bottom: 12px;
+
+.sidebar-row i,
+.status-strip i,
+.agent-pane header i {
+  display: inline-block;
+  flex: 0 0 6px;
+  width: 6px;
+  height: 6px;
+  border: 1px solid var(--tmux-ide-status-neutral);
+  border-radius: 50%;
+}
+
+[data-state="connected"],
+[data-state="complete"] {
+  border-color: var(--tmux-ide-status-success) !important;
+  background: var(--tmux-ide-status-success);
+}
+
+[data-state="running"] {
+  border-color: var(--tmux-ide-status-info) !important;
+  background: var(--tmux-ide-status-info);
+}
+
+[data-state="reconnecting"],
+[data-state="recovery"],
+[data-state="recovering"],
+[data-state="warning"] {
+  border-color: var(--tmux-ide-status-warning) !important;
+  background: var(--tmux-ide-status-warning);
+}
+
+.sidebar-row span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar-row b {
+  width: 5px;
+  height: 5px;
+  margin-left: auto;
+  border-radius: 50%;
+  background: var(--tmux-ide-border-attention);
+}
+
+.workspace-main {
+  display: grid;
+  grid-template-rows: minmax(216px, 7fr) minmax(180px, 3fr);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--tmux-ide-surface-canvas);
+}
+
+.workspace-main[data-dock-mode="collapsed"] {
+  grid-template-rows: minmax(0, 1fr) 28px;
+}
+
+.workspace-main[data-dock-mode="maximized"] {
+  grid-template-rows: 0 minmax(0, 1fr);
+}
+
+.workspace-canvas {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+}
+
+.workspace-canvas[hidden] {
+  display: none;
+}
+
+.home-canvas {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(260px, 0.7fr);
+  gap: 20px;
+  align-items: center;
+  padding: clamp(28px, 6vw, 72px);
+}
+
+.home-canvas__intro {
+  max-width: 620px;
+}
+
+.eyebrow {
   color: var(--tmux-ide-text-link);
-  font:
-    600 11px/1.2 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.11em;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
-h1 {
-  max-width: 760px;
-  margin: 0;
-  font-size: clamp(38px, 5vw, 70px);
-  line-height: 0.98;
-  letter-spacing: -0.055em;
+
+.home-canvas h1 {
+  margin: 5px 0 12px;
+  color: var(--tmux-ide-text-bright);
+  font-size: clamp(28px, 4vw, 52px);
+  line-height: 1;
+  letter-spacing: -0.05em;
 }
-.canvas__lead {
-  max-width: 660px;
-  margin: 26px 0 38px;
+
+.home-canvas p {
+  max-width: 540px;
   color: var(--tmux-ide-text-secondary);
-  font-size: 16px;
-  line-height: 1.65;
 }
-.cards {
-  display: grid;
-  grid-template-columns: minmax(220px, 0.8fr) minmax(300px, 1.2fr);
-  gap: 14px;
-  max-width: 880px;
-}
-.card {
-  position: relative;
-  min-height: 210px;
-  padding: 24px;
-  overflow: hidden;
-  border: 1px solid var(--tmux-ide-border-subtle);
-  border-radius: 12px;
-  background: linear-gradient(
-    145deg,
-    var(--tmux-ide-surface-panel-raised),
-    var(--tmux-ide-surface-panel)
-  );
-  box-shadow: var(--tmux-ide-elevation-floating-shadow);
-}
-.card__icon {
-  margin-bottom: 30px;
-  color: var(--tmux-ide-text-link);
-  font:
-    600 12px ui-monospace,
-    monospace;
-}
-.card h2 {
-  margin: 0 0 8px;
-  font-size: 18px;
-}
-.card p {
-  margin: 0 0 22px;
-  color: var(--tmux-ide-text-muted);
-  font-size: 13px;
-  line-height: 1.55;
-}
-.primary-action {
-  padding: 9px 13px;
+
+.home-canvas button {
+  height: 28px;
+  margin-top: 10px;
+  padding: 0 10px;
   border: 1px solid var(--tmux-ide-border-focused);
-  border-radius: 7px;
+  border-radius: var(--tmux-ide-shape-control);
   color: var(--tmux-ide-selection-selection-text);
   background: var(--tmux-ide-selection-selection);
 }
-.card--terminal {
+
+.readiness-card {
+  padding: 14px;
+  border: 1px solid var(--tmux-ide-border-subtle);
+  border-radius: var(--tmux-ide-shape-panel);
+  background: var(--tmux-ide-surface-panel);
+  box-shadow: var(--tmux-ide-elevation-floating-shadow);
+}
+
+.readiness-card header,
+.dock-surface__content > header,
+.canvas-toolbar {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+}
+
+.readiness-card h2 {
+  margin: 0;
+  font-size: 12px;
+}
+
+.readiness-card header span {
+  padding: 0 5px;
+  color: var(--tmux-ide-surface-canvas);
+  font-size: 9px;
+  line-height: 16px;
+  text-transform: uppercase;
+}
+
+.readiness-card p {
+  display: flex;
+  gap: 8px;
+  margin: 10px 0 0;
+  font-size: 11px;
+}
+
+.readiness-card p i {
+  width: 5px;
+  height: 5px;
+  margin-top: 6px;
+  border-radius: 50%;
+  background: var(--tmux-ide-status-success);
+}
+
+.readiness-card p.warning i {
+  background: var(--tmux-ide-status-warning);
+}
+
+.terminal-canvas {
+  padding: 8px;
+}
+
+.canvas-toolbar {
+  height: 27px;
+  padding: 0 4px 7px;
+  color: var(--tmux-ide-text-muted);
+}
+
+.canvas-toolbar strong {
+  color: var(--tmux-ide-text-primary);
+}
+
+.canvas-toolbar small {
+  color: var(--tmux-ide-status-success);
+}
+
+.agent-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(90px, 1fr));
+  gap: 6px;
+  height: calc(100% - 27px);
+}
+
+.agent-pane {
+  display: grid;
+  grid-template-rows: 24px minmax(0, 1fr) 18px;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--tmux-ide-border-default);
   background: var(--tmux-ide-surface-terminal);
 }
-.terminal-dots {
-  position: absolute;
-  top: 14px;
-  left: 16px;
-  display: flex;
-  gap: 6px;
-}
-.terminal-dots i {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--tmux-ide-border-default);
-}
-.card pre {
-  margin: 0;
-  color: var(--tmux-ide-text-secondary);
-  font:
-    13px/1.8 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-}
-.card pre span {
-  color: var(--tmux-ide-text-link);
-}
-.card pre b {
-  color: var(--tmux-ide-text-muted);
-  font-weight: 400;
+
+.agent-pane[data-state="running"] {
+  border-color: var(--tmux-ide-border-focused) !important;
 }
 
-.inspector {
-  padding: 18px;
-  border-left: 1px solid var(--tmux-ide-border-subtle);
-}
-.inspector h2 {
-  margin: 4px 0 20px;
-  font-size: 12px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-.inspector dl {
-  margin: 0;
-}
-.inspector dl div {
+.agent-pane > header,
+.agent-pane > footer {
   display: flex;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 9px 0;
-  border-bottom: 1px solid var(--tmux-ide-border-subtle);
-  font-size: 12px;
-}
-.inspector dt {
-  color: var(--tmux-ide-text-muted);
-}
-.inspector dd {
-  margin: 0;
-  color: var(--tmux-ide-text-primary);
-  text-align: right;
-}
-.boundary-note {
-  margin-top: 22px;
-  padding: 12px;
-  border: 1px solid var(--tmux-ide-status-info);
-  border-radius: 8px;
-  color: var(--tmux-ide-text-secondary);
-  background: color-mix(in srgb, var(--tmux-ide-surface-panel) 80%, var(--tmux-ide-status-info));
-  font-size: 11px;
-  line-height: 1.5;
-}
-.boundary-note span {
-  display: block;
-  margin-bottom: 4px;
-  color: var(--tmux-ide-text-link);
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.statusbar {
-  display: flex;
+  min-width: 0;
   align-items: center;
   justify-content: space-between;
-  padding: 0 10px;
+  padding: 0 7px;
+  overflow: hidden;
+  color: var(--tmux-ide-text-muted);
+  background: var(--tmux-ide-surface-header);
+  font-size: 10px;
+}
+
+.agent-pane > header > span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.agent-pane > footer {
+  border-top: 1px solid var(--tmux-ide-border-subtle);
+  white-space: nowrap;
+}
+
+.agent-pane__body {
+  padding: 9px;
+  overflow: auto;
+  color: var(--tmux-ide-text-secondary);
+}
+
+.agent-pane__body p {
+  margin: 7px 0;
+}
+
+.agent-prompt {
+  color: var(--tmux-ide-text-link);
+}
+
+.workspace-dock,
+.workspace-dock .workbench-dock {
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+}
+
+.app .workbench-dock__bar,
+.app .workbench-dock__tab,
+.app .workbench-dock__action {
+  height: 28px;
+  min-height: 28px;
+}
+
+.app .workbench-dock__tab {
+  gap: 6px;
+  padding: 0 8px;
+}
+
+.app .workbench-dock__glyph {
+  display: inline-flex;
+}
+
+.app .workbench-dock__action {
+  display: grid;
+  width: 28px;
+  min-width: 28px;
+  padding: 0;
+  place-items: center;
+}
+
+.dock-surface {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  min-width: 0;
+  min-height: 100%;
+}
+
+.dock-surface__rail {
+  display: flex;
+  justify-content: center;
+  padding-top: 9px;
+  color: var(--tmux-ide-text-link);
+  border-right: 1px solid var(--tmux-ide-border-subtle);
+  background: var(--tmux-ide-surface-header);
+}
+
+.dock-surface__content {
+  min-width: 0;
+  padding: 8px 10px;
+  overflow: auto;
+}
+
+.dock-surface__content > header {
+  height: 22px;
+  color: var(--tmux-ide-text-primary);
+  border-bottom: 1px solid var(--tmux-ide-border-subtle);
+}
+
+.dock-surface__content > header span,
+.surface-summary code {
+  color: var(--tmux-ide-text-muted);
+}
+
+.surface-summary,
+.mission-summary {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding-top: 10px;
+}
+
+.surface-summary code {
+  padding: 0 5px;
+  background: var(--tmux-ide-surface-command);
+}
+
+.mission-summary > div {
+  display: flex;
+  flex-direction: column;
+  margin-right: auto;
+}
+
+.mission-summary small {
+  color: var(--tmux-ide-status-info);
+  text-transform: uppercase;
+}
+
+.status-strip {
+  z-index: 10;
+  display: flex;
+  min-width: 0;
+  height: 18px;
+  align-items: center;
+  gap: 14px;
+  padding: 0 6px;
+  overflow: hidden;
   border-top: 1px solid var(--tmux-ide-border-subtle);
   color: var(--tmux-ide-text-muted);
   background: var(--tmux-ide-surface-header);
-  font:
-    11px ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-}
-.status-dot {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  margin-right: 6px;
-  border-radius: 50%;
-  background: var(--tmux-ide-status-success);
-  box-shadow: 0 0 8px color-mix(in srgb, var(--tmux-ide-status-success) 54%, transparent);
+  font-size: 10px;
+  line-height: 17px;
+  white-space: nowrap;
 }
 
-@media (max-width: 980px) {
-  .workbench {
-    grid-template-columns: 64px minmax(420px, 1fr);
+.status-strip__connection {
+  display: flex;
+  flex: 0 1 auto;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  color: var(--tmux-ide-text-secondary);
+}
+
+.status-strip__connection span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.status-strip__safe {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+}
+
+.status-strip__guidance {
+  flex: 0 0 auto;
+  color: var(--tmux-ide-text-link);
+  font-size: 10px;
+}
+
+.command-palette-overlay {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  padding-top: 54px;
+  visibility: hidden;
+  background: color-mix(in srgb, var(--tmux-ide-surface-canvas) 46%, transparent);
+}
+
+.command-palette-overlay--open {
+  visibility: visible;
+}
+
+.command-palette {
+  width: min(624px, 64vw, calc(100vw - 80px));
+  max-height: 360px;
+  align-self: flex-start;
+  overflow: hidden;
+  border: 1px solid var(--tmux-ide-border-default);
+  border-radius: var(--tmux-ide-shape-floating);
+  background: var(--tmux-ide-surface-command);
+  box-shadow: var(--tmux-ide-elevation-palette-shadow);
+}
+
+.command-palette__query {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  height: 46px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 14px;
+}
+
+.command-palette__query svg {
+  color: var(--tmux-ide-text-link);
+}
+
+.command-palette__query input {
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  color: var(--tmux-ide-text-bright);
+  background: transparent;
+}
+
+.command-palette__query input::placeholder {
+  color: var(--tmux-ide-text-muted);
+}
+
+.command-palette__query kbd,
+.command-palette__option kbd {
+  padding: 0 5px;
+  border: 1px solid var(--tmux-ide-border-subtle);
+  border-radius: var(--tmux-ide-shape-control);
+  background: var(--tmux-ide-surface-panel);
+  font-size: 10px;
+}
+
+.command-palette__rule {
+  height: 1px;
+  margin: 0 14px 8px;
+  background: var(--tmux-ide-border-subtle);
+}
+
+.command-palette__list {
+  max-height: 258px;
+  padding: 0 8px 8px;
+  overflow: auto;
+}
+
+.command-palette__option {
+  display: grid;
+  grid-template-columns: 18px minmax(110px, 1fr) auto auto;
+  min-height: 34px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 7px;
+  color: var(--tmux-ide-text-secondary);
+  cursor: default;
+}
+
+.command-palette__option--selected:not([aria-disabled="true"]),
+.command-palette__option--hovered:not([aria-disabled="true"]) {
+  color: var(--tmux-ide-selection-selection-text);
+  background: var(--tmux-ide-selection-selection);
+}
+
+.command-palette__option[aria-disabled="true"] {
+  color: var(--tmux-ide-control-disabled-foreground);
+}
+
+.command-palette__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-palette__current {
+  color: var(--tmux-ide-status-success);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.command-palette__reason {
+  max-width: 190px;
+  overflow: hidden;
+  color: var(--tmux-ide-text-muted);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-palette__empty {
+  margin: 24px;
+  color: var(--tmux-ide-text-muted);
+  text-align: center;
+}
+
+.command-palette__footer {
+  display: flex;
+  height: 27px;
+  align-items: center;
+  gap: 14px;
+  padding: 0 14px;
+  border-top: 1px solid var(--tmux-ide-border-subtle);
+  color: var(--tmux-ide-text-muted);
+  background: var(--tmux-ide-surface-panel);
+  font-size: 10px;
+}
+
+@media (min-width: 1440px) {
+  .titlebar__brand {
+    flex-basis: 184px;
   }
-  .rail__item {
+
+  .shell-workbench {
+    grid-template-columns: 184px minmax(0, 1fr);
+  }
+
+  .workspace-main {
+    grid-template-rows: minmax(288px, 7fr) minmax(252px, 3fr);
+  }
+}
+
+@media (max-width: 999px) {
+  .titlebar__brand {
+    flex-basis: 48px;
     justify-content: center;
+    padding: 0;
   }
-  .rail__item:not(.rail__item--active) {
-    color: transparent;
-    font-size: 0;
-  }
-  .rail__item--active {
-    font-size: 0;
-  }
-  .rail__item span {
-    font-size: 16px;
-  }
-  .inspector {
+
+  .titlebar__brand strong,
+  .titlebar__brand span {
     display: none;
+  }
+
+  .shell-workbench {
+    grid-template-columns: 48px minmax(0, 1fr);
+  }
+
+  .workspace-sidebar {
+    padding-inline: 5px;
+  }
+
+  .workspace-sidebar__project {
+    justify-content: center;
+    padding: 4px 0;
+  }
+
+  .workspace-sidebar__project > span:last-child,
+  .workspace-sidebar h2,
+  .sidebar-row span,
+  .sidebar-row b {
+    display: none;
+  }
+
+  .sidebar-row {
+    justify-content: center;
+    padding: 0;
+  }
+
+  .workspace-main {
+    grid-template-rows: minmax(144px, 7fr) minmax(126px, 3fr);
+  }
+
+  .home-canvas {
+    grid-template-columns: 1fr;
+  }
+
+  .readiness-card {
+    display: none;
+  }
+
+  .app .workbench-dock__shortcut {
+    display: none;
+  }
+
+  .status-strip {
+    gap: 8px;
+  }
+
+  .status-strip__connection {
+    flex: 1 1 auto;
+  }
+
+  .status-strip__safe {
+    display: none;
+  }
+
+  .status-strip__guidance {
+    flex: 0 1 184px;
+    max-width: 184px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+@media (width: 720px) and (height: 480px) {
+  .command-palette {
+    width: 456px;
   }
 }
 
@@ -335,8 +908,8 @@ h1 {
   *::before,
   *::after {
     scroll-behavior: auto !important;
-    transition: none !important;
-    animation: none !important;
+    transition-duration: 0ms !important;
+    animation-duration: 0ms !important;
   }
 }
 
@@ -344,6 +917,6 @@ h1 {
 .app[data-reduced-motion="true"] *::before,
 .app[data-reduced-motion="true"] *::after {
   scroll-behavior: auto !important;
-  transition: none !important;
-  animation: none !important;
+  transition-duration: 0ms !important;
+  animation-duration: 0ms !important;
 }

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -525,10 +525,6 @@ kbd {
   background: var(--tmux-ide-surface-terminal);
 }
 
-.agent-pane[data-state="running"] {
-  border-color: var(--tmux-ide-border-focused) !important;
-}
-
 .agent-pane > header,
 .agent-pane > footer {
   display: flex;

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -104,6 +104,19 @@ input:focus-visible,
   text-overflow: ellipsis;
 }
 
+.titlebar__preview-badge {
+  align-self: center;
+  margin-left: 8px;
+  padding: 0 5px;
+  border: 1px solid var(--tmux-ide-border-attention);
+  border-radius: var(--tmux-ide-shape-status-radius);
+  color: var(--tmux-ide-status-warning);
+  font-size: 9px;
+  line-height: 16px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 .primary-tabs {
   -webkit-app-region: no-drag;
   display: flex;
@@ -315,21 +328,32 @@ kbd {
   border-radius: 50%;
 }
 
-[data-state="connected"],
-[data-state="complete"] {
+.sidebar-row i[data-state="connected"],
+.sidebar-row i[data-state="complete"],
+.status-strip__connection[data-state="connected"] > i,
+.agent-pane[data-state="complete"] header i {
   border-color: var(--tmux-ide-status-success) !important;
   background: var(--tmux-ide-status-success);
 }
 
-[data-state="running"] {
+.sidebar-row i[data-state="running"],
+.status-strip__connection[data-state="running"] > i,
+.agent-pane[data-state="running"] header i {
   border-color: var(--tmux-ide-status-info) !important;
   background: var(--tmux-ide-status-info);
 }
 
-[data-state="reconnecting"],
-[data-state="recovery"],
-[data-state="recovering"],
-[data-state="warning"] {
+.sidebar-row i[data-state="reconnecting"],
+.sidebar-row i[data-state="recovery"],
+.sidebar-row i[data-state="recovering"],
+.sidebar-row i[data-state="warning"],
+.status-strip__connection[data-state="reconnecting"] > i,
+.status-strip__connection[data-state="recovery"] > i,
+.status-strip__connection[data-state="recovering"] > i,
+.status-strip__connection[data-state="warning"] > i,
+.status-strip__connection[data-state="disconnected"] > i,
+.agent-pane[data-state="recovery"] header i,
+.readiness-card header span[data-state="warning"] {
   border-color: var(--tmux-ide-status-warning) !important;
   background: var(--tmux-ide-status-warning);
 }

--- a/packages/daemon/src/tui/mirror/workspace/workbench-dock-opentui.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/workbench-dock-opentui.tsx
@@ -55,7 +55,7 @@ export function createOpenTuiWorkbenchDockHost(
           height={1}
           backgroundColor={palette().background}
           overflow="hidden"
-          onMouseDown={props.onActivate ? () => props.onActivate?.() : undefined}
+          onMouseDown={props.onActivate ? () => props.onActivate?.("mouse") : undefined}
         >
           <text fg={palette().foreground} attributes={props.tab.focused ? 1 : 0}>
             {props.tab.label}
@@ -86,7 +86,7 @@ export function createOpenTuiWorkbenchDockHost(
           height={1}
           backgroundColor={palette().background}
           overflow="hidden"
-          onMouseDown={props.onActivate ? () => props.onActivate?.() : undefined}
+          onMouseDown={props.onActivate ? () => props.onActivate?.("mouse") : undefined}
         >
           <text fg={palette().foreground}>{props.action.label}</text>
         </box>

--- a/packages/daemon/src/ui/workbench-dock/presenter.tsx
+++ b/packages/daemon/src/ui/workbench-dock/presenter.tsx
@@ -5,6 +5,7 @@ export type WorkbenchDockHostTabId = WorkbenchDockNavigationTabId;
 export type WorkbenchDockHostActionId = "toggle-collapse" | "toggle-maximize";
 export type WorkbenchDockHostMode = "collapsed" | "open" | "maximized";
 export type WorkbenchDockHostVariant = "compact" | "standard" | "wide";
+export type WorkbenchDockHostActivationSource = "keyboard" | "mouse";
 
 export const WORKBENCH_DOCK_HOST_TAB_ORDER = Object.freeze([
   "files",
@@ -86,7 +87,8 @@ export type WorkbenchDockTabListLeafProps = ParentProps<{
 
 export interface WorkbenchDockTabLeafProps {
   tab: WorkbenchDockHostTab;
-  onActivate?: () => void;
+  tabStop: boolean;
+  onActivate?: (source: WorkbenchDockHostActivationSource) => void;
 }
 
 export interface WorkbenchDockActionListLeafProps {
@@ -96,7 +98,7 @@ export interface WorkbenchDockActionListLeafProps {
 export interface WorkbenchDockActionLeafProps {
   action: WorkbenchDockHostAction;
   activeTabId: WorkbenchDockHostTabId;
-  onActivate?: () => void;
+  onActivate?: (source: WorkbenchDockHostActivationSource) => void;
 }
 
 export type WorkbenchDockBodyLeafProps = ParentProps<{
@@ -122,8 +124,15 @@ export interface WorkbenchDockPresenterProps {
   projection: WorkbenchDockHostProjection;
   host: WorkbenchDockHostLeaves;
   body?: JSX.Element;
-  onTabActivate?: (tabId: WorkbenchDockHostTabId) => void;
-  onActionActivate?: (actionId: WorkbenchDockHostActionId, nextMode: WorkbenchDockHostMode) => void;
+  onTabActivate?: (
+    tabId: WorkbenchDockHostTabId,
+    source: WorkbenchDockHostActivationSource,
+  ) => void;
+  onActionActivate?: (
+    actionId: WorkbenchDockHostActionId,
+    nextMode: WorkbenchDockHostMode,
+    source: WorkbenchDockHostActivationSource,
+  ) => void;
 }
 
 /** Positional host leaves are safe only while the canonical fixed order holds. */
@@ -163,6 +172,9 @@ export function WorkbenchDockPresenter(props: WorkbenchDockPresenterProps) {
     assertWorkbenchDockHostOrder(props.projection);
     return props.projection;
   };
+  const tabStopId = (): WorkbenchDockHostTabId | undefined =>
+    projection().tabs.find((tab) => tab.selected && !tab.disabled)?.id ??
+    projection().tabs.find((tab) => !tab.disabled)?.id;
 
   return (
     <Root projection={projection()}>
@@ -182,7 +194,10 @@ export function WorkbenchDockPresenter(props: WorkbenchDockPresenterProps) {
             {(tab) => (
               <Tab
                 tab={tab()}
-                onActivate={tab().disabled ? undefined : () => props.onTabActivate?.(tab().id)}
+                tabStop={tab().id === tabStopId()}
+                onActivate={
+                  tab().disabled ? undefined : (source) => props.onTabActivate?.(tab().id, source)
+                }
               />
             )}
           </Index>
@@ -193,7 +208,9 @@ export function WorkbenchDockPresenter(props: WorkbenchDockPresenterProps) {
               <Action
                 action={action()}
                 activeTabId={projection().activeDockTab}
-                onActivate={() => props.onActionActivate?.(action().id, action().nextMode)}
+                onActivate={(source) =>
+                  props.onActionActivate?.(action().id, action().nextMode, source)
+                }
               />
             )}
           </Index>

--- a/packages/daemon/src/ui/workbench-dock/presenter.tsx
+++ b/packages/daemon/src/ui/workbench-dock/presenter.tsx
@@ -1,10 +1,22 @@
-import { For, Show, type Component, type JSX, type ParentProps } from "solid-js";
+import { Index, Show, type Component, type JSX, type ParentProps } from "solid-js";
 import type { WorkbenchDockNavigationTabId } from "./navigation.js";
 
 export type WorkbenchDockHostTabId = WorkbenchDockNavigationTabId;
 export type WorkbenchDockHostActionId = "toggle-collapse" | "toggle-maximize";
 export type WorkbenchDockHostMode = "collapsed" | "open" | "maximized";
 export type WorkbenchDockHostVariant = "compact" | "standard" | "wide";
+
+export const WORKBENCH_DOCK_HOST_TAB_ORDER = Object.freeze([
+  "files",
+  "changes",
+  "missions",
+  "activity",
+] as const satisfies readonly WorkbenchDockHostTabId[]);
+
+export const WORKBENCH_DOCK_HOST_ACTION_ORDER = Object.freeze([
+  "toggle-collapse",
+  "toggle-maximize",
+] as const satisfies readonly WorkbenchDockHostActionId[]);
 
 export interface WorkbenchDockHostRect {
   readonly x: number;
@@ -23,6 +35,8 @@ export interface WorkbenchDockHostTab {
   readonly hovered: boolean;
   readonly attention: boolean;
   readonly disabled: boolean;
+  /** Host-visible explanation for an unavailable canonical surface. */
+  readonly disabledReason?: string | null;
   readonly x: number;
   readonly width: number;
 }
@@ -112,6 +126,24 @@ export interface WorkbenchDockPresenterProps {
   onActionActivate?: (actionId: WorkbenchDockHostActionId, nextMode: WorkbenchDockHostMode) => void;
 }
 
+/** Positional host leaves are safe only while the canonical fixed order holds. */
+export function assertWorkbenchDockHostOrder(projection: WorkbenchDockHostProjection): void {
+  const tabOrder = projection.tabs.map(({ id }) => id);
+  const actionOrder = projection.actions.map(({ id }) => id);
+  if (
+    tabOrder.length !== WORKBENCH_DOCK_HOST_TAB_ORDER.length ||
+    tabOrder.some((id, index) => id !== WORKBENCH_DOCK_HOST_TAB_ORDER[index])
+  ) {
+    throw new Error(`workbench dock tab order changed: ${tabOrder.join(",")}`);
+  }
+  if (
+    actionOrder.length !== WORKBENCH_DOCK_HOST_ACTION_ORDER.length ||
+    actionOrder.some((id, index) => id !== WORKBENCH_DOCK_HOST_ACTION_ORDER[index])
+  ) {
+    throw new Error(`workbench dock action order changed: ${actionOrder.join(",")}`);
+  }
+}
+
 /**
  * Shared Solid control flow for the current production bottom dock.
  *
@@ -127,50 +159,60 @@ export function WorkbenchDockPresenter(props: WorkbenchDockPresenterProps) {
   const ActionList = props.host.ActionList;
   const Action = props.host.Action;
   const Body = props.host.Body;
+  const projection = (): WorkbenchDockHostProjection => {
+    assertWorkbenchDockHostOrder(props.projection);
+    return props.projection;
+  };
 
   return (
-    <Root projection={props.projection}>
-      <TabBar projection={props.projection}>
+    <Root projection={projection()}>
+      <TabBar projection={projection()}>
         <TabList
-          activeTabId={props.projection.activeDockTab}
-          tabs={props.projection.tabs}
-          focused={props.projection.focusZone === "dock-tabs"}
+          activeTabId={projection().activeDockTab}
+          tabs={projection().tabs}
+          focused={projection().focusZone === "dock-tabs"}
         >
-          <For each={props.projection.tabs}>
+          {/*
+           * Contract projections are immutable and therefore refresh with new
+           * object identities. Reference-keyed For remounted focused DOM tabs
+           * (and produced OpenTUI anchor churn) on every semantic command.
+           * Index preserves the host leaf at each asserted canonical slot.
+           */}
+          <Index each={projection().tabs}>
             {(tab) => (
               <Tab
-                tab={tab}
-                onActivate={tab.disabled ? undefined : () => props.onTabActivate?.(tab.id)}
+                tab={tab()}
+                onActivate={tab().disabled ? undefined : () => props.onTabActivate?.(tab().id)}
               />
             )}
-          </For>
+          </Index>
         </TabList>
         <ActionList>
-          <For each={props.projection.actions}>
+          <Index each={projection().actions}>
             {(action) => (
               <Action
-                action={action}
-                activeTabId={props.projection.activeDockTab}
-                onActivate={() => props.onActionActivate?.(action.id, action.nextMode)}
+                action={action()}
+                activeTabId={projection().activeDockTab}
+                onActivate={() => props.onActionActivate?.(action().id, action().nextMode)}
               />
             )}
-          </For>
+          </Index>
         </ActionList>
       </TabBar>
 
-      <For each={props.projection.tabs}>
+      <Index each={projection().tabs}>
         {(tab) => (
           <Body
-            projection={props.projection}
-            tabId={tab.id}
-            active={tab.selected}
-            visible={tab.selected && props.projection.dockBody.height > 0}
-            focused={tab.selected && props.projection.focusZone === "dock-body"}
+            projection={projection()}
+            tabId={tab().id}
+            active={tab().selected}
+            visible={tab().selected && projection().dockBody.height > 0}
+            focused={tab().selected && projection().focusZone === "dock-body"}
           >
-            <Show when={tab.selected}>{props.body}</Show>
+            <Show when={tab().selected}>{props.body}</Show>
           </Body>
         )}
-      </For>
+      </Index>
     </Root>
   );
 }

--- a/packages/daemon/src/ui/workbench-dock/web-host.test.tsx
+++ b/packages/daemon/src/ui/workbench-dock/web-host.test.tsx
@@ -74,6 +74,10 @@ function action(root: HTMLElement, id: string): HTMLButtonElement {
   return root.querySelector<HTMLButtonElement>(`[data-action="${id}"]`)!;
 }
 
+function pointerClick(element: Element): void {
+  element.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+}
+
 describe("shared WorkbenchDockPresenter DOM host", () => {
   it("renders semantic state and records the same activation trace as OpenTUI", () => {
     const { root, trace } = renderDock();
@@ -140,6 +144,76 @@ describe("shared WorkbenchDockPresenter DOM host", () => {
       "tab:activity",
       "tab:files",
     ]);
+  });
+
+  it("preserves exact mouse and keyboard sources across semantic tab and action activation", () => {
+    const calls: string[] = [];
+    const root = document.createElement("div");
+    installCanonicalFixtureVariables(root);
+    document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <WebWorkbenchDock
+            projection={createWorkbenchDockHostFixture()}
+            onTabActivate={(tabId, source) => calls.push(`tab:${tabId}:${source}`)}
+            onActionActivate={(actionId, nextMode, source) =>
+              calls.push(`action:${actionId}:${nextMode}:${source}`)
+            }
+          />
+        ),
+        root,
+      ),
+    );
+
+    pointerClick(tab(root, "files"));
+    tab(root, "missions").focus();
+    for (const key of ["ArrowLeft", "ArrowRight", "End", "Home", "Enter", " "]) {
+      (document.activeElement as HTMLButtonElement).dispatchEvent(
+        new KeyboardEvent("keydown", { key, bubbles: true }),
+      );
+    }
+    pointerClick(action(root, "toggle-collapse"));
+    action(root, "toggle-maximize").click();
+
+    expect(calls).toEqual([
+      "tab:files:mouse",
+      "tab:files:keyboard",
+      "tab:missions:keyboard",
+      "tab:activity:keyboard",
+      "tab:files:keyboard",
+      "tab:files:keyboard",
+      "tab:files:keyboard",
+      "action:toggle-collapse:collapsed:mouse",
+      "action:toggle-maximize:maximized:keyboard",
+    ]);
+  });
+
+  it("reactively falls back to the first enabled tab stop when the selected tab is disabled", () => {
+    const [projection, setProjection] = createSignal(createWorkbenchDockHostFixture());
+    const root = document.createElement("div");
+    installCanonicalFixtureVariables(root);
+    document.body.append(root);
+    disposers.push(render(() => <WebWorkbenchDock projection={projection()} />, root));
+
+    expect(tab(root, "missions").tabIndex).toBe(0);
+    const fresh = createWorkbenchDockHostFixture();
+    setProjection({
+      ...fresh,
+      tabs: fresh.tabs.map((candidate) =>
+        candidate.id === "missions"
+          ? { ...candidate, selected: true, disabled: true, disabledReason: "Unavailable" }
+          : candidate.id === "changes"
+            ? { ...candidate, selected: false, disabled: true }
+            : { ...candidate, selected: false },
+      ),
+    });
+
+    const tabStops = [...root.querySelectorAll<HTMLButtonElement>('[role="tab"]')].filter(
+      (candidate) => candidate.tabIndex === 0,
+    );
+    expect(tab(root, "missions").disabled).toBe(true);
+    expect(tabStops.map((candidate) => candidate.dataset.tabId)).toEqual(["files"]);
   });
 
   it("preserves host leaf identity across fresh immutable projections", () => {

--- a/packages/daemon/src/ui/workbench-dock/web-host.test.tsx
+++ b/packages/daemon/src/ui/workbench-dock/web-host.test.tsx
@@ -1,6 +1,7 @@
 /* @vitest-environment happy-dom */
 import { afterEach, describe, expect, it } from "vitest";
 import { render } from "solid-js/web";
+import { createSignal } from "solid-js";
 import { COHESION_FIXTURE_V1 } from "@tmux-ide/contracts";
 import {
   DOM_EXPERIENCE_VARIABLE,
@@ -14,6 +15,7 @@ import {
   EXPECTED_WORKBENCH_DOCK_KEYBOARD_TRACE,
 } from "./fixture.ts";
 import { WebWorkbenchDock } from "./web-host.tsx";
+import { assertWorkbenchDockHostOrder } from "./presenter.tsx";
 
 const disposers: Array<() => void> = [];
 
@@ -138,6 +140,50 @@ describe("shared WorkbenchDockPresenter DOM host", () => {
       "tab:activity",
       "tab:files",
     ]);
+  });
+
+  it("preserves host leaf identity across fresh immutable projections", () => {
+    const [projection, setProjection] = createSignal(createWorkbenchDockHostFixture());
+    const root = document.createElement("div");
+    installCanonicalFixtureVariables(root);
+    document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <WebWorkbenchDock projection={projection()}>
+            <p>stable body</p>
+          </WebWorkbenchDock>
+        ),
+        root,
+      ),
+    );
+    const filesTab = tab(root, "files");
+    const collapseAction = action(root, "toggle-collapse");
+    const filesPanel = root.querySelector("#workbench-dock-panel-files");
+
+    setProjection(
+      createWorkbenchDockHostFixture({
+        dockMode: "maximized",
+        activeDockTab: "files",
+        focusZone: "dock-body",
+      }),
+    );
+
+    expect(tab(root, "files")).toBe(filesTab);
+    expect(action(root, "toggle-collapse")).toBe(collapseAction);
+    expect(root.querySelector("#workbench-dock-panel-files")).toBe(filesPanel);
+    expect(filesTab.getAttribute("aria-selected")).toBe("true");
+    expect(root.querySelector(".workbench-dock")?.getAttribute("data-mode")).toBe("maximized");
+  });
+
+  it("rejects reordered positional host leaves before rendering the wrong semantics", () => {
+    const fixture = createWorkbenchDockHostFixture();
+    expect(() =>
+      assertWorkbenchDockHostOrder({ ...fixture, tabs: [...fixture.tabs].reverse() }),
+    ).toThrowError("workbench dock tab order changed: activity,missions,changes,files");
+    expect(() =>
+      assertWorkbenchDockHostOrder({ ...fixture, actions: [...fixture.actions].reverse() }),
+    ).toThrowError("workbench dock action order changed: toggle-maximize,toggle-collapse");
   });
 
   it("computes selected, focused, attention, and disabled styles from canonical variables", () => {

--- a/packages/daemon/src/ui/workbench-dock/web-host.tsx
+++ b/packages/daemon/src/ui/workbench-dock/web-host.tsx
@@ -1,4 +1,4 @@
-import { type JSX, type ParentProps } from "solid-js";
+import { createContext, type JSX, type ParentProps, useContext } from "solid-js";
 import {
   WorkbenchDockPresenter,
   type WorkbenchDockHostLeaves,
@@ -21,18 +21,31 @@ export type WebWorkbenchDockProps = ParentProps<{
   projection: WorkbenchDockHostProjection;
   onTabActivate?: (tabId: WorkbenchDockHostTabId) => void;
   onActionActivate?: (actionId: WorkbenchDockHostActionId, nextMode: WorkbenchDockHostMode) => void;
+  renderTabIcon?: (tab: WorkbenchDockHostProjection["tabs"][number]) => JSX.Element;
+  renderActionIcon?: (action: WorkbenchDockHostProjection["actions"][number]) => JSX.Element;
 }>;
+
+interface WebWorkbenchDockRenderers {
+  readonly tabIcon?: WebWorkbenchDockProps["renderTabIcon"];
+  readonly actionIcon?: WebWorkbenchDockProps["renderActionIcon"];
+}
+
+const WebWorkbenchDockRenderContext = createContext<WebWorkbenchDockRenderers>({});
 
 /** Standard Solid DOM host for the shared production dock presenter. */
 export function WebWorkbenchDock(props: WebWorkbenchDockProps) {
   return (
-    <WorkbenchDockPresenter
-      host={WEB_WORKBENCH_DOCK_HOST}
-      projection={props.projection}
-      body={props.children}
-      onTabActivate={props.onTabActivate}
-      onActionActivate={props.onActionActivate}
-    />
+    <WebWorkbenchDockRenderContext.Provider
+      value={{ tabIcon: props.renderTabIcon, actionIcon: props.renderActionIcon }}
+    >
+      <WorkbenchDockPresenter
+        host={WEB_WORKBENCH_DOCK_HOST}
+        projection={props.projection}
+        body={props.children}
+        onTabActivate={props.onTabActivate}
+        onActionActivate={props.onActionActivate}
+      />
+    </WebWorkbenchDockRenderContext.Provider>
   );
 }
 
@@ -97,8 +110,11 @@ export const WEB_WORKBENCH_DOCK_HOST: WorkbenchDockHostLeaves = {
     );
   },
   Tab(props) {
+    const renderers = useContext(WebWorkbenchDockRenderContext);
     const accessibleLabel = () =>
-      props.tab.attention ? `${props.tab.title}, needs attention` : props.tab.title;
+      [props.tab.title, props.tab.attention ? "needs attention" : null, props.tab.disabledReason]
+        .filter(Boolean)
+        .join(", ");
     return (
       <button
         class="workbench-dock__tab"
@@ -112,7 +128,7 @@ export const WEB_WORKBENCH_DOCK_HOST: WorkbenchDockHostLeaves = {
         aria-disabled={props.tab.disabled}
         disabled={props.tab.disabled}
         tabIndex={props.tab.selected && !props.tab.disabled ? 0 : -1}
-        title={`${props.tab.title}${props.tab.shortcut ? ` (${props.tab.shortcut})` : ""}`}
+        title={`${props.tab.title}${props.tab.shortcut ? ` (${props.tab.shortcut})` : ""}${props.tab.disabledReason ? ` — ${props.tab.disabledReason}` : ""}`}
         data-attention={props.tab.attention ? "true" : "false"}
         data-focused={props.tab.focused ? "true" : "false"}
         data-hovered={props.tab.hovered ? "true" : "false"}
@@ -122,7 +138,7 @@ export const WEB_WORKBENCH_DOCK_HOST: WorkbenchDockHostLeaves = {
           {props.tab.shortcut}
         </span>
         <span class="workbench-dock__glyph" aria-hidden="true">
-          {TAB_GLYPHS[props.tab.id]}
+          {renderers.tabIcon?.(props.tab) ?? TAB_GLYPHS[props.tab.id]}
         </span>
         <span class="workbench-dock__title">{props.tab.title}</span>
         <span class="workbench-dock__attention" aria-hidden="true">
@@ -139,6 +155,7 @@ export const WEB_WORKBENCH_DOCK_HOST: WorkbenchDockHostLeaves = {
     );
   },
   Action(props) {
+    const renderers = useContext(WebWorkbenchDockRenderContext);
     const collapse = () => props.action.id === "toggle-collapse";
     return (
       <button
@@ -152,7 +169,7 @@ export const WEB_WORKBENCH_DOCK_HOST: WorkbenchDockHostLeaves = {
         title={props.action.description}
         onClick={() => props.onActivate?.()}
       >
-        {props.action.label.trim()}
+        {renderers.actionIcon?.(props.action) ?? props.action.label.trim()}
       </button>
     );
   },

--- a/packages/daemon/src/ui/workbench-dock/web-host.tsx
+++ b/packages/daemon/src/ui/workbench-dock/web-host.tsx
@@ -5,6 +5,7 @@ import {
   type WorkbenchDockHostProjection,
   type WorkbenchDockHostTabId,
   type WorkbenchDockHostActionId,
+  type WorkbenchDockHostActivationSource,
   type WorkbenchDockHostMode,
 } from "./presenter.js";
 import { workbenchDockNavigationTarget } from "./navigation.js";
@@ -19,8 +20,15 @@ const TAB_GLYPHS: Readonly<Record<WorkbenchDockHostTabId, string>> = {
 
 export type WebWorkbenchDockProps = ParentProps<{
   projection: WorkbenchDockHostProjection;
-  onTabActivate?: (tabId: WorkbenchDockHostTabId) => void;
-  onActionActivate?: (actionId: WorkbenchDockHostActionId, nextMode: WorkbenchDockHostMode) => void;
+  onTabActivate?: (
+    tabId: WorkbenchDockHostTabId,
+    source: WorkbenchDockHostActivationSource,
+  ) => void;
+  onActionActivate?: (
+    actionId: WorkbenchDockHostActionId,
+    nextMode: WorkbenchDockHostMode,
+    source: WorkbenchDockHostActivationSource,
+  ) => void;
   renderTabIcon?: (tab: WorkbenchDockHostProjection["tabs"][number]) => JSX.Element;
   renderActionIcon?: (action: WorkbenchDockHostProjection["actions"][number]) => JSX.Element;
 }>;
@@ -127,12 +135,12 @@ export const WEB_WORKBENCH_DOCK_HOST: WorkbenchDockHostLeaves = {
         aria-selected={props.tab.selected}
         aria-disabled={props.tab.disabled}
         disabled={props.tab.disabled}
-        tabIndex={props.tab.selected && !props.tab.disabled ? 0 : -1}
+        tabIndex={props.tabStop ? 0 : -1}
         title={`${props.tab.title}${props.tab.shortcut ? ` (${props.tab.shortcut})` : ""}${props.tab.disabledReason ? ` — ${props.tab.disabledReason}` : ""}`}
         data-attention={props.tab.attention ? "true" : "false"}
         data-focused={props.tab.focused ? "true" : "false"}
         data-hovered={props.tab.hovered ? "true" : "false"}
-        onClick={() => props.onActivate?.()}
+        onClick={(event) => props.onActivate?.(event.detail === 0 ? "keyboard" : "mouse")}
       >
         <span class="workbench-dock__shortcut" aria-hidden="true">
           {props.tab.shortcut}
@@ -167,7 +175,7 @@ export const WEB_WORKBENCH_DOCK_HOST: WorkbenchDockHostLeaves = {
         aria-pressed={collapse() ? undefined : props.action.active}
         data-action={props.action.id}
         title={props.action.description}
-        onClick={() => props.onActivate?.()}
+        onClick={(event) => props.onActivate?.(event.detail === 0 ? "keyboard" : "mouse")}
       >
         {renderers.actionIcon?.(props.action) ?? props.action.label.trim()}
       </button>


### PR DESCRIPTION
## Summary

- replace the temporary desktop dashboard with the canonical Solid application shell
- keep Home and Terminals as primary modes, with Files, Changes, Missions, and Activity in the responsive bottom dock
- add an instant accessible command palette, native window controls, session/agent sidebar, honest preview state, and status/recovery strip
- reconcile fresh immutable daemon snapshots without remounting stable host leaves
- preserve exact keyboard/mouse command provenance and accessible disabled/selection state

## Review repairs

- made runtime input reactive with explicit same-workspace preservation and identity-change reset rules
- marked fallback fixture data as preview-only and removed false live-process claims
- fixed dock roving focus when the selected tool becomes disabled
- made sidebar session/agent selection visible and accessible
- scoped activity/recovery colors to indicators instead of pane/status surfaces
- fixed palette-trigger keyboard provenance and compact 720px session naming
- preserved stable shared dock leaf identity and canonical fixed order

## Verification

- desktop renderer: 27 tests
- daemon: 2,244 tests
- OpenTUI renderer: 89 tests / 62 snapshots
- Electron: 21 tests plus production smoke
- desktop and daemon typechecks/lint
- desktop production build
- shared dock web build and packed-consumer check
- manual captures at 720x480 and 1280x820; earlier qualification also covered 1600x1000 and dark/light states
- independent adversarial re-review: approved

## Boundary

This PR lands the canonical desktop shell and truthful browser-safe preview. Live daemon/session resources and xterm attachments remain separately owned follow-up cards; tmux remains the terminal substrate rather than the renderer for native app surfaces.
