### PR TITLE
feat(tui): add shared PaneFrame OpenTUI host

### DIFF
--- a/packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx
@@ -10,7 +10,7 @@ import {
   terminalPaneChromeHitTest,
   terminalPaneChromeOverlapsBodies,
 } from "./terminal-pane-chrome.ts";
-import { TerminalPaneChromeLayer } from "./terminal-pane-chrome-view.tsx";
+import { SharedTerminalPaneChromeLayer } from "./terminal-pane-chrome-view.tsx";
 
 interface TestRenderable {
   getChildren(): readonly unknown[];
@@ -170,7 +170,7 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
             chrome={
               <>
                 <text fg={theme.colors.mutedForeground}> 0:agents 1:shell</text>
-                <TerminalPaneChromeLayer theme={theme} layout={layout} layer="native" />
+                <SharedTerminalPaneChromeLayer theme={theme} layout={layout} layer="native" />
               </>
             }
             framebuffer={
@@ -187,7 +187,7 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
                     {sentinel(pane.id, pane.width, pane.height)}
                   </box>
                 ))}
-                <TerminalPaneChromeLayer theme={theme} layout={layout} layer="framebuffer" />
+                <SharedTerminalPaneChromeLayer theme={theme} layout={layout} layer="framebuffer" />
               </box>
             }
           />
@@ -240,7 +240,7 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
             chrome={
               <>
                 <text fg={theme.colors.mutedForeground}> window</text>
-                <TerminalPaneChromeLayer theme={theme} layout={layout} layer="native" />
+                <SharedTerminalPaneChromeLayer theme={theme} layout={layout} layer="native" />
               </>
             }
             framebuffer={<text>B</text>}
@@ -337,7 +337,7 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
       });
       return (
         <box position="relative" width={width} height={height} overflow="hidden">
-          <TerminalPaneChromeLayer theme={theme} layout={layout()} layer="native" />
+          <SharedTerminalPaneChromeLayer theme={theme} layout={layout()} layer="native" />
           <box
             position="absolute"
             left={canvas.framebuffer.x}
@@ -345,7 +345,7 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
             width={canvas.framebuffer.width}
             height={canvas.framebuffer.height}
           >
-            <TerminalPaneChromeLayer theme={theme} layout={layout()} layer="framebuffer" />
+            <SharedTerminalPaneChromeLayer theme={theme} layout={layout()} layer="framebuffer" />
           </box>
         </box>
       );
@@ -359,7 +359,7 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
         const layer = paneId === "%3" ? "framebuffer" : "native";
         return [
           paneId,
-          setup.renderer.root.findDescendantById(`terminal-pane-chrome:${layer}:${paneId}`),
+          setup.renderer.root.findDescendantById(`shared-terminal-pane-chrome:${layer}:${paneId}`),
         ] as const;
       }),
     );
@@ -384,7 +384,9 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
         for (const [paneId, node] of stablePaneNodes) {
           const layer = paneId === "%3" ? "framebuffer" : "native";
           expect(
-            setup.renderer.root.findDescendantById(`terminal-pane-chrome:${layer}:${paneId}`),
+            setup.renderer.root.findDescendantById(
+              `shared-terminal-pane-chrome:${layer}:${paneId}`,
+            ),
           ).toBe(node);
           const currentTree = renderableTree(node as TestRenderable);
           const stableTree = stablePaneTrees.get(paneId)!;

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
@@ -7,8 +7,13 @@ import { SelectableRow } from "../recipes.tsx";
 import { recipePalette } from "../recipes.ts";
 import { colorToThemeBytes, createSemanticThemeSnapshot } from "../theme.ts";
 import { expectFrameBounds, renderForTest, stableFrame } from "../testing/renderer-harness.test.ts";
+import {
+  createPaneFrameFixtureTraceRecorder,
+  PANE_FRAME_FIXTURE_EXPECTED_TRACE,
+  PANE_FRAME_FIXTURE_MODEL,
+} from "../../../ui/pane-frame/fixture.ts";
 import type { PaneFrameInput } from "./pane-frame.ts";
-import { paneFrameHitTest, projectPaneFrame } from "./pane-frame.ts";
+import { paneFrameHitTest, projectPaneFrame, projectSemanticPaneFrame } from "./pane-frame.ts";
 import { PaneFrame } from "./pane-frame.tsx";
 
 const actions = [
@@ -173,6 +178,41 @@ async function renderPane(width: number, height: number) {
 }
 
 describe("PaneFrame OpenTUI renderer", () => {
+  it("renders and activates the shared cohesion fixture through injected OpenTUI leaves", async () => {
+    const theme = createSemanticThemeSnapshot({ mode: "dark" });
+    const recorder = createPaneFrameFixtureTraceRecorder();
+    const projection = projectSemanticPaneFrame({
+      width: 120,
+      height: 40,
+      model: PANE_FRAME_FIXTURE_MODEL,
+    });
+    const setup = await renderForTest(
+      () => (
+        <PaneFrame
+          theme={theme}
+          projection={projection}
+          inputOwner
+          onActionActivate={recorder.onActionActivate}
+          onGripActivate={recorder.onGripActivate}
+        >
+          <text> shared fixture body</text>
+        </PaneFrame>
+      ),
+      { width: 120, height: 40 },
+    );
+    await setup.renderOnce();
+    await setup.mockMouse.click(projection.grip!.x, projection.grip!.y, MouseButtons.LEFT);
+    const split = projection.actions.find((action) => action.id === "split")!;
+    await setup.mockMouse.click(
+      split.start + Math.floor(split.width / 2),
+      projection.header.y,
+      MouseButtons.LEFT,
+    );
+    expect(recorder.trace).toEqual(PANE_FRAME_FIXTURE_EXPECTED_TRACE);
+    expect(stableFrame(setup.captureCharFrame())).toContain(PANE_FRAME_FIXTURE_MODEL.title);
+    setup.renderer.destroy();
+  });
+
   it.each([
     [80, 24, "compact"],
     [120, 40, "standard"],
@@ -217,7 +257,6 @@ describe("PaneFrame OpenTUI renderer", () => {
         },
         marker: "○",
         borderStart: "┌",
-        paletteState: {},
       },
       {
         label: "keyboard-focus-attention",
@@ -231,7 +270,6 @@ describe("PaneFrame OpenTUI renderer", () => {
         },
         marker: "!",
         borderStart: "┌",
-        paletteState: { focused: true, attention: true },
       },
       {
         label: "terminal-focus-attention",
@@ -246,7 +284,6 @@ describe("PaneFrame OpenTUI renderer", () => {
         },
         marker: "▣",
         borderStart: "┌",
-        paletteState: { focused: true, attention: true },
       },
       {
         label: "edit-floating-maximized",
@@ -265,28 +302,29 @@ describe("PaneFrame OpenTUI renderer", () => {
         },
         marker: "◇",
         borderStart: "┏",
-        paletteState: { selected: true, focused: true, attention: true },
       },
     ] as const;
 
-    for (const { label, input, marker, borderStart, paletteState } of cases) {
+    for (const { label, input, marker, borderStart } of cases) {
       const { setup, theme, projection } = await renderStaticPane(input);
       const stable = stableFrame(setup.captureCharFrame());
       expect(stable, label).toMatchSnapshot();
       expect(stable.startsWith(borderStart), label).toBe(true);
       expect(projection.marker, label).toBe(marker);
       expect(projection.titleSpan.text, label).toContain(marker);
-      const palette = recipePalette(theme, paletteState);
+      const appearance = projection.model.appearance;
+      const borderRole = appearance.outerOutline.visible
+        ? (appearance.outerOutline.role ?? appearance.border.role)
+        : appearance.border.role;
       const borderSpan = setup.captureSpans().lines[0]!.spans[0]!;
-      expect(colorKey(borderSpan.fg), label).toBe(colorKey(palette.border));
+      expect(colorKey(borderSpan.fg), label).toBe(colorKey(theme.roles.borders[borderRole]));
       const titleSpan = spanContaining(setup, projection.titleSpan.text, projection.header.y);
       expect(titleSpan, label).toBeDefined();
-      const nativeFocused = projection.focused || projection.terminalFocused;
       expect(colorKey(titleSpan!.fg), label).toBe(
-        colorKey(nativeFocused ? theme.roles.text.primary : theme.roles.text.muted),
+        colorKey(theme.roles.text[appearance.header.text]),
       );
       expect(colorKey(titleSpan!.bg), label).toBe(
-        colorKey(nativeFocused ? theme.roles.surfaces.headerActive : palette.background),
+        colorKey(theme.roles.surfaces[appearance.header.surface]),
       );
       if (label === "edit-floating-maximized") {
         expect(stable).toContain("edit");

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx
@@ -1,6 +1,7 @@
 /* @jsxImportSource @opentui/solid */
 import { MouseButtons } from "@opentui/core/testing";
 import { useKeyboard } from "@opentui/solid";
+import type { PaneVisualStateV1 } from "@tmux-ide/contracts";
 import { createSignal } from "solid-js";
 import { describe, expect, it } from "bun:test";
 import { SelectableRow } from "../recipes.tsx";
@@ -21,6 +22,33 @@ const actions = [
   { id: "mission", label: "mission", compactLabel: "M", description: "Open mission proof" },
   { id: "native", label: "native", compactLabel: "N", description: "Open native surface" },
 ] as const;
+
+function canonicalActionVisualState(
+  controlInteraction: Partial<PaneVisualStateV1["controlInteraction"]> = {},
+): PaneVisualStateV1 {
+  return {
+    structure: "docked",
+    applicationFocus: { pane: true, terminalInput: false, windowActive: true },
+    agentActivity: "idle",
+    domainStatus: "idle",
+    attention: "none",
+    layoutInteraction: {
+      editable: true,
+      selected: false,
+      dragging: false,
+      resizing: false,
+      previewing: false,
+    },
+    controlInteraction: {
+      hover: false,
+      focusVisible: false,
+      pressed: false,
+      disabled: false,
+      loading: false,
+      ...controlInteraction,
+    },
+  };
+}
 
 function colorKey(color: Parameters<typeof colorToThemeBytes>[0]): string {
   return colorToThemeBytes(color).join(",");
@@ -432,6 +460,133 @@ describe("PaneFrame OpenTUI renderer", () => {
     expect(pressedValue).toBeNull();
     expect(stableFrame(setup.captureCharFrame())).not.toContain("◆ native");
     setup.renderer.destroy();
+  });
+
+  it("maps canonical action interaction to exact OpenTUI glyphs, spans, and activation", async () => {
+    const theme = createSemanticThemeSnapshot({ mode: "dark" });
+    const cases = [
+      {
+        label: "disabled",
+        control: { disabled: true },
+        recipe: { disabled: true },
+        glyph: "×",
+        interactive: false,
+        state: "disabled",
+      },
+      {
+        label: "loading",
+        control: { loading: true },
+        recipe: { loading: true },
+        glyph: "…",
+        interactive: false,
+        state: "loading",
+      },
+      {
+        label: "pressed",
+        control: { pressed: true },
+        recipe: { pressed: true },
+        glyph: "◆",
+        interactive: true,
+        state: "pressed",
+      },
+      {
+        label: "focus-visible",
+        control: { focusVisible: true },
+        recipe: { focused: true },
+        glyph: "›",
+        interactive: true,
+        state: "focused",
+      },
+      {
+        label: "hover",
+        control: { hover: true },
+        recipe: { hovered: true },
+        glyph: "·",
+        interactive: true,
+        state: "hovered",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const calls: string[] = [];
+      const projection = projectPaneFrame({
+        width: 120,
+        height: 40,
+        title: `Canonical ${testCase.label}`,
+        kind: "native",
+        focused: true,
+        visualState: canonicalActionVisualState(testCase.control),
+        actions: [actions[0]],
+      });
+      const setup = await renderForTest(
+        () => (
+          <PaneFrame
+            theme={theme}
+            projection={projection}
+            inputOwner
+            onActionActivate={(intent) => calls.push(intent.actionId)}
+          />
+        ),
+        { width: 120, height: 40 },
+      );
+      await setup.renderOnce();
+      const palette = recipePalette(theme, testCase.recipe);
+      const labelSpan = spanContaining(setup, " agent ", projection.header.y);
+      const markerSpan = spanContaining(setup, testCase.glyph, projection.header.y);
+      expect(labelSpan, testCase.label).toBeDefined();
+      expect(markerSpan, testCase.label).toBeDefined();
+      expect(colorKey(labelSpan!.fg), testCase.label).toBe(colorKey(palette.foreground));
+      expect(colorKey(labelSpan!.bg), testCase.label).toBe(colorKey(palette.background));
+      expect(colorKey(markerSpan!.fg), testCase.label).toBe(colorKey(palette.accent));
+      expect(projection.actions[0]!.interactive, testCase.label).toBe(testCase.interactive);
+      expect(projection.actions[0]!.state, testCase.label).toBe(testCase.state);
+
+      const action = projection.actions[0]!;
+      await setup.mockMouse.click(
+        action.start + Math.floor(action.width / 2),
+        projection.header.y,
+        MouseButtons.LEFT,
+      );
+      expect(calls, testCase.label).toEqual(testCase.interactive ? ["agent"] : []);
+      setup.renderer.destroy();
+    }
+  });
+
+  it("keeps the shared presenter passive unless the OpenTUI host owns input", async () => {
+    const theme = createSemanticThemeSnapshot({ mode: "dark" });
+    const projection = projectPaneFrame({
+      width: 120,
+      height: 40,
+      title: "Passive root agreement",
+      kind: "native",
+      focused: true,
+      visualState: canonicalActionVisualState(),
+      actions: [actions[0]],
+    });
+    const action = projection.actions[0]!;
+
+    for (const inputOwner of [false, true]) {
+      const calls: string[] = [];
+      const setup = await renderForTest(
+        () => (
+          <PaneFrame
+            theme={theme}
+            projection={projection}
+            inputOwner={inputOwner}
+            onActionActivate={(intent) => calls.push(`${intent.actionId}:${intent.commandId}`)}
+          />
+        ),
+        { width: 120, height: 40 },
+      );
+      await setup.renderOnce();
+      await setup.mockMouse.click(
+        action.start + Math.floor(action.width / 2),
+        projection.header.y,
+        MouseButtons.LEFT,
+      );
+      expect(calls).toEqual(inputOwner ? ["agent:pane.action.agent"] : []);
+      setup.renderer.destroy();
+    }
   });
 
   it("pins native icon base, hover, disabled, pressed, and hidden states", async () => {

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.test.ts
@@ -1,13 +1,45 @@
 import { describe, expect, it } from "vitest";
 import type { PaneVisualStateV1 } from "@tmux-ide/contracts";
 import { terminalDisplayWidth } from "../panel-host.ts";
-import { paneFrameHitTest, paneFrameVariant, projectPaneFrame } from "./pane-frame.ts";
+import {
+  paneFrameHitTest,
+  paneFrameVariant,
+  projectPaneFrame,
+  projectSemanticPaneFrame,
+} from "./pane-frame.ts";
 
 const actions = [
   { id: "agent", label: "agent", compactLabel: "A", description: "Open agent controls" },
   { id: "mission", label: "mission", compactLabel: "M", description: "Open mission proof" },
   { id: "native", label: "native", compactLabel: "N", description: "Open native surface" },
 ] as const;
+
+function canonicalVisualState(
+  controlInteraction: Partial<PaneVisualStateV1["controlInteraction"]> = {},
+): PaneVisualStateV1 {
+  return {
+    structure: "docked",
+    applicationFocus: { pane: true, terminalInput: false, windowActive: true },
+    agentActivity: "idle",
+    domainStatus: "idle",
+    attention: "none",
+    layoutInteraction: {
+      editable: true,
+      selected: false,
+      dragging: false,
+      resizing: false,
+      previewing: false,
+    },
+    controlInteraction: {
+      hover: false,
+      focusVisible: false,
+      pressed: false,
+      disabled: false,
+      loading: false,
+      ...controlInteraction,
+    },
+  };
+}
 
 describe("PaneFrame projection", () => {
   it.each([
@@ -216,6 +248,144 @@ describe("PaneFrame projection", () => {
     expect(projection.chips).toEqual([
       expect.objectContaining({ kind: "status", label: "idle", tone: "idle" }),
     ]);
+  });
+
+  it.each([
+    ["disabled", { disabled: true }, { disabled: true, loading: false, state: "disabled" }],
+    ["loading", { loading: true }, { disabled: false, loading: true, state: "loading" }],
+  ] as const)(
+    "makes canonical %s actions noninteractive in rendering and hit testing",
+    (_, state, expected) => {
+      const projection = projectPaneFrame({
+        width: 120,
+        height: 40,
+        title: "Canonical action state",
+        kind: "native",
+        focused: true,
+        visualState: canonicalVisualState(state),
+        actions: [actions[0]],
+      });
+      const action = projection.actions[0]!;
+      expect(action).toMatchObject({ ...expected, interactive: false });
+      expect(
+        paneFrameHitTest(
+          projection,
+          action.start + Math.floor(action.width / 2),
+          projection.header.y,
+        ),
+      ).toMatchObject({ area: "header" });
+    },
+  );
+
+  it.each([
+    ["hover", { hover: true }, { hovered: true, pressed: false, focused: false, state: "hovered" }],
+    [
+      "pressed",
+      { pressed: true },
+      { hovered: false, pressed: true, focused: false, state: "pressed" },
+    ],
+    [
+      "focus-visible",
+      { focusVisible: true },
+      { hovered: false, pressed: false, focused: true, state: "focused" },
+    ],
+  ] as const)("projects canonical %s into explicit OpenTUI action state", (_, state, expected) => {
+    const projection = projectPaneFrame({
+      width: 120,
+      height: 40,
+      title: "Canonical action state",
+      kind: "native",
+      focused: true,
+      visualState: canonicalVisualState(state),
+      actions: [actions[0]],
+    });
+    const action = projection.actions[0]!;
+    expect(action).toMatchObject({
+      ...expected,
+      interactive: true,
+      disabled: false,
+      loading: false,
+    });
+    expect(
+      paneFrameHitTest(
+        projection,
+        action.start + Math.floor(action.width / 2),
+        projection.header.y,
+      ),
+    ).toMatchObject({ area: "action", actionId: "agent" });
+  });
+
+  it("applies disabled then loading before simultaneous transient action states", () => {
+    const project = (controlInteraction: Partial<PaneVisualStateV1["controlInteraction"]>) =>
+      projectPaneFrame({
+        width: 120,
+        height: 40,
+        title: "Canonical precedence",
+        kind: "native",
+        focused: true,
+        visualState: canonicalVisualState(controlInteraction),
+        hoveredActionIndex: 0,
+        pressedActionIndex: 0,
+        actions: [actions[0]],
+      }).actions[0]!;
+    expect(
+      project({
+        hover: true,
+        focusVisible: true,
+        pressed: true,
+        disabled: true,
+        loading: true,
+      }),
+    ).toMatchObject({
+      disabled: true,
+      loading: false,
+      pressed: false,
+      focused: false,
+      hovered: false,
+      interactive: false,
+      state: "disabled",
+    });
+    expect(
+      project({ hover: true, focusVisible: true, pressed: true, loading: true }),
+    ).toMatchObject({
+      disabled: false,
+      loading: true,
+      pressed: false,
+      focused: false,
+      hovered: false,
+      interactive: false,
+      state: "loading",
+    });
+  });
+
+  it("renders a busy semantic action as loading and removes its cell target", () => {
+    const base = projectPaneFrame({
+      width: 120,
+      height: 40,
+      title: "Busy semantic action",
+      kind: "native",
+      focused: true,
+      actions: [actions[0]],
+    });
+    const model = {
+      ...base.model,
+      actions: base.model.actions.map((action) => ({ ...action, busy: true })),
+    };
+    const projection = projectSemanticPaneFrame({ width: 120, height: 40, model });
+    const action = projection.actions[0]!;
+    expect(action).toMatchObject({
+      loading: true,
+      disabled: false,
+      interactive: false,
+      state: "loading",
+    });
+    expect(
+      paneFrameHitTest(
+        projection,
+        action.start + Math.floor(action.width / 2),
+        projection.header.y,
+      ),
+    ).toMatchObject({ area: "header" });
   });
 
   it("keeps semantic status while progressively dropping actions then state on narrow panes", () => {

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { PaneVisualStateV1 } from "@tmux-ide/contracts";
 import { terminalDisplayWidth } from "../panel-host.ts";
 import { paneFrameHitTest, paneFrameVariant, projectPaneFrame } from "./pane-frame.ts";
 
@@ -160,6 +161,60 @@ describe("PaneFrame projection", () => {
       "edit",
       "float",
       "maximized",
+    ]);
+  });
+
+  it("lets canonical PaneAppearance override every conflicting legacy state flag", () => {
+    const visualState: PaneVisualStateV1 = {
+      structure: "docked",
+      applicationFocus: { pane: false, terminalInput: false, windowActive: true },
+      agentActivity: "idle",
+      domainStatus: "idle",
+      attention: "none",
+      layoutInteraction: {
+        editable: true,
+        selected: false,
+        dragging: false,
+        resizing: false,
+        previewing: false,
+      },
+      controlInteraction: {
+        hover: false,
+        focusVisible: false,
+        pressed: false,
+        disabled: false,
+        loading: false,
+      },
+    };
+    const projection = projectPaneFrame({
+      width: 120,
+      height: 40,
+      title: "Canonical pane",
+      kind: "native",
+      focused: true,
+      terminalFocused: true,
+      attention: true,
+      windowEditSelected: true,
+      floating: true,
+      maximized: true,
+      status: "idle",
+      statusTone: "blocked",
+      visualState,
+    });
+    expect(projection.marker).toBe("○");
+    expect(projection).toMatchObject({
+      focused: false,
+      terminalFocused: false,
+      attention: false,
+      windowEditSelected: false,
+      floating: false,
+      maximized: false,
+    });
+    expect(projection.model.appearance.accessibility.description).toBe(
+      "docked pane, idle status, idle agent",
+    );
+    expect(projection.chips).toEqual([
+      expect.objectContaining({ kind: "status", label: "idle", tone: "idle" }),
     ]);
   });
 

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
@@ -110,8 +110,36 @@ export interface PaneFrameActionChip extends PaneFrameAction {
   fullLabel: string;
   start: number;
   width: number;
+  active: boolean;
+  disabled: boolean;
+  attention: boolean;
+  focused: boolean;
   hovered: boolean;
+  interactive: boolean;
+  loading: boolean;
   pressed: boolean;
+  state: EffectivePaneFrameActionVisualState;
+}
+
+export type EffectivePaneFrameActionVisualState =
+  | "disabled"
+  | "loading"
+  | "pressed"
+  | "focused"
+  | "attention"
+  | "hovered"
+  | "base";
+
+export interface EffectivePaneFrameActionState {
+  readonly active: boolean;
+  readonly disabled: boolean;
+  readonly attention: boolean;
+  readonly focused: boolean;
+  readonly hovered: boolean;
+  readonly interactive: boolean;
+  readonly loading: boolean;
+  readonly pressed: boolean;
+  readonly state: EffectivePaneFrameActionVisualState;
 }
 
 export type PaneFrameChip = PaneFrameStatusChip | PaneFrameStateChip | PaneFrameActionChip;
@@ -346,6 +374,57 @@ export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
   });
 }
 
+/**
+ * One action-state boundary shared by rendering and hit testing.
+ *
+ * Precedence is disabled -> loading -> pressed -> focus-visible -> attention ->
+ * hover -> base. Disabled/loading suppress every transient state,
+ * and only an effective interactive action may own a cell target.
+ */
+export function resolveEffectivePaneFrameActionState(input: {
+  appearance: PaneFrameModel["appearance"];
+  action: SemanticPaneFrameAction;
+  attention: boolean;
+  hostHovered: boolean;
+  hostPressed: boolean;
+}): EffectivePaneFrameActionState {
+  const global = input.appearance.action;
+  const explicitDisabled = global.disabled || !input.action.available;
+  const loading = !explicitDisabled && (global.loading || input.action.busy);
+  const disabled =
+    explicitDisabled || (!global.interactive && !global.loading && !input.action.busy);
+  const interactive = global.interactive && input.action.available && !input.action.busy;
+  const transient = interactive && !disabled && !loading;
+  const pressed = transient && (input.hostPressed || input.action.pressed || global.pressed);
+  const focused = transient && global.focusVisible;
+  const attention = transient && input.attention;
+  const hovered = transient && (input.hostHovered || global.hover);
+  const state: EffectivePaneFrameActionVisualState = disabled
+    ? "disabled"
+    : loading
+      ? "loading"
+      : pressed
+        ? "pressed"
+        : focused
+          ? "focused"
+          : attention
+            ? "attention"
+            : hovered
+              ? "hovered"
+              : "base";
+  return {
+    active: state === "pressed" && input.action.pressed,
+    disabled,
+    attention: state === "attention",
+    focused: state === "focused",
+    hovered: state === "hovered",
+    interactive,
+    loading,
+    pressed: state === "pressed",
+    state,
+  };
+}
+
 /** Cell geometry for a shared semantic PaneFrame model. */
 export function projectSemanticPaneFrame(
   input: SemanticPaneFrameProjectionInput,
@@ -375,6 +454,13 @@ export function projectSemanticPaneFrame(
   );
   const actions = input.model.actions.map((semanticAction, index) => {
     const presentation = presentations.get(semanticAction.id);
+    const effective = resolveEffectivePaneFrameActionState({
+      appearance,
+      action: semanticAction,
+      attention: presentation?.attention === true,
+      hostHovered: input.hoveredActionIndex === index,
+      hostPressed: input.pressedActionIndex === index,
+    });
     const action: PaneFrameAction = {
       id: semanticAction.id,
       commandId: semanticAction.commandId,
@@ -382,10 +468,10 @@ export function projectSemanticPaneFrame(
       compactLabel: presentation?.compactLabel,
       icon: presentation ? presentation.icon : semanticAction.icon,
       description: semanticAction.description ?? semanticAction.label,
-      active: semanticAction.pressed,
-      disabled: !semanticAction.available || semanticAction.busy,
-      attention: presentation?.attention,
-      pressed: semanticAction.pressed,
+      active: effective.active,
+      disabled: effective.disabled,
+      attention: effective.attention,
+      pressed: effective.pressed,
       hidden: presentation?.hidden,
     };
     return {
@@ -398,8 +484,15 @@ export function projectSemanticPaneFrame(
         : variant === "compact"
           ? (action.compactLabel ?? action.label)
           : action.label,
-      hovered: input.hoveredActionIndex === index,
-      pressed: input.pressedActionIndex === index || action.pressed === true,
+      active: effective.active,
+      disabled: effective.disabled,
+      attention: effective.attention,
+      focused: effective.focused,
+      hovered: effective.hovered,
+      interactive: effective.interactive,
+      loading: effective.loading,
+      pressed: effective.pressed,
+      state: effective.state,
     };
   });
   const visible = fitChips(header.width, variant, status, stateChips, actions);
@@ -599,7 +692,7 @@ export function paneFrameHitTest(
   }
   const actionIndex = projection.actions.findIndex(
     (action) =>
-      !action.disabled &&
+      action.interactive &&
       cellY === projection.header.y &&
       cellX >= action.start &&
       cellX < action.start + action.width,

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.ts
@@ -1,3 +1,18 @@
+import {
+  resolvePaneAppearance,
+  type CanonicalDomainStatus,
+  type CommandId,
+  type PaneRoleId,
+  type PaneVisualStateV1,
+  type SemanticProductId,
+  type StatusToneRole,
+} from "@tmux-ide/contracts";
+import type {
+  PaneFrameAction as SemanticPaneFrameAction,
+  PaneFrameChip as SemanticPaneFrameChip,
+  PaneFrameModel,
+  PaneFrameStatus as SemanticPaneFrameStatus,
+} from "../../../ui/pane-frame/presenter.tsx";
 import { terminalDisplayWidth } from "../panel-host.ts";
 import { actionChipWidth, iconButtonWidth, type RecipeTone, type Rect } from "../recipes.ts";
 import { clipWorkspaceText } from "./text.ts";
@@ -16,6 +31,7 @@ export type PaneFrameKind =
 
 export interface PaneFrameAction {
   id: string;
+  commandId?: CommandId;
   label: string;
   compactLabel?: string;
   icon?: WorkspaceIconId;
@@ -28,6 +44,8 @@ export interface PaneFrameAction {
 }
 
 export interface PaneFrameInput {
+  /** Stable renderer-neutral identity. Live tmux ids are encoded by their host adapter. */
+  paneId?: SemanticProductId;
   width: number;
   height: number;
   title: string;
@@ -45,6 +63,18 @@ export interface PaneFrameInput {
   actions?: readonly PaneFrameAction[];
   hoveredActionIndex?: number | null;
   pressedActionIndex?: number | null;
+  /** Canonical state wins over every legacy compatibility flag above. */
+  visualState?: PaneVisualStateV1;
+}
+
+export interface SemanticPaneFrameProjectionInput {
+  width: number;
+  height: number;
+  model: PaneFrameModel;
+  dirty?: boolean;
+  actionPresentation?: readonly PaneFrameAction[];
+  hoveredActionIndex?: number | null;
+  pressedActionIndex?: number | null;
 }
 
 export interface PaneFrameSpan extends Rect {
@@ -57,6 +87,7 @@ export interface PaneFrameGripSpan extends PaneFrameSpan {
 
 export interface PaneFrameStatusChip {
   kind: "status";
+  id: SemanticProductId;
   label: string;
   tone: Exclude<RecipeTone, "neutral" | "accent">;
   start: number;
@@ -65,7 +96,7 @@ export interface PaneFrameStatusChip {
 
 export interface PaneFrameStateChip {
   kind: "state";
-  id: "edit" | "float" | "maximized";
+  id: SemanticProductId;
   label: string;
   tone: RecipeTone;
   start: number;
@@ -88,6 +119,8 @@ export type PaneFrameChip = PaneFrameStatusChip | PaneFrameStateChip | PaneFrame
 export type PaneFrameBorderStyle = "none" | "single" | "strong";
 
 export interface PaneFrameProjection {
+  /** Shared semantic presenter input; all semantic state priority is resolved here. */
+  model: PaneFrameModel;
   width: number;
   height: number;
   variant: PaneFrameVariant;
@@ -121,17 +154,6 @@ export type PaneFrameHit =
   | { area: "border" }
   | null;
 
-const KIND_ICONS: Readonly<Record<PaneFrameKind, WorkspaceIconId>> = {
-  home: "home",
-  terminals: "terminals",
-  files: "files",
-  diff: "changes",
-  missions: "missions",
-  activity: "activity",
-  preview: "preview",
-  native: "native",
-};
-
 const STATUS_GLYPHS: Readonly<Record<Exclude<RecipeTone, "neutral" | "accent">, string>> = {
   blocked: "!",
   working: "●",
@@ -140,6 +162,171 @@ const STATUS_GLYPHS: Readonly<Record<Exclude<RecipeTone, "neutral" | "accent">, 
   unknown: "?",
 };
 
+const ROLE_BY_KIND: Readonly<Record<PaneFrameKind, PaneRoleId>> = {
+  home: "home",
+  terminals: "terminal",
+  files: "files",
+  diff: "changes",
+  missions: "missions",
+  activity: "activity",
+  preview: "preview",
+  native: "native",
+};
+
+const ICON_BY_ROLE: Readonly<Record<PaneRoleId, WorkspaceIconId>> = {
+  home: "home",
+  terminal: "terminals",
+  files: "files",
+  changes: "changes",
+  missions: "missions",
+  activity: "activity",
+  preview: "preview",
+  native: "native",
+};
+
+function domainStatusForRecipeTone(tone: PaneFrameInput["statusTone"]): CanonicalDomainStatus {
+  if (tone === "blocked") return "blocked";
+  if (tone === "working") return "running";
+  if (tone === "done") return "done";
+  if (tone === "unknown") return "disconnected";
+  return "idle";
+}
+
+function recipeToneForStatus(tone: StatusToneRole | null): RecipeTone {
+  if (tone === null) return "neutral";
+  if (tone === "warning") return "blocked";
+  if (tone === "info") return "working";
+  if (tone === "success") return "done";
+  if (tone === "danger") return "unknown";
+  return "idle";
+}
+
+function recipeDomainTone(tone: StatusToneRole): Exclude<RecipeTone, "neutral" | "accent"> {
+  const recipeTone = recipeToneForStatus(tone);
+  return recipeTone === "neutral" || recipeTone === "accent" ? "idle" : recipeTone;
+}
+
+function semanticId(value: string, fallback: string): SemanticProductId {
+  const normalized = value
+    .trim()
+    .replace(/[^A-Za-z0-9._:-]+/gu, "-")
+    .replace(/^-+|-+$/gu, "");
+  return (
+    normalized && /^[A-Za-z0-9]/u.test(normalized) ? normalized : fallback
+  ) as SemanticProductId;
+}
+
+function commandIdForAction(action: PaneFrameAction): CommandId {
+  if (action.commandId) return action.commandId;
+  const suffix =
+    action.id
+      .trim()
+      .replace(/[^A-Za-z0-9-]+/gu, "-")
+      .replace(/^-+|-+$/gu, "") || "activate";
+  return `pane.action.${suffix}` as CommandId;
+}
+
+function paneFrameVisualState(input: PaneFrameInput): PaneVisualStateV1 {
+  if (input.visualState) return input.visualState;
+  const domainStatus = domainStatusForRecipeTone(input.statusTone);
+  return {
+    structure: input.maximized ? "maximized" : input.floating ? "floating" : "docked",
+    applicationFocus: {
+      pane: input.focused,
+      terminalInput: input.terminalFocused === true,
+      windowActive: true,
+    },
+    agentActivity:
+      domainStatus === "running"
+        ? "running"
+        : domainStatus === "done"
+          ? "complete"
+          : domainStatus === "blocked"
+            ? "waiting"
+            : domainStatus === "disconnected"
+              ? "disconnected"
+              : "idle",
+    domainStatus,
+    attention:
+      input.attention === true ? (domainStatus === "blocked" ? "warning" : "requested") : "none",
+    layoutInteraction: {
+      editable: true,
+      selected: input.windowEditSelected === true,
+      dragging: false,
+      resizing: false,
+      previewing: false,
+    },
+    controlInteraction: {
+      hover: false,
+      focusVisible: false,
+      pressed: false,
+      disabled: false,
+      loading: false,
+    },
+  };
+}
+
+function legacyStateChips(
+  input: PaneFrameInput,
+  appearance: PaneFrameModel["appearance"],
+): SemanticPaneFrameChip[] {
+  const chips: SemanticPaneFrameChip[] = [];
+  if (appearance.accessibility.layoutSelected) {
+    chips.push({ id: "edit", kind: "mode", label: "edit", tone: "info" });
+  }
+  if (input.visualState ? appearance.structure === "floating" : input.floating === true) {
+    chips.push({ id: "float", kind: "state", label: "float", tone: null });
+  }
+  if (input.visualState ? appearance.structure === "maximized" : input.maximized === true) {
+    chips.push({ id: "maximized", kind: "state", label: "max", tone: "info" });
+  }
+  return chips;
+}
+
+/** Compatibility adapter. New hosts should construct the model directly. */
+export function paneFrameModel(input: PaneFrameInput): PaneFrameModel {
+  const appearance = resolvePaneAppearance(paneFrameVisualState(input));
+  const status: SemanticPaneFrameStatus | null = input.status
+    ? {
+        id: "status.domain",
+        label: input.status,
+        description: appearance.accessibility.description,
+        tone: appearance.status.domainTone,
+        busy: appearance.accessibility.busy,
+      }
+    : null;
+  const actions: SemanticPaneFrameAction[] = (input.actions ?? []).map((action) => ({
+    id: semanticId(action.id, "action.activate"),
+    commandId: commandIdForAction(action),
+    icon: action.icon ?? "command",
+    label: action.label,
+    description: action.description,
+    available: action.disabled !== true,
+    disabledReason: action.disabled ? action.description : null,
+    pressed: action.active === true || action.pressed === true,
+    busy: false,
+  }));
+  return {
+    pane: {
+      id: input.paneId ?? "pane.preview",
+      kind: ROLE_BY_KIND[input.kind],
+    },
+    appearance,
+    title: input.title,
+    subtitle: input.subtitle ?? null,
+    status,
+    chips: legacyStateChips(input, appearance),
+    actions,
+  };
+}
+
+function compactChipLabel(chip: SemanticPaneFrameChip): string {
+  if (chip.id === "edit") return "E";
+  if (chip.id === "float") return "F";
+  if (chip.id === "maximized") return "M";
+  return clipWorkspaceText(chip.label, 1);
+}
+
 export function paneFrameVariant(width: number, height: number): PaneFrameVariant {
   if (width >= 160 && height >= 44) return "wide";
   if (width >= 100 && height >= 28) return "standard";
@@ -147,6 +334,22 @@ export function paneFrameVariant(width: number, height: number): PaneFrameVarian
 }
 
 export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
+  const model = paneFrameModel(input);
+  return projectSemanticPaneFrame({
+    width: input.width,
+    height: input.height,
+    model,
+    dirty: input.dirty,
+    actionPresentation: input.actions,
+    hoveredActionIndex: input.hoveredActionIndex,
+    pressedActionIndex: input.pressedActionIndex,
+  });
+}
+
+/** Cell geometry for a shared semantic PaneFrame model. */
+export function projectSemanticPaneFrame(
+  input: SemanticPaneFrameProjectionInput,
+): PaneFrameProjection {
   const width = Math.max(0, Math.floor(input.width));
   const height = Math.max(0, Math.floor(input.height));
   const variant = paneFrameVariant(width, height);
@@ -158,33 +361,47 @@ export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
   const bodyHeight = Math.max(0, innerHeight - headerHeight);
   const header: Rect = { x: inset, y: inset, width: innerWidth, height: headerHeight };
   const body: Rect = { x: inset, y: inset + headerHeight, width: innerWidth, height: bodyHeight };
-  const terminalFocused = input.terminalFocused === true;
-  const attention = input.attention === true;
-  const windowEditSelected = input.windowEditSelected === true;
-  const floating = input.floating === true;
-  const maximized = input.maximized === true;
-  const marker = paneFrameMarker({
-    windowEditSelected,
-    terminalFocused,
-    attention,
-    focused: input.focused,
-    floating,
+  const { appearance } = input.model;
+  const terminalFocused = appearance.accessibility.terminalInputOwner;
+  const attention = appearance.accessibility.hasAttention;
+  const windowEditSelected = appearance.accessibility.layoutSelected;
+  const floating = appearance.structure === "floating";
+  const maximized = appearance.structure === "maximized";
+  const marker = paneFrameMarker(appearance);
+  const status = statusChip(input.model.status, variant);
+  const stateChips = projectStateChips(input.model.chips, variant);
+  const presentations = new Map(
+    (input.actionPresentation ?? []).map((action) => [action.id, action]),
+  );
+  const actions = input.model.actions.map((semanticAction, index) => {
+    const presentation = presentations.get(semanticAction.id);
+    const action: PaneFrameAction = {
+      id: semanticAction.id,
+      commandId: semanticAction.commandId,
+      label: semanticAction.label,
+      compactLabel: presentation?.compactLabel,
+      icon: presentation ? presentation.icon : semanticAction.icon,
+      description: semanticAction.description ?? semanticAction.label,
+      active: semanticAction.pressed,
+      disabled: !semanticAction.available || semanticAction.busy,
+      attention: presentation?.attention,
+      pressed: semanticAction.pressed,
+      hidden: presentation?.hidden,
+    };
+    return {
+      ...action,
+      kind: "action" as const,
+      fullLabel: action.label,
+      appearance: action.icon ? ("icon" as const) : ("label" as const),
+      label: action.icon
+        ? workspaceIcon(action.icon)
+        : variant === "compact"
+          ? (action.compactLabel ?? action.label)
+          : action.label,
+      hovered: input.hoveredActionIndex === index,
+      pressed: input.pressedActionIndex === index || action.pressed === true,
+    };
   });
-  const status = statusChip(input.status, input.statusTone, variant);
-  const stateChips = projectStateChips({ windowEditSelected, floating, maximized, variant });
-  const actions = (input.actions ?? []).map((action, index) => ({
-    ...action,
-    kind: "action" as const,
-    fullLabel: action.label,
-    appearance: action.icon ? ("icon" as const) : ("label" as const),
-    label: action.icon
-      ? workspaceIcon(action.icon)
-      : variant === "compact"
-        ? (action.compactLabel ?? action.label)
-        : action.label,
-    hovered: input.hoveredActionIndex === index,
-    pressed: input.pressedActionIndex === index || action.pressed === true,
-  }));
   const visible = fitChips(header.width, variant, status, stateChips, actions);
   const chips = positionChips(header.x + header.width, visible);
   const firstChip = chips[0]?.start ?? header.x + header.width;
@@ -196,12 +413,12 @@ export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
   const titleStart = header.x + (grip ? grip.width + 1 : 0);
   const titleBudget = Math.max(0, firstChip - titleStart - (chips.length > 0 ? 1 : 0));
   const dirty = input.dirty ? " •" : "";
-  const kindGlyph = workspaceIcon(KIND_ICONS[input.kind]);
+  const kindGlyph = workspaceIcon(ICON_BY_ROLE[input.model.pane.kind]);
   const titlePrefix = `${marker} ${kindGlyph} `;
-  const requestedTitle = `${titlePrefix}${input.title}${dirty}`;
-  const showSubtitle = variant !== "compact" && !!input.subtitle;
+  const requestedTitle = `${titlePrefix}${input.model.title}${dirty}`;
+  const showSubtitle = variant !== "compact" && !!input.model.subtitle;
   const subtitleDividerWidth = showSubtitle ? 3 : 0;
-  const subtitlePreferred = showSubtitle ? ` · ${input.subtitle}` : "";
+  const subtitlePreferred = showSubtitle ? ` · ${input.model.subtitle}` : "";
   const titleOnlyBudget = showSubtitle
     ? Math.max(4, Math.floor(titleBudget * (variant === "wide" ? 0.58 : 0.68)))
     : titleBudget;
@@ -224,12 +441,13 @@ export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
       : null;
 
   return {
+    model: input.model,
     width,
     height,
     variant,
     outer: { x: 0, y: 0, width, height },
     border: { x: 0, y: 0, width, height },
-    borderStyle: bordered ? (windowEditSelected ? "strong" : "single") : "none",
+    borderStyle: bordered ? (appearance.outerOutline.visible ? "strong" : "single") : "none",
     header,
     body,
     grip,
@@ -245,7 +463,7 @@ export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
     glyph: kindGlyph,
     title: titleText,
     subtitle: subtitleText,
-    focused: input.focused,
+    focused: appearance.accessibility.focused,
     terminalFocused,
     attention,
     windowEditSelected,
@@ -256,53 +474,39 @@ export function projectPaneFrame(input: PaneFrameInput): PaneFrameProjection {
   };
 }
 
-function paneFrameMarker(state: {
-  windowEditSelected: boolean;
-  terminalFocused: boolean;
-  attention: boolean;
-  focused: boolean;
-  floating: boolean;
-}): string {
-  if (state.windowEditSelected) return "◇";
-  if (state.terminalFocused) return "▣";
-  if (state.attention) return "!";
-  if (state.focused) return "●";
-  if (state.floating) return "◌";
+function paneFrameMarker(appearance: PaneFrameModel["appearance"]): string {
+  if (appearance.accessibility.layoutSelected) return "◇";
+  if (appearance.accessibility.terminalInputOwner) return "▣";
+  if (appearance.accessibility.hasAttention) return "!";
+  if (appearance.accessibility.focused) return "●";
+  if (appearance.structure === "floating") return "◌";
   return "○";
 }
 
 function statusChip(
-  status: string | null | undefined,
-  tone: PaneFrameInput["statusTone"],
+  status: PaneFrameModel["status"],
   variant: PaneFrameVariant,
 ): Omit<PaneFrameStatusChip, "start" | "width"> | null {
   if (!status) return null;
-  const resolvedTone = tone ?? "unknown";
+  const resolvedTone = recipeDomainTone(status.tone);
   return {
     kind: "status",
-    label: variant === "compact" ? STATUS_GLYPHS[resolvedTone] : status,
+    id: status.id,
+    label: variant === "compact" ? STATUS_GLYPHS[resolvedTone] : status.label,
     tone: resolvedTone,
   };
 }
 
-function projectStateChips(input: {
-  windowEditSelected: boolean;
-  floating: boolean;
-  maximized: boolean;
-  variant: PaneFrameVariant;
-}): Omit<PaneFrameStateChip, "start" | "width">[] {
-  const compact = input.variant === "compact";
-  const chips: Omit<PaneFrameStateChip, "start" | "width">[] = [];
-  if (input.windowEditSelected) {
-    chips.push({ kind: "state", id: "edit", label: compact ? "E" : "edit", tone: "accent" });
-  }
-  if (input.floating) {
-    chips.push({ kind: "state", id: "float", label: compact ? "F" : "float", tone: "neutral" });
-  }
-  if (input.maximized) {
-    chips.push({ kind: "state", id: "maximized", label: compact ? "M" : "max", tone: "accent" });
-  }
-  return chips;
+function projectStateChips(
+  chips: readonly SemanticPaneFrameChip[],
+  variant: PaneFrameVariant,
+): Omit<PaneFrameStateChip, "start" | "width">[] {
+  return chips.map((chip) => ({
+    kind: "state",
+    id: chip.id,
+    label: variant === "compact" ? compactChipLabel(chip) : chip.label,
+    tone: recipeToneForStatus(chip.tone),
+  }));
 }
 
 function chipWidth(

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
@@ -1,6 +1,18 @@
 /* @jsxImportSource @opentui/solid */
 import type { JSX } from "@opentui/solid";
-import { createMemo, For, Show } from "solid-js";
+import { createContext, createMemo, For, Show, useContext } from "solid-js";
+import {
+  PaneFramePresenter,
+  type PaneFrameActionLeafProps,
+  type PaneFrameActionListLeafProps,
+  type PaneFrameBodyLeafProps,
+  type PaneFrameGripLeafProps,
+  type PaneFrameHeaderLeafProps,
+  type PaneFrameHostLeaves,
+  type PaneFrameRootLeafProps,
+  type PaneFrameStatusLeafProps,
+  type PaneFrameTitleLeafProps,
+} from "../../../ui/pane-frame/presenter.tsx";
 import { ActionChip, Badge, IconButton, StatusChip } from "../recipes.tsx";
 import { recipePalette } from "../recipes.ts";
 import type { SemanticThemeSnapshot } from "../theme.ts";
@@ -9,6 +21,20 @@ import type { PaneFrameChip, PaneFrameProjection } from "./pane-frame.ts";
 export interface PaneFrameHeaderProps {
   theme: SemanticThemeSnapshot;
   projection: PaneFrameProjection;
+}
+
+interface OpenTuiPaneFrameHostContext {
+  theme: () => SemanticThemeSnapshot;
+  projection: () => PaneFrameProjection;
+  inputOwner: () => boolean;
+}
+
+const OpenTuiPaneFrameContext = createContext<OpenTuiPaneFrameHostContext>();
+
+function useOpenTuiPaneFrameHost(): OpenTuiPaneFrameHostContext {
+  const context = useContext(OpenTuiPaneFrameContext);
+  if (!context) throw new Error("OpenTUI PaneFrame host leaves require their host context");
+  return context;
 }
 
 function framePalette(theme: SemanticThemeSnapshot, projection: PaneFrameProjection) {
@@ -197,74 +223,260 @@ export function PaneFrameHeader(props: PaneFrameHeaderProps) {
   );
 }
 
-export interface PaneFrameProps extends PaneFrameHeaderProps {
-  children?: JSX.Element;
+function semanticBorderColor(
+  theme: SemanticThemeSnapshot,
+  appearance: PaneFrameRootLeafProps["appearance"],
+) {
+  const role = appearance.outerOutline.visible
+    ? (appearance.outerOutline.role ?? appearance.border.role)
+    : appearance.border.role;
+  return theme.roles.borders[role];
 }
 
-export function PaneFrame(props: PaneFrameProps) {
-  const palette = () => framePalette(props.theme, props.projection);
-  const glyphs = () => borderGlyphs(props.projection.borderStyle);
+function OpenTuiRoot(props: PaneFrameRootLeafProps) {
+  const host = useOpenTuiPaneFrameHost();
+  const projection = host.projection;
+  const glyphs = () => borderGlyphs(projection().borderStyle);
+  const border = () => semanticBorderColor(host.theme(), props.appearance);
   return (
     <box
-      width={props.projection.width}
-      height={props.projection.height}
+      id={`pane-frame:${props.pane.id}:root`}
+      width={projection().width}
+      height={projection().height}
       position="relative"
-      backgroundColor={props.theme.roles.surfaces.canvas}
+      backgroundColor={host.theme().roles.surfaces.canvas}
       overflow="hidden"
     >
-      <Show when={props.projection.borderStyle !== "none" && props.projection.width > 1}>
-        <box position="absolute" left={0} top={0} width={props.projection.width} height={1}>
-          <text fg={palette().border}>
-            {`${glyphs().tl}${glyphs().h.repeat(Math.max(0, props.projection.width - 2))}${glyphs().tr}`}
+      <Show when={projection().borderStyle !== "none" && projection().width > 1}>
+        <box position="absolute" left={0} top={0} width={projection().width} height={1}>
+          <text fg={border()}>
+            {`${glyphs().tl}${glyphs().h.repeat(Math.max(0, projection().width - 2))}${glyphs().tr}`}
           </text>
         </box>
         <box
           position="absolute"
           left={0}
-          top={Math.max(0, props.projection.height - 1)}
-          width={props.projection.width}
+          top={Math.max(0, projection().height - 1)}
+          width={projection().width}
           height={1}
         >
-          <text fg={palette().border}>
-            {`${glyphs().bl}${glyphs().h.repeat(Math.max(0, props.projection.width - 2))}${glyphs().br}`}
+          <text fg={border()}>
+            {`${glyphs().bl}${glyphs().h.repeat(Math.max(0, projection().width - 2))}${glyphs().br}`}
           </text>
         </box>
-        <Show when={props.projection.height > 2}>
-          <box position="absolute" left={0} top={1} width={1} height={props.projection.height - 2}>
-            <text fg={palette().border}>
-              {Array(props.projection.height - 2)
+        <Show when={projection().height > 2}>
+          <box position="absolute" left={0} top={1} width={1} height={projection().height - 2}>
+            <text fg={border()}>
+              {Array(projection().height - 2)
                 .fill(glyphs().v)
                 .join("\n")}
             </text>
           </box>
           <box
             position="absolute"
-            left={Math.max(0, props.projection.width - 1)}
+            left={Math.max(0, projection().width - 1)}
             top={1}
             width={1}
-            height={props.projection.height - 2}
+            height={projection().height - 2}
           >
-            <text fg={palette().border}>
-              {Array(props.projection.height - 2)
+            <text fg={border()}>
+              {Array(projection().height - 2)
                 .fill(glyphs().v)
                 .join("\n")}
             </text>
           </box>
         </Show>
       </Show>
-      <PaneFrameHeader theme={props.theme} projection={props.projection} />
-      <box
-        position="absolute"
-        left={props.projection.body.x}
-        top={props.projection.body.y}
-        width={props.projection.body.width}
-        height={props.projection.body.height}
-        flexDirection="column"
-        backgroundColor={props.theme.roles.surfaces.terminal}
-        overflow="hidden"
-      >
-        {props.children}
-      </box>
+      {props.children}
     </box>
+  );
+}
+
+function OpenTuiHeader(props: PaneFrameHeaderLeafProps) {
+  const host = useOpenTuiPaneFrameHost();
+  const projection = host.projection;
+  return (
+    <box
+      id={`pane-frame:${props.pane.id}:header`}
+      position="absolute"
+      left={projection().header.x}
+      top={projection().header.y}
+      width={projection().header.width}
+      height={projection().header.height}
+      backgroundColor={host.theme().roles.surfaces[props.appearance.header.surface]}
+      overflow="hidden"
+    >
+      {props.children}
+    </box>
+  );
+}
+
+function OpenTuiGrip(props: PaneFrameGripLeafProps) {
+  const host = useOpenTuiPaneFrameHost();
+  const projection = host.projection;
+  return (
+    <Show when={projection().grip !== null}>
+      <box
+        id={`pane-frame:${props.pane.id}:grip`}
+        position="absolute"
+        left={projection().grip!.x - projection().header.x}
+        top={0}
+        width={projection().grip!.width}
+        height={1}
+        onMouseDown={host.inputOwner() ? props.onActivate : undefined}
+      >
+        <text fg={semanticBorderColor(host.theme(), props.appearance)}>
+          {projection().grip!.text}
+        </text>
+      </box>
+    </Show>
+  );
+}
+
+function OpenTuiTitle(props: PaneFrameTitleLeafProps) {
+  const host = useOpenTuiPaneFrameHost();
+  const projection = host.projection;
+  const titleColor = () => host.theme().roles.text[props.appearance.header.text];
+  return (
+    <>
+      <box
+        id={`pane-frame:${props.pane.id}:title`}
+        position="absolute"
+        left={projection().titleSpan.x - projection().header.x}
+        top={0}
+        width={projection().titleSpan.width}
+        height={1}
+      >
+        <text fg={titleColor()} attributes={props.appearance.header.focused ? 1 : 0}>
+          {projection().titleSpan.text}
+        </text>
+      </box>
+      <Show when={projection().subtitleSpan !== null}>
+        <box
+          id={`pane-frame:${props.pane.id}:subtitle`}
+          position="absolute"
+          left={projection().subtitleSpan!.x - projection().header.x}
+          top={0}
+          width={projection().subtitleSpan!.width}
+          height={1}
+        >
+          <text fg={host.theme().roles.text.muted}>{projection().subtitleSpan!.text}</text>
+        </box>
+      </Show>
+    </>
+  );
+}
+
+function projectedStatusChip(
+  projection: PaneFrameProjection,
+  props: PaneFrameStatusLeafProps,
+): PaneFrameChip | null {
+  return (
+    projection.chips.find((chip) => {
+      if (props.item.kind === "status") return chip.kind === "status" && chip.id === props.item.id;
+      return chip.kind === "state" && chip.id === props.item.id;
+    }) ?? null
+  );
+}
+
+function OpenTuiStatus(props: PaneFrameStatusLeafProps) {
+  const host = useOpenTuiPaneFrameHost();
+  const chip = () => projectedStatusChip(host.projection(), props);
+  return (
+    <Show when={chip() !== null}>
+      <box
+        id={`pane-frame:${props.pane.id}:${props.item.kind}:${props.item.id}`}
+        position="absolute"
+        left={chip()!.start - host.projection().header.x}
+        top={0}
+        width={chip()!.width}
+        height={1}
+      >
+        <Chip theme={host.theme()} chip={chip()!} />
+      </box>
+    </Show>
+  );
+}
+
+function OpenTuiActionList(props: PaneFrameActionListLeafProps) {
+  return props.children;
+}
+
+function OpenTuiAction(props: PaneFrameActionLeafProps) {
+  const host = useOpenTuiPaneFrameHost();
+  const chip = () =>
+    host.projection().actions.find((action) => action.id === props.action.id) ?? null;
+  return (
+    <Show when={chip() !== null}>
+      <box
+        id={`pane-frame:${props.pane.id}:action:${props.action.id}`}
+        position="absolute"
+        left={chip()!.start - host.projection().header.x}
+        top={0}
+        width={chip()!.width}
+        height={1}
+        onMouseDown={host.inputOwner() && props.interactive ? props.onActivate : undefined}
+      >
+        <Chip theme={host.theme()} chip={chip()!} />
+      </box>
+    </Show>
+  );
+}
+
+function OpenTuiBody(props: PaneFrameBodyLeafProps) {
+  const host = useOpenTuiPaneFrameHost();
+  const projection = host.projection;
+  return (
+    <box
+      id={`pane-frame:${props.pane.id}:body`}
+      position="absolute"
+      left={projection().body.x}
+      top={projection().body.y}
+      width={projection().body.width}
+      height={projection().body.height}
+      flexDirection="column"
+      backgroundColor={host.theme().roles.surfaces.terminal}
+      overflow="hidden"
+    >
+      {props.children}
+    </box>
+  );
+}
+
+export const OPEN_TUI_PANE_FRAME_HOST = Object.freeze({
+  Root: OpenTuiRoot,
+  Header: OpenTuiHeader,
+  Grip: OpenTuiGrip,
+  Title: OpenTuiTitle,
+  Status: OpenTuiStatus,
+  ActionList: OpenTuiActionList,
+  Action: OpenTuiAction,
+  Body: OpenTuiBody,
+}) satisfies PaneFrameHostLeaves;
+
+export interface PaneFrameProps extends PaneFrameHeaderProps {
+  children?: JSX.Element;
+  /** Standalone fixture/test ownership only. Production terminal chrome stays passive. */
+  inputOwner?: boolean;
+  onActionActivate?: Parameters<typeof PaneFramePresenter>[0]["onActionActivate"];
+  onGripActivate?: Parameters<typeof PaneFramePresenter>[0]["onGripActivate"];
+}
+
+export function PaneFrame(props: PaneFrameProps) {
+  const context: OpenTuiPaneFrameHostContext = {
+    theme: () => props.theme,
+    projection: () => props.projection,
+    inputOwner: () => props.inputOwner === true,
+  };
+  return (
+    <OpenTuiPaneFrameContext.Provider value={context}>
+      <PaneFramePresenter
+        model={props.projection.model}
+        host={OPEN_TUI_PANE_FRAME_HOST}
+        body={props.children}
+        onActionActivate={props.onActionActivate}
+        onGripActivate={props.onGripActivate}
+      />
+    </OpenTuiPaneFrameContext.Provider>
   );
 }

--- a/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/pane-frame.tsx
@@ -112,8 +112,10 @@ function Chip(props: { theme: SemanticThemeSnapshot; chip: PaneFrameChip }) {
             hovered={action()!.hovered}
             pressed={action()!.pressed}
             selected={action()!.active}
+            focused={action()!.focused}
             disabled={action()!.disabled}
             attention={action()!.attention}
+            loading={action()!.loading}
           />
         }
       >
@@ -126,8 +128,10 @@ function Chip(props: { theme: SemanticThemeSnapshot; chip: PaneFrameChip }) {
           // Icon identity (□/▣) communicates toggle state. Keep the idle
           // control transparent like native window chrome.
           selected={false}
+          focused={action()!.focused}
           disabled={action()!.disabled}
           attention={action()!.attention}
+          loading={action()!.loading}
           hidden={action()!.hidden}
         />
       </Show>
@@ -415,7 +419,11 @@ function OpenTuiAction(props: PaneFrameActionLeafProps) {
         top={0}
         width={chip()!.width}
         height={1}
-        onMouseDown={host.inputOwner() && props.interactive ? props.onActivate : undefined}
+        onMouseDown={
+          host.inputOwner() && props.interactive && chip()!.interactive
+            ? props.onActivate
+            : undefined
+        }
       >
         <Chip theme={host.theme()} chip={chip()!} />
       </box>

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome-view.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome-view.tsx
@@ -1,7 +1,7 @@
 /* @jsxImportSource @opentui/solid */
 import { createMemo, For } from "solid-js";
 import type { SemanticThemeSnapshot } from "../theme.ts";
-import { PaneFrameHeader } from "./pane-frame.tsx";
+import { PaneFrame, PaneFrameHeader } from "./pane-frame.tsx";
 import type {
   TerminalPaneChromeLayout,
   TerminalPaneChromeProjection,
@@ -53,6 +53,44 @@ export function TerminalPaneChromeLayer(props: TerminalPaneChromeLayerProps) {
             overflow="hidden"
           >
             <PaneFrameHeader theme={props.theme} projection={frame()} />
+          </box>
+        );
+      }}
+    </For>
+  );
+}
+
+/** Card 22.4b OpenTUI host. Card 22.4b2 owns the one-line production-root swap. */
+export function SharedTerminalPaneChromeLayer(props: TerminalPaneChromeLayerProps) {
+  const projections = (): readonly TerminalPaneChromeProjection[] =>
+    props.layer === "native" ? props.layout.native : props.layout.framebuffer;
+  const projectionIds = createMemo(
+    () =>
+      projections()
+        .filter((projection) => projection.frame !== null)
+        .map((projection) => projection.paneId),
+    undefined,
+    { equals: sameIds },
+  );
+  const projectionsById = createMemo(
+    () => new Map(projections().map((projection) => [projection.paneId, projection])),
+  );
+  return (
+    <For each={projectionIds()}>
+      {(paneId) => {
+        const pane = () => projectionsById().get(paneId)!;
+        const frame = () => pane().frame!;
+        return (
+          <box
+            id={`shared-terminal-pane-chrome:${props.layer}:${paneId}`}
+            position="absolute"
+            left={pane().layerRect.x}
+            top={pane().layerRect.y}
+            width={pane().layerRect.width}
+            height={pane().layerRect.height}
+            overflow="hidden"
+          >
+            <PaneFrame theme={props.theme} projection={frame()} />
           </box>
         );
       }}

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.test.ts
@@ -1,14 +1,18 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { projectAgentTerminalCanvas } from "./agent-terminal-canvas.ts";
 import {
+  CARD_22_4B2_PANE_FRAME_ROOT_WIRING_DEFERRALS,
   dispatchTerminalPaneChromePointerIntent,
   projectTerminalPaneChrome,
   reconcileTerminalPaneChromeActionTarget,
+  terminalPaneChromeActionTargetForIntent,
   terminalPaneChromeHitTest,
   terminalPaneChromeMotionState,
   terminalPaneChromeOverlapsBodies,
   terminalPaneChromePointerIntent,
   terminalPaneChromeTitle,
+  terminalPaneSemanticId,
   type TerminalPaneChromePane,
 } from "./terminal-pane-chrome.ts";
 
@@ -212,6 +216,21 @@ describe("terminal pane chrome projection", () => {
       paneId: "%2",
       actionId: "zoom",
       actionIndex: zoomIndex,
+      semanticIntent: {
+        kind: "action",
+        paneId: terminalPaneSemanticId("%2"),
+        actionId: "zoom",
+        commandId: "workspace.windowMode.maximize.toggle",
+      },
+    });
+    const intent = terminalPaneChromePointerIntent(layout, x, y, "down");
+    expect(
+      intent?.kind === "action"
+        ? terminalPaneChromeActionTargetForIntent(layout, intent.semanticIntent)
+        : null,
+    ).toEqual({
+      paneId: "%2",
+      actionIndex: zoomIndex,
     });
     expect(terminalPaneChromePointerIntent(layout, second.canvasRect.x, y, "down")).toEqual({
       kind: "focus",
@@ -235,7 +254,18 @@ describe("terminal pane chrome projection", () => {
     const calls: string[] = [];
     const ptyWrites: string[] = [];
     dispatchTerminalPaneChromePointerIntent(
-      { kind: "action", paneId: "%9", actionId: "zoom", actionIndex: 0 },
+      {
+        kind: "action",
+        paneId: "%9",
+        actionId: "zoom",
+        actionIndex: 0,
+        semanticIntent: {
+          kind: "action",
+          paneId: terminalPaneSemanticId("%9"),
+          actionId: "zoom",
+          commandId: "workspace.windowMode.maximize.toggle",
+        },
+      },
       {
         hover: () => calls.push("hover"),
         focus: (paneId) => calls.push(`focus:${paneId}`),
@@ -246,6 +276,21 @@ describe("terminal pane chrome projection", () => {
     );
     expect(calls).toEqual(["focus:%9", "zoom:%9"]);
     expect(ptyWrites).toEqual([]);
+  });
+
+  it("keeps the one-item production root swap executable and owned by Card 22.4b2", () => {
+    const appSource = readFileSync(new URL("../app.tsx", import.meta.url), "utf8");
+    expect(CARD_22_4B2_PANE_FRAME_ROOT_WIRING_DEFERRALS).toEqual([
+      {
+        component: "TerminalPaneChromeLayer",
+        replacement: "SharedTerminalPaneChromeLayer",
+        owner: "22.4b2",
+      },
+    ]);
+    expect(appSource).toContain(
+      'import { TerminalPaneChromeLayer } from "./workspace/terminal-pane-chrome-view.tsx"',
+    );
+    expect(appSource).not.toContain("SharedTerminalPaneChromeLayer");
   });
 
   it("lets non-action lower-header cells fall through to separator resize", () => {

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.test.ts
@@ -32,6 +32,15 @@ function pane(overrides: Partial<TerminalPaneChromePane>): TerminalPaneChromePan
 }
 
 describe("terminal pane chrome projection", () => {
+  it("encodes and bounds live tmux ids at the semantic schema boundary", () => {
+    expect(terminalPaneSemanticId("%7")).toBe("pane.tmux.25-37");
+    const first = terminalPaneSemanticId(`%${"pane-".repeat(80)}a`);
+    const second = terminalPaneSemanticId(`%${"pane-".repeat(80)}b`);
+    expect(first.length).toBeLessThanOrEqual(128);
+    expect(first).toMatch(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u);
+    expect(second).not.toBe(first);
+  });
+
   it("segments the native header for horizontal panes without touching either body", () => {
     const panes = [
       pane({ id: "%1", width: 59 }),

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts
@@ -1,9 +1,10 @@
-import type {
-  AgentActivity,
-  CanonicalDomainStatus,
-  PaneAttention,
-  PaneVisualStateV1,
-  SemanticProductId,
+import {
+  SemanticProductIdSchemaZ,
+  type AgentActivity,
+  type CanonicalDomainStatus,
+  type PaneAttention,
+  type PaneVisualStateV1,
+  type SemanticProductId,
 } from "@tmux-ide/contracts";
 import type { PaneFrameActionIntent } from "../../../ui/pane-frame/presenter.tsx";
 import { terminalDisplayWidth } from "../panel-host.ts";
@@ -12,6 +13,7 @@ import type { AgentTerminalCanvasProjection } from "./agent-terminal-canvas.ts";
 import {
   paneFrameHitTest,
   projectPaneFrame,
+  resolveEffectivePaneFrameActionState,
   type PaneFrameActionChip,
   type PaneFrameHit,
   type PaneFrameProjection,
@@ -140,10 +142,24 @@ export const CARD_22_4B2_PANE_FRAME_ROOT_WIRING_DEFERRALS = Object.freeze([
 
 /** Live tmux ids are transport identities, so encode them before crossing the semantic boundary. */
 export function terminalPaneSemanticId(paneId: string): SemanticProductId {
-  const encoded = Array.from(paneId, (character) => character.codePointAt(0)!.toString(16)).join(
-    "-",
-  );
-  return `pane.tmux.${encoded || "empty"}` as SemanticProductId;
+  const prefix = "pane.tmux.";
+  const encoded =
+    Array.from(paneId, (character) => character.codePointAt(0)!.toString(16)).join("-") || "empty";
+  const maximumEncodedLength = 128 - prefix.length;
+  const hash = stablePaneIdHash(paneId);
+  const bounded =
+    encoded.length <= maximumEncodedLength
+      ? encoded
+      : `${encoded.slice(0, maximumEncodedLength - hash.length - 1)}-${hash}`;
+  return SemanticProductIdSchemaZ.parse(`${prefix}${bounded}`);
+}
+
+function stablePaneIdHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = Math.imul(hash ^ value.charCodeAt(index), 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
 }
 
 /**
@@ -488,6 +504,14 @@ function paneHeaderFrame(
   const projectedActions: PaneFrameActionChip[] = [];
   const pushAction = (index: number, chipWidth: number) => {
     const action = actions[index]!;
+    const semanticAction = full.model.actions[index]!;
+    const effective = resolveEffectivePaneFrameActionState({
+      appearance: full.model.appearance,
+      action: semanticAction,
+      attention: false,
+      hostHovered: hovered?.paneId === pane.id && hovered.actionIndex === index,
+      hostPressed: pressed?.paneId === pane.id && pressed.actionIndex === index,
+    });
     projectedActions.push({
       ...action,
       kind: "action",
@@ -496,8 +520,15 @@ function paneHeaderFrame(
       fullLabel: action.label,
       start: actionX,
       width: chipWidth,
-      hovered: hovered?.paneId === pane.id && hovered.actionIndex === index,
-      pressed: pressed?.paneId === pane.id && pressed.actionIndex === index,
+      active: effective.active,
+      disabled: effective.disabled,
+      attention: effective.attention,
+      focused: effective.focused,
+      hovered: effective.hovered,
+      interactive: effective.interactive,
+      loading: effective.loading,
+      pressed: effective.pressed,
+      state: effective.state,
     });
     actionX += chipWidth + 1;
   };

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts
@@ -1,3 +1,11 @@
+import type {
+  AgentActivity,
+  CanonicalDomainStatus,
+  PaneAttention,
+  PaneVisualStateV1,
+  SemanticProductId,
+} from "@tmux-ide/contracts";
+import type { PaneFrameActionIntent } from "../../../ui/pane-frame/presenter.tsx";
 import { terminalDisplayWidth } from "../panel-host.ts";
 import { iconButtonWidth, type RecipeTone, type Rect } from "../recipes.ts";
 import type { AgentTerminalCanvasProjection } from "./agent-terminal-canvas.ts";
@@ -30,6 +38,9 @@ export interface TerminalPaneChromeMetadata {
   status?: string | null;
   statusTone?: Exclude<RecipeTone, "neutral" | "accent">;
   attention?: boolean;
+  agentActivity?: AgentActivity;
+  domainStatus?: CanonicalDomainStatus;
+  attentionKind?: PaneAttention;
 }
 
 export interface TerminalPaneChromeActionTarget {
@@ -83,7 +94,13 @@ export interface TerminalPaneChromeHit {
 export type TerminalPaneChromePointerIntent =
   | { kind: "hover"; target: TerminalPaneChromeHoverTarget | null }
   | { kind: "focus"; paneId: string }
-  | { kind: "action"; paneId: string; actionId: string; actionIndex: number }
+  | {
+      kind: "action";
+      paneId: string;
+      actionId: string;
+      actionIndex: number;
+      semanticIntent: PaneFrameActionIntent;
+    }
   | { kind: "menu"; paneId: string }
   | { kind: "settle"; paneId: string }
   | { kind: "consume"; paneId: string }
@@ -92,7 +109,12 @@ export type TerminalPaneChromePointerIntent =
 export interface TerminalPaneChromePointerEffects {
   hover(target: TerminalPaneChromeHoverTarget | null): void;
   focus(paneId: string): void;
-  action(paneId: string, actionId: string, actionIndex: number): void;
+  action(
+    paneId: string,
+    actionId: string,
+    actionIndex: number,
+    semanticIntent: PaneFrameActionIntent,
+  ): void;
   menu(paneId: string): void;
   settle(paneId: string): void;
 }
@@ -105,6 +127,23 @@ export interface TerminalPaneChromeMotionState {
 interface Segment {
   start: number;
   end: number;
+}
+
+/** One executable production-root handoff; Card 22.4b2 must remove it when wiring the new host. */
+export const CARD_22_4B2_PANE_FRAME_ROOT_WIRING_DEFERRALS = Object.freeze([
+  Object.freeze({
+    component: "TerminalPaneChromeLayer",
+    replacement: "SharedTerminalPaneChromeLayer",
+    owner: "22.4b2",
+  }),
+] as const);
+
+/** Live tmux ids are transport identities, so encode them before crossing the semantic boundary. */
+export function terminalPaneSemanticId(paneId: string): SemanticProductId {
+  const encoded = Array.from(paneId, (character) => character.codePointAt(0)!.toString(16)).join(
+    "-",
+  );
+  return `pane.tmux.${encoded || "empty"}` as SemanticProductId;
 }
 
 /**
@@ -230,6 +269,44 @@ export function terminalPaneChromeHitTest(
   return null;
 }
 
+export function terminalPaneChromeSemanticActionIntent(
+  layout: TerminalPaneChromeLayout,
+  paneId: string,
+  hit: Extract<Exclude<PaneFrameHit, null>, { area: "action" }>,
+): PaneFrameActionIntent | null {
+  const pane = [...layout.native, ...layout.framebuffer].find(
+    (projection) => projection.paneId === paneId,
+  );
+  const action = pane?.frame?.model.actions.find((candidate) => candidate.id === hit.actionId);
+  if (!pane?.frame || !action) return null;
+  return {
+    kind: "action",
+    paneId: pane.frame.model.pane.id,
+    actionId: action.id,
+    commandId: action.commandId,
+  };
+}
+
+/** Reverse the renderer-neutral intent into the existing live tmux cell target. */
+export function terminalPaneChromeActionTargetForIntent(
+  layout: TerminalPaneChromeLayout,
+  intent: PaneFrameActionIntent,
+): TerminalPaneChromeActionTarget | null {
+  for (const pane of [...layout.native, ...layout.framebuffer]) {
+    if (pane.frame?.model.pane.id !== intent.paneId) continue;
+    const actionIndex = pane.frame.actions.findIndex(
+      (action) =>
+        action.id === intent.actionId &&
+        pane.frame?.model.actions.some(
+          (semanticAction) =>
+            semanticAction.id === action.id && semanticAction.commandId === intent.commandId,
+        ),
+    );
+    if (actionIndex >= 0) return { paneId: pane.paneId, actionIndex };
+  }
+  return null;
+}
+
 /** Root-owned pointer policy. A chrome cell is always consumed and never PTY-routed. */
 export function terminalPaneChromePointerIntent(
   layout: TerminalPaneChromeLayout,
@@ -269,11 +346,18 @@ export function terminalPaneChromePointerIntent(
     };
   }
   if (eventType === "down" && result.hit.area === "action") {
+    const semanticIntent = terminalPaneChromeSemanticActionIntent(
+      layout,
+      result.paneId,
+      result.hit,
+    );
+    if (!semanticIntent) return { kind: "consume", paneId: result.paneId };
     return {
       kind: "action",
       paneId: result.paneId,
       actionId: result.hit.actionId,
       actionIndex: result.hit.actionIndex,
+      semanticIntent,
     };
   }
   if (eventType === "down") return { kind: "focus", paneId: result.paneId };
@@ -293,7 +377,7 @@ export function dispatchTerminalPaneChromePointerIntent(
   else if (intent.kind === "focus") effects.focus(intent.paneId);
   else if (intent.kind === "action") {
     effects.focus(intent.paneId);
-    effects.action(intent.paneId, intent.actionId, intent.actionIndex);
+    effects.action(intent.paneId, intent.actionId, intent.actionIndex, intent.semanticIntent);
   } else if (intent.kind === "menu") {
     effects.focus(intent.paneId);
     effects.menu(intent.paneId);
@@ -347,6 +431,7 @@ function paneHeaderFrame(
   const actions = [
     {
       id: "zoom",
+      commandId: "workspace.windowMode.maximize.toggle" as const,
       label: pane.zoomed ? "restore" : "zoom",
       compactLabel: pane.zoomed ? "R" : "Z",
       icon: pane.zoomed ? "restore" : "maximize",
@@ -356,6 +441,7 @@ function paneHeaderFrame(
     },
     {
       id: "menu",
+      commandId: "workspace.pane.menu.open" as const,
       label: "more",
       compactLabel: ".",
       icon: "more",
@@ -364,6 +450,7 @@ function paneHeaderFrame(
     },
   ] as const;
   const input = {
+    paneId: terminalPaneSemanticId(pane.id),
     width,
     height: 1,
     title,
@@ -374,6 +461,7 @@ function paneHeaderFrame(
     attention: metadata?.attention === true,
     status: metadata?.status,
     statusTone: metadata?.statusTone,
+    visualState: terminalPaneVisualState(pane, metadata),
     hoveredActionIndex: hovered?.paneId === pane.id ? hovered.actionIndex : null,
     pressedActionIndex: pressed?.paneId === pane.id ? pressed.actionIndex : null,
     actions,
@@ -421,6 +509,7 @@ function paneHeaderFrame(
   const titleWidth = terminalDisplayWidth(titleText);
   return {
     ...base,
+    model: full.model,
     grip: null,
     title: titleText,
     subtitle: "",
@@ -428,6 +517,64 @@ function paneHeaderFrame(
     subtitleSpan: null,
     chips: projectedActions,
     actions: projectedActions,
+  };
+}
+
+function terminalPaneDomainStatus(
+  metadata: TerminalPaneChromeMetadata | undefined,
+): CanonicalDomainStatus {
+  if (metadata?.domainStatus) return metadata.domainStatus;
+  if (metadata?.statusTone === "working") return "running";
+  if (metadata?.statusTone === "blocked") return "blocked";
+  if (metadata?.statusTone === "done") return "done";
+  if (metadata?.statusTone === "unknown") return "disconnected";
+  return "idle";
+}
+
+function terminalPaneAgentActivity(
+  metadata: TerminalPaneChromeMetadata | undefined,
+  status: CanonicalDomainStatus,
+): AgentActivity {
+  if (metadata?.agentActivity) return metadata.agentActivity;
+  if (status === "running") return "running";
+  if (status === "blocked" || status === "review") return "waiting";
+  if (status === "done") return "complete";
+  if (status === "disconnected") return "disconnected";
+  if (status === "recovering") return "running";
+  return "idle";
+}
+
+function terminalPaneVisualState(
+  pane: TerminalPaneChromePane,
+  metadata: TerminalPaneChromeMetadata | undefined,
+): PaneVisualStateV1 {
+  const domainStatus = terminalPaneDomainStatus(metadata);
+  return {
+    structure: pane.zoomed ? "maximized" : "docked",
+    applicationFocus: {
+      pane: pane.active,
+      terminalInput: pane.active,
+      windowActive: true,
+    },
+    agentActivity: terminalPaneAgentActivity(metadata, domainStatus),
+    domainStatus,
+    attention:
+      metadata?.attentionKind ??
+      (metadata?.attention ? (domainStatus === "blocked" ? "warning" : "requested") : "none"),
+    layoutInteraction: {
+      editable: true,
+      selected: false,
+      dragging: false,
+      resizing: false,
+      previewing: false,
+    },
+    controlInteraction: {
+      hover: false,
+      focusVisible: false,
+      pressed: false,
+      disabled: false,
+      loading: false,
+    },
   };
 }
 

--- a/packages/daemon/tsconfig.workbench-dock-opentui.json
+++ b/packages/daemon/tsconfig.workbench-dock-opentui.json
@@ -9,6 +9,8 @@
     "src/js-yaml.d.ts",
     "src/ui/pane-frame/presenter.tsx",
     "src/ui/workbench-dock/presenter.tsx",
+    "src/tui/mirror/workspace/pane-frame.tsx",
+    "src/tui/mirror/workspace/terminal-pane-chrome-view.tsx",
     "src/tui/mirror/workspace/workbench-dock-opentui.tsx",
     "src/tui/mirror/workspace/workbench-shell.tsx"
   ],


### PR DESCRIPTION
## Summary

- add the OpenTUI host leaves for the renderer-neutral shared PaneFrame presenter
- map live tmux pane metadata into semantic pane identity, appearance, chips, status, and actions
- keep cell geometry, clipping, hit zones, tmux sizing, and focus-before-action in the OpenTUI host
- preserve keyed pane/action renderables across fresh projections to prevent anchor churn and flicker

## Review repair

- introduce one effective action-state boundary for canonical disabled, loading, pressed, focus-visible, attention, hover, and base precedence
- make projection, label/icon rendering, hit testing, and OpenTUI activation consume the same effective interactivity
- prevent globally disabled/loading controls from appearing or behaving as interactive in passive root routing
- schema-parse and deterministically bound encoded tmux pane IDs at the semantic boundary

## Verification

- focused projection/model: 41 tests
- focused PaneFrame renderer: 26 tests / 23 snapshots
- full OpenTUI renderer: 92 tests / 62 snapshots
- daemon typecheck and TUI build
- full `pnpm check`, including packed install smoke and native dependency validation
- stable renderable identity stress across fresh projections
- independent adversarial re-review: approved

## Boundary

This card deliberately does not edit `app.tsx`. The exact one-item production handoff from `TerminalPaneChromeLayer` to `SharedTerminalPaneChromeLayer` remains owned by Card 22.4b2, so the root keeps sole input/effect ownership until that integration lands.
