### PR TITLE
feat(desktop): broker daemon resources through Electron host

### DIFF
--- a/apps/desktop-renderer/index.html
+++ b/apps/desktop-renderer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' ws://127.0.0.1:5173; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
     />
     <meta name="color-scheme" content="dark light" />
     <title>tmux-ide</title>

--- a/apps/desktop-renderer/src/App.test.tsx
+++ b/apps/desktop-renderer/src/App.test.tsx
@@ -87,6 +87,20 @@ describe("desktop App host lifecycle", () => {
           return stopTheme;
         },
       },
+      daemon: {
+        listWorkspaces: async () => ({
+          status: "error",
+          error: { code: "preview-only", reason: "test boundary" },
+        }),
+        fetchApplicationShell: async () => ({
+          status: "error",
+          error: { code: "preview-only", reason: "test boundary" },
+        }),
+        subscribe: async () => ({
+          status: "error",
+          error: { code: "preview-only", reason: "test boundary" },
+        }),
+      },
     };
     const root = document.createElement("div");
     document.body.append(root);

--- a/apps/desktop-renderer/src/experience/application-shell.test.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.test.tsx
@@ -62,6 +62,20 @@ function host(): HostCapabilities {
       getState: async () => ({ mode: "dark", highContrast: false, reducedMotion: false }),
       onChanged: () => () => undefined,
     },
+    daemon: {
+      listWorkspaces: async () => ({
+        status: "error",
+        error: { code: "preview-only", reason: "fixture only" },
+      }),
+      fetchApplicationShell: async () => ({
+        status: "error",
+        error: { code: "preview-only", reason: "fixture only" },
+      }),
+      subscribe: async () => ({
+        status: "error",
+        error: { code: "preview-only", reason: "fixture only" },
+      }),
+    },
   };
 }
 
@@ -494,8 +508,7 @@ describe("visible DOM application shell", () => {
     {
       state: {
         status: "connected" as const,
-        descriptor: {
-          apiBaseUrl: "http://127.0.0.1:6060",
+        identity: {
           protocolVersion: 1,
           productVersion: "2.8.0",
           instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",

--- a/apps/desktop-renderer/src/experience/application-shell.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.tsx
@@ -8,7 +8,7 @@ import {
   type ApplicationShellProjectionInputV1,
   type ApplicationShellProjectionV1,
   type CommandSource,
-  type DesktopDaemonHostState,
+  type DesktopDaemonCapabilityState,
   type DesktopWindowState,
   type FocusZone,
   type HostCapabilities,
@@ -62,7 +62,7 @@ const PALETTE_OVERLAY_ID = "overlay.palette.trace";
 
 export interface DomApplicationShellProps {
   readonly host: HostCapabilities;
-  readonly daemonState?: DesktopDaemonHostState;
+  readonly daemonState?: DesktopDaemonCapabilityState;
   readonly runtime?: string;
   readonly platform?: string;
   readonly windowState?: DesktopWindowState | null;
@@ -251,7 +251,7 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
     if (props.daemonState?.status === "connected") {
       return {
         state: "connected" as const,
-        message: `Daemon connected — ${props.daemonState.descriptor.productVersion}`,
+        message: `Daemon connected — ${props.daemonState.identity.productVersion}`,
         safeState: "Preview data remains illustrative",
         nextAction: "Live workspace loading is not enabled in this build",
       };

--- a/apps/desktop-renderer/src/host-capabilities.test.ts
+++ b/apps/desktop-renderer/src/host-capabilities.test.ts
@@ -24,11 +24,22 @@ describe("renderer host capabilities", () => {
       runtime: "browser",
       platform: "darwin",
     });
+    await expect(host.daemon.listWorkspaces()).resolves.toMatchObject({
+      status: "error",
+      error: { code: "preview-only" },
+    });
+    await expect(
+      host.daemon.fetchApplicationShell({ workspaceName: "preview" }),
+    ).resolves.toMatchObject({ status: "error", error: { code: "preview-only" } });
+    await expect(
+      host.daemon.subscribe({ workspaceNames: ["preview"] }, vi.fn()),
+    ).resolves.toMatchObject({ status: "error", error: { code: "preview-only" } });
   });
 
-  it("rejects a broad or incomplete preload object", async () => {
-    const host = resolveHostCapabilities({ apiVersion: 1, send: () => undefined });
-    expect((await host.bootstrap()).runtime).toBe("browser");
+  it("does not silently downgrade a present incompatible preload object", () => {
+    expect(() => resolveHostCapabilities({ apiVersion: 2, send: () => undefined })).toThrow(
+      "present but incompatible",
+    );
   });
 
   it("validates payloads returned by an otherwise typed preload", async () => {

--- a/apps/desktop-renderer/src/host-capabilities.ts
+++ b/apps/desktop-renderer/src/host-capabilities.ts
@@ -53,6 +53,11 @@ function browserWindowState(): DesktopWindowState {
   };
 }
 
+const PREVIEW_DAEMON_ERROR = Object.freeze({
+  code: "preview-only" as const,
+  reason: "Live daemon resources are unavailable in browser preview.",
+});
+
 function subscribeMedia(listener: (state: DesktopThemeState) => void): () => void {
   const queries = [
     window.matchMedia("(prefers-color-scheme: dark)"),
@@ -102,6 +107,11 @@ export function createBrowserHostCapabilities(): HostCapabilities {
       getState: async () => browserTheme(),
       onChanged: subscribeMedia,
     },
+    daemon: {
+      listWorkspaces: async () => ({ status: "error", error: PREVIEW_DAEMON_ERROR }),
+      fetchApplicationShell: async () => ({ status: "error", error: PREVIEW_DAEMON_ERROR }),
+      subscribe: async () => ({ status: "error", error: PREVIEW_DAEMON_ERROR }),
+    },
   };
   return capabilities;
 }
@@ -121,14 +131,21 @@ function hasNarrowFacade(value: unknown): value is HostCapabilities {
     typeof candidate.menu?.showApplicationMenu === "function" &&
     typeof candidate.dialog?.selectProjectDirectory === "function" &&
     typeof candidate.theme?.getState === "function" &&
-    typeof candidate.theme?.onChanged === "function"
+    typeof candidate.theme?.onChanged === "function" &&
+    typeof candidate.daemon?.listWorkspaces === "function" &&
+    typeof candidate.daemon?.fetchApplicationShell === "function" &&
+    typeof candidate.daemon?.subscribe === "function"
   );
 }
 
 export function resolveHostCapabilities(
   candidate: unknown = typeof window === "undefined" ? undefined : window.tmuxIdeHost,
 ): HostCapabilities {
-  return hasNarrowFacade(candidate) ? candidate : createBrowserHostCapabilities();
+  if (candidate == null) return createBrowserHostCapabilities();
+  if (!hasNarrowFacade(candidate)) {
+    throw new Error("Desktop host bridge is present but incompatible with this renderer.");
+  }
+  return candidate;
 }
 
 export async function readHostBootstrap(host: HostCapabilities) {

--- a/apps/desktop-renderer/src/runtime/host-daemon-transport.test.ts
+++ b/apps/desktop-renderer/src/runtime/host-daemon-transport.test.ts
@@ -1,0 +1,180 @@
+import {
+  APPLICATION_SHELL_RESOURCE_VERSION,
+  COHESION_FIXTURE_V1,
+  type DesktopDaemonEvent,
+  type HostCapabilities,
+} from "@tmux-ide/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { createHostDaemonTransport } from "./host-daemon-transport.ts";
+
+const DAEMON = {
+  protocolVersion: 1,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-21T00:00:00.000Z",
+} as const;
+
+const RESOURCE = {
+  project: COHESION_FIXTURE_V1.project,
+  workspace: COHESION_FIXTURE_V1.workspace,
+  dock: COHESION_FIXTURE_V1.dock,
+  focus: COHESION_FIXTURE_V1.focus,
+  connection: COHESION_FIXTURE_V1.connection,
+};
+
+function daemonHost(
+  overrides: Partial<HostCapabilities["daemon"]> = {},
+): Pick<HostCapabilities, "daemon"> {
+  return {
+    daemon: {
+      listWorkspaces: async () => ({
+        status: "ok",
+        daemon: DAEMON,
+        workspaces: [{ workspaceName: "product" }],
+      }),
+      fetchApplicationShell: async () => ({
+        status: "ok",
+        envelope: {
+          version: APPLICATION_SHELL_RESOURCE_VERSION,
+          daemon: DAEMON,
+          resource: RESOURCE,
+        },
+      }),
+      subscribe: async () => ({ status: "subscribed", unsubscribe: () => undefined }),
+      ...overrides,
+    },
+  };
+}
+
+describe("HostCapabilities-backed daemon transport", () => {
+  it("fetches by semantic workspace only and verifies the returned generation", async () => {
+    const fetchApplicationShell = vi.fn(daemonHost().daemon.fetchApplicationShell);
+    const transport = createHostDaemonTransport(
+      daemonHost({
+        fetchApplicationShell,
+      }),
+    );
+    const result = await transport.fetchApplicationShell(
+      { daemon: DAEMON, workspaceName: "product" },
+      new AbortController().signal,
+    );
+    expect(result).toEqual(RESOURCE);
+    expect(fetchApplicationShell).toHaveBeenCalledWith({ workspaceName: "product" });
+    expect(JSON.stringify(fetchApplicationShell.mock.calls)).not.toMatch(
+      /apiBaseUrl|sessionName|token|authorization/iu,
+    );
+
+    await expect(
+      createHostDaemonTransport(
+        daemonHost({
+          fetchApplicationShell: async () => ({
+            status: "ok",
+            envelope: {
+              version: APPLICATION_SHELL_RESOURCE_VERSION,
+              daemon: { ...DAEMON, instanceId: "66ab67ed-18fe-431b-913b-70972b78c96f" },
+              resource: RESOURCE,
+            },
+          }),
+        }),
+      ).fetchApplicationShell(
+        { daemon: DAEMON, workspaceName: "product" },
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({ kind: "daemon-identity-mismatch" });
+  });
+
+  it("maps bounded host failures and honors renderer cancellation", async () => {
+    const unavailable = createHostDaemonTransport(
+      daemonHost({
+        fetchApplicationShell: async () => ({
+          status: "error",
+          error: { code: "workspace-not-found", reason: "The workspace is unavailable." },
+        }),
+      }),
+    );
+    await expect(
+      unavailable.fetchApplicationShell(
+        { daemon: DAEMON, workspaceName: "missing" },
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({ kind: "not-found", statusCode: 404 });
+
+    const pending = createHostDaemonTransport(
+      daemonHost({
+        fetchApplicationShell: async () => new Promise(() => undefined),
+      }),
+    );
+    const controller = new AbortController();
+    const request = pending.fetchApplicationShell(
+      { daemon: DAEMON, workspaceName: "product" },
+      controller.signal,
+    );
+    controller.abort();
+    await expect(request).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("adapts sanitized host invalidations without creating another socket authority", async () => {
+    let publish: ((event: DesktopDaemonEvent) => void) | undefined;
+    const unsubscribe = vi.fn();
+    const subscribe = vi.fn(async (_request, listener) => {
+      publish = listener;
+      return { status: "subscribed" as const, unsubscribe };
+    });
+    const transport = createHostDaemonTransport(daemonHost({ subscribe }));
+    const handlers = {
+      onVerifiedOpen: vi.fn(),
+      onInvalidate: vi.fn(),
+      onProtocolError: vi.fn(),
+      onPeerMismatch: vi.fn(),
+      onMalformedFrame: vi.fn(),
+      onClose: vi.fn(),
+      onError: vi.fn(),
+    };
+    const connection = transport.connectEvents(
+      { daemon: DAEMON, workspaceName: "product" },
+      handlers,
+    );
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledOnce());
+    expect(subscribe.mock.calls[0]?.[0]).toEqual({ workspaceNames: ["product"] });
+
+    publish?.({ type: "connection.changed", state: "live", error: null });
+    publish?.({ type: "application-shell.changed", workspaceName: "another-workspace" });
+    publish?.({ type: "application-shell.changed", workspaceName: "product" });
+    publish?.({
+      type: "connection.changed",
+      state: "degraded",
+      error: {
+        code: "daemon-identity-mismatch",
+        reason: "The daemon generation changed during the resource request.",
+      },
+    });
+    expect(handlers.onVerifiedOpen).toHaveBeenCalledOnce();
+    expect(handlers.onInvalidate).toHaveBeenCalledOnce();
+    expect(handlers.onPeerMismatch).toHaveBeenCalledOnce();
+
+    publish?.({
+      type: "connection.changed",
+      state: "degraded",
+      error: { code: "protocol-error", reason: "The subscription was rejected." },
+    });
+    expect(handlers.onProtocolError).toHaveBeenCalledOnce();
+
+    connection.close();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    publish?.({ type: "workspaces.changed" });
+    expect(handlers.onInvalidate).toHaveBeenCalledOnce();
+  });
+
+  it("rejects raw route metadata in a store target", () => {
+    const transport = createHostDaemonTransport(daemonHost());
+    expect(() =>
+      transport.validateTarget({
+        daemon: DAEMON,
+        workspaceName: "product",
+        apiBaseUrl: "http://127.0.0.1:6060",
+        sessionName: "raw-session",
+      }),
+    ).toThrow("invalid or incompatible");
+  });
+});

--- a/apps/desktop-renderer/src/runtime/host-daemon-transport.ts
+++ b/apps/desktop-renderer/src/runtime/host-daemon-transport.ts
@@ -1,0 +1,166 @@
+import {
+  DesktopApplicationShellTargetSchemaZ,
+  isDaemonWireProtocolCompatible,
+  type DaemonInstanceIdentity,
+  type DesktopDaemonCapabilityError,
+  type DesktopDaemonEvent,
+  type HostCapabilities,
+} from "@tmux-ide/contracts";
+
+import type { DesktopApplicationShellTarget } from "./connection-state.ts";
+import {
+  DaemonTransportError,
+  type DaemonEventConnection,
+  type DaemonEventHandlers,
+  type DesktopDaemonTransport,
+} from "./daemon-transport.ts";
+
+function sameDaemonGeneration(
+  expected: DaemonInstanceIdentity,
+  actual: DaemonInstanceIdentity,
+): boolean {
+  return (
+    actual.protocolVersion === expected.protocolVersion &&
+    actual.productVersion === expected.productVersion &&
+    actual.instanceId === expected.instanceId &&
+    actual.startedAt === expected.startedAt
+  );
+}
+
+function validateTarget(value: unknown): DesktopApplicationShellTarget {
+  const parsed = DesktopApplicationShellTargetSchemaZ.safeParse(value);
+  if (!parsed.success || !isDaemonWireProtocolCompatible(parsed.data.daemon.protocolVersion)) {
+    throw new DaemonTransportError(
+      "descriptor-invalid",
+      "Desktop host application-shell target is invalid or incompatible.",
+    );
+  }
+  return parsed.data;
+}
+
+function transportError(error: DesktopDaemonCapabilityError): DaemonTransportError {
+  switch (error.code) {
+    case "workspace-not-found":
+      return new DaemonTransportError("not-found", error.reason, 404);
+    case "invalid-request":
+      return new DaemonTransportError("descriptor-invalid", error.reason);
+    case "daemon-identity-mismatch":
+      return new DaemonTransportError("daemon-identity-mismatch", error.reason);
+    case "invalid-response":
+    case "response-too-large":
+      return new DaemonTransportError("schema-invalid", error.reason);
+    default:
+      return new DaemonTransportError("network-error", error.reason);
+  }
+}
+
+function aborted(): Error {
+  const error = new Error("Desktop daemon resource request was aborted.");
+  error.name = "AbortError";
+  return error;
+}
+
+function eventToHandler(
+  event: DesktopDaemonEvent,
+  workspaceName: string,
+  handlers: DaemonEventHandlers,
+): void {
+  if (event.type === "workspaces.changed") {
+    handlers.onInvalidate();
+    return;
+  }
+  if (event.type === "application-shell.changed") {
+    if (event.workspaceName === workspaceName) handlers.onInvalidate();
+    return;
+  }
+  if (event.state === "live") {
+    handlers.onVerifiedOpen();
+    return;
+  }
+  if (event.error?.code === "daemon-identity-mismatch") {
+    handlers.onPeerMismatch(event.error.reason);
+    return;
+  }
+  if (event.error?.code === "invalid-response" || event.error?.code === "response-too-large") {
+    handlers.onMalformedFrame(event.error.reason);
+    return;
+  }
+  if (event.error?.code === "event-unavailable") {
+    handlers.onClose();
+    return;
+  }
+  if (event.error?.code === "protocol-error") {
+    handlers.onProtocolError(event.error.reason);
+    return;
+  }
+  handlers.onError(event.error?.reason ?? "Desktop daemon event connection degraded.");
+}
+
+/**
+ * Production renderer adapter. It delegates every resource operation to the
+ * reviewed HostCapabilities facade and therefore never constructs a URL,
+ * request header, daemon credential, raw session target, or physical socket.
+ */
+export function createHostDaemonTransport(
+  host: Pick<HostCapabilities, "daemon">,
+): DesktopDaemonTransport {
+  return {
+    validateTarget,
+
+    async fetchApplicationShell(target, signal) {
+      const safeTarget = validateTarget(target);
+      if (signal.aborted) throw aborted();
+      const request = host.daemon.fetchApplicationShell({
+        workspaceName: safeTarget.workspaceName,
+      });
+      let rejectAborted: (() => void) | undefined;
+      const abortRequest = new Promise<never>((_resolve, reject) => {
+        rejectAborted = () => reject(aborted());
+        signal.addEventListener("abort", rejectAborted, { once: true });
+      });
+      let result: Awaited<typeof request>;
+      try {
+        result = await Promise.race([request, abortRequest]);
+      } finally {
+        if (rejectAborted) signal.removeEventListener("abort", rejectAborted);
+      }
+      if (result.status === "error") throw transportError(result.error);
+      if (!sameDaemonGeneration(safeTarget.daemon, result.envelope.daemon)) {
+        throw new DaemonTransportError(
+          "daemon-identity-mismatch",
+          "Desktop host returned a resource from another daemon generation.",
+        );
+      }
+      return result.envelope.resource;
+    },
+
+    connectEvents(target, handlers): DaemonEventConnection {
+      const safeTarget = validateTarget(target);
+      let closed = false;
+      let unsubscribe: (() => void) | null = null;
+      void host.daemon
+        .subscribe({ workspaceNames: [safeTarget.workspaceName] }, (event) => {
+          if (!closed) eventToHandler(event, safeTarget.workspaceName, handlers);
+        })
+        .then((result) => {
+          if (result.status === "error") {
+            if (!closed) handlers.onError(result.error.reason);
+            return;
+          }
+          if (closed) result.unsubscribe();
+          else unsubscribe = result.unsubscribe;
+        })
+        .catch(() => {
+          if (!closed) handlers.onError("Desktop host event subscription failed.");
+        });
+      return {
+        close: () => {
+          if (closed) return;
+          closed = true;
+          unsubscribe?.();
+          unsubscribe = null;
+        },
+      };
+    },
+  };
+}

--- a/apps/desktop-renderer/src/runtime/index.ts
+++ b/apps/desktop-renderer/src/runtime/index.ts
@@ -6,4 +6,5 @@ export type {
   DaemonTransportErrorKind,
   DesktopDaemonTransport,
 } from "./daemon-transport.ts";
+export { createHostDaemonTransport } from "./host-daemon-transport.ts";
 export * from "./desktop-resource-store.ts";

--- a/apps/desktop-renderer/vite.config.ts
+++ b/apps/desktop-renderer/vite.config.ts
@@ -3,7 +3,16 @@ import solid from "vite-plugin-solid";
 
 export default defineConfig({
   base: "./",
-  plugins: [solid()],
+  plugins: [
+    solid(),
+    {
+      name: "desktop-preview-hmr-policy",
+      apply: "serve",
+      transformIndexHtml(html) {
+        return html.replace("connect-src 'self'", "connect-src 'self' ws://127.0.0.1:5173");
+      },
+    },
+  ],
   build: {
     target: "es2022",
     sourcemap: true,

--- a/apps/electron-shell/scripts/build.mjs
+++ b/apps/electron-shell/scripts/build.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir, readFile, rm } from "node:fs/promises";
+import { cp, mkdir, readFile, readdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -52,4 +52,26 @@ for (const directive of [
 }
 if (/unsafe-(?:inline|eval)/u.test(rendererHtml)) {
   throw new Error("desktop renderer CSP must not permit unsafe-inline or unsafe-eval");
+}
+if (/connect-src[^;]*(?:127\.0\.0\.1|localhost|\[::1\]|https?:|wss?:)/u.test(rendererHtml)) {
+  throw new Error("packaged desktop renderer CSP must not permit daemon or network origins");
+}
+if (/connect-src[^;]*\*/u.test(rendererHtml)) {
+  throw new Error("packaged desktop renderer CSP must not permit a wildcard connection source");
+}
+
+const rendererAssets = await readdir(join(dist, "renderer", "assets"));
+for (const asset of rendererAssets.filter((name) => name.endsWith(".js"))) {
+  const source = await readFile(join(dist, "renderer", "assets", asset), "utf8");
+  for (const forbidden of [
+    "/api/workspaces",
+    "/api/resources/workspace-catalog",
+    "/ws/events",
+    "http://127.0.0.1",
+    "http://localhost",
+  ]) {
+    if (source.includes(forbidden)) {
+      throw new Error(`packaged renderer contains a daemon-network route: ${forbidden}`);
+    }
+  }
 }

--- a/apps/electron-shell/src/daemon-resource-broker.test.ts
+++ b/apps/electron-shell/src/daemon-resource-broker.test.ts
@@ -142,7 +142,25 @@ describe("Electron main daemon resource broker", () => {
     });
   });
 
-  it("rejects workspace collisions after semantic name normalization", async () => {
+  it.each([" docs ", "docs "])(
+    "rejects a non-canonical raw catalog workspace name %j",
+    async (workspaceName) => {
+      const broker = new DaemonResourceBroker({
+        daemon: CONNECTED,
+        fetch: async () =>
+          json({
+            ...WORKSPACE_CATALOG,
+            workspaces: [{ workspaceName, sessionName: "docs-one" }],
+          }),
+      });
+      await expect(broker.listWorkspaces()).resolves.toMatchObject({
+        status: "error",
+        error: { code: "invalid-response" },
+      });
+    },
+  );
+
+  it("rejects duplicate canonical raw catalog identities", async () => {
     const broker = new DaemonResourceBroker({
       daemon: CONNECTED,
       fetch: async () =>
@@ -150,7 +168,7 @@ describe("Electron main daemon resource broker", () => {
           ...WORKSPACE_CATALOG,
           workspaces: [
             { workspaceName: "docs", sessionName: "docs-one" },
-            { workspaceName: " docs ", sessionName: "docs-two" },
+            { workspaceName: "docs", sessionName: "docs-two" },
           ],
         }),
     });
@@ -347,22 +365,10 @@ describe("Electron main daemon resource broker", () => {
     expect(first.filter((event) => event.type === "connection.changed")).toHaveLength(1);
   });
 
-  it("normalizes workspace event updates into the same single catalog mapping", async () => {
-    const socket = new FakeSocket();
-    const events: DesktopDaemonEvent[] = [];
-    const broker = new DaemonResourceBroker({
-      daemon: CONNECTED,
-      fetch: async () => json(WORKSPACE_CATALOG),
-      createWebSocket: () => socket,
-    });
-    expect((await broker.subscribe(["docs"], (event) => events.push(event))).status).toBe(
-      "subscribed",
-    );
-    socket.emit("open");
-    socket.emit("message", JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }));
-    socket.emit(
-      "message",
-      JSON.stringify({
+  it.each([
+    {
+      name: "padded add",
+      frame: {
         type: "workspace.added",
         workspace: {
           name: " docs ",
@@ -371,22 +377,77 @@ describe("Electron main daemon resource broker", () => {
           ideConfigPath: null,
           addedAt: "2026-07-21T00:00:00.000Z",
         },
-      }),
-    );
-    events.length = 0;
-    socket.emit(
-      "message",
-      JSON.stringify({ type: "terminals.changed", sessionName: "durable-docs" }),
-    );
-    socket.emit(
-      "message",
-      JSON.stringify({ type: "terminals.changed", sessionName: "docs-replaced" }),
-    );
-    expect(events).toEqual([{ type: "application-shell.changed", workspaceName: "docs" }]);
+      },
+    },
+    { name: "padded remove", frame: { type: "workspace.removed", name: " docs " } },
+    {
+      name: "canonical add collision",
+      frame: {
+        type: "workspace.added",
+        workspace: {
+          name: "docs",
+          sessionName: "docs-replaced",
+          projectDir: "/private/replaced",
+          ideConfigPath: null,
+          addedAt: "2026-07-21T00:00:00.000Z",
+        },
+      },
+    },
+  ])(
+    "rejects $name, reloads the stamped catalog, and preserves the original subscription",
+    async ({ frame }) => {
+      const originalSocket = new FakeSocket();
+      const refreshedSocket = new FakeSocket();
+      const sockets = [originalSocket, refreshedSocket];
+      const fetch = vi.fn(async () => json(WORKSPACE_CATALOG));
+      const createWebSocket = vi.fn(() => sockets.shift()!);
+      const events: DesktopDaemonEvent[] = [];
+      const broker = new DaemonResourceBroker({
+        daemon: CONNECTED,
+        fetch,
+        createWebSocket,
+      });
+      expect((await broker.subscribe(["docs"], (event) => events.push(event))).status).toBe(
+        "subscribed",
+      );
+      originalSocket.emit("open");
+      originalSocket.emit(
+        "message",
+        JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }),
+      );
+      events.length = 0;
 
-    socket.emit("message", JSON.stringify({ type: "workspace.removed", name: " docs " }));
-    expect(socket.close).toHaveBeenCalledWith(1000, "renderer released");
-  });
+      originalSocket.emit("message", JSON.stringify(frame));
+      expect(originalSocket.close).toHaveBeenCalledWith(1002, expect.any(String));
+      expect(events.at(-1)).toMatchObject({
+        type: "connection.changed",
+        state: "degraded",
+        error: { code: "invalid-response" },
+      });
+      await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(createWebSocket).toHaveBeenCalledTimes(2));
+
+      refreshedSocket.emit("open");
+      refreshedSocket.emit(
+        "message",
+        JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }),
+      );
+      expect(refreshedSocket.sent.map((value) => JSON.parse(value))).toContainEqual({
+        type: "subscribe",
+        sessions: ["durable-docs"],
+      });
+      events.length = 0;
+      refreshedSocket.emit(
+        "message",
+        JSON.stringify({ type: "terminals.changed", sessionName: "durable-docs" }),
+      );
+      refreshedSocket.emit(
+        "message",
+        JSON.stringify({ type: "terminals.changed", sessionName: "docs-replaced" }),
+      );
+      expect(events).toEqual([{ type: "application-shell.changed", workspaceName: "docs" }]);
+    },
+  );
 
   it.each([false, true])(
     "bounds the event handshake when socket open=%s and clears it on release",

--- a/apps/electron-shell/src/daemon-resource-broker.test.ts
+++ b/apps/electron-shell/src/daemon-resource-broker.test.ts
@@ -1,0 +1,489 @@
+import {
+  APPLICATION_SHELL_RESOURCE_VERSION,
+  COHESION_FIXTURE_V1,
+  type DesktopDaemonEvent,
+  type DesktopDaemonHostState,
+} from "@tmux-ide/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { DaemonResourceBroker, type BrokerEventSocket } from "./daemon-resource-broker.ts";
+
+const IDENTITY = {
+  protocolVersion: 1,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-21T00:00:00.000Z",
+} as const;
+
+const CONNECTED: DesktopDaemonHostState = {
+  status: "connected",
+  descriptor: { apiBaseUrl: "http://127.0.0.1:6060", ...IDENTITY },
+};
+
+const WORKSPACE_CATALOG = {
+  version: 1,
+  daemon: IDENTITY,
+  workspaces: [
+    {
+      workspaceName: "product workspace",
+      sessionName: "server/session:42",
+    },
+    {
+      workspaceName: "docs",
+      sessionName: "durable-docs",
+    },
+  ],
+};
+
+const APPLICATION_SHELL_ENVELOPE = {
+  version: APPLICATION_SHELL_RESOURCE_VERSION,
+  daemon: IDENTITY,
+  resource: {
+    project: COHESION_FIXTURE_V1.project,
+    workspace: COHESION_FIXTURE_V1.workspace,
+    dock: COHESION_FIXTURE_V1.dock,
+    focus: COHESION_FIXTURE_V1.focus,
+    connection: COHESION_FIXTURE_V1.connection,
+  },
+};
+
+function json(value: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set("content-type", "application/json; charset=utf-8");
+  return new Response(JSON.stringify(value), { ...init, headers });
+}
+
+type FakeSocketEvent = "open" | "message" | "close" | "error";
+
+class FakeSocket implements BrokerEventSocket {
+  readyState = 0;
+  readonly sent: string[] = [];
+  readonly close = vi.fn((_: number, __: string) => {
+    this.readyState = 3;
+  });
+  readonly #listeners = new Map<FakeSocketEvent, Array<(event: { data?: unknown }) => void>>();
+
+  addEventListener(type: FakeSocketEvent, listener: (event: { data?: unknown }) => void): void {
+    const listeners = this.#listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.#listeners.set(type, listeners);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  emit(type: FakeSocketEvent, data?: unknown): void {
+    if (type === "open") this.readyState = 1;
+    for (const listener of this.#listeners.get(type) ?? []) listener({ data });
+  }
+}
+
+describe("Electron main daemon resource broker", () => {
+  it("resolves a semantic workspace through the typed catalog and exposes no daemon route facts", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      requests.push({ url, init });
+      return url.endsWith("/api/resources/workspace-catalog")
+        ? json(WORKSPACE_CATALOG)
+        : json(APPLICATION_SHELL_ENVELOPE);
+    });
+    const broker = new DaemonResourceBroker({ daemon: CONNECTED, fetch });
+
+    const listed = await broker.listWorkspaces();
+    expect(listed).toEqual({
+      status: "ok",
+      daemon: IDENTITY,
+      workspaces: [{ workspaceName: "product workspace" }, { workspaceName: "docs" }],
+    });
+    expect(JSON.stringify(listed)).not.toMatch(/sessionName|projectDir|apiBaseUrl|private|token/iu);
+
+    const resource = await broker.fetchApplicationShell("product workspace");
+    expect(resource).toEqual({ status: "ok", envelope: APPLICATION_SHELL_ENVELOPE });
+    expect(requests.map(({ url }) => url)).toEqual([
+      "http://127.0.0.1:6060/api/resources/workspace-catalog",
+      "http://127.0.0.1:6060/api/resources/workspace-catalog",
+      "http://127.0.0.1:6060/api/project/server%2Fsession%3A42/application-shell",
+    ]);
+    expect(requests.every(({ init }) => init?.method === "GET" && init.redirect === "error")).toBe(
+      true,
+    );
+    expect(JSON.stringify(requests.map(({ init }) => init?.headers))).not.toMatch(/bearer|token/iu);
+  });
+
+  it("never lets an unknown semantic name become a daemon route", async () => {
+    const fetch = vi.fn(async () => json(WORKSPACE_CATALOG));
+    const broker = new DaemonResourceBroker({ daemon: CONNECTED, fetch });
+    await expect(broker.fetchApplicationShell("../../escape")).resolves.toEqual({
+      status: "error",
+      error: {
+        code: "workspace-not-found",
+        reason: "The requested workspace is unavailable.",
+      },
+    });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["protocolVersion", { protocolVersion: 2 }],
+    ["productVersion", { productVersion: "2.8.1" }],
+    ["instanceId", { instanceId: "66ab67ed-18fe-431b-913b-70972b78c96f" }],
+    ["startedAt", { startedAt: "2026-07-21T00:00:01.000Z" }],
+  ])("rejects a catalog whose daemon %s is from another generation", async (_field, changed) => {
+    const broker = new DaemonResourceBroker({
+      daemon: CONNECTED,
+      fetch: async () =>
+        json({ ...WORKSPACE_CATALOG, daemon: { ...WORKSPACE_CATALOG.daemon, ...changed } }),
+    });
+    await expect(broker.listWorkspaces()).resolves.toMatchObject({
+      status: "error",
+      error: { code: "daemon-identity-mismatch" },
+    });
+  });
+
+  it("rejects workspace collisions after semantic name normalization", async () => {
+    const broker = new DaemonResourceBroker({
+      daemon: CONNECTED,
+      fetch: async () =>
+        json({
+          ...WORKSPACE_CATALOG,
+          workspaces: [
+            { workspaceName: "docs", sessionName: "docs-one" },
+            { workspaceName: " docs ", sessionName: "docs-two" },
+          ],
+        }),
+    });
+    await expect(broker.listWorkspaces()).resolves.toMatchObject({
+      status: "error",
+      error: { code: "invalid-response" },
+    });
+  });
+
+  it("rejects duplicate subscription names after semantic normalization", async () => {
+    const fetch = vi.fn(async () => json(WORKSPACE_CATALOG));
+    const broker = new DaemonResourceBroker({ daemon: CONNECTED, fetch });
+    await expect(broker.subscribe(["docs", " docs "], vi.fn())).resolves.toMatchObject({
+      status: "error",
+      error: { code: "invalid-request" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "redirect",
+      fetch: async () =>
+        Object.defineProperty(json(WORKSPACE_CATALOG), "redirected", { value: true }) as Response,
+      code: "request-failed",
+    },
+    {
+      name: "oversized",
+      fetch: async () =>
+        new Response(JSON.stringify(WORKSPACE_CATALOG), {
+          headers: { "content-type": "application/json", "content-length": "9999999" },
+        }),
+      code: "response-too-large",
+    },
+    {
+      name: "wrong content type",
+      fetch: async () => new Response("{}", { headers: { "content-type": "text/html" } }),
+      code: "invalid-response",
+    },
+    {
+      name: "JSON-derived but non-JSON media type",
+      fetch: async () =>
+        new Response(JSON.stringify(WORKSPACE_CATALOG), {
+          headers: { "content-type": "application/json-patch+json" },
+        }),
+      code: "invalid-response",
+    },
+    {
+      name: "invalid strict schema",
+      fetch: async () => json({ ...WORKSPACE_CATALOG, token: "do-not-reflect" }),
+      code: "invalid-response",
+    },
+  ])("returns a bounded redacted error for $name", async ({ fetch, code }) => {
+    const broker = new DaemonResourceBroker({ daemon: CONNECTED, fetch });
+    const result = await broker.listWorkspaces();
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.code).toBe(code);
+      expect(JSON.stringify(result.error)).not.toMatch(/6060|workspaces|private|token|html/iu);
+      expect(result.error.reason.length).toBeLessThanOrEqual(240);
+    }
+  });
+
+  it("bounds request time and aborts a renderer generation on release", async () => {
+    let signal: AbortSignal | undefined;
+    const never = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
+        new Promise((_resolve, reject) => {
+          signal = init?.signal ?? undefined;
+          init?.signal?.addEventListener("abort", () => reject(new Error("secret abort detail")));
+        }),
+    );
+    const timed = new DaemonResourceBroker({
+      daemon: CONNECTED,
+      fetch: never,
+      requestTimeoutMs: 5,
+    });
+    await expect(timed.listWorkspaces()).resolves.toMatchObject({
+      status: "error",
+      error: { code: "request-timeout" },
+    });
+    expect(signal?.aborted).toBe(true);
+
+    const released = new DaemonResourceBroker({ daemon: CONNECTED, fetch: never });
+    const pending = released.listWorkspaces();
+    await vi.waitFor(() => expect(never).toHaveBeenCalledTimes(2));
+    released.releaseRenderer();
+    await expect(pending).resolves.toMatchObject({ status: "error", error: { code: "disposed" } });
+  });
+
+  it("does no HTTP or WebSocket work when the verified daemon is unavailable", async () => {
+    const fetch = vi.fn();
+    const createWebSocket = vi.fn();
+    const broker = new DaemonResourceBroker({
+      daemon: {
+        status: "unavailable",
+        code: "record-missing",
+        reason: "/private/path must not be reflected",
+      },
+      fetch,
+      createWebSocket,
+    });
+    expect(await broker.listWorkspaces()).toMatchObject({
+      status: "error",
+      error: { code: "daemon-unavailable" },
+    });
+    expect(await broker.subscribe(["product workspace"], vi.fn())).toMatchObject({
+      status: "error",
+      error: { code: "daemon-unavailable" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(createWebSocket).not.toHaveBeenCalled();
+  });
+
+  it("multiplexes semantic subscribers over one identity-gated socket and sanitizes frames", async () => {
+    const fetch = vi.fn(async () => json(WORKSPACE_CATALOG));
+    const socket = new FakeSocket();
+    const createWebSocket = vi.fn(() => socket);
+    const first: DesktopDaemonEvent[] = [];
+    const second: DesktopDaemonEvent[] = [];
+    const broker = new DaemonResourceBroker({ daemon: CONNECTED, fetch, createWebSocket });
+
+    const one = await broker.subscribe(["product workspace"], (event) => first.push(event));
+    const two = await broker.subscribe(["docs"], (event) => second.push(event));
+    expect(one.status).toBe("subscribed");
+    expect(two.status).toBe("subscribed");
+    expect(createWebSocket).toHaveBeenCalledOnce();
+    expect(createWebSocket).toHaveBeenCalledWith("ws://127.0.0.1:6060/ws/events");
+
+    socket.emit("open");
+    expect(socket.sent).toEqual([]);
+    socket.emit("message", JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }));
+    expect(JSON.parse(socket.sent[0]!)).toEqual({
+      type: "subscribe",
+      sessions: ["server/session:42", "durable-docs"],
+    });
+    socket.emit(
+      "message",
+      JSON.stringify({ type: "terminals.changed", sessionName: "server/session:42" }),
+    );
+    expect(first.at(-1)).toEqual({
+      type: "application-shell.changed",
+      workspaceName: "product workspace",
+    });
+    expect(second.some((event) => event.type === "application-shell.changed")).toBe(false);
+
+    socket.emit(
+      "message",
+      JSON.stringify({
+        type: "workspace.added",
+        workspace: {
+          name: "secret-free",
+          sessionName: "raw-secret-session",
+          projectDir: "/private/leak",
+          ideConfigPath: null,
+          addedAt: "2026-07-21T00:00:00.000Z",
+        },
+      }),
+    );
+    expect(first.at(-1)).toEqual({ type: "workspaces.changed" });
+    expect(JSON.stringify([...first, ...second])).not.toMatch(
+      /raw-secret|private\/leak|sessionName/iu,
+    );
+
+    if (one.status === "subscribed") one.unsubscribe();
+    expect(JSON.parse(socket.sent.at(-1)!)).toEqual({
+      type: "unsubscribe",
+      sessions: ["server/session:42"],
+    });
+    if (two.status === "subscribed") two.unsubscribe();
+    expect(socket.close).toHaveBeenCalledWith(1000, "renderer released");
+  });
+
+  it("targets an immediate verified live event to a subscriber joining an open socket", async () => {
+    const socket = new FakeSocket();
+    const first: DesktopDaemonEvent[] = [];
+    const second: DesktopDaemonEvent[] = [];
+    const broker = new DaemonResourceBroker({
+      daemon: CONNECTED,
+      fetch: async () => json(WORKSPACE_CATALOG),
+      createWebSocket: () => socket,
+    });
+    expect(
+      (await broker.subscribe(["product workspace"], (event) => first.push(event))).status,
+    ).toBe("subscribed");
+    socket.emit("open");
+    socket.emit("message", JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }));
+    expect(first.filter((event) => event.type === "connection.changed")).toHaveLength(1);
+
+    expect((await broker.subscribe(["docs"], (event) => second.push(event))).status).toBe(
+      "subscribed",
+    );
+    expect(second).toEqual([{ type: "connection.changed", state: "live", error: null }]);
+    expect(first.filter((event) => event.type === "connection.changed")).toHaveLength(1);
+  });
+
+  it("normalizes workspace event updates into the same single catalog mapping", async () => {
+    const socket = new FakeSocket();
+    const events: DesktopDaemonEvent[] = [];
+    const broker = new DaemonResourceBroker({
+      daemon: CONNECTED,
+      fetch: async () => json(WORKSPACE_CATALOG),
+      createWebSocket: () => socket,
+    });
+    expect((await broker.subscribe(["docs"], (event) => events.push(event))).status).toBe(
+      "subscribed",
+    );
+    socket.emit("open");
+    socket.emit("message", JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }));
+    socket.emit(
+      "message",
+      JSON.stringify({
+        type: "workspace.added",
+        workspace: {
+          name: " docs ",
+          sessionName: "docs-replaced",
+          projectDir: "/private/replaced",
+          ideConfigPath: null,
+          addedAt: "2026-07-21T00:00:00.000Z",
+        },
+      }),
+    );
+    events.length = 0;
+    socket.emit(
+      "message",
+      JSON.stringify({ type: "terminals.changed", sessionName: "durable-docs" }),
+    );
+    socket.emit(
+      "message",
+      JSON.stringify({ type: "terminals.changed", sessionName: "docs-replaced" }),
+    );
+    expect(events).toEqual([{ type: "application-shell.changed", workspaceName: "docs" }]);
+
+    socket.emit("message", JSON.stringify({ type: "workspace.removed", name: " docs " }));
+    expect(socket.close).toHaveBeenCalledWith(1000, "renderer released");
+  });
+
+  it.each([false, true])(
+    "bounds the event handshake when socket open=%s and clears it on release",
+    async (opened) => {
+      vi.useFakeTimers();
+      try {
+        const socket = new FakeSocket();
+        const events: DesktopDaemonEvent[] = [];
+        const broker = new DaemonResourceBroker({
+          daemon: CONNECTED,
+          fetch: async () => json(WORKSPACE_CATALOG),
+          createWebSocket: () => socket,
+          eventHandshakeTimeoutMs: 10,
+        });
+        expect((await broker.subscribe(["docs"], (event) => events.push(event))).status).toBe(
+          "subscribed",
+        );
+        if (opened) socket.emit("open");
+        await vi.advanceTimersByTimeAsync(10);
+        expect(events.at(-1)).toMatchObject({
+          type: "connection.changed",
+          state: "degraded",
+          error: { code: "event-unavailable" },
+        });
+        expect(socket.close).toHaveBeenCalledWith(1008, "event handshake timeout");
+
+        const releasedSocket = new FakeSocket();
+        const releasedEvents: DesktopDaemonEvent[] = [];
+        const released = new DaemonResourceBroker({
+          daemon: CONNECTED,
+          fetch: async () => json(WORKSPACE_CATALOG),
+          createWebSocket: () => releasedSocket,
+          eventHandshakeTimeoutMs: 10,
+        });
+        await released.subscribe(["docs"], (event) => releasedEvents.push(event));
+        released.releaseRenderer();
+        await vi.advanceTimersByTimeAsync(10);
+        expect(releasedEvents).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("closes an errored physical event socket", async () => {
+    const socket = new FakeSocket();
+    const events: DesktopDaemonEvent[] = [];
+    const broker = new DaemonResourceBroker({
+      daemon: CONNECTED,
+      fetch: async () => json(WORKSPACE_CATALOG),
+      createWebSocket: () => socket,
+    });
+    await broker.subscribe(["docs"], (event) => events.push(event));
+    socket.emit("error");
+    expect(socket.close).toHaveBeenCalledWith(1011, "event connection failed");
+    expect(events.at(-1)).toMatchObject({ error: { code: "event-unavailable" } });
+  });
+
+  it("rejects an event peer mismatch and never sends the subscription", async () => {
+    const socket = new FakeSocket();
+    const events: DesktopDaemonEvent[] = [];
+    const broker = new DaemonResourceBroker({
+      daemon: CONNECTED,
+      fetch: async () => json(WORKSPACE_CATALOG),
+      createWebSocket: () => socket,
+    });
+    expect((await broker.subscribe(["docs"], (event) => events.push(event))).status).toBe(
+      "subscribed",
+    );
+    socket.emit("open");
+    socket.emit(
+      "message",
+      JSON.stringify({
+        type: "hello",
+        daemon: { ...IDENTITY, instanceId: "66ab67ed-18fe-431b-913b-70972b78c96f" },
+        sessions: [],
+      }),
+    );
+    expect(socket.sent).toEqual([]);
+    expect(socket.close).toHaveBeenCalledWith(1008, "daemon generation mismatch");
+    expect(events.at(-1)).toMatchObject({
+      type: "connection.changed",
+      state: "degraded",
+      error: { code: "daemon-identity-mismatch" },
+    });
+  });
+
+  it("rejects event data that arrives before the socket open boundary", async () => {
+    const socket = new FakeSocket();
+    const broker = new DaemonResourceBroker({
+      daemon: CONNECTED,
+      fetch: async () => json(WORKSPACE_CATALOG),
+      createWebSocket: () => socket,
+    });
+    expect((await broker.subscribe(["docs"], vi.fn())).status).toBe("subscribed");
+    socket.emit("message", JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }));
+    expect(socket.sent).toEqual([]);
+    expect(socket.close).toHaveBeenCalledWith(1002, "event frame before open");
+  });
+});

--- a/apps/electron-shell/src/daemon-resource-broker.ts
+++ b/apps/electron-shell/src/daemon-resource-broker.ts
@@ -384,8 +384,8 @@ export class DaemonResourceBroker {
       throw new BrokerFailure(daemonCapabilityError("daemon-identity-mismatch"));
     }
     const catalog = parsed.data.workspaces.map((entry) => this.#normalizeCatalogEntry(entry));
-    const normalizedNames = catalog.map(({ workspaceName }) => workspaceName);
-    if (new Set(normalizedNames).size !== normalizedNames.length) {
+    const canonicalNames = catalog.map(({ workspaceName }) => workspaceName);
+    if (new Set(canonicalNames).size !== canonicalNames.length) {
       throw new BrokerFailure(daemonCapabilityError("invalid-response"));
     }
     this.#workspaceCatalog = new Map(catalog.map((entry) => [entry.workspaceName, entry]));
@@ -403,7 +403,7 @@ export class DaemonResourceBroker {
         const code = character.charCodeAt(0);
         return code >= 32 && code !== 127;
       });
-    if (!workspaceName.success || !validSessionName) {
+    if (!workspaceName.success || workspaceName.data !== entry.workspaceName || !validSessionName) {
       throw new BrokerFailure(daemonCapabilityError("invalid-response"));
     }
     return { workspaceName: workspaceName.data, sessionName: entry.sessionName };
@@ -598,9 +598,13 @@ export class DaemonResourceBroker {
             workspaceName: frame.workspace.name,
             sessionName: frame.workspace.sessionName,
           });
+          if (this.#workspaceCatalog.has(entry.workspaceName)) {
+            this.#rejectWorkspaceUpdate("workspace identity collision");
+            return;
+          }
           this.#workspaceCatalog.set(entry.workspaceName, entry);
         } catch {
-          this.#rejectSocketFrame("invalid workspace update");
+          this.#rejectWorkspaceUpdate("invalid workspace update");
           return;
         }
         this.#emit({ type: "workspaces.changed" });
@@ -609,11 +613,15 @@ export class DaemonResourceBroker {
       case "workspace.removed":
         {
           const name = DesktopWorkspaceNameSchemaZ.safeParse(frame.name);
-          if (!name.success) {
-            this.#rejectSocketFrame("invalid workspace update");
+          if (
+            !name.success ||
+            name.data !== frame.name ||
+            !this.#workspaceCatalog.has(frame.name)
+          ) {
+            this.#rejectWorkspaceUpdate("invalid workspace update");
             return;
           }
-          this.#workspaceCatalog.delete(name.data);
+          this.#workspaceCatalog.delete(frame.name);
         }
         this.#emit({ type: "workspaces.changed" });
         this.#synchronizeSocket();
@@ -745,6 +753,25 @@ export class DaemonResourceBroker {
       error: daemonCapabilityError("invalid-response"),
     });
     this.#closeSocket(1002, reason);
+  }
+
+  #rejectWorkspaceUpdate(reason: string): void {
+    this.#rejectSocketFrame(reason);
+    void this.#refreshCatalogAfterRejectedUpdate();
+  }
+
+  async #refreshCatalogAfterRejectedUpdate(): Promise<void> {
+    try {
+      await this.#loadWorkspaceCatalog();
+      if (!this.#disposed) this.#synchronizeSocket();
+    } catch (error) {
+      if (this.#disposed) return;
+      this.#emit({
+        type: "connection.changed",
+        state: "degraded",
+        error: this.#boundedError(error),
+      });
+    }
   }
 
   #closeSocket(code = 1000, reason = "renderer released"): void {

--- a/apps/electron-shell/src/daemon-resource-broker.ts
+++ b/apps/electron-shell/src/daemon-resource-broker.ts
@@ -1,0 +1,761 @@
+import {
+  ApplicationShellResourceV1SchemaZ,
+  DaemonEventClientFrameSchemaZ,
+  DaemonEventServerFrameSchemaZ,
+  DesktopDaemonEventSchemaZ,
+  DesktopDaemonEventSubscriptionRequestSchemaZ,
+  DesktopDaemonFetchApplicationShellRequestSchemaZ,
+  DesktopDaemonFetchApplicationShellResultSchemaZ,
+  DesktopDaemonHostStateSchemaZ,
+  DesktopDaemonListWorkspacesResultSchemaZ,
+  DesktopWorkspaceNameSchemaZ,
+  WorkspaceCatalogResourceV1SchemaZ,
+  type DaemonEventServerFrame,
+  type DaemonInstanceIdentity,
+  type DesktopDaemonCapabilityError,
+  type DesktopDaemonCapabilityErrorCode,
+  type DesktopDaemonEvent,
+  type DesktopDaemonFetchApplicationShellResult,
+  type DesktopDaemonHostState,
+  type DesktopDaemonListWorkspacesResult,
+} from "@tmux-ide/contracts";
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 3_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 1024 * 1024;
+const DEFAULT_MAX_EVENT_BYTES = 512 * 1024;
+const DEFAULT_EVENT_HANDSHAKE_TIMEOUT_MS = 3_000;
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
+
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  const candidate = value ?? fallback;
+  if (!Number.isInteger(candidate) || candidate < minimum || candidate > maximum) {
+    throw new Error(
+      `daemon resource broker limit must be an integer from ${minimum} through ${maximum}`,
+    );
+  }
+  return candidate;
+}
+
+type BrokerFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+type SocketEventType = "open" | "message" | "close" | "error";
+type SocketEvent = { readonly data?: unknown };
+type SocketListener = (event: SocketEvent) => void;
+
+export interface BrokerEventSocket {
+  readonly readyState: number;
+  addEventListener(type: SocketEventType, listener: SocketListener): void;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+export interface DaemonResourceBrokerDependencies {
+  readonly daemon: DesktopDaemonHostState;
+  readonly fetch?: BrokerFetch;
+  readonly createWebSocket?: (url: string) => BrokerEventSocket;
+  readonly requestTimeoutMs?: number;
+  readonly maxResponseBytes?: number;
+  readonly maxEventBytes?: number;
+  readonly eventHandshakeTimeoutMs?: number;
+}
+
+export type BrokerSubscriptionResult =
+  | { readonly status: "subscribed"; readonly unsubscribe: () => void }
+  | { readonly status: "error"; readonly error: DesktopDaemonCapabilityError };
+
+interface WorkspaceCatalogEntry {
+  readonly workspaceName: string;
+  readonly sessionName: string;
+}
+
+interface BrokerSubscription {
+  readonly workspaceNames: ReadonlySet<string>;
+  readonly listener: (event: DesktopDaemonEvent) => void;
+}
+
+class BrokerFailure extends Error {
+  constructor(readonly error: DesktopDaemonCapabilityError) {
+    super(error.reason);
+  }
+}
+
+const ERROR_REASON: Record<DesktopDaemonCapabilityErrorCode, string> = {
+  "preview-only": "Live daemon resources are unavailable in browser preview.",
+  "daemon-unavailable": "The canonical daemon is unavailable.",
+  "daemon-degraded": "The canonical daemon could not be trusted.",
+  "invalid-request": "The desktop daemon request was invalid.",
+  "workspace-not-found": "The requested workspace is unavailable.",
+  "request-timeout": "The daemon resource request timed out.",
+  "response-too-large": "The daemon resource response exceeded its size limit.",
+  "invalid-response": "The daemon returned an invalid resource response.",
+  "daemon-identity-mismatch": "The daemon generation changed during the resource request.",
+  "request-failed": "The daemon resource request failed.",
+  "event-unavailable": "The daemon event connection is unavailable.",
+  "protocol-error": "The daemon event protocol rejected the subscription.",
+  disposed: "The desktop daemon resource broker was disposed.",
+};
+
+export function daemonCapabilityError(
+  code: DesktopDaemonCapabilityErrorCode,
+): DesktopDaemonCapabilityError {
+  return { code, reason: ERROR_REASON[code] };
+}
+
+export function rendererDaemonState(daemon: DesktopDaemonHostState):
+  | { readonly status: "connected"; readonly identity: DaemonInstanceIdentity }
+  | {
+      readonly status: "unavailable" | "degraded";
+      readonly code: Extract<
+        DesktopDaemonHostState,
+        { status: "unavailable" | "degraded" }
+      >["code"];
+      readonly reason: string;
+    } {
+  if (daemon.status === "connected") {
+    const { protocolVersion, productVersion, instanceId, startedAt } = daemon.descriptor;
+    return {
+      status: "connected",
+      identity: { protocolVersion, productVersion, instanceId, startedAt },
+    };
+  }
+  return {
+    status: daemon.status,
+    code: daemon.code,
+    reason:
+      daemon.status === "degraded"
+        ? "Canonical daemon verification is degraded."
+        : "The canonical daemon is unavailable.",
+  };
+}
+
+function daemonIdentity(
+  daemon: Extract<DesktopDaemonHostState, { status: "connected" }>,
+): DaemonInstanceIdentity {
+  const { protocolVersion, productVersion, instanceId, startedAt } = daemon.descriptor;
+  return { protocolVersion, productVersion, instanceId, startedAt };
+}
+
+function sameIdentity(left: DaemonInstanceIdentity, right: DaemonInstanceIdentity): boolean {
+  return (
+    left.protocolVersion === right.protocolVersion &&
+    left.productVersion === right.productVersion &&
+    left.instanceId === right.instanceId &&
+    left.startedAt === right.startedAt
+  );
+}
+
+function defaultFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  return globalThis.fetch(input, init);
+}
+
+function defaultWebSocket(url: string): BrokerEventSocket {
+  return new globalThis.WebSocket(url) as unknown as BrokerEventSocket;
+}
+
+async function readBoundedJson(response: Response, maximumBytes: number): Promise<unknown> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null && Number(declaredLength) > maximumBytes) {
+    throw new BrokerFailure(daemonCapabilityError("response-too-large"));
+  }
+  const contentType = response.headers.get("content-type") ?? "";
+  const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
+  if (mediaType !== "application/json") {
+    throw new BrokerFailure(daemonCapabilityError("invalid-response"));
+  }
+  if (!response.body) throw new BrokerFailure(daemonCapabilityError("invalid-response"));
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      size += next.value.byteLength;
+      if (size > maximumBytes) {
+        await reader.cancel();
+        throw new BrokerFailure(daemonCapabilityError("response-too-large"));
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(body));
+  } catch {
+    throw new BrokerFailure(daemonCapabilityError("invalid-response"));
+  }
+}
+
+export class DaemonResourceBroker {
+  readonly #daemon: DesktopDaemonHostState;
+  readonly #fetch: BrokerFetch;
+  readonly #createWebSocket: (url: string) => BrokerEventSocket;
+  readonly #requestTimeoutMs: number;
+  readonly #maxResponseBytes: number;
+  readonly #maxEventBytes: number;
+  readonly #eventHandshakeTimeoutMs: number;
+  readonly #controllers = new Set<AbortController>();
+  readonly #subscriptions = new Map<number, BrokerSubscription>();
+
+  #disposed = false;
+  #rendererGeneration = 0;
+  #nextSubscription = 0;
+  #workspaceCatalog = new Map<string, WorkspaceCatalogEntry>();
+  #socket: BrokerEventSocket | null = null;
+  #sentSessions = new Set<string>();
+  #socketPeerVerified = false;
+  #socketOpened = false;
+  #socketHandshakeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(dependencies: DaemonResourceBrokerDependencies) {
+    this.#daemon = DesktopDaemonHostStateSchemaZ.parse(dependencies.daemon);
+    this.#fetch = dependencies.fetch ?? defaultFetch;
+    this.#createWebSocket = dependencies.createWebSocket ?? defaultWebSocket;
+    this.#requestTimeoutMs = boundedInteger(
+      dependencies.requestTimeoutMs,
+      DEFAULT_REQUEST_TIMEOUT_MS,
+      1,
+      30_000,
+    );
+    this.#maxResponseBytes = boundedInteger(
+      dependencies.maxResponseBytes,
+      DEFAULT_MAX_RESPONSE_BYTES,
+      1_024,
+      8 * 1024 * 1024,
+    );
+    this.#maxEventBytes = boundedInteger(
+      dependencies.maxEventBytes,
+      DEFAULT_MAX_EVENT_BYTES,
+      1_024,
+      4 * 1024 * 1024,
+    );
+    this.#eventHandshakeTimeoutMs = boundedInteger(
+      dependencies.eventHandshakeTimeoutMs,
+      DEFAULT_EVENT_HANDSHAKE_TIMEOUT_MS,
+      1,
+      30_000,
+    );
+  }
+
+  async listWorkspaces(): Promise<DesktopDaemonListWorkspacesResult> {
+    if (this.#daemon.status !== "connected") return this.#disconnectedResult();
+    try {
+      const workspaces = await this.#loadWorkspaceCatalog();
+      const result: DesktopDaemonListWorkspacesResult = {
+        status: "ok",
+        daemon: daemonIdentity(this.#daemon),
+        workspaces: workspaces.map(({ workspaceName }) => ({ workspaceName })),
+      };
+      return DesktopDaemonListWorkspacesResultSchemaZ.parse(result);
+    } catch (error) {
+      return { status: "error", error: this.#boundedError(error) };
+    }
+  }
+
+  async fetchApplicationShell(
+    workspaceName: string,
+  ): Promise<DesktopDaemonFetchApplicationShellResult> {
+    if (this.#daemon.status !== "connected") return this.#disconnectedResult();
+    try {
+      const request = DesktopDaemonFetchApplicationShellRequestSchemaZ.safeParse({ workspaceName });
+      if (!request.success) throw new BrokerFailure(daemonCapabilityError("invalid-request"));
+      const workspaces = await this.#loadWorkspaceCatalog();
+      const workspace = workspaces.find(
+        (candidate) => candidate.workspaceName === request.data.workspaceName,
+      );
+      if (!workspace) throw new BrokerFailure(daemonCapabilityError("workspace-not-found"));
+      const raw = await this.#requestJson(
+        `/api/project/${encodeURIComponent(workspace.sessionName)}/application-shell`,
+      );
+      const envelope = ApplicationShellResourceV1SchemaZ.parse(raw);
+      if (!sameIdentity(envelope.daemon, daemonIdentity(this.#daemon))) {
+        throw new BrokerFailure(daemonCapabilityError("daemon-identity-mismatch"));
+      }
+      return DesktopDaemonFetchApplicationShellResultSchemaZ.parse({
+        status: "ok",
+        envelope,
+      });
+    } catch (error) {
+      return { status: "error", error: this.#boundedError(error) };
+    }
+  }
+
+  async subscribe(
+    workspaceNames: readonly string[],
+    listener: (event: DesktopDaemonEvent) => void,
+  ): Promise<BrokerSubscriptionResult> {
+    if (this.#daemon.status !== "connected") return this.#disconnectedResult();
+    if (this.#disposed) return { status: "error", error: daemonCapabilityError("disposed") };
+    const parsed = DesktopDaemonEventSubscriptionRequestSchemaZ.safeParse({ workspaceNames });
+    if (!parsed.success) {
+      return { status: "error", error: daemonCapabilityError("invalid-request") };
+    }
+    try {
+      const catalog = await this.#loadWorkspaceCatalog();
+      const known = new Set(catalog.map(({ workspaceName }) => workspaceName));
+      if (parsed.data.workspaceNames.some((name) => !known.has(name))) {
+        return { status: "error", error: daemonCapabilityError("workspace-not-found") };
+      }
+      const id = ++this.#nextSubscription;
+      this.#subscriptions.set(id, {
+        workspaceNames: new Set(parsed.data.workspaceNames),
+        listener,
+      });
+      try {
+        this.#synchronizeSocket();
+      } catch {
+        this.#subscriptions.delete(id);
+        return { status: "error", error: daemonCapabilityError("event-unavailable") };
+      }
+      if (this.#socket?.readyState === WS_OPEN && this.#socketPeerVerified) {
+        this.#deliver(this.#subscriptions.get(id), {
+          type: "connection.changed",
+          state: "live",
+          error: null,
+        });
+      }
+      let active = true;
+      return {
+        status: "subscribed",
+        unsubscribe: () => {
+          if (!active) return;
+          active = false;
+          this.#subscriptions.delete(id);
+          this.#synchronizeSocket();
+        },
+      };
+    } catch (error) {
+      return { status: "error", error: this.#boundedError(error) };
+    }
+  }
+
+  /** Releases one renderer generation while keeping the app-level broker reusable. */
+  releaseRenderer(): void {
+    this.#rendererGeneration += 1;
+    for (const controller of this.#controllers) controller.abort();
+    this.#controllers.clear();
+    this.#subscriptions.clear();
+    this.#closeSocket();
+  }
+
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    this.releaseRenderer();
+  }
+
+  #disconnectedResult(): { status: "error"; error: DesktopDaemonCapabilityError } {
+    return {
+      status: "error",
+      error: daemonCapabilityError(
+        this.#daemon.status === "degraded" ? "daemon-degraded" : "daemon-unavailable",
+      ),
+    };
+  }
+
+  #boundedError(error: unknown): DesktopDaemonCapabilityError {
+    if (error instanceof BrokerFailure) return error.error;
+    return daemonCapabilityError(this.#disposed ? "disposed" : "request-failed");
+  }
+
+  async #loadWorkspaceCatalog(): Promise<WorkspaceCatalogEntry[]> {
+    if (this.#daemon.status !== "connected") {
+      throw new BrokerFailure(daemonCapabilityError("daemon-unavailable"));
+    }
+    const expectedDaemon = daemonIdentity(this.#daemon);
+    const raw = await this.#requestJson("/api/resources/workspace-catalog");
+    const parsed = WorkspaceCatalogResourceV1SchemaZ.safeParse(raw);
+    if (!parsed.success) throw new BrokerFailure(daemonCapabilityError("invalid-response"));
+    if (!sameIdentity(parsed.data.daemon, expectedDaemon)) {
+      throw new BrokerFailure(daemonCapabilityError("daemon-identity-mismatch"));
+    }
+    const catalog = parsed.data.workspaces.map((entry) => this.#normalizeCatalogEntry(entry));
+    const normalizedNames = catalog.map(({ workspaceName }) => workspaceName);
+    if (new Set(normalizedNames).size !== normalizedNames.length) {
+      throw new BrokerFailure(daemonCapabilityError("invalid-response"));
+    }
+    this.#workspaceCatalog = new Map(catalog.map((entry) => [entry.workspaceName, entry]));
+    return catalog;
+  }
+
+  #normalizeCatalogEntry(entry: {
+    readonly workspaceName: string;
+    readonly sessionName: string;
+  }): WorkspaceCatalogEntry {
+    const workspaceName = DesktopWorkspaceNameSchemaZ.safeParse(entry.workspaceName);
+    const validSessionName =
+      entry.sessionName.length <= 160 &&
+      [...entry.sessionName].every((character) => {
+        const code = character.charCodeAt(0);
+        return code >= 32 && code !== 127;
+      });
+    if (!workspaceName.success || !validSessionName) {
+      throw new BrokerFailure(daemonCapabilityError("invalid-response"));
+    }
+    return { workspaceName: workspaceName.data, sessionName: entry.sessionName };
+  }
+
+  async #requestJson(pathname: string): Promise<unknown> {
+    if (this.#disposed) throw new BrokerFailure(daemonCapabilityError("disposed"));
+    if (this.#daemon.status !== "connected") {
+      throw new BrokerFailure(daemonCapabilityError("daemon-unavailable"));
+    }
+    const requestGeneration = this.#rendererGeneration;
+    const base = new URL(this.#daemon.descriptor.apiBaseUrl);
+    const url = new URL(pathname, base);
+    if (url.origin !== base.origin || url.username || url.password) {
+      throw new BrokerFailure(daemonCapabilityError("invalid-request"));
+    }
+    const controller = new AbortController();
+    this.#controllers.add(controller);
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(() => {
+        controller.abort();
+        reject(new BrokerFailure(daemonCapabilityError("request-timeout")));
+      }, this.#requestTimeoutMs);
+      timeout.unref?.();
+    });
+    const operation = (async (): Promise<unknown> => {
+      const response = await this.#fetch(url, {
+        method: "GET",
+        headers: { accept: "application/json" },
+        cache: "no-store",
+        credentials: "omit",
+        redirect: "error",
+        signal: controller.signal,
+      });
+      if (response.redirected) throw new BrokerFailure(daemonCapabilityError("request-failed"));
+      if (!response.ok) {
+        throw new BrokerFailure(
+          daemonCapabilityError(response.status === 404 ? "workspace-not-found" : "request-failed"),
+        );
+      }
+      return readBoundedJson(response, this.#maxResponseBytes);
+    })();
+    try {
+      const result = await Promise.race([operation, deadline]);
+      if (requestGeneration !== this.#rendererGeneration) {
+        throw new BrokerFailure(daemonCapabilityError("disposed"));
+      }
+      return result;
+    } catch (error) {
+      if (error instanceof BrokerFailure) throw error;
+      if (requestGeneration !== this.#rendererGeneration || this.#disposed) {
+        throw new BrokerFailure(daemonCapabilityError("disposed"));
+      }
+      throw new BrokerFailure(daemonCapabilityError("request-failed"));
+    } finally {
+      controller.abort();
+      this.#controllers.delete(controller);
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+
+  #requiredSessions(): Set<string> {
+    const required = new Set<string>();
+    for (const subscription of this.#subscriptions.values()) {
+      for (const name of subscription.workspaceNames) {
+        const sessionName = this.#workspaceCatalog.get(name)?.sessionName;
+        if (sessionName) required.add(sessionName);
+      }
+    }
+    return required;
+  }
+
+  #synchronizeSocket(): void {
+    const required = this.#requiredSessions();
+    if (required.size === 0) {
+      this.#closeSocket();
+      return;
+    }
+    if (!this.#socket) {
+      if (this.#daemon.status !== "connected") return;
+      const url = new URL("/ws/events", this.#daemon.descriptor.apiBaseUrl);
+      url.protocol = "ws:";
+      const socket = this.#createWebSocket(url.toString());
+      this.#socket = socket;
+      this.#socketPeerVerified = false;
+      this.#socketOpened = false;
+      this.#sentSessions.clear();
+      this.#startSocketHandshakeTimer(socket);
+      socket.addEventListener("open", () => {
+        if (this.#socket !== socket) return;
+        this.#socketOpened = true;
+        // The first frame must authenticate the non-secret daemon generation.
+      });
+      socket.addEventListener("message", (event) => this.#receiveSocketEvent(socket, event.data));
+      socket.addEventListener("close", () => this.#socketClosed(socket));
+      socket.addEventListener("error", () => this.#socketErrored(socket));
+      return;
+    }
+    if (this.#socket.readyState === WS_OPEN && this.#socketPeerVerified) {
+      this.#sendSubscriptionDelta(required);
+    }
+  }
+
+  #receiveSocketEvent(socket: BrokerEventSocket, data: unknown): void {
+    if (this.#socket !== socket) return;
+    if (!this.#socketOpened) {
+      this.#emit({
+        type: "connection.changed",
+        state: "degraded",
+        error: daemonCapabilityError("invalid-response"),
+      });
+      this.#closeSocket(1002, "event frame before open");
+      return;
+    }
+    if (
+      typeof data !== "string" ||
+      new TextEncoder().encode(data).byteLength > this.#maxEventBytes
+    ) {
+      this.#emit({
+        type: "connection.changed",
+        state: "degraded",
+        error: daemonCapabilityError("invalid-response"),
+      });
+      this.#closeSocket(1009, "invalid event frame");
+      return;
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(data);
+    } catch {
+      this.#emit({
+        type: "connection.changed",
+        state: "degraded",
+        error: daemonCapabilityError("invalid-response"),
+      });
+      this.#closeSocket(1002, "invalid event frame");
+      return;
+    }
+    const parsed = DaemonEventServerFrameSchemaZ.safeParse(raw);
+    if (!parsed.success) {
+      this.#emit({
+        type: "connection.changed",
+        state: "degraded",
+        error: daemonCapabilityError("invalid-response"),
+      });
+      this.#closeSocket(1002, "invalid event frame");
+      return;
+    }
+    if (!this.#socketPeerVerified) {
+      if (
+        parsed.data.type !== "hello" ||
+        this.#daemon.status !== "connected" ||
+        !sameIdentity(parsed.data.daemon, daemonIdentity(this.#daemon))
+      ) {
+        this.#emit({
+          type: "connection.changed",
+          state: "degraded",
+          error: daemonCapabilityError("daemon-identity-mismatch"),
+        });
+        this.#closeSocket(1008, "daemon generation mismatch");
+        return;
+      }
+      this.#socketPeerVerified = true;
+      this.#clearSocketHandshakeTimer();
+      this.#sendSubscriptionDelta(this.#requiredSessions());
+      this.#emit({ type: "connection.changed", state: "live", error: null });
+      return;
+    }
+    if (parsed.data.type === "hello") {
+      this.#emit({
+        type: "connection.changed",
+        state: "degraded",
+        error: daemonCapabilityError("invalid-response"),
+      });
+      this.#closeSocket(1002, "duplicate hello frame");
+      return;
+    }
+    this.#projectServerFrame(parsed.data);
+  }
+
+  #projectServerFrame(frame: DaemonEventServerFrame): void {
+    switch (frame.type) {
+      case "snapshot":
+      case "config.changed":
+      case "terminals.changed":
+        this.#emitForSession(frame.sessionName);
+        return;
+      case "workspace.added":
+        try {
+          const entry = this.#normalizeCatalogEntry({
+            workspaceName: frame.workspace.name,
+            sessionName: frame.workspace.sessionName,
+          });
+          this.#workspaceCatalog.set(entry.workspaceName, entry);
+        } catch {
+          this.#rejectSocketFrame("invalid workspace update");
+          return;
+        }
+        this.#emit({ type: "workspaces.changed" });
+        this.#synchronizeSocket();
+        return;
+      case "workspace.removed":
+        {
+          const name = DesktopWorkspaceNameSchemaZ.safeParse(frame.name);
+          if (!name.success) {
+            this.#rejectSocketFrame("invalid workspace update");
+            return;
+          }
+          this.#workspaceCatalog.delete(name.data);
+        }
+        this.#emit({ type: "workspaces.changed" });
+        this.#synchronizeSocket();
+        return;
+      case "sessions.changed":
+      case "projects.changed":
+      case "action.complete":
+        this.#emit({ type: "workspaces.changed" });
+        for (const workspace of this.#workspaceCatalog.values()) {
+          this.#emit({
+            type: "application-shell.changed",
+            workspaceName: workspace.workspaceName,
+          });
+        }
+        return;
+      case "protocol.error":
+        this.#emit({
+          type: "connection.changed",
+          state: "degraded",
+          error: daemonCapabilityError("protocol-error"),
+        });
+        return;
+      default:
+        // init output and protocol keepalives are not renderer resources.
+        return;
+    }
+  }
+
+  #emitForSession(sessionName: string): void {
+    for (const workspace of this.#workspaceCatalog.values()) {
+      if (workspace.sessionName === sessionName) {
+        this.#emit({
+          type: "application-shell.changed",
+          workspaceName: workspace.workspaceName,
+        });
+      }
+    }
+  }
+
+  #emit(raw: DesktopDaemonEvent): void {
+    const event = DesktopDaemonEventSchemaZ.parse(raw);
+    for (const subscription of this.#subscriptions.values()) {
+      if (
+        event.type === "application-shell.changed" &&
+        !subscription.workspaceNames.has(event.workspaceName)
+      ) {
+        continue;
+      }
+      this.#deliver(subscription, event);
+    }
+  }
+
+  #deliver(subscription: BrokerSubscription | undefined, event: DesktopDaemonEvent): void {
+    if (!subscription) return;
+    try {
+      subscription.listener(DesktopDaemonEventSchemaZ.parse(event));
+    } catch {
+      // A renderer listener cannot destabilize the single physical socket.
+    }
+  }
+
+  #sendSubscriptionDelta(required: Set<string>): void {
+    if (!this.#socket || this.#socket.readyState !== WS_OPEN || !this.#socketPeerVerified) return;
+    const removed = [...this.#sentSessions].filter((name) => !required.has(name));
+    const added = [...required].filter((name) => !this.#sentSessions.has(name));
+    if (removed.length > 0) {
+      this.#socket.send(
+        JSON.stringify(
+          DaemonEventClientFrameSchemaZ.parse({ type: "unsubscribe", sessions: removed }),
+        ),
+      );
+    }
+    if (added.length > 0) {
+      this.#socket.send(
+        JSON.stringify(DaemonEventClientFrameSchemaZ.parse({ type: "subscribe", sessions: added })),
+      );
+    }
+    this.#sentSessions = required;
+  }
+
+  #socketClosed(socket: BrokerEventSocket): void {
+    if (this.#socket !== socket) return;
+    this.#clearSocketHandshakeTimer();
+    this.#socket = null;
+    this.#socketPeerVerified = false;
+    this.#socketOpened = false;
+    this.#sentSessions.clear();
+    this.#emit({
+      type: "connection.changed",
+      state: "degraded",
+      error: daemonCapabilityError("event-unavailable"),
+    });
+  }
+
+  #socketErrored(socket: BrokerEventSocket): void {
+    if (this.#socket !== socket) return;
+    this.#emit({
+      type: "connection.changed",
+      state: "degraded",
+      error: daemonCapabilityError("event-unavailable"),
+    });
+    this.#closeSocket(1011, "event connection failed");
+  }
+
+  #startSocketHandshakeTimer(socket: BrokerEventSocket): void {
+    this.#clearSocketHandshakeTimer();
+    this.#socketHandshakeTimer = setTimeout(() => {
+      if (this.#socket !== socket || this.#socketPeerVerified) return;
+      this.#emit({
+        type: "connection.changed",
+        state: "degraded",
+        error: daemonCapabilityError("event-unavailable"),
+      });
+      this.#closeSocket(1008, "event handshake timeout");
+    }, this.#eventHandshakeTimeoutMs);
+    this.#socketHandshakeTimer.unref?.();
+  }
+
+  #clearSocketHandshakeTimer(): void {
+    if (!this.#socketHandshakeTimer) return;
+    clearTimeout(this.#socketHandshakeTimer);
+    this.#socketHandshakeTimer = null;
+  }
+
+  #rejectSocketFrame(reason: string): void {
+    this.#emit({
+      type: "connection.changed",
+      state: "degraded",
+      error: daemonCapabilityError("invalid-response"),
+    });
+    this.#closeSocket(1002, reason);
+  }
+
+  #closeSocket(code = 1000, reason = "renderer released"): void {
+    const socket = this.#socket;
+    this.#clearSocketHandshakeTimer();
+    this.#socket = null;
+    this.#socketPeerVerified = false;
+    this.#socketOpened = false;
+    this.#sentSessions.clear();
+    if (socket && (socket.readyState === WS_CONNECTING || socket.readyState === WS_OPEN)) {
+      socket.close(code, reason);
+    }
+  }
+}

--- a/apps/electron-shell/src/host-ipc.test.ts
+++ b/apps/electron-shell/src/host-ipc.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from "electron";
 
+import type { DaemonResourceBroker } from "./daemon-resource-broker.ts";
 import { registerHostIpc, rendererLocationIsTrusted } from "./host-ipc.ts";
 import { HOST_IPC } from "./ipc-channels.ts";
 
 describe("host IPC trust boundary", () => {
-  it("accepts only the current window main frame and removes every handler", () => {
-    const handlers = new Map<string, (event: IpcMainInvokeEvent) => unknown>();
+  it("accepts only the current window main frame and removes every handler", async () => {
+    const handlers = new Map<string, (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown>();
     const ipcMain = {
-      handle: (channel: string, handler: (event: IpcMainInvokeEvent) => unknown) =>
-        handlers.set(channel, handler),
+      handle: (
+        channel: string,
+        handler: (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown,
+      ) => handlers.set(channel, handler),
       removeHandler: (channel: string) => handlers.delete(channel),
     } as unknown as IpcMain;
     const mainFrame = { url: "file:///trusted/renderer/index.html" };
@@ -31,12 +34,36 @@ describe("host IPC trust boundary", () => {
         startedAt: "2026-07-21T00:00:00.000Z",
       },
     };
-    const unregister = registerHostIpc({
+    let publishDaemonEvent: ((event: { type: "workspaces.changed" }) => void) | undefined;
+    const stopDaemonSubscription = vi.fn();
+    const daemonResources = {
+      listWorkspaces: vi.fn(async () => ({
+        status: "ok",
+        daemon: {
+          protocolVersion: 1,
+          productVersion: "2.8.0",
+          instanceId: daemon.descriptor.instanceId,
+          startedAt: daemon.descriptor.startedAt,
+        },
+        workspaces: [{ workspaceName: "product" }],
+      })),
+      fetchApplicationShell: vi.fn(async () => ({
+        status: "error",
+        error: { code: "workspace-not-found", reason: "The requested workspace is unavailable." },
+      })),
+      subscribe: vi.fn(async (_names, listener) => {
+        publishDaemonEvent = listener;
+        return { status: "subscribed", unsubscribe: stopDaemonSubscription };
+      }),
+      releaseRenderer: vi.fn(),
+    } as unknown as DaemonResourceBroker;
+    const registration = registerHostIpc({
       ipcMain,
       getWindow: () => window,
       appVersion: "test",
       platform: "darwin",
       daemon,
+      daemonResources,
       requestQuit: vi.fn(),
       selectProjectDirectory: async () => null,
       getTheme: () => ({ mode: "dark", highContrast: false, reducedMotion: false }),
@@ -47,9 +74,15 @@ describe("host IPC trust boundary", () => {
     });
 
     const bootstrap = handlers.get(HOST_IPC.bootstrap);
-    expect(
-      bootstrap?.({ sender: webContents, senderFrame: mainFrame } as unknown as IpcMainInvokeEvent),
-    ).toMatchObject({ runtime: "electron", appVersion: "test", daemon });
+    const trustedEvent = {
+      sender: webContents,
+      senderFrame: mainFrame,
+    } as unknown as IpcMainInvokeEvent;
+    expect(bootstrap?.(trustedEvent)).toMatchObject({
+      runtime: "electron",
+      appVersion: "test",
+      daemon: { status: "connected", identity: { instanceId: daemon.descriptor.instanceId } },
+    });
     expect(() =>
       bootstrap?.({ sender: webContents, senderFrame: {} } as unknown as IpcMainInvokeEvent),
     ).toThrow("untrusted renderer");
@@ -57,15 +90,220 @@ describe("host IPC trust boundary", () => {
       bootstrap?.({ sender: { id: 8 }, senderFrame: mainFrame } as unknown as IpcMainInvokeEvent),
     ).toThrow("untrusted renderer");
 
+    expect(await handlers.get(HOST_IPC.daemonListWorkspaces)?.(trustedEvent)).toMatchObject({
+      status: "ok",
+      workspaces: [{ workspaceName: "product" }],
+    });
+    expect(
+      await handlers.get(HOST_IPC.daemonFetchApplicationShell)?.(trustedEvent, {
+        workspaceName: "product",
+      }),
+    ).toMatchObject({ status: "error", error: { code: "workspace-not-found" } });
+    expect(
+      await handlers.get(HOST_IPC.daemonFetchApplicationShell)?.(trustedEvent, {
+        workspaceName: "product",
+        sessionName: "raw-target",
+      }),
+    ).toMatchObject({ status: "error", error: { code: "invalid-request" } });
+    expect(daemonResources.fetchApplicationShell).toHaveBeenCalledOnce();
+
+    const subscribed = await handlers.get(HOST_IPC.daemonSubscribe)?.(trustedEvent, {
+      workspaceNames: ["product"],
+    });
+    expect(subscribed).toEqual({
+      status: "subscribed",
+      subscriptionId: "desktop-subscription-1",
+    });
+    publishDaemonEvent?.({ type: "workspaces.changed" });
+    expect(webContents.send).toHaveBeenCalledWith(HOST_IPC.daemonEvent, {
+      subscriptionId: "desktop-subscription-1",
+      event: { type: "workspaces.changed" },
+    });
+
+    let finishList: (() => void) | undefined;
+    vi.mocked(daemonResources.listWorkspaces).mockImplementationOnce(
+      async () =>
+        new Promise((resolve) => {
+          finishList = () =>
+            resolve({
+              status: "ok",
+              daemon: {
+                protocolVersion: 1,
+                productVersion: "2.8.0",
+                instanceId: daemon.descriptor.instanceId,
+                startedAt: daemon.descriptor.startedAt,
+              },
+              workspaces: [{ workspaceName: "product" }],
+            });
+        }),
+    );
+    const pendingList = handlers.get(HOST_IPC.daemonListWorkspaces)?.(trustedEvent);
+    mainFrame.url = "https://attacker.invalid/renderer";
+    finishList?.();
+    await expect(pendingList).rejects.toThrow("untrusted renderer");
+    mainFrame.url = "file:///trusted/renderer/index.html";
+
     // A redirect must not retain bridge authority merely because the Electron
     // WebContents and WebFrameMain objects are still the expected identities.
     mainFrame.url = "https://attacker.invalid/renderer";
     expect(() =>
       bootstrap?.({ sender: webContents, senderFrame: mainFrame } as unknown as IpcMainInvokeEvent),
     ).toThrow("untrusted renderer");
+    publishDaemonEvent?.({ type: "workspaces.changed" });
+    expect(webContents.send).toHaveBeenCalledTimes(1);
 
-    unregister();
+    mainFrame.url = "file:///trusted/renderer/index.html";
+    await handlers.get(HOST_IPC.daemonUnsubscribe)?.(trustedEvent, "desktop-subscription-1");
+    expect(stopDaemonSubscription).toHaveBeenCalledOnce();
+
+    // A same-location bootstrap still creates a new renderer document
+    // generation. An older invoke must not regain authority after its await.
+    let finishGenerationList: (() => void) | undefined;
+    vi.mocked(daemonResources.listWorkspaces).mockImplementationOnce(
+      async () =>
+        new Promise((resolve) => {
+          finishGenerationList = () =>
+            resolve({
+              status: "ok",
+              daemon: {
+                protocolVersion: 1,
+                productVersion: "2.8.0",
+                instanceId: daemon.descriptor.instanceId,
+                startedAt: daemon.descriptor.startedAt,
+              },
+              workspaces: [{ workspaceName: "product" }],
+            });
+        }),
+    );
+    const oldGenerationList = handlers.get(HOST_IPC.daemonListWorkspaces)?.(trustedEvent);
+    bootstrap?.(trustedEvent);
+    finishGenerationList?.();
+    await expect(oldGenerationList).rejects.toThrow("untrusted renderer generation");
+
+    registration.dispose();
+    expect(daemonResources.releaseRenderer).toHaveBeenCalledTimes(2);
     expect(handlers.size).toBe(0);
+  });
+
+  it("releases generation authority on navigation, renderer loss, crash, and window close", async () => {
+    const handlers = new Map<string, (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown>();
+    const ipcMain = {
+      handle: (
+        channel: string,
+        handler: (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown,
+      ) => handlers.set(channel, handler),
+      removeHandler: (channel: string) => handlers.delete(channel),
+    } as unknown as IpcMain;
+    const webContentsListeners = new Map<string, Set<(...args: never[]) => void>>();
+    const windowListeners = new Map<string, Set<(...args: never[]) => void>>();
+    const add = (
+      listeners: Map<string, Set<(...args: never[]) => void>>,
+      name: string,
+      listener: (...args: never[]) => void,
+    ) => {
+      const current = listeners.get(name) ?? new Set();
+      current.add(listener);
+      listeners.set(name, current);
+    };
+    const remove = (
+      listeners: Map<string, Set<(...args: never[]) => void>>,
+      name: string,
+      listener: (...args: never[]) => void,
+    ) => listeners.get(name)?.delete(listener);
+    const emit = (
+      listeners: Map<string, Set<(...args: never[]) => void>>,
+      name: string,
+      ...args: unknown[]
+    ) => {
+      for (const listener of listeners.get(name) ?? []) listener(...(args as never[]));
+    };
+    const mainFrame = { url: "file:///trusted/renderer/index.html" };
+    const webContents = {
+      id: 9,
+      mainFrame,
+      send: vi.fn(),
+      on: (name: string, listener: (...args: never[]) => void) =>
+        add(webContentsListeners, name, listener),
+      removeListener: (name: string, listener: (...args: never[]) => void) =>
+        remove(webContentsListeners, name, listener),
+    };
+    const window = {
+      isDestroyed: () => false,
+      isMaximized: () => false,
+      isFullScreen: () => false,
+      isFocused: () => true,
+      webContents,
+      on: (name: string, listener: (...args: never[]) => void) =>
+        add(windowListeners, name, listener),
+      removeListener: (name: string, listener: (...args: never[]) => void) =>
+        remove(windowListeners, name, listener),
+    } as unknown as BrowserWindow;
+    const stop = vi.fn();
+    let publish: ((event: { type: "workspaces.changed" }) => void) | undefined;
+    const daemonResources = {
+      subscribe: vi.fn(async (_names, listener) => {
+        publish = listener;
+        return { status: "subscribed", unsubscribe: stop };
+      }),
+      releaseRenderer: vi.fn(),
+    } as unknown as DaemonResourceBroker;
+    const registration = registerHostIpc({
+      ipcMain,
+      getWindow: () => window,
+      appVersion: "test",
+      platform: "darwin",
+      daemon: {
+        status: "connected",
+        descriptor: {
+          apiBaseUrl: "http://127.0.0.1:6060",
+          protocolVersion: 1,
+          productVersion: "2.8.0",
+          instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+          startedAt: "2026-07-21T00:00:00.000Z",
+        },
+      },
+      daemonResources,
+      requestQuit: vi.fn(),
+      selectProjectDirectory: async () => null,
+      getTheme: () => ({ mode: "dark", highContrast: false, reducedMotion: false }),
+      trustedRendererLocation: {
+        kind: "packaged-url",
+        url: "file:///trusted/renderer/index.html",
+      },
+    });
+    registration.bindWindow(window);
+    const event = { sender: webContents, senderFrame: mainFrame } as unknown as IpcMainInvokeEvent;
+    const bootstrap = handlers.get(HOST_IPC.bootstrap)!;
+    const subscribe = handlers.get(HOST_IPC.daemonSubscribe)!;
+
+    bootstrap(event);
+    await subscribe(event, { workspaceNames: ["product"] });
+    emit(webContentsListeners, "did-start-navigation", {}, "file:///trusted", false, true);
+    expect(stop).toHaveBeenCalledTimes(1);
+    publish?.({ type: "workspaces.changed" });
+    expect(webContents.send).not.toHaveBeenCalled();
+
+    bootstrap(event);
+    await subscribe(event, { workspaceNames: ["product"] });
+    emit(webContentsListeners, "did-start-loading");
+    expect(stop).toHaveBeenCalledTimes(2);
+
+    bootstrap(event);
+    await subscribe(event, { workspaceNames: ["product"] });
+    emit(webContentsListeners, "render-process-gone", {}, {});
+    expect(stop).toHaveBeenCalledTimes(3);
+
+    bootstrap(event);
+    await subscribe(event, { workspaceNames: ["product"] });
+    emit(webContentsListeners, "destroyed");
+    expect(stop).toHaveBeenCalledTimes(4);
+
+    bootstrap(event);
+    await subscribe(event, { workspaceNames: ["product"] });
+    emit(windowListeners, "closed");
+    expect(stop).toHaveBeenCalledTimes(5);
+    expect(daemonResources.releaseRenderer).toHaveBeenCalledTimes(5);
+    registration.dispose();
   });
 
   it("accepts a configured development origin but not a lookalike or foreign origin", () => {

--- a/apps/electron-shell/src/host-ipc.ts
+++ b/apps/electron-shell/src/host-ipc.ts
@@ -1,6 +1,12 @@
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from "electron";
 import {
   DESKTOP_HOST_API_VERSION,
+  DesktopDaemonEventSubscriptionRequestSchemaZ,
+  DesktopDaemonEventWireEnvelopeSchemaZ,
+  DesktopDaemonFetchApplicationShellRequestSchemaZ,
+  DesktopDaemonSubscriptionIdSchemaZ,
+  DesktopDaemonSubscribeWireResultSchemaZ,
+  DesktopHostBootstrapSchemaZ,
   type DesktopDaemonPreflight,
   type DesktopHostBootstrap,
   type DesktopPlatform,
@@ -8,6 +14,11 @@ import {
   type DesktopWindowState,
 } from "@tmux-ide/contracts";
 
+import {
+  daemonCapabilityError,
+  rendererDaemonState,
+  type DaemonResourceBroker,
+} from "./daemon-resource-broker.ts";
 import { HOST_INVOKE_CHANNELS, HOST_IPC } from "./ipc-channels.ts";
 
 export interface HostIpcDependencies {
@@ -16,6 +27,7 @@ export interface HostIpcDependencies {
   appVersion: string;
   platform: DesktopPlatform;
   daemon: DesktopDaemonPreflight;
+  daemonResources: DaemonResourceBroker;
   rendererDidBootstrap?: () => void;
   requestQuit: () => void;
   selectProjectDirectory: (window: BrowserWindow) => Promise<string | null>;
@@ -66,17 +78,116 @@ function trustedWindow(
   return window;
 }
 
-export function registerHostIpc(deps: HostIpcDependencies): () => void {
+function currentTrustedWindow(
+  getWindow: () => BrowserWindow | null,
+  trustedRendererLocation: TrustedRendererLocation,
+): BrowserWindow | null {
+  const window = getWindow();
+  if (
+    !window ||
+    window.isDestroyed() ||
+    !rendererLocationIsTrusted(window.webContents.mainFrame.url, trustedRendererLocation)
+  ) {
+    return null;
+  }
+  return window;
+}
+
+export interface RegisteredHostIpc {
+  dispose(): void;
+  releaseRenderer(): void;
+  bindWindow(window: BrowserWindow): void;
+}
+
+export function registerHostIpc(deps: HostIpcDependencies): RegisteredHostIpc {
+  interface RendererAuthority {
+    readonly generation: number;
+    readonly window: BrowserWindow;
+    readonly webContentsId: number;
+    readonly mainFrame: IpcMainInvokeEvent["senderFrame"];
+  }
+  interface DaemonSubscriptionAuthority {
+    readonly generation: number;
+    readonly unsubscribe: () => void;
+  }
+
+  const daemonSubscriptions = new Map<string, DaemonSubscriptionAuthority>();
+  let nextDaemonSubscription = 0;
+  let nextRendererGeneration = 0;
+  let rendererAuthority: RendererAuthority | null = null;
+  let boundWindow: BrowserWindow | null = null;
+  let unbindWindow: (() => void) | null = null;
+
+  const releaseRenderer = (): void => {
+    const active = rendererAuthority !== null || daemonSubscriptions.size > 0;
+    rendererAuthority = null;
+    for (const subscription of daemonSubscriptions.values()) subscription.unsubscribe();
+    daemonSubscriptions.clear();
+    if (active) deps.daemonResources.releaseRenderer();
+  };
+
+  const beginRendererGeneration = (event: IpcMainInvokeEvent): RendererAuthority => {
+    const window = trustedWindow(event, deps.getWindow, deps.trustedRendererLocation);
+    releaseRenderer();
+    rendererAuthority = {
+      generation: ++nextRendererGeneration,
+      window,
+      webContentsId: window.webContents.id,
+      mainFrame: event.senderFrame,
+    };
+    return rendererAuthority;
+  };
+
+  const trustedRendererAuthority = (event: IpcMainInvokeEvent): RendererAuthority => {
+    const window = trustedWindow(event, deps.getWindow, deps.trustedRendererLocation);
+    const authority = rendererAuthority;
+    if (
+      !authority ||
+      authority.window !== window ||
+      authority.webContentsId !== event.sender.id ||
+      authority.mainFrame !== event.senderFrame
+    ) {
+      throw new Error("desktop host request came from an untrusted renderer generation");
+    }
+    return authority;
+  };
+
+  const assertRendererAuthority = (
+    event: IpcMainInvokeEvent,
+    expectedGeneration: number,
+  ): RendererAuthority => {
+    const authority = trustedRendererAuthority(event);
+    if (authority.generation !== expectedGeneration) {
+      throw new Error("desktop host request came from an untrusted renderer generation");
+    }
+    return authority;
+  };
+
+  const currentAuthorityWindow = (expectedGeneration: number): BrowserWindow | null => {
+    const authority = rendererAuthority;
+    const window = currentTrustedWindow(deps.getWindow, deps.trustedRendererLocation);
+    if (
+      !authority ||
+      !window ||
+      authority.generation !== expectedGeneration ||
+      authority.window !== window ||
+      authority.webContentsId !== window.webContents.id ||
+      authority.mainFrame !== window.webContents.mainFrame
+    ) {
+      return null;
+    }
+    return window;
+  };
   const handle = (
     channel: (typeof HOST_INVOKE_CHANNELS)[number],
-    handler: (event: IpcMainInvokeEvent) => unknown,
+    handler: (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown,
   ) => {
     deps.ipcMain.removeHandler(channel);
     deps.ipcMain.handle(channel, handler);
   };
 
   handle(HOST_IPC.bootstrap, (event): DesktopHostBootstrap => {
-    const window = trustedWindow(event, deps.getWindow, deps.trustedRendererLocation);
+    const { window } = beginRendererGeneration(event);
     const bootstrap: DesktopHostBootstrap = {
       apiVersion: DESKTOP_HOST_API_VERSION,
       runtime: "electron",
@@ -84,48 +195,169 @@ export function registerHostIpc(deps: HostIpcDependencies): () => void {
       appVersion: deps.appVersion,
       theme: deps.getTheme(),
       window: snapshotWindow(window),
-      daemon: deps.daemon,
+      daemon: rendererDaemonState(deps.daemon),
     };
     deps.rendererDidBootstrap?.();
-    return bootstrap;
+    return DesktopHostBootstrapSchemaZ.parse(bootstrap);
   });
   handle(HOST_IPC.lifecycleQuit, (event) => {
-    trustedWindow(event, deps.getWindow, deps.trustedRendererLocation);
+    trustedRendererAuthority(event);
     deps.requestQuit();
   });
   handle(HOST_IPC.windowGetState, (event) =>
-    snapshotWindow(trustedWindow(event, deps.getWindow, deps.trustedRendererLocation)),
+    snapshotWindow(trustedRendererAuthority(event).window),
   );
   handle(HOST_IPC.windowMinimize, (event) => {
-    const window = trustedWindow(event, deps.getWindow, deps.trustedRendererLocation);
+    const { window } = trustedRendererAuthority(event);
     window.minimize();
     return snapshotWindow(window);
   });
   handle(HOST_IPC.windowToggleMaximized, (event) => {
-    const window = trustedWindow(event, deps.getWindow, deps.trustedRendererLocation);
+    const { window } = trustedRendererAuthority(event);
     if (window.isMaximized()) window.unmaximize();
     else window.maximize();
     return snapshotWindow(window);
   });
   handle(HOST_IPC.windowClose, (event) => {
-    trustedWindow(event, deps.getWindow, deps.trustedRendererLocation).close();
+    trustedRendererAuthority(event).window.close();
   });
   handle(HOST_IPC.menuShowApplication, (event) => {
-    trustedWindow(event, deps.getWindow, deps.trustedRendererLocation);
+    trustedRendererAuthority(event);
     return { status: "unavailable" as const };
   });
   handle(HOST_IPC.dialogSelectProjectDirectory, async (event) => {
-    const window = trustedWindow(event, deps.getWindow, deps.trustedRendererLocation);
+    const authority = trustedRendererAuthority(event);
+    const { window } = authority;
     const path = await deps.selectProjectDirectory(window);
+    assertRendererAuthority(event, authority.generation);
     return path ? { path } : null;
   });
   handle(HOST_IPC.themeGetState, (event) => {
-    trustedWindow(event, deps.getWindow, deps.trustedRendererLocation);
+    trustedRendererAuthority(event);
     return deps.getTheme();
   });
 
-  return () => {
-    for (const channel of HOST_INVOKE_CHANNELS) deps.ipcMain.removeHandler(channel);
+  handle(HOST_IPC.daemonListWorkspaces, async (event, ...args) => {
+    const authority = trustedRendererAuthority(event);
+    if (args.length !== 0) {
+      return { status: "error" as const, error: daemonCapabilityError("invalid-request") };
+    }
+    const result = await deps.daemonResources.listWorkspaces();
+    assertRendererAuthority(event, authority.generation);
+    return result;
+  });
+  handle(HOST_IPC.daemonFetchApplicationShell, async (event, ...args) => {
+    const authority = trustedRendererAuthority(event);
+    if (args.length !== 1) {
+      return { status: "error" as const, error: daemonCapabilityError("invalid-request") };
+    }
+    const request = DesktopDaemonFetchApplicationShellRequestSchemaZ.safeParse(args[0]);
+    if (!request.success) {
+      return { status: "error" as const, error: daemonCapabilityError("invalid-request") };
+    }
+    const result = await deps.daemonResources.fetchApplicationShell(request.data.workspaceName);
+    assertRendererAuthority(event, authority.generation);
+    return result;
+  });
+  handle(HOST_IPC.daemonSubscribe, async (event, ...args) => {
+    const authority = trustedRendererAuthority(event);
+    if (args.length !== 1) {
+      return { status: "error" as const, error: daemonCapabilityError("invalid-request") };
+    }
+    const request = DesktopDaemonEventSubscriptionRequestSchemaZ.safeParse(args[0]);
+    if (!request.success) {
+      return { status: "error" as const, error: daemonCapabilityError("invalid-request") };
+    }
+    const subscriptionId = DesktopDaemonSubscriptionIdSchemaZ.parse(
+      `desktop-subscription-${++nextDaemonSubscription}`,
+    );
+    const result = await deps.daemonResources.subscribe(
+      request.data.workspaceNames,
+      (daemonEvent) => {
+        const window = currentAuthorityWindow(authority.generation);
+        if (!window) return;
+        window.webContents.send(
+          HOST_IPC.daemonEvent,
+          DesktopDaemonEventWireEnvelopeSchemaZ.parse({ subscriptionId, event: daemonEvent }),
+        );
+      },
+    );
+    if (result.status === "error") {
+      assertRendererAuthority(event, authority.generation);
+      return result;
+    }
+    try {
+      assertRendererAuthority(event, authority.generation);
+    } catch (error) {
+      result.unsubscribe();
+      throw error;
+    }
+    daemonSubscriptions.set(subscriptionId, {
+      generation: authority.generation,
+      unsubscribe: result.unsubscribe,
+    });
+    return DesktopDaemonSubscribeWireResultSchemaZ.parse({ status: "subscribed", subscriptionId });
+  });
+  handle(HOST_IPC.daemonUnsubscribe, (event, ...args) => {
+    const authority = trustedRendererAuthority(event);
+    if (args.length !== 1) {
+      return { status: "error" as const, error: daemonCapabilityError("invalid-request") };
+    }
+    const id = DesktopDaemonSubscriptionIdSchemaZ.safeParse(args[0]);
+    if (!id.success) {
+      return { status: "error" as const, error: daemonCapabilityError("invalid-request") };
+    }
+    const subscription = daemonSubscriptions.get(id.data);
+    if (subscription?.generation === authority.generation) {
+      subscription.unsubscribe();
+      daemonSubscriptions.delete(id.data);
+    }
+    return { status: "ok" as const };
+  });
+
+  const bindWindow = (window: BrowserWindow): void => {
+    if (boundWindow === window) return;
+    unbindWindow?.();
+    releaseRenderer();
+    boundWindow = window;
+    const releaseBoundRenderer = (): void => {
+      if (boundWindow === window) releaseRenderer();
+    };
+    const onNavigation = (
+      _event: Electron.Event,
+      _url: string,
+      _isInPlace: boolean,
+      isMainFrame: boolean,
+    ): void => {
+      if (isMainFrame) releaseBoundRenderer();
+    };
+    const onLoading = (): void => releaseBoundRenderer();
+    const onRenderProcessGone = (): void => releaseBoundRenderer();
+    const onDestroyed = (): void => releaseBoundRenderer();
+    const onClosed = (): void => releaseBoundRenderer();
+    window.webContents.on("did-start-navigation", onNavigation);
+    window.webContents.on("did-start-loading", onLoading);
+    window.webContents.on("render-process-gone", onRenderProcessGone);
+    window.webContents.on("destroyed", onDestroyed);
+    window.on("closed", onClosed);
+    unbindWindow = () => {
+      window.webContents.removeListener("did-start-navigation", onNavigation);
+      window.webContents.removeListener("did-start-loading", onLoading);
+      window.webContents.removeListener("render-process-gone", onRenderProcessGone);
+      window.webContents.removeListener("destroyed", onDestroyed);
+      window.removeListener("closed", onClosed);
+      if (boundWindow === window) boundWindow = null;
+    };
+  };
+  return {
+    bindWindow,
+    releaseRenderer,
+    dispose: () => {
+      releaseRenderer();
+      unbindWindow?.();
+      unbindWindow = null;
+      for (const channel of HOST_INVOKE_CHANNELS) deps.ipcMain.removeHandler(channel);
+    },
   };
 }
 

--- a/apps/electron-shell/src/import-boundaries.test.ts
+++ b/apps/electron-shell/src/import-boundaries.test.ts
@@ -57,6 +57,10 @@ describe("desktop process boundaries", () => {
       HOST_IPC.menuShowApplication,
       HOST_IPC.dialogSelectProjectDirectory,
       HOST_IPC.themeGetState,
+      HOST_IPC.daemonListWorkspaces,
+      HOST_IPC.daemonFetchApplicationShell,
+      HOST_IPC.daemonSubscribe,
+      HOST_IPC.daemonUnsubscribe,
     ]);
     expect(Object.values(HOST_IPC)).not.toContain("tmux-ide:host/send");
     expect(Object.values(HOST_IPC)).not.toContain("tmux-ide:host/eval");
@@ -73,6 +77,8 @@ describe("desktop process boundaries", () => {
       false,
     );
     expect(importedSpecifiers(preload).some(isNodeBuiltin)).toBe(false);
+    expect(preload).not.toContain("apiBaseUrl");
+    expect(preload).not.toMatch(/\bfetch\s*\(|new\s+WebSocket\b/u);
   });
 
   it("ships a strict browser renderer policy", async () => {
@@ -80,6 +86,16 @@ describe("desktop process boundaries", () => {
     expect(html).toContain("default-src 'self'");
     expect(html).toContain("object-src 'none'");
     expect(html).toContain("frame-ancestors 'none'");
+    expect(html).toContain("connect-src 'self'");
+    expect(html).not.toMatch(/connect-src[^;]*(?:127\.0\.0\.1|localhost|\[::1\]|https?:|wss?:)/u);
+    expect(html).not.toMatch(/connect-src[^;]*\*/u);
     expect(html).not.toMatch(/unsafe-(?:inline|eval)/u);
+
+    const vite = await readFile(
+      join(packageRoot, "..", "desktop-renderer", "vite.config.ts"),
+      "utf8",
+    );
+    expect(vite).toContain('apply: "serve"');
+    expect(vite).toContain("ws://127.0.0.1:5173");
   });
 });

--- a/apps/electron-shell/src/ipc-channels.ts
+++ b/apps/electron-shell/src/ipc-channels.ts
@@ -11,6 +11,11 @@ export const HOST_IPC = {
   dialogSelectProjectDirectory: "tmux-ide:host/dialog/select-project-directory",
   themeGetState: "tmux-ide:host/theme/get-state",
   themeChanged: "tmux-ide:host/theme/changed",
+  daemonListWorkspaces: "tmux-ide:host/daemon/list-workspaces",
+  daemonFetchApplicationShell: "tmux-ide:host/daemon/fetch-application-shell",
+  daemonSubscribe: "tmux-ide:host/daemon/subscribe",
+  daemonUnsubscribe: "tmux-ide:host/daemon/unsubscribe",
+  daemonEvent: "tmux-ide:host/daemon/event",
 } as const;
 
 export const HOST_INVOKE_CHANNELS = [
@@ -23,4 +28,8 @@ export const HOST_INVOKE_CHANNELS = [
   HOST_IPC.menuShowApplication,
   HOST_IPC.dialogSelectProjectDirectory,
   HOST_IPC.themeGetState,
+  HOST_IPC.daemonListWorkspaces,
+  HOST_IPC.daemonFetchApplicationShell,
+  HOST_IPC.daemonSubscribe,
+  HOST_IPC.daemonUnsubscribe,
 ] as const;

--- a/apps/electron-shell/src/main.ts
+++ b/apps/electron-shell/src/main.ts
@@ -9,10 +9,12 @@ import {
   runDaemonPreflight,
   type DaemonPreflight,
 } from "./daemon-preflight.ts";
+import { DaemonResourceBroker } from "./daemon-resource-broker.ts";
 import {
   publishTheme,
   publishWindowState,
   registerHostIpc,
+  type RegisteredHostIpc,
   type TrustedRendererLocation,
 } from "./host-ipc.ts";
 import { ShutdownBarrier } from "./shutdown-barrier.ts";
@@ -74,7 +76,7 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
   }
 
   let currentWindow: BrowserWindow | null = null;
-  let unregisterIpc: (() => void) | null = null;
+  let hostIpc: RegisteredHostIpc | null = null;
   let quittingAfterBarrier = false;
   let persistTimer: ReturnType<typeof setTimeout> | null = null;
   let lastBoundsWrite = Promise.resolve();
@@ -94,6 +96,7 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
     join(app.getPath("userData"), "window-state.json"),
   );
   const daemon = await runDaemonPreflight(deps.daemonPreflight ?? canonicalDaemonPreflight);
+  const daemonResources = new DaemonResourceBroker({ daemon });
   const developmentUrl = trustedDevelopmentUrl();
   const packagedRendererPath = join(__dirname, "renderer", "index.html");
   const trustedRendererLocation: TrustedRendererLocation = developmentUrl
@@ -139,6 +142,7 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
     });
     currentWindow = window;
     denyRendererEscapes(window.webContents);
+    hostIpc?.bindWindow(window);
 
     window.on("maximize", () => publishWindowState(window));
     window.on("unmaximize", () => publishWindowState(window));
@@ -150,7 +154,10 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
     window.on("resize", scheduleBoundsPersistence);
     window.on("close", () => void persistBounds());
     window.on("closed", () => {
-      if (currentWindow === window) currentWindow = null;
+      if (currentWindow === window) {
+        currentWindow = null;
+        hostIpc?.releaseRenderer();
+      }
     });
 
     try {
@@ -169,12 +176,13 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
     return window;
   };
 
-  unregisterIpc = registerHostIpc({
+  hostIpc = registerHostIpc({
     ipcMain,
     getWindow: () => currentWindow,
     appVersion: app.getVersion(),
     platform: platform(),
     daemon,
+    daemonResources,
     rendererDidBootstrap: () => rendererDidBootstrap?.(),
     requestQuit: () => app.quit(),
     selectProjectDirectory: async (window) => {
@@ -217,7 +225,8 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
         persistBounds,
         () => {
           if (persistTimer) clearTimeout(persistTimer);
-          unregisterIpc?.();
+          hostIpc?.dispose();
+          daemonResources.dispose();
           nativeTheme.removeListener("updated", onThemeUpdated);
         },
       ])

--- a/apps/electron-shell/src/preload.test.ts
+++ b/apps/electron-shell/src/preload.test.ts
@@ -1,0 +1,55 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { DesktopDaemonEvent, HostCapabilities } from "@tmux-ide/contracts";
+
+import { HOST_IPC } from "./ipc-channels.ts";
+
+const electron = vi.hoisted(() => {
+  const listeners = new Map<string, (event: unknown, value: unknown) => void>();
+  return {
+    listeners,
+    exposeInMainWorld: vi.fn(),
+    invoke: vi.fn(),
+    on: vi.fn((channel: string, listener: (event: unknown, value: unknown) => void) => {
+      listeners.set(channel, listener);
+    }),
+    removeListener: vi.fn(),
+  };
+});
+
+vi.mock("electron", () => ({
+  contextBridge: { exposeInMainWorld: electron.exposeInMainWorld },
+  ipcRenderer: {
+    invoke: electron.invoke,
+    on: electron.on,
+    removeListener: electron.removeListener,
+  },
+}));
+
+beforeAll(async () => {
+  await import("./preload.ts");
+});
+
+describe("desktop preload daemon bridge", () => {
+  it("hands off a verified event that arrives before the subscribe invoke resolves", async () => {
+    const subscriptionId = "desktop-subscription-1";
+    const earlyEvent: DesktopDaemonEvent = {
+      type: "connection.changed",
+      state: "live",
+      error: null,
+    };
+    electron.invoke.mockImplementationOnce(async (channel: string) => {
+      expect(channel).toBe(HOST_IPC.daemonSubscribe);
+      electron.listeners.get(HOST_IPC.daemonEvent)?.({}, { subscriptionId, event: earlyEvent });
+      return { status: "subscribed", subscriptionId };
+    });
+    const capabilities = electron.exposeInMainWorld.mock.calls[0]?.[1] as HostCapabilities;
+    const received: DesktopDaemonEvent[] = [];
+    const result = await capabilities.daemon.subscribe({ workspaceNames: ["product"] }, (event) =>
+      received.push(event),
+    );
+
+    expect(result.status).toBe("subscribed");
+    expect(received).toEqual([earlyEvent]);
+  });
+});

--- a/apps/electron-shell/src/preload.ts
+++ b/apps/electron-shell/src/preload.ts
@@ -1,17 +1,55 @@
 import { contextBridge, ipcRenderer } from "electron";
 import {
   DESKTOP_HOST_API_VERSION,
+  DesktopDaemonEventSubscriptionRequestSchemaZ,
+  DesktopDaemonEventWireEnvelopeSchemaZ,
+  DesktopDaemonFetchApplicationShellRequestSchemaZ,
+  DesktopDaemonFetchApplicationShellResultSchemaZ,
+  DesktopDaemonListWorkspacesResultSchemaZ,
+  DesktopDaemonSubscribeWireResultSchemaZ,
   DesktopDirectorySelectionSchemaZ,
   DesktopHostBootstrapSchemaZ,
   DesktopMenuResultSchemaZ,
   DesktopThemeStateSchemaZ,
   DesktopWindowStateSchemaZ,
+  type DesktopDaemonEvent,
+  type DesktopDaemonEventSubscriptionRequest,
+  type DesktopDaemonFetchApplicationShellRequest,
   type DesktopThemeState,
   type DesktopWindowState,
   type HostCapabilities,
 } from "@tmux-ide/contracts";
 
 import { HOST_IPC } from "./ipc-channels.ts";
+
+const daemonListeners = new Map<string, (event: DesktopDaemonEvent) => void>();
+const earlyDaemonEvents = new Map<string, DesktopDaemonEvent[]>();
+
+function deliverDaemonEvent(
+  listener: (event: DesktopDaemonEvent) => void,
+  event: DesktopDaemonEvent,
+): void {
+  try {
+    listener(event);
+  } catch {
+    // One application listener cannot break the preload event bridge.
+  }
+}
+
+ipcRenderer.on(HOST_IPC.daemonEvent, (_event, value: unknown) => {
+  const envelope = DesktopDaemonEventWireEnvelopeSchemaZ.parse(value);
+  const listener = daemonListeners.get(envelope.subscriptionId);
+  if (listener) {
+    deliverDaemonEvent(listener, envelope.event);
+    return;
+  }
+  // The socket can open while the subscribe invoke response is in flight.
+  // Keep only a tiny bounded handoff buffer for that single IPC race.
+  if (earlyDaemonEvents.size >= 64 && !earlyDaemonEvents.has(envelope.subscriptionId)) return;
+  const queued = earlyDaemonEvents.get(envelope.subscriptionId) ?? [];
+  if (queued.length < 8) queued.push(envelope.event);
+  earlyDaemonEvents.set(envelope.subscriptionId, queued);
+});
 
 function onValidatedEvent<T>(
   channel: string,
@@ -68,6 +106,46 @@ const capabilities: HostCapabilities = Object.freeze({
         (value) => DesktopThemeStateSchemaZ.parse(value),
         listener,
       ),
+  }),
+  daemon: Object.freeze({
+    listWorkspaces: async () =>
+      DesktopDaemonListWorkspacesResultSchemaZ.parse(
+        await ipcRenderer.invoke(HOST_IPC.daemonListWorkspaces),
+      ),
+    fetchApplicationShell: async (request: DesktopDaemonFetchApplicationShellRequest) => {
+      const parsed = DesktopDaemonFetchApplicationShellRequestSchemaZ.parse(request);
+      return DesktopDaemonFetchApplicationShellResultSchemaZ.parse(
+        await ipcRenderer.invoke(HOST_IPC.daemonFetchApplicationShell, parsed),
+      );
+    },
+    subscribe: async (
+      request: DesktopDaemonEventSubscriptionRequest,
+      listener: (event: DesktopDaemonEvent) => void,
+    ) => {
+      const parsed = DesktopDaemonEventSubscriptionRequestSchemaZ.parse(request);
+      const result = DesktopDaemonSubscribeWireResultSchemaZ.parse(
+        await ipcRenderer.invoke(HOST_IPC.daemonSubscribe, parsed),
+      );
+      if (result.status === "error") return result;
+      daemonListeners.set(result.subscriptionId, listener);
+      for (const event of earlyDaemonEvents.get(result.subscriptionId) ?? []) {
+        deliverDaemonEvent(listener, event);
+      }
+      earlyDaemonEvents.delete(result.subscriptionId);
+      let active = true;
+      return {
+        status: "subscribed" as const,
+        unsubscribe: () => {
+          if (!active) return;
+          active = false;
+          daemonListeners.delete(result.subscriptionId);
+          earlyDaemonEvents.delete(result.subscriptionId);
+          void ipcRenderer.invoke(HOST_IPC.daemonUnsubscribe, result.subscriptionId).catch(() => {
+            // Main also clears subscriptions when the renderer/window is released.
+          });
+        },
+      };
+    },
   }),
 });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2483,136 +2483,8 @@ var init_commands = __esm({
   }
 });
 
-// packages/contracts/src/daemon-wire.ts
-import { z as z16 } from "zod";
-function isDaemonWireProtocolCompatible(protocolVersion) {
-  return protocolVersion === DAEMON_WIRE_PROTOCOL_VERSION;
-}
-var DAEMON_WIRE_PROTOCOL_VERSION, DaemonWireProtocolVersionSchema, DaemonInstanceIdSchema, DaemonInstanceIdentitySchemaZ, CanonicalDaemonInfoSchema, DaemonHealthSchema, DaemonHealthzSchema, DaemonIdentitySchema;
-var init_daemon_wire = __esm({
-  "packages/contracts/src/daemon-wire.ts"() {
-    "use strict";
-    DAEMON_WIRE_PROTOCOL_VERSION = 1;
-    DaemonWireProtocolVersionSchema = z16.number().int().positive();
-    DaemonInstanceIdSchema = z16.uuid();
-    DaemonInstanceIdentitySchemaZ = z16.object({
-      protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z16.string().trim().min(1),
-      instanceId: DaemonInstanceIdSchema,
-      startedAt: z16.iso.datetime({ offset: true })
-    }).strict();
-    CanonicalDaemonInfoSchema = z16.object({
-      pid: z16.number().int().positive(),
-      port: z16.number().int().min(1).max(65535),
-      protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z16.string().trim().min(1),
-      instanceId: DaemonInstanceIdSchema,
-      startedAt: z16.iso.datetime({ offset: true }),
-      bindHostname: z16.string().trim().min(1),
-      authToken: z16.string().min(1).nullable()
-    });
-    DaemonHealthSchema = z16.object({
-      ok: z16.literal(true),
-      protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z16.string().trim().min(1),
-      uptime: z16.number().nonnegative()
-    });
-    DaemonHealthzSchema = z16.object({
-      ok: z16.literal(true),
-      protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z16.string().trim().min(1),
-      uptimeMs: z16.number().nonnegative()
-    });
-    DaemonIdentitySchema = z16.object({
-      ok: z16.literal(true),
-      pid: z16.number().int().positive(),
-      protocolVersion: DaemonWireProtocolVersionSchema,
-      productVersion: z16.string().trim().min(1),
-      instanceId: DaemonInstanceIdSchema,
-      startedAt: z16.iso.datetime({ offset: true })
-    });
-  }
-});
-
-// packages/contracts/src/desktop-host.ts
-import { z as z17 } from "zod";
-var DESKTOP_HOST_API_VERSION, DesktopRuntimeKindSchemaZ, DesktopPlatformSchemaZ, DesktopThemeModeSchemaZ, DesktopThemeStateSchemaZ, DesktopWindowStateSchemaZ, DesktopDaemonLoopbackUrlSchemaZ, DesktopDaemonHostDescriptorSchemaZ, DesktopApplicationShellTargetSchemaZ, DesktopDaemonHostIssueCodeSchemaZ, DesktopDaemonHostIssueSchemaFields, DesktopDaemonHostStateSchemaZ, DesktopDaemonPreflightSchemaZ, DesktopHostBootstrapSchemaZ, DesktopMenuResultSchemaZ, DesktopDirectorySelectionSchemaZ;
-var init_desktop_host = __esm({
-  "packages/contracts/src/desktop-host.ts"() {
-    "use strict";
-    init_daemon_wire();
-    DESKTOP_HOST_API_VERSION = 2;
-    DesktopRuntimeKindSchemaZ = z17.enum(["browser", "electron"]);
-    DesktopPlatformSchemaZ = z17.enum(["darwin", "linux", "win32", "unknown"]);
-    DesktopThemeModeSchemaZ = z17.enum(["light", "dark"]);
-    DesktopThemeStateSchemaZ = z17.object({
-      mode: DesktopThemeModeSchemaZ,
-      highContrast: z17.boolean(),
-      reducedMotion: z17.boolean()
-    }).strict();
-    DesktopWindowStateSchemaZ = z17.object({
-      maximized: z17.boolean(),
-      fullscreen: z17.boolean(),
-      focused: z17.boolean()
-    }).strict();
-    DesktopDaemonLoopbackUrlSchemaZ = z17.url().refine((value) => {
-      const url = new URL(value);
-      return url.protocol === "http:" && (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]") && url.username.length === 0 && url.password.length === 0 && url.pathname === "/" && url.search.length === 0 && url.hash.length === 0;
-    }, "daemon URL must be an uncredentialed loopback HTTP origin");
-    DesktopDaemonHostDescriptorSchemaZ = z17.object({
-      apiBaseUrl: DesktopDaemonLoopbackUrlSchemaZ,
-      protocolVersion: z17.number().int().positive(),
-      productVersion: z17.string().trim().min(1),
-      instanceId: z17.uuid(),
-      startedAt: z17.iso.datetime({ offset: true })
-    }).strict();
-    DesktopApplicationShellTargetSchemaZ = z17.object({
-      daemon: DaemonInstanceIdentitySchemaZ,
-      workspaceName: z17.string().trim().min(1).max(160)
-    }).strict();
-    DesktopDaemonHostIssueCodeSchemaZ = z17.enum([
-      "record-missing",
-      "record-invalid",
-      "endpoint-not-loopback",
-      "protocol-incompatible",
-      "process-not-running",
-      "identity-unreachable",
-      "identity-mismatch",
-      "health-unreachable",
-      "health-mismatch",
-      "probe-failed",
-      "probe-timeout",
-      "preview-only"
-    ]);
-    DesktopDaemonHostIssueSchemaFields = {
-      code: DesktopDaemonHostIssueCodeSchemaZ,
-      reason: z17.string().min(1)
-    };
-    DesktopDaemonHostStateSchemaZ = z17.discriminatedUnion("status", [
-      z17.object({
-        status: z17.literal("connected"),
-        descriptor: DesktopDaemonHostDescriptorSchemaZ
-      }).strict(),
-      z17.object({ status: z17.literal("unavailable"), ...DesktopDaemonHostIssueSchemaFields }).strict(),
-      z17.object({ status: z17.literal("degraded"), ...DesktopDaemonHostIssueSchemaFields }).strict()
-    ]);
-    DesktopDaemonPreflightSchemaZ = DesktopDaemonHostStateSchemaZ;
-    DesktopHostBootstrapSchemaZ = z17.object({
-      apiVersion: z17.literal(DESKTOP_HOST_API_VERSION),
-      runtime: DesktopRuntimeKindSchemaZ,
-      platform: DesktopPlatformSchemaZ,
-      appVersion: z17.string().min(1),
-      theme: DesktopThemeStateSchemaZ,
-      window: DesktopWindowStateSchemaZ,
-      daemon: DesktopDaemonPreflightSchemaZ
-    }).strict();
-    DesktopMenuResultSchemaZ = z17.object({ status: z17.literal("unavailable") }).strict();
-    DesktopDirectorySelectionSchemaZ = z17.object({ path: z17.string().min(1) }).strict();
-  }
-});
-
 // packages/contracts/src/experience-identifiers.ts
-import { z as z18 } from "zod";
+import { z as z16 } from "zod";
 var SEMANTIC_ICON_IDS, SemanticIconIdSchemaZ, PANE_ROLE_IDS, PaneRoleIdSchemaZ;
 var init_experience_identifiers = __esm({
   "packages/contracts/src/experience-identifiers.ts"() {
@@ -2643,7 +2515,7 @@ var init_experience_identifiers = __esm({
       "refresh",
       "command"
     ];
-    SemanticIconIdSchemaZ = z18.enum(SEMANTIC_ICON_IDS);
+    SemanticIconIdSchemaZ = z16.enum(SEMANTIC_ICON_IDS);
     PANE_ROLE_IDS = [
       "home",
       "terminal",
@@ -2654,19 +2526,19 @@ var init_experience_identifiers = __esm({
       "preview",
       "native"
     ];
-    PaneRoleIdSchemaZ = z18.enum(PANE_ROLE_IDS);
+    PaneRoleIdSchemaZ = z16.enum(PANE_ROLE_IDS);
   }
 });
 
 // packages/contracts/src/pane-appearance.ts
-import { z as z19 } from "zod";
+import { z as z17 } from "zod";
 var SemanticProductIdSchemaZ, PANE_STRUCTURE_IDS, PaneStructureSchemaZ, AGENT_ACTIVITY_IDS, AgentActivitySchemaZ, CANONICAL_DOMAIN_STATUS_IDS, CanonicalDomainStatusSchemaZ, PANE_ATTENTION_IDS, PaneAttentionSchemaZ, PaneVisualStateV1SchemaZ, DOMAIN_STATUS_TONES;
 var init_pane_appearance = __esm({
   "packages/contracts/src/pane-appearance.ts"() {
     "use strict";
-    SemanticProductIdSchemaZ = z19.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u, "semantic id contains a transport-only character");
+    SemanticProductIdSchemaZ = z17.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u, "semantic id contains a transport-only character");
     PANE_STRUCTURE_IDS = ["docked", "floating", "maximized"];
-    PaneStructureSchemaZ = z19.enum(PANE_STRUCTURE_IDS);
+    PaneStructureSchemaZ = z17.enum(PANE_STRUCTURE_IDS);
     AGENT_ACTIVITY_IDS = [
       "idle",
       "running",
@@ -2675,7 +2547,7 @@ var init_pane_appearance = __esm({
       "failed",
       "disconnected"
     ];
-    AgentActivitySchemaZ = z19.enum(AGENT_ACTIVITY_IDS);
+    AgentActivitySchemaZ = z17.enum(AGENT_ACTIVITY_IDS);
     CANONICAL_DOMAIN_STATUS_IDS = [
       "idle",
       "running",
@@ -2685,7 +2557,7 @@ var init_pane_appearance = __esm({
       "disconnected",
       "recovering"
     ];
-    CanonicalDomainStatusSchemaZ = z19.enum(CANONICAL_DOMAIN_STATUS_IDS);
+    CanonicalDomainStatusSchemaZ = z17.enum(CANONICAL_DOMAIN_STATUS_IDS);
     PANE_ATTENTION_IDS = [
       "none",
       "unread",
@@ -2694,26 +2566,26 @@ var init_pane_appearance = __esm({
       "destructive",
       "recovery"
     ];
-    PaneAttentionSchemaZ = z19.enum(PANE_ATTENTION_IDS);
-    PaneVisualStateV1SchemaZ = z19.object({
+    PaneAttentionSchemaZ = z17.enum(PANE_ATTENTION_IDS);
+    PaneVisualStateV1SchemaZ = z17.object({
       structure: PaneStructureSchemaZ,
-      applicationFocus: z19.object({ pane: z19.boolean(), terminalInput: z19.boolean(), windowActive: z19.boolean() }).strict(),
+      applicationFocus: z17.object({ pane: z17.boolean(), terminalInput: z17.boolean(), windowActive: z17.boolean() }).strict(),
       agentActivity: AgentActivitySchemaZ,
       domainStatus: CanonicalDomainStatusSchemaZ,
       attention: PaneAttentionSchemaZ,
-      layoutInteraction: z19.object({
-        editable: z19.boolean(),
-        selected: z19.boolean(),
-        dragging: z19.boolean(),
-        resizing: z19.boolean(),
-        previewing: z19.boolean()
+      layoutInteraction: z17.object({
+        editable: z17.boolean(),
+        selected: z17.boolean(),
+        dragging: z17.boolean(),
+        resizing: z17.boolean(),
+        previewing: z17.boolean()
       }).strict(),
-      controlInteraction: z19.object({
-        hover: z19.boolean(),
-        focusVisible: z19.boolean(),
-        pressed: z19.boolean(),
-        disabled: z19.boolean(),
-        loading: z19.boolean()
+      controlInteraction: z17.object({
+        hover: z17.boolean(),
+        focusVisible: z17.boolean(),
+        pressed: z17.boolean(),
+        disabled: z17.boolean(),
+        loading: z17.boolean()
       }).strict()
     }).strict();
     DOMAIN_STATUS_TONES = Object.freeze({
@@ -2729,7 +2601,7 @@ var init_pane_appearance = __esm({
 });
 
 // packages/contracts/src/experience-shell.ts
-import { z as z20 } from "zod";
+import { z as z18 } from "zod";
 function deepFreezeData(value) {
   if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
   for (const child of Object.values(value)) deepFreezeData(child);
@@ -2742,7 +2614,7 @@ var init_experience_shell = __esm({
     init_commands();
     init_experience_identifiers();
     init_pane_appearance();
-    ShellAreaIdSchemaZ = z20.enum([
+    ShellAreaIdSchemaZ = z18.enum([
       "application-bar",
       "sidebar",
       "primary-navigation",
@@ -2752,14 +2624,14 @@ var init_experience_shell = __esm({
       "status-strip"
     ]);
     PRIMARY_WORKSPACE_MODE_IDS = Object.freeze(["home", "terminals"]);
-    PrimaryWorkspaceModeIdSchemaZ = z20.enum(PRIMARY_WORKSPACE_MODE_IDS);
+    PrimaryWorkspaceModeIdSchemaZ = z18.enum(PRIMARY_WORKSPACE_MODE_IDS);
     DOCK_TOOL_IDS = Object.freeze(["files", "changes", "missions", "activity"]);
-    DockToolIdSchemaZ = z20.enum(DOCK_TOOL_IDS);
+    DockToolIdSchemaZ = z18.enum(DOCK_TOOL_IDS);
     PRODUCT_SURFACE_IDS = Object.freeze([
       ...PRIMARY_WORKSPACE_MODE_IDS,
       ...DOCK_TOOL_IDS
     ]);
-    ProductSurfaceIdSchemaZ = z20.enum(PRODUCT_SURFACE_IDS);
+    ProductSurfaceIdSchemaZ = z18.enum(PRODUCT_SURFACE_IDS);
     CANONICAL_SHELL_AREAS = deepFreezeData([
       { id: "application-bar", label: "Application bar", order: 0 },
       { id: "sidebar", label: "Workspace sidebar", order: 1 },
@@ -2769,35 +2641,35 @@ var init_experience_shell = __esm({
       { id: "bottom-dock", label: "Bottom dock", order: 5 },
       { id: "status-strip", label: "Status and recovery", order: 6 }
     ]);
-    SurfaceKindSchemaZ = z20.enum(["primary-mode", "dock-tool"]);
-    ApplicationShellDockModeSchemaZ = z20.enum(["collapsed", "open", "maximized"]);
-    SurfaceCommandTemplateSchemaZ = z20.discriminatedUnion("id", [
-      z20.object({
-        id: z20.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
-        args: z20.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict()
+    SurfaceKindSchemaZ = z18.enum(["primary-mode", "dock-tool"]);
+    ApplicationShellDockModeSchemaZ = z18.enum(["collapsed", "open", "maximized"]);
+    SurfaceCommandTemplateSchemaZ = z18.discriminatedUnion("id", [
+      z18.object({
+        id: z18.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
+        args: z18.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict()
       }).strict(),
-      z20.object({
-        id: z20.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
-        args: z20.object({ tool: DockToolIdSchemaZ }).strict()
+      z18.object({
+        id: z18.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
+        args: z18.object({ tool: DockToolIdSchemaZ }).strict()
       }).strict(),
-      z20.object({
-        id: z20.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
-        args: z20.object({ mode: ApplicationShellDockModeSchemaZ }).strict()
+      z18.object({
+        id: z18.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
+        args: z18.object({ mode: ApplicationShellDockModeSchemaZ }).strict()
       }).strict(),
-      z20.object({
-        id: z20.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
-        args: z20.object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ }).strict()
+      z18.object({
+        id: z18.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
+        args: z18.object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ }).strict()
       }).strict()
     ]);
-    ProductSurfaceDefinitionSchemaZ = z20.object({
+    ProductSurfaceDefinitionSchemaZ = z18.object({
       id: ProductSurfaceIdSchemaZ,
       icon: SemanticIconIdSchemaZ,
-      label: z20.string().min(1).max(160),
+      label: z18.string().min(1).max(160),
       kind: SurfaceKindSchemaZ,
-      area: z20.enum(["workspace-canvas", "bottom-dock"]),
-      order: z20.number().int().nonnegative(),
+      area: z18.enum(["workspace-canvas", "bottom-dock"]),
+      order: z18.number().int().nonnegative(),
       owningMode: PrimaryWorkspaceModeIdSchemaZ,
-      shortcut: z20.string().min(1).max(32),
+      shortcut: z18.string().min(1).max(32),
       activation: SurfaceCommandTemplateSchemaZ
     }).strict().superRefine((surface, ctx) => {
       if (surface.kind === "primary-mode" && surface.activation.id !== APPLICATION_SHELL_COMMAND_IDS.activateMode) {
@@ -2901,7 +2773,7 @@ var init_experience_shell = __esm({
 });
 
 // packages/contracts/src/focus-overlay.ts
-import { z as z21 } from "zod";
+import { z as z19 } from "zod";
 function resolveSemanticInputLayer(state) {
   const parsed = FocusOverlayStateV1SchemaZ.parse(state);
   let winner = null;
@@ -2920,7 +2792,7 @@ var init_focus_overlay = __esm({
     "use strict";
     init_experience_shell();
     init_pane_appearance();
-    FocusZoneSchemaZ = z21.enum([
+    FocusZoneSchemaZ = z19.enum([
       "application-bar",
       "sidebar",
       "primary-navigation",
@@ -2930,45 +2802,45 @@ var init_focus_overlay = __esm({
       "status-strip",
       "terminal"
     ]);
-    SemanticFocusTargetSchemaZ = z21.discriminatedUnion("kind", [
-      z21.object({ kind: z21.literal("zone"), zone: FocusZoneSchemaZ }).strict(),
-      z21.object({
-        kind: z21.literal("pane"),
+    SemanticFocusTargetSchemaZ = z19.discriminatedUnion("kind", [
+      z19.object({ kind: z19.literal("zone"), zone: FocusZoneSchemaZ }).strict(),
+      z19.object({
+        kind: z19.literal("pane"),
         paneId: SemanticProductIdSchemaZ,
-        input: z21.enum(["chrome", "terminal"])
+        input: z19.enum(["chrome", "terminal"])
       }).strict(),
-      z21.object({ kind: z21.literal("dock-tool"), tool: DockToolIdSchemaZ }).strict(),
-      z21.object({
-        kind: z21.literal("control"),
+      z19.object({ kind: z19.literal("dock-tool"), tool: DockToolIdSchemaZ }).strict(),
+      z19.object({
+        kind: z19.literal("control"),
         controlId: SemanticProductIdSchemaZ,
         zone: FocusZoneSchemaZ
       }).strict()
     ]);
-    OverlayKindSchemaZ = z21.enum(["modal-dialog", "command-palette", "context-menu"]);
-    SemanticOverlaySchemaZ = z21.object({
+    OverlayKindSchemaZ = z19.enum(["modal-dialog", "command-palette", "context-menu"]);
+    SemanticOverlaySchemaZ = z19.object({
       id: SemanticProductIdSchemaZ,
       kind: OverlayKindSchemaZ,
       focusReturnTarget: SemanticFocusTargetSchemaZ
     }).strict();
-    FocusOverlayStateV1SchemaZ = z21.object({
-      windowActivity: z21.enum(["active", "inactive"]),
+    FocusOverlayStateV1SchemaZ = z19.object({
+      windowActivity: z19.enum(["active", "inactive"]),
       focusZone: FocusZoneSchemaZ,
       appFocusedPaneId: SemanticProductIdSchemaZ.nullable(),
       terminalInputPaneId: SemanticProductIdSchemaZ.nullable(),
       layoutSelectedPaneId: SemanticProductIdSchemaZ.nullable(),
-      overlays: z21.array(SemanticOverlaySchemaZ).max(16)
+      overlays: z19.array(SemanticOverlaySchemaZ).max(16)
     }).strict().superRefine((state, ctx) => {
       const ids = state.overlays.map((overlay) => overlay.id);
       if (new Set(ids).size !== ids.length) {
         ctx.addIssue({
-          code: z21.ZodIssueCode.custom,
+          code: z19.ZodIssueCode.custom,
           message: "overlay ids must be unique",
           path: ["overlays"]
         });
       }
       if (state.terminalInputPaneId !== null && state.appFocusedPaneId !== state.terminalInputPaneId) {
         ctx.addIssue({
-          code: z21.ZodIssueCode.custom,
+          code: z19.ZodIssueCode.custom,
           message: "terminal input owner must also be the app-focused pane",
           path: ["terminalInputPaneId"]
         });
@@ -2983,7 +2855,7 @@ var init_focus_overlay = __esm({
 });
 
 // packages/contracts/src/visual-tokens.ts
-import { z as z22 } from "zod";
+import { z as z20 } from "zod";
 function color(hex) {
   const normalized = hex.replace(/^#/u, "");
   return {
@@ -3145,32 +3017,32 @@ var init_visual_tokens = __esm({
     MOTION_DURATION_ROLES = ["instant", "fast", "standard", "emphasized"];
     TYPOGRAPHY_TOKEN_ROLES = ["workspace", "label", "title", "metadata", "code"];
     WINDOW_ACTIVITY_TOKEN_ROLES = ["active", "inactive"];
-    RendererNeutralColorSchemaZ = z22.object({
-      space: z22.literal("srgb"),
-      red: z22.number().int().min(0).max(255),
-      green: z22.number().int().min(0).max(255),
-      blue: z22.number().int().min(0).max(255),
-      alpha: z22.number().int().min(0).max(255)
+    RendererNeutralColorSchemaZ = z20.object({
+      space: z20.literal("srgb"),
+      red: z20.number().int().min(0).max(255),
+      green: z20.number().int().min(0).max(255),
+      blue: z20.number().int().min(0).max(255),
+      alpha: z20.number().int().min(0).max(255)
     }).strict();
-    RhythmValueSchemaZ = z22.object({ unit: z22.literal("rhythm"), value: z22.number().finite().min(0).max(16) }).strict();
-    RatioValueSchemaZ = z22.object({ unit: z22.literal("ratio"), value: z22.number().finite().min(0).max(20) }).strict();
-    DurationValueSchemaZ = z22.object({ unit: z22.literal("ms"), value: z22.number().finite().min(0).max(1e4) }).strict();
-    ElevationValueSchemaZ = z22.object({
-      level: z22.number().int().min(0).max(4),
-      intent: z22.enum(["flat", "raised", "overlay"])
+    RhythmValueSchemaZ = z20.object({ unit: z20.literal("rhythm"), value: z20.number().finite().min(0).max(16) }).strict();
+    RatioValueSchemaZ = z20.object({ unit: z20.literal("ratio"), value: z20.number().finite().min(0).max(20) }).strict();
+    DurationValueSchemaZ = z20.object({ unit: z20.literal("ms"), value: z20.number().finite().min(0).max(1e4) }).strict();
+    ElevationValueSchemaZ = z20.object({
+      level: z20.number().int().min(0).max(4),
+      intent: z20.enum(["flat", "raised", "overlay"])
     }).strict();
-    TypographyValueSchemaZ = z22.object({
-      family: z22.enum(["monospace", "system"]),
-      weight: z22.enum(["regular", "medium", "semibold", "bold"]),
+    TypographyValueSchemaZ = z20.object({
+      family: z20.enum(["monospace", "system"]),
+      weight: z20.enum(["regular", "medium", "semibold", "bold"]),
       lineHeight: RatioValueSchemaZ,
-      truncation: z22.enum(["ellipsis", "clip", "wrap"])
+      truncation: z20.enum(["ellipsis", "clip", "wrap"])
     }).strict();
-    MotionEasingSchemaZ = z22.object({
-      standard: z22.enum(["linear", "standard", "decelerate"]),
-      emphasized: z22.enum(["linear", "standard", "decelerate"])
+    MotionEasingSchemaZ = z20.object({
+      standard: z20.enum(["linear", "standard", "decelerate"]),
+      emphasized: z20.enum(["linear", "standard", "decelerate"])
     }).strict();
-    WindowActivityValueSchemaZ = z22.object({ opacity: RatioValueSchemaZ, contrast: RatioValueSchemaZ }).strict();
-    SurfacesSchemaZ = z22.object({
+    WindowActivityValueSchemaZ = z20.object({ opacity: RatioValueSchemaZ, contrast: RatioValueSchemaZ }).strict();
+    SurfacesSchemaZ = z20.object({
       canvas: RendererNeutralColorSchemaZ,
       panel: RendererNeutralColorSchemaZ,
       panelRaised: RendererNeutralColorSchemaZ,
@@ -3179,7 +3051,7 @@ var init_visual_tokens = __esm({
       headerActive: RendererNeutralColorSchemaZ,
       command: RendererNeutralColorSchemaZ
     }).strict();
-    TextSchemaZ = z22.object({
+    TextSchemaZ = z20.object({
       primary: RendererNeutralColorSchemaZ,
       secondary: RendererNeutralColorSchemaZ,
       muted: RendererNeutralColorSchemaZ,
@@ -3187,7 +3059,7 @@ var init_visual_tokens = __esm({
       inverse: RendererNeutralColorSchemaZ,
       link: RendererNeutralColorSchemaZ
     }).strict();
-    BordersSchemaZ = z22.object({
+    BordersSchemaZ = z20.object({
       subtle: RendererNeutralColorSchemaZ,
       default: RendererNeutralColorSchemaZ,
       focused: RendererNeutralColorSchemaZ,
@@ -3195,21 +3067,21 @@ var init_visual_tokens = __esm({
       attention: RendererNeutralColorSchemaZ,
       danger: RendererNeutralColorSchemaZ
     }).strict();
-    StatusToneSchemaZ = z22.object({
+    StatusToneSchemaZ = z20.object({
       neutral: RendererNeutralColorSchemaZ,
       info: RendererNeutralColorSchemaZ,
       warning: RendererNeutralColorSchemaZ,
       danger: RendererNeutralColorSchemaZ,
       success: RendererNeutralColorSchemaZ
     }).strict();
-    SelectionSchemaZ = z22.object({
+    SelectionSchemaZ = z20.object({
       selection: RendererNeutralColorSchemaZ,
       selectionText: RendererNeutralColorSchemaZ,
       hover: RendererNeutralColorSchemaZ,
       pressed: RendererNeutralColorSchemaZ,
       disabled: RendererNeutralColorSchemaZ
     }).strict();
-    DensitySchemaZ = z22.object({
+    DensitySchemaZ = z20.object({
       cellHeight: RhythmValueSchemaZ,
       headerHeight: RhythmValueSchemaZ,
       statusHeight: RhythmValueSchemaZ,
@@ -3217,39 +3089,39 @@ var init_visual_tokens = __esm({
       sectionGap: RhythmValueSchemaZ,
       controlPadding: RhythmValueSchemaZ
     }).strict();
-    ShapeSchemaZ = z22.object({
+    ShapeSchemaZ = z20.object({
       dockedRadius: RhythmValueSchemaZ,
       floatingRadius: RhythmValueSchemaZ,
       controlRadius: RhythmValueSchemaZ,
       statusRadius: RhythmValueSchemaZ
     }).strict();
-    ElevationSchemaZ = z22.object({
+    ElevationSchemaZ = z20.object({
       floating: ElevationValueSchemaZ,
       palette: ElevationValueSchemaZ,
       windowMode: ElevationValueSchemaZ
     }).strict();
-    MotionSchemaZ = z22.object({
+    MotionSchemaZ = z20.object({
       instant: DurationValueSchemaZ,
       fast: DurationValueSchemaZ,
       standard: DurationValueSchemaZ,
       emphasized: DurationValueSchemaZ,
       easing: MotionEasingSchemaZ
     }).strict();
-    TypographySchemaZ = z22.object({
+    TypographySchemaZ = z20.object({
       workspace: TypographyValueSchemaZ,
       label: TypographyValueSchemaZ,
       title: TypographyValueSchemaZ,
       metadata: TypographyValueSchemaZ,
       code: TypographyValueSchemaZ
     }).strict();
-    FocusSchemaZ = z22.object({
+    FocusSchemaZ = z20.object({
       outline: RhythmValueSchemaZ,
       outlineOffset: RhythmValueSchemaZ,
       focusContrast: RatioValueSchemaZ,
       highContrastOutline: RendererNeutralColorSchemaZ
     }).strict();
-    WindowActivitySchemaZ = z22.object({ active: WindowActivityValueSchemaZ, inactive: WindowActivityValueSchemaZ }).strict();
-    VisualTokensV1SchemaZ = z22.object({
+    WindowActivitySchemaZ = z20.object({ active: WindowActivityValueSchemaZ, inactive: WindowActivityValueSchemaZ }).strict();
+    VisualTokensV1SchemaZ = z20.object({
       surfaces: SurfacesSchemaZ,
       text: TextSchemaZ,
       borders: BordersSchemaZ,
@@ -3263,7 +3135,7 @@ var init_visual_tokens = __esm({
       focus: FocusSchemaZ,
       windowActivity: WindowActivitySchemaZ
     }).strict();
-    VisualTokenOverridesV1SchemaZ = z22.object({
+    VisualTokenOverridesV1SchemaZ = z20.object({
       surfaces: SurfacesSchemaZ.partial().optional(),
       text: TextSchemaZ.partial().optional(),
       borders: BordersSchemaZ.partial().optional(),
@@ -3277,24 +3149,24 @@ var init_visual_tokens = __esm({
       focus: FocusSchemaZ.partial().optional(),
       windowActivity: WindowActivitySchemaZ.partial().optional()
     }).strict();
-    ThemeIdSchemaZ = z22.string().min(1).max(80).regex(/^[a-z0-9][a-z0-9._-]*$/u);
-    ThemeNameSchemaZ = z22.string().min(1).max(120);
-    ThemeAppearanceSchemaZ = z22.enum(["dark", "light"]);
-    VisualThemeDocumentV1SchemaZ = z22.object({
-      version: z22.literal(VISUAL_THEME_VERSION),
+    ThemeIdSchemaZ = z20.string().min(1).max(80).regex(/^[a-z0-9][a-z0-9._-]*$/u);
+    ThemeNameSchemaZ = z20.string().min(1).max(120);
+    ThemeAppearanceSchemaZ = z20.enum(["dark", "light"]);
+    VisualThemeDocumentV1SchemaZ = z20.object({
+      version: z20.literal(VISUAL_THEME_VERSION),
       id: ThemeIdSchemaZ,
       name: ThemeNameSchemaZ,
       appearance: ThemeAppearanceSchemaZ.optional(),
       overrides: VisualTokenOverridesV1SchemaZ
     }).strict();
-    VisualThemeDocumentV0SchemaZ = z22.object({
-      version: z22.literal(0),
+    VisualThemeDocumentV0SchemaZ = z20.object({
+      version: z20.literal(0),
       id: ThemeIdSchemaZ,
       name: ThemeNameSchemaZ,
       appearance: ThemeAppearanceSchemaZ.optional(),
       tokens: VisualTokenOverridesV1SchemaZ
     }).strict();
-    ThemeAccessibilityPreferencesSchemaZ = z22.object({ reducedMotion: z22.boolean(), increasedContrast: z22.boolean() }).strict();
+    ThemeAccessibilityPreferencesSchemaZ = z20.object({ reducedMotion: z20.boolean(), increasedContrast: z20.boolean() }).strict();
     groupSchemas = {
       surfaces: {
         canvas: RendererNeutralColorSchemaZ,
@@ -3363,7 +3235,7 @@ var init_visual_tokens = __esm({
 });
 
 // packages/contracts/src/cohesion-fixture.ts
-import { z as z23 } from "zod";
+import { z as z21 } from "zod";
 function deepFreeze(value) {
   if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
   for (const child of Object.values(value)) deepFreeze(child);
@@ -3380,29 +3252,29 @@ var init_cohesion_fixture = __esm({
     init_pane_appearance();
     init_visual_tokens();
     COHESION_FIXTURE_VERSION = 1;
-    LabelSchemaZ = z23.string().min(1).max(160);
-    OptionalLabelSchemaZ = z23.string().min(1).max(240).nullable();
-    ReadinessSchemaZ = z23.object({
-      state: z23.enum(["ready", "warning", "blocked"]),
-      facts: z23.array(LabelSchemaZ).max(24),
-      warnings: z23.array(LabelSchemaZ).max(24)
+    LabelSchemaZ = z21.string().min(1).max(160);
+    OptionalLabelSchemaZ = z21.string().min(1).max(240).nullable();
+    ReadinessSchemaZ = z21.object({
+      state: z21.enum(["ready", "warning", "blocked"]),
+      facts: z21.array(LabelSchemaZ).max(24),
+      warnings: z21.array(LabelSchemaZ).max(24)
     }).strict();
-    SessionSidebarItemSchemaZ = z23.object({
+    SessionSidebarItemSchemaZ = z21.object({
       id: SemanticProductIdSchemaZ,
       label: LabelSchemaZ,
-      state: z23.enum(["connected", "reconnecting", "disconnected"]),
-      active: z23.boolean()
+      state: z21.enum(["connected", "reconnecting", "disconnected"]),
+      active: z21.boolean()
     }).strict();
-    AgentSidebarItemSchemaZ = z23.object({
+    AgentSidebarItemSchemaZ = z21.object({
       id: SemanticProductIdSchemaZ,
       name: LabelSchemaZ,
-      harness: z23.enum(["codex", "claude-code", "custom"]),
+      harness: z21.enum(["codex", "claude-code", "custom"]),
       activity: AgentActivitySchemaZ,
       paneId: SemanticProductIdSchemaZ.nullable(),
-      attention: z23.boolean()
+      attention: z21.boolean()
     }).strict();
-    PaneActionSchemaZ = z23.object({
-      id: z23.enum([
+    PaneActionSchemaZ = z21.object({
+      id: z21.enum([
         "focus-terminal",
         "split",
         "duplicate",
@@ -3413,13 +3285,13 @@ var init_cohesion_fixture = __esm({
       icon: SemanticIconIdSchemaZ,
       label: LabelSchemaZ,
       commandId: CommandIdSchemaZ,
-      available: z23.boolean(),
+      available: z21.boolean(),
       disabledReason: OptionalLabelSchemaZ
     }).strict().refine((action) => action.available === (action.disabledReason === null), {
       message: "available actions must not have a disabled reason and unavailable actions must",
       path: ["disabledReason"]
     });
-    PaneFixtureSchemaZ = z23.object({
+    PaneFixtureSchemaZ = z21.object({
       id: SemanticProductIdSchemaZ,
       role: PaneRoleIdSchemaZ,
       title: LabelSchemaZ,
@@ -3427,7 +3299,7 @@ var init_cohesion_fixture = __esm({
       terminalSourceId: SemanticProductIdSchemaZ.nullable(),
       agentId: SemanticProductIdSchemaZ.nullable(),
       state: PaneVisualStateV1SchemaZ,
-      actions: z23.array(PaneActionSchemaZ).min(1).max(6)
+      actions: z21.array(PaneActionSchemaZ).min(1).max(6)
     }).strict().superRefine((pane, ctx) => {
       const expectedOrder = [
         "focus-terminal",
@@ -3442,7 +3314,7 @@ var init_cohesion_fixture = __esm({
         const order = expectedOrder.indexOf(action.id);
         if (order <= last) {
           ctx.addIssue({
-            code: z23.ZodIssueCode.custom,
+            code: z21.ZodIssueCode.custom,
             message: "pane actions must follow canonical action order",
             path: ["actions", index, "id"]
           });
@@ -3450,74 +3322,74 @@ var init_cohesion_fixture = __esm({
         last = order;
       }
     });
-    DockToolDataSchemaZ = z23.discriminatedUnion("kind", [
-      z23.object({
-        kind: z23.literal("files"),
+    DockToolDataSchemaZ = z21.discriminatedUnion("kind", [
+      z21.object({
+        kind: z21.literal("files"),
         selectedResourceId: SemanticProductIdSchemaZ.nullable(),
-        fileCount: z23.number().int().nonnegative()
+        fileCount: z21.number().int().nonnegative()
       }).strict(),
-      z23.object({
-        kind: z23.literal("changes"),
+      z21.object({
+        kind: z21.literal("changes"),
         selectedResourceId: SemanticProductIdSchemaZ.nullable(),
-        changeCount: z23.number().int().nonnegative()
+        changeCount: z21.number().int().nonnegative()
       }).strict(),
-      z23.object({
-        kind: z23.literal("missions"),
+      z21.object({
+        kind: z21.literal("missions"),
         missionId: SemanticProductIdSchemaZ,
         title: LabelSchemaZ,
         status: CanonicalDomainStatusSchemaZ,
-        goalCount: z23.number().int().nonnegative(),
-        taskCount: z23.number().int().nonnegative()
+        goalCount: z21.number().int().nonnegative(),
+        taskCount: z21.number().int().nonnegative()
       }).strict(),
-      z23.object({
-        kind: z23.literal("activity"),
-        eventCount: z23.number().int().nonnegative(),
+      z21.object({
+        kind: z21.literal("activity"),
+        eventCount: z21.number().int().nonnegative(),
         latestEventLabel: OptionalLabelSchemaZ
       }).strict()
     ]);
-    DockToolFixtureSchemaZ = z23.object({
+    DockToolFixtureSchemaZ = z21.object({
       id: DockToolIdSchemaZ,
       label: LabelSchemaZ,
       shortcut: LabelSchemaZ,
-      unreadCount: z23.number().int().nonnegative(),
+      unreadCount: z21.number().int().nonnegative(),
       disabledReason: OptionalLabelSchemaZ,
       data: DockToolDataSchemaZ
     }).strict().refine((tool) => tool.id === tool.data.kind, {
       message: "dock tool data kind must match its canonical tool id",
       path: ["data", "kind"]
     });
-    ConnectionRecoverySchemaZ = z23.object({
-      state: z23.enum(["connected", "reconnecting", "disconnected", "recovering"]),
+    ConnectionRecoverySchemaZ = z21.object({
+      state: z21.enum(["connected", "reconnecting", "disconnected", "recovering"]),
       message: LabelSchemaZ,
       safeState: LabelSchemaZ,
       nextAction: LabelSchemaZ
     }).strict();
-    CohesionFixtureV1SchemaZ = z23.object({
-      version: z23.literal(COHESION_FIXTURE_VERSION),
-      project: z23.object({
+    CohesionFixtureV1SchemaZ = z21.object({
+      version: z21.literal(COHESION_FIXTURE_VERSION),
+      project: z21.object({
         id: SemanticProductIdSchemaZ,
         name: LabelSchemaZ,
         rootLabel: LabelSchemaZ,
         readiness: ReadinessSchemaZ
       }).strict(),
-      workspace: z23.object({
+      workspace: z21.object({
         id: SemanticProductIdSchemaZ,
         name: LabelSchemaZ,
         activeMode: PrimaryWorkspaceModeIdSchemaZ,
         session: SessionSidebarItemSchemaZ,
-        sidebar: z23.object({
-          sessions: z23.array(SessionSidebarItemSchemaZ).min(1).max(32),
-          agents: z23.array(AgentSidebarItemSchemaZ).max(64)
+        sidebar: z21.object({
+          sessions: z21.array(SessionSidebarItemSchemaZ).min(1).max(32),
+          agents: z21.array(AgentSidebarItemSchemaZ).max(64)
         }).strict()
       }).strict(),
-      panes: z23.array(PaneFixtureSchemaZ).min(1).max(32),
-      dock: z23.object({
-        mode: z23.enum(["collapsed", "open", "maximized"]),
+      panes: z21.array(PaneFixtureSchemaZ).min(1).max(32),
+      dock: z21.object({
+        mode: z21.enum(["collapsed", "open", "maximized"]),
         activeTool: DockToolIdSchemaZ,
-        tools: z23.array(DockToolFixtureSchemaZ).length(4)
+        tools: z21.array(DockToolFixtureSchemaZ).length(4)
       }).strict(),
       focus: FocusOverlayStateV1SchemaZ,
-      theme: z23.object({
+      theme: z21.object({
         user: VisualThemeDocumentV1SchemaZ.nullable(),
         project: VisualThemeDocumentV1SchemaZ.nullable(),
         accessibility: ThemeAccessibilityPreferencesSchemaZ
@@ -3528,7 +3400,7 @@ var init_cohesion_fixture = __esm({
       const paneIdSet = new Set(paneIds);
       if (paneIdSet.size !== paneIds.length) {
         ctx.addIssue({
-          code: z23.ZodIssueCode.custom,
+          code: z21.ZodIssueCode.custom,
           message: "pane ids must be unique",
           path: ["panes"]
         });
@@ -3536,7 +3408,7 @@ var init_cohesion_fixture = __esm({
       const agentIds = fixture.workspace.sidebar.agents.map((agent) => agent.id);
       if (new Set(agentIds).size !== agentIds.length) {
         ctx.addIssue({
-          code: z23.ZodIssueCode.custom,
+          code: z21.ZodIssueCode.custom,
           message: "agent ids must be unique",
           path: ["workspace", "sidebar", "agents"]
         });
@@ -3544,7 +3416,7 @@ var init_cohesion_fixture = __esm({
       const sessionIds = fixture.workspace.sidebar.sessions.map((session) => session.id);
       if (new Set(sessionIds).size !== sessionIds.length) {
         ctx.addIssue({
-          code: z23.ZodIssueCode.custom,
+          code: z21.ZodIssueCode.custom,
           message: "session ids must be unique",
           path: ["workspace", "sidebar", "sessions"]
         });
@@ -3553,7 +3425,7 @@ var init_cohesion_fixture = __esm({
         (session) => session.id === fixture.workspace.session.id
       )) {
         ctx.addIssue({
-          code: z23.ZodIssueCode.custom,
+          code: z21.ZodIssueCode.custom,
           message: "active session must be present in the sidebar",
           path: ["workspace", "session", "id"]
         });
@@ -3561,7 +3433,7 @@ var init_cohesion_fixture = __esm({
       for (const [index, agent] of fixture.workspace.sidebar.agents.entries()) {
         if (agent.paneId !== null && !paneIdSet.has(agent.paneId)) {
           ctx.addIssue({
-            code: z23.ZodIssueCode.custom,
+            code: z21.ZodIssueCode.custom,
             message: "agent pane must exist in fixture panes",
             path: ["workspace", "sidebar", "agents", index, "paneId"]
           });
@@ -3575,7 +3447,7 @@ var init_cohesion_fixture = __esm({
       for (const paneId of focusReferences) {
         if (paneId !== null && !paneIdSet.has(paneId)) {
           ctx.addIssue({
-            code: z23.ZodIssueCode.custom,
+            code: z21.ZodIssueCode.custom,
             message: "focus state references an unknown pane",
             path: ["focus"]
           });
@@ -3587,28 +3459,28 @@ var init_cohesion_fixture = __esm({
         const shouldBeSelected = pane.id === fixture.focus.layoutSelectedPaneId;
         if (pane.state.applicationFocus.pane !== shouldBeFocused) {
           ctx.addIssue({
-            code: z23.ZodIssueCode.custom,
+            code: z21.ZodIssueCode.custom,
             message: "pane focus channel must match canonical focus state",
             path: ["panes", index, "state", "applicationFocus", "pane"]
           });
         }
         if (pane.state.applicationFocus.terminalInput !== shouldOwnTerminal) {
           ctx.addIssue({
-            code: z23.ZodIssueCode.custom,
+            code: z21.ZodIssueCode.custom,
             message: "terminal input channel must match canonical focus state",
             path: ["panes", index, "state", "applicationFocus", "terminalInput"]
           });
         }
         if (pane.state.layoutInteraction.selected !== shouldBeSelected) {
           ctx.addIssue({
-            code: z23.ZodIssueCode.custom,
+            code: z21.ZodIssueCode.custom,
             message: "layout selection channel must match canonical focus state",
             path: ["panes", index, "state", "layoutInteraction", "selected"]
           });
         }
         if (pane.state.applicationFocus.windowActive !== (fixture.focus.windowActivity === "active")) {
           ctx.addIssue({
-            code: z23.ZodIssueCode.custom,
+            code: z21.ZodIssueCode.custom,
             message: "pane window activity must match canonical focus state",
             path: ["panes", index, "state", "applicationFocus", "windowActive"]
           });
@@ -3620,7 +3492,7 @@ var init_cohesion_fixture = __esm({
       const actualDockOrder = fixture.dock.tools.map((tool) => tool.id);
       if (actualDockOrder.some((tool, index) => tool !== expectedDockOrder[index])) {
         ctx.addIssue({
-          code: z23.ZodIssueCode.custom,
+          code: z21.ZodIssueCode.custom,
           message: "dock tools must use canonical identity and order",
           path: ["dock", "tools"]
         });
@@ -3942,7 +3814,7 @@ var init_cohesion_fixture = __esm({
 });
 
 // packages/contracts/src/application-shell.ts
-import { z as z24 } from "zod";
+import { z as z22 } from "zod";
 function deepFreeze2(value) {
   if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
   for (const child of Object.values(value)) deepFreeze2(child);
@@ -4128,7 +4000,7 @@ var init_application_shell = __esm({
     init_pane_appearance();
     APPLICATION_SHELL_PROJECTION_VERSION = 1;
     APPLICATION_SHELL_TRACE_VERSION = 1;
-    ApplicationShellProjectionInputV1SchemaZ = z24.object({
+    ApplicationShellProjectionInputV1SchemaZ = z22.object({
       project: CohesionFixtureV1SchemaZ.shape.project,
       workspace: CohesionFixtureV1SchemaZ.shape.workspace,
       dock: CohesionFixtureV1SchemaZ.shape.dock,
@@ -4136,67 +4008,67 @@ var init_application_shell = __esm({
       connection: CohesionFixtureV1SchemaZ.shape.connection
     }).strict();
     WorkspaceFixtureSchemaZ = CohesionFixtureV1SchemaZ.shape.workspace;
-    ApplicationShellSurfaceProjectionSchemaZ = z24.object({
+    ApplicationShellSurfaceProjectionSchemaZ = z22.object({
       id: ProductSurfaceIdSchemaZ,
       icon: SemanticIconIdSchemaZ,
-      label: z24.string().min(1).max(160),
-      kind: z24.enum(["primary-mode", "dock-tool"]),
-      area: z24.enum(["workspace-canvas", "bottom-dock"]),
-      order: z24.number().int().nonnegative(),
+      label: z22.string().min(1).max(160),
+      kind: z22.enum(["primary-mode", "dock-tool"]),
+      area: z22.enum(["workspace-canvas", "bottom-dock"]),
+      order: z22.number().int().nonnegative(),
       owningMode: PrimaryWorkspaceModeIdSchemaZ,
-      shortcut: z24.string().min(1).max(32),
+      shortcut: z22.string().min(1).max(32),
       activation: SurfaceCommandTemplateSchemaZ,
-      active: z24.boolean(),
-      attention: z24.boolean(),
-      disabledReason: z24.string().min(1).max(240).nullable()
+      active: z22.boolean(),
+      attention: z22.boolean(),
+      disabledReason: z22.string().min(1).max(240).nullable()
     }).strict();
-    ApplicationShellProjectionV1SchemaZ = z24.object({
-      version: z24.literal(APPLICATION_SHELL_PROJECTION_VERSION),
+    ApplicationShellProjectionV1SchemaZ = z22.object({
+      version: z22.literal(APPLICATION_SHELL_PROJECTION_VERSION),
       project: CohesionFixtureV1SchemaZ.shape.project,
-      workspace: z24.object({
+      workspace: z22.object({
         id: SemanticProductIdSchemaZ,
-        name: z24.string().min(1).max(160)
+        name: z22.string().min(1).max(160)
       }).strict(),
-      sidebar: z24.object({
+      sidebar: z22.object({
         activeSessionId: SemanticProductIdSchemaZ,
         sessions: WorkspaceFixtureSchemaZ.shape.sidebar.shape.sessions,
         agents: WorkspaceFixtureSchemaZ.shape.sidebar.shape.agents
       }).strict(),
-      primaryNavigation: z24.object({
+      primaryNavigation: z22.object({
         activeMode: PrimaryWorkspaceModeIdSchemaZ,
-        items: z24.array(ApplicationShellSurfaceProjectionSchemaZ)
+        items: z22.array(ApplicationShellSurfaceProjectionSchemaZ)
       }).strict(),
-      workspaceCanvas: z24.object({ activeMode: PrimaryWorkspaceModeIdSchemaZ }).strict(),
-      bottomDock: z24.object({
+      workspaceCanvas: z22.object({ activeMode: PrimaryWorkspaceModeIdSchemaZ }).strict(),
+      bottomDock: z22.object({
         mode: ApplicationShellDockModeSchemaZ,
         activeTool: DockToolIdSchemaZ,
-        tools: z24.array(ApplicationShellSurfaceProjectionSchemaZ)
+        tools: z22.array(ApplicationShellSurfaceProjectionSchemaZ)
       }).strict(),
       statusStrip: CohesionFixtureV1SchemaZ.shape.connection,
-      focus: z24.object({
-        windowActivity: z24.enum(["active", "inactive"]),
+      focus: z22.object({
+        windowActivity: z22.enum(["active", "inactive"]),
         zone: FocusZoneSchemaZ,
         appFocusedPaneId: SemanticProductIdSchemaZ.nullable(),
         terminalInputPaneId: SemanticProductIdSchemaZ.nullable(),
         layoutSelectedPaneId: SemanticProductIdSchemaZ.nullable(),
-        overlays: z24.array(SemanticOverlaySchemaZ).max(16),
-        palette: z24.object({
-          open: z24.boolean(),
+        overlays: z22.array(SemanticOverlaySchemaZ).max(16),
+        palette: z22.object({
+          open: z22.boolean(),
           overlayId: SemanticProductIdSchemaZ.nullable(),
           focusReturnTarget: SemanticFocusTargetSchemaZ.nullable()
         }).strict()
       }).strict()
     }).strict();
-    ApplicationShellActivateModeArgumentsSchemaZ = z24.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict();
-    ApplicationShellActivateDockToolArgumentsSchemaZ = z24.object({ tool: DockToolIdSchemaZ }).strict();
-    ApplicationShellSetDockModeArgumentsSchemaZ = z24.object({ mode: ApplicationShellDockModeSchemaZ }).strict();
-    ApplicationShellMoveFocusArgumentsSchemaZ = z24.object({ target: SemanticFocusTargetSchemaZ }).strict();
-    ApplicationShellOpenPaletteArgumentsSchemaZ = z24.object({
+    ApplicationShellActivateModeArgumentsSchemaZ = z22.object({ mode: PrimaryWorkspaceModeIdSchemaZ }).strict();
+    ApplicationShellActivateDockToolArgumentsSchemaZ = z22.object({ tool: DockToolIdSchemaZ }).strict();
+    ApplicationShellSetDockModeArgumentsSchemaZ = z22.object({ mode: ApplicationShellDockModeSchemaZ }).strict();
+    ApplicationShellMoveFocusArgumentsSchemaZ = z22.object({ target: SemanticFocusTargetSchemaZ }).strict();
+    ApplicationShellOpenPaletteArgumentsSchemaZ = z22.object({
       overlayId: SemanticProductIdSchemaZ,
       focusReturnTarget: SemanticFocusTargetSchemaZ
     }).strict();
-    ApplicationShellClosePaletteArgumentsSchemaZ = z24.object({ overlayId: SemanticProductIdSchemaZ }).strict();
-    ApplicationShellSelectResourceArgumentsSchemaZ = z24.object({
+    ApplicationShellClosePaletteArgumentsSchemaZ = z22.object({ overlayId: SemanticProductIdSchemaZ }).strict();
+    ApplicationShellSelectResourceArgumentsSchemaZ = z22.object({
       surface: ProductSurfaceIdSchemaZ,
       resourceId: SemanticProductIdSchemaZ
     }).strict();
@@ -4209,46 +4081,46 @@ var init_application_shell = __esm({
       [APPLICATION_SHELL_COMMAND_IDS.closePalette]: ApplicationShellClosePaletteArgumentsSchemaZ,
       [APPLICATION_SHELL_COMMAND_IDS.selectResource]: ApplicationShellSelectResourceArgumentsSchemaZ
     });
-    ApplicationShellCommandInvocationSchemaZ = z24.discriminatedUnion("id", [
-      z24.object({
-        version: z24.literal(COMMAND_PROTOCOL_VERSION),
-        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
+    ApplicationShellCommandInvocationSchemaZ = z22.discriminatedUnion("id", [
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.activateMode),
         source: CommandSourceSchemaZ,
         args: ApplicationShellActivateModeArgumentsSchemaZ
       }).strict(),
-      z24.object({
-        version: z24.literal(COMMAND_PROTOCOL_VERSION),
-        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.activateDockTool),
         source: CommandSourceSchemaZ,
         args: ApplicationShellActivateDockToolArgumentsSchemaZ
       }).strict(),
-      z24.object({
-        version: z24.literal(COMMAND_PROTOCOL_VERSION),
-        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.setDockMode),
         source: CommandSourceSchemaZ,
         args: ApplicationShellSetDockModeArgumentsSchemaZ
       }).strict(),
-      z24.object({
-        version: z24.literal(COMMAND_PROTOCOL_VERSION),
-        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.moveFocus),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.moveFocus),
         source: CommandSourceSchemaZ,
         args: ApplicationShellMoveFocusArgumentsSchemaZ
       }).strict(),
-      z24.object({
-        version: z24.literal(COMMAND_PROTOCOL_VERSION),
-        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.openPalette),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.openPalette),
         source: CommandSourceSchemaZ,
         args: ApplicationShellOpenPaletteArgumentsSchemaZ
       }).strict(),
-      z24.object({
-        version: z24.literal(COMMAND_PROTOCOL_VERSION),
-        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.closePalette),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.closePalette),
         source: CommandSourceSchemaZ,
         args: ApplicationShellClosePaletteArgumentsSchemaZ
       }).strict(),
-      z24.object({
-        version: z24.literal(COMMAND_PROTOCOL_VERSION),
-        id: z24.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
+      z22.object({
+        version: z22.literal(COMMAND_PROTOCOL_VERSION),
+        id: z22.literal(APPLICATION_SHELL_COMMAND_IDS.selectResource),
         source: CommandSourceSchemaZ,
         args: ApplicationShellSelectResourceArgumentsSchemaZ
       }).strict()
@@ -4289,13 +4161,13 @@ var init_application_shell = __esm({
         })
       )
     );
-    ApplicationShellResourceSelectionSchemaZ = z24.object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ }).strict();
-    ApplicationShellReplayStateV1SchemaZ = z24.object({
+    ApplicationShellResourceSelectionSchemaZ = z22.object({ surface: ProductSurfaceIdSchemaZ, resourceId: SemanticProductIdSchemaZ }).strict();
+    ApplicationShellReplayStateV1SchemaZ = z22.object({
       activeMode: PrimaryWorkspaceModeIdSchemaZ,
       dockMode: ApplicationShellDockModeSchemaZ,
       activeDockTool: DockToolIdSchemaZ,
       focus: FocusOverlayStateV1SchemaZ,
-      selectedResources: z24.array(ApplicationShellResourceSelectionSchemaZ)
+      selectedResources: z22.array(ApplicationShellResourceSelectionSchemaZ)
     }).strict().superRefine((state, ctx) => {
       const surfaces = state.selectedResources.map(({ surface }) => surface);
       if (new Set(surfaces).size !== surfaces.length) {
@@ -4306,10 +4178,10 @@ var init_application_shell = __esm({
         });
       }
     });
-    ApplicationShellActionTraceV1BaseSchemaZ = z24.object({
-      version: z24.literal(APPLICATION_SHELL_TRACE_VERSION),
+    ApplicationShellActionTraceV1BaseSchemaZ = z22.object({
+      version: z22.literal(APPLICATION_SHELL_TRACE_VERSION),
       initialState: ApplicationShellReplayStateV1SchemaZ,
-      invocations: z24.array(ApplicationShellCommandInvocationSchemaZ),
+      invocations: z22.array(ApplicationShellCommandInvocationSchemaZ),
       finalState: ApplicationShellReplayStateV1SchemaZ
     }).strict();
     ApplicationShellActionTraceV1SchemaZ = ApplicationShellActionTraceV1BaseSchemaZ.superRefine((trace, ctx) => {
@@ -4333,8 +4205,59 @@ var init_application_shell = __esm({
   }
 });
 
+// packages/contracts/src/daemon-wire.ts
+import { z as z23 } from "zod";
+function isDaemonWireProtocolCompatible(protocolVersion) {
+  return protocolVersion === DAEMON_WIRE_PROTOCOL_VERSION;
+}
+var DAEMON_WIRE_PROTOCOL_VERSION, DaemonWireProtocolVersionSchema, DaemonInstanceIdSchema, DaemonInstanceIdentitySchemaZ, CanonicalDaemonInfoSchema, DaemonHealthSchema, DaemonHealthzSchema, DaemonIdentitySchema;
+var init_daemon_wire = __esm({
+  "packages/contracts/src/daemon-wire.ts"() {
+    "use strict";
+    DAEMON_WIRE_PROTOCOL_VERSION = 1;
+    DaemonWireProtocolVersionSchema = z23.number().int().positive();
+    DaemonInstanceIdSchema = z23.uuid();
+    DaemonInstanceIdentitySchemaZ = z23.object({
+      protocolVersion: DaemonWireProtocolVersionSchema,
+      productVersion: z23.string().trim().min(1),
+      instanceId: DaemonInstanceIdSchema,
+      startedAt: z23.iso.datetime({ offset: true })
+    }).strict();
+    CanonicalDaemonInfoSchema = z23.object({
+      pid: z23.number().int().positive(),
+      port: z23.number().int().min(1).max(65535),
+      protocolVersion: DaemonWireProtocolVersionSchema,
+      productVersion: z23.string().trim().min(1),
+      instanceId: DaemonInstanceIdSchema,
+      startedAt: z23.iso.datetime({ offset: true }),
+      bindHostname: z23.string().trim().min(1),
+      authToken: z23.string().min(1).nullable()
+    });
+    DaemonHealthSchema = z23.object({
+      ok: z23.literal(true),
+      protocolVersion: DaemonWireProtocolVersionSchema,
+      productVersion: z23.string().trim().min(1),
+      uptime: z23.number().nonnegative()
+    });
+    DaemonHealthzSchema = z23.object({
+      ok: z23.literal(true),
+      protocolVersion: DaemonWireProtocolVersionSchema,
+      productVersion: z23.string().trim().min(1),
+      uptimeMs: z23.number().nonnegative()
+    });
+    DaemonIdentitySchema = z23.object({
+      ok: z23.literal(true),
+      pid: z23.number().int().positive(),
+      protocolVersion: DaemonWireProtocolVersionSchema,
+      productVersion: z23.string().trim().min(1),
+      instanceId: DaemonInstanceIdSchema,
+      startedAt: z23.iso.datetime({ offset: true })
+    });
+  }
+});
+
 // packages/contracts/src/application-shell-resource.ts
-import { z as z25 } from "zod";
+import { z as z24 } from "zod";
 var APPLICATION_SHELL_RESOURCE_VERSION, ApplicationShellResourceV1SchemaZ;
 var init_application_shell_resource = __esm({
   "packages/contracts/src/application-shell-resource.ts"() {
@@ -4342,10 +4265,184 @@ var init_application_shell_resource = __esm({
     init_application_shell();
     init_daemon_wire();
     APPLICATION_SHELL_RESOURCE_VERSION = 1;
-    ApplicationShellResourceV1SchemaZ = z25.object({
-      version: z25.literal(APPLICATION_SHELL_RESOURCE_VERSION),
+    ApplicationShellResourceV1SchemaZ = z24.object({
+      version: z24.literal(APPLICATION_SHELL_RESOURCE_VERSION),
       daemon: DaemonInstanceIdentitySchemaZ,
       resource: ApplicationShellProjectionInputV1SchemaZ
+    }).strict();
+  }
+});
+
+// packages/contracts/src/desktop-host.ts
+import { z as z25 } from "zod";
+var DESKTOP_HOST_API_VERSION, DesktopRuntimeKindSchemaZ, DesktopPlatformSchemaZ, DesktopThemeModeSchemaZ, DesktopThemeStateSchemaZ, DesktopWindowStateSchemaZ, DesktopDaemonLoopbackUrlSchemaZ, DesktopDaemonHostDescriptorSchemaZ, DesktopDaemonHostIssueCodeSchemaZ, DesktopDaemonHostIssueSchemaFields, DesktopDaemonCapabilityIssueSchemaFields, DesktopDaemonHostStateSchemaZ, DesktopDaemonCapabilityStateSchemaZ, DesktopWorkspaceNameSchemaZ, DesktopDaemonCapabilityErrorCodeSchemaZ, DesktopDaemonCapabilityErrorSchemaZ, DesktopDaemonWorkspaceSummarySchemaZ, DesktopDaemonListWorkspacesResultSchemaZ, DesktopDaemonFetchApplicationShellRequestSchemaZ, DesktopApplicationShellTargetSchemaZ, DesktopDaemonFetchApplicationShellResultSchemaZ, DesktopDaemonEventSubscriptionRequestSchemaZ, DesktopDaemonSubscriptionIdSchemaZ, DesktopDaemonEventSchemaZ, DesktopDaemonSubscribeWireResultSchemaZ, DesktopDaemonEventWireEnvelopeSchemaZ, DesktopHostBootstrapSchemaZ, DesktopMenuResultSchemaZ, DesktopDirectorySelectionSchemaZ;
+var init_desktop_host = __esm({
+  "packages/contracts/src/desktop-host.ts"() {
+    "use strict";
+    init_application_shell_resource();
+    init_daemon_wire();
+    DESKTOP_HOST_API_VERSION = 3;
+    DesktopRuntimeKindSchemaZ = z25.enum(["browser", "electron"]);
+    DesktopPlatformSchemaZ = z25.enum(["darwin", "linux", "win32", "unknown"]);
+    DesktopThemeModeSchemaZ = z25.enum(["light", "dark"]);
+    DesktopThemeStateSchemaZ = z25.object({
+      mode: DesktopThemeModeSchemaZ,
+      highContrast: z25.boolean(),
+      reducedMotion: z25.boolean()
+    }).strict();
+    DesktopWindowStateSchemaZ = z25.object({
+      maximized: z25.boolean(),
+      fullscreen: z25.boolean(),
+      focused: z25.boolean()
+    }).strict();
+    DesktopDaemonLoopbackUrlSchemaZ = z25.url().refine((value) => {
+      const url = new URL(value);
+      return url.protocol === "http:" && (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]") && url.username.length === 0 && url.password.length === 0 && url.pathname === "/" && url.search.length === 0 && url.hash.length === 0;
+    }, "daemon URL must be an uncredentialed loopback HTTP origin");
+    DesktopDaemonHostDescriptorSchemaZ = z25.object({
+      apiBaseUrl: DesktopDaemonLoopbackUrlSchemaZ,
+      protocolVersion: z25.number().int().positive(),
+      productVersion: z25.string().trim().min(1),
+      instanceId: z25.uuid(),
+      startedAt: z25.iso.datetime({ offset: true })
+    }).strict();
+    DesktopDaemonHostIssueCodeSchemaZ = z25.enum([
+      "record-missing",
+      "record-invalid",
+      "endpoint-not-loopback",
+      "protocol-incompatible",
+      "process-not-running",
+      "identity-unreachable",
+      "identity-mismatch",
+      "health-unreachable",
+      "health-mismatch",
+      "probe-failed",
+      "probe-timeout",
+      "preview-only"
+    ]);
+    DesktopDaemonHostIssueSchemaFields = {
+      code: DesktopDaemonHostIssueCodeSchemaZ,
+      reason: z25.string().min(1)
+    };
+    DesktopDaemonCapabilityIssueSchemaFields = {
+      code: DesktopDaemonHostIssueCodeSchemaZ,
+      reason: z25.string().min(1).max(240)
+    };
+    DesktopDaemonHostStateSchemaZ = z25.discriminatedUnion("status", [
+      z25.object({
+        status: z25.literal("connected"),
+        descriptor: DesktopDaemonHostDescriptorSchemaZ
+      }).strict(),
+      z25.object({ status: z25.literal("unavailable"), ...DesktopDaemonHostIssueSchemaFields }).strict(),
+      z25.object({ status: z25.literal("degraded"), ...DesktopDaemonHostIssueSchemaFields }).strict()
+    ]);
+    DesktopDaemonCapabilityStateSchemaZ = z25.discriminatedUnion("status", [
+      z25.object({ status: z25.literal("connected"), identity: DaemonInstanceIdentitySchemaZ }).strict(),
+      z25.object({ status: z25.literal("unavailable"), ...DesktopDaemonCapabilityIssueSchemaFields }).strict(),
+      z25.object({ status: z25.literal("degraded"), ...DesktopDaemonCapabilityIssueSchemaFields }).strict()
+    ]);
+    DesktopWorkspaceNameSchemaZ = z25.string().trim().min(1).max(160).refine(
+      (value) => [...value].every((character) => {
+        const code = character.charCodeAt(0);
+        return code >= 32 && code !== 127;
+      }),
+      "workspace name contains control characters"
+    );
+    DesktopDaemonCapabilityErrorCodeSchemaZ = z25.enum([
+      "preview-only",
+      "daemon-unavailable",
+      "daemon-degraded",
+      "invalid-request",
+      "workspace-not-found",
+      "request-timeout",
+      "response-too-large",
+      "invalid-response",
+      "daemon-identity-mismatch",
+      "request-failed",
+      "event-unavailable",
+      "protocol-error",
+      "disposed"
+    ]);
+    DesktopDaemonCapabilityErrorSchemaZ = z25.object({
+      code: DesktopDaemonCapabilityErrorCodeSchemaZ,
+      reason: z25.string().min(1).max(240)
+    }).strict();
+    DesktopDaemonWorkspaceSummarySchemaZ = z25.object({ workspaceName: DesktopWorkspaceNameSchemaZ }).strict();
+    DesktopDaemonListWorkspacesResultSchemaZ = z25.discriminatedUnion("status", [
+      z25.object({
+        status: z25.literal("ok"),
+        daemon: DaemonInstanceIdentitySchemaZ,
+        workspaces: z25.array(DesktopDaemonWorkspaceSummarySchemaZ)
+      }).strict(),
+      z25.object({ status: z25.literal("error"), error: DesktopDaemonCapabilityErrorSchemaZ }).strict()
+    ]);
+    DesktopDaemonFetchApplicationShellRequestSchemaZ = z25.object({ workspaceName: DesktopWorkspaceNameSchemaZ }).strict();
+    DesktopApplicationShellTargetSchemaZ = z25.object({
+      daemon: DaemonInstanceIdentitySchemaZ,
+      workspaceName: DesktopWorkspaceNameSchemaZ
+    }).strict();
+    DesktopDaemonFetchApplicationShellResultSchemaZ = z25.discriminatedUnion("status", [
+      z25.object({ status: z25.literal("ok"), envelope: ApplicationShellResourceV1SchemaZ }).strict(),
+      z25.object({ status: z25.literal("error"), error: DesktopDaemonCapabilityErrorSchemaZ }).strict()
+    ]);
+    DesktopDaemonEventSubscriptionRequestSchemaZ = z25.object({
+      workspaceNames: z25.array(DesktopWorkspaceNameSchemaZ).min(1).max(64)
+    }).strict().superRefine(({ workspaceNames }, ctx) => {
+      if (new Set(workspaceNames).size !== workspaceNames.length) {
+        ctx.addIssue({ code: "custom", message: "workspace names must be unique" });
+      }
+    });
+    DesktopDaemonSubscriptionIdSchemaZ = z25.string().regex(/^desktop-subscription-[1-9][0-9]{0,9}$/u);
+    DesktopDaemonEventSchemaZ = z25.discriminatedUnion("type", [
+      z25.object({ type: z25.literal("workspaces.changed") }).strict(),
+      z25.object({
+        type: z25.literal("application-shell.changed"),
+        workspaceName: DesktopWorkspaceNameSchemaZ
+      }).strict(),
+      z25.object({
+        type: z25.literal("connection.changed"),
+        state: z25.enum(["live", "degraded"]),
+        error: DesktopDaemonCapabilityErrorSchemaZ.nullable()
+      }).strict()
+    ]);
+    DesktopDaemonSubscribeWireResultSchemaZ = z25.discriminatedUnion("status", [
+      z25.object({ status: z25.literal("subscribed"), subscriptionId: DesktopDaemonSubscriptionIdSchemaZ }).strict(),
+      z25.object({ status: z25.literal("error"), error: DesktopDaemonCapabilityErrorSchemaZ }).strict()
+    ]);
+    DesktopDaemonEventWireEnvelopeSchemaZ = z25.object({
+      subscriptionId: DesktopDaemonSubscriptionIdSchemaZ,
+      event: DesktopDaemonEventSchemaZ
+    }).strict();
+    DesktopHostBootstrapSchemaZ = z25.object({
+      apiVersion: z25.literal(DESKTOP_HOST_API_VERSION),
+      runtime: DesktopRuntimeKindSchemaZ,
+      platform: DesktopPlatformSchemaZ,
+      appVersion: z25.string().min(1),
+      theme: DesktopThemeStateSchemaZ,
+      window: DesktopWindowStateSchemaZ,
+      daemon: DesktopDaemonCapabilityStateSchemaZ
+    }).strict();
+    DesktopMenuResultSchemaZ = z25.object({ status: z25.literal("unavailable") }).strict();
+    DesktopDirectorySelectionSchemaZ = z25.object({ path: z25.string().min(1) }).strict();
+  }
+});
+
+// packages/contracts/src/workspace-catalog-resource.ts
+import { z as z26 } from "zod";
+var WORKSPACE_CATALOG_RESOURCE_VERSION, WorkspaceCatalogEntryV1SchemaZ, WorkspaceCatalogResourceV1SchemaZ;
+var init_workspace_catalog_resource = __esm({
+  "packages/contracts/src/workspace-catalog-resource.ts"() {
+    "use strict";
+    init_daemon_wire();
+    WORKSPACE_CATALOG_RESOURCE_VERSION = 1;
+    WorkspaceCatalogEntryV1SchemaZ = z26.object({
+      workspaceName: z26.string().min(1),
+      sessionName: z26.string().min(1)
+    }).strict();
+    WorkspaceCatalogResourceV1SchemaZ = z26.object({
+      version: z26.literal(WORKSPACE_CATALOG_RESOURCE_VERSION),
+      daemon: DaemonInstanceIdentitySchemaZ,
+      workspaces: z26.array(WorkspaceCatalogEntryV1SchemaZ)
     }).strict();
   }
 });
@@ -4453,7 +4550,7 @@ var init_visual_recipes = __esm({
 });
 
 // packages/contracts/src/daemon-resources.ts
-import { z as z26 } from "zod";
+import { z as z27 } from "zod";
 var DaemonSessionOverviewSchemaZ, DaemonPaneInfoSchemaZ, DaemonSessionsResponseSchemaZ, DaemonProjectResponseSchemaZ, DaemonPanesResponseSchemaZ, DaemonWorkspaceSchemaZ, DaemonWorkspacesResponseSchemaZ, DaemonWorkspaceResponseSchemaZ, DaemonRegisteredProjectSchemaZ, DaemonProjectsResponseSchemaZ, DaemonRegisteredProjectResponseSchemaZ, DaemonProjectTemplateSchemaZ, DaemonProjectTemplatesResponseSchemaZ;
 var init_daemon_resources = __esm({
   "packages/contracts/src/daemon-resources.ts"() {
@@ -4462,131 +4559,131 @@ var init_daemon_resources = __esm({
     init_workspace();
     DaemonSessionOverviewSchemaZ = SessionOverviewSchemaZ.strict();
     DaemonPaneInfoSchemaZ = PaneInfoSchemaZ.strict();
-    DaemonSessionsResponseSchemaZ = z26.object({
-      sessions: z26.array(DaemonSessionOverviewSchemaZ)
+    DaemonSessionsResponseSchemaZ = z27.object({
+      sessions: z27.array(DaemonSessionOverviewSchemaZ)
     }).strict();
-    DaemonProjectResponseSchemaZ = z26.object({
-      session: z26.string(),
-      dir: z26.string(),
-      panes: z26.array(DaemonPaneInfoSchemaZ)
+    DaemonProjectResponseSchemaZ = z27.object({
+      session: z27.string(),
+      dir: z27.string(),
+      panes: z27.array(DaemonPaneInfoSchemaZ)
     }).strict();
-    DaemonPanesResponseSchemaZ = z26.object({
-      panes: z26.array(DaemonPaneInfoSchemaZ)
+    DaemonPanesResponseSchemaZ = z27.object({
+      panes: z27.array(DaemonPaneInfoSchemaZ)
     }).strict();
     DaemonWorkspaceSchemaZ = WorkspaceSchemaZ.strict();
-    DaemonWorkspacesResponseSchemaZ = z26.object({
-      workspaces: z26.array(DaemonWorkspaceSchemaZ)
+    DaemonWorkspacesResponseSchemaZ = z27.object({
+      workspaces: z27.array(DaemonWorkspaceSchemaZ)
     }).strict();
-    DaemonWorkspaceResponseSchemaZ = z26.object({
+    DaemonWorkspaceResponseSchemaZ = z27.object({
       workspace: DaemonWorkspaceSchemaZ
     }).strict();
-    DaemonRegisteredProjectSchemaZ = z26.object({
-      name: z26.string(),
-      dir: z26.string(),
-      hasIdeYml: z26.boolean(),
-      hasWorkspaceConfig: z26.boolean().optional(),
-      configKind: z26.enum(["workspace", "legacy", "none"]).optional(),
-      configPath: z26.string().nullable().optional(),
-      ideConfigPath: z26.string().nullable().optional(),
-      gitOrigin: z26.string().nullable(),
-      gitBranch: z26.string().nullable(),
-      registeredAt: z26.string()
+    DaemonRegisteredProjectSchemaZ = z27.object({
+      name: z27.string(),
+      dir: z27.string(),
+      hasIdeYml: z27.boolean(),
+      hasWorkspaceConfig: z27.boolean().optional(),
+      configKind: z27.enum(["workspace", "legacy", "none"]).optional(),
+      configPath: z27.string().nullable().optional(),
+      ideConfigPath: z27.string().nullable().optional(),
+      gitOrigin: z27.string().nullable(),
+      gitBranch: z27.string().nullable(),
+      registeredAt: z27.string()
     }).strict();
-    DaemonProjectsResponseSchemaZ = z26.object({
-      projects: z26.array(DaemonRegisteredProjectSchemaZ)
+    DaemonProjectsResponseSchemaZ = z27.object({
+      projects: z27.array(DaemonRegisteredProjectSchemaZ)
     }).strict();
-    DaemonRegisteredProjectResponseSchemaZ = z26.object({
+    DaemonRegisteredProjectResponseSchemaZ = z27.object({
       project: DaemonRegisteredProjectSchemaZ
     }).strict();
-    DaemonProjectTemplateSchemaZ = z26.object({
-      id: z26.string(),
-      label: z26.string(),
-      description: z26.string()
+    DaemonProjectTemplateSchemaZ = z27.object({
+      id: z27.string(),
+      label: z27.string(),
+      description: z27.string()
     }).strict();
-    DaemonProjectTemplatesResponseSchemaZ = z26.object({
-      templates: z26.array(DaemonProjectTemplateSchemaZ)
+    DaemonProjectTemplatesResponseSchemaZ = z27.object({
+      templates: z27.array(DaemonProjectTemplateSchemaZ)
     }).strict();
   }
 });
 
 // packages/contracts/src/daemon-events.ts
-import { z as z27 } from "zod";
+import { z as z28 } from "zod";
 var SessionNamesSchemaZ, DaemonEventSubscribeFrameSchemaZ, DaemonEventUnsubscribeFrameSchemaZ, DaemonEventPingFrameSchemaZ, DaemonEventClientFrameSchemaZ, DaemonSessionSnapshotSchemaZ, DaemonEventHelloFrameSchemaZ, DaemonEventSnapshotFrameSchemaZ, DaemonEventSessionsChangedFrameSchemaZ, DaemonEventProjectsChangedFrameSchemaZ, DaemonEventInitOutputFrameSchemaZ, DaemonEventInitErrorFrameSchemaZ, DaemonEventPongFrameSchemaZ, DaemonEventActionCompleteFrameSchemaZ, DaemonEventConfigChangedFrameSchemaZ, DaemonEventTerminalsChangedFrameSchemaZ, DaemonEventWorkspaceAddedFrameSchemaZ, DaemonEventWorkspaceRemovedFrameSchemaZ, DaemonEventProtocolErrorCodeSchemaZ, DaemonEventProtocolErrorFrameSchemaZ, DaemonEventServerFrameSchemaZ;
 var init_daemon_events = __esm({
   "packages/contracts/src/daemon-events.ts"() {
     "use strict";
     init_daemon_resources();
     init_daemon_wire();
-    SessionNamesSchemaZ = z27.array(z27.string());
-    DaemonEventSubscribeFrameSchemaZ = z27.object({
-      type: z27.literal("subscribe"),
+    SessionNamesSchemaZ = z28.array(z28.string());
+    DaemonEventSubscribeFrameSchemaZ = z28.object({
+      type: z28.literal("subscribe"),
       sessions: SessionNamesSchemaZ
     }).strict();
-    DaemonEventUnsubscribeFrameSchemaZ = z27.object({
-      type: z27.literal("unsubscribe"),
+    DaemonEventUnsubscribeFrameSchemaZ = z28.object({
+      type: z28.literal("unsubscribe"),
       sessions: SessionNamesSchemaZ
     }).strict();
-    DaemonEventPingFrameSchemaZ = z27.object({ type: z27.literal("ping") }).strict();
-    DaemonEventClientFrameSchemaZ = z27.discriminatedUnion("type", [
+    DaemonEventPingFrameSchemaZ = z28.object({ type: z28.literal("ping") }).strict();
+    DaemonEventClientFrameSchemaZ = z28.discriminatedUnion("type", [
       DaemonEventSubscribeFrameSchemaZ,
       DaemonEventUnsubscribeFrameSchemaZ,
       DaemonEventPingFrameSchemaZ
     ]);
-    DaemonSessionSnapshotSchemaZ = z27.object({
+    DaemonSessionSnapshotSchemaZ = z28.object({
       project: DaemonProjectResponseSchemaZ
     }).strict();
-    DaemonEventHelloFrameSchemaZ = z27.object({
-      type: z27.literal("hello"),
+    DaemonEventHelloFrameSchemaZ = z28.object({
+      type: z28.literal("hello"),
       daemon: DaemonInstanceIdentitySchemaZ,
-      sessions: z27.array(DaemonSessionOverviewSchemaZ)
+      sessions: z28.array(DaemonSessionOverviewSchemaZ)
     }).strict();
-    DaemonEventSnapshotFrameSchemaZ = z27.object({
-      type: z27.literal("snapshot"),
-      sessionName: z27.string(),
+    DaemonEventSnapshotFrameSchemaZ = z28.object({
+      type: z28.literal("snapshot"),
+      sessionName: z28.string(),
       data: DaemonSessionSnapshotSchemaZ
     }).strict();
-    DaemonEventSessionsChangedFrameSchemaZ = z27.object({ type: z27.literal("sessions.changed") }).strict();
-    DaemonEventProjectsChangedFrameSchemaZ = z27.object({ type: z27.literal("projects.changed") }).strict();
-    DaemonEventInitOutputFrameSchemaZ = z27.object({
-      type: z27.literal("init.output"),
-      jobId: z27.string(),
-      chunk: z27.string(),
-      done: z27.boolean().optional()
+    DaemonEventSessionsChangedFrameSchemaZ = z28.object({ type: z28.literal("sessions.changed") }).strict();
+    DaemonEventProjectsChangedFrameSchemaZ = z28.object({ type: z28.literal("projects.changed") }).strict();
+    DaemonEventInitOutputFrameSchemaZ = z28.object({
+      type: z28.literal("init.output"),
+      jobId: z28.string(),
+      chunk: z28.string(),
+      done: z28.boolean().optional()
     }).strict();
-    DaemonEventInitErrorFrameSchemaZ = z27.object({
-      type: z27.literal("init.error"),
-      jobId: z27.string(),
-      message: z27.string()
+    DaemonEventInitErrorFrameSchemaZ = z28.object({
+      type: z28.literal("init.error"),
+      jobId: z28.string(),
+      message: z28.string()
     }).strict();
-    DaemonEventPongFrameSchemaZ = z27.object({ type: z27.literal("pong") }).strict();
-    DaemonEventActionCompleteFrameSchemaZ = z27.object({
-      type: z27.literal("action.complete"),
-      name: z27.string(),
-      result: z27.unknown()
+    DaemonEventPongFrameSchemaZ = z28.object({ type: z28.literal("pong") }).strict();
+    DaemonEventActionCompleteFrameSchemaZ = z28.object({
+      type: z28.literal("action.complete"),
+      name: z28.string(),
+      result: z28.unknown()
     }).strict();
-    DaemonEventConfigChangedFrameSchemaZ = z27.object({
-      type: z27.literal("config.changed"),
-      sessionName: z27.string()
+    DaemonEventConfigChangedFrameSchemaZ = z28.object({
+      type: z28.literal("config.changed"),
+      sessionName: z28.string()
     }).strict();
-    DaemonEventTerminalsChangedFrameSchemaZ = z27.object({
-      type: z27.literal("terminals.changed"),
-      sessionName: z27.string()
+    DaemonEventTerminalsChangedFrameSchemaZ = z28.object({
+      type: z28.literal("terminals.changed"),
+      sessionName: z28.string()
     }).strict();
-    DaemonEventWorkspaceAddedFrameSchemaZ = z27.object({
-      type: z27.literal("workspace.added"),
+    DaemonEventWorkspaceAddedFrameSchemaZ = z28.object({
+      type: z28.literal("workspace.added"),
       workspace: DaemonWorkspaceSchemaZ
     }).strict();
-    DaemonEventWorkspaceRemovedFrameSchemaZ = z27.object({
-      type: z27.literal("workspace.removed"),
-      name: z27.string()
+    DaemonEventWorkspaceRemovedFrameSchemaZ = z28.object({
+      type: z28.literal("workspace.removed"),
+      name: z28.string()
     }).strict();
-    DaemonEventProtocolErrorCodeSchemaZ = z27.enum(["invalid-json", "invalid-frame"]);
-    DaemonEventProtocolErrorFrameSchemaZ = z27.object({
-      type: z27.literal("protocol.error"),
+    DaemonEventProtocolErrorCodeSchemaZ = z28.enum(["invalid-json", "invalid-frame"]);
+    DaemonEventProtocolErrorFrameSchemaZ = z28.object({
+      type: z28.literal("protocol.error"),
       code: DaemonEventProtocolErrorCodeSchemaZ,
-      message: z27.string()
+      message: z28.string()
     }).strict();
-    DaemonEventServerFrameSchemaZ = z27.discriminatedUnion("type", [
+    DaemonEventServerFrameSchemaZ = z28.discriminatedUnion("type", [
       DaemonEventHelloFrameSchemaZ,
       DaemonEventSnapshotFrameSchemaZ,
       DaemonEventSessionsChangedFrameSchemaZ,
@@ -4629,6 +4726,7 @@ var init_src = __esm({
     init_experience_shell();
     init_application_shell();
     init_application_shell_resource();
+    init_workspace_catalog_resource();
     init_visual_tokens();
     init_visual_recipes();
     init_pane_appearance();
@@ -9836,20 +9934,20 @@ var init_session_id = __esm({
 });
 
 // packages/daemon/src/schemas/registry.ts
-import { z as z28 } from "zod";
+import { z as z29 } from "zod";
 var RegisteredProjectSchemaZ, RegisterProjectRequestSchemaZ, InitProjectRequestSchemaZ;
 var init_registry = __esm({
   "packages/daemon/src/schemas/registry.ts"() {
     "use strict";
     init_src();
     RegisteredProjectSchemaZ = DaemonRegisteredProjectSchemaZ;
-    RegisterProjectRequestSchemaZ = z28.object({
-      dir: z28.string().min(1),
-      name: z28.string().min(1).optional()
+    RegisterProjectRequestSchemaZ = z29.object({
+      dir: z29.string().min(1),
+      name: z29.string().min(1).optional()
     });
-    InitProjectRequestSchemaZ = z28.object({
-      dir: z28.string().min(1),
-      template: z28.string().min(1).optional()
+    InitProjectRequestSchemaZ = z29.object({
+      dir: z29.string().min(1),
+      template: z29.string().min(1).optional()
     });
   }
 });
@@ -9911,7 +10009,7 @@ import { EventEmitter } from "node:events";
 import { existsSync as existsSync15, mkdirSync as mkdirSync9, readFileSync as readFileSync11, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir10 } from "node:os";
 import { dirname as dirname15, isAbsolute as isAbsolute3, join as join14, resolve as resolve11 } from "node:path";
-import { z as z29 } from "zod";
+import { z as z30 } from "zod";
 function applyAction(state, action) {
   switch (action.type) {
     case "register":
@@ -10050,9 +10148,9 @@ var init_project_registry = __esm({
     init_registry();
     init_project_probe();
     REGISTRY_DIR_ENV = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ = z29.object({
-      version: z29.literal(1),
-      projects: z29.array(RegisteredProjectSchemaZ)
+    RegistryFileSchemaZ = z30.object({
+      version: z30.literal(1),
+      projects: z30.array(RegisteredProjectSchemaZ)
     });
     ProjectRegistryError = class extends Error {
       code;
@@ -10824,7 +10922,7 @@ var init_notify_state = __esm({
 import { existsSync as existsSync19, mkdirSync as mkdirSync12, readFileSync as readFileSync14, renameSync as renameSync7, writeFileSync as writeFileSync11 } from "node:fs";
 import { homedir as homedir12 } from "node:os";
 import { dirname as dirname17, join as join18 } from "node:path";
-import { z as z30 } from "zod";
+import { z as z31 } from "zod";
 function isBareShell(cmd) {
   return /^-?(zsh|bash|sh|fish|dash|ksh|tcsh|csh|nu)$/.test(cmd.trim());
 }
@@ -10996,32 +11094,32 @@ var init_snapshot2 = __esm({
     init_src2();
     init_process_tree();
     init_sessions2();
-    PaneSnapshotSchemaZ = z30.object({
-      index: z30.number(),
-      cwd: z30.string(),
-      command: z30.string().nullable(),
-      agent: z30.string().nullable(),
-      agentSessionId: z30.string().nullable(),
-      agentState: z30.string().nullable(),
-      title: z30.string()
+    PaneSnapshotSchemaZ = z31.object({
+      index: z31.number(),
+      cwd: z31.string(),
+      command: z31.string().nullable(),
+      agent: z31.string().nullable(),
+      agentSessionId: z31.string().nullable(),
+      agentState: z31.string().nullable(),
+      title: z31.string()
     });
-    WindowSnapshotSchemaZ = z30.object({
-      index: z30.number(),
-      name: z30.string(),
-      active: z30.boolean(),
-      layout: z30.string(),
-      panes: z30.array(PaneSnapshotSchemaZ)
+    WindowSnapshotSchemaZ = z31.object({
+      index: z31.number(),
+      name: z31.string(),
+      active: z31.boolean(),
+      layout: z31.string(),
+      panes: z31.array(PaneSnapshotSchemaZ)
     });
-    SessionSnapshotSchemaZ = z30.object({
-      name: z30.string(),
-      cwd: z30.string(),
-      adopted: z30.boolean(),
-      windows: z30.array(WindowSnapshotSchemaZ)
+    SessionSnapshotSchemaZ = z31.object({
+      name: z31.string(),
+      cwd: z31.string(),
+      adopted: z31.boolean(),
+      windows: z31.array(WindowSnapshotSchemaZ)
     });
-    FleetSnapshotSchemaZ = z30.object({
-      version: z30.literal(1),
-      savedAt: z30.string(),
-      sessions: z30.array(SessionSnapshotSchemaZ)
+    FleetSnapshotSchemaZ = z31.object({
+      version: z31.literal(1),
+      savedAt: z31.string(),
+      sessions: z31.array(SessionSnapshotSchemaZ)
     });
     SNAPSHOT_PANE_FORMAT = [
       "#{session_name}",
@@ -14054,7 +14152,7 @@ import { EventEmitter as EventEmitter3 } from "node:events";
 import { existsSync as existsSync26, mkdirSync as mkdirSync17, readFileSync as readFileSync20, renameSync as renameSync9, writeFileSync as writeFileSync16 } from "node:fs";
 import { homedir as homedir16 } from "node:os";
 import { dirname as dirname24, join as join24 } from "node:path";
-import { z as z31 } from "zod";
+import { z as z32 } from "zod";
 function getDefaultWorkspaceRegistry() {
   if (!_default) _default = new WorkspaceRegistry();
   return _default;
@@ -14077,9 +14175,9 @@ var init_workspace_registry = __esm({
     "use strict";
     init_src();
     REGISTRY_DIR_ENV3 = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ2 = z31.object({
-      version: z31.literal(1),
-      workspaces: z31.array(WorkspaceSchemaZ)
+    RegistryFileSchemaZ2 = z32.object({
+      version: z32.literal(1),
+      workspaces: z32.array(WorkspaceSchemaZ)
     });
     WorkspaceAlreadyExistsError = class extends Error {
       code = "ALREADY_EXISTS";
@@ -14924,74 +15022,74 @@ var init_log = __esm({
 });
 
 // packages/daemon/src/command-center/schemas.ts
-import { z as z32 } from "zod";
+import { z as z33 } from "zod";
 var updateTaskSchema, createTaskSchema, savePlanSchema, savePlanContentSchema, sendCommandSchema, createMilestoneSchema, updateMilestoneSchema, updateAssertionSchema, triggerResearchSchema, launchSchema, stopSchema, skillNameRegex, createSkillSchema, updateSkillSchema;
 var init_schemas = __esm({
   "packages/daemon/src/command-center/schemas.ts"() {
     "use strict";
-    updateTaskSchema = z32.object({
-      status: z32.enum(["todo", "in-progress", "review", "done"]).optional(),
-      assignee: z32.string().optional(),
-      title: z32.string().optional(),
-      description: z32.string().optional(),
-      priority: z32.number().optional()
+    updateTaskSchema = z33.object({
+      status: z33.enum(["todo", "in-progress", "review", "done"]).optional(),
+      assignee: z33.string().optional(),
+      title: z33.string().optional(),
+      description: z33.string().optional(),
+      priority: z33.number().optional()
     });
-    createTaskSchema = z32.object({
-      title: z32.string().trim().min(1, "Title is required"),
-      description: z32.string().optional(),
-      priority: z32.number().optional(),
-      goal: z32.string().optional(),
-      tags: z32.array(z32.string()).optional()
+    createTaskSchema = z33.object({
+      title: z33.string().trim().min(1, "Title is required"),
+      description: z33.string().optional(),
+      priority: z33.number().optional(),
+      goal: z33.string().optional(),
+      tags: z33.array(z33.string()).optional()
     });
-    savePlanSchema = z32.object({
-      content: z32.string().max(1e6, "Plan content is too large")
+    savePlanSchema = z33.object({
+      content: z33.string().max(1e6, "Plan content is too large")
     });
-    savePlanContentSchema = z32.object({
-      content: z32.string().max(1e6, "Plan content is too large")
+    savePlanContentSchema = z33.object({
+      content: z33.string().max(1e6, "Plan content is too large")
     });
-    sendCommandSchema = z32.object({
-      target: z32.string().min(1, "Target pane is required"),
-      message: z32.string().min(1, "Message is required"),
-      noEnter: z32.boolean().optional()
+    sendCommandSchema = z33.object({
+      target: z33.string().min(1, "Target pane is required"),
+      message: z33.string().min(1, "Message is required"),
+      noEnter: z33.boolean().optional()
     });
-    createMilestoneSchema = z32.object({
-      title: z32.string().trim().min(1, "Title is required"),
-      sequence: z32.number().int().positive(),
-      description: z32.string().optional()
+    createMilestoneSchema = z33.object({
+      title: z33.string().trim().min(1, "Title is required"),
+      sequence: z33.number().int().positive(),
+      description: z33.string().optional()
     });
-    updateMilestoneSchema = z32.object({
-      status: z32.enum(["locked", "active", "done", "validating"]).optional(),
-      title: z32.string().optional(),
-      description: z32.string().optional()
+    updateMilestoneSchema = z33.object({
+      status: z33.enum(["locked", "active", "done", "validating"]).optional(),
+      title: z33.string().optional(),
+      description: z33.string().optional()
     });
-    updateAssertionSchema = z32.object({
-      status: z32.enum(["pending", "passing", "failing", "blocked"]),
-      evidence: z32.string().optional(),
-      verifiedBy: z32.string().optional()
+    updateAssertionSchema = z33.object({
+      status: z33.enum(["pending", "passing", "failing", "blocked"]),
+      evidence: z33.string().optional(),
+      verifiedBy: z33.string().optional()
     });
-    triggerResearchSchema = z32.object({
-      type: z32.string().trim().min(1, "Research type is required")
+    triggerResearchSchema = z33.object({
+      type: z33.string().trim().min(1, "Research type is required")
     });
-    launchSchema = z32.object({
-      attach: z32.boolean().optional()
+    launchSchema = z33.object({
+      attach: z33.boolean().optional()
     }).optional();
-    stopSchema = z32.object({}).optional();
+    stopSchema = z33.object({}).optional();
     skillNameRegex = /^[A-Za-z0-9._ -]+$/;
-    createSkillSchema = z32.object({
-      name: z32.string().trim().min(1, "Skill name is required").regex(
+    createSkillSchema = z33.object({
+      name: z33.string().trim().min(1, "Skill name is required").regex(
         skillNameRegex,
         "Skill name may only contain letters, digits, dot, dash, underscore, or space"
       ),
-      role: z32.string().trim().optional(),
-      description: z32.string().optional(),
-      specialties: z32.array(z32.string()).optional(),
-      body: z32.string().optional()
+      role: z33.string().trim().optional(),
+      description: z33.string().optional(),
+      specialties: z33.array(z33.string()).optional(),
+      body: z33.string().optional()
     });
-    updateSkillSchema = z32.object({
-      role: z32.string().trim().optional(),
-      description: z32.string().optional(),
-      specialties: z32.array(z32.string()).optional(),
-      body: z32.string().optional()
+    updateSkillSchema = z33.object({
+      role: z33.string().trim().optional(),
+      description: z33.string().optional(),
+      specialties: z33.array(z33.string()).optional(),
+      body: z33.string().optional()
     });
   }
 });
@@ -16236,64 +16334,64 @@ var init_project_init_runner = __esm({
 });
 
 // packages/daemon/src/schemas/inspect.ts
-import { z as z33 } from "zod";
+import { z as z34 } from "zod";
 var ProjectInspectDetectedSchemaZ, ProjectInspectSchemaZ, InspectFilesystemRequestSchemaZ, OnboardProjectRequestSchemaZ;
 var init_inspect = __esm({
   "packages/daemon/src/schemas/inspect.ts"() {
     "use strict";
-    ProjectInspectDetectedSchemaZ = z33.object({
+    ProjectInspectDetectedSchemaZ = z34.object({
       /** Detected package manager from lockfile, or `null`. */
-      packageManager: z33.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
+      packageManager: z34.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
       /** Detected frameworks (e.g. `["next", "convex"]`). Empty array when none. */
-      frameworks: z33.array(z33.string()),
+      frameworks: z34.array(z34.string()),
       /** Suggested dev command (e.g. `pnpm dev`). `null` if no dev script found. */
-      devCommand: z33.string().nullable(),
+      devCommand: z34.string().nullable(),
       /** Suggested test command (e.g. `pnpm test`). `null` if no test script found. */
-      testCommand: z33.string().nullable()
+      testCommand: z34.string().nullable()
     });
-    ProjectInspectSchemaZ = z33.object({
+    ProjectInspectSchemaZ = z34.object({
       /** Sanitized basename of the directory — safe to use as a tmux session name. */
-      name: z33.string(),
+      name: z34.string(),
       /** Absolute, canonical path to the directory. */
-      dir: z33.string(),
+      dir: z34.string(),
       /** Whether `<dir>/ide.yml` exists. Legacy compatibility fact. */
-      hasIdeYml: z33.boolean(),
+      hasIdeYml: z34.boolean(),
       /** Whether `.tmux-ide/workspace.yml` exists or wins discovery. */
-      hasWorkspaceConfig: z33.boolean().optional(),
+      hasWorkspaceConfig: z34.boolean().optional(),
       /** Generalized winning config kind. Added without replacing `hasIdeYml`. */
-      configKind: z33.enum(["workspace", "legacy", "none"]).optional(),
+      configKind: z34.enum(["workspace", "legacy", "none"]).optional(),
       /** Generalized winning config path. Added without replacing legacy path facts. */
-      configPath: z33.string().nullable().optional(),
+      configPath: z34.string().nullable().optional(),
       /** Legacy config path when an `ide.yml` is present. */
-      ideConfigPath: z33.string().nullable().optional(),
+      ideConfigPath: z34.string().nullable().optional(),
       /** Git remote origin URL, or `null` if not a git repo / no origin / probe failed. */
-      gitOrigin: z33.string().nullable(),
+      gitOrigin: z34.string().nullable(),
       /** Current git branch, or `null` if not a git repo / detached HEAD / probe failed. */
-      gitBranch: z33.string().nullable(),
+      gitBranch: z34.string().nullable(),
       /** Detected stack signals (reuses `tmux-ide detect` logic). */
       detected: ProjectInspectDetectedSchemaZ
     });
-    InspectFilesystemRequestSchemaZ = z33.object({
-      dir: z33.string().min(1)
+    InspectFilesystemRequestSchemaZ = z34.object({
+      dir: z34.string().min(1)
     });
-    OnboardProjectRequestSchemaZ = z33.object({
-      dir: z33.string().min(1),
+    OnboardProjectRequestSchemaZ = z34.object({
+      dir: z34.string().min(1),
       /** Optional override for the project name — defaults to inspect.name. */
-      name: z33.string().min(1).optional(),
+      name: z34.string().min(1).optional(),
       /** 1, 2, or 3 — how many Claude panes to scaffold in the top row. */
-      agents: z33.number().int().min(1).max(3),
+      agents: z34.number().int().min(1).max(3),
       /**
        * Optional per-agent pane titles. When provided, length must equal
        * `agents`; the server uses these as `title:` for the Claude panes
        * instead of the canonical `Lead`/`Teammate N`/`Claude N` defaults.
        */
-      agentNames: z33.array(z33.string().min(1)).optional(),
+      agentNames: z34.array(z34.string().min(1)).optional(),
       /** Dev server command (e.g. `pnpm dev`). Omit / null to skip the dev pane. */
-      devCommand: z33.string().min(1).nullable().optional(),
+      devCommand: z34.string().min(1).nullable().optional(),
       /** Test command (e.g. `pnpm test`). Currently informational; stored for later. */
-      testCommand: z33.string().min(1).nullable().optional(),
+      testCommand: z34.string().min(1).nullable().optional(),
       /** Lint command (e.g. `pnpm lint`). Currently informational; stored for later. */
-      lintCommand: z33.string().min(1).nullable().optional()
+      lintCommand: z34.string().min(1).nullable().optional()
     });
   }
 });
@@ -16905,6 +17003,14 @@ function createApp(options = {}) {
   app.get("/api/workspaces", (c) => {
     const registry = getDefaultWorkspaceRegistry();
     return c.json({ workspaces: registry.list() });
+  });
+  app.get("/api/resources/workspace-catalog", (c) => {
+    const registry = getDefaultWorkspaceRegistry();
+    return c.json({
+      version: WORKSPACE_CATALOG_RESOURCE_VERSION,
+      daemon: daemonInstanceIdentity,
+      workspaces: registry.list().map(({ name, sessionName }) => ({ workspaceName: name, sessionName }))
+    });
   });
   app.get("/api/workspaces/:name", (c) => {
     const name = c.req.param("name");
@@ -18465,7 +18571,7 @@ var init_daemon_embed = __esm({
 
 // packages/daemon/src/lib/cli-action-bridge.ts
 import { createRequire as createRequire3 } from "node:module";
-import { z as z34 } from "zod";
+import { z as z35 } from "zod";
 function timeoutSignal3(ms) {
   const controller = new AbortController();
   setTimeout(() => controller.abort(), ms).unref?.();
@@ -18564,7 +18670,7 @@ async function tryDispatchAction(name, input, options = {}) {
       details: failure.data.error.details
     });
   }
-  const success = z34.object({ ok: z34.literal(true), result: contract.result }).safeParse(body);
+  const success = z35.object({ ok: z35.literal(true), result: contract.result }).safeParse(body);
   if (!success.success) return null;
   return success.data.result;
 }
@@ -18575,12 +18681,12 @@ var init_cli_action_bridge = __esm({
     init_contract();
     init_canonical_daemon();
     init_daemon_embed();
-    FailureEnvelopeZ = z34.object({
-      ok: z34.literal(false),
-      error: z34.object({
-        code: z34.string(),
-        message: z34.string(),
-        details: z34.unknown().optional()
+    FailureEnvelopeZ = z35.object({
+      ok: z35.literal(false),
+      error: z35.object({
+        code: z35.string(),
+        message: z35.string(),
+        details: z35.unknown().optional()
       })
     });
     deps = {

--- a/packages/contracts/src/__tests__/daemon-events.test.ts
+++ b/packages/contracts/src/__tests__/daemon-events.test.ts
@@ -99,7 +99,7 @@ describe("daemon event contracts", () => {
     }
   });
 
-  it("requires a strict daemon generation on hello", () => {
+  it("requires a strict non-secret daemon generation on hello", () => {
     expect(
       DaemonEventServerFrameSchemaZ.safeParse({ type: "hello", daemon, sessions: [] }).success,
     ).toBe(true);

--- a/packages/contracts/src/__tests__/daemon-resources.test.ts
+++ b/packages/contracts/src/__tests__/daemon-resources.test.ts
@@ -7,6 +7,17 @@ import {
   DaemonSessionsResponseSchemaZ,
   DaemonWorkspacesResponseSchemaZ,
 } from "../daemon-resources.ts";
+import {
+  WORKSPACE_CATALOG_RESOURCE_VERSION,
+  WorkspaceCatalogResourceV1SchemaZ,
+} from "../workspace-catalog-resource.ts";
+
+const daemon = {
+  protocolVersion: 1,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-21T12:00:00.000Z",
+};
 
 const pane = {
   id: "%7",
@@ -108,6 +119,24 @@ describe("daemon REST resources", () => {
             typo: true,
           },
         ],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("strictly parses the generation-stamped workspace catalog resource", () => {
+    const resource = {
+      version: WORKSPACE_CATALOG_RESOURCE_VERSION,
+      daemon,
+      workspaces: [{ workspaceName: "tmux-ide", sessionName: "tmux-ide-live" }],
+    };
+    expect(WorkspaceCatalogResourceV1SchemaZ.parse(resource)).toEqual(resource);
+    expect(
+      WorkspaceCatalogResourceV1SchemaZ.safeParse({ ...resource, apiBaseUrl: "secret" }).success,
+    ).toBe(false);
+    expect(
+      WorkspaceCatalogResourceV1SchemaZ.safeParse({
+        ...resource,
+        workspaces: [{ ...resource.workspaces[0], projectDir: "/private/project" }],
       }).success,
     ).toBe(false);
   });

--- a/packages/contracts/src/__tests__/desktop-host.test.ts
+++ b/packages/contracts/src/__tests__/desktop-host.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   DESKTOP_HOST_API_VERSION,
   DesktopApplicationShellTargetSchemaZ,
+  DesktopDaemonCapabilityStateSchemaZ,
+  DesktopDaemonEventSubscriptionRequestSchemaZ,
+  DesktopDaemonFetchApplicationShellRequestSchemaZ,
+  DesktopDaemonListWorkspacesResultSchemaZ,
   DesktopDaemonPreflightSchemaZ,
   DesktopDaemonHostDescriptorSchemaZ,
   DesktopHostBootstrapSchemaZ,
@@ -20,7 +24,7 @@ describe("desktop host contract", () => {
         window: { maximized: false, fullscreen: false, focused: true },
         daemon: { status: "unavailable", code: "record-missing", reason: "owner not installed" },
       }),
-    ).toMatchObject({ apiVersion: 2, runtime: "electron" });
+    ).toMatchObject({ apiVersion: 3, runtime: "electron" });
   });
 
   it("does not permit unversioned daemon metadata to leak into the facade", () => {
@@ -83,5 +87,60 @@ describe("desktop host contract", () => {
       DesktopApplicationShellTargetSchemaZ.safeParse({ ...target, token: "secret" }).success,
     ).toBe(false);
     expect(DesktopApplicationShellTargetSchemaZ.safeParse(null).success).toBe(false);
+  });
+
+  it("keeps the renderer-visible connected state identity-only", () => {
+    const identity = {
+      protocolVersion: 1,
+      productVersion: "2.8.0",
+      instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+      startedAt: "2026-07-21T00:00:00.000Z",
+    };
+    expect(DesktopDaemonCapabilityStateSchemaZ.parse({ status: "connected", identity })).toEqual({
+      status: "connected",
+      identity,
+    });
+    for (const forbidden of [
+      { apiBaseUrl: "http://127.0.0.1:6060" },
+      { token: "secret" },
+      { sessionName: "raw-session" },
+    ]) {
+      expect(
+        DesktopDaemonCapabilityStateSchemaZ.safeParse({
+          status: "connected",
+          identity,
+          ...forbidden,
+        }).success,
+      ).toBe(false);
+    }
+  });
+
+  it("accepts only bounded semantic daemon capability messages", () => {
+    expect(
+      DesktopDaemonFetchApplicationShellRequestSchemaZ.parse({ workspaceName: " product " }),
+    ).toEqual({ workspaceName: "product" });
+    expect(
+      DesktopDaemonFetchApplicationShellRequestSchemaZ.safeParse({
+        workspaceName: "product",
+        sessionName: "raw-session",
+      }).success,
+    ).toBe(false);
+    expect(
+      DesktopDaemonEventSubscriptionRequestSchemaZ.safeParse({
+        workspaceNames: ["product", "product"],
+      }).success,
+    ).toBe(false);
+    expect(
+      DesktopDaemonListWorkspacesResultSchemaZ.safeParse({
+        status: "ok",
+        daemon: {
+          protocolVersion: 1,
+          productVersion: "2.8.0",
+          instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+          startedAt: "2026-07-21T00:00:00.000Z",
+        },
+        workspaces: [{ workspaceName: "product", projectDir: "/private/leak" }],
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/contracts/src/desktop-host.ts
+++ b/packages/contracts/src/desktop-host.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
+import { ApplicationShellResourceV1SchemaZ } from "./application-shell-resource.ts";
 import { DaemonInstanceIdentitySchemaZ } from "./daemon-wire.ts";
 
 /** Versioned, deliberately narrow bridge exposed by a desktop host preload. */
-export const DESKTOP_HOST_API_VERSION = 2 as const;
+export const DESKTOP_HOST_API_VERSION = 3 as const;
 
 export const DesktopRuntimeKindSchemaZ = z.enum(["browser", "electron"]);
 export const DesktopPlatformSchemaZ = z.enum(["darwin", "linux", "win32", "unknown"]);
@@ -37,7 +38,7 @@ const DesktopDaemonLoopbackUrlSchemaZ = z.url().refine((value) => {
   );
 }, "daemon URL must be an uncredentialed loopback HTTP origin");
 
-/** Verified daemon identity safe to cross the main → preload → renderer boundary. */
+/** Verified daemon descriptor retained by desktop main-process transports. */
 export const DesktopDaemonHostDescriptorSchemaZ = z
   .object({
     apiBaseUrl: DesktopDaemonLoopbackUrlSchemaZ,
@@ -45,13 +46,6 @@ export const DesktopDaemonHostDescriptorSchemaZ = z
     productVersion: z.string().trim().min(1),
     instanceId: z.uuid(),
     startedAt: z.iso.datetime({ offset: true }),
-  })
-  .strict();
-
-export const DesktopApplicationShellTargetSchemaZ = z
-  .object({
-    daemon: DaemonInstanceIdentitySchemaZ,
-    workspaceName: z.string().trim().min(1).max(160),
   })
   .strict();
 
@@ -75,6 +69,11 @@ const DesktopDaemonHostIssueSchemaFields = {
   reason: z.string().min(1),
 } as const;
 
+const DesktopDaemonCapabilityIssueSchemaFields = {
+  code: DesktopDaemonHostIssueCodeSchemaZ,
+  reason: z.string().min(1).max(240),
+} as const;
+
 export const DesktopDaemonHostStateSchemaZ = z.discriminatedUnion("status", [
   z
     .object({
@@ -89,6 +88,134 @@ export const DesktopDaemonHostStateSchemaZ = z.discriminatedUnion("status", [
 /** @deprecated Compatibility name for existing host bootstrap consumers. */
 export const DesktopDaemonPreflightSchemaZ = DesktopDaemonHostStateSchemaZ;
 
+/**
+ * Renderer-safe daemon availability. The verified origin and process identity
+ * deliberately remain in Electron main; browser code receives neither.
+ */
+export const DesktopDaemonCapabilityStateSchemaZ = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("connected"), identity: DaemonInstanceIdentitySchemaZ }).strict(),
+  z
+    .object({ status: z.literal("unavailable"), ...DesktopDaemonCapabilityIssueSchemaFields })
+    .strict(),
+  z.object({ status: z.literal("degraded"), ...DesktopDaemonCapabilityIssueSchemaFields }).strict(),
+]);
+
+export const DesktopWorkspaceNameSchemaZ = z
+  .string()
+  .trim()
+  .min(1)
+  .max(160)
+  .refine(
+    (value) =>
+      [...value].every((character) => {
+        const code = character.charCodeAt(0);
+        return code >= 32 && code !== 127;
+      }),
+    "workspace name contains control characters",
+  );
+
+export const DesktopDaemonCapabilityErrorCodeSchemaZ = z.enum([
+  "preview-only",
+  "daemon-unavailable",
+  "daemon-degraded",
+  "invalid-request",
+  "workspace-not-found",
+  "request-timeout",
+  "response-too-large",
+  "invalid-response",
+  "daemon-identity-mismatch",
+  "request-failed",
+  "event-unavailable",
+  "protocol-error",
+  "disposed",
+]);
+
+export const DesktopDaemonCapabilityErrorSchemaZ = z
+  .object({
+    code: DesktopDaemonCapabilityErrorCodeSchemaZ,
+    reason: z.string().min(1).max(240),
+  })
+  .strict();
+
+export const DesktopDaemonWorkspaceSummarySchemaZ = z
+  .object({ workspaceName: DesktopWorkspaceNameSchemaZ })
+  .strict();
+
+export const DesktopDaemonListWorkspacesResultSchemaZ = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("ok"),
+      daemon: DaemonInstanceIdentitySchemaZ,
+      workspaces: z.array(DesktopDaemonWorkspaceSummarySchemaZ),
+    })
+    .strict(),
+  z.object({ status: z.literal("error"), error: DesktopDaemonCapabilityErrorSchemaZ }).strict(),
+]);
+
+export const DesktopDaemonFetchApplicationShellRequestSchemaZ = z
+  .object({ workspaceName: DesktopWorkspaceNameSchemaZ })
+  .strict();
+
+/** Store key: semantic workspace plus a non-secret daemon generation. */
+export const DesktopApplicationShellTargetSchemaZ = z
+  .object({
+    daemon: DaemonInstanceIdentitySchemaZ,
+    workspaceName: DesktopWorkspaceNameSchemaZ,
+  })
+  .strict();
+
+export const DesktopDaemonFetchApplicationShellResultSchemaZ = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("ok"), envelope: ApplicationShellResourceV1SchemaZ }).strict(),
+  z.object({ status: z.literal("error"), error: DesktopDaemonCapabilityErrorSchemaZ }).strict(),
+]);
+
+export const DesktopDaemonEventSubscriptionRequestSchemaZ = z
+  .object({
+    workspaceNames: z.array(DesktopWorkspaceNameSchemaZ).min(1).max(64),
+  })
+  .strict()
+  .superRefine(({ workspaceNames }, ctx) => {
+    if (new Set(workspaceNames).size !== workspaceNames.length) {
+      ctx.addIssue({ code: "custom", message: "workspace names must be unique" });
+    }
+  });
+
+export const DesktopDaemonSubscriptionIdSchemaZ = z
+  .string()
+  .regex(/^desktop-subscription-[1-9][0-9]{0,9}$/u);
+
+export const DesktopDaemonEventSchemaZ = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("workspaces.changed") }).strict(),
+  z
+    .object({
+      type: z.literal("application-shell.changed"),
+      workspaceName: DesktopWorkspaceNameSchemaZ,
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("connection.changed"),
+      state: z.enum(["live", "degraded"]),
+      error: DesktopDaemonCapabilityErrorSchemaZ.nullable(),
+    })
+    .strict(),
+]);
+
+/** Private main/preload wire shapes. Subscription ids never reach application code. */
+export const DesktopDaemonSubscribeWireResultSchemaZ = z.discriminatedUnion("status", [
+  z
+    .object({ status: z.literal("subscribed"), subscriptionId: DesktopDaemonSubscriptionIdSchemaZ })
+    .strict(),
+  z.object({ status: z.literal("error"), error: DesktopDaemonCapabilityErrorSchemaZ }).strict(),
+]);
+
+export const DesktopDaemonEventWireEnvelopeSchemaZ = z
+  .object({
+    subscriptionId: DesktopDaemonSubscriptionIdSchemaZ,
+    event: DesktopDaemonEventSchemaZ,
+  })
+  .strict();
+
 export const DesktopHostBootstrapSchemaZ = z
   .object({
     apiVersion: z.literal(DESKTOP_HOST_API_VERSION),
@@ -97,7 +224,7 @@ export const DesktopHostBootstrapSchemaZ = z
     appVersion: z.string().min(1),
     theme: DesktopThemeStateSchemaZ,
     window: DesktopWindowStateSchemaZ,
-    daemon: DesktopDaemonPreflightSchemaZ,
+    daemon: DesktopDaemonCapabilityStateSchemaZ,
   })
   .strict();
 
@@ -109,15 +236,40 @@ export type DesktopPlatform = z.infer<typeof DesktopPlatformSchemaZ>;
 export type DesktopThemeState = z.infer<typeof DesktopThemeStateSchemaZ>;
 export type DesktopWindowState = z.infer<typeof DesktopWindowStateSchemaZ>;
 export type DesktopDaemonHostDescriptor = z.infer<typeof DesktopDaemonHostDescriptorSchemaZ>;
-export type DesktopApplicationShellTarget = z.infer<typeof DesktopApplicationShellTargetSchemaZ>;
 export type DesktopDaemonHostIssueCode = z.infer<typeof DesktopDaemonHostIssueCodeSchemaZ>;
 export type DesktopDaemonHostState = z.infer<typeof DesktopDaemonHostStateSchemaZ>;
+export type DesktopDaemonCapabilityState = z.infer<typeof DesktopDaemonCapabilityStateSchemaZ>;
+export type DesktopDaemonCapabilityErrorCode = z.infer<
+  typeof DesktopDaemonCapabilityErrorCodeSchemaZ
+>;
+export type DesktopDaemonCapabilityError = z.infer<typeof DesktopDaemonCapabilityErrorSchemaZ>;
+export type DesktopDaemonWorkspaceSummary = z.infer<typeof DesktopDaemonWorkspaceSummarySchemaZ>;
+export type DesktopDaemonListWorkspacesResult = z.infer<
+  typeof DesktopDaemonListWorkspacesResultSchemaZ
+>;
+export type DesktopDaemonFetchApplicationShellRequest = z.infer<
+  typeof DesktopDaemonFetchApplicationShellRequestSchemaZ
+>;
+export type DesktopApplicationShellTarget = z.infer<typeof DesktopApplicationShellTargetSchemaZ>;
+export type DesktopDaemonFetchApplicationShellResult = z.infer<
+  typeof DesktopDaemonFetchApplicationShellResultSchemaZ
+>;
+export type DesktopDaemonEventSubscriptionRequest = z.infer<
+  typeof DesktopDaemonEventSubscriptionRequestSchemaZ
+>;
+export type DesktopDaemonEvent = z.infer<typeof DesktopDaemonEventSchemaZ>;
+export type DesktopDaemonSubscribeWireResult = z.infer<
+  typeof DesktopDaemonSubscribeWireResultSchemaZ
+>;
 /** @deprecated Compatibility name for existing host bootstrap consumers. */
 export type DesktopDaemonPreflight = DesktopDaemonHostState;
 export type DesktopHostBootstrap = z.infer<typeof DesktopHostBootstrapSchemaZ>;
 export type DesktopMenuResult = z.infer<typeof DesktopMenuResultSchemaZ>;
 export type DesktopDirectorySelection = z.infer<typeof DesktopDirectorySelectionSchemaZ>;
 export type DesktopHostUnsubscribe = () => void;
+export type DesktopDaemonHostSubscriptionResult =
+  | { readonly status: "subscribed"; readonly unsubscribe: DesktopHostUnsubscribe }
+  | { readonly status: "error"; readonly error: DesktopDaemonCapabilityError };
 
 /**
  * The complete renderer-visible desktop surface. It intentionally has no
@@ -146,5 +298,15 @@ export interface HostCapabilities {
   readonly theme: {
     getState(): Promise<DesktopThemeState>;
     onChanged(listener: (state: DesktopThemeState) => void): DesktopHostUnsubscribe;
+  };
+  readonly daemon: {
+    listWorkspaces(): Promise<DesktopDaemonListWorkspacesResult>;
+    fetchApplicationShell(
+      request: DesktopDaemonFetchApplicationShellRequest,
+    ): Promise<DesktopDaemonFetchApplicationShellResult>;
+    subscribe(
+      request: DesktopDaemonEventSubscriptionRequest,
+      listener: (event: DesktopDaemonEvent) => void,
+    ): Promise<DesktopDaemonHostSubscriptionResult>;
   };
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -34,6 +34,7 @@ export * from "./experience-identifiers.ts";
 export * from "./experience-shell.ts";
 export * from "./application-shell.ts";
 export * from "./application-shell-resource.ts";
+export * from "./workspace-catalog-resource.ts";
 export * from "./visual-tokens.ts";
 export * from "./visual-recipes.ts";
 export * from "./pane-appearance.ts";

--- a/packages/contracts/src/workspace-catalog-resource.ts
+++ b/packages/contracts/src/workspace-catalog-resource.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+import { DaemonInstanceIdentitySchemaZ } from "./daemon-wire.ts";
+
+export const WORKSPACE_CATALOG_RESOURCE_VERSION = 1 as const;
+
+/**
+ * Minimal daemon-private workspace routing record. The session name is needed
+ * by trusted transports, but project paths and configuration metadata are not.
+ */
+export const WorkspaceCatalogEntryV1SchemaZ = z
+  .object({
+    workspaceName: z.string().min(1),
+    sessionName: z.string().min(1),
+  })
+  .strict();
+
+/**
+ * Generation-stamped catalog used by trusted hosts before they retain any
+ * workspace-to-session routing decision.
+ */
+export const WorkspaceCatalogResourceV1SchemaZ = z
+  .object({
+    version: z.literal(WORKSPACE_CATALOG_RESOURCE_VERSION),
+    daemon: DaemonInstanceIdentitySchemaZ,
+    workspaces: z.array(WorkspaceCatalogEntryV1SchemaZ),
+  })
+  .strict();
+
+export type WorkspaceCatalogEntryV1 = z.infer<typeof WorkspaceCatalogEntryV1SchemaZ>;
+export type WorkspaceCatalogResourceV1 = z.infer<typeof WorkspaceCatalogResourceV1SchemaZ>;

--- a/packages/daemon/src/command-center/server.ts
+++ b/packages/daemon/src/command-center/server.ts
@@ -36,9 +36,11 @@ import {
 import {
   AddWorkspaceRequestSchemaZ,
   APPLICATION_SHELL_RESOURCE_VERSION,
+  WORKSPACE_CATALOG_RESOURCE_VERSION,
   DAEMON_WIRE_PROTOCOL_VERSION,
   DaemonInstanceIdentitySchemaZ,
   type ApplicationShellResourceV1,
+  type WorkspaceCatalogResourceV1,
   type DaemonInstanceIdentity,
   type DaemonPanesResponse,
   type DaemonProjectResponse,
@@ -407,6 +409,17 @@ export function createApp(options: CreateAppOptions = {}): Hono {
   app.get("/api/workspaces", (c) => {
     const registry = getDefaultWorkspaceRegistry();
     return c.json({ workspaces: registry.list() } satisfies DaemonWorkspacesResponse);
+  });
+
+  app.get("/api/resources/workspace-catalog", (c) => {
+    const registry = getDefaultWorkspaceRegistry();
+    return c.json({
+      version: WORKSPACE_CATALOG_RESOURCE_VERSION,
+      daemon: daemonInstanceIdentity,
+      workspaces: registry
+        .list()
+        .map(({ name, sessionName }) => ({ workspaceName: name, sessionName })),
+    } satisfies WorkspaceCatalogResourceV1);
   });
 
   app.get("/api/workspaces/:name", (c) => {

--- a/packages/daemon/src/command-center/workspaces.test.ts
+++ b/packages/daemon/src/command-center/workspaces.test.ts
@@ -45,6 +45,20 @@ describe("REST /api/workspaces", () => {
     expect((body.workspaces[0] as { name: string }).name).toBe("alpha");
   });
 
+  it("GET resource catalog is generation-stamped and excludes project metadata", async () => {
+    registry.add({ name: "alpha", sessionName: "alpha-live", projectDir: "/tmp/alpha" });
+    const app = createApp({ daemonIdentity: TEST_DAEMON_IDENTITY });
+    const res = await app.request("/api/resources/workspace-catalog");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({
+      version: 1,
+      daemon: TEST_DAEMON_IDENTITY,
+      workspaces: [{ workspaceName: "alpha", sessionName: "alpha-live" }],
+    });
+    expect(JSON.stringify(body)).not.toMatch(/projectDir|ideConfigPath|configPath/);
+  });
+
   it("POST adds a workspace and returns 201 with the new entry", async () => {
     const app = createApp();
     const res = await app.request("/api/workspaces", {


### PR DESCRIPTION
## Summary
- add a typed Electron-main daemon resource broker with semantic workspace APIs
- keep daemon URLs, raw session mappings, sockets, and trust decisions out of the renderer
- generation-bind catalogs/resources/events and bind subscriptions to renderer document lifetime
- enforce bounded handshakes, strict media/CSP rules, canonical workspace identity, and safe recovery

## Verification
- full `pnpm check` passed
- Electron 65, contracts 113, renderer 57, daemon 2289 tests passed
- independent adversarial re-review approved with no blocker/high/medium findings

## Scope
No App/live catalog chooser/xterm terminal UI wiring in this slice.