### PR TITLE
feat(tui): ship shared production pane chrome

### DIFF
--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -380,7 +380,7 @@ import {
   type TerminalPaneChromeHoverTarget,
   type TerminalPaneChromeMetadata,
 } from "./workspace/terminal-pane-chrome.ts";
-import { TerminalPaneChromeLayer } from "./workspace/terminal-pane-chrome-view.tsx";
+import { SharedTerminalPaneChromeLayer } from "./workspace/terminal-pane-chrome-view.tsx";
 import {
   workbenchCanvasPanelForShortcut,
   workbenchCanvasShortcutForPanel,
@@ -6411,11 +6411,6 @@ try {
       else if (id === "refresh") refreshTree();
     };
 
-    /** The root pane-chrome dispatcher focuses before calling this command edge. */
-    const runTerminalPaneAction = (paneId: string, id: string) => {
-      if (id === "zoom") void mirror?.command(`resize-pane -Z -t ${paneId}`).catch(() => {});
-    };
-
     /** The strip as THREE static texts (pre/active/post) whose STRINGS update.
      *  KNOWN UPSTREAM QUIRK: clicks landing exactly ON this row's label cells
      *  are swallowed before dispatch regardless of node structure (For-of-texts,
@@ -6791,10 +6786,13 @@ try {
             dispatchTerminalPaneChromePointerIntent(paneChromeIntent, {
               hover: setHoveredTerminalPaneAction,
               focus: (paneId) => mirror?.focus(paneId),
-              action: (paneId, actionId, actionIndex) => {
+              action: (paneId, _actionId, actionIndex, semanticIntent) => {
                 setPressedTerminalPaneAction({ paneId, actionIndex });
-                if (actionId === "menu") openPaneActions(paneId);
-                else runTerminalPaneAction(paneId, actionId);
+                if (semanticIntent.commandId === "workspace.pane.menu.open") {
+                  openPaneActions(paneId);
+                } else if (semanticIntent.commandId === "workspace.windowMode.maximize.toggle") {
+                  void mirror?.command(`resize-pane -Z -t ${paneId}`).catch(() => {});
+                }
               },
               menu: openPaneActions,
               settle: () => settleTerminalGestureBoundary(e),
@@ -7922,7 +7920,7 @@ try {
                         {/* Segmented pane chrome occupies gy=1, immediately above
                   the exact tmux framebuffer. The layer is passive; root routing
                   owns every action and lifecycle effect. */}
-                        <TerminalPaneChromeLayer
+                        <SharedTerminalPaneChromeLayer
                           theme={semanticTheme()}
                           layout={terminalPaneChromeLayout()}
                           layer="native"
@@ -8061,7 +8059,7 @@ try {
                   separator cells. Focus belongs to this semantic pane chrome,
                   while the pure projection proves no emitted rectangle
                   intersects a pane framebuffer. */}
-                        <TerminalPaneChromeLayer
+                        <SharedTerminalPaneChromeLayer
                           theme={semanticTheme()}
                           layout={terminalPaneChromeLayout()}
                           layer="framebuffer"

--- a/packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx
@@ -9,6 +9,8 @@ import {
   projectTerminalPaneChrome,
   terminalPaneChromeHitTest,
   terminalPaneChromeOverlapsBodies,
+  type TerminalPaneChromeLayout,
+  type TerminalPaneChromePane,
 } from "./terminal-pane-chrome.ts";
 import { SharedTerminalPaneChromeLayer } from "./terminal-pane-chrome-view.tsx";
 
@@ -269,144 +271,292 @@ describe("AgentTerminalCanvas OpenTUI renderer", () => {
     },
   );
 
-  it("keeps pane and action renderables stable across fresh projection objects", async () => {
-    const width = 100;
-    const height = 14;
-    const theme = createSemanticThemeSnapshot({ mode: "dark" });
-    const canvas = projectAgentTerminalCanvas({ width, height, chromeRows: 2 });
-    const states = [
-      { active: "%1", hoveredPane: "%1", hoveredAction: 0, pressedAction: null },
-      { active: "%2", hoveredPane: "%2", hoveredAction: 1, pressedAction: null },
-      { active: "%3", hoveredPane: "%3", hoveredAction: 0, pressedAction: 0 },
-      { active: "%1", hoveredPane: "%1", hoveredAction: 0, pressedAction: null },
-    ] as const;
-    let drive!: (state: (typeof states)[number]) => void;
-
-    function Harness() {
-      const [state, setState] = createSignal<(typeof states)[number]>(states[0]);
-      drive = setState;
-      const layout = createMemo(() => {
-        const current = state();
-        // Deliberately allocate every pane, metadata map, projection, frame,
-        // chip, and action again. This is the production projection contract.
-        return projectTerminalPaneChrome({
-          canvas,
-          panes: [
-            {
-              id: "%1",
-              left: 0,
-              top: 0,
-              width: 49,
-              height: canvas.framebuffer.height,
-              active: current.active === "%1",
-              zoomed: false,
-            },
-            {
-              id: "%2",
-              left: 50,
-              top: 0,
-              width: 50,
-              height: 5,
-              active: current.active === "%2",
-              zoomed: false,
-            },
-            {
-              id: "%3",
-              left: 50,
-              top: 6,
-              width: 50,
-              height: canvas.framebuffer.height - 6,
-              active: current.active === "%3",
-              zoomed: false,
-            },
-          ],
-          metadataByPane: new Map([
-            ["%1", { title: "Codex PM", status: "working", statusTone: "working" as const }],
-            ["%2", { title: "Codex builder", status: "working", statusTone: "working" as const }],
-            ["%3", { title: "Claude review", status: "idle", statusTone: "idle" as const }],
-          ]),
-          hoveredAction: {
-            paneId: current.hoveredPane,
-            actionIndex: current.hoveredAction,
-          },
-          pressedAction:
-            current.pressedAction === null
-              ? null
-              : { paneId: current.hoveredPane, actionIndex: current.pressedAction },
-        });
-      });
-      return (
-        <box position="relative" width={width} height={height} overflow="hidden">
-          <SharedTerminalPaneChromeLayer theme={theme} layout={layout()} layer="native" />
-          <box
-            position="absolute"
-            left={canvas.framebuffer.x}
-            top={canvas.framebuffer.y}
-            width={canvas.framebuffer.width}
-            height={canvas.framebuffer.height}
-          >
-            <SharedTerminalPaneChromeLayer theme={theme} layout={layout()} layer="framebuffer" />
-          </box>
-        </box>
-      );
-    }
-
-    const setup = await renderForTest(() => <Harness />, { width, height });
-    await setup.renderOnce();
-    const initialCount = renderableCount(setup.renderer.root);
-    const stablePaneNodes = new Map(
-      ["%1", "%2", "%3"].map((paneId) => {
-        const layer = paneId === "%3" ? "framebuffer" : "native";
-        return [
-          paneId,
-          setup.renderer.root.findDescendantById(`shared-terminal-pane-chrome:${layer}:${paneId}`),
-        ] as const;
-      }),
-    );
-    expect([...stablePaneNodes.values()].every(Boolean)).toBe(true);
-    const stablePaneTrees = new Map(
-      [...stablePaneNodes].map(([paneId, node]) => [
-        paneId,
-        renderableTree(node as TestRenderable),
-      ]),
-    );
-
-    const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
-    const framesByState = new Map<string, string>();
-    try {
-      for (let index = 0; index < 24; index += 1) {
-        const state = states[index % states.length]!;
-        drive({ ...state });
-        await setup.renderOnce();
-        expect(renderableCount(setup.renderer.root)).toBe(initialCount);
-        for (const [paneId, node] of stablePaneNodes) {
-          const layer = paneId === "%3" ? "framebuffer" : "native";
-          expect(
-            setup.renderer.root.findDescendantById(
-              `shared-terminal-pane-chrome:${layer}:${paneId}`,
-            ),
-          ).toBe(node);
-          const currentTree = renderableTree(node as TestRenderable);
-          const stableTree = stablePaneTrees.get(paneId)!;
-          expect(currentTree).toHaveLength(stableTree.length);
-          currentTree.forEach((renderable, childIndex) => {
-            expect(renderable).toBe(stableTree[childIndex]);
-          });
-        }
-        const key = JSON.stringify(state);
-        const frame = stableFrame(setup.captureCharFrame());
-        const previous = framesByState.get(key);
-        if (previous) expect(frame).toBe(previous);
-        else framesByState.set(key, frame);
+  it.each([
+    [80, 24],
+    [120, 40],
+    [200, 60],
+  ] as const)(
+    "keeps pane chrome stable through production topology churn at %sx%s",
+    async (width, height) => {
+      type Topology = "base" | "added" | "migrated" | "zoomed";
+      interface StressState {
+        topology: Topology;
+        active: string;
+        attention: string | null;
+        hoveredAction: number | null;
+        pressed: boolean;
       }
-    } finally {
-      console.warn = originalWarn;
-      setup.renderer.destroy();
-    }
-    expect(warnings.filter((warning) => /insertBefore|anchor|reconcil/iu.test(warning))).toEqual(
-      [],
-    );
-  });
+
+      const theme = createSemanticThemeSnapshot({ mode: "dark" });
+      const canvas = projectAgentTerminalCanvas({ width, height, chromeRows: 2 });
+      const framebuffer = canvas.framebuffer;
+      const leftWidth = Math.floor((framebuffer.width - 1) / 2);
+      const rightLeft = leftWidth + 1;
+      const rightWidth = framebuffer.width - rightLeft;
+      const upperHeight = Math.floor((framebuffer.height - 1) / 2);
+      const lowerTop = upperHeight + 1;
+      const firstLeftWidth = Math.floor((leftWidth - 1) / 2);
+      const addedLeft = firstLeftWidth + 1;
+      const addedWidth = leftWidth - addedLeft;
+      const states: readonly StressState[] = [
+        {
+          topology: "base",
+          active: "%1",
+          attention: null,
+          hoveredAction: 0,
+          pressed: false,
+        },
+        {
+          topology: "base",
+          active: "%2",
+          attention: "%3",
+          hoveredAction: 1,
+          pressed: true,
+        },
+        {
+          topology: "added",
+          active: "%4",
+          attention: "%2",
+          hoveredAction: 0,
+          pressed: false,
+        },
+        {
+          topology: "added",
+          active: "%1",
+          attention: "%4",
+          hoveredAction: 1,
+          pressed: true,
+        },
+        {
+          topology: "base",
+          active: "%3",
+          attention: null,
+          hoveredAction: 0,
+          pressed: false,
+        },
+        {
+          topology: "migrated",
+          active: "%3",
+          attention: "%2",
+          hoveredAction: 1,
+          pressed: false,
+        },
+        {
+          topology: "migrated",
+          active: "%2",
+          attention: "%3",
+          hoveredAction: 0,
+          pressed: true,
+        },
+        {
+          topology: "base",
+          active: "%2",
+          attention: "%1",
+          hoveredAction: 1,
+          pressed: false,
+        },
+        {
+          topology: "zoomed",
+          active: "%2",
+          attention: "%2",
+          hoveredAction: 0,
+          pressed: true,
+        },
+        {
+          topology: "base",
+          active: "%1",
+          attention: null,
+          hoveredAction: 0,
+          pressed: false,
+        },
+      ];
+
+      const pane = (
+        current: StressState,
+        id: string,
+        left: number,
+        top: number,
+        paneWidth: number,
+        paneHeight: number,
+      ): TerminalPaneChromePane => ({
+        id,
+        left,
+        top,
+        width: paneWidth,
+        height: paneHeight,
+        active: current.active === id,
+        zoomed: current.topology === "zoomed",
+      });
+      const panesFor = (current: StressState): readonly TerminalPaneChromePane[] => {
+        if (current.topology === "zoomed") {
+          return [pane(current, "%2", 0, 0, framebuffer.width, framebuffer.height)];
+        }
+        const leftPanes =
+          current.topology === "added"
+            ? [
+                pane(current, "%1", 0, 0, firstLeftWidth, framebuffer.height),
+                pane(current, "%4", addedLeft, 0, addedWidth, framebuffer.height),
+              ]
+            : [pane(current, "%1", 0, 0, leftWidth, framebuffer.height)];
+        const upperId = current.topology === "migrated" ? "%3" : "%2";
+        const lowerId = current.topology === "migrated" ? "%2" : "%3";
+        return [
+          ...leftPanes,
+          pane(current, upperId, rightLeft, 0, rightWidth, upperHeight),
+          pane(current, lowerId, rightLeft, lowerTop, rightWidth, framebuffer.height - lowerTop),
+        ];
+      };
+
+      let drive!: (state: StressState) => void;
+      let readLayout!: () => TerminalPaneChromeLayout;
+      let readPanes!: () => readonly TerminalPaneChromePane[];
+
+      function Harness() {
+        const [state, setState] = createSignal<StressState>(states[0]!);
+        drive = setState;
+        const livePanes = createMemo(() => panesFor(state()));
+        const layout = createMemo(() => {
+          const current = state();
+          const panes = livePanes();
+          return projectTerminalPaneChrome({
+            canvas,
+            panes,
+            metadataByPane: new Map(
+              panes.map((candidate) => {
+                const attention = current.attention === candidate.id;
+                return [
+                  candidate.id,
+                  {
+                    title: `Agent ${candidate.id}`,
+                    status: attention ? "blocked" : "working",
+                    statusTone: attention ? ("blocked" as const) : ("working" as const),
+                    attention,
+                  },
+                ] as const;
+              }),
+            ),
+            hoveredAction: {
+              paneId: current.active,
+              actionIndex: current.hoveredAction,
+            },
+            pressedAction: current.pressed
+              ? { paneId: current.active, actionIndex: current.hoveredAction ?? 0 }
+              : null,
+          });
+        });
+        readLayout = layout;
+        readPanes = livePanes;
+        return (
+          <AgentTerminalCanvas
+            theme={theme}
+            projection={canvas}
+            chrome={
+              <>
+                <text fg={theme.roles.text.muted}> production window</text>
+                <SharedTerminalPaneChromeLayer theme={theme} layout={layout()} layer="native" />
+              </>
+            }
+            framebuffer={
+              <box
+                position="relative"
+                width={framebuffer.width}
+                height={framebuffer.height}
+                backgroundColor={theme.roles.surfaces.terminal}
+              >
+                <box position="absolute" left={0} bottom={0} width={1} height={1}>
+                  <text fg={theme.roles.text.muted}>·</text>
+                </box>
+                <SharedTerminalPaneChromeLayer
+                  theme={theme}
+                  layout={layout()}
+                  layer="framebuffer"
+                />
+              </box>
+            }
+          />
+        );
+      }
+
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      const originalError = console.error;
+      const captureWarning = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+      console.warn = captureWarning;
+      console.error = captureWarning;
+      const setup = await renderForTest(() => <Harness />, { width, height });
+      const countsByTopology = new Map<Topology, number>();
+      const framesByState = new Map<string, string>();
+      let previousTopology: Topology | null = null;
+      let previousNodes = new Map<string, unknown>();
+      let previousTrees = new Map<string, readonly unknown[]>();
+      try {
+        for (let index = 0; index < states.length * 3; index += 1) {
+          const state = states[index % states.length]!;
+          drive({ ...state });
+          await setup.renderOnce();
+
+          const layout = readLayout();
+          const panes = readPanes();
+          const projections = [...layout.native, ...layout.framebuffer].filter(
+            (projection) => projection.frame !== null,
+          );
+          expect(canvas.tmuxSize).toEqual({ cols: width, rows: height - 2 });
+          expect(
+            projections.every(
+              (projection) => !terminalPaneChromeOverlapsBodies({ canvas, panes }, projection),
+            ),
+          ).toBe(true);
+
+          const nodes = new Map<string, unknown>();
+          const trees = new Map<string, readonly unknown[]>();
+          for (const projection of projections) {
+            const key = `${projection.layer}:${projection.paneId}`;
+            const node = setup.renderer.root.findDescendantById(
+              `shared-terminal-pane-chrome:${key}`,
+            );
+            expect(node).toBeDefined();
+            expect(nodes.has(key)).toBe(false);
+            nodes.set(key, node);
+            trees.set(key, renderableTree(node as TestRenderable));
+          }
+          expect(nodes.size).toBe(projections.length);
+
+          for (const [key, node] of nodes) {
+            if (!previousNodes.has(key)) continue;
+            expect(node).toBe(previousNodes.get(key));
+            if (previousTopology !== state.topology) continue;
+            const previousTree = previousTrees.get(key)!;
+            const tree = trees.get(key)!;
+            expect(tree).toHaveLength(previousTree.length);
+            tree.forEach((renderable, childIndex) => {
+              expect(renderable).toBe(previousTree[childIndex]);
+            });
+          }
+
+          const renderables = renderableCount(setup.renderer.root);
+          const previousCount = countsByTopology.get(state.topology);
+          if (previousCount === undefined) countsByTopology.set(state.topology, renderables);
+          else expect(renderables).toBe(previousCount);
+
+          const frame = stableFrame(setup.captureCharFrame());
+          expectFrameBounds(frame, width, height);
+          const stateKey = JSON.stringify(state);
+          const previousFrame = framesByState.get(stateKey);
+          if (previousFrame === undefined) framesByState.set(stateKey, frame);
+          else expect(frame).toBe(previousFrame);
+
+          previousTopology = state.topology;
+          previousNodes = nodes;
+          previousTrees = trees;
+        }
+      } finally {
+        console.warn = originalWarn;
+        console.error = originalError;
+        setup.renderer.destroy();
+      }
+      expect(warnings.filter((warning) => /insertBefore|anchor|reconcil/iu.test(warning))).toEqual(
+        [],
+      );
+    },
+  );
 });

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome-view.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome-view.tsx
@@ -1,13 +1,13 @@
 /* @jsxImportSource @opentui/solid */
 import { createMemo, For } from "solid-js";
 import type { SemanticThemeSnapshot } from "../theme.ts";
-import { PaneFrame, PaneFrameHeader } from "./pane-frame.tsx";
+import { PaneFrame } from "./pane-frame.tsx";
 import type {
   TerminalPaneChromeLayout,
   TerminalPaneChromeProjection,
 } from "./terminal-pane-chrome.ts";
 
-export interface TerminalPaneChromeLayerProps {
+export interface SharedTerminalPaneChromeLayerProps {
   theme: SemanticThemeSnapshot;
   layout: TerminalPaneChromeLayout;
   layer: "native" | "framebuffer";
@@ -18,52 +18,13 @@ function sameIds(left: readonly string[], right: readonly string[]): boolean {
 }
 
 /** Passive projection surface; the application root remains the only input owner. */
-export function TerminalPaneChromeLayer(props: TerminalPaneChromeLayerProps) {
+export function SharedTerminalPaneChromeLayer(props: SharedTerminalPaneChromeLayerProps) {
   const projections = (): readonly TerminalPaneChromeProjection[] =>
     props.layer === "native" ? props.layout.native : props.layout.framebuffer;
   // projectTerminalPaneChrome intentionally returns immutable value objects.
-  // Keying Solid's <For> by those short-lived objects made every hover/focus
-  // tick tear down and reinsert the complete pane header. Key by the tmux pane
-  // id instead, then resolve the latest value through a memo. The renderables
-  // now survive visual-state updates and only their properties change.
-  const projectionIds = createMemo(
-    () =>
-      projections()
-        .filter((projection) => projection.frame !== null)
-        .map((p) => p.paneId),
-    undefined,
-    { equals: sameIds },
-  );
-  const projectionsById = createMemo(
-    () => new Map(projections().map((projection) => [projection.paneId, projection])),
-  );
-  return (
-    <For each={projectionIds()}>
-      {(paneId) => {
-        const pane = () => projectionsById().get(paneId)!;
-        const frame = () => pane().frame!;
-        return (
-          <box
-            id={`terminal-pane-chrome:${props.layer}:${paneId}`}
-            position="absolute"
-            left={pane().layerRect.x}
-            top={pane().layerRect.y}
-            width={pane().layerRect.width}
-            height={pane().layerRect.height}
-            overflow="hidden"
-          >
-            <PaneFrameHeader theme={props.theme} projection={frame()} />
-          </box>
-        );
-      }}
-    </For>
-  );
-}
-
-/** Card 22.4b OpenTUI host. Card 22.4b2 owns the one-line production-root swap. */
-export function SharedTerminalPaneChromeLayer(props: TerminalPaneChromeLayerProps) {
-  const projections = (): readonly TerminalPaneChromeProjection[] =>
-    props.layer === "native" ? props.layout.native : props.layout.framebuffer;
+  // Keying Solid's <For> by those short-lived objects would tear down and
+  // reinsert every header on visual-state ticks. Resolve fresh values through
+  // pane ids so resident renderables survive focus/status/action changes.
   const projectionIds = createMemo(
     () =>
       projections()

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.test.ts
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.test.ts
@@ -2,7 +2,6 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { projectAgentTerminalCanvas } from "./agent-terminal-canvas.ts";
 import {
-  CARD_22_4B2_PANE_FRAME_ROOT_WIRING_DEFERRALS,
   dispatchTerminalPaneChromePointerIntent,
   projectTerminalPaneChrome,
   reconcileTerminalPaneChromeActionTarget,
@@ -259,47 +258,107 @@ describe("terminal pane chrome projection", () => {
     });
   });
 
-  it("dispatches nonfocused zoom as focus then effect with no PTY transport", () => {
+  it("dispatches semantic pane actions after focus without writing to the PTY", () => {
     const calls: string[] = [];
+    const controlCommands: string[] = [];
+    const openedMenus: string[] = [];
     const ptyWrites: string[] = [];
+    const effects = {
+      hover: () => calls.push("hover"),
+      focus: (paneId: string) => calls.push(`focus:${paneId}`),
+      action: (
+        paneId: string,
+        _actionId: string,
+        _actionIndex: number,
+        semanticIntent: {
+          commandId: string;
+        },
+      ) => {
+        calls.push(`action:${semanticIntent.commandId}:${paneId}`);
+        if (semanticIntent.commandId === "workspace.windowMode.maximize.toggle") {
+          controlCommands.push(`resize-pane -Z -t ${paneId}`);
+        } else if (semanticIntent.commandId === "workspace.pane.menu.open") {
+          openedMenus.push(paneId);
+        }
+      },
+      menu: (paneId: string) => {
+        calls.push(`menu:${paneId}`);
+        openedMenus.push(paneId);
+      },
+      settle: (paneId: string) => calls.push(`settle:${paneId}`),
+    };
     dispatchTerminalPaneChromePointerIntent(
       {
         kind: "action",
         paneId: "%9",
-        actionId: "zoom",
+        actionId: "visual-zoom-control",
         actionIndex: 0,
         semanticIntent: {
           kind: "action",
           paneId: terminalPaneSemanticId("%9"),
-          actionId: "zoom",
+          actionId: "visual-zoom-control",
           commandId: "workspace.windowMode.maximize.toggle",
         },
       },
-      {
-        hover: () => calls.push("hover"),
-        focus: (paneId) => calls.push(`focus:${paneId}`),
-        action: (paneId, actionId) => calls.push(`${actionId}:${paneId}`),
-        menu: (paneId) => calls.push(`menu:${paneId}`),
-        settle: (paneId) => calls.push(`settle:${paneId}`),
-      },
+      effects,
     );
-    expect(calls).toEqual(["focus:%9", "zoom:%9"]);
+    dispatchTerminalPaneChromePointerIntent(
+      {
+        kind: "action",
+        paneId: "%8",
+        actionId: "visual-overflow-control",
+        actionIndex: 1,
+        semanticIntent: {
+          kind: "action",
+          paneId: terminalPaneSemanticId("%8"),
+          actionId: "visual-overflow-control",
+          commandId: "workspace.pane.menu.open",
+        },
+      },
+      effects,
+    );
+    dispatchTerminalPaneChromePointerIntent({ kind: "menu", paneId: "%7" }, effects);
+    expect(calls).toEqual([
+      "focus:%9",
+      "action:workspace.windowMode.maximize.toggle:%9",
+      "focus:%8",
+      "action:workspace.pane.menu.open:%8",
+      "focus:%7",
+      "menu:%7",
+    ]);
+    expect(controlCommands).toEqual(["resize-pane -Z -t %9"]);
+    expect(openedMenus).toEqual(["%8", "%7"]);
     expect(ptyWrites).toEqual([]);
   });
 
-  it("keeps the one-item production root swap executable and owned by Card 22.4b2", () => {
+  it("mounts exactly two passive shared hosts and routes their semantic commands at root", () => {
     const appSource = readFileSync(new URL("../app.tsx", import.meta.url), "utf8");
-    expect(CARD_22_4B2_PANE_FRAME_ROOT_WIRING_DEFERRALS).toEqual([
-      {
-        component: "TerminalPaneChromeLayer",
-        replacement: "SharedTerminalPaneChromeLayer",
-        owner: "22.4b2",
-      },
-    ]);
-    expect(appSource).toContain(
-      'import { TerminalPaneChromeLayer } from "./workspace/terminal-pane-chrome-view.tsx"',
+    const hostSource = readFileSync(
+      new URL("./terminal-pane-chrome-view.tsx", import.meta.url),
+      "utf8",
     );
-    expect(appSource).not.toContain("SharedTerminalPaneChromeLayer");
+    const productionHosts = appSource.match(/<SharedTerminalPaneChromeLayer\b[\s\S]*?\/>/gu) ?? [];
+    expect(productionHosts).toHaveLength(2);
+    expect(productionHosts.map((host) => host.match(/layer="([^"]+)"/u)?.[1])).toEqual([
+      "native",
+      "framebuffer",
+    ]);
+    for (const host of productionHosts) {
+      expect(host).toContain("theme={semanticTheme()}");
+      expect(host).toContain("layout={terminalPaneChromeLayout()}");
+      expect(host).not.toMatch(/\b(?:inputOwner|onActionActivate|onGripActivate)\b/u);
+    }
+    expect(appSource).not.toMatch(/<TerminalPaneChromeLayer\b/u);
+    expect(hostSource).not.toContain("function TerminalPaneChromeLayer");
+    expect(hostSource).not.toMatch(
+      /\b(?:useKeyboard|usePaste|onMount|onCleanup|createEffect|process\.exit)\b|mirror\?*\.|\.command\(/u,
+    );
+    expect(appSource).toContain("action: (paneId, _actionId, actionIndex, semanticIntent) => {");
+    expect(appSource).toContain('semanticIntent.commandId === "workspace.pane.menu.open"');
+    expect(appSource).toContain(
+      'semanticIntent.commandId === "workspace.windowMode.maximize.toggle"',
+    );
+    expect(appSource).toContain("mirror?.command(`resize-pane -Z -t ${paneId}`)");
   });
 
   it("lets non-action lower-header cells fall through to separator resize", () => {

--- a/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts
+++ b/packages/daemon/src/tui/mirror/workspace/terminal-pane-chrome.ts
@@ -131,15 +131,6 @@ interface Segment {
   end: number;
 }
 
-/** One executable production-root handoff; Card 22.4b2 must remove it when wiring the new host. */
-export const CARD_22_4B2_PANE_FRAME_ROOT_WIRING_DEFERRALS = Object.freeze([
-  Object.freeze({
-    component: "TerminalPaneChromeLayer",
-    replacement: "SharedTerminalPaneChromeLayer",
-    owner: "22.4b2",
-  }),
-] as const);
-
 /** Live tmux ids are transport identities, so encode them before crossing the semantic boundary. */
 export function terminalPaneSemanticId(paneId: string): SemanticProductId {
   const prefix = "pane.tmux.";


### PR DESCRIPTION
## Outcome

Replaces the legacy production terminal chrome with the shared passive PaneFrame host in both native and framebuffer render paths.

## Included

- exactly two passive SharedTerminalPaneChromeLayer production mounts
- root-owned semantic maximize and pane-menu routing
- focus-before-action with raw tmux pane IDs retained only for transport/context
- unchanged terminal sizing, body geometry, search footer and lower separator resize fallthrough
- legacy layer and deferred production-swap marker removed
- 80x24, 120x40 and 200x60 churn/flicker stress for add/remove, migration, zoom, status and attention
- stable renderable identity/count/bounds and anchor-warning assertions

## Verification

- full pnpm check passed before final conflict-free rebase
- daemon: 2,273 tests passed
- full renderer: 94 tests, 9,476 assertions
- focused chrome: 23 tests passed
- focused renderer: 18 tests, 15 snapshots, 7,361 assertions
- daemon/OpenTUI/web typechecks, build:tui, docs, packaging, native deps and diff-check passed

Independent release review: APPROVED.