### PR TITLE
feat(desktop): attach Electron to canonical daemon

### DIFF
--- a/apps/desktop-renderer/src/App.test.tsx
+++ b/apps/desktop-renderer/src/App.test.tsx
@@ -108,12 +108,15 @@ describe("desktop App host lifecycle", () => {
       appVersion: "test",
       theme: { mode: "light", highContrast: true, reducedMotion: false },
       window: initialWindow,
-      daemon: { status: "deferred", reason: "test boundary" },
+      daemon: { status: "unavailable", code: "preview-only", reason: "test boundary" },
     });
     await vi.waitFor(() => {
       expect(app.dataset.increasedContrast).toBe("true");
       expect(app.dataset.reducedMotion).toBe("false");
       expect(root.querySelector(".window-controls")).not.toBeNull();
+      expect(root.querySelector(".status-strip__connection")?.textContent).toContain(
+        "Daemon unavailable — test boundary",
+      );
     });
     expect(styles).toMatch(
       /\.window-controls button \{[\s\S]*?transition:\s*color var\(--tmux-ide-motion-fast\) linear,\s*background-color var\(--tmux-ide-motion-fast\) linear;/u,

--- a/apps/desktop-renderer/src/App.tsx
+++ b/apps/desktop-renderer/src/App.tsx
@@ -56,6 +56,7 @@ export function App(props: AppProps = {}) {
     >
       <DomApplicationShell
         host={host}
+        daemonState={bootstrap()?.daemon}
         runtime={bootstrap()?.runtime}
         platform={bootstrap()?.platform}
         windowState={effectiveWindow()}

--- a/apps/desktop-renderer/src/experience/application-shell.test.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.test.tsx
@@ -40,7 +40,7 @@ function host(): HostCapabilities {
       appVersion: "test",
       theme: { mode: "dark", highContrast: false, reducedMotion: false },
       window: WINDOW_STATE,
-      daemon: { status: "deferred", reason: "fixture only" },
+      daemon: { status: "unavailable", code: "preview-only", reason: "fixture only" },
     }),
     lifecycle: { requestQuit: async () => undefined },
     window: {
@@ -436,12 +436,72 @@ describe("visible DOM application shell", () => {
     );
     expect(root.querySelector(".status-strip")?.getAttribute("data-shell-source")).toBe("preview");
     expect(root.querySelector(".status-strip__connection")?.textContent).toContain(
-      "Preview workspace — no daemon connection",
+      "Preview workspace — daemon state is still loading",
     );
     expect(root.querySelector(".status-strip__safe")?.textContent).toBe("Illustrative data only");
     expect(root.textContent).not.toContain("agent processes remain active");
     expect(root.textContent).not.toContain("Retry the attachment");
   });
+
+  it.each([
+    {
+      state: {
+        status: "connected" as const,
+        descriptor: {
+          apiBaseUrl: "http://127.0.0.1:6060",
+          protocolVersion: 1,
+          productVersion: "2.8.0",
+          instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+          startedAt: "2026-07-21T00:00:00.000Z",
+        },
+      },
+      message: "Daemon connected — 2.8.0",
+      safe: "Preview data remains illustrative",
+    },
+    {
+      state: {
+        status: "unavailable" as const,
+        code: "health-unreachable" as const,
+        reason: "Health endpoint is unreachable",
+      },
+      message: "Daemon unavailable — Health endpoint is unreachable",
+      safe: "Illustrative data only",
+    },
+    {
+      state: {
+        status: "degraded" as const,
+        code: "identity-mismatch" as const,
+        reason: "Identity does not match",
+      },
+      message: "Daemon verification degraded — Identity does not match",
+      safe: "Illustrative data only",
+    },
+  ])(
+    "surfaces honest $state.status host state without relabeling preview data",
+    ({ state, message, safe }) => {
+      const root = document.createElement("div");
+      document.body.append(root);
+      disposers.push(
+        render(
+          () => (
+            <DomApplicationShell
+              host={host()}
+              daemonState={state}
+              runtime="electron"
+              platform="darwin"
+              windowState={WINDOW_STATE}
+              dataMode="preview"
+            />
+          ),
+          root,
+        ),
+      );
+
+      expect(root.querySelector(".titlebar__preview-badge")?.textContent).toBe("Preview data");
+      expect(root.querySelector(".status-strip__connection")?.textContent).toContain(message);
+      expect(root.querySelector(".status-strip__safe")?.textContent).toBe(safe);
+    },
+  );
 
   it("reacts to replacement snapshots while preserving valid local state and stable leaves", async () => {
     const initial = createDefaultDomShellInput();

--- a/apps/desktop-renderer/src/experience/application-shell.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.tsx
@@ -8,6 +8,7 @@ import {
   type ApplicationShellProjectionInputV1,
   type ApplicationShellProjectionV1,
   type CommandSource,
+  type DesktopDaemonHostState,
   type DesktopWindowState,
   type FocusZone,
   type HostCapabilities,
@@ -52,6 +53,7 @@ const PALETTE_OVERLAY_ID = "overlay.palette.trace";
 
 export interface DomApplicationShellProps {
   readonly host: HostCapabilities;
+  readonly daemonState?: DesktopDaemonHostState;
   readonly runtime?: string;
   readonly platform?: string;
   readonly windowState?: DesktopWindowState | null;
@@ -171,16 +173,39 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
   const shell = createMemo(() => projectDomApplicationShell(input(), state()));
   const dock = createMemo(() => projectDomWorkbenchDock(shell(), viewport()));
   const paletteEntries = createMemo(() => createDomPaletteEntries(shell()));
-  const statusStrip = createMemo(() =>
-    dataMode() === "preview"
-      ? {
-          state: "disconnected" as const,
-          message: "Preview workspace — no daemon connection",
-          safeState: "Illustrative data only",
-          nextAction: "Connect the desktop host to load a workspace",
-        }
-      : shell().statusStrip,
-  );
+  const statusStrip = createMemo(() => {
+    if (dataMode() !== "preview") return shell().statusStrip;
+    if (props.daemonState?.status === "connected") {
+      return {
+        state: "connected" as const,
+        message: `Daemon connected — ${props.daemonState.descriptor.productVersion}`,
+        safeState: "Preview data remains illustrative",
+        nextAction: "Live workspace loading is not enabled in this build",
+      };
+    }
+    if (props.daemonState?.status === "degraded") {
+      return {
+        state: "recovering" as const,
+        message: `Daemon verification degraded — ${props.daemonState.reason}`,
+        safeState: "Illustrative data only",
+        nextAction: "Repair the canonical daemon record and reopen the app",
+      };
+    }
+    if (props.daemonState?.status === "unavailable") {
+      return {
+        state: "disconnected" as const,
+        message: `Daemon unavailable — ${props.daemonState.reason}`,
+        safeState: "Illustrative data only",
+        nextAction: "Start tmux-ide --headless and reopen the app",
+      };
+    }
+    return {
+      state: "disconnected" as const,
+      message: "Preview workspace — daemon state is still loading",
+      safeState: "Illustrative data only",
+      nextAction: "Wait for desktop host verification",
+    };
+  });
 
   createEffect(() => {
     const nextInput = input();

--- a/apps/desktop-renderer/src/host-capabilities.ts
+++ b/apps/desktop-renderer/src/host-capabilities.ts
@@ -77,8 +77,9 @@ export function createBrowserHostCapabilities(): HostCapabilities {
       theme: browserTheme(),
       window: browserWindowState(),
       daemon: {
-        status: "deferred",
-        reason: "Browser preview does not own the desktop daemon lifecycle.",
+        status: "unavailable",
+        code: "preview-only",
+        reason: "Browser preview does not attach to the desktop daemon.",
       },
     }),
     lifecycle: {

--- a/apps/electron-shell/src/daemon-preflight.test.ts
+++ b/apps/electron-shell/src/daemon-preflight.test.ts
@@ -1,12 +1,227 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  DAEMON_WIRE_PROTOCOL_VERSION,
+  type CanonicalDaemonInfo,
+  type DaemonHealth,
+  type DaemonIdentity,
+} from "@tmux-ide/contracts";
 
-import { runDaemonPreflight, type DaemonPreflight } from "./daemon-preflight.ts";
+import {
+  createCanonicalDaemonPreflight,
+  runDaemonPreflight,
+  type CanonicalDaemonAttachOperations,
+  type DaemonPreflight,
+} from "./daemon-preflight.ts";
+
+const info: CanonicalDaemonInfo = {
+  pid: 4242,
+  port: 6060,
+  protocolVersion: DAEMON_WIRE_PROTOCOL_VERSION,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-21T00:00:00.000Z",
+  bindHostname: "127.0.0.1",
+  authToken: "must-not-cross-ipc",
+};
+
+const identity: DaemonIdentity = {
+  ok: true,
+  pid: info.pid,
+  protocolVersion: info.protocolVersion,
+  productVersion: info.productVersion,
+  instanceId: info.instanceId,
+  startedAt: info.startedAt,
+};
+
+const health: DaemonHealth = {
+  ok: true,
+  protocolVersion: info.protocolVersion,
+  productVersion: info.productVersion,
+  uptime: 30,
+};
+
+function operations(
+  overrides: Partial<CanonicalDaemonAttachOperations> = {},
+): CanonicalDaemonAttachOperations {
+  return {
+    inspect: () => ({
+      status: "valid",
+      info,
+      observation: { dev: 1, ino: 2, size: 3, mtimeMs: 4 },
+    }),
+    isAlive: async () => true,
+    probeIdentity: async () => identity,
+    probeHealth: async () => health,
+    httpOrigin: () => "http://127.0.0.1:6060",
+    ...overrides,
+  };
+}
+
+describe("canonical Electron daemon attachment", () => {
+  it("reports a missing record without attempting a spawn or network probe", async () => {
+    const probeIdentity = vi.fn(async () => identity);
+    const preflight = createCanonicalDaemonPreflight(
+      operations({ inspect: () => ({ status: "missing" }), probeIdentity }),
+    );
+
+    await expect(runDaemonPreflight(preflight)).resolves.toEqual({
+      status: "unavailable",
+      code: "record-missing",
+      reason: "No running canonical tmux-ide daemon was found.",
+    });
+    expect(probeIdentity).not.toHaveBeenCalled();
+  });
+
+  it.each(["malformed-json", "unsafe-permissions", "parent-unsafe-permissions"] as const)(
+    "degrades an insecure or malformed record (%s)",
+    async (reason) => {
+      const preflight = createCanonicalDaemonPreflight(
+        operations({
+          inspect: () => ({
+            status: "invalid",
+            reason,
+            detail: "record failed secure inspection",
+            ownerPid: null,
+            observation: null,
+          }),
+        }),
+      );
+
+      await expect(runDaemonPreflight(preflight)).resolves.toMatchObject({
+        status: "degraded",
+        code: "record-invalid",
+        reason: expect.stringContaining(reason),
+      });
+    },
+  );
+
+  it("reports a stale process as unavailable", async () => {
+    const preflight = createCanonicalDaemonPreflight(operations({ isAlive: async () => false }));
+    await expect(runDaemonPreflight(preflight)).resolves.toMatchObject({
+      status: "unavailable",
+      code: "process-not-running",
+    });
+  });
+
+  it("refuses a non-loopback endpoint before probing it", async () => {
+    const probeIdentity = vi.fn(async () => identity);
+    const preflight = createCanonicalDaemonPreflight(
+      operations({ httpOrigin: () => "http://192.0.2.10:6060", probeIdentity }),
+    );
+    await expect(runDaemonPreflight(preflight)).resolves.toMatchObject({
+      status: "degraded",
+      code: "endpoint-not-loopback",
+    });
+    expect(probeIdentity).not.toHaveBeenCalled();
+  });
+
+  it("refuses incompatible record, identity, and health protocol versions", async () => {
+    const recordPreflight = createCanonicalDaemonPreflight(
+      operations({
+        inspect: () => ({
+          status: "valid",
+          info: { ...info, protocolVersion: 99 },
+          observation: { dev: 1, ino: 2, size: 3, mtimeMs: 4 },
+        }),
+      }),
+    );
+    await expect(runDaemonPreflight(recordPreflight)).resolves.toMatchObject({
+      status: "degraded",
+      code: "protocol-incompatible",
+    });
+
+    const identityPreflight = createCanonicalDaemonPreflight(
+      operations({ probeIdentity: async () => ({ ...identity, protocolVersion: 99 }) }),
+    );
+    await expect(runDaemonPreflight(identityPreflight)).resolves.toMatchObject({
+      status: "degraded",
+      code: "protocol-incompatible",
+    });
+
+    const healthPreflight = createCanonicalDaemonPreflight(
+      operations({ probeHealth: async () => ({ ...health, protocolVersion: 99 }) }),
+    );
+    await expect(runDaemonPreflight(healthPreflight)).resolves.toMatchObject({
+      status: "degraded",
+      code: "protocol-incompatible",
+    });
+  });
+
+  it.each([
+    { field: "pid", value: info.pid + 1 },
+    { field: "instanceId", value: "3adfc6e2-f1ae-4e63-b9df-7e8eb0ea94d4" },
+    { field: "startedAt", value: "2026-07-21T00:00:01.000Z" },
+    { field: "productVersion", value: "9.0.0" },
+  ] as const)("degrades a mismatched identity $field", async ({ field, value }) => {
+    const preflight = createCanonicalDaemonPreflight(
+      operations({ probeIdentity: async () => ({ ...identity, [field]: value }) }),
+    );
+    await expect(runDaemonPreflight(preflight)).resolves.toMatchObject({
+      status: "degraded",
+      code: "identity-mismatch",
+    });
+  });
+
+  it("distinguishes unreachable identity and health endpoints", async () => {
+    const identityPreflight = createCanonicalDaemonPreflight(
+      operations({ probeIdentity: async () => null }),
+    );
+    await expect(runDaemonPreflight(identityPreflight)).resolves.toMatchObject({
+      status: "unavailable",
+      code: "identity-unreachable",
+    });
+
+    const healthPreflight = createCanonicalDaemonPreflight(
+      operations({ probeHealth: async () => null }),
+    );
+    await expect(runDaemonPreflight(healthPreflight)).resolves.toMatchObject({
+      status: "unavailable",
+      code: "health-unreachable",
+    });
+  });
+
+  it("degrades health metadata that disagrees with the verified record", async () => {
+    const preflight = createCanonicalDaemonPreflight(
+      operations({ probeHealth: async () => ({ ...health, productVersion: "9.0.0" }) }),
+    );
+    await expect(runDaemonPreflight(preflight)).resolves.toMatchObject({
+      status: "degraded",
+      code: "health-mismatch",
+    });
+  });
+
+  it("reuses a valid daemon and exposes only the bounded renderer-safe descriptor", async () => {
+    const preflight = createCanonicalDaemonPreflight(operations());
+    const result = await runDaemonPreflight(preflight);
+
+    expect(result).toEqual({
+      status: "connected",
+      descriptor: {
+        apiBaseUrl: "http://127.0.0.1:6060",
+        protocolVersion: 1,
+        productVersion: "2.8.0",
+        instanceId: info.instanceId,
+        startedAt: info.startedAt,
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(String(info.pid));
+    expect(JSON.stringify(result)).not.toContain(info.authToken);
+  });
+});
 
 describe("runDaemonPreflight", () => {
-  it("returns an injected probe result", async () => {
-    const probe = vi.fn(async () => ({ status: "absent" as const }));
+  it("validates and returns an injected host state", async () => {
+    const probe = vi.fn(async () => ({
+      status: "unavailable" as const,
+      code: "record-missing" as const,
+      reason: "not running",
+    }));
 
-    await expect(runDaemonPreflight({ probe })).resolves.toEqual({ status: "absent" });
+    await expect(runDaemonPreflight({ probe })).resolves.toEqual({
+      status: "unavailable",
+      code: "record-missing",
+      reason: "not running",
+    });
     expect(probe).toHaveBeenCalledOnce();
   });
 
@@ -19,6 +234,7 @@ describe("runDaemonPreflight", () => {
 
     await expect(runDaemonPreflight(preflight)).resolves.toEqual({
       status: "unavailable",
+      code: "probe-failed",
       reason: "socket rejected",
     });
   });
@@ -38,6 +254,7 @@ describe("runDaemonPreflight", () => {
 
     await expect(result).resolves.toEqual({
       status: "unavailable",
+      code: "probe-timeout",
       reason: "Daemon preflight timed out after 25ms.",
     });
     expect(signal?.aborted).toBe(true);

--- a/apps/electron-shell/src/daemon-preflight.ts
+++ b/apps/electron-shell/src/daemon-preflight.ts
@@ -1,45 +1,206 @@
-import type { DesktopDaemonPreflight } from "@tmux-ide/contracts";
+import {
+  DesktopDaemonHostStateSchemaZ,
+  isDaemonWireProtocolCompatible,
+  type CanonicalDaemonInfo,
+  type DaemonHealth,
+  type DaemonIdentity,
+  type DesktopDaemonHostState,
+} from "@tmux-ide/contracts";
+import {
+  canonicalDaemonUrl,
+  inspectCanonicalDaemonInfo,
+  isCanonicalDaemonAlive,
+  probeCanonicalDaemonHealth,
+  probeCanonicalDaemonIdentity,
+  type CanonicalDaemonInfoState,
+} from "../../../packages/daemon/src/canonical.ts";
 
 export interface DaemonPreflight {
-  probe(signal: AbortSignal): Promise<DesktopDaemonPreflight>;
+  probe(signal: AbortSignal): Promise<DesktopDaemonHostState>;
 }
 
-/**
- * Card19b does not own or duplicate the unfinished canonical daemon launcher.
- * A later card injects the real probe at this seam.
- */
-export const deferredDaemonPreflight: DaemonPreflight = {
-  probe: async () => ({
-    status: "deferred",
-    reason: "Canonical headless daemon ownership is not part of the Electron shell foundation.",
-  }),
+export interface CanonicalDaemonAttachOperations {
+  inspect(): CanonicalDaemonInfoState;
+  isAlive(info: CanonicalDaemonInfo): Promise<boolean>;
+  probeIdentity(info: CanonicalDaemonInfo): Promise<DaemonIdentity | null>;
+  probeHealth(info: CanonicalDaemonInfo): Promise<DaemonHealth | null>;
+  httpOrigin(info: CanonicalDaemonInfo): string;
+}
+
+const canonicalAttachOperations: CanonicalDaemonAttachOperations = {
+  inspect: inspectCanonicalDaemonInfo,
+  isAlive: isCanonicalDaemonAlive,
+  probeIdentity: probeCanonicalDaemonIdentity,
+  probeHealth: probeCanonicalDaemonHealth,
+  httpOrigin: (info) => canonicalDaemonUrl("http", info.bindHostname, info.port),
 };
+
+function unavailable(
+  code: Extract<DesktopDaemonHostState, { status: "unavailable" }>["code"],
+  reason: string,
+): DesktopDaemonHostState {
+  return { status: "unavailable", code, reason };
+}
+
+function degraded(
+  code: Extract<DesktopDaemonHostState, { status: "degraded" }>["code"],
+  reason: string,
+): DesktopDaemonHostState {
+  return { status: "degraded", code, reason };
+}
+
+function probeWasAborted(signal: AbortSignal): DesktopDaemonHostState | null {
+  return signal.aborted
+    ? unavailable("probe-timeout", "Canonical daemon verification was cancelled.")
+    : null;
+}
+
+function endpointIsLoopback(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === "http:" &&
+      (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]") &&
+      url.username.length === 0 &&
+      url.password.length === 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function createCanonicalDaemonPreflight(
+  operations: CanonicalDaemonAttachOperations = canonicalAttachOperations,
+): DaemonPreflight {
+  return {
+    probe: async (signal) => {
+      const state = operations.inspect();
+      if (state.status === "missing") {
+        return unavailable("record-missing", "No running canonical tmux-ide daemon was found.");
+      }
+      if (state.status === "invalid") {
+        return degraded(
+          "record-invalid",
+          `Canonical daemon record is not trustworthy (${state.reason}): ${state.detail}`,
+        );
+      }
+      const { info } = state;
+      if (!isDaemonWireProtocolCompatible(info.protocolVersion)) {
+        return degraded(
+          "protocol-incompatible",
+          `Canonical daemon protocol ${info.protocolVersion} is not supported by this app.`,
+        );
+      }
+
+      const apiBaseUrl = operations.httpOrigin(info);
+      if (!endpointIsLoopback(apiBaseUrl)) {
+        return degraded(
+          "endpoint-not-loopback",
+          "Canonical daemon endpoint did not resolve to a loopback HTTP origin.",
+        );
+      }
+      const abortedBeforePid = probeWasAborted(signal);
+      if (abortedBeforePid) return abortedBeforePid;
+      if (!(await operations.isAlive(info))) {
+        return unavailable("process-not-running", "Canonical daemon process is no longer running.");
+      }
+
+      const abortedBeforeIdentity = probeWasAborted(signal);
+      if (abortedBeforeIdentity) return abortedBeforeIdentity;
+      const identity = await operations.probeIdentity(info);
+      if (!identity) {
+        return unavailable(
+          "identity-unreachable",
+          "Canonical daemon identity endpoint could not be verified.",
+        );
+      }
+      if (!isDaemonWireProtocolCompatible(identity.protocolVersion)) {
+        return degraded(
+          "protocol-incompatible",
+          `Canonical daemon identity protocol ${identity.protocolVersion} is not supported by this app.`,
+        );
+      }
+      if (
+        identity.pid !== info.pid ||
+        identity.protocolVersion !== info.protocolVersion ||
+        identity.productVersion !== info.productVersion ||
+        identity.instanceId !== info.instanceId ||
+        identity.startedAt !== info.startedAt
+      ) {
+        return degraded(
+          "identity-mismatch",
+          "Canonical daemon identity does not match the securely discovered record.",
+        );
+      }
+
+      const abortedBeforeHealth = probeWasAborted(signal);
+      if (abortedBeforeHealth) return abortedBeforeHealth;
+      const health = await operations.probeHealth(info);
+      if (!health) {
+        return unavailable(
+          "health-unreachable",
+          "Canonical daemon health endpoint is unreachable.",
+        );
+      }
+      if (!isDaemonWireProtocolCompatible(health.protocolVersion)) {
+        return degraded(
+          "protocol-incompatible",
+          `Canonical daemon health protocol ${health.protocolVersion} is not supported by this app.`,
+        );
+      }
+      if (
+        health.protocolVersion !== info.protocolVersion ||
+        health.productVersion !== info.productVersion
+      ) {
+        return degraded(
+          "health-mismatch",
+          "Canonical daemon health metadata does not match its discovered identity.",
+        );
+      }
+
+      return {
+        status: "connected",
+        descriptor: {
+          apiBaseUrl,
+          protocolVersion: info.protocolVersion,
+          productVersion: info.productVersion,
+          instanceId: info.instanceId,
+          startedAt: info.startedAt,
+        },
+      };
+    },
+  };
+}
+
+export const canonicalDaemonPreflight = createCanonicalDaemonPreflight();
 
 export async function runDaemonPreflight(
   preflight: DaemonPreflight,
-  timeoutMs = 1_500,
-): Promise<DesktopDaemonPreflight> {
+  timeoutMs = 2_500,
+): Promise<DesktopDaemonHostState> {
   const controller = new AbortController();
   let timeout: ReturnType<typeof setTimeout> | undefined;
-  const deadline = new Promise<DesktopDaemonPreflight>((resolve) => {
+  const deadline = new Promise<DesktopDaemonHostState>((resolve) => {
     timeout = setTimeout(() => {
       controller.abort();
-      resolve({
-        status: "unavailable",
-        reason: `Daemon preflight timed out after ${timeoutMs}ms.`,
-      });
+      resolve(unavailable("probe-timeout", `Daemon preflight timed out after ${timeoutMs}ms.`));
     }, timeoutMs);
     timeout.unref?.();
   });
 
   try {
-    return await Promise.race([
-      preflight.probe(controller.signal).catch((error: unknown) => ({
-        status: "unavailable" as const,
-        reason: error instanceof Error ? error.message : "Daemon preflight failed.",
-      })),
+    const result = await Promise.race([
+      preflight
+        .probe(controller.signal)
+        .catch((error: unknown) =>
+          unavailable(
+            "probe-failed",
+            error instanceof Error ? error.message : "Daemon preflight failed.",
+          ),
+        ),
       deadline,
     ]);
+    return DesktopDaemonHostStateSchemaZ.parse(result);
   } finally {
     if (timeout) clearTimeout(timeout);
   }

--- a/apps/electron-shell/src/host-ipc.test.ts
+++ b/apps/electron-shell/src/host-ipc.test.ts
@@ -21,12 +21,22 @@ describe("host IPC trust boundary", () => {
       isFocused: () => true,
       webContents,
     } as unknown as BrowserWindow;
+    const daemon = {
+      status: "connected" as const,
+      descriptor: {
+        apiBaseUrl: "http://127.0.0.1:6060",
+        protocolVersion: 1,
+        productVersion: "2.8.0",
+        instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+        startedAt: "2026-07-21T00:00:00.000Z",
+      },
+    };
     const unregister = registerHostIpc({
       ipcMain,
       getWindow: () => window,
       appVersion: "test",
       platform: "darwin",
-      daemon: { status: "absent" },
+      daemon,
       requestQuit: vi.fn(),
       selectProjectDirectory: async () => null,
       getTheme: () => ({ mode: "dark", highContrast: false, reducedMotion: false }),
@@ -39,7 +49,7 @@ describe("host IPC trust boundary", () => {
     const bootstrap = handlers.get(HOST_IPC.bootstrap);
     expect(
       bootstrap?.({ sender: webContents, senderFrame: mainFrame } as unknown as IpcMainInvokeEvent),
-    ).toMatchObject({ runtime: "electron", appVersion: "test" });
+    ).toMatchObject({ runtime: "electron", appVersion: "test", daemon });
     expect(() =>
       bootstrap?.({ sender: webContents, senderFrame: {} } as unknown as IpcMainInvokeEvent),
     ).toThrow("untrusted renderer");

--- a/apps/electron-shell/src/import-boundaries.test.ts
+++ b/apps/electron-shell/src/import-boundaries.test.ts
@@ -63,6 +63,18 @@ describe("desktop process boundaries", () => {
     expect(Object.values(HOST_IPC)).not.toContain("tmux-ide:host/command");
   });
 
+  it("keeps canonical daemon attachment in Electron main and out of preload", async () => {
+    const preflight = await readFile(join(packageRoot, "src", "daemon-preflight.ts"), "utf8");
+    const preload = await readFile(join(packageRoot, "src", "preload.ts"), "utf8");
+
+    expect(importedSpecifiers(preflight)).toContain("../../../packages/daemon/src/canonical.ts");
+    expect(importedSpecifiers(preflight)).not.toContain("@tmux-ide/daemon");
+    expect(importedSpecifiers(preload).some((specifier) => specifier.includes("daemon/src"))).toBe(
+      false,
+    );
+    expect(importedSpecifiers(preload).some(isNodeBuiltin)).toBe(false);
+  });
+
   it("ships a strict browser renderer policy", async () => {
     const html = await readFile(join(packageRoot, "..", "desktop-renderer", "index.html"), "utf8");
     expect(html).toContain("default-src 'self'");

--- a/apps/electron-shell/src/main.ts
+++ b/apps/electron-shell/src/main.ts
@@ -5,7 +5,7 @@ import { app, BrowserWindow, dialog, ipcMain, nativeTheme, screen, session } fro
 import type { DesktopPlatform, DesktopThemeState } from "@tmux-ide/contracts";
 
 import {
-  deferredDaemonPreflight,
+  canonicalDaemonPreflight,
   runDaemonPreflight,
   type DaemonPreflight,
 } from "./daemon-preflight.ts";
@@ -93,7 +93,7 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
   const stateStore = new DesktopWindowStateStore(
     join(app.getPath("userData"), "window-state.json"),
   );
-  const daemon = await runDaemonPreflight(deps.daemonPreflight ?? deferredDaemonPreflight);
+  const daemon = await runDaemonPreflight(deps.daemonPreflight ?? canonicalDaemonPreflight);
   const developmentUrl = trustedDevelopmentUrl();
   const packagedRendererPath = join(__dirname, "renderer", "index.html");
   const trustedRendererLocation: TrustedRendererLocation = developmentUrl

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2393,11 +2393,11 @@ var init_commands = __esm({
 
 // packages/contracts/src/desktop-host.ts
 import { z as z15 } from "zod";
-var DESKTOP_HOST_API_VERSION, DesktopRuntimeKindSchemaZ, DesktopPlatformSchemaZ, DesktopThemeModeSchemaZ, DesktopThemeStateSchemaZ, DesktopWindowStateSchemaZ, DesktopDaemonPreflightSchemaZ, DesktopHostBootstrapSchemaZ, DesktopMenuResultSchemaZ, DesktopDirectorySelectionSchemaZ;
+var DESKTOP_HOST_API_VERSION, DesktopRuntimeKindSchemaZ, DesktopPlatformSchemaZ, DesktopThemeModeSchemaZ, DesktopThemeStateSchemaZ, DesktopWindowStateSchemaZ, DesktopDaemonLoopbackUrlSchemaZ, DesktopDaemonHostDescriptorSchemaZ, DesktopDaemonHostIssueCodeSchemaZ, DesktopDaemonHostIssueSchemaFields, DesktopDaemonHostStateSchemaZ, DesktopDaemonPreflightSchemaZ, DesktopHostBootstrapSchemaZ, DesktopMenuResultSchemaZ, DesktopDirectorySelectionSchemaZ;
 var init_desktop_host = __esm({
   "packages/contracts/src/desktop-host.ts"() {
     "use strict";
-    DESKTOP_HOST_API_VERSION = 1;
+    DESKTOP_HOST_API_VERSION = 2;
     DesktopRuntimeKindSchemaZ = z15.enum(["browser", "electron"]);
     DesktopPlatformSchemaZ = z15.enum(["darwin", "linux", "win32", "unknown"]);
     DesktopThemeModeSchemaZ = z15.enum(["light", "dark"]);
@@ -2411,12 +2411,44 @@ var init_desktop_host = __esm({
       fullscreen: z15.boolean(),
       focused: z15.boolean()
     }).strict();
-    DesktopDaemonPreflightSchemaZ = z15.discriminatedUnion("status", [
-      z15.object({ status: z15.literal("ready"), apiBaseUrl: z15.string().url() }).strict(),
-      z15.object({ status: z15.literal("absent") }).strict(),
-      z15.object({ status: z15.literal("deferred"), reason: z15.string().min(1) }).strict(),
-      z15.object({ status: z15.literal("unavailable"), reason: z15.string().min(1) }).strict()
+    DesktopDaemonLoopbackUrlSchemaZ = z15.url().refine((value) => {
+      const url = new URL(value);
+      return url.protocol === "http:" && (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]") && url.username.length === 0 && url.password.length === 0 && url.pathname === "/" && url.search.length === 0 && url.hash.length === 0;
+    }, "daemon URL must be an uncredentialed loopback HTTP origin");
+    DesktopDaemonHostDescriptorSchemaZ = z15.object({
+      apiBaseUrl: DesktopDaemonLoopbackUrlSchemaZ,
+      protocolVersion: z15.number().int().positive(),
+      productVersion: z15.string().trim().min(1),
+      instanceId: z15.uuid(),
+      startedAt: z15.iso.datetime({ offset: true })
+    }).strict();
+    DesktopDaemonHostIssueCodeSchemaZ = z15.enum([
+      "record-missing",
+      "record-invalid",
+      "endpoint-not-loopback",
+      "protocol-incompatible",
+      "process-not-running",
+      "identity-unreachable",
+      "identity-mismatch",
+      "health-unreachable",
+      "health-mismatch",
+      "probe-failed",
+      "probe-timeout",
+      "preview-only"
     ]);
+    DesktopDaemonHostIssueSchemaFields = {
+      code: DesktopDaemonHostIssueCodeSchemaZ,
+      reason: z15.string().min(1)
+    };
+    DesktopDaemonHostStateSchemaZ = z15.discriminatedUnion("status", [
+      z15.object({
+        status: z15.literal("connected"),
+        descriptor: DesktopDaemonHostDescriptorSchemaZ
+      }).strict(),
+      z15.object({ status: z15.literal("unavailable"), ...DesktopDaemonHostIssueSchemaFields }).strict(),
+      z15.object({ status: z15.literal("degraded"), ...DesktopDaemonHostIssueSchemaFields }).strict()
+    ]);
+    DesktopDaemonPreflightSchemaZ = DesktopDaemonHostStateSchemaZ;
     DesktopHostBootstrapSchemaZ = z15.object({
       apiVersion: z15.literal(DESKTOP_HOST_API_VERSION),
       runtime: DesktopRuntimeKindSchemaZ,
@@ -4300,6 +4332,156 @@ var init_daemon_wire = __esm({
   }
 });
 
+// packages/contracts/src/daemon-resources.ts
+import { z as z24 } from "zod";
+var DaemonSessionOverviewSchemaZ, DaemonPaneInfoSchemaZ, DaemonSessionsResponseSchemaZ, DaemonProjectResponseSchemaZ, DaemonPanesResponseSchemaZ, DaemonWorkspaceSchemaZ, DaemonWorkspacesResponseSchemaZ, DaemonWorkspaceResponseSchemaZ, DaemonRegisteredProjectSchemaZ, DaemonProjectsResponseSchemaZ, DaemonRegisteredProjectResponseSchemaZ, DaemonProjectTemplateSchemaZ, DaemonProjectTemplatesResponseSchemaZ;
+var init_daemon_resources = __esm({
+  "packages/contracts/src/daemon-resources.ts"() {
+    "use strict";
+    init_domain();
+    init_workspace();
+    DaemonSessionOverviewSchemaZ = SessionOverviewSchemaZ.strict();
+    DaemonPaneInfoSchemaZ = PaneInfoSchemaZ.strict();
+    DaemonSessionsResponseSchemaZ = z24.object({
+      sessions: z24.array(DaemonSessionOverviewSchemaZ)
+    }).strict();
+    DaemonProjectResponseSchemaZ = z24.object({
+      session: z24.string(),
+      dir: z24.string(),
+      panes: z24.array(DaemonPaneInfoSchemaZ)
+    }).strict();
+    DaemonPanesResponseSchemaZ = z24.object({
+      panes: z24.array(DaemonPaneInfoSchemaZ)
+    }).strict();
+    DaemonWorkspaceSchemaZ = WorkspaceSchemaZ.strict();
+    DaemonWorkspacesResponseSchemaZ = z24.object({
+      workspaces: z24.array(DaemonWorkspaceSchemaZ)
+    }).strict();
+    DaemonWorkspaceResponseSchemaZ = z24.object({
+      workspace: DaemonWorkspaceSchemaZ
+    }).strict();
+    DaemonRegisteredProjectSchemaZ = z24.object({
+      name: z24.string(),
+      dir: z24.string(),
+      hasIdeYml: z24.boolean(),
+      hasWorkspaceConfig: z24.boolean().optional(),
+      configKind: z24.enum(["workspace", "legacy", "none"]).optional(),
+      configPath: z24.string().nullable().optional(),
+      ideConfigPath: z24.string().nullable().optional(),
+      gitOrigin: z24.string().nullable(),
+      gitBranch: z24.string().nullable(),
+      registeredAt: z24.string()
+    }).strict();
+    DaemonProjectsResponseSchemaZ = z24.object({
+      projects: z24.array(DaemonRegisteredProjectSchemaZ)
+    }).strict();
+    DaemonRegisteredProjectResponseSchemaZ = z24.object({
+      project: DaemonRegisteredProjectSchemaZ
+    }).strict();
+    DaemonProjectTemplateSchemaZ = z24.object({
+      id: z24.string(),
+      label: z24.string(),
+      description: z24.string()
+    }).strict();
+    DaemonProjectTemplatesResponseSchemaZ = z24.object({
+      templates: z24.array(DaemonProjectTemplateSchemaZ)
+    }).strict();
+  }
+});
+
+// packages/contracts/src/daemon-events.ts
+import { z as z25 } from "zod";
+var SessionNamesSchemaZ, DaemonEventSubscribeFrameSchemaZ, DaemonEventUnsubscribeFrameSchemaZ, DaemonEventPingFrameSchemaZ, DaemonEventClientFrameSchemaZ, DaemonSessionSnapshotSchemaZ, DaemonEventHelloFrameSchemaZ, DaemonEventSnapshotFrameSchemaZ, DaemonEventSessionsChangedFrameSchemaZ, DaemonEventProjectsChangedFrameSchemaZ, DaemonEventInitOutputFrameSchemaZ, DaemonEventInitErrorFrameSchemaZ, DaemonEventPongFrameSchemaZ, DaemonEventActionCompleteFrameSchemaZ, DaemonEventConfigChangedFrameSchemaZ, DaemonEventTerminalsChangedFrameSchemaZ, DaemonEventWorkspaceAddedFrameSchemaZ, DaemonEventWorkspaceRemovedFrameSchemaZ, DaemonEventProtocolErrorCodeSchemaZ, DaemonEventProtocolErrorFrameSchemaZ, DaemonEventServerFrameSchemaZ;
+var init_daemon_events = __esm({
+  "packages/contracts/src/daemon-events.ts"() {
+    "use strict";
+    init_daemon_resources();
+    SessionNamesSchemaZ = z25.array(z25.string());
+    DaemonEventSubscribeFrameSchemaZ = z25.object({
+      type: z25.literal("subscribe"),
+      sessions: SessionNamesSchemaZ
+    }).strict();
+    DaemonEventUnsubscribeFrameSchemaZ = z25.object({
+      type: z25.literal("unsubscribe"),
+      sessions: SessionNamesSchemaZ
+    }).strict();
+    DaemonEventPingFrameSchemaZ = z25.object({ type: z25.literal("ping") }).strict();
+    DaemonEventClientFrameSchemaZ = z25.discriminatedUnion("type", [
+      DaemonEventSubscribeFrameSchemaZ,
+      DaemonEventUnsubscribeFrameSchemaZ,
+      DaemonEventPingFrameSchemaZ
+    ]);
+    DaemonSessionSnapshotSchemaZ = z25.object({
+      project: DaemonProjectResponseSchemaZ
+    }).strict();
+    DaemonEventHelloFrameSchemaZ = z25.object({
+      type: z25.literal("hello"),
+      sessions: z25.array(DaemonSessionOverviewSchemaZ)
+    }).strict();
+    DaemonEventSnapshotFrameSchemaZ = z25.object({
+      type: z25.literal("snapshot"),
+      sessionName: z25.string(),
+      data: DaemonSessionSnapshotSchemaZ
+    }).strict();
+    DaemonEventSessionsChangedFrameSchemaZ = z25.object({ type: z25.literal("sessions.changed") }).strict();
+    DaemonEventProjectsChangedFrameSchemaZ = z25.object({ type: z25.literal("projects.changed") }).strict();
+    DaemonEventInitOutputFrameSchemaZ = z25.object({
+      type: z25.literal("init.output"),
+      jobId: z25.string(),
+      chunk: z25.string(),
+      done: z25.boolean().optional()
+    }).strict();
+    DaemonEventInitErrorFrameSchemaZ = z25.object({
+      type: z25.literal("init.error"),
+      jobId: z25.string(),
+      message: z25.string()
+    }).strict();
+    DaemonEventPongFrameSchemaZ = z25.object({ type: z25.literal("pong") }).strict();
+    DaemonEventActionCompleteFrameSchemaZ = z25.object({
+      type: z25.literal("action.complete"),
+      name: z25.string(),
+      result: z25.unknown()
+    }).strict();
+    DaemonEventConfigChangedFrameSchemaZ = z25.object({
+      type: z25.literal("config.changed"),
+      sessionName: z25.string()
+    }).strict();
+    DaemonEventTerminalsChangedFrameSchemaZ = z25.object({
+      type: z25.literal("terminals.changed"),
+      sessionName: z25.string()
+    }).strict();
+    DaemonEventWorkspaceAddedFrameSchemaZ = z25.object({
+      type: z25.literal("workspace.added"),
+      workspace: DaemonWorkspaceSchemaZ
+    }).strict();
+    DaemonEventWorkspaceRemovedFrameSchemaZ = z25.object({
+      type: z25.literal("workspace.removed"),
+      name: z25.string()
+    }).strict();
+    DaemonEventProtocolErrorCodeSchemaZ = z25.enum(["invalid-json", "invalid-frame"]);
+    DaemonEventProtocolErrorFrameSchemaZ = z25.object({
+      type: z25.literal("protocol.error"),
+      code: DaemonEventProtocolErrorCodeSchemaZ,
+      message: z25.string()
+    }).strict();
+    DaemonEventServerFrameSchemaZ = z25.discriminatedUnion("type", [
+      DaemonEventHelloFrameSchemaZ,
+      DaemonEventSnapshotFrameSchemaZ,
+      DaemonEventSessionsChangedFrameSchemaZ,
+      DaemonEventProjectsChangedFrameSchemaZ,
+      DaemonEventInitOutputFrameSchemaZ,
+      DaemonEventInitErrorFrameSchemaZ,
+      DaemonEventPongFrameSchemaZ,
+      DaemonEventActionCompleteFrameSchemaZ,
+      DaemonEventConfigChangedFrameSchemaZ,
+      DaemonEventTerminalsChangedFrameSchemaZ,
+      DaemonEventWorkspaceAddedFrameSchemaZ,
+      DaemonEventWorkspaceRemovedFrameSchemaZ,
+      DaemonEventProtocolErrorFrameSchemaZ
+    ]);
+  }
+});
+
 // packages/contracts/src/index.ts
 var init_src = __esm({
   "packages/contracts/src/index.ts"() {
@@ -4329,6 +4511,8 @@ var init_src = __esm({
     init_focus_overlay();
     init_cohesion_fixture();
     init_daemon_wire();
+    init_daemon_resources();
+    init_daemon_events();
   }
 });
 
@@ -9528,45 +9712,20 @@ var init_session_id = __esm({
 });
 
 // packages/daemon/src/schemas/registry.ts
-import { z as z24 } from "zod";
-var RegisteredProjectSchemaZ, RegisterProjectRequestSchemaZ, InitProjectRequestSchemaZ, ProjectTemplateSchemaZ;
+import { z as z26 } from "zod";
+var RegisteredProjectSchemaZ, RegisterProjectRequestSchemaZ, InitProjectRequestSchemaZ;
 var init_registry = __esm({
   "packages/daemon/src/schemas/registry.ts"() {
     "use strict";
-    RegisteredProjectSchemaZ = z24.object({
-      /** Unique registry key. Defaults to `basename(dir)`; collisions resolved by appending `-2`, `-3`, … */
-      name: z24.string(),
-      /** Absolute path to the project directory. */
-      dir: z24.string(),
-      /** Whether `<dir>/ide.yml` exists; refreshed on register and on `probe()`. */
-      hasIdeYml: z24.boolean(),
-      /** Whether `.tmux-ide/workspace.yml` exists or wins discovery. */
-      hasWorkspaceConfig: z24.boolean().optional(),
-      /** Generalized winning config kind. Added without replacing `hasIdeYml`. */
-      configKind: z24.enum(["workspace", "legacy", "none"]).optional(),
-      /** Generalized winning config path. */
-      configPath: z24.string().nullable().optional(),
-      /** Legacy config path when an `ide.yml` is present. */
-      ideConfigPath: z24.string().nullable().optional(),
-      /** Git remote origin URL, or `null` if not a git repo / no origin / probe failed. */
-      gitOrigin: z24.string().nullable(),
-      /** Current git branch, or `null` if not a git repo / detached HEAD / probe failed. */
-      gitBranch: z24.string().nullable(),
-      /** ISO-8601 timestamp the project was first registered. */
-      registeredAt: z24.string()
+    init_src();
+    RegisteredProjectSchemaZ = DaemonRegisteredProjectSchemaZ;
+    RegisterProjectRequestSchemaZ = z26.object({
+      dir: z26.string().min(1),
+      name: z26.string().min(1).optional()
     });
-    RegisterProjectRequestSchemaZ = z24.object({
-      dir: z24.string().min(1),
-      name: z24.string().min(1).optional()
-    });
-    InitProjectRequestSchemaZ = z24.object({
-      dir: z24.string().min(1),
-      template: z24.string().min(1).optional()
-    });
-    ProjectTemplateSchemaZ = z24.object({
-      id: z24.string(),
-      label: z24.string(),
-      description: z24.string()
+    InitProjectRequestSchemaZ = z26.object({
+      dir: z26.string().min(1),
+      template: z26.string().min(1).optional()
     });
   }
 });
@@ -9628,7 +9787,7 @@ import { EventEmitter } from "node:events";
 import { existsSync as existsSync15, mkdirSync as mkdirSync9, readFileSync as readFileSync11, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir10 } from "node:os";
 import { dirname as dirname15, isAbsolute as isAbsolute3, join as join14, resolve as resolve11 } from "node:path";
-import { z as z25 } from "zod";
+import { z as z27 } from "zod";
 function applyAction(state, action) {
   switch (action.type) {
     case "register":
@@ -9767,9 +9926,9 @@ var init_project_registry = __esm({
     init_registry();
     init_project_probe();
     REGISTRY_DIR_ENV = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ = z25.object({
-      version: z25.literal(1),
-      projects: z25.array(RegisteredProjectSchemaZ)
+    RegistryFileSchemaZ = z27.object({
+      version: z27.literal(1),
+      projects: z27.array(RegisteredProjectSchemaZ)
     });
     ProjectRegistryError = class extends Error {
       code;
@@ -10541,7 +10700,7 @@ var init_notify_state = __esm({
 import { existsSync as existsSync19, mkdirSync as mkdirSync12, readFileSync as readFileSync14, renameSync as renameSync7, writeFileSync as writeFileSync11 } from "node:fs";
 import { homedir as homedir12 } from "node:os";
 import { dirname as dirname17, join as join18 } from "node:path";
-import { z as z26 } from "zod";
+import { z as z28 } from "zod";
 function isBareShell(cmd) {
   return /^-?(zsh|bash|sh|fish|dash|ksh|tcsh|csh|nu)$/.test(cmd.trim());
 }
@@ -10713,32 +10872,32 @@ var init_snapshot2 = __esm({
     init_src2();
     init_process_tree();
     init_sessions2();
-    PaneSnapshotSchemaZ = z26.object({
-      index: z26.number(),
-      cwd: z26.string(),
-      command: z26.string().nullable(),
-      agent: z26.string().nullable(),
-      agentSessionId: z26.string().nullable(),
-      agentState: z26.string().nullable(),
-      title: z26.string()
+    PaneSnapshotSchemaZ = z28.object({
+      index: z28.number(),
+      cwd: z28.string(),
+      command: z28.string().nullable(),
+      agent: z28.string().nullable(),
+      agentSessionId: z28.string().nullable(),
+      agentState: z28.string().nullable(),
+      title: z28.string()
     });
-    WindowSnapshotSchemaZ = z26.object({
-      index: z26.number(),
-      name: z26.string(),
-      active: z26.boolean(),
-      layout: z26.string(),
-      panes: z26.array(PaneSnapshotSchemaZ)
+    WindowSnapshotSchemaZ = z28.object({
+      index: z28.number(),
+      name: z28.string(),
+      active: z28.boolean(),
+      layout: z28.string(),
+      panes: z28.array(PaneSnapshotSchemaZ)
     });
-    SessionSnapshotSchemaZ = z26.object({
-      name: z26.string(),
-      cwd: z26.string(),
-      adopted: z26.boolean(),
-      windows: z26.array(WindowSnapshotSchemaZ)
+    SessionSnapshotSchemaZ = z28.object({
+      name: z28.string(),
+      cwd: z28.string(),
+      adopted: z28.boolean(),
+      windows: z28.array(WindowSnapshotSchemaZ)
     });
-    FleetSnapshotSchemaZ = z26.object({
-      version: z26.literal(1),
-      savedAt: z26.string(),
-      sessions: z26.array(SessionSnapshotSchemaZ)
+    FleetSnapshotSchemaZ = z28.object({
+      version: z28.literal(1),
+      savedAt: z28.string(),
+      sessions: z28.array(SessionSnapshotSchemaZ)
     });
     SNAPSHOT_PANE_FORMAT = [
       "#{session_name}",
@@ -11418,6 +11577,7 @@ import {
   chmodSync as chmodSync3,
   closeSync as closeSync2,
   constants,
+  fchmodSync,
   fstatSync,
   linkSync as linkSync2,
   lstatSync,
@@ -11448,6 +11608,48 @@ function observation(stat) {
 function sameObservation(left, right) {
   return left.dev === right.dev && left.ino === right.ino && left.size === right.size && left.mtimeMs === right.mtimeMs;
 }
+function sameFileIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+function canonicalDaemonRootError(detail) {
+  return new Error(`canonical daemon parent ${detail}`);
+}
+function prepareCanonicalDaemonRoot(root) {
+  let descriptor2;
+  try {
+    try {
+      mkdirSync13(root, { recursive: true, mode: 448 });
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+    }
+    const pathStat = lstatSync(root);
+    if (pathStat.isSymbolicLink()) {
+      throw canonicalDaemonRootError("must not be a symbolic link");
+    }
+    if (!pathStat.isDirectory()) {
+      throw canonicalDaemonRootError("must be a directory");
+    }
+    if (typeof process.getuid === "function" && pathStat.uid !== process.getuid()) {
+      throw canonicalDaemonRootError("must be owned by the current user");
+    }
+    descriptor2 = openSync2(
+      root,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0) | (constants.O_DIRECTORY ?? 0)
+    );
+    const openedStat = fstatSync(descriptor2);
+    if (!openedStat.isDirectory() || !sameFileIdentity(pathStat, openedStat) || typeof process.getuid === "function" && openedStat.uid !== process.getuid()) {
+      throw canonicalDaemonRootError("changed or became unsafe while it was opened");
+    }
+    fchmodSync(descriptor2, 448);
+    const hardenedStat = fstatSync(descriptor2);
+    const currentPathStat = lstatSync(root);
+    if (!hardenedStat.isDirectory() || !sameFileIdentity(openedStat, hardenedStat) || typeof process.getuid === "function" && hardenedStat.uid !== process.getuid() || (hardenedStat.mode & 63) !== 0 || currentPathStat.isSymbolicLink() || !currentPathStat.isDirectory() || !sameFileIdentity(hardenedStat, currentPathStat) || typeof process.getuid === "function" && currentPathStat.uid !== process.getuid() || (currentPathStat.mode & 63) !== 0) {
+      throw canonicalDaemonRootError("changed or became unsafe while it was hardened");
+    }
+  } finally {
+    if (descriptor2 !== void 0) closeSync2(descriptor2);
+  }
+}
 function invalidState(reason, detail, ownerPid = null, observed = null) {
   return { status: "invalid", reason, detail, ownerPid, observation: observed };
 }
@@ -11461,6 +11663,39 @@ function inspectCanonicalDaemonInfoPath(path2) {
   try {
     const pathStat = lstatSync(path2);
     const pathObservation = observation(pathStat);
+    const parentStat = lstatSync(dirname18(path2));
+    if (parentStat.isSymbolicLink()) {
+      return invalidState(
+        "parent-symlink",
+        "daemon.json parent must not be a symbolic link",
+        null,
+        pathObservation
+      );
+    }
+    if (!parentStat.isDirectory()) {
+      return invalidState(
+        "parent-not-directory",
+        "daemon.json parent must be a directory",
+        null,
+        pathObservation
+      );
+    }
+    if (typeof process.getuid === "function" && parentStat.uid !== process.getuid()) {
+      return invalidState(
+        "parent-wrong-owner",
+        "daemon.json parent is not owned by the current user",
+        null,
+        pathObservation
+      );
+    }
+    if ((parentStat.mode & 63) !== 0) {
+      return invalidState(
+        "parent-unsafe-permissions",
+        "daemon.json parent must be accessible only by its owner",
+        null,
+        pathObservation
+      );
+    }
     if (pathStat.isSymbolicLink()) {
       return invalidState(
         "symlink",
@@ -11499,7 +11734,8 @@ function inspectCanonicalDaemonInfoPath(path2) {
     descriptor2 = openSync2(path2, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
     const openedStat = fstatSync(descriptor2);
     const openedObservation = observation(openedStat);
-    if (!openedStat.isFile() || !sameObservation(pathObservation, openedObservation) || typeof process.getuid === "function" && openedStat.uid !== process.getuid() || (openedStat.mode & 63) !== 0) {
+    const reopenedParentStat = lstatSync(dirname18(path2));
+    if (!openedStat.isFile() || !sameObservation(pathObservation, openedObservation) || !sameFileIdentity(parentStat, reopenedParentStat) || !reopenedParentStat.isDirectory() || typeof process.getuid === "function" && openedStat.uid !== process.getuid() || (openedStat.mode & 63) !== 0 || typeof process.getuid === "function" && reopenedParentStat.uid !== process.getuid() || (reopenedParentStat.mode & 63) !== 0) {
       return invalidState(
         "changed-while-opening",
         "daemon.json changed or became unsafe while it was opened",
@@ -11618,7 +11854,14 @@ function retireCanonicalClaimIfMatches(expected) {
 function tryAcquireCanonicalDaemonClaim() {
   const path2 = getCanonicalDaemonClaimPath();
   const root = dirname18(path2);
-  mkdirSync13(root, { recursive: true, mode: 448 });
+  try {
+    prepareCanonicalDaemonRoot(root);
+  } catch (error) {
+    return {
+      status: "invalid",
+      detail: error instanceof Error ? error.message : "canonical daemon parent could not be prepared"
+    };
+  }
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const claim = {
       claimId: randomUUID(),
@@ -11673,7 +11916,7 @@ function releaseCanonicalDaemonClaim(claim) {
 function writeCanonicalDaemonInfo(info, claim) {
   assertCanonicalDaemonClaimHeld(claim);
   const path2 = getCanonicalDaemonInfoPath();
-  mkdirSync13(dirname18(path2), { recursive: true, mode: 448 });
+  prepareCanonicalDaemonRoot(dirname18(path2));
   const tmpPath = `${path2}.${claim.claimId}.${randomUUID()}.tmp`;
   const persisted = {
     pid: info.pid,
@@ -13687,7 +13930,7 @@ import { EventEmitter as EventEmitter3 } from "node:events";
 import { existsSync as existsSync26, mkdirSync as mkdirSync17, readFileSync as readFileSync20, renameSync as renameSync9, writeFileSync as writeFileSync16 } from "node:fs";
 import { homedir as homedir16 } from "node:os";
 import { dirname as dirname24, join as join24 } from "node:path";
-import { z as z27 } from "zod";
+import { z as z29 } from "zod";
 function getDefaultWorkspaceRegistry() {
   if (!_default) _default = new WorkspaceRegistry();
   return _default;
@@ -13710,9 +13953,9 @@ var init_workspace_registry = __esm({
     "use strict";
     init_src();
     REGISTRY_DIR_ENV3 = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ2 = z27.object({
-      version: z27.literal(1),
-      workspaces: z27.array(WorkspaceSchemaZ)
+    RegistryFileSchemaZ2 = z29.object({
+      version: z29.literal(1),
+      workspaces: z29.array(WorkspaceSchemaZ)
     });
     WorkspaceAlreadyExistsError = class extends Error {
       code = "ALREADY_EXISTS";
@@ -14067,16 +14310,27 @@ function handleWsEventsConnection(socket) {
   };
   ws.on("message", (data) => {
     if (closed) return;
-    let parsed = null;
+    let raw;
     try {
-      const obj = JSON.parse(rawDataToText2(data));
-      if (obj && typeof obj === "object" && typeof obj.type === "string") {
-        parsed = obj;
-      }
+      raw = JSON.parse(rawDataToText2(data));
     } catch {
+      send2({
+        type: "protocol.error",
+        code: "invalid-json",
+        message: "Client frame must be valid JSON."
+      });
       return;
     }
-    if (!parsed) return;
+    const result = DaemonEventClientFrameSchemaZ.safeParse(raw);
+    if (!result.success) {
+      send2({
+        type: "protocol.error",
+        code: "invalid-frame",
+        message: "Client frame does not match the daemon event protocol."
+      });
+      return;
+    }
+    const parsed = result.data;
     if (parsed.type === "subscribe") {
       for (const name of parsed.sessions) subscribe(name);
       return;
@@ -14106,6 +14360,7 @@ var init_ws_events = __esm({
     init_discovery();
     init_project_registry();
     init_workspace_registry();
+    init_src();
     WS_OPEN2 = 1;
     KEEPALIVE_INTERVAL_MS = 25e3;
     SESSIONS_POLL_MS = 2e3;
@@ -14545,74 +14800,74 @@ var init_log = __esm({
 });
 
 // packages/daemon/src/command-center/schemas.ts
-import { z as z28 } from "zod";
+import { z as z30 } from "zod";
 var updateTaskSchema, createTaskSchema, savePlanSchema, savePlanContentSchema, sendCommandSchema, createMilestoneSchema, updateMilestoneSchema, updateAssertionSchema, triggerResearchSchema, launchSchema, stopSchema, skillNameRegex, createSkillSchema, updateSkillSchema;
 var init_schemas = __esm({
   "packages/daemon/src/command-center/schemas.ts"() {
     "use strict";
-    updateTaskSchema = z28.object({
-      status: z28.enum(["todo", "in-progress", "review", "done"]).optional(),
-      assignee: z28.string().optional(),
-      title: z28.string().optional(),
-      description: z28.string().optional(),
-      priority: z28.number().optional()
+    updateTaskSchema = z30.object({
+      status: z30.enum(["todo", "in-progress", "review", "done"]).optional(),
+      assignee: z30.string().optional(),
+      title: z30.string().optional(),
+      description: z30.string().optional(),
+      priority: z30.number().optional()
     });
-    createTaskSchema = z28.object({
-      title: z28.string().trim().min(1, "Title is required"),
-      description: z28.string().optional(),
-      priority: z28.number().optional(),
-      goal: z28.string().optional(),
-      tags: z28.array(z28.string()).optional()
+    createTaskSchema = z30.object({
+      title: z30.string().trim().min(1, "Title is required"),
+      description: z30.string().optional(),
+      priority: z30.number().optional(),
+      goal: z30.string().optional(),
+      tags: z30.array(z30.string()).optional()
     });
-    savePlanSchema = z28.object({
-      content: z28.string().max(1e6, "Plan content is too large")
+    savePlanSchema = z30.object({
+      content: z30.string().max(1e6, "Plan content is too large")
     });
-    savePlanContentSchema = z28.object({
-      content: z28.string().max(1e6, "Plan content is too large")
+    savePlanContentSchema = z30.object({
+      content: z30.string().max(1e6, "Plan content is too large")
     });
-    sendCommandSchema = z28.object({
-      target: z28.string().min(1, "Target pane is required"),
-      message: z28.string().min(1, "Message is required"),
-      noEnter: z28.boolean().optional()
+    sendCommandSchema = z30.object({
+      target: z30.string().min(1, "Target pane is required"),
+      message: z30.string().min(1, "Message is required"),
+      noEnter: z30.boolean().optional()
     });
-    createMilestoneSchema = z28.object({
-      title: z28.string().trim().min(1, "Title is required"),
-      sequence: z28.number().int().positive(),
-      description: z28.string().optional()
+    createMilestoneSchema = z30.object({
+      title: z30.string().trim().min(1, "Title is required"),
+      sequence: z30.number().int().positive(),
+      description: z30.string().optional()
     });
-    updateMilestoneSchema = z28.object({
-      status: z28.enum(["locked", "active", "done", "validating"]).optional(),
-      title: z28.string().optional(),
-      description: z28.string().optional()
+    updateMilestoneSchema = z30.object({
+      status: z30.enum(["locked", "active", "done", "validating"]).optional(),
+      title: z30.string().optional(),
+      description: z30.string().optional()
     });
-    updateAssertionSchema = z28.object({
-      status: z28.enum(["pending", "passing", "failing", "blocked"]),
-      evidence: z28.string().optional(),
-      verifiedBy: z28.string().optional()
+    updateAssertionSchema = z30.object({
+      status: z30.enum(["pending", "passing", "failing", "blocked"]),
+      evidence: z30.string().optional(),
+      verifiedBy: z30.string().optional()
     });
-    triggerResearchSchema = z28.object({
-      type: z28.string().trim().min(1, "Research type is required")
+    triggerResearchSchema = z30.object({
+      type: z30.string().trim().min(1, "Research type is required")
     });
-    launchSchema = z28.object({
-      attach: z28.boolean().optional()
+    launchSchema = z30.object({
+      attach: z30.boolean().optional()
     }).optional();
-    stopSchema = z28.object({}).optional();
+    stopSchema = z30.object({}).optional();
     skillNameRegex = /^[A-Za-z0-9._ -]+$/;
-    createSkillSchema = z28.object({
-      name: z28.string().trim().min(1, "Skill name is required").regex(
+    createSkillSchema = z30.object({
+      name: z30.string().trim().min(1, "Skill name is required").regex(
         skillNameRegex,
         "Skill name may only contain letters, digits, dot, dash, underscore, or space"
       ),
-      role: z28.string().trim().optional(),
-      description: z28.string().optional(),
-      specialties: z28.array(z28.string()).optional(),
-      body: z28.string().optional()
+      role: z30.string().trim().optional(),
+      description: z30.string().optional(),
+      specialties: z30.array(z30.string()).optional(),
+      body: z30.string().optional()
     });
-    updateSkillSchema = z28.object({
-      role: z28.string().trim().optional(),
-      description: z28.string().optional(),
-      specialties: z28.array(z28.string()).optional(),
-      body: z28.string().optional()
+    updateSkillSchema = z30.object({
+      role: z30.string().trim().optional(),
+      description: z30.string().optional(),
+      specialties: z30.array(z30.string()).optional(),
+      body: z30.string().optional()
     });
   }
 });
@@ -15857,64 +16112,64 @@ var init_project_init_runner = __esm({
 });
 
 // packages/daemon/src/schemas/inspect.ts
-import { z as z29 } from "zod";
+import { z as z31 } from "zod";
 var ProjectInspectDetectedSchemaZ, ProjectInspectSchemaZ, InspectFilesystemRequestSchemaZ, OnboardProjectRequestSchemaZ;
 var init_inspect = __esm({
   "packages/daemon/src/schemas/inspect.ts"() {
     "use strict";
-    ProjectInspectDetectedSchemaZ = z29.object({
+    ProjectInspectDetectedSchemaZ = z31.object({
       /** Detected package manager from lockfile, or `null`. */
-      packageManager: z29.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
+      packageManager: z31.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
       /** Detected frameworks (e.g. `["next", "convex"]`). Empty array when none. */
-      frameworks: z29.array(z29.string()),
+      frameworks: z31.array(z31.string()),
       /** Suggested dev command (e.g. `pnpm dev`). `null` if no dev script found. */
-      devCommand: z29.string().nullable(),
+      devCommand: z31.string().nullable(),
       /** Suggested test command (e.g. `pnpm test`). `null` if no test script found. */
-      testCommand: z29.string().nullable()
+      testCommand: z31.string().nullable()
     });
-    ProjectInspectSchemaZ = z29.object({
+    ProjectInspectSchemaZ = z31.object({
       /** Sanitized basename of the directory — safe to use as a tmux session name. */
-      name: z29.string(),
+      name: z31.string(),
       /** Absolute, canonical path to the directory. */
-      dir: z29.string(),
+      dir: z31.string(),
       /** Whether `<dir>/ide.yml` exists. Legacy compatibility fact. */
-      hasIdeYml: z29.boolean(),
+      hasIdeYml: z31.boolean(),
       /** Whether `.tmux-ide/workspace.yml` exists or wins discovery. */
-      hasWorkspaceConfig: z29.boolean().optional(),
+      hasWorkspaceConfig: z31.boolean().optional(),
       /** Generalized winning config kind. Added without replacing `hasIdeYml`. */
-      configKind: z29.enum(["workspace", "legacy", "none"]).optional(),
+      configKind: z31.enum(["workspace", "legacy", "none"]).optional(),
       /** Generalized winning config path. Added without replacing legacy path facts. */
-      configPath: z29.string().nullable().optional(),
+      configPath: z31.string().nullable().optional(),
       /** Legacy config path when an `ide.yml` is present. */
-      ideConfigPath: z29.string().nullable().optional(),
+      ideConfigPath: z31.string().nullable().optional(),
       /** Git remote origin URL, or `null` if not a git repo / no origin / probe failed. */
-      gitOrigin: z29.string().nullable(),
+      gitOrigin: z31.string().nullable(),
       /** Current git branch, or `null` if not a git repo / detached HEAD / probe failed. */
-      gitBranch: z29.string().nullable(),
+      gitBranch: z31.string().nullable(),
       /** Detected stack signals (reuses `tmux-ide detect` logic). */
       detected: ProjectInspectDetectedSchemaZ
     });
-    InspectFilesystemRequestSchemaZ = z29.object({
-      dir: z29.string().min(1)
+    InspectFilesystemRequestSchemaZ = z31.object({
+      dir: z31.string().min(1)
     });
-    OnboardProjectRequestSchemaZ = z29.object({
-      dir: z29.string().min(1),
+    OnboardProjectRequestSchemaZ = z31.object({
+      dir: z31.string().min(1),
       /** Optional override for the project name — defaults to inspect.name. */
-      name: z29.string().min(1).optional(),
+      name: z31.string().min(1).optional(),
       /** 1, 2, or 3 — how many Claude panes to scaffold in the top row. */
-      agents: z29.number().int().min(1).max(3),
+      agents: z31.number().int().min(1).max(3),
       /**
        * Optional per-agent pane titles. When provided, length must equal
        * `agents`; the server uses these as `title:` for the Claude panes
        * instead of the canonical `Lead`/`Teammate N`/`Claude N` defaults.
        */
-      agentNames: z29.array(z29.string().min(1)).optional(),
+      agentNames: z31.array(z31.string().min(1)).optional(),
       /** Dev server command (e.g. `pnpm dev`). Omit / null to skip the dev pane. */
-      devCommand: z29.string().min(1).nullable().optional(),
+      devCommand: z31.string().min(1).nullable().optional(),
       /** Test command (e.g. `pnpm test`). Currently informational; stored for later. */
-      testCommand: z29.string().min(1).nullable().optional(),
+      testCommand: z31.string().min(1).nullable().optional(),
       /** Lint command (e.g. `pnpm lint`). Currently informational; stored for later. */
-      lintCommand: z29.string().min(1).nullable().optional()
+      lintCommand: z31.string().min(1).nullable().optional()
     });
   }
 });
@@ -18074,7 +18329,7 @@ var init_daemon_embed = __esm({
 
 // packages/daemon/src/lib/cli-action-bridge.ts
 import { createRequire as createRequire3 } from "node:module";
-import { z as z30 } from "zod";
+import { z as z32 } from "zod";
 function timeoutSignal3(ms) {
   const controller = new AbortController();
   setTimeout(() => controller.abort(), ms).unref?.();
@@ -18173,7 +18428,7 @@ async function tryDispatchAction(name, input, options = {}) {
       details: failure.data.error.details
     });
   }
-  const success = z30.object({ ok: z30.literal(true), result: contract.result }).safeParse(body);
+  const success = z32.object({ ok: z32.literal(true), result: contract.result }).safeParse(body);
   if (!success.success) return null;
   return success.data.result;
 }
@@ -18184,12 +18439,12 @@ var init_cli_action_bridge = __esm({
     init_contract();
     init_canonical_daemon();
     init_daemon_embed();
-    FailureEnvelopeZ = z30.object({
-      ok: z30.literal(false),
-      error: z30.object({
-        code: z30.string(),
-        message: z30.string(),
-        details: z30.unknown().optional()
+    FailureEnvelopeZ = z32.object({
+      ok: z32.literal(false),
+      error: z32.object({
+        code: z32.string(),
+        message: z32.string(),
+        details: z32.unknown().optional()
       })
     });
     deps = {

--- a/packages/contracts/src/__tests__/desktop-host.test.ts
+++ b/packages/contracts/src/__tests__/desktop-host.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   DESKTOP_HOST_API_VERSION,
   DesktopDaemonPreflightSchemaZ,
+  DesktopDaemonHostDescriptorSchemaZ,
   DesktopHostBootstrapSchemaZ,
 } from "../desktop-host.ts";
 
@@ -16,18 +17,53 @@ describe("desktop host contract", () => {
         appVersion: "2.8.0",
         theme: { mode: "dark", highContrast: false, reducedMotion: false },
         window: { maximized: false, fullscreen: false, focused: true },
-        daemon: { status: "deferred", reason: "owner not installed" },
+        daemon: { status: "unavailable", code: "record-missing", reason: "owner not installed" },
       }),
-    ).toMatchObject({ apiVersion: 1, runtime: "electron" });
+    ).toMatchObject({ apiVersion: 2, runtime: "electron" });
   });
 
   it("does not permit unversioned daemon metadata to leak into the facade", () => {
     expect(() =>
       DesktopDaemonPreflightSchemaZ.parse({
-        status: "ready",
-        apiBaseUrl: "http://127.0.0.1:6060",
+        status: "connected",
+        descriptor: {
+          apiBaseUrl: "http://127.0.0.1:6060",
+          protocolVersion: 1,
+          productVersion: "2.8.0",
+          instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+          startedAt: "2026-07-21T00:00:00.000Z",
+        },
         pid: 42,
       }),
     ).toThrow();
+  });
+
+  it("exposes only an uncredentialed loopback daemon descriptor", () => {
+    const descriptor = {
+      apiBaseUrl: "http://127.0.0.1:6060",
+      protocolVersion: 1,
+      productVersion: "2.8.0",
+      instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+      startedAt: "2026-07-21T00:00:00.000Z",
+    };
+    expect(DesktopDaemonHostDescriptorSchemaZ.parse(descriptor)).toEqual(descriptor);
+    expect(
+      DesktopDaemonHostDescriptorSchemaZ.safeParse({
+        ...descriptor,
+        apiBaseUrl: "http://192.0.2.1:6060",
+      }).success,
+    ).toBe(false);
+    expect(
+      DesktopDaemonHostDescriptorSchemaZ.safeParse({
+        ...descriptor,
+        apiBaseUrl: "http://secret@127.0.0.1:6060",
+      }).success,
+    ).toBe(false);
+    expect(
+      DesktopDaemonHostDescriptorSchemaZ.safeParse({
+        ...descriptor,
+        authToken: "must-not-cross-ipc",
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/contracts/src/desktop-host.ts
+++ b/packages/contracts/src/desktop-host.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 /** Versioned, deliberately narrow bridge exposed by a desktop host preload. */
-export const DESKTOP_HOST_API_VERSION = 1 as const;
+export const DESKTOP_HOST_API_VERSION = 2 as const;
 
 export const DesktopRuntimeKindSchemaZ = z.enum(["browser", "electron"]);
 export const DesktopPlatformSchemaZ = z.enum(["darwin", "linux", "win32", "unknown"]);
@@ -23,12 +23,63 @@ export const DesktopWindowStateSchemaZ = z
   })
   .strict();
 
-export const DesktopDaemonPreflightSchemaZ = z.discriminatedUnion("status", [
-  z.object({ status: z.literal("ready"), apiBaseUrl: z.string().url() }).strict(),
-  z.object({ status: z.literal("absent") }).strict(),
-  z.object({ status: z.literal("deferred"), reason: z.string().min(1) }).strict(),
-  z.object({ status: z.literal("unavailable"), reason: z.string().min(1) }).strict(),
+const DesktopDaemonLoopbackUrlSchemaZ = z.url().refine((value) => {
+  const url = new URL(value);
+  return (
+    url.protocol === "http:" &&
+    (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]") &&
+    url.username.length === 0 &&
+    url.password.length === 0 &&
+    url.pathname === "/" &&
+    url.search.length === 0 &&
+    url.hash.length === 0
+  );
+}, "daemon URL must be an uncredentialed loopback HTTP origin");
+
+/** Verified daemon identity safe to cross the main → preload → renderer boundary. */
+export const DesktopDaemonHostDescriptorSchemaZ = z
+  .object({
+    apiBaseUrl: DesktopDaemonLoopbackUrlSchemaZ,
+    protocolVersion: z.number().int().positive(),
+    productVersion: z.string().trim().min(1),
+    instanceId: z.uuid(),
+    startedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export const DesktopDaemonHostIssueCodeSchemaZ = z.enum([
+  "record-missing",
+  "record-invalid",
+  "endpoint-not-loopback",
+  "protocol-incompatible",
+  "process-not-running",
+  "identity-unreachable",
+  "identity-mismatch",
+  "health-unreachable",
+  "health-mismatch",
+  "probe-failed",
+  "probe-timeout",
+  "preview-only",
 ]);
+
+const DesktopDaemonHostIssueSchemaFields = {
+  code: DesktopDaemonHostIssueCodeSchemaZ,
+  reason: z.string().min(1),
+} as const;
+
+export const DesktopDaemonHostStateSchemaZ = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("connected"),
+      descriptor: DesktopDaemonHostDescriptorSchemaZ,
+    })
+    .strict(),
+  z.object({ status: z.literal("unavailable"), ...DesktopDaemonHostIssueSchemaFields }).strict(),
+  z.object({ status: z.literal("degraded"), ...DesktopDaemonHostIssueSchemaFields }).strict(),
+]);
+
+/** @deprecated Compatibility name for existing host bootstrap consumers. */
+export const DesktopDaemonPreflightSchemaZ = DesktopDaemonHostStateSchemaZ;
 
 export const DesktopHostBootstrapSchemaZ = z
   .object({
@@ -49,7 +100,11 @@ export type DesktopRuntimeKind = z.infer<typeof DesktopRuntimeKindSchemaZ>;
 export type DesktopPlatform = z.infer<typeof DesktopPlatformSchemaZ>;
 export type DesktopThemeState = z.infer<typeof DesktopThemeStateSchemaZ>;
 export type DesktopWindowState = z.infer<typeof DesktopWindowStateSchemaZ>;
-export type DesktopDaemonPreflight = z.infer<typeof DesktopDaemonPreflightSchemaZ>;
+export type DesktopDaemonHostDescriptor = z.infer<typeof DesktopDaemonHostDescriptorSchemaZ>;
+export type DesktopDaemonHostIssueCode = z.infer<typeof DesktopDaemonHostIssueCodeSchemaZ>;
+export type DesktopDaemonHostState = z.infer<typeof DesktopDaemonHostStateSchemaZ>;
+/** @deprecated Compatibility name for existing host bootstrap consumers. */
+export type DesktopDaemonPreflight = DesktopDaemonHostState;
 export type DesktopHostBootstrap = z.infer<typeof DesktopHostBootstrapSchemaZ>;
 export type DesktopMenuResult = z.infer<typeof DesktopMenuResultSchemaZ>;
 export type DesktopDirectorySelection = z.infer<typeof DesktopDirectorySelectionSchemaZ>;

--- a/packages/daemon/src/lib/__tests__/headless-cli-entrypoint.test.ts
+++ b/packages/daemon/src/lib/__tests__/headless-cli-entrypoint.test.ts
@@ -43,7 +43,8 @@ beforeEach(() => {
   const home = join(tempDir, "home");
   const state = join(tempDir, "state");
   mkdirSync(home, { recursive: true });
-  mkdirSync(state, { recursive: true });
+  mkdirSync(state, { recursive: true, mode: 0o700 });
+  chmodSync(state, 0o700);
   writeFileSync(
     join(state, "app-settings.json"),
     `${JSON.stringify({ remoteAccess: { enabled: true, token: "must-not-be-inherited" } })}\n`,
@@ -299,7 +300,7 @@ describe.sequential("shipped tmux-ide --headless entrypoint", () => {
     const losers = contenders.filter((child) => child !== owner);
     const loserResults = await Promise.all(losers.map((child) => waitForExit(child, 20_000)));
     for (const result of loserResults) {
-      expect(result.code).toBe(0);
+      expect(result, result.stderr).toMatchObject({ code: 0, signal: null });
       expect(JSON.parse(result.stdout.trim())).toMatchObject({
         status: "already-running",
         pid: info.pid,

--- a/packages/daemon/src/lib/canonical-daemon.test.ts
+++ b/packages/daemon/src/lib/canonical-daemon.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   chmodSync,
   mkdtempSync,
+  mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -194,6 +196,25 @@ describe("canonical daemon info", () => {
     expect(readCanonicalDaemonInfo()?.authToken).toBe("remote-secret");
   });
 
+  it("refuses to publish through a symlinked parent without chmodding its target", () => {
+    const claim = acquireClaim();
+    const target = `${tempDir}.symlink-target`;
+    renameSync(tempDir, target);
+    chmodSync(target, 0o755);
+    symlinkSync(target, tempDir);
+    try {
+      expect(() => writeCanonicalDaemonInfo(info(6060), claim)).toThrow(
+        "canonical daemon parent must not be a symbolic link",
+      );
+      expect(statSync(target).mode & 0o777).toBe(0o755);
+      expect(() => statSync(join(target, "daemon.json"))).toThrow();
+    } finally {
+      rmSync(tempDir, { force: true });
+      renameSync(target, tempDir);
+      chmodSync(tempDir, 0o700);
+    }
+  });
+
   it("rejects a token-bearing file with group or world access", () => {
     const path = getCanonicalDaemonInfoPath();
     writeFileSync(path, JSON.stringify({ ...info(6060), authToken: "leaked" }), { mode: 0o644 });
@@ -294,6 +315,50 @@ describe("canonical daemon info", () => {
     if (replacement.status === "acquired") {
       activeClaim = replacement.claim;
       expect(getCanonicalDaemonClaimPath()).toBe(join(tempDir, "daemon.claim"));
+    }
+  });
+
+  it("creates an absent claim parent as the verified owner-only directory", () => {
+    rmSync(tempDir, { recursive: true });
+
+    acquireClaim();
+
+    const parent = statSync(tempDir);
+    expect(parent.isDirectory()).toBe(true);
+    expect(parent.mode & 0o777).toBe(0o700);
+  });
+
+  it("rejects a symlinked claim parent without chmodding its target", () => {
+    const target = `${tempDir}.symlink-target`;
+    mkdirSync(target, { mode: 0o755 });
+    chmodSync(target, 0o755);
+    rmSync(tempDir, { recursive: true });
+    symlinkSync(target, tempDir);
+    try {
+      expect(tryAcquireCanonicalDaemonClaim()).toEqual({
+        status: "invalid",
+        detail: "canonical daemon parent must not be a symbolic link",
+      });
+      expect(statSync(target).mode & 0o777).toBe(0o755);
+      expect(() => statSync(join(target, "daemon.claim"))).toThrow();
+    } finally {
+      rmSync(tempDir, { force: true });
+      renameSync(target, tempDir);
+      chmodSync(tempDir, 0o700);
+    }
+  });
+
+  it("rejects a non-directory claim parent deterministically", () => {
+    rmSync(tempDir, { recursive: true });
+    writeFileSync(tempDir, "not a directory", { mode: 0o600 });
+    try {
+      expect(tryAcquireCanonicalDaemonClaim()).toEqual({
+        status: "invalid",
+        detail: "canonical daemon parent must be a directory",
+      });
+    } finally {
+      rmSync(tempDir, { force: true });
+      mkdirSync(tempDir, { mode: 0o700 });
     }
   });
 

--- a/packages/daemon/src/lib/canonical-daemon.test.ts
+++ b/packages/daemon/src/lib/canonical-daemon.test.ts
@@ -207,6 +207,21 @@ describe("canonical daemon info", () => {
     });
   });
 
+  it("rejects a daemon record whose parent directory is not owner-only", () => {
+    writeFileSync(getCanonicalDaemonInfoPath(), JSON.stringify(info(6060)), { mode: 0o600 });
+    chmodSync(tempDir, 0o755);
+    try {
+      expect(readCanonicalDaemonInfo()).toBeNull();
+      expect(inspectCanonicalDaemonInfo()).toMatchObject({
+        status: "invalid",
+        reason: "parent-unsafe-permissions",
+        ownerPid: null,
+      });
+    } finally {
+      chmodSync(tempDir, 0o700);
+    }
+  });
+
   it("rejects symlinks and oversized daemon info", () => {
     const path = getCanonicalDaemonInfoPath();
     const target = join(tempDir, "target.json");

--- a/packages/daemon/src/lib/canonical-daemon.ts
+++ b/packages/daemon/src/lib/canonical-daemon.ts
@@ -54,6 +54,10 @@ type CanonicalDaemonClaimState =
 const activeClaims = new Set<string>();
 
 export type CanonicalDaemonInfoInvalidReason =
+  | "parent-symlink"
+  | "parent-not-directory"
+  | "parent-wrong-owner"
+  | "parent-unsafe-permissions"
   | "symlink"
   | "not-regular-file"
   | "oversized"
@@ -145,6 +149,39 @@ function inspectCanonicalDaemonInfoPath(path: string): CanonicalDaemonInfoState 
   try {
     const pathStat = lstatSync(path);
     const pathObservation = observation(pathStat);
+    const parentStat = lstatSync(dirname(path));
+    if (parentStat.isSymbolicLink()) {
+      return invalidState(
+        "parent-symlink",
+        "daemon.json parent must not be a symbolic link",
+        null,
+        pathObservation,
+      );
+    }
+    if (!parentStat.isDirectory()) {
+      return invalidState(
+        "parent-not-directory",
+        "daemon.json parent must be a directory",
+        null,
+        pathObservation,
+      );
+    }
+    if (typeof process.getuid === "function" && parentStat.uid !== process.getuid()) {
+      return invalidState(
+        "parent-wrong-owner",
+        "daemon.json parent is not owned by the current user",
+        null,
+        pathObservation,
+      );
+    }
+    if ((parentStat.mode & 0o077) !== 0) {
+      return invalidState(
+        "parent-unsafe-permissions",
+        "daemon.json parent must be accessible only by its owner",
+        null,
+        pathObservation,
+      );
+    }
     if (pathStat.isSymbolicLink()) {
       return invalidState(
         "symlink",
@@ -184,11 +221,16 @@ function inspectCanonicalDaemonInfoPath(path: string): CanonicalDaemonInfoState 
     descriptor = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
     const openedStat = fstatSync(descriptor);
     const openedObservation = observation(openedStat);
+    const reopenedParentStat = lstatSync(dirname(path));
     if (
       !openedStat.isFile() ||
       !sameObservation(pathObservation, openedObservation) ||
+      !sameObservation(observation(parentStat), observation(reopenedParentStat)) ||
+      !reopenedParentStat.isDirectory() ||
       (typeof process.getuid === "function" && openedStat.uid !== process.getuid()) ||
-      (openedStat.mode & 0o077) !== 0
+      (openedStat.mode & 0o077) !== 0 ||
+      (typeof process.getuid === "function" && reopenedParentStat.uid !== process.getuid()) ||
+      (reopenedParentStat.mode & 0o077) !== 0
     ) {
       return invalidState(
         "changed-while-opening",
@@ -340,6 +382,7 @@ export function tryAcquireCanonicalDaemonClaim(): CanonicalDaemonClaimAttempt {
   const path = getCanonicalDaemonClaimPath();
   const root = dirname(path);
   mkdirSync(root, { recursive: true, mode: 0o700 });
+  chmodSync(root, 0o700);
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const claim: CanonicalDaemonClaim = {
@@ -405,6 +448,7 @@ export function writeCanonicalDaemonInfo(
   assertCanonicalDaemonClaimHeld(claim);
   const path = getCanonicalDaemonInfoPath();
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  chmodSync(dirname(path), 0o700);
   const tmpPath = `${path}.${claim.claimId}.${randomUUID()}.tmp`;
   const persisted: CanonicalDaemonInfo = {
     pid: info.pid,

--- a/packages/daemon/src/lib/canonical-daemon.ts
+++ b/packages/daemon/src/lib/canonical-daemon.ts
@@ -295,7 +295,7 @@ function inspectCanonicalDaemonInfoPath(path: string): CanonicalDaemonInfoState 
     if (
       !openedStat.isFile() ||
       !sameObservation(pathObservation, openedObservation) ||
-      !sameObservation(observation(parentStat), observation(reopenedParentStat)) ||
+      !sameFileIdentity(parentStat, reopenedParentStat) ||
       !reopenedParentStat.isDirectory() ||
       (typeof process.getuid === "function" && openedStat.uid !== process.getuid()) ||
       (openedStat.mode & 0o077) !== 0 ||

--- a/packages/daemon/src/lib/canonical-daemon.ts
+++ b/packages/daemon/src/lib/canonical-daemon.ts
@@ -2,6 +2,7 @@ import {
   chmodSync,
   closeSync,
   constants,
+  fchmodSync,
   fstatSync,
   linkSync,
   lstatSync,
@@ -127,6 +128,75 @@ function sameObservation(
     left.size === right.size &&
     left.mtimeMs === right.mtimeMs
   );
+}
+
+function sameFileIdentity(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function canonicalDaemonRootError(detail: string): Error {
+  return new Error(`canonical daemon parent ${detail}`);
+}
+
+/**
+ * Create or harden the daemon record parent without ever path-chmodding an
+ * untrusted endpoint. The directory descriptor pins the object being changed;
+ * the final lstat proves the configured path still names that same object.
+ */
+function prepareCanonicalDaemonRoot(root: string): void {
+  let descriptor: number | undefined;
+  try {
+    try {
+      mkdirSync(root, { recursive: true, mode: 0o700 });
+    } catch (error) {
+      // Recursive mkdir reports EEXIST for a non-directory endpoint. Let the
+      // lstat below classify it deterministically instead of trusting it.
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+
+    const pathStat = lstatSync(root);
+    if (pathStat.isSymbolicLink()) {
+      throw canonicalDaemonRootError("must not be a symbolic link");
+    }
+    if (!pathStat.isDirectory()) {
+      throw canonicalDaemonRootError("must be a directory");
+    }
+    if (typeof process.getuid === "function" && pathStat.uid !== process.getuid()) {
+      throw canonicalDaemonRootError("must be owned by the current user");
+    }
+
+    descriptor = openSync(
+      root,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0) | (constants.O_DIRECTORY ?? 0),
+    );
+    const openedStat = fstatSync(descriptor);
+    if (
+      !openedStat.isDirectory() ||
+      !sameFileIdentity(pathStat, openedStat) ||
+      (typeof process.getuid === "function" && openedStat.uid !== process.getuid())
+    ) {
+      throw canonicalDaemonRootError("changed or became unsafe while it was opened");
+    }
+
+    fchmodSync(descriptor, 0o700);
+    const hardenedStat = fstatSync(descriptor);
+    const currentPathStat = lstatSync(root);
+    if (
+      !hardenedStat.isDirectory() ||
+      !sameFileIdentity(openedStat, hardenedStat) ||
+      (typeof process.getuid === "function" && hardenedStat.uid !== process.getuid()) ||
+      (hardenedStat.mode & 0o077) !== 0 ||
+      currentPathStat.isSymbolicLink() ||
+      !currentPathStat.isDirectory() ||
+      !sameFileIdentity(hardenedStat, currentPathStat) ||
+      (typeof process.getuid === "function" && currentPathStat.uid !== process.getuid()) ||
+      (currentPathStat.mode & 0o077) !== 0
+    ) {
+      throw canonicalDaemonRootError("changed or became unsafe while it was hardened");
+    }
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
 }
 
 function invalidState(
@@ -381,8 +451,15 @@ function retireCanonicalClaimIfMatches(expected: CanonicalDaemonClaim): boolean 
 export function tryAcquireCanonicalDaemonClaim(): CanonicalDaemonClaimAttempt {
   const path = getCanonicalDaemonClaimPath();
   const root = dirname(path);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
-  chmodSync(root, 0o700);
+  try {
+    prepareCanonicalDaemonRoot(root);
+  } catch (error) {
+    return {
+      status: "invalid",
+      detail:
+        error instanceof Error ? error.message : "canonical daemon parent could not be prepared",
+    };
+  }
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const claim: CanonicalDaemonClaim = {
@@ -447,8 +524,7 @@ export function writeCanonicalDaemonInfo(
 ): void {
   assertCanonicalDaemonClaimHeld(claim);
   const path = getCanonicalDaemonInfoPath();
-  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-  chmodSync(dirname(path), 0o700);
+  prepareCanonicalDaemonRoot(dirname(path));
   const tmpPath = `${path}.${claim.claimId}.${randomUUID()}.tmp`;
   const persisted: CanonicalDaemonInfo = {
     pid: info.pid,


### PR DESCRIPTION
## Outcome

Replaces the permanently deferred Electron daemon preflight with a secure attach-only connection to an already-running canonical tmux-ide daemon.

## Included

- strict connected/unavailable/degraded host-state contract
- canonical record parent/file, loopback, PID, protocol, identity, instance and health verification
- descriptor-pinned parent hardening with symlink/race defense
- bounded secret-free daemon descriptor over validated Electron IPC
- honest renderer connection labeling while preview data remains explicitly marked
- no daemon spawn/supervision, renderer fetch, CSP expansion, xterm, PTY or tmux attachment

## Verification

- contracts: 102 tests passed
- Electron: 36 tests passed
- desktop renderer: 30 tests passed
- canonical daemon: 22 tests passed
- relevant typechecks/lints, Electron production build+smoke, Prettier and diff-check passed
- full gate reached 2,270 passing daemon tests; three unrelated live-tmux WebSocket tests exceeded their 5s timeout under load and passed 3/3 with a 20s timeout

Independent security review and repair re-review: APPROVED.