### PR TITLE
feat(contracts): share daemon resource and event schemas

### DIFF
--- a/packages/contracts/src/__tests__/daemon-events.test.ts
+++ b/packages/contracts/src/__tests__/daemon-events.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { DaemonEventClientFrameSchemaZ, DaemonEventServerFrameSchemaZ } from "../daemon-events.ts";
+
+describe("daemon event contracts", () => {
+  it("accepts every client frame and rejects missing or extra fields", () => {
+    expect(
+      DaemonEventClientFrameSchemaZ.parse({ type: "subscribe", sessions: ["tmux-ide"] }),
+    ).toEqual({ type: "subscribe", sessions: ["tmux-ide"] });
+    expect(
+      DaemonEventClientFrameSchemaZ.safeParse({ type: "unsubscribe", sessions: [] }).success,
+    ).toBe(true);
+    expect(DaemonEventClientFrameSchemaZ.safeParse({ type: "ping" }).success).toBe(true);
+
+    expect(DaemonEventClientFrameSchemaZ.safeParse({ type: "subscribe" }).success).toBe(false);
+    expect(
+      DaemonEventClientFrameSchemaZ.safeParse({
+        type: "subscribe",
+        sessions: [],
+        typo: true,
+      }).success,
+    ).toBe(false);
+    expect(DaemonEventClientFrameSchemaZ.safeParse({ type: "ping", sessions: [] }).success).toBe(
+      false,
+    );
+  });
+
+  it("strictly parses snapshots and protocol errors", () => {
+    const snapshot = {
+      type: "snapshot",
+      sessionName: "tmux-ide",
+      data: {
+        project: {
+          session: "tmux-ide",
+          dir: "/repo/tmux-ide",
+          panes: [],
+        },
+      },
+    } as const;
+    expect(DaemonEventServerFrameSchemaZ.parse(snapshot)).toEqual(snapshot);
+    expect(DaemonEventServerFrameSchemaZ.safeParse({ ...snapshot, unexpected: true }).success).toBe(
+      false,
+    );
+    expect(
+      DaemonEventServerFrameSchemaZ.safeParse({
+        ...snapshot,
+        data: { project: { ...snapshot.data.project, unexpected: true } },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      DaemonEventServerFrameSchemaZ.safeParse({
+        type: "protocol.error",
+        code: "invalid-frame",
+        message: "Client frame does not match the daemon event protocol.",
+      }).success,
+    ).toBe(true);
+    expect(
+      DaemonEventServerFrameSchemaZ.safeParse({
+        type: "protocol.error",
+        code: "unknown",
+        message: "nope",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("keeps every historical server discriminator parseable", () => {
+    const frames = [
+      { type: "hello", sessions: [] },
+      { type: "sessions.changed" },
+      { type: "projects.changed" },
+      { type: "init.output", jobId: "job-1", chunk: "working", done: false },
+      { type: "init.error", jobId: "job-1", message: "failed" },
+      { type: "pong" },
+      { type: "action.complete", name: "project.launch", result: { ok: true } },
+      { type: "config.changed", sessionName: "tmux-ide" },
+      { type: "terminals.changed", sessionName: "tmux-ide" },
+      {
+        type: "workspace.added",
+        workspace: {
+          name: "tmux-ide",
+          sessionName: "tmux-ide",
+          projectDir: "/repo/tmux-ide",
+          ideConfigPath: null,
+          addedAt: "2026-07-21T12:00:00.000Z",
+        },
+      },
+      { type: "workspace.removed", name: "tmux-ide" },
+    ];
+
+    for (const frame of frames) {
+      expect(DaemonEventServerFrameSchemaZ.safeParse(frame).success, frame.type).toBe(true);
+    }
+  });
+});

--- a/packages/contracts/src/__tests__/daemon-resources.test.ts
+++ b/packages/contracts/src/__tests__/daemon-resources.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  DaemonPanesResponseSchemaZ,
+  DaemonProjectResponseSchemaZ,
+  DaemonProjectsResponseSchemaZ,
+  DaemonProjectTemplatesResponseSchemaZ,
+  DaemonSessionsResponseSchemaZ,
+  DaemonWorkspacesResponseSchemaZ,
+} from "../daemon-resources.ts";
+
+const pane = {
+  id: "%7",
+  index: 0,
+  title: "Codex",
+  currentCommand: "codex",
+  width: 120,
+  height: 40,
+  active: true,
+  role: "teammate" as const,
+  name: "Implementer",
+  type: null,
+};
+
+describe("daemon REST resources", () => {
+  it("parses the current session, project, and pane response shapes", () => {
+    expect(
+      DaemonSessionsResponseSchemaZ.parse({
+        sessions: [{ name: "tmux-ide", dir: "/repo/tmux-ide" }],
+      }),
+    ).toEqual({ sessions: [{ name: "tmux-ide", dir: "/repo/tmux-ide" }] });
+
+    expect(
+      DaemonProjectResponseSchemaZ.parse({
+        session: "tmux-ide",
+        dir: "/repo/tmux-ide",
+        panes: [pane],
+      }).panes,
+    ).toEqual([pane]);
+    expect(DaemonPanesResponseSchemaZ.parse({ panes: [pane] })).toEqual({ panes: [pane] });
+  });
+
+  it("parses workspace, registry, and project-template envelopes", () => {
+    expect(
+      DaemonWorkspacesResponseSchemaZ.safeParse({
+        workspaces: [
+          {
+            name: "tmux-ide",
+            sessionName: "tmux-ide",
+            projectDir: "/repo/tmux-ide",
+            ideConfigPath: null,
+            configKind: "workspace",
+            configPath: "/repo/tmux-ide/.tmux-ide/workspace.yml",
+            hasWorkspaceConfig: true,
+            addedAt: "2026-07-21T12:00:00.000Z",
+          },
+        ],
+      }).success,
+    ).toBe(true);
+
+    expect(
+      DaemonProjectsResponseSchemaZ.safeParse({
+        projects: [
+          {
+            name: "tmux-ide",
+            dir: "/repo/tmux-ide",
+            hasIdeYml: false,
+            hasWorkspaceConfig: true,
+            configKind: "workspace",
+            configPath: "/repo/tmux-ide/.tmux-ide/workspace.yml",
+            ideConfigPath: null,
+            gitOrigin: "git@github.com:wavyrai/tmux-ide.git",
+            gitBranch: "main",
+            registeredAt: "2026-07-21T12:00:00.000Z",
+          },
+        ],
+      }).success,
+    ).toBe(true);
+
+    expect(
+      DaemonProjectTemplatesResponseSchemaZ.parse({
+        templates: [{ id: "default", label: "Default", description: "A balanced workspace" }],
+      }).templates[0]?.id,
+    ).toBe("default");
+  });
+
+  it("rejects unknown envelope and nested resource fields", () => {
+    expect(DaemonSessionsResponseSchemaZ.safeParse({ sessions: [], typo: true }).success).toBe(
+      false,
+    );
+    expect(
+      DaemonSessionsResponseSchemaZ.safeParse({
+        sessions: [{ name: "tmux-ide", dir: "/repo", typo: true }],
+      }).success,
+    ).toBe(false);
+    expect(DaemonPanesResponseSchemaZ.safeParse({ panes: [{ ...pane, typo: true }] }).success).toBe(
+      false,
+    );
+    expect(
+      DaemonProjectsResponseSchemaZ.safeParse({
+        projects: [
+          {
+            name: "tmux-ide",
+            dir: "/repo",
+            hasIdeYml: false,
+            gitOrigin: null,
+            gitBranch: null,
+            registeredAt: "now",
+            typo: true,
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/contracts/src/daemon-events.ts
+++ b/packages/contracts/src/daemon-events.ts
@@ -1,0 +1,146 @@
+import { z } from "zod";
+import {
+  DaemonProjectResponseSchemaZ,
+  DaemonSessionOverviewSchemaZ,
+  DaemonWorkspaceSchemaZ,
+} from "./daemon-resources.ts";
+
+/** Shared, browser-safe protocol for the daemon's unified /ws/events socket. */
+
+const SessionNamesSchemaZ = z.array(z.string());
+
+export const DaemonEventSubscribeFrameSchemaZ = z
+  .object({
+    type: z.literal("subscribe"),
+    sessions: SessionNamesSchemaZ,
+  })
+  .strict();
+
+export const DaemonEventUnsubscribeFrameSchemaZ = z
+  .object({
+    type: z.literal("unsubscribe"),
+    sessions: SessionNamesSchemaZ,
+  })
+  .strict();
+
+export const DaemonEventPingFrameSchemaZ = z.object({ type: z.literal("ping") }).strict();
+
+export const DaemonEventClientFrameSchemaZ = z.discriminatedUnion("type", [
+  DaemonEventSubscribeFrameSchemaZ,
+  DaemonEventUnsubscribeFrameSchemaZ,
+  DaemonEventPingFrameSchemaZ,
+]);
+export type DaemonEventClientFrame = z.infer<typeof DaemonEventClientFrameSchemaZ>;
+
+export const DaemonSessionSnapshotSchemaZ = z
+  .object({
+    project: DaemonProjectResponseSchemaZ,
+  })
+  .strict();
+export type DaemonSessionSnapshot = z.infer<typeof DaemonSessionSnapshotSchemaZ>;
+
+export const DaemonEventHelloFrameSchemaZ = z
+  .object({
+    type: z.literal("hello"),
+    sessions: z.array(DaemonSessionOverviewSchemaZ),
+  })
+  .strict();
+
+export const DaemonEventSnapshotFrameSchemaZ = z
+  .object({
+    type: z.literal("snapshot"),
+    sessionName: z.string(),
+    data: DaemonSessionSnapshotSchemaZ,
+  })
+  .strict();
+
+export const DaemonEventSessionsChangedFrameSchemaZ = z
+  .object({ type: z.literal("sessions.changed") })
+  .strict();
+
+export const DaemonEventProjectsChangedFrameSchemaZ = z
+  .object({ type: z.literal("projects.changed") })
+  .strict();
+
+export const DaemonEventInitOutputFrameSchemaZ = z
+  .object({
+    type: z.literal("init.output"),
+    jobId: z.string(),
+    chunk: z.string(),
+    done: z.boolean().optional(),
+  })
+  .strict();
+
+export const DaemonEventInitErrorFrameSchemaZ = z
+  .object({
+    type: z.literal("init.error"),
+    jobId: z.string(),
+    message: z.string(),
+  })
+  .strict();
+
+export const DaemonEventPongFrameSchemaZ = z.object({ type: z.literal("pong") }).strict();
+
+export const DaemonEventActionCompleteFrameSchemaZ = z
+  .object({
+    type: z.literal("action.complete"),
+    name: z.string(),
+    result: z.unknown(),
+  })
+  .strict();
+
+export const DaemonEventConfigChangedFrameSchemaZ = z
+  .object({
+    type: z.literal("config.changed"),
+    sessionName: z.string(),
+  })
+  .strict();
+
+export const DaemonEventTerminalsChangedFrameSchemaZ = z
+  .object({
+    type: z.literal("terminals.changed"),
+    sessionName: z.string(),
+  })
+  .strict();
+
+export const DaemonEventWorkspaceAddedFrameSchemaZ = z
+  .object({
+    type: z.literal("workspace.added"),
+    workspace: DaemonWorkspaceSchemaZ,
+  })
+  .strict();
+
+export const DaemonEventWorkspaceRemovedFrameSchemaZ = z
+  .object({
+    type: z.literal("workspace.removed"),
+    name: z.string(),
+  })
+  .strict();
+
+export const DaemonEventProtocolErrorCodeSchemaZ = z.enum(["invalid-json", "invalid-frame"]);
+export type DaemonEventProtocolErrorCode = z.infer<typeof DaemonEventProtocolErrorCodeSchemaZ>;
+
+export const DaemonEventProtocolErrorFrameSchemaZ = z
+  .object({
+    type: z.literal("protocol.error"),
+    code: DaemonEventProtocolErrorCodeSchemaZ,
+    message: z.string(),
+  })
+  .strict();
+
+export const DaemonEventServerFrameSchemaZ = z.discriminatedUnion("type", [
+  DaemonEventHelloFrameSchemaZ,
+  DaemonEventSnapshotFrameSchemaZ,
+  DaemonEventSessionsChangedFrameSchemaZ,
+  DaemonEventProjectsChangedFrameSchemaZ,
+  DaemonEventInitOutputFrameSchemaZ,
+  DaemonEventInitErrorFrameSchemaZ,
+  DaemonEventPongFrameSchemaZ,
+  DaemonEventActionCompleteFrameSchemaZ,
+  DaemonEventConfigChangedFrameSchemaZ,
+  DaemonEventTerminalsChangedFrameSchemaZ,
+  DaemonEventWorkspaceAddedFrameSchemaZ,
+  DaemonEventWorkspaceRemovedFrameSchemaZ,
+  DaemonEventProtocolErrorFrameSchemaZ,
+]);
+export type DaemonEventServerFrame = z.infer<typeof DaemonEventServerFrameSchemaZ>;

--- a/packages/contracts/src/daemon-resources.ts
+++ b/packages/contracts/src/daemon-resources.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+import { PaneInfoSchemaZ, SessionOverviewSchemaZ } from "./domain.ts";
+import { WorkspaceSchemaZ } from "./workspace.ts";
+
+/**
+ * Browser-safe response contracts for the daemon's read-only REST resources.
+ *
+ * These schemas intentionally describe the wire boundary rather than daemon
+ * implementation objects. Every object is strict so a renderer cannot
+ * silently accept a misspelled or newer field and then make decisions from a
+ * partially understood response.
+ */
+
+export const DaemonSessionOverviewSchemaZ = SessionOverviewSchemaZ.strict();
+export type DaemonSessionOverview = z.infer<typeof DaemonSessionOverviewSchemaZ>;
+
+export const DaemonPaneInfoSchemaZ = PaneInfoSchemaZ.strict();
+export type DaemonPaneInfo = z.infer<typeof DaemonPaneInfoSchemaZ>;
+
+export const DaemonSessionsResponseSchemaZ = z
+  .object({
+    sessions: z.array(DaemonSessionOverviewSchemaZ),
+  })
+  .strict();
+export type DaemonSessionsResponse = z.infer<typeof DaemonSessionsResponseSchemaZ>;
+
+/** GET /api/project/:name returns this resource without another wrapper. */
+export const DaemonProjectResponseSchemaZ = z
+  .object({
+    session: z.string(),
+    dir: z.string(),
+    panes: z.array(DaemonPaneInfoSchemaZ),
+  })
+  .strict();
+export type DaemonProjectResponse = z.infer<typeof DaemonProjectResponseSchemaZ>;
+
+export const DaemonPanesResponseSchemaZ = z
+  .object({
+    panes: z.array(DaemonPaneInfoSchemaZ),
+  })
+  .strict();
+export type DaemonPanesResponse = z.infer<typeof DaemonPanesResponseSchemaZ>;
+
+export const DaemonWorkspaceSchemaZ = WorkspaceSchemaZ.strict();
+export type DaemonWorkspace = z.infer<typeof DaemonWorkspaceSchemaZ>;
+
+export const DaemonWorkspacesResponseSchemaZ = z
+  .object({
+    workspaces: z.array(DaemonWorkspaceSchemaZ),
+  })
+  .strict();
+export type DaemonWorkspacesResponse = z.infer<typeof DaemonWorkspacesResponseSchemaZ>;
+
+export const DaemonWorkspaceResponseSchemaZ = z
+  .object({
+    workspace: DaemonWorkspaceSchemaZ,
+  })
+  .strict();
+export type DaemonWorkspaceResponse = z.infer<typeof DaemonWorkspaceResponseSchemaZ>;
+
+/** Registry entry returned by GET /api/projects. */
+export const DaemonRegisteredProjectSchemaZ = z
+  .object({
+    name: z.string(),
+    dir: z.string(),
+    hasIdeYml: z.boolean(),
+    hasWorkspaceConfig: z.boolean().optional(),
+    configKind: z.enum(["workspace", "legacy", "none"]).optional(),
+    configPath: z.string().nullable().optional(),
+    ideConfigPath: z.string().nullable().optional(),
+    gitOrigin: z.string().nullable(),
+    gitBranch: z.string().nullable(),
+    registeredAt: z.string(),
+  })
+  .strict();
+export type DaemonRegisteredProject = z.infer<typeof DaemonRegisteredProjectSchemaZ>;
+
+export const DaemonProjectsResponseSchemaZ = z
+  .object({
+    projects: z.array(DaemonRegisteredProjectSchemaZ),
+  })
+  .strict();
+export type DaemonProjectsResponse = z.infer<typeof DaemonProjectsResponseSchemaZ>;
+
+export const DaemonRegisteredProjectResponseSchemaZ = z
+  .object({
+    project: DaemonRegisteredProjectSchemaZ,
+  })
+  .strict();
+export type DaemonRegisteredProjectResponse = z.infer<
+  typeof DaemonRegisteredProjectResponseSchemaZ
+>;
+
+export const DaemonProjectTemplateSchemaZ = z
+  .object({
+    id: z.string(),
+    label: z.string(),
+    description: z.string(),
+  })
+  .strict();
+export type DaemonProjectTemplate = z.infer<typeof DaemonProjectTemplateSchemaZ>;
+
+export const DaemonProjectTemplatesResponseSchemaZ = z
+  .object({
+    templates: z.array(DaemonProjectTemplateSchemaZ),
+  })
+  .strict();
+export type DaemonProjectTemplatesResponse = z.infer<typeof DaemonProjectTemplatesResponseSchemaZ>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -38,3 +38,5 @@ export * from "./pane-appearance.ts";
 export * from "./focus-overlay.ts";
 export * from "./cohesion-fixture.ts";
 export * from "./daemon-wire.ts";
+export * from "./daemon-resources.ts";
+export * from "./daemon-events.ts";

--- a/packages/daemon/src/command-center/server.ts
+++ b/packages/daemon/src/command-center/server.ts
@@ -33,7 +33,18 @@ import {
   WorkspaceAlreadyExistsError,
   WorkspaceNotFoundError,
 } from "../lib/workspace-registry.ts";
-import { AddWorkspaceRequestSchemaZ, DAEMON_WIRE_PROTOCOL_VERSION } from "@tmux-ide/contracts";
+import {
+  AddWorkspaceRequestSchemaZ,
+  DAEMON_WIRE_PROTOCOL_VERSION,
+  type DaemonPanesResponse,
+  type DaemonProjectResponse,
+  type DaemonProjectsResponse,
+  type DaemonProjectTemplatesResponse,
+  type DaemonRegisteredProjectResponse,
+  type DaemonSessionsResponse,
+  type DaemonWorkspaceResponse,
+  type DaemonWorkspacesResponse,
+} from "@tmux-ide/contracts";
 import { sendCommandSchema } from "./schemas.ts";
 import {
   createScriptTerminalId,
@@ -374,7 +385,7 @@ export function createApp(options: CreateAppOptions = {}): Hono {
   app.get("/api/sessions", (c) => {
     const sessions = discoverSessions();
     const overviews = buildOverviews(sessions);
-    return c.json({ sessions: overviews });
+    return c.json({ sessions: overviews } satisfies DaemonSessionsResponse);
   });
 
   // ---------------------------------------------------------------------
@@ -386,7 +397,7 @@ export function createApp(options: CreateAppOptions = {}): Hono {
 
   app.get("/api/workspaces", (c) => {
     const registry = getDefaultWorkspaceRegistry();
-    return c.json({ workspaces: registry.list() });
+    return c.json({ workspaces: registry.list() } satisfies DaemonWorkspacesResponse);
   });
 
   app.get("/api/workspaces/:name", (c) => {
@@ -394,7 +405,7 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     const registry = getDefaultWorkspaceRegistry();
     const workspace = registry.get(name);
     if (!workspace) return c.json({ error: "Workspace not found" }, 404);
-    return c.json({ workspace });
+    return c.json({ workspace } satisfies DaemonWorkspaceResponse);
   });
 
   app.post("/api/workspaces", zValidator("json", AddWorkspaceRequestSchemaZ), async (c) => {
@@ -415,7 +426,7 @@ export function createApp(options: CreateAppOptions = {}): Hono {
         configPath: body.configPath ?? facts.configPath,
         hasWorkspaceConfig: body.hasWorkspaceConfig ?? facts.hasWorkspaceConfig,
       });
-      return c.json({ workspace }, 201);
+      return c.json({ workspace } satisfies DaemonWorkspaceResponse, 201);
     } catch (err) {
       if (err instanceof WorkspaceAlreadyExistsError) {
         return c.json({ error: err.message, code: err.code }, 409);
@@ -449,7 +460,7 @@ export function createApp(options: CreateAppOptions = {}): Hono {
       return c.json({ error: "Session not found" }, 404);
     }
     const detail = buildProjectDetail(session);
-    return c.json({ ...detail });
+    return c.json({ ...detail } satisfies DaemonProjectResponse);
   });
 
   app.get("/api/project/:name/panes", (c) => {
@@ -480,7 +491,7 @@ export function createApp(options: CreateAppOptions = {}): Hono {
         name: p.name,
         type: p.type,
       })),
-    });
+    } satisfies DaemonPanesResponse);
   });
 
   app.get("/api/project/:name/terminals", async (c) => {
@@ -995,11 +1006,11 @@ export function createApp(options: CreateAppOptions = {}): Hono {
   // --- Project registry ---
 
   app.get("/api/projects", (c) => {
-    return c.json({ projects: listProjects() });
+    return c.json({ projects: listProjects() } satisfies DaemonProjectsResponse);
   });
 
   app.get("/api/projects/templates", (c) => {
-    return c.json({ templates: listAvailableTemplates() });
+    return c.json({ templates: listAvailableTemplates() } satisfies DaemonProjectTemplatesResponse);
   });
 
   app.post("/api/projects", async (c) => {
@@ -1018,7 +1029,7 @@ export function createApp(options: CreateAppOptions = {}): Hono {
         dir: parsed.data.dir,
         name: parsed.data.name,
       });
-      return c.json({ project }, 201);
+      return c.json({ project } satisfies DaemonRegisteredProjectResponse, 201);
     } catch (err) {
       if (err instanceof ProjectDirNotFoundError) {
         return c.json({ error: err.message, code: err.code }, 400);
@@ -1050,7 +1061,7 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     }
     try {
       const project = await refreshProject(name);
-      return c.json({ project });
+      return c.json({ project } satisfies DaemonRegisteredProjectResponse);
     } catch (err) {
       if (err instanceof ProjectNotFoundError) {
         return c.json({ error: err.message, code: err.code }, 404);
@@ -1187,7 +1198,7 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     // Now register — this also broadcasts `projects.changed`.
     try {
       const project = await registerProject({ dir, name: finalName });
-      return c.json({ project }, 201);
+      return c.json({ project } satisfies DaemonRegisteredProjectResponse, 201);
     } catch (err) {
       if (err instanceof ProjectAlreadyRegisteredError) {
         return c.json({ error: err.message, code: err.code, suggestion: err.suggestion }, 409);

--- a/packages/daemon/src/command-center/ws-events.ts
+++ b/packages/daemon/src/command-center/ws-events.ts
@@ -15,8 +15,13 @@ import type { RawData, WebSocket } from "ws";
 import { discoverSessions, buildOverviews, buildProjectDetail } from "./discovery.ts";
 import { projectRegistryEmitter } from "../lib/project-registry.ts";
 import { getDefaultWorkspaceRegistry } from "../lib/workspace-registry.ts";
-import type { ServerFrame, ClientFrame } from "../schemas/ws-events.ts";
-import type { Workspace } from "@tmux-ide/contracts";
+import {
+  DaemonEventClientFrameSchemaZ,
+  type DaemonEventClientFrame,
+  type DaemonEventServerFrame,
+  type DaemonSessionSnapshot,
+  type Workspace,
+} from "@tmux-ide/contracts";
 
 const WS_OPEN = 1;
 const KEEPALIVE_INTERVAL_MS = 25_000;
@@ -144,7 +149,7 @@ function rawDataToText(data: RawData | string): string {
  * Build the snapshot payload pushed to a client when they subscribe to a
  * session — the live project + pane state.
  */
-export function buildSessionSnapshot(sessionName: string): unknown | null {
+export function buildSessionSnapshot(sessionName: string): DaemonSessionSnapshot | null {
   const session = discoverSessions().find((s) => s.name === sessionName);
   if (!session) return null;
   return { project: buildProjectDetail(session) };
@@ -159,7 +164,7 @@ export function handleWsEventsConnection(socket: WebSocket | WsLike): void {
   const subscriptions = new Set<string>();
   let closed = false;
 
-  const send = (frame: ServerFrame): void => {
+  const send = (frame: DaemonEventServerFrame): void => {
     if (closed || ws.readyState !== WS_OPEN) return;
     try {
       ws.send(JSON.stringify(frame));
@@ -177,7 +182,7 @@ export function handleWsEventsConnection(socket: WebSocket | WsLike): void {
   };
 
   const broadcastInitOutputForClient = (jobId: string, chunk: string, done?: boolean): void => {
-    const frame: ServerFrame =
+    const frame: DaemonEventServerFrame =
       done === undefined
         ? { type: "init.output", jobId, chunk }
         : { type: "init.output", jobId, chunk, done };
@@ -197,7 +202,7 @@ export function handleWsEventsConnection(socket: WebSocket | WsLike): void {
   };
 
   const broadcastTerminalsChangedForClient = (sessionName: string): void => {
-    send({ type: "terminals.changed", sessionName } as ServerFrame);
+    send({ type: "terminals.changed", sessionName });
   };
 
   // Per-connection subscription to the current workspace-registry singleton.
@@ -236,7 +241,7 @@ export function handleWsEventsConnection(socket: WebSocket | WsLike): void {
     if (session) {
       const data = buildSessionSnapshot(sessionName);
       if (data) {
-        send({ type: "snapshot", sessionName, data: data as Record<string, unknown> });
+        send({ type: "snapshot", sessionName, data });
       }
     }
   };
@@ -259,16 +264,27 @@ export function handleWsEventsConnection(socket: WebSocket | WsLike): void {
 
   ws.on("message", (data) => {
     if (closed) return;
-    let parsed: ClientFrame | null = null;
+    let raw: unknown;
     try {
-      const obj = JSON.parse(rawDataToText(data));
-      if (obj && typeof obj === "object" && typeof (obj as { type?: unknown }).type === "string") {
-        parsed = obj as ClientFrame;
-      }
+      raw = JSON.parse(rawDataToText(data));
     } catch {
-      return; // ignore non-JSON / malformed frames
+      send({
+        type: "protocol.error",
+        code: "invalid-json",
+        message: "Client frame must be valid JSON.",
+      });
+      return;
     }
-    if (!parsed) return;
+    const result = DaemonEventClientFrameSchemaZ.safeParse(raw);
+    if (!result.success) {
+      send({
+        type: "protocol.error",
+        code: "invalid-frame",
+        message: "Client frame does not match the daemon event protocol.",
+      });
+      return;
+    }
+    const parsed: DaemonEventClientFrame = result.data;
 
     if (parsed.type === "subscribe") {
       for (const name of parsed.sessions) subscribe(name);

--- a/packages/daemon/src/lib/__tests__/ws-events-protocol.test.ts
+++ b/packages/daemon/src/lib/__tests__/ws-events-protocol.test.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it } from "vitest";
+import { DaemonEventServerFrameSchemaZ, type DaemonEventServerFrame } from "@tmux-ide/contracts";
+import {
+  _detachProjectRegistryListenerForTests,
+  _stopSessionsPollerForTests,
+  handleWsEventsConnection,
+} from "../../command-center/ws-events.ts";
+
+class ProtocolWebSocket extends EventEmitter {
+  readyState = 1;
+  readonly sent: string[] = [];
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  receive(data: string): void {
+    this.emit("message", data, false);
+  }
+
+  disconnect(): void {
+    this.readyState = 3;
+    this.emit("close");
+  }
+}
+
+function frames(socket: ProtocolWebSocket): DaemonEventServerFrame[] {
+  return socket.sent.map((value) => DaemonEventServerFrameSchemaZ.parse(JSON.parse(value)));
+}
+
+afterEach(() => {
+  _stopSessionsPollerForTests();
+  _detachProjectRegistryListenerForTests();
+});
+
+describe("/ws/events client frame protocol", () => {
+  it("reports malformed JSON deterministically and keeps the socket usable", () => {
+    const socket = new ProtocolWebSocket();
+    handleWsEventsConnection(socket);
+    socket.sent.length = 0;
+
+    socket.receive("not-json");
+    socket.receive(JSON.stringify({ type: "ping" }));
+
+    expect(frames(socket)).toEqual([
+      {
+        type: "protocol.error",
+        code: "invalid-json",
+        message: "Client frame must be valid JSON.",
+      },
+      { type: "pong" },
+    ]);
+    socket.disconnect();
+  });
+
+  it("rejects malformed subscribe frames without throwing or changing subscription state", () => {
+    const socket = new ProtocolWebSocket();
+    handleWsEventsConnection(socket);
+    socket.sent.length = 0;
+
+    expect(() => socket.receive(JSON.stringify({ type: "subscribe" }))).not.toThrow();
+    expect(() =>
+      socket.receive(JSON.stringify({ type: "subscribe", sessions: "tmux-ide", unexpected: true })),
+    ).not.toThrow();
+    socket.receive(JSON.stringify({ type: "ping" }));
+
+    expect(frames(socket)).toEqual([
+      {
+        type: "protocol.error",
+        code: "invalid-frame",
+        message: "Client frame does not match the daemon event protocol.",
+      },
+      {
+        type: "protocol.error",
+        code: "invalid-frame",
+        message: "Client frame does not match the daemon event protocol.",
+      },
+      { type: "pong" },
+    ]);
+    socket.disconnect();
+  });
+
+  it("rejects unknown and extra client fields rather than accepting structural lookalikes", () => {
+    const socket = new ProtocolWebSocket();
+    handleWsEventsConnection(socket);
+    socket.sent.length = 0;
+
+    socket.receive(JSON.stringify({ type: "ping", extra: true }));
+    socket.receive(JSON.stringify({ type: "future.event" }));
+
+    expect(frames(socket).map(({ type }) => type)).toEqual(["protocol.error", "protocol.error"]);
+    socket.disconnect();
+  });
+});

--- a/packages/daemon/src/schemas/registry.ts
+++ b/packages/daemon/src/schemas/registry.ts
@@ -9,31 +9,16 @@
  */
 
 import { z } from "zod";
+import {
+  DaemonProjectTemplateSchemaZ,
+  DaemonRegisteredProjectSchemaZ,
+  type DaemonProjectTemplate,
+  type DaemonRegisteredProject,
+} from "@tmux-ide/contracts";
 
-export const RegisteredProjectSchemaZ = z.object({
-  /** Unique registry key. Defaults to `basename(dir)`; collisions resolved by appending `-2`, `-3`, … */
-  name: z.string(),
-  /** Absolute path to the project directory. */
-  dir: z.string(),
-  /** Whether `<dir>/ide.yml` exists; refreshed on register and on `probe()`. */
-  hasIdeYml: z.boolean(),
-  /** Whether `.tmux-ide/workspace.yml` exists or wins discovery. */
-  hasWorkspaceConfig: z.boolean().optional(),
-  /** Generalized winning config kind. Added without replacing `hasIdeYml`. */
-  configKind: z.enum(["workspace", "legacy", "none"]).optional(),
-  /** Generalized winning config path. */
-  configPath: z.string().nullable().optional(),
-  /** Legacy config path when an `ide.yml` is present. */
-  ideConfigPath: z.string().nullable().optional(),
-  /** Git remote origin URL, or `null` if not a git repo / no origin / probe failed. */
-  gitOrigin: z.string().nullable(),
-  /** Current git branch, or `null` if not a git repo / detached HEAD / probe failed. */
-  gitBranch: z.string().nullable(),
-  /** ISO-8601 timestamp the project was first registered. */
-  registeredAt: z.string(),
-});
-
-export type RegisteredProject = z.infer<typeof RegisteredProjectSchemaZ>;
+/** Compatibility names for the canonical browser-safe resource contract. */
+export const RegisteredProjectSchemaZ = DaemonRegisteredProjectSchemaZ;
+export type RegisteredProject = DaemonRegisteredProject;
 
 // ---------------------------------------------------------------------------
 // REST request bodies
@@ -55,9 +40,5 @@ export type InitProjectRequest = z.infer<typeof InitProjectRequestSchemaZ>;
 // Template metadata (returned by GET /api/projects/templates)
 // ---------------------------------------------------------------------------
 
-export const ProjectTemplateSchemaZ = z.object({
-  id: z.string(),
-  label: z.string(),
-  description: z.string(),
-});
-export type ProjectTemplate = z.infer<typeof ProjectTemplateSchemaZ>;
+export const ProjectTemplateSchemaZ = DaemonProjectTemplateSchemaZ;
+export type ProjectTemplate = DaemonProjectTemplate;

--- a/packages/daemon/src/schemas/ws-events.ts
+++ b/packages/daemon/src/schemas/ws-events.ts
@@ -1,135 +1,18 @@
 /**
- * Protocol contracts for the unified `/ws/events` WebSocket channel.
+ * Compatibility re-exports for the unified `/ws/events` protocol.
  *
- * Single push channel clients subscribe to for session / pane / workspace
- * changes. One socket replaces a fan of individual SSE streams that hit
- * Chrome's 6-per-origin HTTP/1.1 limit.
- *
- * Add new frame variants by appending to the union; do not rename existing
- * fields.
+ * The canonical, browser-safe schemas live in `@tmux-ide/contracts`. Keep this
+ * module so existing daemon imports do not need to move in lock-step.
  */
 
-import { z } from "zod";
-import { SessionOverviewSchemaZ } from "./domain.ts";
-import { WorkspaceAddedFrameSchemaZ, WorkspaceRemovedFrameSchemaZ } from "@tmux-ide/contracts";
+export {
+  DaemonEventClientFrameSchemaZ as ClientFrameSchemaZ,
+  DaemonEventServerFrameSchemaZ as ServerFrameSchemaZ,
+  DaemonSessionSnapshotSchemaZ as SessionSnapshotSchemaZ,
+} from "@tmux-ide/contracts";
 
-// ---------------------------------------------------------------------------
-// Snapshot payload — mirrors what `/api/project/<name>/stream` already pushes
-// as its `snapshot` SSE event. Kept loose (passthrough) so that adding fields
-// on the producer side does not require shipping schema updates lock-step
-// with consumers. Consumers should validate fields they actually read.
-// ---------------------------------------------------------------------------
-
-export const SessionSnapshotSchemaZ = z.record(z.string(), z.unknown());
-export type SessionSnapshot = z.infer<typeof SessionSnapshotSchemaZ>;
-
-// ---------------------------------------------------------------------------
-// Client → Server frames
-// ---------------------------------------------------------------------------
-
-const SubscribeFrameZ = z.object({
-  type: z.literal("subscribe"),
-  sessions: z.array(z.string()),
-});
-
-const UnsubscribeFrameZ = z.object({
-  type: z.literal("unsubscribe"),
-  sessions: z.array(z.string()),
-});
-
-const PingFrameZ = z.object({
-  type: z.literal("ping"),
-});
-
-export const ClientFrameSchemaZ = z.discriminatedUnion("type", [
-  SubscribeFrameZ,
-  UnsubscribeFrameZ,
-  PingFrameZ,
-]);
-
-export type ClientFrame = z.infer<typeof ClientFrameSchemaZ>;
-
-// ---------------------------------------------------------------------------
-// Server → Client frames
-// ---------------------------------------------------------------------------
-
-const HelloFrameZ = z.object({
-  type: z.literal("hello"),
-  sessions: z.array(SessionOverviewSchemaZ),
-});
-
-const SnapshotFrameZ = z.object({
-  type: z.literal("snapshot"),
-  sessionName: z.string(),
-  data: SessionSnapshotSchemaZ,
-});
-
-const SessionsChangedFrameZ = z.object({
-  type: z.literal("sessions.changed"),
-});
-
-// Project-registry has changed (register / unregister / re-probe / init success).
-// Clients re-fetch GET /api/projects.
-const ProjectsChangedFrameZ = z.object({
-  type: z.literal("projects.changed"),
-});
-
-// Streaming output from `tmux-ide init` invoked via POST /api/projects/init.
-// `chunk` is a single line of stdout/stderr (newline stripped). `done: true`
-// is set on the final frame for the job; no more `init.output` frames will
-// follow for this jobId.
-const InitOutputFrameZ = z.object({
-  type: z.literal("init.output"),
-  jobId: z.string(),
-  chunk: z.string(),
-  done: z.boolean().optional(),
-});
-
-// Init job failed. Terminal — no `init.output` follow-ups.
-const InitErrorFrameZ = z.object({
-  type: z.literal("init.error"),
-  jobId: z.string(),
-  message: z.string(),
-});
-
-const PongFrameZ = z.object({
-  type: z.literal("pong"),
-});
-
-// Broadcast after a successful v2 action dispatch. Clients use these frames to
-// invalidate caches without ad-hoc refetches (e.g. invalidate the project list
-// after `project.launch` succeeds). `name` matches the action name in
-// `command-center/actions/contract.ts`. `result` is loose at the schema layer
-// because each action has its own result shape.
-const ActionCompleteFrameZ = z.object({
-  type: z.literal("action.complete"),
-  name: z.string(),
-  result: z.unknown(),
-});
-
-const ConfigChangedFrameZ = z.object({
-  type: z.literal("config.changed"),
-  sessionName: z.string(),
-});
-
-const TerminalsChangedFrameZ = z.object({
-  type: z.literal("terminals.changed"),
-  sessionName: z.string(),
-});
-
-export const ServerFrameSchemaZ = z.discriminatedUnion("type", [
-  HelloFrameZ,
-  SnapshotFrameZ,
-  SessionsChangedFrameZ,
-  ProjectsChangedFrameZ,
-  InitOutputFrameZ,
-  InitErrorFrameZ,
-  PongFrameZ,
-  ActionCompleteFrameZ,
-  ConfigChangedFrameZ,
-  TerminalsChangedFrameZ,
-  WorkspaceAddedFrameSchemaZ,
-  WorkspaceRemovedFrameSchemaZ,
-]);
-
-export type ServerFrame = z.infer<typeof ServerFrameSchemaZ>;
+export type {
+  DaemonEventClientFrame as ClientFrame,
+  DaemonEventServerFrame as ServerFrame,
+  DaemonSessionSnapshot as SessionSnapshot,
+} from "@tmux-ide/contracts";


### PR DESCRIPTION
## Outcome

Adds browser-safe shared contracts for daemon REST resources and event WebSocket frames, making the desktop live-resource boundary strict and reusable.

## Included

- strict session, project, pane, workspace, registry, and template resource schemas
- strict historical server-event and client command schemas
- compatibility re-exports for existing daemon imports
- producer-side satisfies checks on current REST routes
- recoverable protocol.error replies for invalid JSON and malformed frames
- continued socket usability after protocol errors

## Verification

- contracts: 101 tests passed
- focused protocol/resource/browser-boundary: 10 tests passed
- contracts and daemon typechecks passed
- browser-target contract bundle passed
- npm pack dry-run and diff-check passed

Independent adversarial review: APPROVED.