### PR TITLE
feat(desktop): add semantic terminal creation flow

### DIFF
--- a/apps/desktop-renderer/src/experience/create-pane-flow-presenter.test.ts
+++ b/apps/desktop-renderer/src/experience/create-pane-flow-presenter.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createPaneSubmission,
+  projectCreatePaneFlow,
+  type CreatePaneFlowCatalogs,
+} from "./create-pane-flow-presenter.ts";
+
+function catalogs(): CreatePaneFlowCatalogs {
+  return {
+    workspaces: {
+      status: "ready",
+      items: [
+        { name: "tmux-ide", label: "tmux-ide", available: true },
+        { name: "docs/site", label: "Documentation", available: false },
+      ],
+    },
+    harnessProfiles: {
+      status: "ready",
+      items: [
+        {
+          id: "codex-implementer",
+          label: "Codex implementer",
+          description: "Codex with the project implementation profile",
+          available: true,
+        },
+      ],
+    },
+    missions: {
+      status: "ready",
+      items: [{ id: "parity", label: "Product parity", available: true }],
+    },
+  };
+}
+
+describe("create pane flow presenter", () => {
+  it("accepts slash workspace names while omitting duplicates and non-canonical collisions", () => {
+    const projection = projectCreatePaneFlow({
+      ...catalogs(),
+      workspaces: {
+        status: "ready",
+        items: [
+          { name: "tmux-ide", label: "tmux-ide", available: true },
+          { name: "tmux-ide", label: "Duplicate", available: true },
+          { name: " docs ", label: "Non-canonical", available: true },
+          { name: "valid", label: " padded ", available: true },
+        ],
+      },
+    });
+
+    expect(projection.workspaces.items).toEqual([
+      { name: "tmux-ide", label: "tmux-ide", available: true },
+    ]);
+    expect(projection.workspaces.invalidOptionCount).toBe(3);
+    expect(Object.isFrozen(projection.workspaces.items)).toBe(true);
+  });
+
+  it("reconstructs exact safe option fields and rejects nonboolean availability", () => {
+    const projection = projectCreatePaneFlow({
+      workspaces: {
+        status: "ready",
+        items: [
+          {
+            name: "docs/site",
+            label: "Documentation",
+            available: true,
+            cwd: "/Users/private",
+            sessionName: "secret-session",
+            token: "secret-token",
+          },
+          { name: "bad", label: "Bad", available: "yes", command: "shell" },
+        ],
+      },
+      harnessProfiles: {
+        status: "ready",
+        items: [
+          {
+            id: "codex",
+            label: "Codex",
+            description: "Implementation profile",
+            available: true,
+            argv: ["codex", "--yolo"],
+            command: "codex",
+            cwd: "/private",
+            token: "secret-token",
+          },
+          { id: "bad", label: "Bad", available: 1, command: "codex" },
+        ],
+      },
+      missions: {
+        status: "ready",
+        items: [
+          {
+            id: "parity",
+            label: "Parity",
+            available: true,
+            sessionName: "secret-session",
+          },
+          { id: "bad", label: "Bad", available: "true", token: "secret" },
+        ],
+      },
+    } as unknown as CreatePaneFlowCatalogs);
+
+    expect(projection.workspaces.items).toEqual([
+      { name: "docs/site", label: "Documentation", available: true },
+    ]);
+    expect(projection.workspaces.invalidOptionCount).toBe(1);
+    expect(projection.harnessProfiles.items).toEqual([
+      {
+        id: "codex",
+        label: "Codex",
+        description: "Implementation profile",
+        available: true,
+      },
+    ]);
+    expect(projection.harnessProfiles.invalidOptionCount).toBe(1);
+    expect(projection.missions.items).toEqual([{ id: "parity", label: "Parity", available: true }]);
+    expect(projection.missions.invalidOptionCount).toBe(1);
+    expect(JSON.stringify(projection)).not.toMatch(
+      /cwd|argv|command|sessionName|token|secret-session|secret-token/u,
+    );
+  });
+
+  it("requires exact available workspace membership and reports the first field", () => {
+    const projection = projectCreatePaneFlow(catalogs());
+
+    expect(
+      createPaneSubmission(
+        projection,
+        {
+          kind: "terminal",
+          workspaceName: "unknown",
+          displayTitle: "",
+          harnessProfileId: "",
+          role: "implementer",
+          missionId: "",
+        },
+        { kind: "keyboard", surface: "create-pane-dialog" },
+      ),
+    ).toEqual({
+      ok: false,
+      errors: { workspaceName: "Choose an available workspace." },
+      firstInvalidField: "workspaceName",
+    });
+  });
+
+  it("distinguishes loading, unavailable, and empty workspace states", () => {
+    for (const [workspaces, message] of [
+      [{ status: "loading" as const }, "Workspace choices are still loading."],
+      [{ status: "unavailable" as const }, "Workspace choices are unavailable."],
+      [{ status: "ready" as const, items: [] }, "No workspace is available yet."],
+    ] as const) {
+      const result = createPaneSubmission(
+        projectCreatePaneFlow({ ...catalogs(), workspaces }),
+        {
+          kind: "terminal",
+          workspaceName: "",
+          displayTitle: "",
+          harnessProfileId: "",
+          role: "implementer",
+          missionId: "",
+        },
+        { kind: "keyboard", surface: "create-pane-dialog" },
+      );
+      expect(result).toMatchObject({ ok: false, errors: { workspaceName: message } });
+    }
+  });
+
+  it("creates a terminal invocation with a trimmed optional title", () => {
+    const result = createPaneSubmission(
+      projectCreatePaneFlow(catalogs()),
+      {
+        kind: "terminal",
+        workspaceName: "tmux-ide",
+        displayTitle: "  Release shell  ",
+        harnessProfileId: "",
+        role: "implementer",
+        missionId: "",
+      },
+      { kind: "palette", surface: "command-palette" },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      invocation: {
+        version: 1,
+        id: "workspace.pane.create",
+        source: { kind: "palette", surface: "command-palette" },
+        args: {
+          kind: "terminal",
+          workspaceName: "tmux-ide",
+          displayTitle: "Release shell",
+        },
+      },
+    });
+  });
+
+  it("requires an exposed harness while keeping mission assignment optional", () => {
+    const projection = projectCreatePaneFlow(catalogs());
+    const missingHarness = createPaneSubmission(
+      projection,
+      {
+        kind: "agent",
+        workspaceName: "tmux-ide",
+        displayTitle: "",
+        harnessProfileId: "",
+        role: "reviewer",
+        missionId: "",
+      },
+      { kind: "mouse", surface: "create-pane-dialog" },
+    );
+    expect(missingHarness).toMatchObject({
+      ok: false,
+      errors: { harnessProfileId: "Choose an agent profile." },
+    });
+
+    const valid = createPaneSubmission(
+      projection,
+      {
+        kind: "agent",
+        workspaceName: "tmux-ide",
+        displayTitle: "Reviewer",
+        harnessProfileId: "codex-implementer",
+        role: "reviewer",
+        missionId: "parity",
+      },
+      { kind: "mouse", surface: "create-pane-dialog" },
+    );
+    expect(valid).toMatchObject({
+      ok: true,
+      invocation: {
+        args: {
+          kind: "agent",
+          workspaceName: "tmux-ide",
+          harnessProfileId: "codex-implementer",
+          role: "reviewer",
+          missionId: "parity",
+        },
+      },
+    });
+  });
+
+  it("rejects selected agent resources that disappear during catalog churn", () => {
+    const draft = {
+      kind: "agent" as const,
+      workspaceName: "tmux-ide",
+      displayTitle: "",
+      harnessProfileId: "codex-implementer",
+      role: "implementer" as const,
+      missionId: "parity",
+    };
+    const workspaceGone = createPaneSubmission(
+      projectCreatePaneFlow({
+        ...catalogs(),
+        workspaces: { status: "ready", items: [] },
+      }),
+      draft,
+      { kind: "keyboard", surface: "create-pane-dialog" },
+    );
+    expect(workspaceGone).toMatchObject({
+      ok: false,
+      errors: { workspaceName: "No workspace is available yet." },
+    });
+
+    const harnessGone = createPaneSubmission(
+      projectCreatePaneFlow({
+        ...catalogs(),
+        harnessProfiles: { status: "ready", items: [] },
+      }),
+      draft,
+      { kind: "keyboard", surface: "create-pane-dialog" },
+    );
+    expect(harnessGone).toMatchObject({
+      ok: false,
+      errors: { harnessProfileId: "No agent profile is available yet." },
+    });
+
+    const missionGone = createPaneSubmission(
+      projectCreatePaneFlow({
+        ...catalogs(),
+        missions: { status: "ready", items: [] },
+      }),
+      draft,
+      { kind: "keyboard", surface: "create-pane-dialog" },
+    );
+    expect(missionGone).toMatchObject({
+      ok: false,
+      errors: { missionId: "Choose an available mission or leave it unassigned." },
+    });
+  });
+});

--- a/apps/desktop-renderer/src/experience/create-pane-flow-presenter.ts
+++ b/apps/desktop-renderer/src/experience/create-pane-flow-presenter.ts
@@ -1,0 +1,331 @@
+import {
+  WorkspaceAgentRoleSchemaZ,
+  WorkspacePaneDisplayTitleSchemaZ,
+  WorkspacePaneCreationReferenceSchemaZ,
+  WorkspacePaneCreationWorkspaceNameSchemaZ,
+  workspacePaneCreateInvocation,
+  type CommandSource,
+  type WorkspaceAgentRole,
+  type WorkspacePaneCreateInvocation,
+} from "@tmux-ide/contracts";
+
+export type CreatePaneKind = "terminal" | "agent";
+
+export interface CreatePaneWorkspaceOption {
+  readonly name: string;
+  readonly label: string;
+  readonly available: boolean;
+}
+
+export interface CreatePaneHarnessOption {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly available: boolean;
+}
+
+export interface CreatePaneMissionOption {
+  readonly id: string;
+  readonly label: string;
+  readonly available: boolean;
+}
+
+export type CreatePaneCatalogState<Item> =
+  | { readonly status: "loading" }
+  | { readonly status: "unavailable" }
+  | { readonly status: "ready"; readonly items: readonly Item[] };
+
+export interface CreatePaneFlowCatalogs {
+  readonly workspaces: CreatePaneCatalogState<CreatePaneWorkspaceOption>;
+  readonly harnessProfiles: CreatePaneCatalogState<CreatePaneHarnessOption>;
+  readonly missions: CreatePaneCatalogState<CreatePaneMissionOption>;
+}
+
+interface ProjectedCatalog<Item> {
+  readonly status: CreatePaneCatalogState<Item>["status"];
+  readonly items: readonly Item[];
+  readonly invalidOptionCount: number;
+}
+
+export interface CreatePaneFlowProjection {
+  readonly workspaces: ProjectedCatalog<CreatePaneWorkspaceOption>;
+  readonly harnessProfiles: ProjectedCatalog<CreatePaneHarnessOption>;
+  readonly missions: ProjectedCatalog<CreatePaneMissionOption>;
+  readonly roles: readonly WorkspaceAgentRole[];
+}
+
+export interface CreatePaneDraft {
+  readonly kind: CreatePaneKind;
+  readonly workspaceName: string;
+  readonly displayTitle: string;
+  readonly harnessProfileId: string;
+  readonly role: WorkspaceAgentRole;
+  readonly missionId: string;
+}
+
+export type CreatePaneField =
+  | "workspaceName"
+  | "displayTitle"
+  | "harnessProfileId"
+  | "role"
+  | "missionId";
+
+export type CreatePaneFieldErrors = Readonly<Partial<Record<CreatePaneField, string>>>;
+
+export type CreatePaneSubmission =
+  | {
+      readonly ok: true;
+      readonly invocation: WorkspacePaneCreateInvocation;
+    }
+  | {
+      readonly ok: false;
+      readonly errors: CreatePaneFieldErrors;
+      readonly firstInvalidField: CreatePaneField;
+    };
+
+const ROLES = Object.freeze([
+  "manager",
+  "implementer",
+  "reviewer",
+  "researcher",
+  "validator",
+] as const satisfies readonly WorkspaceAgentRole[]);
+
+function frozen<Value>(value: Value): Value {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const nested of Object.values(value)) frozen(nested);
+  }
+  return value;
+}
+
+function validLabel(value: string): boolean {
+  const containsControl = [...value].some((character) => {
+    const code = character.codePointAt(0) ?? 0;
+    return code <= 31 || code === 127;
+  });
+  return value === value.trim() && value.length >= 1 && value.length <= 120 && !containsControl;
+}
+
+function emptyCatalog<Item>(status: "loading" | "unavailable"): ProjectedCatalog<Item> {
+  return frozen({ status, items: [], invalidOptionCount: 0 });
+}
+
+function asRecord(value: unknown): Readonly<Record<string, unknown>> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : null;
+}
+
+function projectWorkspaceCatalog(
+  catalog: CreatePaneCatalogState<CreatePaneWorkspaceOption>,
+): ProjectedCatalog<CreatePaneWorkspaceOption> {
+  if (catalog.status !== "ready") {
+    return emptyCatalog(catalog.status);
+  }
+  if (!Array.isArray(catalog.items)) {
+    return frozen({ status: "ready", items: [], invalidOptionCount: 1 });
+  }
+
+  const names = new Set<string>();
+  const items: CreatePaneWorkspaceOption[] = [];
+  let invalidOptionCount = 0;
+  for (const candidate of catalog.items as readonly unknown[]) {
+    const item = asRecord(candidate);
+    if (
+      !item ||
+      typeof item.name !== "string" ||
+      !WorkspacePaneCreationWorkspaceNameSchemaZ.safeParse(item.name).success ||
+      typeof item.label !== "string" ||
+      !validLabel(item.label) ||
+      typeof item.available !== "boolean" ||
+      names.has(item.name)
+    ) {
+      invalidOptionCount += 1;
+      continue;
+    }
+    names.add(item.name);
+    items.push({ name: item.name, label: item.label, available: item.available });
+  }
+  return frozen({ status: "ready", items, invalidOptionCount });
+}
+
+function projectHarnessCatalog(
+  catalog: CreatePaneCatalogState<CreatePaneHarnessOption>,
+): ProjectedCatalog<CreatePaneHarnessOption> {
+  if (catalog.status !== "ready") return emptyCatalog(catalog.status);
+  if (!Array.isArray(catalog.items)) {
+    return frozen({ status: "ready", items: [], invalidOptionCount: 1 });
+  }
+  const ids = new Set<string>();
+  const items: CreatePaneHarnessOption[] = [];
+  let invalidOptionCount = 0;
+  for (const candidate of catalog.items as readonly unknown[]) {
+    const item = asRecord(candidate);
+    if (
+      !item ||
+      typeof item.id !== "string" ||
+      !WorkspacePaneCreationReferenceSchemaZ.safeParse(item.id).success ||
+      typeof item.label !== "string" ||
+      !validLabel(item.label) ||
+      typeof item.available !== "boolean" ||
+      ids.has(item.id) ||
+      ("description" in item &&
+        item.description !== undefined &&
+        (typeof item.description !== "string" || !validLabel(item.description)))
+    ) {
+      invalidOptionCount += 1;
+      continue;
+    }
+    ids.add(item.id);
+    items.push({
+      id: item.id,
+      label: item.label,
+      ...(typeof item.description === "string" ? { description: item.description } : {}),
+      available: item.available,
+    });
+  }
+  return frozen({ status: "ready", items, invalidOptionCount });
+}
+
+function projectMissionCatalog(
+  catalog: CreatePaneCatalogState<CreatePaneMissionOption>,
+): ProjectedCatalog<CreatePaneMissionOption> {
+  if (catalog.status !== "ready") return emptyCatalog(catalog.status);
+  if (!Array.isArray(catalog.items)) {
+    return frozen({ status: "ready", items: [], invalidOptionCount: 1 });
+  }
+  const ids = new Set<string>();
+  const items: CreatePaneMissionOption[] = [];
+  let invalidOptionCount = 0;
+  for (const candidate of catalog.items as readonly unknown[]) {
+    const item = asRecord(candidate);
+    if (
+      !item ||
+      typeof item.id !== "string" ||
+      !WorkspacePaneCreationReferenceSchemaZ.safeParse(item.id).success ||
+      typeof item.label !== "string" ||
+      !validLabel(item.label) ||
+      typeof item.available !== "boolean" ||
+      ids.has(item.id)
+    ) {
+      invalidOptionCount += 1;
+      continue;
+    }
+    ids.add(item.id);
+    items.push({ id: item.id, label: item.label, available: item.available });
+  }
+  return frozen({ status: "ready", items, invalidOptionCount });
+}
+
+/** Pure, defensive catalog projection consumed by the Solid dialog. */
+export function projectCreatePaneFlow(catalogs: CreatePaneFlowCatalogs): CreatePaneFlowProjection {
+  return frozen({
+    workspaces: projectWorkspaceCatalog(catalogs.workspaces),
+    harnessProfiles: projectHarnessCatalog(catalogs.harnessProfiles),
+    missions: projectMissionCatalog(catalogs.missions),
+    roles: ROLES,
+  });
+}
+
+function selectedAvailable<Item extends { readonly id: string; readonly available: boolean }>(
+  catalog: ProjectedCatalog<Item>,
+  id: string,
+): boolean {
+  return (
+    catalog.status === "ready" && catalog.items.some((item) => item.id === id && item.available)
+  );
+}
+
+function workspaceError(
+  projection: CreatePaneFlowProjection,
+  workspaceName: string,
+): string | undefined {
+  if (projection.workspaces.status === "loading") return "Workspace choices are still loading.";
+  if (projection.workspaces.status === "unavailable") return "Workspace choices are unavailable.";
+  if (projection.workspaces.items.length === 0) return "No workspace is available yet.";
+  if (!workspaceName) return "Choose a workspace.";
+  if (
+    projection.workspaces.status !== "ready" ||
+    !projection.workspaces.items.some((item) => item.name === workspaceName && item.available)
+  ) {
+    return "Choose an available workspace.";
+  }
+  return undefined;
+}
+
+/**
+ * Build the sole command callback payload. Exact catalog membership is checked
+ * here before shared contract validation, so typed input cannot forge a hidden
+ * workspace, harness, or mission identity.
+ */
+export function createPaneSubmission(
+  projection: CreatePaneFlowProjection,
+  draft: CreatePaneDraft,
+  source: CommandSource,
+): CreatePaneSubmission {
+  const errors: Partial<Record<CreatePaneField, string>> = {};
+  const workspace = workspaceError(projection, draft.workspaceName);
+  if (workspace) errors.workspaceName = workspace;
+
+  const displayTitle = draft.displayTitle.trim();
+  if (displayTitle && !WorkspacePaneDisplayTitleSchemaZ.safeParse(displayTitle).success) {
+    errors.displayTitle = "Use 80 characters or fewer without control characters.";
+  }
+
+  if (draft.kind === "agent") {
+    if (projection.harnessProfiles.status === "loading") {
+      errors.harnessProfileId = "Agent profiles are still loading.";
+    } else if (projection.harnessProfiles.status === "unavailable") {
+      errors.harnessProfileId = "Agent profiles are unavailable.";
+    } else if (projection.harnessProfiles.items.length === 0) {
+      errors.harnessProfileId = "No agent profile is available yet.";
+    } else if (!draft.harnessProfileId) {
+      errors.harnessProfileId = "Choose an agent profile.";
+    } else if (!selectedAvailable(projection.harnessProfiles, draft.harnessProfileId)) {
+      errors.harnessProfileId = "Choose an available agent profile.";
+    }
+
+    if (!WorkspaceAgentRoleSchemaZ.safeParse(draft.role).success) {
+      errors.role = "Choose a supported role.";
+    }
+    if (
+      draft.missionId &&
+      (projection.missions.status !== "ready" ||
+        !selectedAvailable(projection.missions, draft.missionId))
+    ) {
+      errors.missionId = "Choose an available mission or leave it unassigned.";
+    }
+  }
+
+  const fieldOrder: readonly CreatePaneField[] = [
+    "workspaceName",
+    "displayTitle",
+    "harnessProfileId",
+    "role",
+    "missionId",
+  ];
+  const firstInvalidField = fieldOrder.find((field) => errors[field]);
+  if (firstInvalidField) {
+    return frozen({ ok: false, errors, firstInvalidField });
+  }
+
+  const common = {
+    workspaceName: draft.workspaceName,
+    ...(displayTitle ? { displayTitle } : {}),
+  };
+  const invocation =
+    draft.kind === "terminal"
+      ? workspacePaneCreateInvocation({ kind: "terminal", ...common }, source)
+      : workspacePaneCreateInvocation(
+          {
+            kind: "agent",
+            ...common,
+            harnessProfileId: draft.harnessProfileId,
+            role: draft.role,
+            ...(draft.missionId ? { missionId: draft.missionId } : {}),
+          },
+          source,
+        );
+  return frozen({ ok: true, invocation });
+}

--- a/apps/desktop-renderer/src/experience/create-pane-flow.md
+++ b/apps/desktop-renderer/src/experience/create-pane-flow.md
@@ -1,0 +1,34 @@
+# Native create terminal / agent flow
+
+`CreatePaneFlow` is an independently composable Solid presenter for the native
+`+` action. It deliberately has no terminal runtime implementation. The
+renderer submits one strict, daemon-owned `workspace.pane.create` invocation;
+tmux remains the only terminal/process authority.
+
+## Required production adapter
+
+App wiring should provide the component with:
+
+1. workspace choices from the generation-bound live workspace catalog, mapped
+   to its canonical `workspaceName`, label, and availability. Never pass the catalog's
+   trusted-host `sessionName` into the renderer;
+2. a future daemon resource containing safe harness profile metadata only:
+   semantic profile ID, display label/description, and availability. Executable,
+   argv, cwd, environment, model launch flags, and adapter internals stay in the
+   daemon;
+3. optional mission projection choices containing semantic ID, label, and
+   availability only; and
+4. an `onCommand` callback routed through a typed Electron host capability for
+   `workspace.pane.create`.
+
+The missing mutation adapter should validate `WorkspacePaneCreateInvocation`,
+pin the current daemon generation, resolve `workspaceName`, `harnessProfileId`,
+role, and `missionId` against daemon-owned registries, and only then ask the
+tmux bridge to create the pane. The adapter must return a semantic result or a
+sanitized error; it must never return tmux IDs, commands, paths, or argv to the
+renderer.
+
+Dock buttons, palette entries, and shortcuts can call
+`workspacePaneCreateInvocation` with their own command source. This preserves
+one semantic command instead of creating surface-specific terminal launch
+paths.

--- a/apps/desktop-renderer/src/experience/create-pane-flow.test.tsx
+++ b/apps/desktop-renderer/src/experience/create-pane-flow.test.tsx
@@ -1,0 +1,396 @@
+/* @vitest-environment happy-dom */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSignal } from "solid-js";
+import { render } from "solid-js/web";
+import type { WorkspacePaneCreateInvocation } from "@tmux-ide/contracts";
+
+import styles from "../styles.css?raw";
+import { CreatePaneFlow } from "./create-pane-flow.tsx";
+import type { CreatePaneFlowCatalogs } from "./create-pane-flow-presenter.ts";
+
+const disposers: Array<() => void> = [];
+
+function readyCatalogs(): CreatePaneFlowCatalogs {
+  return {
+    workspaces: {
+      status: "ready",
+      items: [
+        { name: "tmux-ide", label: "tmux-ide", available: true },
+        { name: "docs/site", label: "Documentation", available: true },
+      ],
+    },
+    harnessProfiles: {
+      status: "ready",
+      items: [
+        {
+          id: "codex-implementer",
+          label: "Codex implementer",
+          description: "Implementation harness",
+          available: true,
+        },
+        { id: "offline", label: "Offline profile", available: false },
+      ],
+    },
+    missions: {
+      status: "ready",
+      items: [{ id: "parity", label: "Gloomberb parity", available: true }],
+    },
+  };
+}
+
+function renderFlow(
+  catalogs: CreatePaneFlowCatalogs | (() => CreatePaneFlowCatalogs) = readyCatalogs(),
+  onCommand: (invocation: WorkspacePaneCreateInvocation) => void | Promise<void> = vi.fn(
+    async () => undefined,
+  ),
+  initialWorkspaceName?: string,
+) {
+  const root = document.createElement("div");
+  document.body.append(root);
+  const [open, setOpen] = createSignal(false);
+  const openChanges: Array<{ open: boolean; source: string }> = [];
+  const catalogsAccessor = typeof catalogs === "function" ? catalogs : () => catalogs;
+  const disposeRender = render(
+    () => (
+      <CreatePaneFlow
+        open={open()}
+        catalogs={catalogsAccessor()}
+        initialWorkspaceName={initialWorkspaceName}
+        onOpenChange={(nextOpen, source) => {
+          openChanges.push({ open: nextOpen, source });
+          setOpen(nextOpen);
+        }}
+        onCommand={onCommand}
+      />
+    ),
+    root,
+  );
+  let disposed = false;
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    disposeRender();
+  };
+  disposers.push(dispose);
+  return { root, open, setOpen, openChanges, onCommand, dispose };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function key(element: EventTarget, value: string, options: KeyboardEventInit = {}): void {
+  element.dispatchEvent(new KeyboardEvent("keydown", { key: value, bubbles: true, ...options }));
+}
+
+function change(element: HTMLInputElement | HTMLSelectElement, value: string): void {
+  element.value = value;
+  element.dispatchEvent(
+    new Event(element instanceof HTMLSelectElement ? "change" : "input", { bubbles: true }),
+  );
+}
+
+function pointerClick(element: Element): void {
+  element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, detail: 1 }));
+  element.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dispose of disposers.splice(0)) dispose();
+  document.body.replaceChildren();
+});
+
+describe("native create terminal / agent flow", () => {
+  it("opens from one keyboard-complete + action, traps focus, and restores focus on Escape", async () => {
+    const { root, openChanges } = renderFlow();
+    const trigger = root.querySelector<HTMLButtonElement>("#create-pane-flow-trigger")!;
+    const overlay = root.querySelector<HTMLElement>(".create-pane-flow__overlay")!;
+    const dialog = root.querySelector<HTMLElement>("#create-pane-flow-dialog")!;
+    const close = root.querySelector<HTMLButtonElement>(".create-pane-flow__close")!;
+    const kindCards = root.querySelectorAll<HTMLButtonElement>(".create-pane-flow__kind-card");
+
+    expect(trigger.textContent).toContain("+");
+    expect(trigger.getAttribute("aria-haspopup")).toBe("dialog");
+    expect(overlay.getAttribute("aria-hidden")).toBe("true");
+    trigger.focus();
+    trigger.click();
+
+    await vi.waitFor(() => expect(document.activeElement).toBe(kindCards[0]));
+    expect(overlay.getAttribute("aria-hidden")).toBe("false");
+    expect(overlay.dataset.transitionSource).toBe("keyboard");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+
+    close.focus();
+    key(close, "Tab", { shiftKey: true });
+    expect(document.activeElement).toBe(kindCards[1]);
+    key(kindCards[1]!, "Tab");
+    expect(document.activeElement).toBe(close);
+
+    key(close, "Escape");
+    await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
+    expect(overlay.getAttribute("aria-hidden")).toBe("true");
+    expect(openChanges).toEqual([
+      { open: true, source: "keyboard" },
+      { open: false, source: "keyboard" },
+    ]);
+  });
+
+  it("submits a terminal from Enter through the canonical semantic command", async () => {
+    const onCommand = vi.fn<(invocation: WorkspacePaneCreateInvocation) => Promise<void>>(
+      async () => undefined,
+    );
+    const { root } = renderFlow(readyCatalogs(), onCommand, "tmux-ide");
+    const trigger = root.querySelector<HTMLButtonElement>("#create-pane-flow-trigger")!;
+    trigger.focus();
+    trigger.click();
+    const terminal = root.querySelectorAll<HTMLButtonElement>(".create-pane-flow__kind-card")[0]!;
+    await vi.waitFor(() => expect(document.activeElement).toBe(terminal));
+
+    key(terminal, "Enter");
+    const workspace = root.querySelector<HTMLSelectElement>("#create-pane-flow-workspace")!;
+    await vi.waitFor(() => expect(document.activeElement).toBe(workspace));
+    expect(workspace.value).toBe("tmux-ide");
+    expect(workspace.required).toBe(true);
+    expect(workspace.getAttribute("aria-required")).toBe("true");
+    const title = root.querySelector<HTMLInputElement>("#create-pane-flow-display-title")!;
+    change(title, "Release shell");
+    key(title, "Enter");
+
+    await vi.waitFor(() => expect(onCommand).toHaveBeenCalledTimes(1));
+    expect(onCommand).toHaveBeenCalledWith({
+      version: 1,
+      id: "workspace.pane.create",
+      source: { kind: "keyboard", surface: "create-pane-dialog" },
+      args: {
+        kind: "terminal",
+        workspaceName: "tmux-ide",
+        displayTitle: "Release shell",
+      },
+    });
+    expect(onCommand.mock.calls[0]?.[0].args).not.toHaveProperty("cwd");
+    expect(onCommand.mock.calls[0]?.[0].args).not.toHaveProperty("sessionName");
+    await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it("submits an agent using only exposed harness, role, and mission resources", async () => {
+    const onCommand = vi.fn<(invocation: WorkspacePaneCreateInvocation) => Promise<void>>(
+      async () => undefined,
+    );
+    const { root } = renderFlow(readyCatalogs(), onCommand);
+    pointerClick(root.querySelector("#create-pane-flow-trigger")!);
+    const agent = root.querySelectorAll<HTMLButtonElement>(".create-pane-flow__kind-card")[1]!;
+    await vi.waitFor(() => expect(document.activeElement).not.toBeNull());
+    pointerClick(agent);
+
+    change(root.querySelector<HTMLSelectElement>("#create-pane-flow-workspace")!, "tmux-ide");
+    change(
+      root.querySelector<HTMLSelectElement>("#create-pane-flow-harness")!,
+      "codex-implementer",
+    );
+    expect(root.querySelector<HTMLSelectElement>("#create-pane-flow-harness")!.required).toBe(true);
+    expect(
+      root
+        .querySelector<HTMLSelectElement>("#create-pane-flow-harness")!
+        .getAttribute("aria-required"),
+    ).toBe("true");
+    change(root.querySelector<HTMLSelectElement>("#create-pane-flow-role")!, "reviewer");
+    change(root.querySelector<HTMLSelectElement>("#create-pane-flow-mission")!, "parity");
+    change(root.querySelector<HTMLInputElement>("#create-pane-flow-display-title")!, "Review");
+    pointerClick(root.querySelector<HTMLButtonElement>(".create-pane-flow__submit")!);
+
+    await vi.waitFor(() => expect(onCommand).toHaveBeenCalledTimes(1));
+    expect(onCommand).toHaveBeenCalledWith({
+      version: 1,
+      id: "workspace.pane.create",
+      source: { kind: "mouse", surface: "create-pane-dialog" },
+      args: {
+        kind: "agent",
+        workspaceName: "tmux-ide",
+        displayTitle: "Review",
+        harnessProfileId: "codex-implementer",
+        role: "reviewer",
+        missionId: "parity",
+      },
+    });
+    expect(onCommand.mock.calls[0]?.[0].args).not.toHaveProperty("argv");
+    expect(onCommand.mock.calls[0]?.[0].args).not.toHaveProperty("command");
+  });
+
+  it("keeps stable dialog/form nodes while switching kind and open state", async () => {
+    const { root } = renderFlow(readyCatalogs(), undefined, "tmux-ide");
+    const overlay = root.querySelector(".create-pane-flow__overlay");
+    const workspace = root.querySelector("#create-pane-flow-workspace");
+    const harness = root.querySelector("#create-pane-flow-harness");
+    const trigger = root.querySelector<HTMLButtonElement>("#create-pane-flow-trigger")!;
+
+    trigger.click();
+    await vi.waitFor(() =>
+      expect(root.querySelector(".create-pane-flow__kind")?.hasAttribute("hidden")).toBe(false),
+    );
+    root.querySelectorAll<HTMLButtonElement>(".create-pane-flow__kind-card")[1]!.click();
+    expect(root.querySelector("#create-pane-flow-workspace")).toBe(workspace);
+    expect(root.querySelector("#create-pane-flow-harness")).toBe(harness);
+    root.querySelector<HTMLButtonElement>(".create-pane-flow__form-heading button")!.click();
+    root.querySelector<HTMLButtonElement>(".create-pane-flow__close")!.click();
+    await vi.waitFor(() =>
+      expect(root.querySelector(".create-pane-flow__overlay")?.getAttribute("aria-hidden")).toBe(
+        "true",
+      ),
+    );
+
+    expect(root.querySelector(".create-pane-flow__overlay")).toBe(overlay);
+    expect(root.querySelector("#create-pane-flow-workspace")).toBe(workspace);
+    expect(root.querySelector("#create-pane-flow-harness")).toBe(harness);
+  });
+
+  it("shows explicit loading and empty states instead of guessing resources", async () => {
+    const { root } = renderFlow({
+      workspaces: { status: "loading" },
+      harnessProfiles: { status: "ready", items: [] },
+      missions: { status: "unavailable" },
+    });
+    root.querySelector<HTMLButtonElement>("#create-pane-flow-trigger")!.click();
+    const agent = root.querySelectorAll<HTMLButtonElement>(".create-pane-flow__kind-card")[1]!;
+    await vi.waitFor(() => expect(document.activeElement).toBeDefined());
+    agent.click();
+
+    const workspace = root.querySelector<HTMLSelectElement>("#create-pane-flow-workspace")!;
+    const harness = root.querySelector<HTMLSelectElement>("#create-pane-flow-harness")!;
+    const mission = root.querySelector<HTMLSelectElement>("#create-pane-flow-mission")!;
+    const title = root.querySelector<HTMLInputElement>("#create-pane-flow-display-title")!;
+    await vi.waitFor(() => expect(document.activeElement).toBe(title));
+    expect(workspace.disabled).toBe(true);
+    expect(workspace.textContent).toContain("Loading workspaces");
+    expect(harness.textContent).toContain("No agent profiles available");
+    expect(root.textContent).toContain("No profiles are exposed yet");
+    expect(mission.disabled).toBe(true);
+    expect(mission.textContent).toContain("Missions unavailable");
+
+    root.querySelector<HTMLButtonElement>(".create-pane-flow__submit")!.click();
+    await vi.waitFor(() =>
+      expect(root.textContent).toContain("Workspace choices are still loading"),
+    );
+    expect(document.activeElement).toBe(root.querySelector(`#create-pane-flow-workspace-error`));
+  });
+
+  it.each(["loading", "unavailable"] as const)(
+    "focuses the first enabled form field when workspace choices are %s",
+    async (status) => {
+      const { root } = renderFlow({
+        ...readyCatalogs(),
+        workspaces: { status },
+      });
+      root.querySelector<HTMLButtonElement>("#create-pane-flow-trigger")!.click();
+      root.querySelectorAll<HTMLButtonElement>(".create-pane-flow__kind-card")[0]!.click();
+
+      const workspace = root.querySelector<HTMLSelectElement>("#create-pane-flow-workspace")!;
+      const title = root.querySelector<HTMLInputElement>("#create-pane-flow-display-title")!;
+      expect(workspace.disabled).toBe(true);
+      await vi.waitFor(() => expect(document.activeElement).toBe(title));
+    },
+  );
+
+  it("preserves selections and reports a sanitized callback failure", async () => {
+    const onCommand = vi.fn<(invocation: WorkspacePaneCreateInvocation) => Promise<void>>(
+      async () => {
+        throw new Error("secret cwd /Users/private and pane %42");
+      },
+    );
+    const { root } = renderFlow(readyCatalogs(), onCommand, "tmux-ide");
+    root.querySelector<HTMLButtonElement>("#create-pane-flow-trigger")!.click();
+    root.querySelectorAll<HTMLButtonElement>(".create-pane-flow__kind-card")[0]!.click();
+    const title = root.querySelector<HTMLInputElement>("#create-pane-flow-display-title")!;
+    change(title, "Keep me");
+    root.querySelector<HTMLButtonElement>(".create-pane-flow__submit")!.click();
+
+    await vi.waitFor(() => expect(root.querySelector('[role="alert"]')).not.toBeNull());
+    expect(root.querySelector('[role="alert"]')?.textContent).toContain(
+      "could not submit this request",
+    );
+    expect(root.textContent).not.toContain("/Users/private");
+    expect(root.textContent).not.toContain("%42");
+    expect(title.value).toBe("Keep me");
+    expect(root.querySelector(".create-pane-flow__overlay")?.getAttribute("aria-hidden")).toBe(
+      "false",
+    );
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "retires pending submission callbacks when the component unmounts before %s",
+    async (outcome) => {
+      const pending = deferred();
+      const onCommand = vi.fn(() => pending.promise);
+      const { root, openChanges, dispose } = renderFlow(readyCatalogs(), onCommand, "tmux-ide");
+      root.querySelector<HTMLButtonElement>("#create-pane-flow-trigger")!.click();
+      root.querySelectorAll<HTMLButtonElement>(".create-pane-flow__kind-card")[0]!.click();
+      root.querySelector<HTMLButtonElement>(".create-pane-flow__submit")!.click();
+      await vi.waitFor(() => expect(onCommand).toHaveBeenCalledTimes(1));
+
+      dispose();
+      if (outcome === "resolve") pending.resolve();
+      else pending.reject(new Error("late secret /Users/private %42"));
+      await pending.promise.catch(() => undefined);
+      await Promise.resolve();
+
+      expect(root.childElementCount).toBe(0);
+      expect(openChanges).toEqual([{ open: true, source: "keyboard" }]);
+    },
+  );
+
+  it("associates role and mission errors when selected agent resources become invalid", async () => {
+    const [catalogs, setCatalogs] = createSignal(readyCatalogs());
+    const { root, onCommand } = renderFlow(catalogs, undefined, "tmux-ide");
+    root.querySelector<HTMLButtonElement>("#create-pane-flow-trigger")!.click();
+    root.querySelectorAll<HTMLButtonElement>(".create-pane-flow__kind-card")[1]!.click();
+    change(
+      root.querySelector<HTMLSelectElement>("#create-pane-flow-harness")!,
+      "codex-implementer",
+    );
+
+    const role = root.querySelector<HTMLSelectElement>("#create-pane-flow-role")!;
+    change(role, "unsupported-role");
+    root.querySelector<HTMLButtonElement>(".create-pane-flow__submit")!.click();
+    await vi.waitFor(() =>
+      expect(root.querySelector("#create-pane-flow-role-error")).not.toBeNull(),
+    );
+    expect(role.getAttribute("aria-describedby")).toBe("create-pane-flow-role-error");
+    expect(document.activeElement).toBe(role);
+    expect(onCommand).not.toHaveBeenCalled();
+
+    change(role, "reviewer");
+    const mission = root.querySelector<HTMLSelectElement>("#create-pane-flow-mission")!;
+    change(mission, "parity");
+    setCatalogs({
+      ...readyCatalogs(),
+      missions: { status: "ready", items: [] },
+    });
+    await vi.waitFor(() => expect(mission.querySelector('[value="parity"]')).toBeNull());
+    root.querySelector<HTMLButtonElement>(".create-pane-flow__submit")!.click();
+
+    await vi.waitFor(() =>
+      expect(root.querySelector("#create-pane-flow-mission-error")).not.toBeNull(),
+    );
+    expect(mission.getAttribute("aria-describedby")).toBe("create-pane-flow-mission-error");
+    expect(root.querySelector("#create-pane-flow-mission-error")?.textContent).toContain(
+      "available mission",
+    );
+    expect(document.activeElement).toBe(mission);
+    expect(onCommand).not.toHaveBeenCalled();
+  });
+
+  it("animates pointer-open overlays only and honors product reduced-motion policy", () => {
+    expect(styles).toContain('.create-pane-flow__overlay[data-transition-source="mouse"]');
+    expect(styles).not.toContain('.create-pane-flow__overlay[data-transition-source="keyboard"]');
+    expect(styles).not.toMatch(/\.create-pane-flow[^}]*transition-all/gu);
+    expect(styles).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?transition-duration: 0ms !important;[\s\S]*?animation-duration: 0ms !important;/u,
+    );
+  });
+});

--- a/apps/desktop-renderer/src/experience/create-pane-flow.tsx
+++ b/apps/desktop-renderer/src/experience/create-pane-flow.tsx
@@ -1,0 +1,671 @@
+import type { WorkspaceAgentRole, WorkspacePaneCreateInvocation } from "@tmux-ide/contracts";
+import { For, Show, createEffect, createMemo, createSignal, on, onCleanup } from "solid-js";
+
+import { DomIcon } from "./dom-icon.tsx";
+import {
+  createPaneSubmission,
+  projectCreatePaneFlow,
+  type CreatePaneField,
+  type CreatePaneFieldErrors,
+  type CreatePaneFlowCatalogs,
+  type CreatePaneKind,
+} from "./create-pane-flow-presenter.ts";
+
+type InteractionSource = "keyboard" | "mouse" | "program";
+
+export interface CreatePaneFlowProps {
+  readonly open: boolean;
+  readonly catalogs: CreatePaneFlowCatalogs;
+  readonly initialWorkspaceName?: string;
+  readonly onOpenChange: (open: boolean, source: InteractionSource) => void;
+  readonly onCommand: (invocation: WorkspacePaneCreateInvocation) => void | Promise<void>;
+}
+
+const DIALOG_TITLE_ID = "create-pane-flow-title";
+const DIALOG_DESCRIPTION_ID = "create-pane-flow-description";
+const WORKSPACE_FIELD_ID = "create-pane-flow-workspace";
+const TITLE_FIELD_ID = "create-pane-flow-display-title";
+const HARNESS_FIELD_ID = "create-pane-flow-harness";
+const ROLE_FIELD_ID = "create-pane-flow-role";
+const MISSION_FIELD_ID = "create-pane-flow-mission";
+
+const ROLE_LABELS = Object.freeze({
+  manager: "Manager",
+  implementer: "Implementer",
+  reviewer: "Reviewer",
+  researcher: "Researcher",
+  validator: "Validator",
+} satisfies Record<WorkspaceAgentRole, string>);
+
+function fieldElementId(field: CreatePaneField): string {
+  return {
+    workspaceName: WORKSPACE_FIELD_ID,
+    displayTitle: TITLE_FIELD_ID,
+    harnessProfileId: HARNESS_FIELD_ID,
+    role: ROLE_FIELD_ID,
+    missionId: MISSION_FIELD_ID,
+  }[field];
+}
+
+function enabledInitialWorkspace(
+  initialWorkspaceName: string | undefined,
+  catalogs: ReturnType<typeof projectCreatePaneFlow>,
+): string {
+  if (!initialWorkspaceName || catalogs.workspaces.status !== "ready") return "";
+  return catalogs.workspaces.items.some(
+    (item) => item.name === initialWorkspaceName && item.available,
+  )
+    ? initialWorkspaceName
+    : "";
+}
+
+function focusableChildren(host: HTMLElement): HTMLElement[] {
+  return Array.from(
+    host.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), input:not(:disabled), select:not(:disabled), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter(
+    (element) =>
+      !element.closest("[hidden]") &&
+      element.getAttribute("aria-hidden") !== "true" &&
+      !element.hasAttribute("inert"),
+  );
+}
+
+function focusFirstFormField(host: HTMLFormElement): void {
+  const field = Array.from(
+    host.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
+      "input:not(:disabled), select:not(:disabled)",
+    ),
+  ).find((element) => !element.closest("[hidden]"));
+  field?.focus();
+}
+
+function focusInvalidField(field: CreatePaneField): void {
+  const control = document.getElementById(fieldElementId(field));
+  if (
+    control instanceof HTMLButtonElement ||
+    control instanceof HTMLInputElement ||
+    control instanceof HTMLSelectElement
+  ) {
+    if (!control.disabled) {
+      control.focus();
+      return;
+    }
+  }
+  document.getElementById(`${fieldElementId(field)}-error`)?.focus();
+}
+
+/**
+ * Native tmux-ide create affordance and modal presenter.
+ *
+ * This component never accepts a command, cwd, session name, pane target, or
+ * executable. Its only effect is the strict semantic command callback.
+ */
+export function CreatePaneFlow(props: CreatePaneFlowProps) {
+  const projection = createMemo(() => projectCreatePaneFlow(props.catalogs));
+  const [kind, setKind] = createSignal<CreatePaneKind | null>(null);
+  const [workspaceName, setWorkspaceName] = createSignal("");
+  const [displayTitle, setDisplayTitle] = createSignal("");
+  const [harnessProfileId, setHarnessProfileId] = createSignal("");
+  const [role, setRole] = createSignal<WorkspaceAgentRole>("implementer");
+  const [missionId, setMissionId] = createSignal("");
+  const [errors, setErrors] = createSignal<CreatePaneFieldErrors>({});
+  const [dispatching, setDispatching] = createSignal(false);
+  const [dispatchError, setDispatchError] = createSignal(false);
+  const [transitionSource, setTransitionSource] = createSignal<InteractionSource>("program");
+  let overlay: HTMLDivElement | undefined;
+  let dialog: HTMLElement | undefined;
+  let form: HTMLFormElement | undefined;
+  let firstKindButton: HTMLButtonElement | undefined;
+  let previousFocus: HTMLElement | null = null;
+  let lastInteractionSource: Exclude<InteractionSource, "program"> = "keyboard";
+  let openGeneration = 0;
+  let disposed = false;
+
+  const resetDraft = (): void => {
+    setKind(null);
+    setWorkspaceName(enabledInitialWorkspace(props.initialWorkspaceName, projection()));
+    setDisplayTitle("");
+    setHarnessProfileId("");
+    setRole("implementer");
+    setMissionId("");
+    setErrors({});
+    setDispatching(false);
+    setDispatchError(false);
+  };
+
+  createEffect(
+    on(
+      () => props.open,
+      (open, previousOpen) => {
+        if (!overlay) return;
+        overlay.inert = !open;
+        if (open) {
+          openGeneration += 1;
+          previousFocus =
+            document.activeElement instanceof HTMLElement ? document.activeElement : null;
+          resetDraft();
+          queueMicrotask(() => {
+            if (!disposed) firstKindButton?.focus();
+          });
+          return;
+        }
+        if (previousOpen) {
+          queueMicrotask(() => {
+            if (!disposed && previousFocus?.isConnected) previousFocus.focus();
+          });
+        }
+      },
+    ),
+  );
+
+  onCleanup(() => {
+    disposed = true;
+    openGeneration += 1;
+    previousFocus = null;
+  });
+
+  const requestOpen = (source: InteractionSource): void => {
+    if (disposed) return;
+    setTransitionSource(source);
+    props.onOpenChange(true, source);
+  };
+
+  const requestClose = (source: InteractionSource): void => {
+    if (disposed) return;
+    setTransitionSource(source);
+    props.onOpenChange(false, source);
+  };
+
+  const clearError = (field: CreatePaneField): void => {
+    if (!errors()[field]) return;
+    setErrors((current) => {
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  };
+
+  const chooseKind = (nextKind: CreatePaneKind): void => {
+    setKind(nextKind);
+    setErrors({});
+    setDispatchError(false);
+    queueMicrotask(() => {
+      if (!disposed && form) focusFirstFormField(form);
+    });
+  };
+
+  const backToKind = (): void => {
+    setKind(null);
+    setErrors({});
+    setDispatchError(false);
+    queueMicrotask(() => {
+      if (!disposed) firstKindButton?.focus();
+    });
+  };
+
+  const submit = async (source: Exclude<InteractionSource, "program">): Promise<void> => {
+    const selectedKind = kind();
+    if (!selectedKind || dispatching()) return;
+    const submission = createPaneSubmission(
+      projection(),
+      {
+        kind: selectedKind,
+        workspaceName: workspaceName(),
+        displayTitle: displayTitle(),
+        harnessProfileId: harnessProfileId(),
+        role: role(),
+        missionId: missionId(),
+      },
+      { kind: source, surface: "create-pane-dialog" },
+    );
+    if (!submission.ok) {
+      setErrors(submission.errors);
+      setDispatchError(false);
+      queueMicrotask(() => {
+        if (!disposed) focusInvalidField(submission.firstInvalidField);
+      });
+      return;
+    }
+
+    const generation = openGeneration;
+    setErrors({});
+    setDispatchError(false);
+    setDispatching(true);
+    try {
+      await props.onCommand(submission.invocation);
+      if (disposed || generation !== openGeneration) return;
+      if (props.open) requestClose(source);
+    } catch {
+      if (disposed || generation !== openGeneration) return;
+      if (props.open) setDispatchError(true);
+    } finally {
+      if (!disposed && generation === openGeneration) setDispatching(false);
+    }
+  };
+
+  const handleDialogKeyDown = (event: KeyboardEvent): void => {
+    lastInteractionSource = "keyboard";
+    if (event.key === "Escape") {
+      event.preventDefault();
+      requestClose("keyboard");
+      return;
+    }
+    if (event.key === "Tab" && dialog) {
+      const focusable = focusableChildren(dialog);
+      if (focusable.length === 0) return;
+      const activeIndex = focusable.indexOf(document.activeElement as HTMLElement);
+      const nextIndex = event.shiftKey
+        ? activeIndex <= 0
+          ? focusable.length - 1
+          : activeIndex - 1
+        : activeIndex < 0 || activeIndex === focusable.length - 1
+          ? 0
+          : activeIndex + 1;
+      event.preventDefault();
+      focusable[nextIndex]?.focus();
+      return;
+    }
+    if (event.key !== "Enter") return;
+    const target = event.target;
+    if (target instanceof HTMLButtonElement && target.dataset.enterAction === "true") {
+      event.preventDefault();
+      target.click();
+      return;
+    }
+    if (target instanceof HTMLInputElement && target.type === "text" && kind()) {
+      event.preventDefault();
+      void submit("keyboard");
+    }
+  };
+
+  const catalogWarningCount = createMemo(
+    () =>
+      projection().workspaces.invalidOptionCount +
+      projection().harnessProfiles.invalidOptionCount +
+      projection().missions.invalidOptionCount,
+  );
+
+  return (
+    <div class="create-pane-flow">
+      <button
+        id="create-pane-flow-trigger"
+        class="create-pane-flow__trigger"
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={props.open}
+        aria-controls="create-pane-flow-dialog"
+        title="New terminal or agent"
+        onClick={(event) => requestOpen(event.detail === 0 ? "keyboard" : "mouse")}
+      >
+        <span aria-hidden="true">+</span>
+        <span class="sr-only">New terminal or agent</span>
+      </button>
+
+      <div
+        ref={(element) => {
+          overlay = element;
+          element.inert = !props.open;
+        }}
+        class="create-pane-flow__overlay"
+        classList={{ "create-pane-flow__overlay--open": props.open }}
+        aria-hidden={props.open ? "false" : "true"}
+        data-overlay-root="true"
+        data-transition-source={transitionSource()}
+        onMouseDown={(event) => {
+          lastInteractionSource = "mouse";
+          if (event.target === event.currentTarget) requestClose("mouse");
+        }}
+      >
+        <section
+          ref={(element) => {
+            dialog = element;
+          }}
+          id="create-pane-flow-dialog"
+          class="create-pane-flow__dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={DIALOG_TITLE_ID}
+          aria-describedby={DIALOG_DESCRIPTION_ID}
+          aria-busy={dispatching()}
+          onKeyDown={handleDialogKeyDown}
+        >
+          <header class="create-pane-flow__header">
+            <span>
+              <small>tmux-backed workspace</small>
+              <h2 id={DIALOG_TITLE_ID}>New terminal or agent</h2>
+            </span>
+            <button
+              type="button"
+              class="create-pane-flow__close"
+              aria-label="Close create dialog"
+              title="Close (Esc)"
+              onClick={(event) => requestClose(event.detail === 0 ? "keyboard" : "mouse")}
+            >
+              <DomIcon id="close" usage="action" />
+            </button>
+          </header>
+          <p id={DIALOG_DESCRIPTION_ID} class="create-pane-flow__description">
+            tmux-ide resolves processes, directories, and panes. Choose only the product resources
+            you want to create.
+          </p>
+
+          <div class="create-pane-flow__kind" hidden={kind() !== null}>
+            <p class="create-pane-flow__eyebrow">What do you want to add?</p>
+            <div class="create-pane-flow__kind-grid" role="group" aria-label="Creation type">
+              <button
+                ref={(element) => {
+                  firstKindButton = element;
+                }}
+                type="button"
+                class="create-pane-flow__kind-card"
+                data-enter-action="true"
+                onClick={() => chooseKind("terminal")}
+              >
+                <DomIcon id="terminals" usage="rail" />
+                <strong>Terminal</strong>
+                <span>A native terminal view backed by a daemon-owned tmux pane.</span>
+                <kbd>↵</kbd>
+              </button>
+              <button
+                type="button"
+                class="create-pane-flow__kind-card"
+                data-enter-action="true"
+                onClick={() => chooseKind("agent")}
+              >
+                <DomIcon id="missions" usage="rail" />
+                <strong>Agent</strong>
+                <span>Start an exposed harness profile with a role and optional mission.</span>
+                <kbd>↵</kbd>
+              </button>
+            </div>
+          </div>
+
+          <form
+            ref={(element) => {
+              form = element;
+            }}
+            class="create-pane-flow__form"
+            hidden={kind() === null}
+            novalidate
+            onSubmit={(event) => {
+              event.preventDefault();
+              void submit(lastInteractionSource);
+            }}
+          >
+            <div class="create-pane-flow__form-heading">
+              <button type="button" data-enter-action="true" onClick={backToKind}>
+                ← Choose type
+              </button>
+              <span data-kind={kind() ?? undefined}>
+                {kind() === "agent" ? "Agent" : "Terminal"}
+              </span>
+            </div>
+
+            <label class="create-pane-flow__field" for={WORKSPACE_FIELD_ID}>
+              <span>
+                Workspace <b aria-hidden="true">*</b>
+              </span>
+              <select
+                id={WORKSPACE_FIELD_ID}
+                value={workspaceName()}
+                disabled={projection().workspaces.status !== "ready"}
+                required
+                aria-required="true"
+                aria-invalid={Boolean(errors().workspaceName)}
+                aria-describedby={
+                  errors().workspaceName ? `${WORKSPACE_FIELD_ID}-error` : undefined
+                }
+                onChange={(event) => {
+                  setWorkspaceName(event.currentTarget.value);
+                  clearError("workspaceName");
+                }}
+              >
+                <option value="">
+                  {projection().workspaces.status === "loading"
+                    ? "Loading workspaces…"
+                    : projection().workspaces.status === "unavailable"
+                      ? "Workspaces unavailable"
+                      : projection().workspaces.items.length === 0
+                        ? "No workspaces available"
+                        : "Choose a workspace…"}
+                </option>
+                <For each={projection().workspaces.items}>
+                  {(workspace) => (
+                    <option value={workspace.name} disabled={!workspace.available}>
+                      {workspace.label}
+                      {workspace.available ? "" : " — unavailable"}
+                    </option>
+                  )}
+                </For>
+              </select>
+              <Show when={errors().workspaceName}>
+                {(message) => (
+                  <small
+                    id={`${WORKSPACE_FIELD_ID}-error`}
+                    class="create-pane-flow__error"
+                    role="alert"
+                    tabIndex={-1}
+                  >
+                    {message()}
+                  </small>
+                )}
+              </Show>
+              <Show
+                when={
+                  projection().workspaces.status === "ready" &&
+                  projection().workspaces.items.length === 0
+                }
+              >
+                <small class="create-pane-flow__empty">
+                  Open a project from Home, then return here to create its first terminal.
+                </small>
+              </Show>
+            </label>
+
+            <label class="create-pane-flow__field" for={TITLE_FIELD_ID}>
+              <span>
+                Display title <em>optional</em>
+              </span>
+              <input
+                id={TITLE_FIELD_ID}
+                type="text"
+                maxlength={80}
+                value={displayTitle()}
+                placeholder={kind() === "agent" ? "API implementer" : "Release shell"}
+                aria-invalid={Boolean(errors().displayTitle)}
+                aria-describedby={
+                  errors().displayTitle ? `${TITLE_FIELD_ID}-error` : `${TITLE_FIELD_ID}-hint`
+                }
+                onInput={(event) => {
+                  setDisplayTitle(event.currentTarget.value);
+                  clearError("displayTitle");
+                }}
+              />
+              <small id={`${TITLE_FIELD_ID}-hint`}>
+                Presentation only; it never becomes a command.
+              </small>
+              <Show when={errors().displayTitle}>
+                {(message) => (
+                  <small
+                    id={`${TITLE_FIELD_ID}-error`}
+                    class="create-pane-flow__error"
+                    role="alert"
+                    tabIndex={-1}
+                  >
+                    {message()}
+                  </small>
+                )}
+              </Show>
+            </label>
+
+            <div class="create-pane-flow__agent-fields" hidden={kind() !== "agent"}>
+              <label class="create-pane-flow__field" for={HARNESS_FIELD_ID}>
+                <span>
+                  Agent profile <b aria-hidden="true">*</b>
+                </span>
+                <select
+                  id={HARNESS_FIELD_ID}
+                  value={harnessProfileId()}
+                  disabled={projection().harnessProfiles.status !== "ready"}
+                  required
+                  aria-required="true"
+                  aria-invalid={Boolean(errors().harnessProfileId)}
+                  aria-describedby={
+                    errors().harnessProfileId ? `${HARNESS_FIELD_ID}-error` : undefined
+                  }
+                  onChange={(event) => {
+                    setHarnessProfileId(event.currentTarget.value);
+                    clearError("harnessProfileId");
+                  }}
+                >
+                  <option value="">
+                    {projection().harnessProfiles.status === "loading"
+                      ? "Loading agent profiles…"
+                      : projection().harnessProfiles.status === "unavailable"
+                        ? "Agent profiles unavailable"
+                        : projection().harnessProfiles.items.length === 0
+                          ? "No agent profiles available"
+                          : "Choose an agent profile…"}
+                  </option>
+                  <For each={projection().harnessProfiles.items}>
+                    {(harness) => (
+                      <option value={harness.id} disabled={!harness.available}>
+                        {harness.label}
+                        {harness.available ? "" : " — unavailable"}
+                      </option>
+                    )}
+                  </For>
+                </select>
+                <Show when={errors().harnessProfileId}>
+                  {(message) => (
+                    <small
+                      id={`${HARNESS_FIELD_ID}-error`}
+                      class="create-pane-flow__error"
+                      role="alert"
+                      tabIndex={-1}
+                    >
+                      {message()}
+                    </small>
+                  )}
+                </Show>
+                <Show
+                  when={
+                    projection().harnessProfiles.status === "ready" &&
+                    projection().harnessProfiles.items.length === 0
+                  }
+                >
+                  <small class="create-pane-flow__empty">
+                    No profiles are exposed yet. Add one from Workspace settings.
+                  </small>
+                </Show>
+              </label>
+
+              <div class="create-pane-flow__field-row">
+                <label class="create-pane-flow__field" for={ROLE_FIELD_ID}>
+                  <span>Role</span>
+                  <select
+                    id={ROLE_FIELD_ID}
+                    value={role()}
+                    aria-invalid={Boolean(errors().role)}
+                    aria-describedby={errors().role ? `${ROLE_FIELD_ID}-error` : undefined}
+                    onChange={(event) => {
+                      setRole(event.currentTarget.value as WorkspaceAgentRole);
+                      clearError("role");
+                    }}
+                  >
+                    <For each={projection().roles}>
+                      {(roleOption) => (
+                        <option value={roleOption}>{ROLE_LABELS[roleOption]}</option>
+                      )}
+                    </For>
+                  </select>
+                  <Show when={errors().role}>
+                    {(message) => (
+                      <small
+                        id={`${ROLE_FIELD_ID}-error`}
+                        class="create-pane-flow__error"
+                        role="alert"
+                        tabIndex={-1}
+                      >
+                        {message()}
+                      </small>
+                    )}
+                  </Show>
+                </label>
+
+                <label class="create-pane-flow__field" for={MISSION_FIELD_ID}>
+                  <span>
+                    Mission <em>optional</em>
+                  </span>
+                  <select
+                    id={MISSION_FIELD_ID}
+                    value={missionId()}
+                    disabled={projection().missions.status !== "ready"}
+                    aria-invalid={Boolean(errors().missionId)}
+                    aria-describedby={errors().missionId ? `${MISSION_FIELD_ID}-error` : undefined}
+                    onChange={(event) => {
+                      setMissionId(event.currentTarget.value);
+                      clearError("missionId");
+                    }}
+                  >
+                    <option value="">
+                      {projection().missions.status === "loading"
+                        ? "Loading missions…"
+                        : projection().missions.status === "unavailable"
+                          ? "Missions unavailable"
+                          : "No mission"}
+                    </option>
+                    <For each={projection().missions.items}>
+                      {(mission) => (
+                        <option value={mission.id} disabled={!mission.available}>
+                          {mission.label}
+                        </option>
+                      )}
+                    </For>
+                  </select>
+                  <Show when={errors().missionId}>
+                    {(message) => (
+                      <small
+                        id={`${MISSION_FIELD_ID}-error`}
+                        class="create-pane-flow__error"
+                        role="alert"
+                        tabIndex={-1}
+                      >
+                        {message()}
+                      </small>
+                    )}
+                  </Show>
+                </label>
+              </div>
+            </div>
+
+            <Show when={catalogWarningCount() > 0}>
+              <p class="create-pane-flow__notice" role="status">
+                Some invalid catalog choices were safely omitted.
+              </p>
+            </Show>
+            <Show when={dispatchError()}>
+              <p class="create-pane-flow__notice create-pane-flow__notice--error" role="alert">
+                tmux-ide could not submit this request. Your selections are still here.
+              </p>
+            </Show>
+
+            <footer class="create-pane-flow__footer">
+              <span>Esc cancel · ↵ create</span>
+              <button
+                type="submit"
+                class="create-pane-flow__submit"
+                data-enter-action="true"
+                disabled={dispatching()}
+              >
+                {dispatching() ? `Creating ${kind() ?? "pane"}…` : `Create ${kind() ?? "pane"}`}
+              </button>
+            </footer>
+          </form>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop-renderer/src/experience/index.ts
+++ b/apps/desktop-renderer/src/experience/index.ts
@@ -3,3 +3,5 @@ export * from "./dom-icons.ts";
 export * from "./dom-icon.tsx";
 export * from "./dom-shell.ts";
 export * from "./application-shell.tsx";
+export * from "./create-pane-flow-presenter.ts";
+export * from "./create-pane-flow.tsx";

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -22,12 +22,14 @@ body,
 }
 
 button,
-input {
+input,
+select {
   font: inherit;
 }
 
 button:focus-visible,
 input:focus-visible,
+select:focus-visible,
 [tabindex]:focus-visible {
   outline: var(--tmux-ide-focus-outline) solid var(--tmux-ide-border-focused);
   outline-offset: calc(-1 * var(--tmux-ide-focus-outline-offset));
@@ -800,6 +802,374 @@ kbd {
   color: var(--tmux-ide-text-muted);
   background: var(--tmux-ide-surface-panel);
   font-size: 10px;
+}
+
+.create-pane-flow [hidden] {
+  display: none !important;
+}
+
+.create-pane-flow__trigger {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--tmux-ide-border-default);
+  border-radius: var(--tmux-ide-shape-control);
+  color: var(--tmux-ide-text-secondary);
+  background: var(--tmux-ide-surface-panel-raised);
+  cursor: pointer;
+}
+
+.create-pane-flow__trigger > span:first-child {
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 1;
+  transform: translateY(-1px);
+}
+
+.create-pane-flow__trigger:hover {
+  color: var(--tmux-ide-text-bright);
+  border-color: var(--tmux-ide-border-focused);
+  background: var(--tmux-ide-selection-hover);
+}
+
+.create-pane-flow__overlay {
+  position: fixed;
+  z-index: 120;
+  inset: 0;
+  display: grid;
+  padding: 42px 24px;
+  visibility: hidden;
+  place-items: start center;
+  opacity: 0;
+  background: color-mix(in srgb, var(--tmux-ide-surface-canvas) 54%, transparent);
+  pointer-events: none;
+}
+
+.create-pane-flow__overlay--open {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.create-pane-flow__overlay[data-transition-source="mouse"] {
+  transition:
+    opacity var(--tmux-ide-motion-fast) cubic-bezier(0.895, 0.03, 0.685, 0.22),
+    visibility 0ms linear var(--tmux-ide-motion-fast);
+}
+
+.create-pane-flow__overlay--open[data-transition-source="mouse"] {
+  transition:
+    opacity var(--tmux-ide-motion-standard) cubic-bezier(0.32, 0.72, 0, 1),
+    visibility 0ms linear;
+}
+
+.create-pane-flow__dialog {
+  display: flex;
+  width: min(548px, calc(100vw - 48px));
+  max-height: calc(100vh - 84px);
+  flex-direction: column;
+  overflow: hidden auto;
+  border: 1px solid var(--tmux-ide-border-default);
+  border-radius: var(--tmux-ide-shape-floating);
+  color: var(--tmux-ide-text-primary);
+  background: var(--tmux-ide-surface-command);
+  box-shadow: var(--tmux-ide-elevation-palette-shadow);
+  transform: scale(0.98);
+}
+
+.create-pane-flow__overlay--open .create-pane-flow__dialog {
+  transform: scale(1);
+}
+
+.create-pane-flow__overlay[data-transition-source="mouse"] .create-pane-flow__dialog {
+  transition: transform var(--tmux-ide-motion-fast) cubic-bezier(0.895, 0.03, 0.685, 0.22);
+}
+
+.create-pane-flow__overlay--open[data-transition-source="mouse"] .create-pane-flow__dialog {
+  transition: transform var(--tmux-ide-motion-standard) cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.create-pane-flow__header {
+  display: flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 8px 10px 8px 16px;
+  border-bottom: 1px solid var(--tmux-ide-border-subtle);
+  background: var(--tmux-ide-surface-header);
+}
+
+.create-pane-flow__header > span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.create-pane-flow__header small,
+.create-pane-flow__eyebrow {
+  margin: 0;
+  color: var(--tmux-ide-text-muted);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.create-pane-flow__header h2 {
+  margin: 0;
+  color: var(--tmux-ide-text-bright);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.create-pane-flow__close {
+  display: grid;
+  flex: 0 0 28px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  color: var(--tmux-ide-text-muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.create-pane-flow__close:hover {
+  color: var(--tmux-ide-text-bright);
+  background: var(--tmux-ide-selection-hover);
+}
+
+.create-pane-flow__description {
+  margin: 0;
+  padding: 12px 16px 0;
+  color: var(--tmux-ide-text-secondary);
+  font-size: 11px;
+  line-height: 16px;
+}
+
+.create-pane-flow__kind {
+  padding: 16px;
+}
+
+.create-pane-flow__kind-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 7px;
+}
+
+.create-pane-flow__kind-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  min-height: 104px;
+  align-content: start;
+  align-items: center;
+  gap: 4px 8px;
+  padding: 13px;
+  border: 1px solid var(--tmux-ide-border-default);
+  border-radius: var(--tmux-ide-shape-control);
+  color: var(--tmux-ide-text-secondary);
+  background: var(--tmux-ide-surface-panel);
+  text-align: left;
+  cursor: pointer;
+}
+
+.create-pane-flow__kind-card:hover,
+.create-pane-flow__kind-card:focus-visible {
+  color: var(--tmux-ide-text-primary);
+  border-color: var(--tmux-ide-border-focused);
+  background: var(--tmux-ide-selection-hover);
+}
+
+.create-pane-flow__kind-card > svg {
+  grid-row: 1;
+  color: var(--tmux-ide-text-link);
+}
+
+.create-pane-flow__kind-card > strong {
+  grid-row: 1;
+  color: var(--tmux-ide-text-bright);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.create-pane-flow__kind-card > span {
+  grid-column: 1 / -1;
+  color: var(--tmux-ide-text-muted);
+  font-size: 10px;
+  line-height: 15px;
+}
+
+.create-pane-flow__kind-card > kbd {
+  grid-row: 1;
+  padding: 0 5px;
+  border: 1px solid var(--tmux-ide-border-subtle);
+  border-radius: var(--tmux-ide-shape-control);
+  background: var(--tmux-ide-surface-panel-raised);
+  font-size: 9px;
+}
+
+.create-pane-flow__form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 13px 16px 0;
+}
+
+.create-pane-flow__form-heading {
+  display: flex;
+  height: 26px;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--tmux-ide-border-subtle);
+}
+
+.create-pane-flow__form-heading button {
+  padding: 0;
+  border: 0;
+  color: var(--tmux-ide-text-link);
+  background: transparent;
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.create-pane-flow__form-heading > span {
+  color: var(--tmux-ide-text-muted);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.create-pane-flow__field,
+.create-pane-flow__agent-fields {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.create-pane-flow__field > span {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  color: var(--tmux-ide-text-secondary);
+  font-size: 10px;
+}
+
+.create-pane-flow__field > span b {
+  color: var(--tmux-ide-status-warning);
+  font-weight: 500;
+}
+
+.create-pane-flow__field > span em {
+  color: var(--tmux-ide-text-muted);
+  font-size: 9px;
+  font-style: normal;
+}
+
+.create-pane-flow__field input,
+.create-pane-flow__field select {
+  width: 100%;
+  min-width: 0;
+  height: 32px;
+  padding: 0 9px;
+  border: 1px solid var(--tmux-ide-border-default);
+  border-radius: var(--tmux-ide-shape-control);
+  color: var(--tmux-ide-text-primary);
+  background: var(--tmux-ide-surface-terminal);
+  color-scheme: dark;
+}
+
+.create-pane-flow__field input::placeholder {
+  color: var(--tmux-ide-text-muted);
+}
+
+.create-pane-flow__field input:disabled,
+.create-pane-flow__field select:disabled {
+  color: var(--tmux-ide-control-disabled-foreground);
+  background: var(--tmux-ide-control-disabled-background);
+  cursor: not-allowed;
+}
+
+.create-pane-flow__field input[aria-invalid="true"],
+.create-pane-flow__field select[aria-invalid="true"] {
+  border-color: var(--tmux-ide-border-danger);
+}
+
+.create-pane-flow__field > small {
+  color: var(--tmux-ide-text-muted);
+  font-size: 9px;
+  line-height: 13px;
+}
+
+.create-pane-flow__field > .create-pane-flow__error {
+  color: var(--tmux-ide-status-danger);
+}
+
+.create-pane-flow__field > .create-pane-flow__empty {
+  padding: 6px 8px;
+  border-left: 2px solid var(--tmux-ide-border-attention);
+  color: var(--tmux-ide-text-secondary);
+  background: var(--tmux-ide-surface-panel);
+}
+
+.create-pane-flow__field-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.create-pane-flow__notice {
+  margin: 0;
+  padding: 7px 9px;
+  border: 1px solid var(--tmux-ide-border-attention);
+  color: var(--tmux-ide-status-warning);
+  background: var(--tmux-ide-surface-panel);
+  font-size: 10px;
+}
+
+.create-pane-flow__notice--error {
+  border-color: var(--tmux-ide-border-danger);
+  color: var(--tmux-ide-status-danger);
+}
+
+.create-pane-flow__footer {
+  display: flex;
+  min-height: 50px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 2px -16px 0;
+  padding: 9px 16px;
+  border-top: 1px solid var(--tmux-ide-border-subtle);
+  color: var(--tmux-ide-text-muted);
+  background: var(--tmux-ide-surface-panel);
+  font-size: 9px;
+}
+
+.create-pane-flow__submit {
+  min-width: 124px;
+  height: 30px;
+  padding: 0 12px;
+  border: 1px solid var(--tmux-ide-border-focused);
+  border-radius: var(--tmux-ide-shape-control);
+  color: var(--tmux-ide-selection-selection-text);
+  background: var(--tmux-ide-selection-selection);
+  cursor: pointer;
+}
+
+.create-pane-flow__submit:disabled {
+  border-color: var(--tmux-ide-border-subtle);
+  color: var(--tmux-ide-control-disabled-foreground);
+  background: var(--tmux-ide-control-disabled-background);
+  cursor: wait;
 }
 
 @media (min-width: 1440px) {

--- a/packages/contracts/src/__tests__/workspace-pane-creation.test.ts
+++ b/packages/contracts/src/__tests__/workspace-pane-creation.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  WORKSPACE_PANE_CREATE_COMMAND_DESCRIPTOR,
+  WORKSPACE_PANE_CREATE_COMMAND_ID,
+  WorkspacePaneCreateInvocationSchemaZ,
+  WorkspacePaneCreationReferenceSchemaZ,
+  WorkspacePaneCreationWorkspaceNameSchemaZ,
+  workspacePaneCreateInvocation,
+} from "../workspace-pane-creation.ts";
+
+describe("semantic workspace pane creation command", () => {
+  it("publishes one daemon-owned descriptor for every host surface", () => {
+    expect(WORKSPACE_PANE_CREATE_COMMAND_DESCRIPTOR).toEqual({
+      version: 1,
+      id: WORKSPACE_PANE_CREATE_COMMAND_ID,
+      owner: "daemon",
+      label: "Create terminal or agent",
+      description:
+        "Ask the daemon to create a tmux-backed terminal or harness-backed agent from semantic workspace resources.",
+      category: "workspace",
+      schemas: { input: "workspace.pane.create.input.v1" },
+      dangerous: false,
+      confirmation: "none",
+    });
+    expect(Object.isFrozen(WORKSPACE_PANE_CREATE_COMMAND_DESCRIPTOR)).toBe(true);
+  });
+
+  it("round-trips a terminal request containing presentation identity only", () => {
+    const invocation = workspacePaneCreateInvocation(
+      {
+        kind: "terminal",
+        workspaceName: "tmux-ide/docs",
+        displayTitle: "Release shell",
+      },
+      { kind: "palette", surface: "command-palette" },
+    );
+
+    expect(
+      WorkspacePaneCreateInvocationSchemaZ.parse(JSON.parse(JSON.stringify(invocation))),
+    ).toEqual(invocation);
+    expect(invocation.args).not.toHaveProperty("cwd");
+    expect(invocation.args).not.toHaveProperty("argv");
+    expect(Object.isFrozen(invocation.args)).toBe(true);
+  });
+
+  it("round-trips an agent request using an exposed harness and mission identity", () => {
+    expect(
+      workspacePaneCreateInvocation(
+        {
+          kind: "agent",
+          workspaceName: "tmux-ide",
+          harnessProfileId: "codex-implementer",
+          role: "implementer",
+          missionId: "gloomberb-parity",
+        },
+        { kind: "mouse", surface: "create-pane-dialog" },
+      ),
+    ).toMatchObject({
+      id: WORKSPACE_PANE_CREATE_COMMAND_ID,
+      args: {
+        kind: "agent",
+        harnessProfileId: "codex-implementer",
+        role: "implementer",
+        missionId: "gloomberb-parity",
+      },
+    });
+  });
+
+  const forbiddenRuntimeFields = [
+    ["cwd", "/Users/example/project"],
+    ["argv", ["codex", "--yolo"]],
+    ["command", "claude"],
+    ["sessionName", "tmux-ide"],
+    ["paneId", "%42"],
+    ["token", "renderer-secret"],
+    ["executable", "/usr/local/bin/codex"],
+    ["env", { SECRET: "value" }],
+    ["model", "provider-owned-model"],
+  ] as const;
+
+  it.each(forbiddenRuntimeFields)(
+    "rejects terminal renderer-owned runtime field %s",
+    (field, value) => {
+      expect(
+        WorkspacePaneCreateInvocationSchemaZ.safeParse({
+          version: 1,
+          id: WORKSPACE_PANE_CREATE_COMMAND_ID,
+          source: { kind: "mouse", surface: "create-pane-dialog" },
+          args: { kind: "terminal", workspaceName: "tmux-ide", [field]: value },
+        }).success,
+      ).toBe(false);
+    },
+  );
+
+  it.each(forbiddenRuntimeFields)(
+    "rejects agent renderer-owned runtime field %s",
+    (field, value) => {
+      expect(
+        WorkspacePaneCreateInvocationSchemaZ.safeParse({
+          version: 1,
+          id: WORKSPACE_PANE_CREATE_COMMAND_ID,
+          source: { kind: "mouse", surface: "create-pane-dialog" },
+          args: {
+            kind: "agent",
+            workspaceName: "tmux-ide",
+            harnessProfileId: "codex",
+            role: "implementer",
+            [field]: value,
+          },
+        }).success,
+      ).toBe(false);
+    },
+  );
+
+  it.each([
+    ["token", "renderer-secret"],
+    ["daemonUrl", "http://127.0.0.1:9999"],
+    ["sessionName", "tmux-ide"],
+    ["paneId", "%42"],
+  ])("rejects invocation-level runtime field %s", (field, value) => {
+    expect(
+      WorkspacePaneCreateInvocationSchemaZ.safeParse({
+        version: 1,
+        id: WORKSPACE_PANE_CREATE_COMMAND_ID,
+        source: { kind: "mouse", surface: "create-pane-dialog" },
+        args: { kind: "terminal", workspaceName: "tmux-ide" },
+        [field]: value,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("uses canonical desktop workspace names losslessly, including slash names", () => {
+    expect(WorkspacePaneCreationWorkspaceNameSchemaZ.parse("docs/site")).toBe("docs/site");
+    expect(WorkspacePaneCreationWorkspaceNameSchemaZ.safeParse(" docs/site ").success).toBe(false);
+    expect(WorkspacePaneCreationWorkspaceNameSchemaZ.safeParse("\u0000docs").success).toBe(false);
+  });
+
+  it.each(["%42", "$session", "@window", "/tmp/project", "folder\\project", " padded "])(
+    "rejects raw runtime or path-shaped reference %s",
+    (reference) => {
+      expect(WorkspacePaneCreationReferenceSchemaZ.safeParse(reference).success).toBe(false);
+    },
+  );
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -35,6 +35,7 @@ export * from "./experience-shell.ts";
 export * from "./application-shell.ts";
 export * from "./application-shell-resource.ts";
 export * from "./workspace-catalog-resource.ts";
+export * from "./workspace-pane-creation.ts";
 export * from "./visual-tokens.ts";
 export * from "./visual-recipes.ts";
 export * from "./pane-appearance.ts";

--- a/packages/contracts/src/workspace-pane-creation.ts
+++ b/packages/contracts/src/workspace-pane-creation.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+
+import {
+  COMMAND_PROTOCOL_VERSION,
+  CommandDescriptorSchemaZ,
+  CommandSourceSchemaZ,
+  type CommandDescriptor,
+  type CommandSource,
+} from "./commands.ts";
+import { DesktopWorkspaceNameSchemaZ } from "./desktop-host.ts";
+import { WorkspaceAgentRoleSchemaZ } from "./workspace-config.ts";
+
+export const WORKSPACE_PANE_CREATE_COMMAND_ID = "workspace.pane.create" as const;
+
+function hasControlCharacters(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.codePointAt(0) ?? 0;
+    return code <= 31 || code === 127;
+  });
+}
+
+/**
+ * An opaque product identity chosen from a host-provided semantic catalog.
+ *
+ * tmux target syntax and filesystem paths are deliberately excluded. The
+ * trusted daemon adapter owns resolution from these identities to runtime
+ * sessions, panes, executables, and working directories.
+ */
+export const WorkspacePaneCreationReferenceSchemaZ = z
+  .string()
+  .min(1)
+  .max(160)
+  .refine((value) => value === value.trim(), "reference must not have outer whitespace")
+  .refine((value) => !hasControlCharacters(value), "reference must not contain controls")
+  .refine((value) => !/[\\/]/u.test(value), "reference must not be a filesystem path")
+  .refine((value) => !/^[%$@]/u.test(value), "reference must not use tmux target syntax");
+
+/**
+ * The desktop workspace catalog's canonical name, accepted only when parsing
+ * is lossless. Slash-containing names remain valid names and are never
+ * interpreted as paths by the renderer.
+ */
+export const WorkspacePaneCreationWorkspaceNameSchemaZ = z
+  .string()
+  .superRefine((raw, context) => {
+    const parsed = DesktopWorkspaceNameSchemaZ.safeParse(raw);
+    if (!parsed.success) {
+      context.addIssue({ code: "custom", message: "invalid desktop workspace name" });
+      return;
+    }
+    if (parsed.data !== raw) {
+      context.addIssue({
+        code: "custom",
+        message: "workspace name must already be in canonical form",
+      });
+    }
+  })
+  .pipe(DesktopWorkspaceNameSchemaZ);
+
+export const WorkspacePaneDisplayTitleSchemaZ = z
+  .string()
+  .min(1)
+  .max(80)
+  .refine((value) => value === value.trim(), "display title must not have outer whitespace")
+  .refine((value) => !hasControlCharacters(value), "display title must not contain controls");
+
+const WorkspacePaneCreationBaseArgumentsSchemaZ = z.object({
+  workspaceName: WorkspacePaneCreationWorkspaceNameSchemaZ,
+  displayTitle: WorkspacePaneDisplayTitleSchemaZ.optional(),
+});
+
+export const WorkspaceTerminalCreateArgumentsSchemaZ =
+  WorkspacePaneCreationBaseArgumentsSchemaZ.extend({
+    kind: z.literal("terminal"),
+  }).strict();
+
+export const WorkspaceAgentCreateArgumentsSchemaZ =
+  WorkspacePaneCreationBaseArgumentsSchemaZ.extend({
+    kind: z.literal("agent"),
+    harnessProfileId: WorkspacePaneCreationReferenceSchemaZ,
+    role: WorkspaceAgentRoleSchemaZ,
+    missionId: WorkspacePaneCreationReferenceSchemaZ.optional(),
+  }).strict();
+
+export const WorkspacePaneCreateArgumentsSchemaZ = z.discriminatedUnion("kind", [
+  WorkspaceTerminalCreateArgumentsSchemaZ,
+  WorkspaceAgentCreateArgumentsSchemaZ,
+]);
+
+export const WorkspacePaneCreateInvocationSchemaZ = z
+  .object({
+    version: z.literal(COMMAND_PROTOCOL_VERSION),
+    id: z.literal(WORKSPACE_PANE_CREATE_COMMAND_ID),
+    source: CommandSourceSchemaZ,
+    args: WorkspacePaneCreateArgumentsSchemaZ,
+  })
+  .strict();
+
+export type WorkspacePaneCreateArguments = z.infer<typeof WorkspacePaneCreateArgumentsSchemaZ>;
+export type WorkspacePaneCreateInvocation = z.infer<typeof WorkspacePaneCreateInvocationSchemaZ>;
+
+function deepFreeze<Value>(value: Value): Value {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const nested of Object.values(value)) deepFreeze(nested);
+  }
+  return value;
+}
+
+export const WORKSPACE_PANE_CREATE_COMMAND_DESCRIPTOR: CommandDescriptor = deepFreeze(
+  CommandDescriptorSchemaZ.parse({
+    version: COMMAND_PROTOCOL_VERSION,
+    id: WORKSPACE_PANE_CREATE_COMMAND_ID,
+    owner: "daemon",
+    label: "Create terminal or agent",
+    description:
+      "Ask the daemon to create a tmux-backed terminal or harness-backed agent from semantic workspace resources.",
+    category: "workspace",
+    schemas: { input: "workspace.pane.create.input.v1" },
+    dangerous: false,
+    confirmation: "none",
+  }),
+);
+
+export function workspacePaneCreateInvocation(
+  args: WorkspacePaneCreateArguments,
+  source: CommandSource,
+): WorkspacePaneCreateInvocation {
+  return deepFreeze(
+    WorkspacePaneCreateInvocationSchemaZ.parse({
+      version: COMMAND_PROTOCOL_VERSION,
+      id: WORKSPACE_PANE_CREATE_COMMAND_ID,
+      source,
+      args,
+    }),
+  );
+}


### PR DESCRIPTION
Adds a native Solid create flow for tmux-backed terminals and harness-backed agents through one daemon-owned semantic command. The renderer chooses only canonical workspace, harness, role, mission, and display metadata; argv, cwd, sessions, panes, tmux targets, and process authority remain daemon-owned. Includes accessible focus lifecycle, async teardown safety, loading/empty/error states, strict defensive catalog projection, and reduced-motion-safe styling. No NodeTerm code, assets, runtime, node-pty, App wiring, or daemon mutation.\n\nValidation: 51 focused tests, contracts and renderer typecheck/lint, Prettier, renderer production build, manual canonical workspace differential. Independent review approved with zero findings.