### PR TITLE
feat(desktop): add generation-bound daemon resource store

### DIFF
--- a/apps/desktop-renderer/src/runtime/connection-state.ts
+++ b/apps/desktop-renderer/src/runtime/connection-state.ts
@@ -1,0 +1,63 @@
+import type {
+  ApplicationShellProjectionInputV1,
+  DesktopApplicationShellTarget as DesktopApplicationShellTargetContract,
+} from "@tmux-ide/contracts";
+
+export type DesktopApplicationShellTarget = DesktopApplicationShellTargetContract;
+
+interface DesktopResourceStateBase {
+  readonly generation: number;
+  /** Null until an untrusted caller target has passed strict validation. */
+  readonly target: DesktopApplicationShellTarget | null;
+}
+
+export type DesktopApplicationShellResourceState =
+  | (DesktopResourceStateBase & {
+      readonly status: "loading";
+      readonly data: null;
+    })
+  | (DesktopResourceStateBase & {
+      readonly status: "live";
+      readonly data: ApplicationShellProjectionInputV1;
+      readonly updatedAt: number;
+    })
+  | (DesktopResourceStateBase & {
+      readonly status: "unavailable";
+      readonly data: null;
+      readonly code: "not-found" | "disconnected" | "reconnect-exhausted";
+      readonly reason: string;
+    })
+  | (DesktopResourceStateBase & {
+      readonly status: "degraded";
+      readonly data: ApplicationShellProjectionInputV1 | null;
+      readonly updatedAt: number | null;
+      readonly code:
+        | "descriptor-invalid"
+        | "daemon-identity-mismatch"
+        | "schema-invalid"
+        | "event-frame-invalid";
+      readonly reason: string;
+    })
+  | (DesktopResourceStateBase & {
+      readonly status: "error";
+      readonly data: null;
+      readonly code: "network-error" | "http-error";
+      readonly reason: string;
+    })
+  | (DesktopResourceStateBase & {
+      readonly status: "stale";
+      readonly data: ApplicationShellProjectionInputV1;
+      readonly updatedAt: number;
+      readonly reason: string;
+    });
+
+export function daemonGenerationKey(target: DesktopApplicationShellTarget): string {
+  const { daemon } = target;
+  return [
+    daemon.protocolVersion,
+    daemon.productVersion,
+    daemon.instanceId,
+    daemon.startedAt,
+    target.workspaceName,
+  ].join("\u0000");
+}

--- a/apps/desktop-renderer/src/runtime/daemon-transport.test.ts
+++ b/apps/desktop-renderer/src/runtime/daemon-transport.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  APPLICATION_SHELL_RESOURCE_VERSION,
+  ApplicationShellProjectionInputV1SchemaZ,
+  COHESION_FIXTURE_V1,
+  type DesktopDaemonHostDescriptor,
+} from "@tmux-ide/contracts";
+
+import {
+  createDirectLoopbackDaemonTransport,
+  DaemonTransportError,
+  type DaemonEventSocket,
+  type DaemonFetch,
+} from "./daemon-transport.ts";
+
+const descriptor: DesktopDaemonHostDescriptor = {
+  apiBaseUrl: "http://127.0.0.1:6060",
+  protocolVersion: 1,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-21T00:00:00.000Z",
+};
+const daemonIdentity = {
+  protocolVersion: descriptor.protocolVersion,
+  productVersion: descriptor.productVersion,
+  instanceId: descriptor.instanceId,
+  startedAt: descriptor.startedAt,
+};
+const resolveSessionName = (workspaceName: string): string =>
+  workspaceName === "project / one" ? "session / one" : workspaceName;
+
+const resource = ApplicationShellProjectionInputV1SchemaZ.parse({
+  project: COHESION_FIXTURE_V1.project,
+  workspace: COHESION_FIXTURE_V1.workspace,
+  dock: COHESION_FIXTURE_V1.dock,
+  focus: { ...COHESION_FIXTURE_V1.focus, overlays: [] },
+  connection: COHESION_FIXTURE_V1.connection,
+});
+
+function resourceEnvelope(value: unknown = resource, daemon: unknown = daemonIdentity): unknown {
+  return { version: APPLICATION_SHELL_RESOURCE_VERSION, daemon, resource: value };
+}
+
+class FakeSocket implements DaemonEventSocket {
+  readyState = 0;
+  readonly sent: string[] = [];
+  readonly closes: Array<{ code?: number; reason?: string }> = [];
+  private readonly listeners = new Map<string, Set<(event: { data?: unknown }) => void>>();
+
+  addEventListener(type: string, listener: (event: { data?: unknown }) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: { data?: unknown }) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.readyState = 3;
+    this.closes.push({ code, reason });
+  }
+
+  emit(type: "open" | "message" | "close" | "error", data?: unknown): void {
+    if (type === "open") this.readyState = 1;
+    for (const listener of this.listeners.get(type) ?? []) listener({ data });
+  }
+}
+
+describe("browser-safe daemon transport", () => {
+  it("fetches and validates the typed application-shell resource without credentials", async () => {
+    const fetch = vi.fn<DaemonFetch>(async () =>
+      Promise.resolve(
+        new Response(JSON.stringify(resourceEnvelope()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+    const transport = createDirectLoopbackDaemonTransport({
+      descriptor,
+      resolveSessionName,
+      fetch,
+    });
+    const result = await transport.fetchApplicationShell(
+      { daemon: daemonIdentity, workspaceName: "project / one" },
+      new AbortController().signal,
+    );
+
+    expect(result).toEqual(resource);
+    expect(fetch).toHaveBeenCalledOnce();
+    const [url, init] = fetch.mock.calls[0]!;
+    expect(String(url)).toBe(
+      "http://127.0.0.1:6060/api/project/session%20%2F%20one/application-shell",
+    );
+    expect(init).toMatchObject({
+      method: "GET",
+      credentials: "omit",
+      cache: "no-store",
+      redirect: "error",
+      headers: { accept: "application/json" },
+    });
+    expect(JSON.stringify(init)).not.toContain("token");
+  });
+
+  it("classifies missing and invalid resources without returning unvalidated data", async () => {
+    const missing = createDirectLoopbackDaemonTransport({
+      descriptor,
+      resolveSessionName,
+      fetch: async () => new Response("not found", { status: 404 }),
+    });
+    await expect(
+      missing.fetchApplicationShell(
+        { daemon: daemonIdentity, workspaceName: "missing" },
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({ kind: "not-found", statusCode: 404 });
+
+    const invalid = createDirectLoopbackDaemonTransport({
+      descriptor,
+      resolveSessionName,
+      fetch: async () => new Response(JSON.stringify({ fixture: "must-not-pass" })),
+    });
+    await expect(
+      invalid.fetchApplicationShell(
+        { daemon: daemonIdentity, workspaceName: "project" },
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({ kind: "schema-invalid" });
+  });
+
+  it("rejects every REST daemon-generation mismatch before returning resource data", async () => {
+    const mismatches = [
+      { ...daemonIdentity, protocolVersion: 2 },
+      { ...daemonIdentity, productVersion: "9.9.9" },
+      { ...daemonIdentity, instanceId: "3adfc6e2-f1ae-4e63-b9df-7e8eb0ea94d4" },
+      { ...daemonIdentity, startedAt: "2026-07-21T00:00:01.000Z" },
+    ];
+    for (const daemon of mismatches) {
+      const transport = createDirectLoopbackDaemonTransport({
+        descriptor,
+        resolveSessionName,
+        fetch: async () => new Response(JSON.stringify(resourceEnvelope(resource, daemon))),
+      });
+      await expect(
+        transport.fetchApplicationShell(
+          { daemon: daemonIdentity, workspaceName: "project" },
+          new AbortController().signal,
+        ),
+      ).rejects.toMatchObject({ kind: "daemon-identity-mismatch" });
+    }
+  });
+
+  it("rejects remote, credentialed, and protocol-incompatible descriptors again", () => {
+    for (const daemon of [
+      { ...descriptor, apiBaseUrl: "http://192.0.2.1:6060" },
+      { ...descriptor, apiBaseUrl: "http://secret@127.0.0.1:6060" },
+      { ...descriptor, protocolVersion: 99 },
+    ]) {
+      expect(() =>
+        createDirectLoopbackDaemonTransport({ descriptor: daemon, resolveSessionName }),
+      ).toThrowError(DaemonTransportError);
+    }
+  });
+
+  it("uses one strict event socket and sends a narrow validated subscription", () => {
+    const socket = new FakeSocket();
+    const createWebSocket = vi.fn(() => socket);
+    const onVerifiedOpen = vi.fn();
+    const onInvalidate = vi.fn();
+    const onMalformedFrame = vi.fn();
+    const transport = createDirectLoopbackDaemonTransport({
+      descriptor,
+      resolveSessionName,
+      createWebSocket,
+    });
+    const connection = transport.connectEvents(
+      { daemon: daemonIdentity, workspaceName: "project" },
+      {
+        onVerifiedOpen,
+        onInvalidate,
+        onProtocolError: vi.fn(),
+        onPeerMismatch: vi.fn(),
+        onMalformedFrame,
+        onClose: vi.fn(),
+        onError: vi.fn(),
+      },
+    );
+
+    expect(createWebSocket).toHaveBeenCalledWith("ws://127.0.0.1:6060/ws/events");
+    socket.emit("open");
+    expect(onVerifiedOpen).not.toHaveBeenCalled();
+    expect(socket.sent).toEqual([]);
+    socket.emit("message", JSON.stringify({ type: "hello", daemon: daemonIdentity, sessions: [] }));
+    expect(onVerifiedOpen).toHaveBeenCalledOnce();
+    expect(socket.sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "subscribe", sessions: ["project"] },
+    ]);
+
+    socket.emit("message", JSON.stringify({ type: "sessions.changed" }));
+    expect(onInvalidate).toHaveBeenCalledOnce();
+    socket.emit("message", "not-json");
+    socket.emit("message", JSON.stringify({ type: "sessions.changed", unexpected: true }));
+    socket.emit("message", new Uint8Array([1, 2, 3]));
+    expect(onMalformedFrame).toHaveBeenCalledTimes(3);
+
+    connection.close();
+    expect(socket.closes).toEqual([{ code: 1000, reason: "Desktop resource store disposed" }]);
+  });
+
+  it("does not authenticate a socket before one matching, secret-free hello", () => {
+    const socket = new FakeSocket();
+    const onVerifiedOpen = vi.fn();
+    const onPeerMismatch = vi.fn();
+    const onMalformedFrame = vi.fn();
+    const transport = createDirectLoopbackDaemonTransport({
+      descriptor,
+      resolveSessionName,
+      createWebSocket: () => socket,
+    });
+    transport.connectEvents(
+      { daemon: daemonIdentity, workspaceName: "project" },
+      {
+        onVerifiedOpen,
+        onInvalidate: vi.fn(),
+        onProtocolError: vi.fn(),
+        onPeerMismatch,
+        onMalformedFrame,
+        onClose: vi.fn(),
+        onError: vi.fn(),
+      },
+    );
+
+    socket.emit("open");
+    socket.emit("message", JSON.stringify({ type: "sessions.changed" }));
+    expect(onMalformedFrame).toHaveBeenCalledOnce();
+    expect(onVerifiedOpen).not.toHaveBeenCalled();
+    expect(socket.sent).toEqual([]);
+
+    socket.emit(
+      "message",
+      JSON.stringify({
+        type: "hello",
+        daemon: { ...daemonIdentity, authToken: "must-not-cross-wire" },
+        sessions: [],
+      }),
+    );
+    expect(onMalformedFrame).toHaveBeenCalledTimes(2);
+    expect(onVerifiedOpen).not.toHaveBeenCalled();
+
+    socket.emit(
+      "message",
+      JSON.stringify({
+        type: "hello",
+        daemon: { ...daemonIdentity, instanceId: "3adfc6e2-f1ae-4e63-b9df-7e8eb0ea94d4" },
+        sessions: [],
+      }),
+    );
+    expect(onPeerMismatch).toHaveBeenCalledOnce();
+    expect(onVerifiedOpen).not.toHaveBeenCalled();
+    expect(socket.closes).toEqual([{ code: 1008, reason: "Daemon identity mismatch" }]);
+  });
+});

--- a/apps/desktop-renderer/src/runtime/daemon-transport.ts
+++ b/apps/desktop-renderer/src/runtime/daemon-transport.ts
@@ -1,0 +1,405 @@
+import {
+  ApplicationShellResourceV1SchemaZ,
+  DaemonEventClientFrameSchemaZ,
+  DaemonEventServerFrameSchemaZ,
+  DesktopApplicationShellTargetSchemaZ,
+  DesktopDaemonHostDescriptorSchemaZ,
+  isDaemonWireProtocolCompatible,
+  type ApplicationShellProjectionInputV1,
+  type DaemonEventServerFrame,
+  type DaemonInstanceIdentity,
+  type DesktopDaemonHostDescriptor,
+} from "@tmux-ide/contracts";
+
+import type { DesktopApplicationShellTarget } from "./connection-state.ts";
+
+export type DaemonTransportErrorKind =
+  | "descriptor-invalid"
+  | "daemon-identity-mismatch"
+  | "not-found"
+  | "network-error"
+  | "http-error"
+  | "schema-invalid";
+
+export class DaemonTransportError extends Error {
+  readonly kind: DaemonTransportErrorKind;
+  readonly statusCode?: number;
+
+  constructor(kind: DaemonTransportErrorKind, message: string, statusCode?: number) {
+    super(message);
+    this.name = "DaemonTransportError";
+    this.kind = kind;
+    this.statusCode = statusCode;
+  }
+}
+
+export type DaemonFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type DaemonSocketEventType = "open" | "message" | "close" | "error";
+type DaemonSocketEvent = { readonly data?: unknown };
+type DaemonSocketListener = (event: DaemonSocketEvent) => void;
+
+export interface DaemonEventSocket {
+  readonly readyState: number;
+  addEventListener(type: DaemonSocketEventType, listener: DaemonSocketListener): void;
+  removeEventListener?(type: DaemonSocketEventType, listener: DaemonSocketListener): void;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+export type DaemonWebSocketFactory = (url: string) => DaemonEventSocket;
+
+export interface DaemonTransportDependencies {
+  readonly descriptor: DesktopDaemonHostDescriptor;
+  /** Semantic workspace → live tmux session resolver; never inferred by name equality. */
+  readonly resolveSessionName: (workspaceName: string) => string;
+  readonly fetch?: DaemonFetch;
+  readonly createWebSocket?: DaemonWebSocketFactory;
+}
+
+export interface DaemonEventHandlers {
+  /** Fires only after a strict hello matches the requested daemon generation. */
+  readonly onVerifiedOpen: () => void;
+  readonly onInvalidate: () => void;
+  readonly onProtocolError: (reason: string) => void;
+  readonly onPeerMismatch: (reason: string) => void;
+  readonly onMalformedFrame: (reason: string) => void;
+  readonly onClose: () => void;
+  readonly onError: (reason: string) => void;
+}
+
+export interface DaemonEventConnection {
+  close(): void;
+}
+
+export interface DesktopDaemonTransport {
+  fetchApplicationShell(
+    target: DesktopApplicationShellTarget,
+    signal: AbortSignal,
+  ): Promise<ApplicationShellProjectionInputV1>;
+  connectEvents(
+    target: DesktopApplicationShellTarget,
+    handlers: DaemonEventHandlers,
+  ): DaemonEventConnection;
+  validateTarget(target: unknown): DesktopApplicationShellTarget;
+}
+
+function defaultFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  return globalThis.fetch(input, init);
+}
+
+function defaultCreateWebSocket(url: string): DaemonEventSocket {
+  return new globalThis.WebSocket(url) as unknown as DaemonEventSocket;
+}
+
+function descriptorError(message: string): DaemonTransportError {
+  return new DaemonTransportError("descriptor-invalid", message);
+}
+
+function peerMismatch(message: string): DaemonTransportError {
+  return new DaemonTransportError("daemon-identity-mismatch", message);
+}
+
+function validatedDescriptor(value: DesktopDaemonHostDescriptor): DesktopDaemonHostDescriptor {
+  const parsed = DesktopDaemonHostDescriptorSchemaZ.safeParse(value);
+  if (!parsed.success) {
+    throw descriptorError(
+      `Daemon descriptor is invalid: ${parsed.error.issues[0]?.message ?? "unknown error"}`,
+    );
+  }
+  if (!isDaemonWireProtocolCompatible(parsed.data.protocolVersion)) {
+    throw descriptorError(
+      `Daemon protocol ${parsed.data.protocolVersion} is not compatible with this renderer.`,
+    );
+  }
+  // The shared schema already restricts this to an uncredentialed loopback
+  // HTTP origin. Keep the explicit check here so this transport remains safe
+  // even if the host boundary is bypassed by a test or future caller.
+  const origin = new URL(parsed.data.apiBaseUrl);
+  if (
+    origin.protocol !== "http:" ||
+    !["127.0.0.1", "localhost", "[::1]"].includes(origin.hostname) ||
+    origin.username.length > 0 ||
+    origin.password.length > 0
+  ) {
+    throw descriptorError("Daemon descriptor must use an uncredentialed loopback HTTP origin.");
+  }
+  return parsed.data;
+}
+
+function validatedTarget(value: unknown): DesktopApplicationShellTarget {
+  const parsed = DesktopApplicationShellTargetSchemaZ.safeParse(value);
+  if (!parsed.success) {
+    throw descriptorError(
+      `Daemon application-shell target is invalid: ${parsed.error.issues[0]?.message ?? "unknown error"}`,
+    );
+  }
+  if (!isDaemonWireProtocolCompatible(parsed.data.daemon.protocolVersion)) {
+    throw descriptorError(
+      `Daemon protocol ${parsed.data.daemon.protocolVersion} is not compatible with this renderer.`,
+    );
+  }
+  return parsed.data;
+}
+
+function applicationShellUrl(descriptor: DesktopDaemonHostDescriptor, sessionName: string): URL {
+  return new URL(
+    `/api/project/${encodeURIComponent(sessionName)}/application-shell`,
+    descriptor.apiBaseUrl,
+  );
+}
+
+function eventSocketUrl(descriptor: DesktopDaemonHostDescriptor): string {
+  const url = new URL("/ws/events", descriptor.apiBaseUrl);
+  url.protocol = "ws:";
+  return url.toString();
+}
+
+function sameDaemonGeneration(
+  expected: DaemonInstanceIdentity,
+  actual: DaemonInstanceIdentity,
+): boolean {
+  return (
+    actual.protocolVersion === expected.protocolVersion &&
+    actual.productVersion === expected.productVersion &&
+    actual.instanceId === expected.instanceId &&
+    actual.startedAt === expected.startedAt
+  );
+}
+
+function requireMatchingPeer(
+  expected: DaemonInstanceIdentity,
+  actual: DaemonInstanceIdentity,
+): void {
+  if (!sameDaemonGeneration(expected, actual)) {
+    throw peerMismatch("Daemon generation did not match the desktop host descriptor.");
+  }
+}
+
+function resolvedSessionName(
+  resolveSessionName: (workspaceName: string) => string,
+  workspaceName: string,
+): string {
+  let sessionName: unknown;
+  try {
+    sessionName = resolveSessionName(workspaceName);
+  } catch {
+    throw descriptorError("Workspace resolver failed to resolve a live session.");
+  }
+  if (
+    typeof sessionName !== "string" ||
+    sessionName.trim().length === 0 ||
+    sessionName.trim().length > 160
+  ) {
+    throw descriptorError("Workspace resolver did not return a valid session name.");
+  }
+  return sessionName.trim();
+}
+
+function isRelevantFrame(
+  frame: DaemonEventServerFrame,
+  workspaceName: string,
+  sessionName: string,
+): boolean {
+  switch (frame.type) {
+    case "snapshot":
+    case "config.changed":
+    case "terminals.changed":
+      return frame.sessionName === sessionName;
+    case "sessions.changed":
+    case "projects.changed":
+    case "action.complete":
+      return true;
+    case "workspace.added":
+      return frame.workspace.name === workspaceName;
+    case "workspace.removed":
+      return frame.name === workspaceName;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Direct loopback transport for isolated development and transport tests.
+ * Production desktop shells inject a HostCapabilities-backed broker transport
+ * so daemon endpoint URLs never need to enter the renderer bootstrap.
+ */
+export function createDirectLoopbackDaemonTransport(
+  dependencies: DaemonTransportDependencies,
+): DesktopDaemonTransport {
+  const descriptor = validatedDescriptor(dependencies.descriptor);
+  const resolveSessionName = dependencies.resolveSessionName;
+  if (typeof resolveSessionName !== "function") {
+    throw descriptorError("Direct loopback transport requires a semantic workspace resolver.");
+  }
+  const fetchImpl = dependencies.fetch ?? defaultFetch;
+  const createWebSocket = dependencies.createWebSocket ?? defaultCreateWebSocket;
+  const validateBoundTarget = (value: unknown): DesktopApplicationShellTarget => {
+    const safeTarget = validatedTarget(value);
+    requireMatchingPeer(safeTarget.daemon, descriptor);
+    return safeTarget;
+  };
+
+  return {
+    validateTarget: validateBoundTarget,
+
+    async fetchApplicationShell(target, signal) {
+      const safeTarget = validateBoundTarget(target);
+      const sessionName = resolvedSessionName(resolveSessionName, safeTarget.workspaceName);
+      let response: Response;
+      try {
+        response = await fetchImpl(applicationShellUrl(descriptor, sessionName), {
+          method: "GET",
+          headers: { accept: "application/json" },
+          credentials: "omit",
+          cache: "no-store",
+          redirect: "error",
+          signal,
+        });
+      } catch (error) {
+        if (signal.aborted) throw error;
+        throw new DaemonTransportError(
+          "network-error",
+          error instanceof Error ? error.message : "Daemon application-shell request failed.",
+        );
+      }
+      if (response.status === 404) {
+        throw new DaemonTransportError(
+          "not-found",
+          `Workspace ${JSON.stringify(safeTarget.workspaceName)} is not available from the daemon.`,
+          404,
+        );
+      }
+      if (!response.ok) {
+        throw new DaemonTransportError(
+          "http-error",
+          `Daemon application-shell request returned HTTP ${response.status}.`,
+          response.status,
+        );
+      }
+
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        throw new DaemonTransportError(
+          "schema-invalid",
+          "Daemon application-shell response was not valid JSON.",
+        );
+      }
+      const parsed = ApplicationShellResourceV1SchemaZ.safeParse(body);
+      if (!parsed.success) {
+        throw new DaemonTransportError(
+          "schema-invalid",
+          `Daemon application-shell response failed validation: ${parsed.error.issues[0]?.message ?? "unknown error"}`,
+        );
+      }
+      requireMatchingPeer(safeTarget.daemon, parsed.data.daemon);
+      return parsed.data.resource;
+    },
+
+    connectEvents(target, handlers) {
+      const safeTarget = validateBoundTarget(target);
+      const sessionName = resolvedSessionName(resolveSessionName, safeTarget.workspaceName);
+      const socket = createWebSocket(eventSocketUrl(descriptor));
+      let closed = false;
+      let socketOpened = false;
+      let peerVerified = false;
+
+      const onOpen: DaemonSocketListener = () => {
+        if (closed) return;
+        socketOpened = true;
+      };
+      const onMessage: DaemonSocketListener = (event) => {
+        if (closed) return;
+        if (typeof event.data !== "string") {
+          handlers.onMalformedFrame("Daemon event frame was not text.");
+          return;
+        }
+        let raw: unknown;
+        try {
+          raw = JSON.parse(event.data);
+        } catch {
+          handlers.onMalformedFrame("Daemon event frame was not valid JSON.");
+          return;
+        }
+        const parsed = DaemonEventServerFrameSchemaZ.safeParse(raw);
+        if (!parsed.success) {
+          handlers.onMalformedFrame("Daemon event frame failed shared protocol validation.");
+          return;
+        }
+        if (!socketOpened) {
+          handlers.onMalformedFrame("Daemon event frame arrived before the socket opened.");
+          return;
+        }
+        if (!peerVerified) {
+          if (parsed.data.type !== "hello") {
+            handlers.onMalformedFrame("Daemon event socket did not begin with a hello frame.");
+            return;
+          }
+          if (!sameDaemonGeneration(safeTarget.daemon, parsed.data.daemon)) {
+            const reason = "Daemon event hello did not match the desktop host descriptor.";
+            closed = true;
+            socket.removeEventListener?.("open", onOpen);
+            socket.removeEventListener?.("message", onMessage);
+            socket.removeEventListener?.("close", onClose);
+            socket.removeEventListener?.("error", onError);
+            handlers.onPeerMismatch(reason);
+            socket.close(1008, "Daemon identity mismatch");
+            return;
+          }
+          try {
+            const subscribe = DaemonEventClientFrameSchemaZ.parse({
+              type: "subscribe",
+              sessions: [sessionName],
+            });
+            socket.send(JSON.stringify(subscribe));
+            peerVerified = true;
+            handlers.onVerifiedOpen();
+          } catch (error) {
+            handlers.onError(
+              error instanceof Error ? error.message : "Daemon event subscription failed.",
+            );
+          }
+          return;
+        }
+        if (parsed.data.type === "hello") {
+          handlers.onMalformedFrame("Daemon event socket sent a duplicate hello frame.");
+          return;
+        }
+        if (parsed.data.type === "protocol.error") {
+          handlers.onProtocolError(parsed.data.message);
+          return;
+        }
+        if (isRelevantFrame(parsed.data, safeTarget.workspaceName, sessionName)) {
+          handlers.onInvalidate();
+        }
+      };
+      const onClose: DaemonSocketListener = () => {
+        if (closed) return;
+        handlers.onClose();
+      };
+      const onError: DaemonSocketListener = () => {
+        if (closed) return;
+        handlers.onError("Daemon event socket reported an error.");
+      };
+
+      socket.addEventListener("open", onOpen);
+      socket.addEventListener("message", onMessage);
+      socket.addEventListener("close", onClose);
+      socket.addEventListener("error", onError);
+
+      return {
+        close() {
+          if (closed) return;
+          closed = true;
+          socket.removeEventListener?.("open", onOpen);
+          socket.removeEventListener?.("message", onMessage);
+          socket.removeEventListener?.("close", onClose);
+          socket.removeEventListener?.("error", onError);
+          socket.close(1000, "Desktop resource store disposed");
+        },
+      };
+    },
+  };
+}

--- a/apps/desktop-renderer/src/runtime/desktop-resource-store.test.ts
+++ b/apps/desktop-renderer/src/runtime/desktop-resource-store.test.ts
@@ -1,0 +1,773 @@
+import { createRoot } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  APPLICATION_SHELL_RESOURCE_VERSION,
+  ApplicationShellProjectionInputV1SchemaZ,
+  COHESION_FIXTURE_V1,
+  DesktopApplicationShellTargetSchemaZ,
+  type ApplicationShellProjectionInputV1,
+  type DesktopDaemonHostDescriptor,
+} from "@tmux-ide/contracts";
+
+import type { DesktopApplicationShellTarget } from "./connection-state.ts";
+import {
+  createDesktopApplicationShellResourceStore,
+  createSolidDesktopApplicationShellResourceStore,
+  type DesktopResourceClock,
+} from "./desktop-resource-store.ts";
+import {
+  createDirectLoopbackDaemonTransport,
+  type DaemonEventHandlers,
+  type DaemonEventSocket,
+  type DaemonFetch,
+  type DesktopDaemonTransport,
+} from "./daemon-transport.ts";
+
+const descriptor: DesktopDaemonHostDescriptor = {
+  apiBaseUrl: "http://127.0.0.1:6060",
+  protocolVersion: 1,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-21T00:00:00.000Z",
+};
+const daemonIdentity = {
+  protocolVersion: descriptor.protocolVersion,
+  productVersion: descriptor.productVersion,
+  instanceId: descriptor.instanceId,
+  startedAt: descriptor.startedAt,
+};
+
+function resource(name: string): ApplicationShellProjectionInputV1 {
+  return ApplicationShellProjectionInputV1SchemaZ.parse({
+    project: { ...COHESION_FIXTURE_V1.project, name },
+    workspace: COHESION_FIXTURE_V1.workspace,
+    dock: COHESION_FIXTURE_V1.dock,
+    focus: { ...COHESION_FIXTURE_V1.focus, overlays: [] },
+    connection: COHESION_FIXTURE_V1.connection,
+  });
+}
+
+function target(workspaceName = "project", daemon = daemonIdentity): DesktopApplicationShellTarget {
+  return { daemon, workspaceName };
+}
+
+function jsonResponse(value: unknown, status = 200, daemon: unknown = daemonIdentity): Response {
+  const body =
+    status >= 200 && status < 300
+      ? { version: APPLICATION_SHELL_RESOURCE_VERSION, daemon, resource: value }
+      : value;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function authenticateSocket(socket: FakeSocket, daemon: unknown = daemonIdentity): void {
+  socket.emit("open");
+  socket.emit("message", JSON.stringify({ type: "hello", daemon, sessions: [] }));
+}
+
+async function settle(): Promise<void> {
+  for (let index = 0; index < 8; index += 1) await Promise.resolve();
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(reason: unknown): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+class FakeSocket implements DaemonEventSocket {
+  readyState = 0;
+  readonly sent: string[] = [];
+  readonly closes: Array<{ code?: number; reason?: string }> = [];
+  private readonly listeners = new Map<string, Set<(event: { data?: unknown }) => void>>();
+
+  addEventListener(type: string, listener: (event: { data?: unknown }) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: { data?: unknown }) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.readyState = 3;
+    this.closes.push({ code, reason });
+  }
+
+  emit(type: "open" | "message" | "close" | "error", data?: unknown): void {
+    if (type === "open") this.readyState = 1;
+    if (type === "close") this.readyState = 3;
+    for (const listener of this.listeners.get(type) ?? []) listener({ data });
+  }
+}
+
+class FakeClock implements DesktopResourceClock {
+  nowValue = 1_000;
+  readonly scheduledDelays: number[] = [];
+  private nextId = 1;
+  private readonly timers = new Map<number, { callback: () => void; delayMs: number }>();
+
+  now(): number {
+    return this.nowValue;
+  }
+
+  setTimeout(callback: () => void, delayMs: number): number {
+    const id = this.nextId;
+    this.nextId += 1;
+    this.timers.set(id, { callback, delayMs });
+    this.scheduledDelays.push(delayMs);
+    return id;
+  }
+
+  clearTimeout(handle: unknown): void {
+    this.timers.delete(handle as number);
+  }
+
+  runNext(): boolean {
+    const next = this.timers.entries().next().value as
+      | [number, { callback: () => void; delayMs: number }]
+      | undefined;
+    if (!next) return false;
+    const [id, timer] = next;
+    this.timers.delete(id);
+    this.nowValue += timer.delayMs;
+    timer.callback();
+    return true;
+  }
+
+  get pendingCount(): number {
+    return this.timers.size;
+  }
+}
+
+function harness(fetch: DaemonFetch): {
+  readonly sockets: FakeSocket[];
+  readonly transport: ReturnType<typeof createDirectLoopbackDaemonTransport>;
+} {
+  const sockets: FakeSocket[] = [];
+  return {
+    sockets,
+    transport: createDirectLoopbackDaemonTransport({
+      descriptor,
+      resolveSessionName: (workspaceName) => workspaceName,
+      fetch,
+      createWebSocket: () => {
+        const socket = new FakeSocket();
+        sockets.push(socket);
+        return socket;
+      },
+    }),
+  };
+}
+
+interface BrokerConnection {
+  readonly target: DesktopApplicationShellTarget;
+  readonly handlers: DaemonEventHandlers;
+  closed: boolean;
+}
+
+function brokerHarness(): {
+  readonly transport: DesktopDaemonTransport;
+  readonly requests: Array<ReturnType<typeof deferred<ApplicationShellProjectionInputV1>>>;
+  readonly signals: AbortSignal[];
+  readonly connections: BrokerConnection[];
+} {
+  const requests: Array<ReturnType<typeof deferred<ApplicationShellProjectionInputV1>>> = [];
+  const signals: AbortSignal[] = [];
+  const connections: BrokerConnection[] = [];
+  return {
+    requests,
+    signals,
+    connections,
+    transport: {
+      validateTarget: (value) => DesktopApplicationShellTargetSchemaZ.parse(value),
+      fetchApplicationShell: (_target, signal) => {
+        const request = deferred<ApplicationShellProjectionInputV1>();
+        requests.push(request);
+        signals.push(signal);
+        return request.promise;
+      },
+      connectEvents: (connectionTarget, handlers) => {
+        const record: BrokerConnection = {
+          target: connectionTarget,
+          handlers,
+          closed: false,
+        };
+        connections.push(record);
+        return { close: () => (record.closed = true) };
+      },
+    },
+  };
+}
+
+describe("desktop application-shell resource store", () => {
+  it("loads the first validated resource and owns one narrowly subscribed socket", async () => {
+    const fetch = vi.fn(async () => jsonResponse(resource("live-project")));
+    const runtime = harness(fetch);
+    const store = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport: runtime.transport,
+    });
+
+    expect(store.getState()).toMatchObject({ status: "loading", data: null });
+    expect(runtime.sockets).toHaveLength(1);
+    await settle();
+    expect(store.getState()).toMatchObject({
+      status: "stale",
+      data: { project: { name: "live-project" } },
+    });
+
+    runtime.sockets[0]!.emit("open");
+    expect(store.getState()).toMatchObject({ status: "stale" });
+    expect(runtime.sockets[0]!.sent).toEqual([]);
+    runtime.sockets[0]!.emit(
+      "message",
+      JSON.stringify({ type: "hello", daemon: daemonIdentity, sessions: [] }),
+    );
+
+    expect(store.getState()).toMatchObject({
+      status: "live",
+      data: { project: { name: "live-project" } },
+    });
+    expect(runtime.sockets[0]!.sent.map((value) => JSON.parse(value))).toEqual([
+      { type: "subscribe", sessions: ["project"] },
+    ]);
+    store.dispose();
+  });
+
+  it("keeps schema failures degraded and never substitutes preview fixture data", async () => {
+    const runtime = harness(async () => jsonResponse({ preview: "not-a-resource" }));
+    const store = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport: runtime.transport,
+    });
+    await settle();
+
+    expect(store.getState()).toMatchObject({
+      status: "degraded",
+      code: "schema-invalid",
+      data: null,
+    });
+    expect(JSON.stringify(store.getState())).not.toContain(COHESION_FIXTURE_V1.project.name);
+    store.dispose();
+  });
+
+  it("distinguishes a missing project and a network failure", async () => {
+    const missingRuntime = harness(async () => jsonResponse({ error: "missing" }, 404));
+    const missing = createDesktopApplicationShellResourceStore({
+      target: target("missing"),
+      transport: missingRuntime.transport,
+    });
+    await settle();
+    expect(missing.getState()).toMatchObject({
+      status: "unavailable",
+      code: "not-found",
+      data: null,
+    });
+    missing.dispose();
+
+    const errorRuntime = harness(async () => {
+      throw new TypeError("connection refused");
+    });
+    const failed = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport: errorRuntime.transport,
+    });
+    await settle();
+    expect(failed.getState()).toMatchObject({
+      status: "error",
+      code: "network-error",
+      data: null,
+      reason: "connection refused",
+    });
+    failed.dispose();
+  });
+
+  it("preserves the last validated resource as stale across HTTP and network refresh failures", async () => {
+    let call = 0;
+    const runtime = harness(async () => {
+      call += 1;
+      if (call === 1) return jsonResponse(resource("validated"));
+      if (call === 2) return jsonResponse({ error: "busy" }, 503);
+      throw new TypeError("connection reset");
+    });
+    const store = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport: runtime.transport,
+    });
+    authenticateSocket(runtime.sockets[0]!);
+    await settle();
+    expect(store.getState()).toMatchObject({
+      status: "live",
+      data: { project: { name: "validated" } },
+    });
+
+    store.refresh();
+    await settle();
+    expect(store.getState()).toMatchObject({
+      status: "stale",
+      data: { project: { name: "validated" } },
+      reason: "Daemon application-shell request returned HTTP 503.",
+    });
+
+    store.refresh();
+    await settle();
+    expect(store.getState()).toMatchObject({
+      status: "stale",
+      data: { project: { name: "validated" } },
+      reason: "connection reset",
+    });
+    store.dispose();
+  });
+
+  it("never becomes live when REST or WebSocket peer identity mismatches", async () => {
+    const wrongDaemon = {
+      ...daemonIdentity,
+      instanceId: "3adfc6e2-f1ae-4e63-b9df-7e8eb0ea94d4",
+    };
+    const restRuntime = harness(async () =>
+      jsonResponse(resource("wrong-rest-peer"), 200, wrongDaemon),
+    );
+    const restStore = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport: restRuntime.transport,
+    });
+    await settle();
+    expect(restStore.getState()).toMatchObject({
+      status: "degraded",
+      code: "daemon-identity-mismatch",
+      data: null,
+    });
+    expect(restRuntime.sockets[0]!.closes).toHaveLength(1);
+    restStore.dispose();
+
+    const pending = deferred<Response>();
+    const wsRuntime = harness(() => pending.promise);
+    const wsStore = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport: wsRuntime.transport,
+    });
+    authenticateSocket(wsRuntime.sockets[0]!, wrongDaemon);
+    expect(wsStore.getState()).toMatchObject({
+      status: "degraded",
+      code: "daemon-identity-mismatch",
+      data: null,
+    });
+    pending.resolve(jsonResponse(resource("too-late")));
+    await settle();
+    expect(wsStore.getState()).toMatchObject({
+      status: "degraded",
+      code: "daemon-identity-mismatch",
+      data: null,
+    });
+    wsStore.dispose();
+  });
+
+  it("never stores or emits null, malformed, or extra-secret targets", () => {
+    for (const untrusted of [
+      null,
+      { daemon: daemonIdentity },
+      { daemon: daemonIdentity, workspaceName: "project", authToken: "must-not-cross-state" },
+    ]) {
+      const fetch = vi.fn(async () => jsonResponse(resource("must-not-load")));
+      const runtime = harness(fetch);
+      const observed: unknown[] = [];
+      const store = createDesktopApplicationShellResourceStore({
+        target: untrusted,
+        transport: runtime.transport,
+      });
+      store.subscribe((state) => observed.push(state));
+
+      expect(store.getState()).toMatchObject({
+        status: "degraded",
+        target: null,
+        code: "descriptor-invalid",
+        data: null,
+      });
+      expect(JSON.stringify(observed)).not.toContain("must-not-cross-state");
+      expect(fetch).not.toHaveBeenCalled();
+      expect(runtime.sockets).toHaveLength(0);
+      store.dispose();
+    }
+  });
+
+  it("marks live data stale on disconnect and refetches after bounded reconnect", async () => {
+    const clock = new FakeClock();
+    const responses = [resource("first"), resource("second")];
+    const fetch = vi.fn(async () => jsonResponse(responses.shift()));
+    const runtime = harness(fetch);
+    const store = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport: runtime.transport,
+      clock,
+      random: () => 0.5,
+      reconnect: { initialDelayMs: 100, maximumDelayMs: 400, maximumAttempts: 3 },
+    });
+    authenticateSocket(runtime.sockets[0]!);
+    await settle();
+
+    runtime.sockets[0]!.emit("close");
+    expect(store.getState()).toMatchObject({
+      status: "stale",
+      data: { project: { name: "first" } },
+    });
+    expect(clock.scheduledDelays).toEqual([100]);
+    expect(clock.pendingCount).toBe(1);
+
+    clock.runNext();
+    expect(runtime.sockets).toHaveLength(2);
+    authenticateSocket(runtime.sockets[1]!);
+    await settle();
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(store.getState()).toMatchObject({
+      status: "live",
+      data: { project: { name: "second" } },
+    });
+    expect(runtime.sockets[0]!.closes).toHaveLength(1);
+    store.dispose();
+  });
+
+  it("rejects malformed event frames, degrades safely, and reconnects", async () => {
+    const clock = new FakeClock();
+    const fetch = vi.fn(async () => jsonResponse(resource("live")));
+    const runtime = harness(fetch);
+    const store = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport: runtime.transport,
+      clock,
+      random: () => 0.5,
+      reconnect: { initialDelayMs: 50 },
+    });
+    authenticateSocket(runtime.sockets[0]!);
+    await settle();
+
+    runtime.sockets[0]!.emit("message", JSON.stringify({ type: "future.event" }));
+    expect(store.getState()).toMatchObject({
+      status: "degraded",
+      code: "event-frame-invalid",
+      data: { project: { name: "live" } },
+    });
+    expect(runtime.sockets[0]!.closes).toHaveLength(1);
+    expect(clock.pendingCount).toBe(1);
+
+    clock.runNext();
+    expect(runtime.sockets).toHaveLength(2);
+    store.dispose();
+  });
+
+  it("only invalidates for relevant validated session and project events", async () => {
+    const fetch = vi.fn(async () => jsonResponse(resource(`load-${fetch.mock.calls.length}`)));
+    const runtime = harness(fetch);
+    const store = createDesktopApplicationShellResourceStore({
+      target: target("project"),
+      transport: runtime.transport,
+    });
+    authenticateSocket(runtime.sockets[0]!);
+    await settle();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    runtime.sockets[0]!.emit(
+      "message",
+      JSON.stringify({ type: "config.changed", sessionName: "other" }),
+    );
+    await settle();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    runtime.sockets[0]!.emit(
+      "message",
+      JSON.stringify({ type: "terminals.changed", sessionName: "project" }),
+    );
+    await settle();
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    runtime.sockets[0]!.emit("message", JSON.stringify({ type: "projects.changed" }));
+    await settle();
+    expect(fetch).toHaveBeenCalledTimes(3);
+    store.dispose();
+  });
+
+  it("guards rapid project switches from stale requests and sockets", async () => {
+    const requests: Array<ReturnType<typeof deferred<Response>>> = [];
+    const signals: AbortSignal[] = [];
+    const fetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const request = deferred<Response>();
+      requests.push(request);
+      signals.push(init!.signal as AbortSignal);
+      return request.promise;
+    });
+    const runtime = harness(fetch);
+    const store = createDesktopApplicationShellResourceStore({
+      target: target("first"),
+      transport: runtime.transport,
+    });
+    const firstGeneration = store.getState().generation;
+
+    store.setTarget(target("second"));
+    expect(signals[0]!.aborted).toBe(true);
+    expect(runtime.sockets[0]!.closes).toHaveLength(1);
+    expect(runtime.sockets).toHaveLength(2);
+    authenticateSocket(runtime.sockets[1]!);
+    requests[1]!.resolve(jsonResponse(resource("second-live")));
+    await settle();
+    expect(store.getState()).toMatchObject({
+      status: "live",
+      target: { workspaceName: "second" },
+      data: { project: { name: "second-live" } },
+    });
+
+    requests[0]!.resolve(jsonResponse(resource("stale-first")));
+    runtime.sockets[0]!.emit("message", JSON.stringify({ type: "projects.changed" }));
+    await settle();
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(store.getState()).toMatchObject({ data: { project: { name: "second-live" } } });
+
+    store.refresh();
+    expect(requests).toHaveLength(3);
+    expect(store.getState().generation).toBe(firstGeneration + 1);
+    store.dispose();
+    expect(signals[2]!.aborted).toBe(true);
+  });
+
+  it("guards daemon-generation switches when using a host-broker transport", async () => {
+    const runtime = brokerHarness();
+    const store = createDesktopApplicationShellResourceStore({
+      target: target("project"),
+      transport: runtime.transport,
+    });
+    const firstGeneration = store.getState().generation;
+    const nextDaemon = {
+      ...daemonIdentity,
+      instanceId: "3adfc6e2-f1ae-4e63-b9df-7e8eb0ea94d4",
+      startedAt: "2026-07-21T00:00:01.000Z",
+    };
+
+    store.setTarget(target("project", nextDaemon));
+    expect(runtime.signals[0]!.aborted).toBe(true);
+    expect(runtime.connections[0]!.closed).toBe(true);
+    expect(store.getState()).toMatchObject({
+      status: "loading",
+      generation: firstGeneration + 1,
+      target: { daemon: { instanceId: nextDaemon.instanceId } },
+      data: null,
+    });
+
+    runtime.connections[0]!.handlers.onVerifiedOpen();
+    runtime.connections[0]!.handlers.onInvalidate();
+    runtime.requests[0]!.resolve(resource("stale-generation"));
+    await settle();
+    expect(store.getState()).toMatchObject({ status: "loading", data: null });
+
+    runtime.connections[1]!.handlers.onVerifiedOpen();
+    runtime.requests[1]!.resolve(resource("current-generation"));
+    await settle();
+    expect(store.getState()).toMatchObject({
+      status: "live",
+      data: { project: { name: "current-generation" } },
+    });
+    store.dispose();
+  });
+
+  it("exhausts reconnect budget under verified open-close and malformed-frame flapping", async () => {
+    const clock = new FakeClock();
+    const runtime = harness(async () => jsonResponse(resource("retained")));
+    const store = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport: runtime.transport,
+      clock,
+      random: () => 0.5,
+      reconnect: {
+        initialDelayMs: 10,
+        maximumDelayMs: 20,
+        maximumAttempts: 2,
+        stabilityWindowMs: 1_000,
+      },
+    });
+    authenticateSocket(runtime.sockets[0]!);
+    await settle();
+
+    runtime.sockets[0]!.emit("close");
+    clock.runNext();
+    authenticateSocket(runtime.sockets[1]!);
+    runtime.sockets[1]!.emit("message", JSON.stringify({ type: "future.event" }));
+    clock.runNext();
+    authenticateSocket(runtime.sockets[2]!);
+    runtime.sockets[2]!.emit(
+      "message",
+      JSON.stringify({
+        type: "protocol.error",
+        code: "invalid-frame",
+        message: "subscription rejected",
+      }),
+    );
+    await settle();
+
+    expect(runtime.sockets).toHaveLength(3);
+    expect(clock.scheduledDelays).toEqual([10, 1_000, 20, 1_000]);
+    expect(clock.pendingCount).toBe(0);
+    expect(store.getState()).toMatchObject({
+      status: "stale",
+      data: { project: { name: "retained" } },
+      reason: "Daemon event reconnection attempts were exhausted.",
+    });
+    store.dispose();
+  });
+
+  it("resets retry budget only after a verified connection survives the stability epoch", async () => {
+    const clock = new FakeClock();
+    const runtime = harness(async () => jsonResponse(resource("stable")));
+    const store = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport: runtime.transport,
+      clock,
+      random: () => 0.5,
+      reconnect: {
+        initialDelayMs: 10,
+        maximumDelayMs: 10,
+        maximumAttempts: 1,
+        stabilityWindowMs: 100,
+      },
+    });
+    authenticateSocket(runtime.sockets[0]!);
+    await settle();
+    runtime.sockets[0]!.emit("close");
+    clock.runNext();
+    authenticateSocket(runtime.sockets[1]!);
+    expect(clock.pendingCount).toBe(1);
+    clock.runNext();
+
+    runtime.sockets[1]!.emit("close");
+    expect(clock.pendingCount).toBe(1);
+    expect(clock.scheduledDelays).toEqual([10, 100, 10]);
+    store.dispose();
+  });
+
+  it("normalizes hostile reconnect overrides into finite bounded work", () => {
+    const clock = new FakeClock();
+    const transport = createDirectLoopbackDaemonTransport({
+      descriptor,
+      resolveSessionName: (workspaceName) => workspaceName,
+      fetch: () => new Promise<Response>(() => undefined),
+      createWebSocket: () => {
+        throw new Error("socket refused");
+      },
+    });
+    const store = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport,
+      clock,
+      random: () => {
+        throw new Error("host entropy unavailable");
+      },
+      reconnect: {
+        initialDelayMs: -1_000,
+        maximumDelayMs: Number.POSITIVE_INFINITY,
+        maximumAttempts: 1_000_000,
+        jitterRatio: 99,
+        stabilityWindowMs: Number.NaN,
+      },
+    });
+
+    let callbacks = 0;
+    while (clock.runNext()) {
+      callbacks += 1;
+      if (callbacks > 25) throw new Error("Reconnect work was not bounded.");
+    }
+    expect(callbacks).toBe(20);
+    expect(clock.scheduledDelays).toHaveLength(20);
+    expect(clock.scheduledDelays.every((delay) => Number.isFinite(delay))).toBe(true);
+    expect(Math.min(...clock.scheduledDelays)).toBeGreaterThanOrEqual(10);
+    expect(Math.max(...clock.scheduledDelays)).toBeLessThanOrEqual(300_000);
+    expect(store.getState()).toMatchObject({
+      status: "unavailable",
+      code: "reconnect-exhausted",
+    });
+    store.dispose();
+  });
+
+  it("bounds reconnect attempts and disposes requests, sockets, timers, and listeners", async () => {
+    const clock = new FakeClock();
+    const pending = deferred<Response>();
+    let signal: AbortSignal | undefined;
+    const fetch: DaemonFetch = (_input, init) => {
+      signal = init?.signal ?? undefined;
+      return pending.promise;
+    };
+    const transport = createDirectLoopbackDaemonTransport({
+      descriptor,
+      resolveSessionName: (workspaceName) => workspaceName,
+      fetch,
+      createWebSocket: () => {
+        throw new Error("socket refused");
+      },
+    });
+    const store = createDesktopApplicationShellResourceStore({
+      target: target(),
+      transport,
+      clock,
+      random: () => 0.5,
+      reconnect: {
+        initialDelayMs: 10,
+        maximumDelayMs: 20,
+        maximumAttempts: 2,
+      },
+    });
+    expect(clock.scheduledDelays).toEqual([10]);
+    clock.runNext();
+    expect(clock.scheduledDelays).toEqual([10, 20]);
+    clock.runNext();
+    expect(store.getState()).toMatchObject({
+      status: "unavailable",
+      code: "reconnect-exhausted",
+    });
+    expect(clock.pendingCount).toBe(0);
+
+    const observed = vi.fn();
+    store.subscribe(observed);
+    const callsBeforeDispose = observed.mock.calls.length;
+    store.dispose();
+    expect(signal?.aborted).toBe(true);
+    expect(clock.pendingCount).toBe(0);
+    pending.resolve(jsonResponse(resource("too-late")));
+    await settle();
+    expect(observed).toHaveBeenCalledTimes(callsBeforeDispose);
+  });
+
+  it("exposes the store as a Solid signal and follows owner cleanup", async () => {
+    const runtime = harness(async () => jsonResponse(resource("solid-live")));
+    let solidStore!: ReturnType<typeof createSolidDesktopApplicationShellResourceStore>;
+    let disposeRoot!: () => void;
+    createRoot((dispose) => {
+      disposeRoot = dispose;
+      solidStore = createSolidDesktopApplicationShellResourceStore({
+        target: target(),
+        transport: runtime.transport,
+      });
+    });
+
+    expect(solidStore.state().status).toBe("loading");
+    authenticateSocket(runtime.sockets[0]!);
+    await settle();
+    expect(solidStore.state()).toMatchObject({
+      status: "live",
+      data: { project: { name: "solid-live" } },
+    });
+    disposeRoot();
+    expect(runtime.sockets[0]!.closes).toHaveLength(1);
+  });
+});

--- a/apps/desktop-renderer/src/runtime/desktop-resource-store.test.ts
+++ b/apps/desktop-renderer/src/runtime/desktop-resource-store.test.ts
@@ -68,7 +68,14 @@ function authenticateSocket(socket: FakeSocket, daemon: unknown = daemonIdentity
 }
 
 async function settle(): Promise<void> {
-  for (let index = 0; index < 8; index += 1) await Promise.resolve();
+  // Response.json() may finish on a later event-loop turn rather than in the
+  // current microtask queue. CI runs the renderer beside the daemon and
+  // Electron suites, so microtask-only draining can observe the store while it
+  // is still legitimately loading. Keep this bounded, but yield real turns.
+  for (let index = 0; index < 4; index += 1) {
+    await Promise.resolve();
+    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+  }
 }
 
 function deferred<T>(): {

--- a/apps/desktop-renderer/src/runtime/desktop-resource-store.ts
+++ b/apps/desktop-renderer/src/runtime/desktop-resource-store.ts
@@ -1,0 +1,647 @@
+import { createSignal, onCleanup, type Accessor } from "solid-js";
+import type { ApplicationShellProjectionInputV1 } from "@tmux-ide/contracts";
+import {
+  DesktopApplicationShellTargetSchemaZ,
+  isDaemonWireProtocolCompatible,
+} from "@tmux-ide/contracts";
+
+import {
+  daemonGenerationKey,
+  type DesktopApplicationShellResourceState,
+  type DesktopApplicationShellTarget,
+} from "./connection-state.ts";
+import {
+  DaemonTransportError,
+  type DaemonEventConnection,
+  type DesktopDaemonTransport,
+} from "./daemon-transport.ts";
+
+export interface DesktopResourceClock {
+  now(): number;
+  setTimeout(callback: () => void, delayMs: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+export interface DesktopReconnectPolicy {
+  readonly initialDelayMs: number;
+  readonly maximumDelayMs: number;
+  readonly maximumAttempts: number;
+  /** Symmetric fraction around the exponential delay, from 0 through 1. */
+  readonly jitterRatio: number;
+  /** A verified connection must survive this long before the retry budget resets. */
+  readonly stabilityWindowMs: number;
+}
+
+export interface DesktopApplicationShellStoreOptions {
+  readonly target: unknown;
+  readonly transport: DesktopDaemonTransport;
+  readonly clock?: DesktopResourceClock;
+  readonly random?: () => number;
+  readonly reconnect?: Partial<DesktopReconnectPolicy>;
+}
+
+export type DesktopResourceStateListener = (state: DesktopApplicationShellResourceState) => void;
+
+export interface DesktopApplicationShellResourceStore {
+  getState(): DesktopApplicationShellResourceState;
+  subscribe(listener: DesktopResourceStateListener): () => void;
+  setTarget(target: unknown): void;
+  refresh(): void;
+  dispose(): void;
+}
+
+export interface SolidDesktopApplicationShellResourceStore {
+  readonly state: Accessor<DesktopApplicationShellResourceState>;
+  setTarget(target: unknown): void;
+  refresh(): void;
+  dispose(): void;
+}
+
+const DEFAULT_RECONNECT: DesktopReconnectPolicy = {
+  initialDelayMs: 250,
+  maximumDelayMs: 8_000,
+  maximumAttempts: 6,
+  jitterRatio: 0.2,
+  stabilityWindowMs: 10_000,
+};
+
+const RECONNECT_LIMITS = {
+  delayMinMs: 10,
+  delayMaxMs: 300_000,
+  attemptsMin: 1,
+  attemptsMax: 20,
+  stabilityMinMs: 100,
+  stabilityMaxMs: 300_000,
+} as const;
+
+const defaultClock: DesktopResourceClock = {
+  now: () => Date.now(),
+  setTimeout: (callback, delayMs) => globalThis.setTimeout(callback, delayMs),
+  clearTimeout: (handle) => globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+function dataFromState(
+  state: DesktopApplicationShellResourceState,
+): ApplicationShellProjectionInputV1 | null {
+  return "data" in state ? state.data : null;
+}
+
+function updatedAtFromState(state: DesktopApplicationShellResourceState): number | null {
+  return "updatedAt" in state ? state.updatedAt : null;
+}
+
+function boundedReconnectDelay(
+  attempt: number,
+  policy: DesktopReconnectPolicy,
+  random: () => number,
+): number {
+  const exponential = Math.min(
+    policy.maximumDelayMs,
+    policy.initialDelayMs * 2 ** Math.max(0, attempt),
+  );
+  let rawSample = 0.5;
+  try {
+    rawSample = random();
+  } catch {
+    // A test/host-provided entropy source cannot break reconnect accounting.
+  }
+  const sample = Number.isFinite(rawSample) ? Math.max(0, Math.min(1, rawSample)) : 0.5;
+  const jitter = 1 - policy.jitterRatio + sample * policy.jitterRatio * 2;
+  return Math.min(policy.maximumDelayMs, Math.max(0, Math.round(exponential * jitter)));
+}
+
+function finiteClamped(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function normalizedReconnectPolicy(
+  overrides: Partial<DesktopReconnectPolicy> | undefined,
+): DesktopReconnectPolicy {
+  const initialDelayMs = Math.round(
+    finiteClamped(
+      overrides?.initialDelayMs,
+      DEFAULT_RECONNECT.initialDelayMs,
+      RECONNECT_LIMITS.delayMinMs,
+      RECONNECT_LIMITS.delayMaxMs,
+    ),
+  );
+  const maximumDelayMs = Math.max(
+    initialDelayMs,
+    Math.round(
+      finiteClamped(
+        overrides?.maximumDelayMs,
+        DEFAULT_RECONNECT.maximumDelayMs,
+        RECONNECT_LIMITS.delayMinMs,
+        RECONNECT_LIMITS.delayMaxMs,
+      ),
+    ),
+  );
+  return {
+    initialDelayMs,
+    maximumDelayMs,
+    maximumAttempts: Math.trunc(
+      finiteClamped(
+        overrides?.maximumAttempts,
+        DEFAULT_RECONNECT.maximumAttempts,
+        RECONNECT_LIMITS.attemptsMin,
+        RECONNECT_LIMITS.attemptsMax,
+      ),
+    ),
+    jitterRatio: finiteClamped(overrides?.jitterRatio, DEFAULT_RECONNECT.jitterRatio, 0, 1),
+    stabilityWindowMs: Math.round(
+      finiteClamped(
+        overrides?.stabilityWindowMs,
+        DEFAULT_RECONNECT.stabilityWindowMs,
+        RECONNECT_LIMITS.stabilityMinMs,
+        RECONNECT_LIMITS.stabilityMaxMs,
+      ),
+    ),
+  };
+}
+
+function validateStoreTarget(value: unknown): DesktopApplicationShellTarget {
+  const parsed = DesktopApplicationShellTargetSchemaZ.safeParse(value);
+  if (!parsed.success) {
+    throw new DaemonTransportError(
+      "descriptor-invalid",
+      `Daemon application-shell target is invalid: ${parsed.error.issues[0]?.message ?? "unknown error"}`,
+    );
+  }
+  if (!isDaemonWireProtocolCompatible(parsed.data.daemon.protocolVersion)) {
+    throw new DaemonTransportError(
+      "descriptor-invalid",
+      `Daemon protocol ${parsed.data.daemon.protocolVersion} is not compatible with this renderer.`,
+    );
+  }
+  return parsed.data;
+}
+
+export function createDesktopApplicationShellResourceStore(
+  options: DesktopApplicationShellStoreOptions,
+): DesktopApplicationShellResourceStore {
+  const transport = options.transport;
+  const clock = options.clock ?? defaultClock;
+  const random = options.random ?? Math.random;
+  const reconnect = normalizedReconnectPolicy(options.reconnect);
+  const listeners = new Set<DesktopResourceStateListener>();
+
+  let disposed = false;
+  let generation = 0;
+  let target: DesktopApplicationShellTarget | null = null;
+  let targetKey = "";
+  let state: DesktopApplicationShellResourceState = {
+    status: "loading",
+    generation,
+    target: null,
+    data: null,
+  };
+  let requestId = 0;
+  let requestController: AbortController | null = null;
+  let connection: DaemonEventConnection | null = null;
+  let connectionId = 0;
+  let eventConnected = false;
+  let reconnectAttempts = 0;
+  let reconnectTimer: unknown | null = null;
+  let stabilityTimer: unknown | null = null;
+  let targetIsValid = false;
+
+  const emit = (next: DesktopApplicationShellResourceState): void => {
+    if (disposed) return;
+    state = next;
+    for (const listener of listeners) listener(next);
+  };
+
+  const current = (expectedGeneration: number, expectedKey: string): boolean =>
+    !disposed && generation === expectedGeneration && targetKey === expectedKey;
+
+  const clearReconnectTimer = (): void => {
+    if (reconnectTimer === null) return;
+    clock.clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  };
+
+  const clearStabilityTimer = (): void => {
+    if (stabilityTimer === null) return;
+    clock.clearTimeout(stabilityTimer);
+    stabilityTimer = null;
+  };
+
+  const retireConnection = (): void => {
+    connectionId += 1;
+    eventConnected = false;
+    clearStabilityTimer();
+    const active = connection;
+    connection = null;
+    active?.close();
+  };
+
+  const abortRequest = (): void => {
+    requestId += 1;
+    requestController?.abort();
+    requestController = null;
+  };
+
+  const emitDisconnected = (reason: string, exhausted = false): void => {
+    const data = dataFromState(state);
+    const updatedAt = updatedAtFromState(state);
+    if (data && updatedAt !== null) {
+      emit({ status: "stale", generation, target, data, updatedAt, reason });
+      return;
+    }
+    emit({
+      status: "unavailable",
+      generation,
+      target,
+      data: null,
+      code: exhausted ? "reconnect-exhausted" : "disconnected",
+      reason,
+    });
+  };
+
+  const emitTransportError = (error: unknown): void => {
+    const data = dataFromState(state);
+    if (error instanceof DaemonTransportError) {
+      if (error.kind === "descriptor-invalid") {
+        emit({
+          status: "degraded",
+          generation,
+          target,
+          data,
+          updatedAt: updatedAtFromState(state),
+          code: "descriptor-invalid",
+          reason: error.message,
+        });
+        return;
+      }
+      if (error.kind === "daemon-identity-mismatch") {
+        emit({
+          status: "degraded",
+          generation,
+          target,
+          data,
+          updatedAt: updatedAtFromState(state),
+          code: "daemon-identity-mismatch",
+          reason: error.message,
+        });
+        return;
+      }
+      if (error.kind === "schema-invalid") {
+        emit({
+          status: "degraded",
+          generation,
+          target,
+          data,
+          updatedAt: updatedAtFromState(state),
+          code: "schema-invalid",
+          reason: error.message,
+        });
+        return;
+      }
+      if (error.kind === "not-found") {
+        emit({
+          status: "unavailable",
+          generation,
+          target,
+          data: null,
+          code: "not-found",
+          reason: error.message,
+        });
+        return;
+      }
+      const updatedAt = updatedAtFromState(state);
+      if (data && updatedAt !== null) {
+        emit({ status: "stale", generation, target, data, updatedAt, reason: error.message });
+      } else {
+        emit({
+          status: "error",
+          generation,
+          target,
+          data: null,
+          code: error.kind === "network-error" ? "network-error" : "http-error",
+          reason: error.message,
+        });
+      }
+      return;
+    }
+    const reason =
+      error instanceof Error ? error.message : "Daemon application-shell request failed.";
+    const updatedAt = updatedAtFromState(state);
+    if (data && updatedAt !== null) {
+      emit({ status: "stale", generation, target, data, updatedAt, reason });
+    } else {
+      emit({
+        status: "error",
+        generation,
+        target,
+        data: null,
+        code: "network-error",
+        reason,
+      });
+    }
+  };
+
+  const fetchResource = (expectedGeneration: number, expectedKey: string): void => {
+    if (!current(expectedGeneration, expectedKey) || !targetIsValid || target === null) return;
+    const requestTarget = target;
+    abortRequest();
+    const activeRequestId = requestId;
+    const controller = new AbortController();
+    requestController = controller;
+    void transport
+      .fetchApplicationShell(requestTarget, controller.signal)
+      .then((data) => {
+        if (
+          controller.signal.aborted ||
+          activeRequestId !== requestId ||
+          !current(expectedGeneration, expectedKey) ||
+          !targetIsValid
+        ) {
+          return;
+        }
+        requestController = null;
+        const updatedAt = clock.now();
+        emit(
+          eventConnected
+            ? { status: "live", generation, target, data, updatedAt }
+            : {
+                status: "stale",
+                generation,
+                target,
+                data,
+                updatedAt,
+                reason: "Daemon event socket is not connected.",
+              },
+        );
+      })
+      .catch((error: unknown) => {
+        if (
+          controller.signal.aborted ||
+          activeRequestId !== requestId ||
+          !current(expectedGeneration, expectedKey)
+        ) {
+          return;
+        }
+        requestController = null;
+        if (error instanceof DaemonTransportError && error.kind === "daemon-identity-mismatch") {
+          targetIsValid = false;
+          retireConnection();
+        }
+        emitTransportError(error);
+      });
+  };
+
+  const scheduleReconnect = (expectedGeneration: number, expectedKey: string): void => {
+    if (!current(expectedGeneration, expectedKey) || reconnectTimer !== null || !targetIsValid) {
+      return;
+    }
+    if (reconnectAttempts >= reconnect.maximumAttempts) {
+      emitDisconnected("Daemon event reconnection attempts were exhausted.", true);
+      return;
+    }
+    const attempt = reconnectAttempts;
+    reconnectAttempts += 1;
+    const delay = boundedReconnectDelay(attempt, reconnect, random);
+    reconnectTimer = clock.setTimeout(() => {
+      reconnectTimer = null;
+      connectEvents(expectedGeneration, expectedKey);
+    }, delay);
+  };
+
+  const handleConnectionLoss = (
+    expectedConnectionId: number,
+    expectedGeneration: number,
+    expectedKey: string,
+    reason: string,
+  ): void => {
+    if (expectedConnectionId !== connectionId || !current(expectedGeneration, expectedKey)) {
+      return;
+    }
+    abortRequest();
+    retireConnection();
+    emitDisconnected(reason);
+    scheduleReconnect(expectedGeneration, expectedKey);
+  };
+
+  function connectEvents(expectedGeneration: number, expectedKey: string): void {
+    if (
+      !current(expectedGeneration, expectedKey) ||
+      !targetIsValid ||
+      target === null ||
+      connection !== null
+    )
+      return;
+    const connectionTarget = target;
+    const activeConnectionId = connectionId;
+    const wasReconnect = reconnectAttempts > 0;
+    try {
+      connection = transport.connectEvents(connectionTarget, {
+        onVerifiedOpen: () => {
+          if (activeConnectionId !== connectionId || !current(expectedGeneration, expectedKey)) {
+            return;
+          }
+          eventConnected = true;
+          clearStabilityTimer();
+          if (reconnectAttempts > 0) {
+            stabilityTimer = clock.setTimeout(() => {
+              stabilityTimer = null;
+              if (
+                activeConnectionId === connectionId &&
+                eventConnected &&
+                current(expectedGeneration, expectedKey)
+              ) {
+                reconnectAttempts = 0;
+              }
+            }, reconnect.stabilityWindowMs);
+          }
+          if (wasReconnect) {
+            fetchResource(expectedGeneration, expectedKey);
+          } else if (state.status === "stale") {
+            emit({
+              status: "live",
+              generation,
+              target,
+              data: state.data,
+              updatedAt: state.updatedAt,
+            });
+          }
+        },
+        onInvalidate: () => {
+          if (activeConnectionId !== connectionId || !current(expectedGeneration, expectedKey)) {
+            return;
+          }
+          fetchResource(expectedGeneration, expectedKey);
+        },
+        onProtocolError: (reason) => {
+          if (activeConnectionId !== connectionId || !current(expectedGeneration, expectedKey)) {
+            return;
+          }
+          const data = dataFromState(state);
+          emit({
+            status: "degraded",
+            generation,
+            target,
+            data,
+            updatedAt: updatedAtFromState(state),
+            code: "event-frame-invalid",
+            reason: `Daemon rejected the event subscription: ${reason}`,
+          });
+          abortRequest();
+          retireConnection();
+          scheduleReconnect(expectedGeneration, expectedKey);
+        },
+        onPeerMismatch: (reason) => {
+          if (activeConnectionId !== connectionId || !current(expectedGeneration, expectedKey)) {
+            return;
+          }
+          targetIsValid = false;
+          abortRequest();
+          const data = dataFromState(state);
+          emit({
+            status: "degraded",
+            generation,
+            target,
+            data,
+            updatedAt: updatedAtFromState(state),
+            code: "daemon-identity-mismatch",
+            reason,
+          });
+          retireConnection();
+        },
+        onMalformedFrame: (reason) => {
+          if (activeConnectionId !== connectionId || !current(expectedGeneration, expectedKey)) {
+            return;
+          }
+          const data = dataFromState(state);
+          emit({
+            status: "degraded",
+            generation,
+            target,
+            data,
+            updatedAt: updatedAtFromState(state),
+            code: "event-frame-invalid",
+            reason,
+          });
+          abortRequest();
+          retireConnection();
+          scheduleReconnect(expectedGeneration, expectedKey);
+        },
+        onClose: () =>
+          handleConnectionLoss(
+            activeConnectionId,
+            expectedGeneration,
+            expectedKey,
+            "Daemon event socket disconnected.",
+          ),
+        onError: (reason) =>
+          handleConnectionLoss(activeConnectionId, expectedGeneration, expectedKey, reason),
+      });
+    } catch (error) {
+      if (!current(expectedGeneration, expectedKey)) return;
+      if (
+        error instanceof DaemonTransportError &&
+        (error.kind === "descriptor-invalid" || error.kind === "daemon-identity-mismatch")
+      ) {
+        targetIsValid = false;
+        emitTransportError(error);
+        return;
+      }
+      emitDisconnected(
+        error instanceof Error ? error.message : "Daemon event socket could not be opened.",
+      );
+      scheduleReconnect(expectedGeneration, expectedKey);
+    }
+  }
+
+  const startTarget = (untrustedTarget: unknown): void => {
+    let nextTarget: DesktopApplicationShellTarget;
+    try {
+      nextTarget = validateStoreTarget(
+        transport.validateTarget(validateStoreTarget(untrustedTarget)),
+      );
+    } catch (error) {
+      clearReconnectTimer();
+      abortRequest();
+      retireConnection();
+      generation += 1;
+      target = null;
+      targetKey = `invalid:${generation}`;
+      reconnectAttempts = 0;
+      targetIsValid = false;
+      emit({ status: "loading", generation, target: null, data: null });
+      emitTransportError(error);
+      return;
+    }
+    const nextKey = daemonGenerationKey(nextTarget);
+    if (target !== null && nextKey === targetKey) return;
+    clearReconnectTimer();
+    abortRequest();
+    retireConnection();
+    generation += 1;
+    target = nextTarget;
+    targetKey = nextKey;
+    reconnectAttempts = 0;
+    targetIsValid = true;
+    emit({ status: "loading", generation, target, data: null });
+    fetchResource(generation, targetKey);
+    connectEvents(generation, targetKey);
+  };
+
+  const store: DesktopApplicationShellResourceStore = {
+    getState: () => state,
+    subscribe(listener) {
+      if (disposed) return () => undefined;
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+    setTarget(nextTarget) {
+      if (disposed) return;
+      startTarget(nextTarget);
+    },
+    refresh() {
+      if (disposed || !targetIsValid) return;
+      fetchResource(generation, targetKey);
+    },
+    dispose() {
+      if (disposed) return;
+      clearReconnectTimer();
+      clearStabilityTimer();
+      abortRequest();
+      retireConnection();
+      disposed = true;
+      listeners.clear();
+    },
+  };
+
+  startTarget(options.target);
+  return store;
+}
+
+/** Solid lifecycle adapter; the underlying store remains framework-independent. */
+export function createSolidDesktopApplicationShellResourceStore(
+  options: DesktopApplicationShellStoreOptions,
+): SolidDesktopApplicationShellResourceStore {
+  const store = createDesktopApplicationShellResourceStore(options);
+  const [state, setState] = createSignal(store.getState(), { equals: false });
+  const unsubscribe = store.subscribe(setState);
+  let disposed = false;
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    unsubscribe();
+    store.dispose();
+  };
+  onCleanup(dispose);
+  return {
+    state,
+    setTarget: (target) => store.setTarget(target),
+    refresh: () => store.refresh(),
+    dispose,
+  };
+}

--- a/apps/desktop-renderer/src/runtime/index.ts
+++ b/apps/desktop-renderer/src/runtime/index.ts
@@ -1,0 +1,9 @@
+export * from "./connection-state.ts";
+export { DaemonTransportError } from "./daemon-transport.ts";
+export type {
+  DaemonEventConnection,
+  DaemonEventHandlers,
+  DaemonTransportErrorKind,
+  DesktopDaemonTransport,
+} from "./daemon-transport.ts";
+export * from "./desktop-resource-store.ts";

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2483,38 +2483,94 @@ var init_commands = __esm({
   }
 });
 
-// packages/contracts/src/desktop-host.ts
+// packages/contracts/src/daemon-wire.ts
 import { z as z16 } from "zod";
-var DESKTOP_HOST_API_VERSION, DesktopRuntimeKindSchemaZ, DesktopPlatformSchemaZ, DesktopThemeModeSchemaZ, DesktopThemeStateSchemaZ, DesktopWindowStateSchemaZ, DesktopDaemonLoopbackUrlSchemaZ, DesktopDaemonHostDescriptorSchemaZ, DesktopDaemonHostIssueCodeSchemaZ, DesktopDaemonHostIssueSchemaFields, DesktopDaemonHostStateSchemaZ, DesktopDaemonPreflightSchemaZ, DesktopHostBootstrapSchemaZ, DesktopMenuResultSchemaZ, DesktopDirectorySelectionSchemaZ;
+function isDaemonWireProtocolCompatible(protocolVersion) {
+  return protocolVersion === DAEMON_WIRE_PROTOCOL_VERSION;
+}
+var DAEMON_WIRE_PROTOCOL_VERSION, DaemonWireProtocolVersionSchema, DaemonInstanceIdSchema, DaemonInstanceIdentitySchemaZ, CanonicalDaemonInfoSchema, DaemonHealthSchema, DaemonHealthzSchema, DaemonIdentitySchema;
+var init_daemon_wire = __esm({
+  "packages/contracts/src/daemon-wire.ts"() {
+    "use strict";
+    DAEMON_WIRE_PROTOCOL_VERSION = 1;
+    DaemonWireProtocolVersionSchema = z16.number().int().positive();
+    DaemonInstanceIdSchema = z16.uuid();
+    DaemonInstanceIdentitySchemaZ = z16.object({
+      protocolVersion: DaemonWireProtocolVersionSchema,
+      productVersion: z16.string().trim().min(1),
+      instanceId: DaemonInstanceIdSchema,
+      startedAt: z16.iso.datetime({ offset: true })
+    }).strict();
+    CanonicalDaemonInfoSchema = z16.object({
+      pid: z16.number().int().positive(),
+      port: z16.number().int().min(1).max(65535),
+      protocolVersion: DaemonWireProtocolVersionSchema,
+      productVersion: z16.string().trim().min(1),
+      instanceId: DaemonInstanceIdSchema,
+      startedAt: z16.iso.datetime({ offset: true }),
+      bindHostname: z16.string().trim().min(1),
+      authToken: z16.string().min(1).nullable()
+    });
+    DaemonHealthSchema = z16.object({
+      ok: z16.literal(true),
+      protocolVersion: DaemonWireProtocolVersionSchema,
+      productVersion: z16.string().trim().min(1),
+      uptime: z16.number().nonnegative()
+    });
+    DaemonHealthzSchema = z16.object({
+      ok: z16.literal(true),
+      protocolVersion: DaemonWireProtocolVersionSchema,
+      productVersion: z16.string().trim().min(1),
+      uptimeMs: z16.number().nonnegative()
+    });
+    DaemonIdentitySchema = z16.object({
+      ok: z16.literal(true),
+      pid: z16.number().int().positive(),
+      protocolVersion: DaemonWireProtocolVersionSchema,
+      productVersion: z16.string().trim().min(1),
+      instanceId: DaemonInstanceIdSchema,
+      startedAt: z16.iso.datetime({ offset: true })
+    });
+  }
+});
+
+// packages/contracts/src/desktop-host.ts
+import { z as z17 } from "zod";
+var DESKTOP_HOST_API_VERSION, DesktopRuntimeKindSchemaZ, DesktopPlatformSchemaZ, DesktopThemeModeSchemaZ, DesktopThemeStateSchemaZ, DesktopWindowStateSchemaZ, DesktopDaemonLoopbackUrlSchemaZ, DesktopDaemonHostDescriptorSchemaZ, DesktopApplicationShellTargetSchemaZ, DesktopDaemonHostIssueCodeSchemaZ, DesktopDaemonHostIssueSchemaFields, DesktopDaemonHostStateSchemaZ, DesktopDaemonPreflightSchemaZ, DesktopHostBootstrapSchemaZ, DesktopMenuResultSchemaZ, DesktopDirectorySelectionSchemaZ;
 var init_desktop_host = __esm({
   "packages/contracts/src/desktop-host.ts"() {
     "use strict";
+    init_daemon_wire();
     DESKTOP_HOST_API_VERSION = 2;
-    DesktopRuntimeKindSchemaZ = z16.enum(["browser", "electron"]);
-    DesktopPlatformSchemaZ = z16.enum(["darwin", "linux", "win32", "unknown"]);
-    DesktopThemeModeSchemaZ = z16.enum(["light", "dark"]);
-    DesktopThemeStateSchemaZ = z16.object({
+    DesktopRuntimeKindSchemaZ = z17.enum(["browser", "electron"]);
+    DesktopPlatformSchemaZ = z17.enum(["darwin", "linux", "win32", "unknown"]);
+    DesktopThemeModeSchemaZ = z17.enum(["light", "dark"]);
+    DesktopThemeStateSchemaZ = z17.object({
       mode: DesktopThemeModeSchemaZ,
-      highContrast: z16.boolean(),
-      reducedMotion: z16.boolean()
+      highContrast: z17.boolean(),
+      reducedMotion: z17.boolean()
     }).strict();
-    DesktopWindowStateSchemaZ = z16.object({
-      maximized: z16.boolean(),
-      fullscreen: z16.boolean(),
-      focused: z16.boolean()
+    DesktopWindowStateSchemaZ = z17.object({
+      maximized: z17.boolean(),
+      fullscreen: z17.boolean(),
+      focused: z17.boolean()
     }).strict();
-    DesktopDaemonLoopbackUrlSchemaZ = z16.url().refine((value) => {
+    DesktopDaemonLoopbackUrlSchemaZ = z17.url().refine((value) => {
       const url = new URL(value);
       return url.protocol === "http:" && (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]") && url.username.length === 0 && url.password.length === 0 && url.pathname === "/" && url.search.length === 0 && url.hash.length === 0;
     }, "daemon URL must be an uncredentialed loopback HTTP origin");
-    DesktopDaemonHostDescriptorSchemaZ = z16.object({
+    DesktopDaemonHostDescriptorSchemaZ = z17.object({
       apiBaseUrl: DesktopDaemonLoopbackUrlSchemaZ,
-      protocolVersion: z16.number().int().positive(),
-      productVersion: z16.string().trim().min(1),
-      instanceId: z16.uuid(),
-      startedAt: z16.iso.datetime({ offset: true })
+      protocolVersion: z17.number().int().positive(),
+      productVersion: z17.string().trim().min(1),
+      instanceId: z17.uuid(),
+      startedAt: z17.iso.datetime({ offset: true })
     }).strict();
-    DesktopDaemonHostIssueCodeSchemaZ = z16.enum([
+    DesktopApplicationShellTargetSchemaZ = z17.object({
+      daemon: DaemonInstanceIdentitySchemaZ,
+      workspaceName: z17.string().trim().min(1).max(160)
+    }).strict();
+    DesktopDaemonHostIssueCodeSchemaZ = z17.enum([
       "record-missing",
       "record-invalid",
       "endpoint-not-loopback",
@@ -2530,33 +2586,33 @@ var init_desktop_host = __esm({
     ]);
     DesktopDaemonHostIssueSchemaFields = {
       code: DesktopDaemonHostIssueCodeSchemaZ,
-      reason: z16.string().min(1)
+      reason: z17.string().min(1)
     };
-    DesktopDaemonHostStateSchemaZ = z16.discriminatedUnion("status", [
-      z16.object({
-        status: z16.literal("connected"),
+    DesktopDaemonHostStateSchemaZ = z17.discriminatedUnion("status", [
+      z17.object({
+        status: z17.literal("connected"),
         descriptor: DesktopDaemonHostDescriptorSchemaZ
       }).strict(),
-      z16.object({ status: z16.literal("unavailable"), ...DesktopDaemonHostIssueSchemaFields }).strict(),
-      z16.object({ status: z16.literal("degraded"), ...DesktopDaemonHostIssueSchemaFields }).strict()
+      z17.object({ status: z17.literal("unavailable"), ...DesktopDaemonHostIssueSchemaFields }).strict(),
+      z17.object({ status: z17.literal("degraded"), ...DesktopDaemonHostIssueSchemaFields }).strict()
     ]);
     DesktopDaemonPreflightSchemaZ = DesktopDaemonHostStateSchemaZ;
-    DesktopHostBootstrapSchemaZ = z16.object({
-      apiVersion: z16.literal(DESKTOP_HOST_API_VERSION),
+    DesktopHostBootstrapSchemaZ = z17.object({
+      apiVersion: z17.literal(DESKTOP_HOST_API_VERSION),
       runtime: DesktopRuntimeKindSchemaZ,
       platform: DesktopPlatformSchemaZ,
-      appVersion: z16.string().min(1),
+      appVersion: z17.string().min(1),
       theme: DesktopThemeStateSchemaZ,
       window: DesktopWindowStateSchemaZ,
       daemon: DesktopDaemonPreflightSchemaZ
     }).strict();
-    DesktopMenuResultSchemaZ = z16.object({ status: z16.literal("unavailable") }).strict();
-    DesktopDirectorySelectionSchemaZ = z16.object({ path: z16.string().min(1) }).strict();
+    DesktopMenuResultSchemaZ = z17.object({ status: z17.literal("unavailable") }).strict();
+    DesktopDirectorySelectionSchemaZ = z17.object({ path: z17.string().min(1) }).strict();
   }
 });
 
 // packages/contracts/src/experience-identifiers.ts
-import { z as z17 } from "zod";
+import { z as z18 } from "zod";
 var SEMANTIC_ICON_IDS, SemanticIconIdSchemaZ, PANE_ROLE_IDS, PaneRoleIdSchemaZ;
 var init_experience_identifiers = __esm({
   "packages/contracts/src/experience-identifiers.ts"() {
@@ -2587,7 +2643,7 @@ var init_experience_identifiers = __esm({
       "refresh",
       "command"
     ];
-    SemanticIconIdSchemaZ = z17.enum(SEMANTIC_ICON_IDS);
+    SemanticIconIdSchemaZ = z18.enum(SEMANTIC_ICON_IDS);
     PANE_ROLE_IDS = [
       "home",
       "terminal",
@@ -2598,19 +2654,19 @@ var init_experience_identifiers = __esm({
       "preview",
       "native"
     ];
-    PaneRoleIdSchemaZ = z17.enum(PANE_ROLE_IDS);
+    PaneRoleIdSchemaZ = z18.enum(PANE_ROLE_IDS);
   }
 });
 
 // packages/contracts/src/pane-appearance.ts
-import { z as z18 } from "zod";
+import { z as z19 } from "zod";
 var SemanticProductIdSchemaZ, PANE_STRUCTURE_IDS, PaneStructureSchemaZ, AGENT_ACTIVITY_IDS, AgentActivitySchemaZ, CANONICAL_DOMAIN_STATUS_IDS, CanonicalDomainStatusSchemaZ, PANE_ATTENTION_IDS, PaneAttentionSchemaZ, PaneVisualStateV1SchemaZ, DOMAIN_STATUS_TONES;
 var init_pane_appearance = __esm({
   "packages/contracts/src/pane-appearance.ts"() {
     "use strict";
-    SemanticProductIdSchemaZ = z18.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u, "semantic id contains a transport-only character");
+    SemanticProductIdSchemaZ = z19.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u, "semantic id contains a transport-only character");
     PANE_STRUCTURE_IDS = ["docked", "floating", "maximized"];
-    PaneStructureSchemaZ = z18.enum(PANE_STRUCTURE_IDS);
+    PaneStructureSchemaZ = z19.enum(PANE_STRUCTURE_IDS);
     AGENT_ACTIVITY_IDS = [
       "idle",
       "running",
@@ -2619,7 +2675,7 @@ var init_pane_appearance = __esm({
       "failed",
       "disconnected"
     ];
-    AgentActivitySchemaZ = z18.enum(AGENT_ACTIVITY_IDS);
+    AgentActivitySchemaZ = z19.enum(AGENT_ACTIVITY_IDS);
     CANONICAL_DOMAIN_STATUS_IDS = [
       "idle",
       "running",
@@ -2629,7 +2685,7 @@ var init_pane_appearance = __esm({
       "disconnected",
       "recovering"
     ];
-    CanonicalDomainStatusSchemaZ = z18.enum(CANONICAL_DOMAIN_STATUS_IDS);
+    CanonicalDomainStatusSchemaZ = z19.enum(CANONICAL_DOMAIN_STATUS_IDS);
     PANE_ATTENTION_IDS = [
       "none",
       "unread",
@@ -2638,26 +2694,26 @@ var init_pane_appearance = __esm({
       "destructive",
       "recovery"
     ];
-    PaneAttentionSchemaZ = z18.enum(PANE_ATTENTION_IDS);
-    PaneVisualStateV1SchemaZ = z18.object({
+    PaneAttentionSchemaZ = z19.enum(PANE_ATTENTION_IDS);
+    PaneVisualStateV1SchemaZ = z19.object({
       structure: PaneStructureSchemaZ,
-      applicationFocus: z18.object({ pane: z18.boolean(), terminalInput: z18.boolean(), windowActive: z18.boolean() }).strict(),
+      applicationFocus: z19.object({ pane: z19.boolean(), terminalInput: z19.boolean(), windowActive: z19.boolean() }).strict(),
       agentActivity: AgentActivitySchemaZ,
       domainStatus: CanonicalDomainStatusSchemaZ,
       attention: PaneAttentionSchemaZ,
-      layoutInteraction: z18.object({
-        editable: z18.boolean(),
-        selected: z18.boolean(),
-        dragging: z18.boolean(),
-        resizing: z18.boolean(),
-        previewing: z18.boolean()
+      layoutInteraction: z19.object({
+        editable: z19.boolean(),
+        selected: z19.boolean(),
+        dragging: z19.boolean(),
+        resizing: z19.boolean(),
+        previewing: z19.boolean()
       }).strict(),
-      controlInteraction: z18.object({
-        hover: z18.boolean(),
-        focusVisible: z18.boolean(),
-        pressed: z18.boolean(),
-        disabled: z18.boolean(),
-        loading: z18.boolean()
+      controlInteraction: z19.object({
+        hover: z19.boolean(),
+        focusVisible: z19.boolean(),
+        pressed: z19.boolean(),
+        disabled: z19.boolean(),
+        loading: z19.boolean()
       }).strict()
     }).strict();
     DOMAIN_STATUS_TONES = Object.freeze({
@@ -2673,7 +2729,7 @@ var init_pane_appearance = __esm({
 });
 
 // packages/contracts/src/experience-shell.ts
-import { z as z19 } from "zod";
+import { z as z20 } from "zod";
 function deepFreezeData(value) {
   if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
   for (const child of Object.values(value)) deepFreezeData(child);
@@ -2686,7 +2742,7 @@ var init_experience_shell = __esm({
     init_commands();
     init_experience_identifiers();
     init_pane_appearance();
-    ShellAreaIdSchemaZ = z19.enum([
+    ShellAreaIdSchemaZ = z20.enum([
       "application-bar",
       "sidebar",
       "primary-navigation",
@@ -2696,14 +2752,14 @@ var init_experience_shell = __esm({
       "status-strip"
     ]);
     PRIMARY_WORKSPACE_MODE_IDS = Object.freeze(["home", "terminals"]);
-    PrimaryWorkspaceModeIdSchemaZ = z19.enum(PRIMARY_WORKSPACE_MODE_IDS);
+    PrimaryWorkspaceModeIdSchemaZ = z20.enum(PRIMARY_WORKSPACE_MODE_IDS);
     DOCK_TOOL_IDS = Object.freeze(["files", "changes", "missions", "activity"]);
-    DockToolIdSchemaZ = z19.enum(DOCK_TOOL_IDS);
+    DockToolIdSchemaZ = z20.enum(DOCK_TOOL_IDS);
     PRODUCT_SURFACE_IDS = Object.freeze([
       ...PRIMARY_WORKSPACE_MODE_IDS,
       ...DOCK_TOOL_IDS
     ]);
-    ProductSurfaceIdSchemaZ = z19.enum(PRODUCT_SURFACE_IDS);
+    ProductSurfaceIdSchemaZ = z20.enum(PRODUCT_SURFACE_IDS);
     CANONICAL_SHELL_AREAS = deepFreezeData([
       { id: "application-bar", label: "Application bar", order: 0 },
       { id: "sidebar", label: "Workspace sidebar", order: 1 },
@@ -2713,35 +2769,35 @@ var init_experience_shell = __esm({
       { id: "bottom-dock", label: "Bottom dock", order: 5 },
       { id: "status-strip", label: "Status and recovery", order: 6 }
     ]);
-    SurfaceKindSchemaZ = z19.enum(["primary-mode", "dock-tool"]);
-    ApplicationShellDockModeSchemaZ = z19.enum(["collapsed", "open", "maximized"]);
-    SurfaceCommandTemplateSchemaZ = z19.discriminatedUnion("id", [
-      z19.object({
-        id: z19.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
-        args: z19.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict()
+    SurfaceKindSchemaZ = z20.enum(["primary-mode", "dock-tool"]);
+    ApplicationShellDockModeSchemaZ = z20.enum(["collapsed", "open", "maximized"]);
+    SurfaceCommandTemplateSchemaZ = z20.discriminatedUnion("id", [
+      z20.object({
+        id: z20.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
+        args: z20.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict()
       }).strict(),
-      z19.object({
-        id: z19.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
-        args: z19.object({ tool: DockToolIdSchemaZ }).strict()
+      z20.object({
+        id: z20.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
+        args: z20.object({ tool: DockToolIdSchemaZ }).strict()
       }).strict(),
-      z19.object({
-        id: z19.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
-        args: z19.object({ mode: ApplicationShellDockModeSchemaZ }).strict()
+      z20.object({
+        id: z20.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
+        args: z20.object({ mode: ApplicationShellDockModeSchemaZ }).strict()
       }).strict(),
-      z19.object({
-        id: z19.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
-        args: z19.object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ }).strict()
+      z20.object({
+        id: z20.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
+        args: z20.object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ }).strict()
       }).strict()
     ]);
-    ProductSurfaceDefinitionSchemaZ = z19.object({
+    ProductSurfaceDefinitionSchemaZ = z20.object({
       id: ProductSurfaceIdSchemaZ,
       icon: SemanticIconIdSchemaZ,
-      label: z19.string().min(1).max(160),
+      label: z20.string().min(1).max(160),
       kind: SurfaceKindSchemaZ,
-      area: z19.enum(["workspace-canvas", "bottom-dock"]),
-      order: z19.number().int().nonnegative(),
+      area: z20.enum(["workspace-canvas", "bottom-dock"]),
+      order: z20.number().int().nonnegative(),
       owningMode: PrimaryWorkspaceModeIdSchemaZ,
-      shortcut: z19.string().min(1).max(32),
+      shortcut: z20.string().min(1).max(32),
       activation: SurfaceCommandTemplateSchemaZ
     }).strict().superRefine((surface, ctx) => {
       if (surface.kind === "primary-mode" && surface.activation.id !== APPLICATION_SHELL_COMMAND_IDS.activateMode) {
@@ -2845,7 +2901,7 @@ var init_experience_shell = __esm({
 });
 
 // packages/contracts/src/focus-overlay.ts
-import { z as z20 } from "zod";
+import { z as z21 } from "zod";
 function resolveSemanticInputLayer(state) {
   const parsed = FocusOverlayStateV1SchemaZ.parse(state);
   let winner = null;
@@ -2864,7 +2920,7 @@ var init_focus_overlay = __esm({
     "use strict";
     init_experience_shell();
     init_pane_appearance();
-    FocusZoneSchemaZ = z20.enum([
+    FocusZoneSchemaZ = z21.enum([
       "application-bar",
       "sidebar",
       "primary-navigation",
@@ -2874,45 +2930,45 @@ var init_focus_overlay = __esm({
       "status-strip",
       "terminal"
     ]);
-    SemanticFocusTargetSchemaZ = z20.discriminatedUnion("kind", [
-      z20.object({ kind: z20.literal("zone"), zone: FocusZoneSchemaZ }).strict(),
-      z20.object({
-        kind: z20.literal("pane"),
+    SemanticFocusTargetSchemaZ = z21.discriminatedUnion("kind", [
+      z21.object({ kind: z21.literal("zone"), zone: FocusZoneSchemaZ }).strict(),
+      z21.object({
+        kind: z21.literal("pane"),
         paneId: SemanticProductIdSchemaZ,
-        input: z20.enum(["chrome", "terminal"])
+        input: z21.enum(["chrome", "terminal"])
       }).strict(),
-      z20.object({ kind: z20.literal("dock-tool"), tool: DockToolIdSchemaZ }).strict(),
-      z20.object({
-        kind: z20.literal("control"),
+      z21.object({ kind: z21.literal("dock-tool"), tool: DockToolIdSchemaZ }).strict(),
+      z21.object({
+        kind: z21.literal("control"),
         controlId: SemanticProductIdSchemaZ,
         zone: FocusZoneSchemaZ
       }).strict()
     ]);
-    OverlayKindSchemaZ = z20.enum(["modal-dialog", "command-palette", "context-menu"]);
-    SemanticOverlaySchemaZ = z20.object({
+    OverlayKindSchemaZ = z21.enum(["modal-dialog", "command-palette", "context-menu"]);
+    SemanticOverlaySchemaZ = z21.object({
       id: SemanticProductIdSchemaZ,
       kind: OverlayKindSchemaZ,
       focusReturnTarget: SemanticFocusTargetSchemaZ
     }).strict();
-    FocusOverlayStateV1SchemaZ = z20.object({
-      windowActivity: z20.enum(["active", "inactive"]),
+    FocusOverlayStateV1SchemaZ = z21.object({
+      windowActivity: z21.enum(["active", "inactive"]),
       focusZone: FocusZoneSchemaZ,
       appFocusedPaneId: SemanticProductIdSchemaZ.nullable(),
       terminalInputPaneId: SemanticProductIdSchemaZ.nullable(),
       layoutSelectedPaneId: SemanticProductIdSchemaZ.nullable(),
-      overlays: z20.array(SemanticOverlaySchemaZ).max(16)
+      overlays: z21.array(SemanticOverlaySchemaZ).max(16)
     }).strict().superRefine((state, ctx) => {
       const ids = state.overlays.map((overlay) => overlay.id);
       if (new Set(ids).size !== ids.length) {
         ctx.addIssue({
-          code: z20.ZodIssueCode.custom,
+          code: z21.ZodIssueCode.custom,
           message: "overlay ids must be unique",
           path: ["overlays"]
         });
       }
       if (state.terminalInputPaneId !== null && state.appFocusedPaneId !== state.terminalInputPaneId) {
         ctx.addIssue({
-          code: z20.ZodIssueCode.custom,
+          code: z21.ZodIssueCode.custom,
           message: "terminal input owner must also be the app-focused pane",
           path: ["terminalInputPaneId"]
         });
@@ -2927,7 +2983,7 @@ var init_focus_overlay = __esm({
 });
 
 // packages/contracts/src/visual-tokens.ts
-import { z as z21 } from "zod";
+import { z as z22 } from "zod";
 function color(hex) {
   const normalized = hex.replace(/^#/u, "");
   return {
@@ -3089,32 +3145,32 @@ var init_visual_tokens = __esm({
     MOTION_DURATION_ROLES = ["instant", "fast", "standard", "emphasized"];
     TYPOGRAPHY_TOKEN_ROLES = ["workspace", "label", "title", "metadata", "code"];
     WINDOW_ACTIVITY_TOKEN_ROLES = ["active", "inactive"];
-    RendererNeutralColorSchemaZ = z21.object({
-      space: z21.literal("srgb"),
-      red: z21.number().int().min(0).max(255),
-      green: z21.number().int().min(0).max(255),
-      blue: z21.number().int().min(0).max(255),
-      alpha: z21.number().int().min(0).max(255)
+    RendererNeutralColorSchemaZ = z22.object({
+      space: z22.literal("srgb"),
+      red: z22.number().int().min(0).max(255),
+      green: z22.number().int().min(0).max(255),
+      blue: z22.number().int().min(0).max(255),
+      alpha: z22.number().int().min(0).max(255)
     }).strict();
-    RhythmValueSchemaZ = z21.object({ unit: z21.literal("rhythm"), value: z21.number().finite().min(0).max(16) }).strict();
-    RatioValueSchemaZ = z21.object({ unit: z21.literal("ratio"), value: z21.number().finite().min(0).max(20) }).strict();
-    DurationValueSchemaZ = z21.object({ unit: z21.literal("ms"), value: z21.number().finite().min(0).max(1e4) }).strict();
-    ElevationValueSchemaZ = z21.object({
-      level: z21.number().int().min(0).max(4),
-      intent: z21.enum(["flat", "raised", "overlay"])
+    RhythmValueSchemaZ = z22.object({ unit: z22.literal("rhythm"), value: z22.number().finite().min(0).max(16) }).strict();
+    RatioValueSchemaZ = z22.object({ unit: z22.literal("ratio"), value: z22.number().finite().min(0).max(20) }).strict();
+    DurationValueSchemaZ = z22.object({ unit: z22.literal("ms"), value: z22.number().finite().min(0).max(1e4) }).strict();
+    ElevationValueSchemaZ = z22.object({
+      level: z22.number().int().min(0).max(4),
+      intent: z22.enum(["flat", "raised", "overlay"])
     }).strict();
-    TypographyValueSchemaZ = z21.object({
-      family: z21.enum(["monospace", "system"]),
-      weight: z21.enum(["regular", "medium", "semibold", "bold"]),
+    TypographyValueSchemaZ = z22.object({
+      family: z22.enum(["monospace", "system"]),
+      weight: z22.enum(["regular", "medium", "semibold", "bold"]),
       lineHeight: RatioValueSchemaZ,
-      truncation: z21.enum(["ellipsis", "clip", "wrap"])
+      truncation: z22.enum(["ellipsis", "clip", "wrap"])
     }).strict();
-    MotionEasingSchemaZ = z21.object({
-      standard: z21.enum(["linear", "standard", "decelerate"]),
-      emphasized: z21.enum(["linear", "standard", "decelerate"])
+    MotionEasingSchemaZ = z22.object({
+      standard: z22.enum(["linear", "standard", "decelerate"]),
+      emphasized: z22.enum(["linear", "standard", "decelerate"])
     }).strict();
-    WindowActivityValueSchemaZ = z21.object({ opacity: RatioValueSchemaZ, contrast: RatioValueSchemaZ }).strict();
-    SurfacesSchemaZ = z21.object({
+    WindowActivityValueSchemaZ = z22.object({ opacity: RatioValueSchemaZ, contrast: RatioValueSchemaZ }).strict();
+    SurfacesSchemaZ = z22.object({
       canvas: RendererNeutralColorSchemaZ,
       panel: RendererNeutralColorSchemaZ,
       panelRaised: RendererNeutralColorSchemaZ,
@@ -3123,7 +3179,7 @@ var init_visual_tokens = __esm({
       headerActive: RendererNeutralColorSchemaZ,
       command: RendererNeutralColorSchemaZ
     }).strict();
-    TextSchemaZ = z21.object({
+    TextSchemaZ = z22.object({
       primary: RendererNeutralColorSchemaZ,
       secondary: RendererNeutralColorSchemaZ,
       muted: RendererNeutralColorSchemaZ,
@@ -3131,7 +3187,7 @@ var init_visual_tokens = __esm({
       inverse: RendererNeutralColorSchemaZ,
       link: RendererNeutralColorSchemaZ
     }).strict();
-    BordersSchemaZ = z21.object({
+    BordersSchemaZ = z22.object({
       subtle: RendererNeutralColorSchemaZ,
       default: RendererNeutralColorSchemaZ,
       focused: RendererNeutralColorSchemaZ,
@@ -3139,21 +3195,21 @@ var init_visual_tokens = __esm({
       attention: RendererNeutralColorSchemaZ,
       danger: RendererNeutralColorSchemaZ
     }).strict();
-    StatusToneSchemaZ = z21.object({
+    StatusToneSchemaZ = z22.object({
       neutral: RendererNeutralColorSchemaZ,
       info: RendererNeutralColorSchemaZ,
       warning: RendererNeutralColorSchemaZ,
       danger: RendererNeutralColorSchemaZ,
       success: RendererNeutralColorSchemaZ
     }).strict();
-    SelectionSchemaZ = z21.object({
+    SelectionSchemaZ = z22.object({
       selection: RendererNeutralColorSchemaZ,
       selectionText: RendererNeutralColorSchemaZ,
       hover: RendererNeutralColorSchemaZ,
       pressed: RendererNeutralColorSchemaZ,
       disabled: RendererNeutralColorSchemaZ
     }).strict();
-    DensitySchemaZ = z21.object({
+    DensitySchemaZ = z22.object({
       cellHeight: RhythmValueSchemaZ,
       headerHeight: RhythmValueSchemaZ,
       statusHeight: RhythmValueSchemaZ,
@@ -3161,39 +3217,39 @@ var init_visual_tokens = __esm({
       sectionGap: RhythmValueSchemaZ,
       controlPadding: RhythmValueSchemaZ
     }).strict();
-    ShapeSchemaZ = z21.object({
+    ShapeSchemaZ = z22.object({
       dockedRadius: RhythmValueSchemaZ,
       floatingRadius: RhythmValueSchemaZ,
       controlRadius: RhythmValueSchemaZ,
       statusRadius: RhythmValueSchemaZ
     }).strict();
-    ElevationSchemaZ = z21.object({
+    ElevationSchemaZ = z22.object({
       floating: ElevationValueSchemaZ,
       palette: ElevationValueSchemaZ,
       windowMode: ElevationValueSchemaZ
     }).strict();
-    MotionSchemaZ = z21.object({
+    MotionSchemaZ = z22.object({
       instant: DurationValueSchemaZ,
       fast: DurationValueSchemaZ,
       standard: DurationValueSchemaZ,
       emphasized: DurationValueSchemaZ,
       easing: MotionEasingSchemaZ
     }).strict();
-    TypographySchemaZ = z21.object({
+    TypographySchemaZ = z22.object({
       workspace: TypographyValueSchemaZ,
       label: TypographyValueSchemaZ,
       title: TypographyValueSchemaZ,
       metadata: TypographyValueSchemaZ,
       code: TypographyValueSchemaZ
     }).strict();
-    FocusSchemaZ = z21.object({
+    FocusSchemaZ = z22.object({
       outline: RhythmValueSchemaZ,
       outlineOffset: RhythmValueSchemaZ,
       focusContrast: RatioValueSchemaZ,
       highContrastOutline: RendererNeutralColorSchemaZ
     }).strict();
-    WindowActivitySchemaZ = z21.object({ active: WindowActivityValueSchemaZ, inactive: WindowActivityValueSchemaZ }).strict();
-    VisualTokensV1SchemaZ = z21.object({
+    WindowActivitySchemaZ = z22.object({ active: WindowActivityValueSchemaZ, inactive: WindowActivityValueSchemaZ }).strict();
+    VisualTokensV1SchemaZ = z22.object({
       surfaces: SurfacesSchemaZ,
       text: TextSchemaZ,
       borders: BordersSchemaZ,
@@ -3207,7 +3263,7 @@ var init_visual_tokens = __esm({
       focus: FocusSchemaZ,
       windowActivity: WindowActivitySchemaZ
     }).strict();
-    VisualTokenOverridesV1SchemaZ = z21.object({
+    VisualTokenOverridesV1SchemaZ = z22.object({
       surfaces: SurfacesSchemaZ.partial().optional(),
       text: TextSchemaZ.partial().optional(),
       borders: BordersSchemaZ.partial().optional(),
@@ -3221,24 +3277,24 @@ var init_visual_tokens = __esm({
       focus: FocusSchemaZ.partial().optional(),
       windowActivity: WindowActivitySchemaZ.partial().optional()
     }).strict();
-    ThemeIdSchemaZ = z21.string().min(1).max(80).regex(/^[a-z0-9][a-z0-9._-]*$/u);
-    ThemeNameSchemaZ = z21.string().min(1).max(120);
-    ThemeAppearanceSchemaZ = z21.enum(["dark", "light"]);
-    VisualThemeDocumentV1SchemaZ = z21.object({
-      version: z21.literal(VISUAL_THEME_VERSION),
+    ThemeIdSchemaZ = z22.string().min(1).max(80).regex(/^[a-z0-9][a-z0-9._-]*$/u);
+    ThemeNameSchemaZ = z22.string().min(1).max(120);
+    ThemeAppearanceSchemaZ = z22.enum(["dark", "light"]);
+    VisualThemeDocumentV1SchemaZ = z22.object({
+      version: z22.literal(VISUAL_THEME_VERSION),
       id: ThemeIdSchemaZ,
       name: ThemeNameSchemaZ,
       appearance: ThemeAppearanceSchemaZ.optional(),
       overrides: VisualTokenOverridesV1SchemaZ
     }).strict();
-    VisualThemeDocumentV0SchemaZ = z21.object({
-      version: z21.literal(0),
+    VisualThemeDocumentV0SchemaZ = z22.object({
+      version: z22.literal(0),
       id: ThemeIdSchemaZ,
       name: ThemeNameSchemaZ,
       appearance: ThemeAppearanceSchemaZ.optional(),
       tokens: VisualTokenOverridesV1SchemaZ
     }).strict();
-    ThemeAccessibilityPreferencesSchemaZ = z21.object({ reducedMotion: z21.boolean(), increasedContrast: z21.boolean() }).strict();
+    ThemeAccessibilityPreferencesSchemaZ = z22.object({ reducedMotion: z22.boolean(), increasedContrast: z22.boolean() }).strict();
     groupSchemas = {
       surfaces: {
         canvas: RendererNeutralColorSchemaZ,
@@ -3307,7 +3363,7 @@ var init_visual_tokens = __esm({
 });
 
 // packages/contracts/src/cohesion-fixture.ts
-import { z as z22 } from "zod";
+import { z as z23 } from "zod";
 function deepFreeze(value) {
   if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
   for (const child of Object.values(value)) deepFreeze(child);
@@ -3324,29 +3380,29 @@ var init_cohesion_fixture = __esm({
     init_pane_appearance();
     init_visual_tokens();
     COHESION_FIXTURE_VERSION = 1;
-    LabelSchemaZ = z22.string().min(1).max(160);
-    OptionalLabelSchemaZ = z22.string().min(1).max(240).nullable();
-    ReadinessSchemaZ = z22.object({
-      state: z22.enum(["ready", "warning", "blocked"]),
-      facts: z22.array(LabelSchemaZ).max(24),
-      warnings: z22.array(LabelSchemaZ).max(24)
+    LabelSchemaZ = z23.string().min(1).max(160);
+    OptionalLabelSchemaZ = z23.string().min(1).max(240).nullable();
+    ReadinessSchemaZ = z23.object({
+      state: z23.enum(["ready", "warning", "blocked"]),
+      facts: z23.array(LabelSchemaZ).max(24),
+      warnings: z23.array(LabelSchemaZ).max(24)
     }).strict();
-    SessionSidebarItemSchemaZ = z22.object({
+    SessionSidebarItemSchemaZ = z23.object({
       id: SemanticProductIdSchemaZ,
       label: LabelSchemaZ,
-      state: z22.enum(["connected", "reconnecting", "disconnected"]),
-      active: z22.boolean()
+      state: z23.enum(["connected", "reconnecting", "disconnected"]),
+      active: z23.boolean()
     }).strict();
-    AgentSidebarItemSchemaZ = z22.object({
+    AgentSidebarItemSchemaZ = z23.object({
       id: SemanticProductIdSchemaZ,
       name: LabelSchemaZ,
-      harness: z22.enum(["codex", "claude-code", "custom"]),
+      harness: z23.enum(["codex", "claude-code", "custom"]),
       activity: AgentActivitySchemaZ,
       paneId: SemanticProductIdSchemaZ.nullable(),
-      attention: z22.boolean()
+      attention: z23.boolean()
     }).strict();
-    PaneActionSchemaZ = z22.object({
-      id: z22.enum([
+    PaneActionSchemaZ = z23.object({
+      id: z23.enum([
         "focus-terminal",
         "split",
         "duplicate",
@@ -3357,13 +3413,13 @@ var init_cohesion_fixture = __esm({
       icon: SemanticIconIdSchemaZ,
       label: LabelSchemaZ,
       commandId: CommandIdSchemaZ,
-      available: z22.boolean(),
+      available: z23.boolean(),
       disabledReason: OptionalLabelSchemaZ
     }).strict().refine((action) => action.available === (action.disabledReason === null), {
       message: "available actions must not have a disabled reason and unavailable actions must",
       path: ["disabledReason"]
     });
-    PaneFixtureSchemaZ = z22.object({
+    PaneFixtureSchemaZ = z23.object({
       id: SemanticProductIdSchemaZ,
       role: PaneRoleIdSchemaZ,
       title: LabelSchemaZ,
@@ -3371,7 +3427,7 @@ var init_cohesion_fixture = __esm({
       terminalSourceId: SemanticProductIdSchemaZ.nullable(),
       agentId: SemanticProductIdSchemaZ.nullable(),
       state: PaneVisualStateV1SchemaZ,
-      actions: z22.array(PaneActionSchemaZ).min(1).max(6)
+      actions: z23.array(PaneActionSchemaZ).min(1).max(6)
     }).strict().superRefine((pane, ctx) => {
       const expectedOrder = [
         "focus-terminal",
@@ -3386,7 +3442,7 @@ var init_cohesion_fixture = __esm({
         const order = expectedOrder.indexOf(action.id);
         if (order <= last) {
           ctx.addIssue({
-            code: z22.ZodIssueCode.custom,
+            code: z23.ZodIssueCode.custom,
             message: "pane actions must follow canonical action order",
             path: ["actions", index, "id"]
           });
@@ -3394,74 +3450,74 @@ var init_cohesion_fixture = __esm({
         last = order;
       }
     });
-    DockToolDataSchemaZ = z22.discriminatedUnion("kind", [
-      z22.object({
-        kind: z22.literal("files"),
+    DockToolDataSchemaZ = z23.discriminatedUnion("kind", [
+      z23.object({
+        kind: z23.literal("files"),
         selectedResourceId: SemanticProductIdSchemaZ.nullable(),
-        fileCount: z22.number().int().nonnegative()
+        fileCount: z23.number().int().nonnegative()
       }).strict(),
-      z22.object({
-        kind: z22.literal("changes"),
+      z23.object({
+        kind: z23.literal("changes"),
         selectedResourceId: SemanticProductIdSchemaZ.nullable(),
-        changeCount: z22.number().int().nonnegative()
+        changeCount: z23.number().int().nonnegative()
       }).strict(),
-      z22.object({
-        kind: z22.literal("missions"),
+      z23.object({
+        kind: z23.literal("missions"),
         missionId: SemanticProductIdSchemaZ,
         title: LabelSchemaZ,
         status: CanonicalDomainStatusSchemaZ,
-        goalCount: z22.number().int().nonnegative(),
-        taskCount: z22.number().int().nonnegative()
+        goalCount: z23.number().int().nonnegative(),
+        taskCount: z23.number().int().nonnegative()
       }).strict(),
-      z22.object({
-        kind: z22.literal("activity"),
-        eventCount: z22.number().int().nonnegative(),
+      z23.object({
+        kind: z23.literal("activity"),
+        eventCount: z23.number().int().nonnegative(),
         latestEventLabel: OptionalLabelSchemaZ
       }).strict()
     ]);
-    DockToolFixtureSchemaZ = z22.object({
+    DockToolFixtureSchemaZ = z23.object({
       id: DockToolIdSchemaZ,
       label: LabelSchemaZ,
       shortcut: LabelSchemaZ,
-      unreadCount: z22.number().int().nonnegative(),
+      unreadCount: z23.number().int().nonnegative(),
       disabledReason: OptionalLabelSchemaZ,
       data: DockToolDataSchemaZ
     }).strict().refine((tool) => tool.id === tool.data.kind, {
       message: "dock tool data kind must match its canonical tool id",
       path: ["data", "kind"]
     });
-    ConnectionRecoverySchemaZ = z22.object({
-      state: z22.enum(["connected", "reconnecting", "disconnected", "recovering"]),
+    ConnectionRecoverySchemaZ = z23.object({
+      state: z23.enum(["connected", "reconnecting", "disconnected", "recovering"]),
       message: LabelSchemaZ,
       safeState: LabelSchemaZ,
       nextAction: LabelSchemaZ
     }).strict();
-    CohesionFixtureV1SchemaZ = z22.object({
-      version: z22.literal(COHESION_FIXTURE_VERSION),
-      project: z22.object({
+    CohesionFixtureV1SchemaZ = z23.object({
+      version: z23.literal(COHESION_FIXTURE_VERSION),
+      project: z23.object({
         id: SemanticProductIdSchemaZ,
         name: LabelSchemaZ,
         rootLabel: LabelSchemaZ,
         readiness: ReadinessSchemaZ
       }).strict(),
-      workspace: z22.object({
+      workspace: z23.object({
         id: SemanticProductIdSchemaZ,
         name: LabelSchemaZ,
         activeMode: PrimaryWorkspaceModeIdSchemaZ,
         session: SessionSidebarItemSchemaZ,
-        sidebar: z22.object({
-          sessions: z22.array(SessionSidebarItemSchemaZ).min(1).max(32),
-          agents: z22.array(AgentSidebarItemSchemaZ).max(64)
+        sidebar: z23.object({
+          sessions: z23.array(SessionSidebarItemSchemaZ).min(1).max(32),
+          agents: z23.array(AgentSidebarItemSchemaZ).max(64)
         }).strict()
       }).strict(),
-      panes: z22.array(PaneFixtureSchemaZ).min(1).max(32),
-      dock: z22.object({
-        mode: z22.enum(["collapsed", "open", "maximized"]),
+      panes: z23.array(PaneFixtureSchemaZ).min(1).max(32),
+      dock: z23.object({
+        mode: z23.enum(["collapsed", "open", "maximized"]),
         activeTool: DockToolIdSchemaZ,
-        tools: z22.array(DockToolFixtureSchemaZ).length(4)
+        tools: z23.array(DockToolFixtureSchemaZ).length(4)
       }).strict(),
       focus: FocusOverlayStateV1SchemaZ,
-      theme: z22.object({
+      theme: z23.object({
         user: VisualThemeDocumentV1SchemaZ.nullable(),
         project: VisualThemeDocumentV1SchemaZ.nullable(),
         accessibility: ThemeAccessibilityPreferencesSchemaZ
@@ -3472,7 +3528,7 @@ var init_cohesion_fixture = __esm({
       const paneIdSet = new Set(paneIds);
       if (paneIdSet.size !== paneIds.length) {
         ctx.addIssue({
-          code: z22.ZodIssueCode.custom,
+          code: z23.ZodIssueCode.custom,
           message: "pane ids must be unique",
           path: ["panes"]
         });
@@ -3480,7 +3536,7 @@ var init_cohesion_fixture = __esm({
       const agentIds = fixture.workspace.sidebar.agents.map((agent) => agent.id);
       if (new Set(agentIds).size !== agentIds.length) {
         ctx.addIssue({
-          code: z22.ZodIssueCode.custom,
+          code: z23.ZodIssueCode.custom,
           message: "agent ids must be unique",
           path: ["workspace", "sidebar", "agents"]
         });
@@ -3488,7 +3544,7 @@ var init_cohesion_fixture = __esm({
       const sessionIds = fixture.workspace.sidebar.sessions.map((session) => session.id);
       if (new Set(sessionIds).size !== sessionIds.length) {
         ctx.addIssue({
-          code: z22.ZodIssueCode.custom,
+          code: z23.ZodIssueCode.custom,
           message: "session ids must be unique",
           path: ["workspace", "sidebar", "sessions"]
         });
@@ -3497,7 +3553,7 @@ var init_cohesion_fixture = __esm({
         (session) => session.id === fixture.workspace.session.id
       )) {
         ctx.addIssue({
-          code: z22.ZodIssueCode.custom,
+          code: z23.ZodIssueCode.custom,
           message: "active session must be present in the sidebar",
           path: ["workspace", "session", "id"]
         });
@@ -3505,7 +3561,7 @@ var init_cohesion_fixture = __esm({
       for (const [index, agent] of fixture.workspace.sidebar.agents.entries()) {
         if (agent.paneId !== null && !paneIdSet.has(agent.paneId)) {
           ctx.addIssue({
-            code: z22.ZodIssueCode.custom,
+            code: z23.ZodIssueCode.custom,
             message: "agent pane must exist in fixture panes",
             path: ["workspace", "sidebar", "agents", index, "paneId"]
           });
@@ -3519,7 +3575,7 @@ var init_cohesion_fixture = __esm({
       for (const paneId of focusReferences) {
         if (paneId !== null && !paneIdSet.has(paneId)) {
           ctx.addIssue({
-            code: z22.ZodIssueCode.custom,
+            code: z23.ZodIssueCode.custom,
             message: "focus state references an unknown pane",
             path: ["focus"]
           });
@@ -3531,28 +3587,28 @@ var init_cohesion_fixture = __esm({
         const shouldBeSelected = pane.id === fixture.focus.layoutSelectedPaneId;
         if (pane.state.applicationFocus.pane !== shouldBeFocused) {
           ctx.addIssue({
-            code: z22.ZodIssueCode.custom,
+            code: z23.ZodIssueCode.custom,
             message: "pane focus channel must match canonical focus state",
             path: ["panes", index, "state", "applicationFocus", "pane"]
           });
         }
         if (pane.state.applicationFocus.terminalInput !== shouldOwnTerminal) {
           ctx.addIssue({
-            code: z22.ZodIssueCode.custom,
+            code: z23.ZodIssueCode.custom,
             message: "terminal input channel must match canonical focus state",
             path: ["panes", index, "state", "applicationFocus", "terminalInput"]
           });
         }
         if (pane.state.layoutInteraction.selected !== shouldBeSelected) {
           ctx.addIssue({
-            code: z22.ZodIssueCode.custom,
+            code: z23.ZodIssueCode.custom,
             message: "layout selection channel must match canonical focus state",
             path: ["panes", index, "state", "layoutInteraction", "selected"]
           });
         }
         if (pane.state.applicationFocus.windowActive !== (fixture.focus.windowActivity === "active")) {
           ctx.addIssue({
-            code: z22.ZodIssueCode.custom,
+            code: z23.ZodIssueCode.custom,
             message: "pane window activity must match canonical focus state",
             path: ["panes", index, "state", "applicationFocus", "windowActive"]
           });
@@ -3564,7 +3620,7 @@ var init_cohesion_fixture = __esm({
       const actualDockOrder = fixture.dock.tools.map((tool) => tool.id);
       if (actualDockOrder.some((tool, index) => tool !== expectedDockOrder[index])) {
         ctx.addIssue({
-          code: z22.ZodIssueCode.custom,
+          code: z23.ZodIssueCode.custom,
           message: "dock tools must use canonical identity and order",
           path: ["dock", "tools"]
         });
@@ -3886,7 +3942,7 @@ var init_cohesion_fixture = __esm({
 });
 
 // packages/contracts/src/application-shell.ts
-import { z as z23 } from "zod";
+import { z as z24 } from "zod";
 function deepFreeze2(value) {
   if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
   for (const child of Object.values(value)) deepFreeze2(child);
@@ -4072,7 +4128,7 @@ var init_application_shell = __esm({
     init_pane_appearance();
     APPLICATION_SHELL_PROJECTION_VERSION = 1;
     APPLICATION_SHELL_TRACE_VERSION = 1;
-    ApplicationShellProjectionInputV1SchemaZ = z23.object({
+    ApplicationShellProjectionInputV1SchemaZ = z24.object({
       project: CohesionFixtureV1SchemaZ.shape.project,
       workspace: CohesionFixtureV1SchemaZ.shape.workspace,
       dock: CohesionFixtureV1SchemaZ.shape.dock,
@@ -4080,67 +4136,67 @@ var init_application_shell = __esm({
       connection: CohesionFixtureV1SchemaZ.shape.connection
     }).strict();
     WorkspaceFixtureSchemaZ = CohesionFixtureV1SchemaZ.shape.workspace;
-    ApplicationShellSurfaceProjectionSchemaZ = z23.object({
+    ApplicationShellSurfaceProjectionSchemaZ = z24.object({
       id: ProductSurfaceIdSchemaZ,
       icon: SemanticIconIdSchemaZ,
-      label: z23.string().min(1).max(160),
-      kind: z23.enum(["primary-mode", "dock-tool"]),
-      area: z23.enum(["workspace-canvas", "bottom-dock"]),
-      order: z23.number().int().nonnegative(),
+      label: z24.string().min(1).max(160),
+      kind: z24.enum(["primary-mode", "dock-tool"]),
+      area: z24.enum(["workspace-canvas", "bottom-dock"]),
+      order: z24.number().int().nonnegative(),
       owningMode: PrimaryWorkspaceModeIdSchemaZ,
-      shortcut: z23.string().min(1).max(32),
+      shortcut: z24.string().min(1).max(32),
       activation: SurfaceCommandTemplateSchemaZ,
-      active: z23.boolean(),
-      attention: z23.boolean(),
-      disabledReason: z23.string().min(1).max(240).nullable()
+      active: z24.boolean(),
+      attention: z24.boolean(),
+      disabledReason: z24.string().min(1).max(240).nullable()
     }).strict();
-    ApplicationShellProjectionV1SchemaZ = z23.object({
-      version: z23.literal(APPLICATION_SHELL_PROJECTION_VERSION),
+    ApplicationShellProjectionV1SchemaZ = z24.object({
+      version: z24.literal(APPLICATION_SHELL_PROJECTION_VERSION),
       project: CohesionFixtureV1SchemaZ.shape.project,
-      workspace: z23.object({
+      workspace: z24.object({
         id: SemanticProductIdSchemaZ,
-        name: z23.string().min(1).max(160)
+        name: z24.string().min(1).max(160)
       }).strict(),
-      sidebar: z23.object({
+      sidebar: z24.object({
         activeSessionId: SemanticProductIdSchemaZ,
         sessions: WorkspaceFixtureSchemaZ.shape.sidebar.shape.sessions,
         agents: WorkspaceFixtureSchemaZ.shape.sidebar.shape.agents
       }).strict(),
-      primaryNavigation: z23.object({
+      primaryNavigation: z24.object({
         activeMode: PrimaryWorkspaceModeIdSchemaZ,
-        items: z23.array(ApplicationShellSurfaceProjectionSchemaZ)
+        items: z24.array(ApplicationShellSurfaceProjectionSchemaZ)
       }).strict(),
-      workspaceCanvas: z23.object({ activeMode: PrimaryWorkspaceModeIdSchemaZ }).strict(),
-      bottomDock: z23.object({
+      workspaceCanvas: z24.object({ activeMode: PrimaryWorkspaceModeIdSchemaZ }).strict(),
+      bottomDock: z24.object({
         mode: ApplicationShellDockModeSchemaZ,
         activeTool: DockToolIdSchemaZ,
-        tools: z23.array(ApplicationShellSurfaceProjectionSchemaZ)
+        tools: z24.array(ApplicationShellSurfaceProjectionSchemaZ)
       }).strict(),
       statusStrip: CohesionFixtureV1SchemaZ.shape.connection,
-      focus: z23.object({
-        windowActivity: z23.enum(["active", "inactive"]),
+      focus: z24.object({
+        windowActivity: z24.enum(["active", "inactive"]),
         zone: FocusZoneSchemaZ,
         appFocusedPaneId: SemanticProductIdSchemaZ.nullable(),
         terminalInputPaneId: SemanticProductIdSchemaZ.nullable(),
         layoutSelectedPaneId: SemanticProductIdSchemaZ.nullable(),
-        overlays: z23.array(SemanticOverlaySchemaZ).max(16),
-        palette: z23.object({
-          open: z23.boolean(),
+        overlays: z24.array(SemanticOverlaySchemaZ).max(16),
+        palette: z24.object({
+          open: z24.boolean(),
           overlayId: SemanticProductIdSchemaZ.nullable(),
           focusReturnTarget: SemanticFocusTargetSchemaZ.nullable()
         }).strict()
       }).strict()
     }).strict();
-    ApplicationShellActivateModeArgumentsSchemaZ = z23.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict();
-    ApplicationShellActivateDockToolArgumentsSchemaZ = z23.object({ tool: DockToolIdSchemaZ }).strict();
-    ApplicationShellSetDockModeArgumentsSchemaZ = z23.object({ mode: ApplicationShellDockModeSchemaZ }).strict();
-    ApplicationShellMoveFocusArgumentsSchemaZ = z23.object({ target: SemanticFocusTargetSchemaZ }).strict();
-    ApplicationShellOpenPaletteArgumentsSchemaZ = z23.object({
+    ApplicationShellActivateModeArgumentsSchemaZ = z24.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict();
+    ApplicationShellActivateDockToolArgumentsSchemaZ = z24.object({ tool: DockToolIdSchemaZ }).strict();
+    ApplicationShellSetDockModeArgumentsSchemaZ = z24.object({ mode: ApplicationShellDockModeSchemaZ }).strict();
+    ApplicationShellMoveFocusArgumentsSchemaZ = z24.object({ target: SemanticFocusTargetSchemaZ }).strict();
+    ApplicationShellOpenPaletteArgumentsSchemaZ = z24.object({
       overlayId: SemanticProductIdSchemaZ,
       focusReturnTarget: SemanticFocusTargetSchemaZ
     }).strict();
-    ApplicationShellClosePaletteArgumentsSchemaZ = z23.object({ overlayId: SemanticProductIdSchemaZ }).strict();
-    ApplicationShellSelectResourceArgumentsSchemaZ = z23.object({
+    ApplicationShellClosePaletteArgumentsSchemaZ = z24.object({ overlayId: SemanticProductIdSchemaZ }).strict();
+    ApplicationShellSelectResourceArgumentsSchemaZ = z24.object({
       surface: ProductSurfaceIdSchemaZ,
       resourceId: SemanticProductIdSchemaZ
     }).strict();
@@ -4153,46 +4209,46 @@ var init_application_shell = __esm({
       [APPLICATION_SHELL_COMMAND_IDS.closePalette]: ApplicationShellClosePaletteArgumentsSchemaZ,
       [APPLICATION_SHELL_COMMAND_IDS.selectResource]: ApplicationShellSelectResourceArgumentsSchemaZ
     });
-    ApplicationShellCommandInvocationSchemaZ = z23.discriminatedUnion("id", [
-      z23.object({
-        version: z23.literal(COMMAND_PROTOCOL_VERSION),
-        id: z23.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
+    ApplicationShellCommandInvocationSchemaZ = z24.discriminatedUnion("id", [
+      z24.object({
+        version: z24.literal(COMMAND_PROTOCOL_VERSION),
+        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
         source: CommandSourceSchemaZ,
         args: ApplicationShellActivateModeArgumentsSchemaZ
       }).strict(),
-      z23.object({
-        version: z23.literal(COMMAND_PROTOCOL_VERSION),
-        id: z23.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
+      z24.object({
+        version: z24.literal(COMMAND_PROTOCOL_VERSION),
+        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
         source: CommandSourceSchemaZ,
         args: ApplicationShellActivateDockToolArgumentsSchemaZ
       }).strict(),
-      z23.object({
-        version: z23.literal(COMMAND_PROTOCOL_VERSION),
-        id: z23.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
+      z24.object({
+        version: z24.literal(COMMAND_PROTOCOL_VERSION),
+        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
         source: CommandSourceSchemaZ,
         args: ApplicationShellSetDockModeArgumentsSchemaZ
       }).strict(),
-      z23.object({
-        version: z23.literal(COMMAND_PROTOCOL_VERSION),
-        id: z23.literal(APPLICATION_SHELL_COMMAND_IDS.moveFocus),
+      z24.object({
+        version: z24.literal(COMMAND_PROTOCOL_VERSION),
+        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.moveFocus),
         source: CommandSourceSchemaZ,
         args: ApplicationShellMoveFocusArgumentsSchemaZ
       }).strict(),
-      z23.object({
-        version: z23.literal(COMMAND_PROTOCOL_VERSION),
-        id: z23.literal(APPLICATION_SHELL_COMMAND_IDS.openPalette),
+      z24.object({
+        version: z24.literal(COMMAND_PROTOCOL_VERSION),
+        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.openPalette),
         source: CommandSourceSchemaZ,
         args: ApplicationShellOpenPaletteArgumentsSchemaZ
       }).strict(),
-      z23.object({
-        version: z23.literal(COMMAND_PROTOCOL_VERSION),
-        id: z23.literal(APPLICATION_SHELL_COMMAND_IDS.closePalette),
+      z24.object({
+        version: z24.literal(COMMAND_PROTOCOL_VERSION),
+        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.closePalette),
         source: CommandSourceSchemaZ,
         args: ApplicationShellClosePaletteArgumentsSchemaZ
       }).strict(),
-      z23.object({
-        version: z23.literal(COMMAND_PROTOCOL_VERSION),
-        id: z23.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
+      z24.object({
+        version: z24.literal(COMMAND_PROTOCOL_VERSION),
+        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
         source: CommandSourceSchemaZ,
         args: ApplicationShellSelectResourceArgumentsSchemaZ
       }).strict()
@@ -4233,13 +4289,13 @@ var init_application_shell = __esm({
         })
       )
     );
-    ApplicationShellResourceSelectionSchemaZ = z23.object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ }).strict();
-    ApplicationShellReplayStateV1SchemaZ = z23.object({
+    ApplicationShellResourceSelectionSchemaZ = z24.object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ }).strict();
+    ApplicationShellReplayStateV1SchemaZ = z24.object({
       activeMode: PrimaryWorkspaceModeIdSchemaZ,
       dockMode: ApplicationShellDockModeSchemaZ,
       activeDockTool: DockToolIdSchemaZ,
       focus: FocusOverlayStateV1SchemaZ,
-      selectedResources: z23.array(ApplicationShellResourceSelectionSchemaZ)
+      selectedResources: z24.array(ApplicationShellResourceSelectionSchemaZ)
     }).strict().superRefine((state, ctx) => {
       const surfaces = state.selectedResources.map(({ surface }) => surface);
       if (new Set(surfaces).size !== surfaces.length) {
@@ -4250,10 +4306,10 @@ var init_application_shell = __esm({
         });
       }
     });
-    ApplicationShellActionTraceV1BaseSchemaZ = z23.object({
-      version: z23.literal(APPLICATION_SHELL_TRACE_VERSION),
+    ApplicationShellActionTraceV1BaseSchemaZ = z24.object({
+      version: z24.literal(APPLICATION_SHELL_TRACE_VERSION),
       initialState: ApplicationShellReplayStateV1SchemaZ,
-      invocations: z23.array(ApplicationShellCommandInvocationSchemaZ),
+      invocations: z24.array(ApplicationShellCommandInvocationSchemaZ),
       finalState: ApplicationShellReplayStateV1SchemaZ
     }).strict();
     ApplicationShellActionTraceV1SchemaZ = ApplicationShellActionTraceV1BaseSchemaZ.superRefine((trace, ctx) => {
@@ -4274,6 +4330,23 @@ var init_application_shell = __esm({
         });
       }
     });
+  }
+});
+
+// packages/contracts/src/application-shell-resource.ts
+import { z as z25 } from "zod";
+var APPLICATION_SHELL_RESOURCE_VERSION, ApplicationShellResourceV1SchemaZ;
+var init_application_shell_resource = __esm({
+  "packages/contracts/src/application-shell-resource.ts"() {
+    "use strict";
+    init_application_shell();
+    init_daemon_wire();
+    APPLICATION_SHELL_RESOURCE_VERSION = 1;
+    ApplicationShellResourceV1SchemaZ = z25.object({
+      version: z25.literal(APPLICATION_SHELL_RESOURCE_VERSION),
+      daemon: DaemonInstanceIdentitySchemaZ,
+      resource: ApplicationShellProjectionInputV1SchemaZ
+    }).strict();
   }
 });
 
@@ -4379,53 +4452,8 @@ var init_visual_recipes = __esm({
   }
 });
 
-// packages/contracts/src/daemon-wire.ts
-import { z as z24 } from "zod";
-function isDaemonWireProtocolCompatible(protocolVersion) {
-  return protocolVersion === DAEMON_WIRE_PROTOCOL_VERSION;
-}
-var DAEMON_WIRE_PROTOCOL_VERSION, DaemonWireProtocolVersionSchema, DaemonInstanceIdSchema, CanonicalDaemonInfoSchema, DaemonHealthSchema, DaemonHealthzSchema, DaemonIdentitySchema;
-var init_daemon_wire = __esm({
-  "packages/contracts/src/daemon-wire.ts"() {
-    "use strict";
-    DAEMON_WIRE_PROTOCOL_VERSION = 1;
-    DaemonWireProtocolVersionSchema = z24.number().int().positive();
-    DaemonInstanceIdSchema = z24.uuid();
-    CanonicalDaemonInfoSchema = z24.object({
-      pid: z24.number().int().positive(),
-      port: z24.number().int().min(1).max(65535),
-      protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z24.string().trim().min(1),
-      instanceId: DaemonInstanceIdSchema,
-      startedAt: z24.iso.datetime({ offset: true }),
-      bindHostname: z24.string().trim().min(1),
-      authToken: z24.string().min(1).nullable()
-    });
-    DaemonHealthSchema = z24.object({
-      ok: z24.literal(true),
-      protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z24.string().trim().min(1),
-      uptime: z24.number().nonnegative()
-    });
-    DaemonHealthzSchema = z24.object({
-      ok: z24.literal(true),
-      protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z24.string().trim().min(1),
-      uptimeMs: z24.number().nonnegative()
-    });
-    DaemonIdentitySchema = z24.object({
-      ok: z24.literal(true),
-      pid: z24.number().int().positive(),
-      protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z24.string().trim().min(1),
-      instanceId: DaemonInstanceIdSchema,
-      startedAt: z24.iso.datetime({ offset: true })
-    });
-  }
-});
-
 // packages/contracts/src/daemon-resources.ts
-import { z as z25 } from "zod";
+import { z as z26 } from "zod";
 var DaemonSessionOverviewSchemaZ, DaemonPaneInfoSchemaZ, DaemonSessionsResponseSchemaZ, DaemonProjectResponseSchemaZ, DaemonPanesResponseSchemaZ, DaemonWorkspaceSchemaZ, DaemonWorkspacesResponseSchemaZ, DaemonWorkspaceResponseSchemaZ, DaemonRegisteredProjectSchemaZ, DaemonProjectsResponseSchemaZ, DaemonRegisteredProjectResponseSchemaZ, DaemonProjectTemplateSchemaZ, DaemonProjectTemplatesResponseSchemaZ;
 var init_daemon_resources = __esm({
   "packages/contracts/src/daemon-resources.ts"() {
@@ -4434,129 +4462,131 @@ var init_daemon_resources = __esm({
     init_workspace();
     DaemonSessionOverviewSchemaZ = SessionOverviewSchemaZ.strict();
     DaemonPaneInfoSchemaZ = PaneInfoSchemaZ.strict();
-    DaemonSessionsResponseSchemaZ = z25.object({
-      sessions: z25.array(DaemonSessionOverviewSchemaZ)
+    DaemonSessionsResponseSchemaZ = z26.object({
+      sessions: z26.array(DaemonSessionOverviewSchemaZ)
     }).strict();
-    DaemonProjectResponseSchemaZ = z25.object({
-      session: z25.string(),
-      dir: z25.string(),
-      panes: z25.array(DaemonPaneInfoSchemaZ)
+    DaemonProjectResponseSchemaZ = z26.object({
+      session: z26.string(),
+      dir: z26.string(),
+      panes: z26.array(DaemonPaneInfoSchemaZ)
     }).strict();
-    DaemonPanesResponseSchemaZ = z25.object({
-      panes: z25.array(DaemonPaneInfoSchemaZ)
+    DaemonPanesResponseSchemaZ = z26.object({
+      panes: z26.array(DaemonPaneInfoSchemaZ)
     }).strict();
     DaemonWorkspaceSchemaZ = WorkspaceSchemaZ.strict();
-    DaemonWorkspacesResponseSchemaZ = z25.object({
-      workspaces: z25.array(DaemonWorkspaceSchemaZ)
+    DaemonWorkspacesResponseSchemaZ = z26.object({
+      workspaces: z26.array(DaemonWorkspaceSchemaZ)
     }).strict();
-    DaemonWorkspaceResponseSchemaZ = z25.object({
+    DaemonWorkspaceResponseSchemaZ = z26.object({
       workspace: DaemonWorkspaceSchemaZ
     }).strict();
-    DaemonRegisteredProjectSchemaZ = z25.object({
-      name: z25.string(),
-      dir: z25.string(),
-      hasIdeYml: z25.boolean(),
-      hasWorkspaceConfig: z25.boolean().optional(),
-      configKind: z25.enum(["workspace", "legacy", "none"]).optional(),
-      configPath: z25.string().nullable().optional(),
-      ideConfigPath: z25.string().nullable().optional(),
-      gitOrigin: z25.string().nullable(),
-      gitBranch: z25.string().nullable(),
-      registeredAt: z25.string()
+    DaemonRegisteredProjectSchemaZ = z26.object({
+      name: z26.string(),
+      dir: z26.string(),
+      hasIdeYml: z26.boolean(),
+      hasWorkspaceConfig: z26.boolean().optional(),
+      configKind: z26.enum(["workspace", "legacy", "none"]).optional(),
+      configPath: z26.string().nullable().optional(),
+      ideConfigPath: z26.string().nullable().optional(),
+      gitOrigin: z26.string().nullable(),
+      gitBranch: z26.string().nullable(),
+      registeredAt: z26.string()
     }).strict();
-    DaemonProjectsResponseSchemaZ = z25.object({
-      projects: z25.array(DaemonRegisteredProjectSchemaZ)
+    DaemonProjectsResponseSchemaZ = z26.object({
+      projects: z26.array(DaemonRegisteredProjectSchemaZ)
     }).strict();
-    DaemonRegisteredProjectResponseSchemaZ = z25.object({
+    DaemonRegisteredProjectResponseSchemaZ = z26.object({
       project: DaemonRegisteredProjectSchemaZ
     }).strict();
-    DaemonProjectTemplateSchemaZ = z25.object({
-      id: z25.string(),
-      label: z25.string(),
-      description: z25.string()
+    DaemonProjectTemplateSchemaZ = z26.object({
+      id: z26.string(),
+      label: z26.string(),
+      description: z26.string()
     }).strict();
-    DaemonProjectTemplatesResponseSchemaZ = z25.object({
-      templates: z25.array(DaemonProjectTemplateSchemaZ)
+    DaemonProjectTemplatesResponseSchemaZ = z26.object({
+      templates: z26.array(DaemonProjectTemplateSchemaZ)
     }).strict();
   }
 });
 
 // packages/contracts/src/daemon-events.ts
-import { z as z26 } from "zod";
+import { z as z27 } from "zod";
 var SessionNamesSchemaZ, DaemonEventSubscribeFrameSchemaZ, DaemonEventUnsubscribeFrameSchemaZ, DaemonEventPingFrameSchemaZ, DaemonEventClientFrameSchemaZ, DaemonSessionSnapshotSchemaZ, DaemonEventHelloFrameSchemaZ, DaemonEventSnapshotFrameSchemaZ, DaemonEventSessionsChangedFrameSchemaZ, DaemonEventProjectsChangedFrameSchemaZ, DaemonEventInitOutputFrameSchemaZ, DaemonEventInitErrorFrameSchemaZ, DaemonEventPongFrameSchemaZ, DaemonEventActionCompleteFrameSchemaZ, DaemonEventConfigChangedFrameSchemaZ, DaemonEventTerminalsChangedFrameSchemaZ, DaemonEventWorkspaceAddedFrameSchemaZ, DaemonEventWorkspaceRemovedFrameSchemaZ, DaemonEventProtocolErrorCodeSchemaZ, DaemonEventProtocolErrorFrameSchemaZ, DaemonEventServerFrameSchemaZ;
 var init_daemon_events = __esm({
   "packages/contracts/src/daemon-events.ts"() {
     "use strict";
     init_daemon_resources();
-    SessionNamesSchemaZ = z26.array(z26.string());
-    DaemonEventSubscribeFrameSchemaZ = z26.object({
-      type: z26.literal("subscribe"),
+    init_daemon_wire();
+    SessionNamesSchemaZ = z27.array(z27.string());
+    DaemonEventSubscribeFrameSchemaZ = z27.object({
+      type: z27.literal("subscribe"),
       sessions: SessionNamesSchemaZ
     }).strict();
-    DaemonEventUnsubscribeFrameSchemaZ = z26.object({
-      type: z26.literal("unsubscribe"),
+    DaemonEventUnsubscribeFrameSchemaZ = z27.object({
+      type: z27.literal("unsubscribe"),
       sessions: SessionNamesSchemaZ
     }).strict();
-    DaemonEventPingFrameSchemaZ = z26.object({ type: z26.literal("ping") }).strict();
-    DaemonEventClientFrameSchemaZ = z26.discriminatedUnion("type", [
+    DaemonEventPingFrameSchemaZ = z27.object({ type: z27.literal("ping") }).strict();
+    DaemonEventClientFrameSchemaZ = z27.discriminatedUnion("type", [
       DaemonEventSubscribeFrameSchemaZ,
       DaemonEventUnsubscribeFrameSchemaZ,
       DaemonEventPingFrameSchemaZ
     ]);
-    DaemonSessionSnapshotSchemaZ = z26.object({
+    DaemonSessionSnapshotSchemaZ = z27.object({
       project: DaemonProjectResponseSchemaZ
     }).strict();
-    DaemonEventHelloFrameSchemaZ = z26.object({
-      type: z26.literal("hello"),
-      sessions: z26.array(DaemonSessionOverviewSchemaZ)
+    DaemonEventHelloFrameSchemaZ = z27.object({
+      type: z27.literal("hello"),
+      daemon: DaemonInstanceIdentitySchemaZ,
+      sessions: z27.array(DaemonSessionOverviewSchemaZ)
     }).strict();
-    DaemonEventSnapshotFrameSchemaZ = z26.object({
-      type: z26.literal("snapshot"),
-      sessionName: z26.string(),
+    DaemonEventSnapshotFrameSchemaZ = z27.object({
+      type: z27.literal("snapshot"),
+      sessionName: z27.string(),
       data: DaemonSessionSnapshotSchemaZ
     }).strict();
-    DaemonEventSessionsChangedFrameSchemaZ = z26.object({ type: z26.literal("sessions.changed") }).strict();
-    DaemonEventProjectsChangedFrameSchemaZ = z26.object({ type: z26.literal("projects.changed") }).strict();
-    DaemonEventInitOutputFrameSchemaZ = z26.object({
-      type: z26.literal("init.output"),
-      jobId: z26.string(),
-      chunk: z26.string(),
-      done: z26.boolean().optional()
+    DaemonEventSessionsChangedFrameSchemaZ = z27.object({ type: z27.literal("sessions.changed") }).strict();
+    DaemonEventProjectsChangedFrameSchemaZ = z27.object({ type: z27.literal("projects.changed") }).strict();
+    DaemonEventInitOutputFrameSchemaZ = z27.object({
+      type: z27.literal("init.output"),
+      jobId: z27.string(),
+      chunk: z27.string(),
+      done: z27.boolean().optional()
     }).strict();
-    DaemonEventInitErrorFrameSchemaZ = z26.object({
-      type: z26.literal("init.error"),
-      jobId: z26.string(),
-      message: z26.string()
+    DaemonEventInitErrorFrameSchemaZ = z27.object({
+      type: z27.literal("init.error"),
+      jobId: z27.string(),
+      message: z27.string()
     }).strict();
-    DaemonEventPongFrameSchemaZ = z26.object({ type: z26.literal("pong") }).strict();
-    DaemonEventActionCompleteFrameSchemaZ = z26.object({
-      type: z26.literal("action.complete"),
-      name: z26.string(),
-      result: z26.unknown()
+    DaemonEventPongFrameSchemaZ = z27.object({ type: z27.literal("pong") }).strict();
+    DaemonEventActionCompleteFrameSchemaZ = z27.object({
+      type: z27.literal("action.complete"),
+      name: z27.string(),
+      result: z27.unknown()
     }).strict();
-    DaemonEventConfigChangedFrameSchemaZ = z26.object({
-      type: z26.literal("config.changed"),
-      sessionName: z26.string()
+    DaemonEventConfigChangedFrameSchemaZ = z27.object({
+      type: z27.literal("config.changed"),
+      sessionName: z27.string()
     }).strict();
-    DaemonEventTerminalsChangedFrameSchemaZ = z26.object({
-      type: z26.literal("terminals.changed"),
-      sessionName: z26.string()
+    DaemonEventTerminalsChangedFrameSchemaZ = z27.object({
+      type: z27.literal("terminals.changed"),
+      sessionName: z27.string()
     }).strict();
-    DaemonEventWorkspaceAddedFrameSchemaZ = z26.object({
-      type: z26.literal("workspace.added"),
+    DaemonEventWorkspaceAddedFrameSchemaZ = z27.object({
+      type: z27.literal("workspace.added"),
       workspace: DaemonWorkspaceSchemaZ
     }).strict();
-    DaemonEventWorkspaceRemovedFrameSchemaZ = z26.object({
-      type: z26.literal("workspace.removed"),
-      name: z26.string()
+    DaemonEventWorkspaceRemovedFrameSchemaZ = z27.object({
+      type: z27.literal("workspace.removed"),
+      name: z27.string()
     }).strict();
-    DaemonEventProtocolErrorCodeSchemaZ = z26.enum(["invalid-json", "invalid-frame"]);
-    DaemonEventProtocolErrorFrameSchemaZ = z26.object({
-      type: z26.literal("protocol.error"),
+    DaemonEventProtocolErrorCodeSchemaZ = z27.enum(["invalid-json", "invalid-frame"]);
+    DaemonEventProtocolErrorFrameSchemaZ = z27.object({
+      type: z27.literal("protocol.error"),
       code: DaemonEventProtocolErrorCodeSchemaZ,
-      message: z26.string()
+      message: z27.string()
     }).strict();
-    DaemonEventServerFrameSchemaZ = z26.discriminatedUnion("type", [
+    DaemonEventServerFrameSchemaZ = z27.discriminatedUnion("type", [
       DaemonEventHelloFrameSchemaZ,
       DaemonEventSnapshotFrameSchemaZ,
       DaemonEventSessionsChangedFrameSchemaZ,
@@ -4598,6 +4628,7 @@ var init_src = __esm({
     init_experience_identifiers();
     init_experience_shell();
     init_application_shell();
+    init_application_shell_resource();
     init_visual_tokens();
     init_visual_recipes();
     init_pane_appearance();
@@ -9805,20 +9836,20 @@ var init_session_id = __esm({
 });
 
 // packages/daemon/src/schemas/registry.ts
-import { z as z27 } from "zod";
+import { z as z28 } from "zod";
 var RegisteredProjectSchemaZ, RegisterProjectRequestSchemaZ, InitProjectRequestSchemaZ;
 var init_registry = __esm({
   "packages/daemon/src/schemas/registry.ts"() {
     "use strict";
     init_src();
     RegisteredProjectSchemaZ = DaemonRegisteredProjectSchemaZ;
-    RegisterProjectRequestSchemaZ = z27.object({
-      dir: z27.string().min(1),
-      name: z27.string().min(1).optional()
+    RegisterProjectRequestSchemaZ = z28.object({
+      dir: z28.string().min(1),
+      name: z28.string().min(1).optional()
     });
-    InitProjectRequestSchemaZ = z27.object({
-      dir: z27.string().min(1),
-      template: z27.string().min(1).optional()
+    InitProjectRequestSchemaZ = z28.object({
+      dir: z28.string().min(1),
+      template: z28.string().min(1).optional()
     });
   }
 });
@@ -9880,7 +9911,7 @@ import { EventEmitter } from "node:events";
 import { existsSync as existsSync15, mkdirSync as mkdirSync9, readFileSync as readFileSync11, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir10 } from "node:os";
 import { dirname as dirname15, isAbsolute as isAbsolute3, join as join14, resolve as resolve11 } from "node:path";
-import { z as z28 } from "zod";
+import { z as z29 } from "zod";
 function applyAction(state, action) {
   switch (action.type) {
     case "register":
@@ -10019,9 +10050,9 @@ var init_project_registry = __esm({
     init_registry();
     init_project_probe();
     REGISTRY_DIR_ENV = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ = z28.object({
-      version: z28.literal(1),
-      projects: z28.array(RegisteredProjectSchemaZ)
+    RegistryFileSchemaZ = z29.object({
+      version: z29.literal(1),
+      projects: z29.array(RegisteredProjectSchemaZ)
     });
     ProjectRegistryError = class extends Error {
       code;
@@ -10793,7 +10824,7 @@ var init_notify_state = __esm({
 import { existsSync as existsSync19, mkdirSync as mkdirSync12, readFileSync as readFileSync14, renameSync as renameSync7, writeFileSync as writeFileSync11 } from "node:fs";
 import { homedir as homedir12 } from "node:os";
 import { dirname as dirname17, join as join18 } from "node:path";
-import { z as z29 } from "zod";
+import { z as z30 } from "zod";
 function isBareShell(cmd) {
   return /^-?(zsh|bash|sh|fish|dash|ksh|tcsh|csh|nu)$/.test(cmd.trim());
 }
@@ -10965,32 +10996,32 @@ var init_snapshot2 = __esm({
     init_src2();
     init_process_tree();
     init_sessions2();
-    PaneSnapshotSchemaZ = z29.object({
-      index: z29.number(),
-      cwd: z29.string(),
-      command: z29.string().nullable(),
-      agent: z29.string().nullable(),
-      agentSessionId: z29.string().nullable(),
-      agentState: z29.string().nullable(),
-      title: z29.string()
+    PaneSnapshotSchemaZ = z30.object({
+      index: z30.number(),
+      cwd: z30.string(),
+      command: z30.string().nullable(),
+      agent: z30.string().nullable(),
+      agentSessionId: z30.string().nullable(),
+      agentState: z30.string().nullable(),
+      title: z30.string()
     });
-    WindowSnapshotSchemaZ = z29.object({
-      index: z29.number(),
-      name: z29.string(),
-      active: z29.boolean(),
-      layout: z29.string(),
-      panes: z29.array(PaneSnapshotSchemaZ)
+    WindowSnapshotSchemaZ = z30.object({
+      index: z30.number(),
+      name: z30.string(),
+      active: z30.boolean(),
+      layout: z30.string(),
+      panes: z30.array(PaneSnapshotSchemaZ)
     });
-    SessionSnapshotSchemaZ = z29.object({
-      name: z29.string(),
-      cwd: z29.string(),
-      adopted: z29.boolean(),
-      windows: z29.array(WindowSnapshotSchemaZ)
+    SessionSnapshotSchemaZ = z30.object({
+      name: z30.string(),
+      cwd: z30.string(),
+      adopted: z30.boolean(),
+      windows: z30.array(WindowSnapshotSchemaZ)
     });
-    FleetSnapshotSchemaZ = z29.object({
-      version: z29.literal(1),
-      savedAt: z29.string(),
-      sessions: z29.array(SessionSnapshotSchemaZ)
+    FleetSnapshotSchemaZ = z30.object({
+      version: z30.literal(1),
+      savedAt: z30.string(),
+      sessions: z30.array(SessionSnapshotSchemaZ)
     });
     SNAPSHOT_PANE_FORMAT = [
       "#{session_name}",
@@ -14023,7 +14054,7 @@ import { EventEmitter as EventEmitter3 } from "node:events";
 import { existsSync as existsSync26, mkdirSync as mkdirSync17, readFileSync as readFileSync20, renameSync as renameSync9, writeFileSync as writeFileSync16 } from "node:fs";
 import { homedir as homedir16 } from "node:os";
 import { dirname as dirname24, join as join24 } from "node:path";
-import { z as z30 } from "zod";
+import { z as z31 } from "zod";
 function getDefaultWorkspaceRegistry() {
   if (!_default) _default = new WorkspaceRegistry();
   return _default;
@@ -14046,9 +14077,9 @@ var init_workspace_registry = __esm({
     "use strict";
     init_src();
     REGISTRY_DIR_ENV3 = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ2 = z30.object({
-      version: z30.literal(1),
-      workspaces: z30.array(WorkspaceSchemaZ)
+    RegistryFileSchemaZ2 = z31.object({
+      version: z31.literal(1),
+      workspaces: z31.array(WorkspaceSchemaZ)
     });
     WorkspaceAlreadyExistsError = class extends Error {
       code = "ALREADY_EXISTS";
@@ -14318,7 +14349,7 @@ function buildSessionSnapshot(sessionName) {
   if (!session) return null;
   return { project: buildProjectDetail(session) };
 }
-function handleWsEventsConnection(socket) {
+function handleWsEventsConnection(socket, daemonIdentity) {
   const ws = socket;
   const subscriptions = /* @__PURE__ */ new Set();
   let closed = false;
@@ -14441,9 +14472,9 @@ function handleWsEventsConnection(socket) {
   ws.on("error", cleanup);
   try {
     const sessions = discoverSessions();
-    send2({ type: "hello", sessions: buildOverviews(sessions) });
+    send2({ type: "hello", daemon: daemonIdentity, sessions: buildOverviews(sessions) });
   } catch {
-    send2({ type: "hello", sessions: [] });
+    send2({ type: "hello", daemon: daemonIdentity, sessions: [] });
   }
 }
 var WS_OPEN2, KEEPALIVE_INTERVAL_MS, SESSIONS_POLL_MS, allClients, sessionsPollTimer, lastSessionsHash, projectRegistryListener;
@@ -14893,74 +14924,74 @@ var init_log = __esm({
 });
 
 // packages/daemon/src/command-center/schemas.ts
-import { z as z31 } from "zod";
+import { z as z32 } from "zod";
 var updateTaskSchema, createTaskSchema, savePlanSchema, savePlanContentSchema, sendCommandSchema, createMilestoneSchema, updateMilestoneSchema, updateAssertionSchema, triggerResearchSchema, launchSchema, stopSchema, skillNameRegex, createSkillSchema, updateSkillSchema;
 var init_schemas = __esm({
   "packages/daemon/src/command-center/schemas.ts"() {
     "use strict";
-    updateTaskSchema = z31.object({
-      status: z31.enum(["todo", "in-progress", "review", "done"]).optional(),
-      assignee: z31.string().optional(),
-      title: z31.string().optional(),
-      description: z31.string().optional(),
-      priority: z31.number().optional()
+    updateTaskSchema = z32.object({
+      status: z32.enum(["todo", "in-progress", "review", "done"]).optional(),
+      assignee: z32.string().optional(),
+      title: z32.string().optional(),
+      description: z32.string().optional(),
+      priority: z32.number().optional()
     });
-    createTaskSchema = z31.object({
-      title: z31.string().trim().min(1, "Title is required"),
-      description: z31.string().optional(),
-      priority: z31.number().optional(),
-      goal: z31.string().optional(),
-      tags: z31.array(z31.string()).optional()
+    createTaskSchema = z32.object({
+      title: z32.string().trim().min(1, "Title is required"),
+      description: z32.string().optional(),
+      priority: z32.number().optional(),
+      goal: z32.string().optional(),
+      tags: z32.array(z32.string()).optional()
     });
-    savePlanSchema = z31.object({
-      content: z31.string().max(1e6, "Plan content is too large")
+    savePlanSchema = z32.object({
+      content: z32.string().max(1e6, "Plan content is too large")
     });
-    savePlanContentSchema = z31.object({
-      content: z31.string().max(1e6, "Plan content is too large")
+    savePlanContentSchema = z32.object({
+      content: z32.string().max(1e6, "Plan content is too large")
     });
-    sendCommandSchema = z31.object({
-      target: z31.string().min(1, "Target pane is required"),
-      message: z31.string().min(1, "Message is required"),
-      noEnter: z31.boolean().optional()
+    sendCommandSchema = z32.object({
+      target: z32.string().min(1, "Target pane is required"),
+      message: z32.string().min(1, "Message is required"),
+      noEnter: z32.boolean().optional()
     });
-    createMilestoneSchema = z31.object({
-      title: z31.string().trim().min(1, "Title is required"),
-      sequence: z31.number().int().positive(),
-      description: z31.string().optional()
+    createMilestoneSchema = z32.object({
+      title: z32.string().trim().min(1, "Title is required"),
+      sequence: z32.number().int().positive(),
+      description: z32.string().optional()
     });
-    updateMilestoneSchema = z31.object({
-      status: z31.enum(["locked", "active", "done", "validating"]).optional(),
-      title: z31.string().optional(),
-      description: z31.string().optional()
+    updateMilestoneSchema = z32.object({
+      status: z32.enum(["locked", "active", "done", "validating"]).optional(),
+      title: z32.string().optional(),
+      description: z32.string().optional()
     });
-    updateAssertionSchema = z31.object({
-      status: z31.enum(["pending", "passing", "failing", "blocked"]),
-      evidence: z31.string().optional(),
-      verifiedBy: z31.string().optional()
+    updateAssertionSchema = z32.object({
+      status: z32.enum(["pending", "passing", "failing", "blocked"]),
+      evidence: z32.string().optional(),
+      verifiedBy: z32.string().optional()
     });
-    triggerResearchSchema = z31.object({
-      type: z31.string().trim().min(1, "Research type is required")
+    triggerResearchSchema = z32.object({
+      type: z32.string().trim().min(1, "Research type is required")
     });
-    launchSchema = z31.object({
-      attach: z31.boolean().optional()
+    launchSchema = z32.object({
+      attach: z32.boolean().optional()
     }).optional();
-    stopSchema = z31.object({}).optional();
+    stopSchema = z32.object({}).optional();
     skillNameRegex = /^[A-Za-z0-9._ -]+$/;
-    createSkillSchema = z31.object({
-      name: z31.string().trim().min(1, "Skill name is required").regex(
+    createSkillSchema = z32.object({
+      name: z32.string().trim().min(1, "Skill name is required").regex(
         skillNameRegex,
         "Skill name may only contain letters, digits, dot, dash, underscore, or space"
       ),
-      role: z31.string().trim().optional(),
-      description: z31.string().optional(),
-      specialties: z31.array(z31.string()).optional(),
-      body: z31.string().optional()
+      role: z32.string().trim().optional(),
+      description: z32.string().optional(),
+      specialties: z32.array(z32.string()).optional(),
+      body: z32.string().optional()
     });
-    updateSkillSchema = z31.object({
-      role: z31.string().trim().optional(),
-      description: z31.string().optional(),
-      specialties: z31.array(z31.string()).optional(),
-      body: z31.string().optional()
+    updateSkillSchema = z32.object({
+      role: z32.string().trim().optional(),
+      description: z32.string().optional(),
+      specialties: z32.array(z32.string()).optional(),
+      body: z32.string().optional()
     });
   }
 });
@@ -16205,64 +16236,64 @@ var init_project_init_runner = __esm({
 });
 
 // packages/daemon/src/schemas/inspect.ts
-import { z as z32 } from "zod";
+import { z as z33 } from "zod";
 var ProjectInspectDetectedSchemaZ, ProjectInspectSchemaZ, InspectFilesystemRequestSchemaZ, OnboardProjectRequestSchemaZ;
 var init_inspect = __esm({
   "packages/daemon/src/schemas/inspect.ts"() {
     "use strict";
-    ProjectInspectDetectedSchemaZ = z32.object({
+    ProjectInspectDetectedSchemaZ = z33.object({
       /** Detected package manager from lockfile, or `null`. */
-      packageManager: z32.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
+      packageManager: z33.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
       /** Detected frameworks (e.g. `["next", "convex"]`). Empty array when none. */
-      frameworks: z32.array(z32.string()),
+      frameworks: z33.array(z33.string()),
       /** Suggested dev command (e.g. `pnpm dev`). `null` if no dev script found. */
-      devCommand: z32.string().nullable(),
+      devCommand: z33.string().nullable(),
       /** Suggested test command (e.g. `pnpm test`). `null` if no test script found. */
-      testCommand: z32.string().nullable()
+      testCommand: z33.string().nullable()
     });
-    ProjectInspectSchemaZ = z32.object({
+    ProjectInspectSchemaZ = z33.object({
       /** Sanitized basename of the directory — safe to use as a tmux session name. */
-      name: z32.string(),
+      name: z33.string(),
       /** Absolute, canonical path to the directory. */
-      dir: z32.string(),
+      dir: z33.string(),
       /** Whether `<dir>/ide.yml` exists. Legacy compatibility fact. */
-      hasIdeYml: z32.boolean(),
+      hasIdeYml: z33.boolean(),
       /** Whether `.tmux-ide/workspace.yml` exists or wins discovery. */
-      hasWorkspaceConfig: z32.boolean().optional(),
+      hasWorkspaceConfig: z33.boolean().optional(),
       /** Generalized winning config kind. Added without replacing `hasIdeYml`. */
-      configKind: z32.enum(["workspace", "legacy", "none"]).optional(),
+      configKind: z33.enum(["workspace", "legacy", "none"]).optional(),
       /** Generalized winning config path. Added without replacing legacy path facts. */
-      configPath: z32.string().nullable().optional(),
+      configPath: z33.string().nullable().optional(),
       /** Legacy config path when an `ide.yml` is present. */
-      ideConfigPath: z32.string().nullable().optional(),
+      ideConfigPath: z33.string().nullable().optional(),
       /** Git remote origin URL, or `null` if not a git repo / no origin / probe failed. */
-      gitOrigin: z32.string().nullable(),
+      gitOrigin: z33.string().nullable(),
       /** Current git branch, or `null` if not a git repo / detached HEAD / probe failed. */
-      gitBranch: z32.string().nullable(),
+      gitBranch: z33.string().nullable(),
       /** Detected stack signals (reuses `tmux-ide detect` logic). */
       detected: ProjectInspectDetectedSchemaZ
     });
-    InspectFilesystemRequestSchemaZ = z32.object({
-      dir: z32.string().min(1)
+    InspectFilesystemRequestSchemaZ = z33.object({
+      dir: z33.string().min(1)
     });
-    OnboardProjectRequestSchemaZ = z32.object({
-      dir: z32.string().min(1),
+    OnboardProjectRequestSchemaZ = z33.object({
+      dir: z33.string().min(1),
       /** Optional override for the project name — defaults to inspect.name. */
-      name: z32.string().min(1).optional(),
+      name: z33.string().min(1).optional(),
       /** 1, 2, or 3 — how many Claude panes to scaffold in the top row. */
-      agents: z32.number().int().min(1).max(3),
+      agents: z33.number().int().min(1).max(3),
       /**
        * Optional per-agent pane titles. When provided, length must equal
        * `agents`; the server uses these as `title:` for the Claude panes
        * instead of the canonical `Lead`/`Teammate N`/`Claude N` defaults.
        */
-      agentNames: z32.array(z32.string().min(1)).optional(),
+      agentNames: z33.array(z33.string().min(1)).optional(),
       /** Dev server command (e.g. `pnpm dev`). Omit / null to skip the dev pane. */
-      devCommand: z32.string().min(1).nullable().optional(),
+      devCommand: z33.string().min(1).nullable().optional(),
       /** Test command (e.g. `pnpm test`). Currently informational; stored for later. */
-      testCommand: z32.string().min(1).nullable().optional(),
+      testCommand: z33.string().min(1).nullable().optional(),
       /** Lint command (e.g. `pnpm lint`). Currently informational; stored for later. */
-      lintCommand: z32.string().min(1).nullable().optional()
+      lintCommand: z33.string().min(1).nullable().optional()
     });
   }
 });
@@ -16773,6 +16804,10 @@ function createApp(options = {}) {
     instanceId: randomUUID4(),
     startedAt: (/* @__PURE__ */ new Date()).toISOString()
   };
+  const daemonInstanceIdentity = DaemonInstanceIdentitySchemaZ.parse({
+    protocolVersion: DAEMON_WIRE_PROTOCOL_VERSION,
+    ...daemonIdentity
+  });
   const healthBootedAt = Date.now();
   const app = new Hono();
   app.use("/*", cors());
@@ -16931,7 +16966,11 @@ function createApp(options = {}) {
     const name = c.req.param("name");
     const session = discoverSessions().find((candidate) => candidate.name === name);
     if (!session) return c.json({ error: "Session not found" }, 404);
-    return c.json(projectApplicationShellResource(session));
+    return c.json({
+      version: APPLICATION_SHELL_RESOURCE_VERSION,
+      daemon: daemonInstanceIdentity,
+      resource: projectApplicationShellResource(session)
+    });
   });
   app.get("/api/project/:name/panes", (c) => {
     const name = c.req.param("name");
@@ -17598,14 +17637,14 @@ function listAvailableTemplates() {
     };
   }).sort((a, b) => a.id.localeCompare(b.id));
 }
-function attachWsEvents(server) {
+function attachWsEvents(server, daemonIdentity) {
   const wss = new WebSocketServer({ noServer: true });
   const upgradeListener = (req, socket, head3) => {
     const url = req.url ?? "/";
     const pathname = url.split("?")[0];
     if (pathname !== "/ws/events") return;
     wss.handleUpgrade(req, socket, head3, (ws) => {
-      handleWsEventsConnection(ws);
+      handleWsEventsConnection(ws, daemonIdentity);
     });
   };
   server.on("upgrade", upgradeListener);
@@ -17809,7 +17848,7 @@ function rejectUpgradeWithPolicy(wss, req, socket, head3) {
     ws.close(1008, "Remote access token required");
   });
 }
-function attachWebSockets(server, opts = {}) {
+function attachWebSockets(server, opts) {
   const eventsWss = new WebSocketServer2({ noServer: true });
   const ptyWss = new WebSocketServer2({ noServer: true });
   const clients = /* @__PURE__ */ new Set();
@@ -17827,7 +17866,7 @@ function attachWebSockets(server, opts = {}) {
     if (pathname === "/ws/events") {
       eventsWss.handleUpgrade(req, socket, head3, (ws) => {
         track(ws);
-        handleWsEventsConnection(ws);
+        handleWsEventsConnection(ws, opts.daemonIdentity);
       });
       return;
     }
@@ -18078,7 +18117,11 @@ async function startHttpServer({
   const { closeClients, closeServers: closeWsServers } = attachWebSockets(server, {
     authToken,
     localBypassToken,
-    bindHostname
+    bindHostname,
+    daemonIdentity: DaemonInstanceIdentitySchemaZ.parse({
+      protocolVersion: DAEMON_WIRE_PROTOCOL_VERSION,
+      ...daemonIdentity
+    })
   });
   await new Promise((resolve29, reject) => {
     const onError = (err) => {
@@ -18422,7 +18465,7 @@ var init_daemon_embed = __esm({
 
 // packages/daemon/src/lib/cli-action-bridge.ts
 import { createRequire as createRequire3 } from "node:module";
-import { z as z33 } from "zod";
+import { z as z34 } from "zod";
 function timeoutSignal3(ms) {
   const controller = new AbortController();
   setTimeout(() => controller.abort(), ms).unref?.();
@@ -18521,7 +18564,7 @@ async function tryDispatchAction(name, input, options = {}) {
       details: failure.data.error.details
     });
   }
-  const success = z33.object({ ok: z33.literal(true), result: contract.result }).safeParse(body);
+  const success = z34.object({ ok: z34.literal(true), result: contract.result }).safeParse(body);
   if (!success.success) return null;
   return success.data.result;
 }
@@ -18532,12 +18575,12 @@ var init_cli_action_bridge = __esm({
     init_contract();
     init_canonical_daemon();
     init_daemon_embed();
-    FailureEnvelopeZ = z33.object({
-      ok: z33.literal(false),
-      error: z33.object({
-        code: z33.string(),
-        message: z33.string(),
-        details: z33.unknown().optional()
+    FailureEnvelopeZ = z34.object({
+      ok: z34.literal(false),
+      error: z34.object({
+        code: z34.string(),
+        message: z34.string(),
+        details: z34.unknown().optional()
       })
     });
     deps = {

--- a/packages/contracts/src/__tests__/application-shell.test.ts
+++ b/packages/contracts/src/__tests__/application-shell.test.ts
@@ -13,6 +13,7 @@ import {
   projectApplicationShellV1,
   replayApplicationShellActionTraceV1,
 } from "../application-shell.ts";
+import { ApplicationShellResourceV1SchemaZ } from "../application-shell-resource.ts";
 import { COHESION_FIXTURE_V1 } from "../cohesion-fixture.ts";
 import {
   APPLICATION_SHELL_COMMAND_IDS,
@@ -50,6 +51,32 @@ const closedOverlayFixture = {
 };
 
 describe("semantic application shell", () => {
+  it("binds the REST resource to one strict daemon generation", () => {
+    const envelope = {
+      version: 1,
+      daemon: {
+        protocolVersion: 1,
+        productVersion: "2.8.0",
+        instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+        startedAt: "2026-07-21T00:00:00.000Z",
+      },
+      resource: {
+        project: COHESION_FIXTURE_V1.project,
+        workspace: COHESION_FIXTURE_V1.workspace,
+        dock: COHESION_FIXTURE_V1.dock,
+        focus: COHESION_FIXTURE_V1.focus,
+        connection: COHESION_FIXTURE_V1.connection,
+      },
+    };
+    expect(ApplicationShellResourceV1SchemaZ.parse(envelope)).toEqual(envelope);
+    expect(
+      ApplicationShellResourceV1SchemaZ.safeParse({
+        ...envelope,
+        daemon: { ...envelope.daemon, token: "secret" },
+      }).success,
+    ).toBe(false);
+  });
+
   it("projects navigation and dock identity only from the canonical surface registry", () => {
     const projection = projectApplicationShellV1(COHESION_FIXTURE_V1);
     const projectedSurfaces = [

--- a/packages/contracts/src/__tests__/daemon-events.test.ts
+++ b/packages/contracts/src/__tests__/daemon-events.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest";
 import { DaemonEventClientFrameSchemaZ, DaemonEventServerFrameSchemaZ } from "../daemon-events.ts";
 
 describe("daemon event contracts", () => {
+  const daemon = {
+    protocolVersion: 1,
+    productVersion: "2.8.0",
+    instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+    startedAt: "2026-07-21T00:00:00.000Z",
+  } as const;
+
   it("accepts every client frame and rejects missing or extra fields", () => {
     expect(
       DaemonEventClientFrameSchemaZ.parse({ type: "subscribe", sessions: ["tmux-ide"] }),
@@ -65,7 +72,7 @@ describe("daemon event contracts", () => {
 
   it("keeps every historical server discriminator parseable", () => {
     const frames = [
-      { type: "hello", sessions: [] },
+      { type: "hello", daemon, sessions: [] },
       { type: "sessions.changed" },
       { type: "projects.changed" },
       { type: "init.output", jobId: "job-1", chunk: "working", done: false },
@@ -90,5 +97,21 @@ describe("daemon event contracts", () => {
     for (const frame of frames) {
       expect(DaemonEventServerFrameSchemaZ.safeParse(frame).success, frame.type).toBe(true);
     }
+  });
+
+  it("requires a strict daemon generation on hello", () => {
+    expect(
+      DaemonEventServerFrameSchemaZ.safeParse({ type: "hello", daemon, sessions: [] }).success,
+    ).toBe(true);
+    expect(DaemonEventServerFrameSchemaZ.safeParse({ type: "hello", sessions: [] }).success).toBe(
+      false,
+    );
+    expect(
+      DaemonEventServerFrameSchemaZ.safeParse({
+        type: "hello",
+        daemon: { ...daemon, authToken: "must-not-cross-wire" },
+        sessions: [],
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/contracts/src/__tests__/desktop-host.test.ts
+++ b/packages/contracts/src/__tests__/desktop-host.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   DESKTOP_HOST_API_VERSION,
+  DesktopApplicationShellTargetSchemaZ,
   DesktopDaemonPreflightSchemaZ,
   DesktopDaemonHostDescriptorSchemaZ,
   DesktopHostBootstrapSchemaZ,
@@ -65,5 +66,22 @@ describe("desktop host contract", () => {
         authToken: "must-not-cross-ipc",
       }).success,
     ).toBe(false);
+  });
+
+  it("rejects malformed or secret-bearing application-shell targets", () => {
+    const target = {
+      daemon: {
+        protocolVersion: 1,
+        productVersion: "2.8.0",
+        instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+        startedAt: "2026-07-21T00:00:00.000Z",
+      },
+      workspaceName: " project ",
+    };
+    expect(DesktopApplicationShellTargetSchemaZ.parse(target).workspaceName).toBe("project");
+    expect(
+      DesktopApplicationShellTargetSchemaZ.safeParse({ ...target, token: "secret" }).success,
+    ).toBe(false);
+    expect(DesktopApplicationShellTargetSchemaZ.safeParse(null).success).toBe(false);
   });
 });

--- a/packages/contracts/src/application-shell-resource.ts
+++ b/packages/contracts/src/application-shell-resource.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+import { ApplicationShellProjectionInputV1SchemaZ } from "./application-shell.ts";
+import { DaemonInstanceIdentitySchemaZ } from "./daemon-wire.ts";
+
+export const APPLICATION_SHELL_RESOURCE_VERSION = 1 as const;
+
+/**
+ * Strict daemon-bound REST envelope. The projection input is not trusted
+ * until the peer identity matches the desktop host's canonical descriptor.
+ */
+export const ApplicationShellResourceV1SchemaZ = z
+  .object({
+    version: z.literal(APPLICATION_SHELL_RESOURCE_VERSION),
+    daemon: DaemonInstanceIdentitySchemaZ,
+    resource: ApplicationShellProjectionInputV1SchemaZ,
+  })
+  .strict();
+
+export type ApplicationShellResourceV1 = z.infer<typeof ApplicationShellResourceV1SchemaZ>;

--- a/packages/contracts/src/daemon-events.ts
+++ b/packages/contracts/src/daemon-events.ts
@@ -4,6 +4,7 @@ import {
   DaemonSessionOverviewSchemaZ,
   DaemonWorkspaceSchemaZ,
 } from "./daemon-resources.ts";
+import { DaemonInstanceIdentitySchemaZ } from "./daemon-wire.ts";
 
 /** Shared, browser-safe protocol for the daemon's unified /ws/events socket. */
 
@@ -42,6 +43,7 @@ export type DaemonSessionSnapshot = z.infer<typeof DaemonSessionSnapshotSchemaZ>
 export const DaemonEventHelloFrameSchemaZ = z
   .object({
     type: z.literal("hello"),
+    daemon: DaemonInstanceIdentitySchemaZ,
     sessions: z.array(DaemonSessionOverviewSchemaZ),
   })
   .strict();

--- a/packages/contracts/src/daemon-wire.ts
+++ b/packages/contracts/src/daemon-wire.ts
@@ -25,6 +25,21 @@ export function isDaemonWireProtocolCompatible(protocolVersion: number): boolean
  */
 export const DaemonInstanceIdSchema = z.uuid();
 
+/**
+ * Browser-safe identity stamped onto authenticated REST resources and the
+ * unified event socket hello. Clients compare every field with the canonical
+ * descriptor supplied by their desktop host before trusting payloads.
+ */
+export const DaemonInstanceIdentitySchemaZ = z
+  .object({
+    protocolVersion: DaemonWireProtocolVersionSchema,
+    productVersion: z.string().trim().min(1),
+    instanceId: DaemonInstanceIdSchema,
+    startedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+export type DaemonInstanceIdentity = z.infer<typeof DaemonInstanceIdentitySchemaZ>;
+
 export const CanonicalDaemonInfoSchema = z.object({
   pid: z.number().int().positive(),
   port: z.number().int().min(1).max(65_535),

--- a/packages/contracts/src/desktop-host.ts
+++ b/packages/contracts/src/desktop-host.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DaemonInstanceIdentitySchemaZ } from "./daemon-wire.ts";
 
 /** Versioned, deliberately narrow bridge exposed by a desktop host preload. */
 export const DESKTOP_HOST_API_VERSION = 2 as const;
@@ -44,6 +45,13 @@ export const DesktopDaemonHostDescriptorSchemaZ = z
     productVersion: z.string().trim().min(1),
     instanceId: z.uuid(),
     startedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export const DesktopApplicationShellTargetSchemaZ = z
+  .object({
+    daemon: DaemonInstanceIdentitySchemaZ,
+    workspaceName: z.string().trim().min(1).max(160),
   })
   .strict();
 
@@ -101,6 +109,7 @@ export type DesktopPlatform = z.infer<typeof DesktopPlatformSchemaZ>;
 export type DesktopThemeState = z.infer<typeof DesktopThemeStateSchemaZ>;
 export type DesktopWindowState = z.infer<typeof DesktopWindowStateSchemaZ>;
 export type DesktopDaemonHostDescriptor = z.infer<typeof DesktopDaemonHostDescriptorSchemaZ>;
+export type DesktopApplicationShellTarget = z.infer<typeof DesktopApplicationShellTargetSchemaZ>;
 export type DesktopDaemonHostIssueCode = z.infer<typeof DesktopDaemonHostIssueCodeSchemaZ>;
 export type DesktopDaemonHostState = z.infer<typeof DesktopDaemonHostStateSchemaZ>;
 /** @deprecated Compatibility name for existing host bootstrap consumers. */

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -33,6 +33,7 @@ export * from "./desktop-host.ts";
 export * from "./experience-identifiers.ts";
 export * from "./experience-shell.ts";
 export * from "./application-shell.ts";
+export * from "./application-shell-resource.ts";
 export * from "./visual-tokens.ts";
 export * from "./visual-recipes.ts";
 export * from "./pane-appearance.ts";

--- a/packages/daemon/src/command-center/projects.test.ts
+++ b/packages/daemon/src/command-center/projects.test.ts
@@ -24,6 +24,12 @@ import { makePane } from "../__tests__/support.ts";
 import type { ServerFrame } from "../schemas/ws-events.ts";
 
 const REGISTRY_DIR_ENV = "TMUX_IDE_REGISTRY_DIR";
+const TEST_DAEMON_IDENTITY = {
+  protocolVersion: 1,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-21T00:00:00.000Z",
+} as const;
 
 class MockWebSocket extends EventEmitter {
   readyState = 1;
@@ -277,7 +283,7 @@ describe("WS broadcast — projects.changed", () => {
   it("connected clients receive projects.changed when a project is registered", async () => {
     const app = createApp();
     const ws = new MockWebSocket();
-    handleWsEventsConnection(ws);
+    handleWsEventsConnection(ws, TEST_DAEMON_IDENTITY);
     ws.sent.length = 0;
 
     const res = await app.request("/api/projects", {
@@ -298,7 +304,7 @@ describe("WS broadcast — projects.changed", () => {
     const before = projectRegistryEmitter.listenerCount("change");
 
     const ws = new MockWebSocket();
-    handleWsEventsConnection(ws);
+    handleWsEventsConnection(ws, TEST_DAEMON_IDENTITY);
     expect(projectRegistryEmitter.listenerCount("change")).toBe(before + 1);
 
     ws.clientClose();

--- a/packages/daemon/src/command-center/resources/application-shell.test.ts
+++ b/packages/daemon/src/command-center/resources/application-shell.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
   ApplicationShellProjectionInputV1SchemaZ,
+  ApplicationShellResourceV1SchemaZ,
   projectApplicationShellV1,
 } from "@tmux-ide/contracts";
 import { _setTmuxRunner } from "../discovery.ts";
@@ -152,6 +153,11 @@ describe("GET /api/project/:name/application-shell", () => {
     );
     const app = createApp({
       remoteAccess: { bindHostname: "0.0.0.0", token: "secret" },
+      daemonIdentity: {
+        productVersion: "2.8.0",
+        instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+        startedAt: "2026-07-21T00:00:00.000Z",
+      },
     });
 
     const denied = await app.request("/api/project/product/application-shell", {
@@ -167,9 +173,14 @@ describe("GET /api/project/:name/application-shell", () => {
     });
     expect(response.status).toBe(200);
     expect(response.headers.get("access-control-allow-origin")).toBe("*");
-    const body = await response.json();
-    expect(ApplicationShellProjectionInputV1SchemaZ.parse(body)).toEqual(body);
-    expect(body.workspace.sidebar.agents[0]).toEqual(
+    const body = ApplicationShellResourceV1SchemaZ.parse(await response.json());
+    expect(body.daemon).toEqual({
+      protocolVersion: 1,
+      productVersion: "2.8.0",
+      instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+      startedAt: "2026-07-21T00:00:00.000Z",
+    });
+    expect(body.resource.workspace.sidebar.agents[0]).toEqual(
       expect.objectContaining({ name: "Codex", paneId: "pane.implementer" }),
     );
     expect(JSON.stringify(body)).not.toContain("%7");

--- a/packages/daemon/src/command-center/server.ts
+++ b/packages/daemon/src/command-center/server.ts
@@ -35,7 +35,11 @@ import {
 } from "../lib/workspace-registry.ts";
 import {
   AddWorkspaceRequestSchemaZ,
+  APPLICATION_SHELL_RESOURCE_VERSION,
   DAEMON_WIRE_PROTOCOL_VERSION,
+  DaemonInstanceIdentitySchemaZ,
+  type ApplicationShellResourceV1,
+  type DaemonInstanceIdentity,
   type DaemonPanesResponse,
   type DaemonProjectResponse,
   type DaemonProjectsResponse,
@@ -265,6 +269,10 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     instanceId: randomUUID(),
     startedAt: new Date().toISOString(),
   };
+  const daemonInstanceIdentity = DaemonInstanceIdentitySchemaZ.parse({
+    protocolVersion: DAEMON_WIRE_PROTOCOL_VERSION,
+    ...daemonIdentity,
+  });
   const healthBootedAt = Date.now();
 
   const app = new Hono();
@@ -468,7 +476,11 @@ export function createApp(options: CreateAppOptions = {}): Hono {
     const name = c.req.param("name");
     const session = discoverSessions().find((candidate) => candidate.name === name);
     if (!session) return c.json({ error: "Session not found" }, 404);
-    return c.json(projectApplicationShellResource(session));
+    return c.json({
+      version: APPLICATION_SHELL_RESOURCE_VERSION,
+      daemon: daemonInstanceIdentity,
+      resource: projectApplicationShellResource(session),
+    } satisfies ApplicationShellResourceV1);
   });
 
   app.get("/api/project/:name/panes", (c) => {
@@ -1285,7 +1297,10 @@ function listAvailableTemplates(): ProjectTemplate[] {
  * SSE endpoints (`/api/events`, `/api/project/<name>/stream`) continue to
  * work alongside this — they will be retired in a follow-up slice.
  */
-export function attachWsEvents(server: import("node:http").Server): {
+export function attachWsEvents(
+  server: import("node:http").Server,
+  daemonIdentity: DaemonInstanceIdentity,
+): {
   close: () => void;
 } {
   const wss = new WebSocketServer({ noServer: true });
@@ -1299,7 +1314,7 @@ export function attachWsEvents(server: import("node:http").Server): {
     const pathname = url.split("?")[0];
     if (pathname !== "/ws/events") return;
     wss.handleUpgrade(req, socket, head, (ws) => {
-      handleWsEventsConnection(ws);
+      handleWsEventsConnection(ws, daemonIdentity);
     });
   };
 

--- a/packages/daemon/src/command-center/workspaces.test.ts
+++ b/packages/daemon/src/command-center/workspaces.test.ts
@@ -9,6 +9,13 @@ import {
 import { handleWsEventsConnection } from "./ws-events.ts";
 import { createApp } from "./server.ts";
 
+const TEST_DAEMON_IDENTITY = {
+  protocolVersion: 1,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-21T00:00:00.000Z",
+} as const;
+
 let tmpDir: string;
 let registry: WorkspaceRegistry;
 
@@ -150,7 +157,7 @@ function makeFakeWs(): FakeWs {
 describe("WS frames — workspace.added / workspace.removed", () => {
   it("emits workspace.added when a workspace is added via the registry", () => {
     const ws = makeFakeWs();
-    handleWsEventsConnection(ws as never);
+    handleWsEventsConnection(ws as never, TEST_DAEMON_IDENTITY);
 
     registry.add({ name: "alpha", projectDir: "/tmp/alpha" });
 
@@ -165,7 +172,7 @@ describe("WS frames — workspace.added / workspace.removed", () => {
   it("emits workspace.removed when a workspace is removed", () => {
     registry.add({ name: "alpha", projectDir: "/tmp/alpha" });
     const ws = makeFakeWs();
-    handleWsEventsConnection(ws as never);
+    handleWsEventsConnection(ws as never, TEST_DAEMON_IDENTITY);
     ws.sent = []; // reset; the connection may have already sent a hello
 
     registry.remove("alpha");
@@ -191,7 +198,7 @@ describe("WS frames — workspace.added / workspace.removed", () => {
     _setDefaultWorkspaceRegistryForTests(reg2);
 
     const ws = makeFakeWs();
-    handleWsEventsConnection(ws as never);
+    handleWsEventsConnection(ws as never, TEST_DAEMON_IDENTITY);
     ws.sent = [];
 
     // load() prunes beta from disk; we simulate the same behavior by directly

--- a/packages/daemon/src/command-center/ws-events.ts
+++ b/packages/daemon/src/command-center/ws-events.ts
@@ -19,6 +19,7 @@ import {
   DaemonEventClientFrameSchemaZ,
   type DaemonEventClientFrame,
   type DaemonEventServerFrame,
+  type DaemonInstanceIdentity,
   type DaemonSessionSnapshot,
   type Workspace,
 } from "@tmux-ide/contracts";
@@ -159,7 +160,10 @@ export function buildSessionSnapshot(sessionName: string): DaemonSessionSnapshot
  * Wire a single WebSocket connection. Tracks per-session subscriptions and
  * tears all listeners down on close — no leaks.
  */
-export function handleWsEventsConnection(socket: WebSocket | WsLike): void {
+export function handleWsEventsConnection(
+  socket: WebSocket | WsLike,
+  daemonIdentity: DaemonInstanceIdentity,
+): void {
   const ws = socket as WsLike;
   const subscriptions = new Set<string>();
   let closed = false;
@@ -307,9 +311,9 @@ export function handleWsEventsConnection(socket: WebSocket | WsLike): void {
   // a separate REST round-trip.
   try {
     const sessions = discoverSessions();
-    send({ type: "hello", sessions: buildOverviews(sessions) });
+    send({ type: "hello", daemon: daemonIdentity, sessions: buildOverviews(sessions) });
   } catch {
-    send({ type: "hello", sessions: [] });
+    send({ type: "hello", daemon: daemonIdentity, sessions: [] });
   }
 }
 

--- a/packages/daemon/src/lib/__tests__/ws-events-protocol.test.ts
+++ b/packages/daemon/src/lib/__tests__/ws-events-protocol.test.ts
@@ -7,6 +7,13 @@ import {
   handleWsEventsConnection,
 } from "../../command-center/ws-events.ts";
 
+const daemonIdentity = {
+  protocolVersion: 1,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-21T00:00:00.000Z",
+} as const;
+
 class ProtocolWebSocket extends EventEmitter {
   readyState = 1;
   readonly sent: string[] = [];
@@ -35,9 +42,17 @@ afterEach(() => {
 });
 
 describe("/ws/events client frame protocol", () => {
+  it("binds the initial hello to the supplied daemon generation", () => {
+    const socket = new ProtocolWebSocket();
+    handleWsEventsConnection(socket, daemonIdentity);
+
+    expect(frames(socket)[0]).toMatchObject({ type: "hello", daemon: daemonIdentity });
+    socket.disconnect();
+  });
+
   it("reports malformed JSON deterministically and keeps the socket usable", () => {
     const socket = new ProtocolWebSocket();
-    handleWsEventsConnection(socket);
+    handleWsEventsConnection(socket, daemonIdentity);
     socket.sent.length = 0;
 
     socket.receive("not-json");
@@ -56,7 +71,7 @@ describe("/ws/events client frame protocol", () => {
 
   it("rejects malformed subscribe frames without throwing or changing subscription state", () => {
     const socket = new ProtocolWebSocket();
-    handleWsEventsConnection(socket);
+    handleWsEventsConnection(socket, daemonIdentity);
     socket.sent.length = 0;
 
     expect(() => socket.receive(JSON.stringify({ type: "subscribe" }))).not.toThrow();
@@ -83,7 +98,7 @@ describe("/ws/events client frame protocol", () => {
 
   it("rejects unknown and extra client fields rather than accepting structural lookalikes", () => {
     const socket = new ProtocolWebSocket();
-    handleWsEventsConnection(socket);
+    handleWsEventsConnection(socket, daemonIdentity);
     socket.sent.length = 0;
 
     socket.receive(JSON.stringify({ type: "ping", extra: true }));

--- a/packages/daemon/src/lib/daemon-embed.ts
+++ b/packages/daemon/src/lib/daemon-embed.ts
@@ -11,7 +11,11 @@ import { createServer, type Server } from "node:http";
 import { createRequire } from "node:module";
 import type { Socket } from "node:net";
 import { WebSocket, WebSocketServer } from "ws";
-import { DAEMON_WIRE_PROTOCOL_VERSION } from "@tmux-ide/contracts";
+import {
+  DAEMON_WIRE_PROTOCOL_VERSION,
+  DaemonInstanceIdentitySchemaZ,
+  type DaemonInstanceIdentity,
+} from "@tmux-ide/contracts";
 import { computeAgentStates, computePortPanes } from "./session-monitor.ts";
 import { DaemonShutdownError, DaemonStartupError } from "./errors.ts";
 import { handlePtyWebSocket, shutdownPtyBridges } from "../server/ws-route.ts";
@@ -284,7 +288,8 @@ function attachWebSockets(
     authToken?: string | null;
     localBypassToken?: string | null;
     bindHostname?: string | null;
-  } = {},
+    daemonIdentity: DaemonInstanceIdentity;
+  },
 ): {
   closeClients: () => void;
   closeServers: () => Promise<void>;
@@ -316,7 +321,7 @@ function attachWebSockets(
     if (pathname === "/ws/events") {
       eventsWss.handleUpgrade(req, socket, head, (ws) => {
         track(ws);
-        handleWsEventsConnection(ws);
+        handleWsEventsConnection(ws, opts.daemonIdentity);
       });
       return;
     }
@@ -639,6 +644,10 @@ async function startHttpServer({
     authToken,
     localBypassToken,
     bindHostname,
+    daemonIdentity: DaemonInstanceIdentitySchemaZ.parse({
+      protocolVersion: DAEMON_WIRE_PROTOCOL_VERSION,
+      ...daemonIdentity,
+    }),
   });
 
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- add strict daemon-generation identity to application-shell REST and event hello contracts
- add an injected, URL-free Solid application-shell resource store with verified peer lifecycle
- preserve stale data, bound reconnect flapping, redact invalid targets, and guard abort/generation races

## Verification
- full `pnpm check` passed
- independent adversarial re-review approved with no blocker/high/medium findings
- focused re-review: 5 files / 38 tests passed

## Scope
No App/CSP/xterm/terminal-attachment wiring in this slice.