### PR TITLE
feat(desktop): add live workspace catalog

### DIFF
--- a/apps/desktop-renderer/src/runtime/index.ts
+++ b/apps/desktop-renderer/src/runtime/index.ts
@@ -8,3 +8,4 @@ export type {
 } from "./daemon-transport.ts";
 export { createHostDaemonTransport } from "./host-daemon-transport.ts";
 export * from "./desktop-resource-store.ts";
+export * from "./workspace-catalog-store.ts";

--- a/apps/desktop-renderer/src/runtime/workspace-catalog-store.test.ts
+++ b/apps/desktop-renderer/src/runtime/workspace-catalog-store.test.ts
@@ -1,0 +1,782 @@
+import { createRoot } from "solid-js";
+import {
+  DESKTOP_HOST_API_VERSION,
+  type DaemonInstanceIdentity,
+  type DesktopDaemonCapabilityState,
+  type DesktopDaemonEvent,
+  type DesktopDaemonHostSubscriptionResult,
+  type DesktopDaemonListWorkspacesResult,
+  type HostCapabilities,
+} from "@tmux-ide/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createDesktopWorkspaceCatalogStore,
+  createSolidDesktopWorkspaceCatalogStore,
+  type DesktopWorkspaceCatalogState,
+} from "./workspace-catalog-store.ts";
+
+const DAEMON: DaemonInstanceIdentity = {
+  protocolVersion: 1,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-21T00:00:00.000Z",
+};
+
+const NEXT_DAEMON: DaemonInstanceIdentity = {
+  ...DAEMON,
+  instanceId: "66ab67ed-18fe-431b-913b-70972b78c96f",
+  startedAt: "2026-07-22T00:00:00.000Z",
+};
+
+const CONNECTED = {
+  status: "connected",
+  identity: DAEMON,
+} satisfies DesktopDaemonCapabilityState;
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error?: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  let rejectPromise: ((error?: unknown) => void) | undefined;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return {
+    promise,
+    resolve: (value) => resolvePromise?.(value),
+    reject: (error) => rejectPromise?.(error),
+  };
+}
+
+function catalog(
+  names: readonly string[],
+  daemon: DaemonInstanceIdentity = DAEMON,
+): DesktopDaemonListWorkspacesResult {
+  return {
+    status: "ok",
+    daemon,
+    workspaces: names.map((workspaceName) => ({ workspaceName })),
+  };
+}
+
+interface FakeDaemonHost {
+  readonly host: Pick<HostCapabilities, "daemon">;
+  readonly listWorkspaces: ReturnType<typeof vi.fn<() => Promise<unknown>>>;
+  readonly subscribe: ReturnType<
+    typeof vi.fn<
+      (
+        request: { readonly workspaceNames: string[] },
+        listener: (event: DesktopDaemonEvent) => void,
+      ) => Promise<DesktopDaemonHostSubscriptionResult>
+    >
+  >;
+  publish(event: DesktopDaemonEvent): void;
+  readonly unsubscribe: ReturnType<typeof vi.fn<() => void>>;
+}
+
+function fakeDaemonHost(
+  listWorkspaces: () => Promise<unknown>,
+  subscribeResult?: () => Promise<DesktopDaemonHostSubscriptionResult>,
+): FakeDaemonHost {
+  let listener: ((event: DesktopDaemonEvent) => void) | null = null;
+  const unsubscribe = vi.fn<() => void>();
+  const list = vi.fn(listWorkspaces);
+  const subscribe = vi.fn(async (request, nextListener) => {
+    listener = nextListener;
+    return subscribeResult ? subscribeResult() : ({ status: "subscribed", unsubscribe } as const);
+  });
+  const daemon: HostCapabilities["daemon"] = {
+    listWorkspaces: list as HostCapabilities["daemon"]["listWorkspaces"],
+    fetchApplicationShell: async () => ({
+      status: "error",
+      error: { code: "preview-only", reason: "not used by catalog tests" },
+    }),
+    subscribe,
+  };
+  return {
+    host: { daemon },
+    listWorkspaces: list,
+    subscribe,
+    publish: (event) => listener?.(event),
+    unsubscribe,
+  };
+}
+
+async function publishLive(fake: FakeDaemonHost): Promise<void> {
+  await vi.waitFor(() => expect(fake.subscribe).toHaveBeenCalledOnce());
+  fake.publish({ type: "connection.changed", state: "live", error: null });
+}
+
+function liveSnapshot(state: DesktopWorkspaceCatalogState) {
+  expect(state.status).toBe("live");
+  if (state.status !== "live") throw new Error("catalog was not live");
+  return state.snapshot;
+}
+
+describe("desktop live workspace catalog and selection store", () => {
+  it.each([
+    {
+      label: "zero",
+      names: [] as string[],
+      view: "onboarding",
+      workspaceName: null,
+      reason: "no-live-workspaces",
+    },
+    {
+      label: "one",
+      names: ["only"],
+      view: "workspace",
+      workspaceName: "only",
+      reason: "only-live-workspace",
+    },
+    {
+      label: "many",
+      names: ["zeta", "alpha"],
+      view: "chooser",
+      workspaceName: null,
+      reason: "multiple-live-workspaces",
+    },
+  ])("projects $label catalogs without choosing an arbitrary first workspace", async (example) => {
+    const fake = fakeDaemonHost(async () => catalog(example.names));
+    const store = createDesktopWorkspaceCatalogStore({ host: fake.host, daemon: CONNECTED });
+    await publishLive(fake);
+    await vi.waitFor(() => expect(store.getState().status).toBe("live"));
+
+    const snapshot = liveSnapshot(store.getState());
+    expect(snapshot.workspaces.map(({ workspaceName }) => workspaceName)).toEqual(
+      [...example.names].sort(),
+    );
+    expect(snapshot.selection).toEqual({
+      view: example.view,
+      workspaceName: example.workspaceName,
+      reason: example.reason,
+    });
+    expect(fake.subscribe).toHaveBeenCalledWith({ workspaceNames: [] }, expect.any(Function));
+    store.dispose();
+  });
+
+  it.each(["startup", "persisted"] as const)(
+    "validates a trusted %s selection against the stamped catalog before selecting it",
+    async (source) => {
+      const pending = deferred<DesktopDaemonListWorkspacesResult>();
+      const fake = fakeDaemonHost(() => pending.promise);
+      const store = createDesktopWorkspaceCatalogStore({
+        host: fake.host,
+        daemon: CONNECTED,
+        initialSelection: { source, workspaceName: "docs" },
+      });
+      expect(store.getState()).toMatchObject({ status: "loading", snapshot: null });
+      pending.resolve(catalog(["app", "docs"]));
+      await publishLive(fake);
+      await vi.waitFor(() => expect(store.getState().status).toBe("live"));
+      expect(liveSnapshot(store.getState()).selection).toEqual({
+        view: "workspace",
+        workspaceName: "docs",
+        reason: source,
+      });
+      store.dispose();
+    },
+  );
+
+  it.each([
+    { source: "startup" as const, workspaceName: " docs ", reason: "startup-selection-invalid" },
+    {
+      source: "persisted" as const,
+      workspaceName: "missing",
+      reason: "persisted-selection-not-found",
+    },
+  ])("does not alias or silently replace an invalid $source selection", async (seed) => {
+    const fake = fakeDaemonHost(async () => catalog(["docs", "app"]));
+    const store = createDesktopWorkspaceCatalogStore({
+      host: fake.host,
+      daemon: CONNECTED,
+      initialSelection: seed,
+    });
+    await publishLive(fake);
+    await vi.waitFor(() => expect(store.getState().status).toBe("live"));
+    expect(liveSnapshot(store.getState()).selection).toEqual({
+      view: "chooser",
+      workspaceName: null,
+      reason: seed.reason,
+    });
+    store.dispose();
+  });
+
+  it("preserves an exact explicit selection, then clears it on removal without switching", async () => {
+    const responses = [catalog(["app", "docs"]), catalog(["app", "docs"]), catalog(["app"])];
+    const fake = fakeDaemonHost(async () => responses.shift()!);
+    const store = createDesktopWorkspaceCatalogStore({ host: fake.host, daemon: CONNECTED });
+    await publishLive(fake);
+    await vi.waitFor(() => expect(store.getState().status).toBe("live"));
+    expect(store.select("docs")).toBe(true);
+    expect(liveSnapshot(store.getState()).selection).toMatchObject({
+      workspaceName: "docs",
+      reason: "explicit",
+    });
+
+    fake.publish({ type: "workspaces.changed" });
+    await vi.waitFor(() => expect(fake.listWorkspaces).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(liveSnapshot(store.getState()).selection.workspaceName).toBe("docs"),
+    );
+    fake.publish({ type: "workspaces.changed" });
+    await vi.waitFor(() => expect(fake.listWorkspaces).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() =>
+      expect(liveSnapshot(store.getState()).selection).toEqual({
+        view: "chooser",
+        workspaceName: null,
+        reason: "selected-workspace-removed",
+      }),
+    );
+    expect(store.select(" missing ")).toBe(false);
+    expect(liveSnapshot(store.getState()).selection.workspaceName).toBeNull();
+    store.dispose();
+  });
+
+  it("ignores a late old-generation response and revalidates the prior exact selection", async () => {
+    const oldResponse = deferred<DesktopDaemonListWorkspacesResult>();
+    let currentDaemon = DAEMON;
+    const fake = fakeDaemonHost(async () =>
+      currentDaemon === DAEMON ? oldResponse.promise : catalog(["docs", "other"], NEXT_DAEMON),
+    );
+    const store = createDesktopWorkspaceCatalogStore({
+      host: fake.host,
+      daemon: CONNECTED,
+      initialSelection: { source: "startup", workspaceName: "docs" },
+    });
+    currentDaemon = NEXT_DAEMON;
+    store.setDaemon({ status: "connected", identity: NEXT_DAEMON });
+    oldResponse.resolve(catalog(["wrong"]));
+    await vi.waitFor(() => expect(fake.subscribe).toHaveBeenCalledTimes(2));
+    fake.publish({ type: "connection.changed", state: "live", error: null });
+    await vi.waitFor(() => expect(store.getState().status).toBe("live"));
+    const snapshot = liveSnapshot(store.getState());
+    expect(snapshot.daemon).toEqual(NEXT_DAEMON);
+    expect(snapshot.workspaces.map(({ workspaceName }) => workspaceName)).toEqual([
+      "docs",
+      "other",
+    ]);
+    expect(snapshot.selection).toEqual({
+      view: "workspace",
+      workspaceName: "docs",
+      reason: "startup",
+    });
+    expect(fake.subscribe).toHaveBeenCalledTimes(2);
+    store.dispose();
+  });
+
+  it.each([
+    { name: "padded", raw: catalog([" docs "]) },
+    { name: "duplicate", raw: catalog(["docs", "docs"]) },
+    {
+      name: "secret-bearing",
+      raw: { ...catalog(["docs"]), token: "top-secret", projectDir: "/private/secret" },
+    },
+  ])("rejects a $name catalog without reflecting untrusted details", async ({ raw }) => {
+    const fake = fakeDaemonHost(async () => raw);
+    const store = createDesktopWorkspaceCatalogStore({ host: fake.host, daemon: CONNECTED });
+    await vi.waitFor(() => expect(store.getState().status).toBe("degraded"));
+    expect(store.getState()).toMatchObject({
+      status: "degraded",
+      code: "invalid-response",
+      reason: "Desktop host returned an invalid workspace catalog.",
+    });
+    expect(JSON.stringify(store.getState())).not.toMatch(/top-secret|private|token/iu);
+    store.dispose();
+  });
+
+  it("rejects a catalog stamped by another daemon generation", async () => {
+    const fake = fakeDaemonHost(async () => catalog(["docs"], NEXT_DAEMON));
+    const store = createDesktopWorkspaceCatalogStore({ host: fake.host, daemon: CONNECTED });
+    await vi.waitFor(() => expect(store.getState().status).toBe("degraded"));
+    expect(store.getState()).toMatchObject({
+      code: "daemon-identity-mismatch",
+      reason: "Workspace catalog came from another daemon generation.",
+    });
+    store.dispose();
+  });
+
+  it.each([
+    {
+      label: "daemon-generation mismatch",
+      terminalCatalog: catalog(["docs"], NEXT_DAEMON),
+      code: "daemon-identity-mismatch" as const,
+      recovery: "refresh" as const,
+    },
+    {
+      label: "daemon-generation mismatch",
+      terminalCatalog: catalog(["docs"], NEXT_DAEMON),
+      code: "daemon-identity-mismatch" as const,
+      recovery: "setDaemon" as const,
+    },
+    {
+      label: "malformed response",
+      terminalCatalog: catalog([" docs "]),
+      code: "invalid-response" as const,
+      recovery: "refresh" as const,
+    },
+    {
+      label: "malformed response",
+      terminalCatalog: catalog([" docs "]),
+      code: "invalid-response" as const,
+      recovery: "setDaemon" as const,
+    },
+  ])(
+    "does not let a late pending subscription recover after a terminal $label until $recovery",
+    async ({ terminalCatalog, code, recovery }) => {
+      vi.useFakeTimers();
+      try {
+        const terminalResponse = deferred<DesktopDaemonListWorkspacesResult>();
+        const pendingSubscription = deferred<DesktopDaemonHostSubscriptionResult>();
+        const retiredUnsubscribe = vi.fn<() => void>();
+        let catalogRequests = 0;
+        let subscriptionAttempts = 0;
+        const fake = fakeDaemonHost(
+          () => {
+            catalogRequests += 1;
+            if (catalogRequests === 1) return Promise.resolve(catalog(["docs"]));
+            if (catalogRequests === 2) return terminalResponse.promise;
+            return Promise.resolve(catalog(["docs"]));
+          },
+          () => {
+            subscriptionAttempts += 1;
+            return subscriptionAttempts === 1
+              ? pendingSubscription.promise
+              : Promise.resolve({
+                  status: "subscribed",
+                  unsubscribe: () => fake.unsubscribe(),
+                });
+          },
+        );
+        const store = createDesktopWorkspaceCatalogStore({
+          host: fake.host,
+          daemon: CONNECTED,
+          retry: { initialDelayMs: 10, maximumDelayMs: 10, maximumAttempts: 2 },
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(store.getState()).toMatchObject({ status: "stale", snapshot: {} });
+        const retiredListener = fake.subscribe.mock.calls[0]![1];
+
+        // Explicit recovery while subscribe() is pending requests a restart,
+        // then the catalog proves that this generation cannot be trusted.
+        store.refresh();
+        terminalResponse.resolve(terminalCatalog);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(store.getState()).toMatchObject({ status: "degraded", code });
+
+        pendingSubscription.resolve({
+          status: "subscribed",
+          unsubscribe: () => retiredUnsubscribe(),
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        retiredListener({ type: "connection.changed", state: "live", error: null });
+        await vi.advanceTimersByTimeAsync(100);
+        expect(retiredUnsubscribe).toHaveBeenCalledOnce();
+        expect(fake.subscribe).toHaveBeenCalledOnce();
+        expect(store.getState()).toMatchObject({ status: "degraded", code });
+
+        // Only an explicit same-generation recovery may reopen after this
+        // terminal catalog boundary.
+        if (recovery === "refresh") store.refresh();
+        else store.setDaemon(CONNECTED);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fake.subscribe).toHaveBeenCalledTimes(2);
+        fake.publish({ type: "connection.changed", state: "live", error: null });
+        expect(store.getState().status).toBe("live");
+        store.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("queues explicit terminal recovery behind the unresolved retired subscription", async () => {
+    vi.useFakeTimers();
+    try {
+      const pendingSubscription = deferred<DesktopDaemonHostSubscriptionResult>();
+      const retiredUnsubscribe = vi.fn<() => void>();
+      let catalogRequests = 0;
+      let subscriptionAttempts = 0;
+      const fake = fakeDaemonHost(
+        () => {
+          catalogRequests += 1;
+          return Promise.resolve(
+            catalogRequests === 1 ? catalog(["docs"], NEXT_DAEMON) : catalog(["docs"]),
+          );
+        },
+        () => {
+          subscriptionAttempts += 1;
+          return subscriptionAttempts === 1
+            ? pendingSubscription.promise
+            : Promise.resolve({
+                status: "subscribed",
+                unsubscribe: () => fake.unsubscribe(),
+              });
+        },
+      );
+      const store = createDesktopWorkspaceCatalogStore({
+        host: fake.host,
+        daemon: CONNECTED,
+        retry: { initialDelayMs: 10, maximumDelayMs: 10, maximumAttempts: 2 },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(store.getState()).toMatchObject({
+        status: "degraded",
+        code: "daemon-identity-mismatch",
+      });
+      const retiredListener = fake.subscribe.mock.calls[0]![1];
+
+      store.refresh();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fake.subscribe).toHaveBeenCalledOnce();
+      retiredListener({ type: "connection.changed", state: "live", error: null });
+      expect(store.getState().status).not.toBe("live");
+
+      pendingSubscription.resolve({
+        status: "subscribed",
+        unsubscribe: () => retiredUnsubscribe(),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(retiredUnsubscribe).toHaveBeenCalledOnce();
+      expect(fake.subscribe).toHaveBeenCalledOnce();
+      retiredListener({ type: "connection.changed", state: "live", error: null });
+      expect(store.getState().status).not.toBe("live");
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(fake.subscribe).toHaveBeenCalledTimes(2);
+      fake.publish({ type: "connection.changed", state: "live", error: null });
+      expect(store.getState().status).toBe("live");
+      store.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("owns one catalog subscription, refetches on invalidation, and disposes late work", async () => {
+    const pendingRefresh = deferred<DesktopDaemonListWorkspacesResult>();
+    const lateSubscription = deferred<DesktopDaemonHostSubscriptionResult>();
+    const unsubscribe = vi.fn();
+    let calls = 0;
+    const fake = fakeDaemonHost(
+      async () => (++calls === 1 ? catalog(["docs", "app"]) : pendingRefresh.promise),
+      () => lateSubscription.promise,
+    );
+    const observed: DesktopWorkspaceCatalogState[] = [];
+    const store = createDesktopWorkspaceCatalogStore({ host: fake.host, daemon: CONNECTED });
+    store.subscribe((next) => observed.push(next));
+    await vi.waitFor(() => expect(fake.listWorkspaces).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(fake.subscribe).toHaveBeenCalledOnce());
+    fake.publish({ type: "workspaces.changed" });
+    await vi.waitFor(() => expect(fake.listWorkspaces).toHaveBeenCalledTimes(2));
+    store.dispose();
+    lateSubscription.resolve({ status: "subscribed", unsubscribe });
+    pendingRefresh.resolve(catalog(["late"]));
+    await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalledOnce());
+    expect(store.getState().status).toBe("disposed");
+    expect(observed.at(-1)?.status).toBe("disposed");
+    expect(fake.subscribe).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(store.getState())).not.toMatch(/late|sessionName|apiBaseUrl|token/iu);
+  });
+
+  it("keeps browser-preview/unavailable hosts no-network and reports the boundary", () => {
+    const fake = fakeDaemonHost(async () => catalog(["must-not-load"]));
+    const store = createDesktopWorkspaceCatalogStore({
+      host: fake.host,
+      daemon: {
+        status: "unavailable",
+        code: "preview-only",
+        reason: "Browser preview does not attach to the desktop daemon.",
+      },
+    });
+    expect(store.getState()).toMatchObject({
+      status: "degraded",
+      code: "daemon-unavailable",
+      reason: "Browser preview does not attach to the desktop daemon.",
+    });
+    expect(fake.listWorkspaces).not.toHaveBeenCalled();
+    expect(fake.subscribe).not.toHaveBeenCalled();
+    store.dispose();
+  });
+
+  it("bounds transient request retries without reconnecting the host event subscription", async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = fakeDaemonHost(async () => ({
+        status: "error",
+        error: { code: "request-failed", reason: "Catalog request unavailable." },
+      }));
+      const store = createDesktopWorkspaceCatalogStore({
+        host: fake.host,
+        daemon: CONNECTED,
+        retry: { initialDelayMs: 10, maximumDelayMs: 10, maximumAttempts: 2 },
+      });
+      await vi.advanceTimersByTimeAsync(25);
+      expect(fake.listWorkspaces).toHaveBeenCalledTimes(3);
+      expect(fake.subscribe).toHaveBeenCalledOnce();
+      expect(store.getState()).toMatchObject({ status: "error", code: "retry-exhausted" });
+      store.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["result error", "promise rejection"] as const)(
+    "recovers a failed initial event subscription after a %s on the same daemon generation",
+    async (failure) => {
+      vi.useFakeTimers();
+      try {
+        let attempts = 0;
+        const fake = fakeDaemonHost(
+          async () => catalog(["docs"]),
+          async () => {
+            attempts += 1;
+            if (attempts > 1) {
+              return { status: "subscribed", unsubscribe: () => fake.unsubscribe() };
+            }
+            if (failure === "promise rejection") throw new Error("private host rejection");
+            return {
+              status: "error",
+              error: { code: "event-unavailable", reason: "Catalog events unavailable." },
+            };
+          },
+        );
+        const store = createDesktopWorkspaceCatalogStore({
+          host: fake.host,
+          daemon: CONNECTED,
+          retry: { initialDelayMs: 10, maximumDelayMs: 10, maximumAttempts: 2 },
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fake.subscribe).toHaveBeenCalledOnce();
+        expect(store.getState().status).not.toBe("live");
+
+        await vi.advanceTimersByTimeAsync(10);
+        expect(fake.subscribe).toHaveBeenCalledTimes(2);
+        fake.publish({ type: "connection.changed", state: "live", error: null });
+        expect(store.getState().status).toBe("live");
+        store.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([
+    { label: "physical close/error", code: "event-unavailable" as const },
+    { label: "protocol failure", code: "protocol-error" as const },
+    { label: "malformed frame", code: "invalid-response" as const },
+    { label: "peer mismatch", code: "daemon-identity-mismatch" as const },
+  ])("retires and recovers its logical subscription after a $label", async ({ code }) => {
+    vi.useFakeTimers();
+    try {
+      const fake = fakeDaemonHost(async () => catalog(["docs"]));
+      const store = createDesktopWorkspaceCatalogStore({
+        host: fake.host,
+        daemon: CONNECTED,
+        retry: { initialDelayMs: 10, maximumDelayMs: 10, maximumAttempts: 2 },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      const retiredListener = fake.subscribe.mock.calls[0]![1];
+      fake.publish({ type: "connection.changed", state: "live", error: null });
+      expect(store.getState().status).toBe("live");
+
+      fake.publish({
+        type: "connection.changed",
+        state: "degraded",
+        error: { code, reason: "Bounded event failure." },
+      });
+      expect(fake.unsubscribe).toHaveBeenCalledOnce();
+      expect(store.getState().status).not.toBe("live");
+      await vi.advanceTimersByTimeAsync(10);
+      expect(fake.subscribe).toHaveBeenCalledTimes(2);
+      fake.publish({ type: "connection.changed", state: "live", error: null });
+      expect(store.getState().status).toBe("live");
+
+      const catalogCalls = fake.listWorkspaces.mock.calls.length;
+      retiredListener({ type: "workspaces.changed" });
+      retiredListener({
+        type: "connection.changed",
+        state: "degraded",
+        error: { code: "event-unavailable", reason: "late callback" },
+      });
+      await vi.advanceTimersByTimeAsync(20);
+      expect(fake.listWorkspaces).toHaveBeenCalledTimes(catalogCalls);
+      expect(fake.subscribe).toHaveBeenCalledTimes(2);
+      expect(store.getState().status).toBe("live");
+      store.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["setDaemon", "refresh"] as const)(
+    "uses %s as an explicit same-generation event recovery boundary",
+    async (action) => {
+      let attempts = 0;
+      const fake = fakeDaemonHost(
+        async () => catalog(["docs"]),
+        async () => {
+          attempts += 1;
+          return attempts === 1
+            ? {
+                status: "error",
+                error: { code: "event-unavailable", reason: "Initial subscription unavailable." },
+              }
+            : { status: "subscribed", unsubscribe: () => fake.unsubscribe() };
+        },
+      );
+      const store = createDesktopWorkspaceCatalogStore({
+        host: fake.host,
+        daemon: CONNECTED,
+        retry: { maximumAttempts: 0 },
+      });
+      await vi.waitFor(() => expect(fake.subscribe).toHaveBeenCalledOnce());
+      await vi.waitFor(() =>
+        expect(store.getState()).toMatchObject({
+          reason: "Daemon catalog event recovery attempts were exhausted.",
+        }),
+      );
+
+      if (action === "setDaemon") store.setDaemon(CONNECTED);
+      else store.refresh();
+      await vi.waitFor(() => expect(fake.subscribe).toHaveBeenCalledTimes(2));
+      fake.publish({ type: "connection.changed", state: "live", error: null });
+      await vi.waitFor(() => expect(store.getState().status).toBe("live"));
+      expect(store.getState().generation).toBe(1);
+      store.dispose();
+    },
+  );
+
+  it("does not overlap a pending logical subscription during explicit same-generation recovery", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = deferred<DesktopDaemonHostSubscriptionResult>();
+      const lateUnsubscribe = vi.fn();
+      let attempts = 0;
+      const fake = fakeDaemonHost(
+        async () => catalog(["docs"]),
+        () => {
+          attempts += 1;
+          return attempts === 1
+            ? pending.promise
+            : Promise.resolve({ status: "subscribed", unsubscribe: () => fake.unsubscribe() });
+        },
+      );
+      const store = createDesktopWorkspaceCatalogStore({
+        host: fake.host,
+        daemon: CONNECTED,
+        retry: { initialDelayMs: 10, maximumDelayMs: 10, maximumAttempts: 2 },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      store.refresh();
+      store.setDaemon(CONNECTED);
+      expect(fake.subscribe).toHaveBeenCalledOnce();
+
+      pending.resolve({ status: "subscribed", unsubscribe: () => lateUnsubscribe() });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(lateUnsubscribe).toHaveBeenCalledOnce();
+      expect(fake.subscribe).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(10);
+      expect(fake.subscribe).toHaveBeenCalledTimes(2);
+      fake.publish({ type: "connection.changed", state: "live", error: null });
+      expect(store.getState().status).toBe("live");
+      store.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds same-generation event recovery and can be disposed with a retry pending", async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = fakeDaemonHost(
+        async () => catalog(["docs"]),
+        async () => ({
+          status: "error",
+          error: { code: "protocol-error", reason: "Subscription rejected." },
+        }),
+      );
+      const store = createDesktopWorkspaceCatalogStore({
+        host: fake.host,
+        daemon: CONNECTED,
+        retry: { initialDelayMs: 10, maximumDelayMs: 10, maximumAttempts: 2 },
+      });
+      await vi.advanceTimersByTimeAsync(100);
+      expect(fake.subscribe).toHaveBeenCalledTimes(3);
+      expect(store.getState()).toMatchObject({
+        reason: "Daemon catalog event recovery attempts were exhausted.",
+      });
+      store.refresh();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fake.subscribe).toHaveBeenCalledTimes(4);
+      store.dispose();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(fake.subscribe).toHaveBeenCalledTimes(4);
+      expect(store.getState().status).toBe("disposed");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("isolates observer and host teardown exceptions after making disposal irrevocable", async () => {
+    const unsubscribe = vi.fn(() => {
+      throw new Error("private host teardown failure");
+    });
+    const fake = fakeDaemonHost(
+      async () => catalog(["docs"]),
+      async () => ({
+        status: "subscribed",
+        unsubscribe,
+      }),
+    );
+    const store = createDesktopWorkspaceCatalogStore({ host: fake.host, daemon: CONNECTED });
+    const observed: string[] = [];
+    expect(() =>
+      store.subscribe(() => {
+        throw new Error("private observer failure");
+      }),
+    ).not.toThrow();
+    store.subscribe((next) => {
+      observed.push(next.status);
+      if (next.status === "disposed") {
+        store.refresh();
+        store.setDaemon(CONNECTED);
+        throw new Error("observer attempted re-entry");
+      }
+    });
+    await publishLive(fake);
+    await vi.waitFor(() => expect(store.getState().status).toBe("live"));
+    const requestCalls = fake.listWorkspaces.mock.calls.length;
+    expect(() => store.dispose()).not.toThrow();
+    expect(store.getState().status).toBe("disposed");
+    expect(observed.at(-1)).toBe("disposed");
+    expect(fake.listWorkspaces).toHaveBeenCalledTimes(requestCalls);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("adapts the pure store to Solid and disposes with its owner", async () => {
+    const fake = fakeDaemonHost(async () => catalog(["docs"]));
+    let disposeOwner!: () => void;
+    let solidStore!: ReturnType<typeof createSolidDesktopWorkspaceCatalogStore>;
+    createRoot((dispose) => {
+      disposeOwner = dispose;
+      solidStore = createSolidDesktopWorkspaceCatalogStore({ host: fake.host, daemon: CONNECTED });
+    });
+    await publishLive(fake);
+    await vi.waitFor(() => expect(solidStore.state().status).toBe("live"));
+    expect(liveSnapshot(solidStore.state()).selection.reason).toBe("only-live-workspace");
+    disposeOwner();
+    expect(fake.unsubscribe).toHaveBeenCalledOnce();
+  });
+});
+
+describe("workspace catalog host contract seam", () => {
+  it("uses the current versioned facade without exposing a generic transport", () => {
+    expect(DESKTOP_HOST_API_VERSION).toBe(3);
+  });
+});

--- a/apps/desktop-renderer/src/runtime/workspace-catalog-store.ts
+++ b/apps/desktop-renderer/src/runtime/workspace-catalog-store.ts
@@ -1,0 +1,986 @@
+import { createSignal, onCleanup, type Accessor } from "solid-js";
+import {
+  DesktopDaemonCapabilityStateSchemaZ,
+  DesktopDaemonListWorkspacesResultSchemaZ,
+  DesktopWorkspaceNameSchemaZ,
+  isDaemonWireProtocolCompatible,
+  type DaemonInstanceIdentity,
+  type DesktopDaemonCapabilityError,
+  type DesktopDaemonEvent,
+  type DesktopDaemonWorkspaceSummary,
+  type HostCapabilities,
+} from "@tmux-ide/contracts";
+
+export type DesktopWorkspaceSelectionSeedSource = "startup" | "persisted";
+
+export interface DesktopWorkspaceSelectionSeed {
+  readonly source: DesktopWorkspaceSelectionSeedSource;
+  readonly workspaceName: unknown;
+}
+
+export type DesktopWorkspaceSelectedReason =
+  | DesktopWorkspaceSelectionSeedSource
+  | "explicit"
+  | "only-live-workspace";
+
+export type DesktopWorkspaceUnselectedReason =
+  | "loading"
+  | "no-live-workspaces"
+  | "multiple-live-workspaces"
+  | "startup-selection-invalid"
+  | "startup-selection-not-found"
+  | "persisted-selection-invalid"
+  | "persisted-selection-not-found"
+  | "selected-workspace-removed"
+  | "explicit-selection-cleared";
+
+export type DesktopWorkspaceSelection =
+  | {
+      readonly view: "workspace";
+      readonly workspaceName: string;
+      readonly reason: DesktopWorkspaceSelectedReason;
+    }
+  | {
+      readonly view: "onboarding" | "chooser";
+      readonly workspaceName: null;
+      readonly reason: DesktopWorkspaceUnselectedReason;
+    };
+
+export interface DesktopWorkspaceCatalogSnapshot {
+  readonly daemon: DaemonInstanceIdentity;
+  readonly workspaces: readonly DesktopDaemonWorkspaceSummary[];
+  readonly selection: DesktopWorkspaceSelection;
+  readonly updatedAt: number;
+}
+
+interface DesktopWorkspaceCatalogStateBase {
+  readonly generation: number;
+  readonly daemon: DaemonInstanceIdentity | null;
+}
+
+export type DesktopWorkspaceCatalogState =
+  | (DesktopWorkspaceCatalogStateBase & {
+      readonly status: "loading";
+      readonly snapshot: null;
+    })
+  | (DesktopWorkspaceCatalogStateBase & {
+      readonly status: "live";
+      readonly snapshot: DesktopWorkspaceCatalogSnapshot;
+    })
+  | (DesktopWorkspaceCatalogStateBase & {
+      readonly status: "stale";
+      readonly snapshot: DesktopWorkspaceCatalogSnapshot;
+      readonly reason: string;
+    })
+  | (DesktopWorkspaceCatalogStateBase & {
+      readonly status: "degraded";
+      readonly snapshot: DesktopWorkspaceCatalogSnapshot | null;
+      readonly code:
+        | "daemon-unavailable"
+        | "daemon-degraded"
+        | "daemon-identity-mismatch"
+        | "invalid-response"
+        | "event-unavailable";
+      readonly reason: string;
+    })
+  | (DesktopWorkspaceCatalogStateBase & {
+      readonly status: "error";
+      readonly snapshot: DesktopWorkspaceCatalogSnapshot | null;
+      readonly code: "request-failed" | "retry-exhausted";
+      readonly reason: string;
+    })
+  | (DesktopWorkspaceCatalogStateBase & {
+      readonly status: "disposed";
+      readonly daemon: null;
+      readonly snapshot: null;
+    });
+
+export interface DesktopWorkspaceCatalogClock {
+  now(): number;
+  setTimeout(callback: () => void, delayMs: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+export interface DesktopWorkspaceCatalogRetryPolicy {
+  readonly initialDelayMs: number;
+  readonly maximumDelayMs: number;
+  readonly maximumAttempts: number;
+}
+
+export interface DesktopWorkspaceCatalogStoreOptions {
+  readonly host: Pick<HostCapabilities, "daemon">;
+  readonly daemon: unknown;
+  readonly initialSelection?: DesktopWorkspaceSelectionSeed;
+  readonly clock?: DesktopWorkspaceCatalogClock;
+  readonly retry?: Partial<DesktopWorkspaceCatalogRetryPolicy>;
+}
+
+export type DesktopWorkspaceCatalogStateListener = (state: DesktopWorkspaceCatalogState) => void;
+
+export interface DesktopWorkspaceCatalogStore {
+  getState(): DesktopWorkspaceCatalogState;
+  subscribe(listener: DesktopWorkspaceCatalogStateListener): () => void;
+  select(workspaceName: unknown): boolean;
+  clearSelection(): void;
+  refresh(): void;
+  setDaemon(daemon: unknown): void;
+  dispose(): void;
+}
+
+export interface SolidDesktopWorkspaceCatalogStore {
+  readonly state: Accessor<DesktopWorkspaceCatalogState>;
+  select(workspaceName: unknown): boolean;
+  clearSelection(): void;
+  refresh(): void;
+  setDaemon(daemon: unknown): void;
+  dispose(): void;
+}
+
+const DEFAULT_RETRY: DesktopWorkspaceCatalogRetryPolicy = {
+  initialDelayMs: 250,
+  maximumDelayMs: 4_000,
+  maximumAttempts: 4,
+};
+
+const defaultClock: DesktopWorkspaceCatalogClock = {
+  now: () => Date.now(),
+  setTimeout: (callback, delayMs) => globalThis.setTimeout(callback, delayMs),
+  clearTimeout: (handle) => globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  if (value === undefined || !Number.isInteger(value)) return fallback;
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function retryPolicy(
+  overrides: Partial<DesktopWorkspaceCatalogRetryPolicy> | undefined,
+): DesktopWorkspaceCatalogRetryPolicy {
+  const initialDelayMs = boundedInteger(
+    overrides?.initialDelayMs,
+    DEFAULT_RETRY.initialDelayMs,
+    10,
+    60_000,
+  );
+  return {
+    initialDelayMs,
+    maximumDelayMs: Math.max(
+      initialDelayMs,
+      boundedInteger(overrides?.maximumDelayMs, DEFAULT_RETRY.maximumDelayMs, 10, 60_000),
+    ),
+    maximumAttempts: boundedInteger(
+      overrides?.maximumAttempts,
+      DEFAULT_RETRY.maximumAttempts,
+      0,
+      10,
+    ),
+  };
+}
+
+function sameDaemon(
+  left: DaemonInstanceIdentity | null,
+  right: DaemonInstanceIdentity | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return (
+    left.protocolVersion === right.protocolVersion &&
+    left.productVersion === right.productVersion &&
+    left.instanceId === right.instanceId &&
+    left.startedAt === right.startedAt
+  );
+}
+
+function daemonKey(daemon: DaemonInstanceIdentity): string {
+  return [daemon.protocolVersion, daemon.productVersion, daemon.instanceId, daemon.startedAt].join(
+    "\u0000",
+  );
+}
+
+function exactWorkspaceName(value: unknown): string | null {
+  const parsed = DesktopWorkspaceNameSchemaZ.safeParse(value);
+  return parsed.success && parsed.data === value ? parsed.data : null;
+}
+
+function safeReason(error: DesktopDaemonCapabilityError): string {
+  // Host capability errors are already bounded and redacted by the shared
+  // contract. Do not incorporate thrown values or schema diagnostics here.
+  return error.reason;
+}
+
+function invalidSeedReason(
+  source: DesktopWorkspaceSelectionSeedSource,
+): DesktopWorkspaceUnselectedReason {
+  return source === "startup" ? "startup-selection-invalid" : "persisted-selection-invalid";
+}
+
+function missingSeedReason(
+  source: DesktopWorkspaceSelectionSeedSource,
+): DesktopWorkspaceUnselectedReason {
+  return source === "startup" ? "startup-selection-not-found" : "persisted-selection-not-found";
+}
+
+function selectionWithoutWorkspace(
+  workspaceCount: number,
+  reason: DesktopWorkspaceUnselectedReason,
+): DesktopWorkspaceSelection {
+  return {
+    view: workspaceCount === 0 ? "onboarding" : "chooser",
+    workspaceName: null,
+    reason,
+  };
+}
+
+function sortWorkspaceSummaries(
+  workspaces: readonly DesktopDaemonWorkspaceSummary[],
+): DesktopDaemonWorkspaceSummary[] {
+  return [...workspaces].sort((left, right) =>
+    left.workspaceName < right.workspaceName
+      ? -1
+      : left.workspaceName > right.workspaceName
+        ? 1
+        : 0,
+  );
+}
+
+function parseCatalogResult(
+  value: unknown,
+  expectedDaemon: DaemonInstanceIdentity,
+):
+  | { readonly status: "ok"; readonly workspaces: DesktopDaemonWorkspaceSummary[] }
+  | { readonly status: "error"; readonly error: DesktopDaemonCapabilityError }
+  | { readonly status: "invalid-response" | "daemon-identity-mismatch" } {
+  const parsed = DesktopDaemonListWorkspacesResultSchemaZ.safeParse(value);
+  if (!parsed.success) return { status: "invalid-response" };
+  if (parsed.data.status === "error") return parsed.data;
+  if (!sameDaemon(parsed.data.daemon, expectedDaemon)) {
+    return { status: "daemon-identity-mismatch" };
+  }
+  const names = new Set<string>();
+  for (let index = 0; index < parsed.data.workspaces.length; index += 1) {
+    const parsedName = parsed.data.workspaces[index]?.workspaceName;
+    const rawName = (value as { workspaces?: Array<{ workspaceName?: unknown }> }).workspaces?.[
+      index
+    ]?.workspaceName;
+    if (parsedName === undefined || parsedName !== rawName || names.has(parsedName)) {
+      return { status: "invalid-response" };
+    }
+    names.add(parsedName);
+  }
+  return { status: "ok", workspaces: sortWorkspaceSummaries(parsed.data.workspaces) };
+}
+
+function connectedIdentity(value: unknown):
+  | { readonly status: "connected"; readonly identity: DaemonInstanceIdentity }
+  | {
+      readonly status: "unavailable" | "degraded" | "invalid";
+      readonly reason: string;
+    } {
+  const parsed = DesktopDaemonCapabilityStateSchemaZ.safeParse(value);
+  if (!parsed.success) {
+    return { status: "invalid", reason: "Desktop daemon capability state is invalid." };
+  }
+  if (parsed.data.status !== "connected") {
+    return { status: parsed.data.status, reason: parsed.data.reason };
+  }
+  if (!isDaemonWireProtocolCompatible(parsed.data.identity.protocolVersion)) {
+    return { status: "invalid", reason: "Desktop daemon protocol is incompatible." };
+  }
+  return { status: "connected", identity: parsed.data.identity };
+}
+
+function snapshotFromState(
+  state: DesktopWorkspaceCatalogState,
+): DesktopWorkspaceCatalogSnapshot | null {
+  return "snapshot" in state ? state.snapshot : null;
+}
+
+function requestShouldRetry(error: DesktopDaemonCapabilityError): boolean {
+  return (
+    error.code === "request-timeout" ||
+    error.code === "request-failed" ||
+    error.code === "event-unavailable"
+  );
+}
+
+function terminalEventFailureCode(
+  error: DesktopDaemonCapabilityError,
+): "daemon-identity-mismatch" | "invalid-response" | null {
+  if (error.code === "daemon-identity-mismatch") return "daemon-identity-mismatch";
+  if (error.code === "invalid-response" || error.code === "protocol-error") {
+    return "invalid-response";
+  }
+  return null;
+}
+
+export function createDesktopWorkspaceCatalogStore(
+  options: DesktopWorkspaceCatalogStoreOptions,
+): DesktopWorkspaceCatalogStore {
+  const host = options.host;
+  const clock = options.clock ?? defaultClock;
+  const retry = retryPolicy(options.retry);
+  const listeners = new Set<DesktopWorkspaceCatalogStateListener>();
+
+  let disposed = false;
+  let generation = 0;
+  let daemon: DaemonInstanceIdentity | null = null;
+  let daemonGeneration = "";
+  let state: DesktopWorkspaceCatalogState = {
+    status: "loading",
+    generation,
+    daemon,
+    snapshot: null,
+  };
+  let requestId = 0;
+  let subscriptionId = 0;
+  let unsubscribeHost: (() => void) | null = null;
+  let pendingSubscriptionId: number | null = null;
+  let eventRetryRequested = false;
+  let requestRetryTimer: unknown | null = null;
+  let requestRetryAttempts = 0;
+  let eventRetryTimer: unknown | null = null;
+  let eventRetryAttempts = 0;
+  let eventLive = false;
+  let selectedWorkspaceName: string | null = null;
+  let selectedReason: DesktopWorkspaceSelectedReason | null = null;
+  let pendingSelection: {
+    readonly source: DesktopWorkspaceSelectionSeedSource;
+    readonly workspaceName: string;
+  } | null = null;
+  let unselectedReason: DesktopWorkspaceUnselectedReason = "loading";
+  let suppressAutomaticSelection = false;
+
+  if (options.initialSelection) {
+    const candidate = exactWorkspaceName(options.initialSelection.workspaceName);
+    if (candidate === null) {
+      unselectedReason = invalidSeedReason(options.initialSelection.source);
+      suppressAutomaticSelection = true;
+    } else {
+      pendingSelection = { source: options.initialSelection.source, workspaceName: candidate };
+    }
+  }
+
+  const notify = (
+    listener: DesktopWorkspaceCatalogStateListener,
+    next: DesktopWorkspaceCatalogState,
+  ): void => {
+    try {
+      listener(next);
+    } catch {
+      // Catalog observers are untrusted application code. One observer must not
+      // interrupt state retirement, another observer, or host cleanup.
+    }
+  };
+
+  const emit = (next: DesktopWorkspaceCatalogState): void => {
+    if (disposed) return;
+    state = next;
+    for (const listener of [...listeners]) {
+      if (disposed) break;
+      notify(listener, next);
+    }
+  };
+
+  const current = (expectedGeneration: number, expectedDaemonGeneration: string): boolean =>
+    !disposed &&
+    generation === expectedGeneration &&
+    daemonGeneration === expectedDaemonGeneration &&
+    daemon !== null;
+
+  const clearTimer = (handle: unknown | null): void => {
+    if (handle === null) return;
+    try {
+      clock.clearTimeout(handle);
+    } catch {
+      // A host clock must not prevent retirement or disposal.
+    }
+  };
+
+  const clearRequestRetry = (): void => {
+    clearTimer(requestRetryTimer);
+    requestRetryTimer = null;
+  };
+
+  const clearEventRetry = (): void => {
+    clearTimer(eventRetryTimer);
+    eventRetryTimer = null;
+  };
+
+  const retireRequest = (): void => {
+    requestId += 1;
+  };
+
+  const retireSubscription = (forgetPending = false): void => {
+    subscriptionId += 1;
+    if (forgetPending) pendingSubscriptionId = null;
+    eventLive = false;
+    const active = unsubscribeHost;
+    unsubscribeHost = null;
+    try {
+      active?.();
+    } catch {
+      // Host teardown is best-effort; the logical generation is already retired.
+    }
+  };
+
+  const selectionFor = (
+    workspaces: readonly DesktopDaemonWorkspaceSummary[],
+  ): DesktopWorkspaceSelection => {
+    const names = new Set(workspaces.map(({ workspaceName }) => workspaceName));
+    if (selectedWorkspaceName !== null) {
+      if (names.has(selectedWorkspaceName)) {
+        return {
+          view: "workspace",
+          workspaceName: selectedWorkspaceName,
+          reason: selectedReason ?? "explicit",
+        };
+      }
+      selectedWorkspaceName = null;
+      selectedReason = null;
+      pendingSelection = null;
+      unselectedReason = "selected-workspace-removed";
+      suppressAutomaticSelection = true;
+    }
+    if (pendingSelection !== null) {
+      if (names.has(pendingSelection.workspaceName)) {
+        selectedWorkspaceName = pendingSelection.workspaceName;
+        selectedReason = pendingSelection.source;
+        pendingSelection = null;
+        suppressAutomaticSelection = false;
+        return {
+          view: "workspace",
+          workspaceName: selectedWorkspaceName,
+          reason: selectedReason,
+        };
+      }
+      unselectedReason = missingSeedReason(pendingSelection.source);
+      pendingSelection = null;
+      suppressAutomaticSelection = true;
+    }
+    if (workspaces.length === 1 && !suppressAutomaticSelection) {
+      selectedWorkspaceName = workspaces[0]!.workspaceName;
+      selectedReason = "only-live-workspace";
+      return {
+        view: "workspace",
+        workspaceName: selectedWorkspaceName,
+        reason: selectedReason,
+      };
+    }
+    if (unselectedReason === "loading") {
+      unselectedReason =
+        workspaces.length === 0 ? "no-live-workspaces" : "multiple-live-workspaces";
+    } else if (
+      unselectedReason === "no-live-workspaces" &&
+      workspaces.length > 0 &&
+      !suppressAutomaticSelection
+    ) {
+      unselectedReason = "multiple-live-workspaces";
+    } else if (unselectedReason === "multiple-live-workspaces" && workspaces.length === 0) {
+      unselectedReason = "no-live-workspaces";
+    }
+    return selectionWithoutWorkspace(workspaces.length, unselectedReason);
+  };
+
+  const updateSelectionSnapshot = (): void => {
+    const snapshot = snapshotFromState(state);
+    if (!snapshot || !daemon) return;
+    const nextSnapshot: DesktopWorkspaceCatalogSnapshot = {
+      ...snapshot,
+      selection: selectionFor(snapshot.workspaces),
+    };
+    if (state.status === "live") emit({ ...state, snapshot: nextSnapshot });
+    else if (state.status === "stale") emit({ ...state, snapshot: nextSnapshot });
+    else if (state.status === "degraded") emit({ ...state, snapshot: nextSnapshot });
+    else if (state.status === "error") emit({ ...state, snapshot: nextSnapshot });
+  };
+
+  const emitCatalog = (workspaces: readonly DesktopDaemonWorkspaceSummary[]): void => {
+    if (!daemon) return;
+    const snapshot: DesktopWorkspaceCatalogSnapshot = {
+      daemon,
+      workspaces,
+      selection: selectionFor(workspaces),
+      updatedAt: clock.now(),
+    };
+    emit(
+      eventLive
+        ? { status: "live", generation, daemon, snapshot }
+        : {
+            status: "stale",
+            generation,
+            daemon,
+            snapshot,
+            reason: "Daemon catalog events are not connected.",
+          },
+    );
+  };
+
+  const emitRequestError = (error: DesktopDaemonCapabilityError, exhausted: boolean): void => {
+    const snapshot = snapshotFromState(state);
+    if (snapshot) {
+      emit({
+        status: "stale",
+        generation,
+        daemon,
+        snapshot,
+        reason: safeReason(error),
+      });
+      return;
+    }
+    emit({
+      status: "error",
+      generation,
+      daemon,
+      snapshot: null,
+      code: exhausted ? "retry-exhausted" : "request-failed",
+      reason: safeReason(error),
+    });
+  };
+
+  const emitEventFailure = (error: DesktopDaemonCapabilityError, exhausted = false): void => {
+    eventLive = false;
+    const snapshot = snapshotFromState(state);
+    const terminalCode = terminalEventFailureCode(error);
+    if (terminalCode !== null) {
+      emit({
+        status: "degraded",
+        generation,
+        daemon,
+        snapshot,
+        code: terminalCode,
+        reason: safeReason(error),
+      });
+      return;
+    }
+    if (snapshot) {
+      emit({
+        status: "stale",
+        generation,
+        daemon,
+        snapshot,
+        reason: exhausted
+          ? "Daemon catalog event recovery attempts were exhausted."
+          : safeReason(error),
+      });
+      return;
+    }
+    emit({
+      status: "degraded",
+      generation,
+      daemon,
+      snapshot: null,
+      code: "event-unavailable",
+      reason: exhausted
+        ? "Daemon catalog event recovery attempts were exhausted."
+        : safeReason(error),
+    });
+  };
+
+  const scheduleRequestRetry = (
+    expectedGeneration: number,
+    expectedDaemonGeneration: string,
+  ): void => {
+    if (
+      requestRetryTimer !== null ||
+      requestRetryAttempts >= retry.maximumAttempts ||
+      !current(expectedGeneration, expectedDaemonGeneration)
+    ) {
+      return;
+    }
+    const delay = Math.min(
+      retry.maximumDelayMs,
+      retry.initialDelayMs * 2 ** Math.max(0, requestRetryAttempts),
+    );
+    requestRetryAttempts += 1;
+    requestRetryTimer = clock.setTimeout(() => {
+      requestRetryTimer = null;
+      fetchCatalog(expectedGeneration, expectedDaemonGeneration);
+    }, delay);
+  };
+
+  const scheduleEventRetry = (
+    expectedGeneration: number,
+    expectedDaemonGeneration: string,
+  ): void => {
+    if (
+      eventRetryTimer !== null ||
+      unsubscribeHost !== null ||
+      !current(expectedGeneration, expectedDaemonGeneration)
+    ) {
+      return;
+    }
+    if (pendingSubscriptionId !== null) {
+      eventRetryRequested = true;
+      return;
+    }
+    if (eventRetryAttempts >= retry.maximumAttempts) {
+      emitEventFailure(
+        {
+          code: "event-unavailable",
+          reason: "Daemon catalog events are unavailable.",
+        },
+        true,
+      );
+      return;
+    }
+    const delay = Math.min(
+      retry.maximumDelayMs,
+      retry.initialDelayMs * 2 ** Math.max(0, eventRetryAttempts),
+    );
+    eventRetryAttempts += 1;
+    eventRetryRequested = false;
+    eventRetryTimer = clock.setTimeout(() => {
+      eventRetryTimer = null;
+      connectEvents(expectedGeneration, expectedDaemonGeneration);
+    }, delay);
+  };
+
+  const recoverEvents = (
+    expectedGeneration: number,
+    expectedDaemonGeneration: string,
+    error: DesktopDaemonCapabilityError,
+  ): void => {
+    if (!current(expectedGeneration, expectedDaemonGeneration)) return;
+    retireSubscription();
+    emitEventFailure(error);
+    scheduleEventRetry(expectedGeneration, expectedDaemonGeneration);
+  };
+
+  function fetchCatalog(expectedGeneration: number, expectedDaemonGeneration: string): void {
+    if (!current(expectedGeneration, expectedDaemonGeneration) || daemon === null) return;
+    retireRequest();
+    const activeRequestId = requestId;
+    const expectedDaemon = daemon;
+    void host.daemon
+      .listWorkspaces()
+      .then((raw) => {
+        if (
+          activeRequestId !== requestId ||
+          !current(expectedGeneration, expectedDaemonGeneration)
+        ) {
+          return;
+        }
+        const result = parseCatalogResult(raw, expectedDaemon);
+        if (result.status === "ok") {
+          clearRequestRetry();
+          requestRetryAttempts = 0;
+          emitCatalog(result.workspaces);
+          return;
+        }
+        if (result.status !== "error") {
+          clearRequestRetry();
+          clearEventRetry();
+          eventRetryRequested = false;
+          // A malformed or differently stamped catalog invalidates the whole
+          // event authority for this daemon generation. Keep tracking a
+          // pending subscribe promise so an explicit recovery queues behind
+          // its eventual teardown instead of creating a parallel logical
+          // subscription. With no explicit recovery intent, its late result
+          // can only unsubscribe itself and can never publish live.
+          retireSubscription();
+          emit({
+            status: "degraded",
+            generation,
+            daemon,
+            snapshot: snapshotFromState(state),
+            code: result.status,
+            reason:
+              result.status === "daemon-identity-mismatch"
+                ? "Workspace catalog came from another daemon generation."
+                : "Desktop host returned an invalid workspace catalog.",
+          });
+          return;
+        }
+        const shouldRetry = requestShouldRetry(result.error);
+        const exhausted = shouldRetry && requestRetryAttempts >= retry.maximumAttempts;
+        emitRequestError(result.error, exhausted);
+        if (shouldRetry && !exhausted) {
+          scheduleRequestRetry(expectedGeneration, expectedDaemonGeneration);
+        }
+      })
+      .catch(() => {
+        if (
+          activeRequestId !== requestId ||
+          !current(expectedGeneration, expectedDaemonGeneration)
+        ) {
+          return;
+        }
+        const error: DesktopDaemonCapabilityError = {
+          code: "request-failed",
+          reason: "Desktop host workspace catalog request failed.",
+        };
+        const exhausted = requestRetryAttempts >= retry.maximumAttempts;
+        emitRequestError(error, exhausted);
+        if (!exhausted) scheduleRequestRetry(expectedGeneration, expectedDaemonGeneration);
+      });
+  }
+
+  function connectEvents(expectedGeneration: number, expectedDaemonGeneration: string): void {
+    if (
+      !current(expectedGeneration, expectedDaemonGeneration) ||
+      pendingSubscriptionId !== null ||
+      unsubscribeHost !== null ||
+      eventLive
+    ) {
+      return;
+    }
+    eventRetryRequested = false;
+    const activeSubscriptionId = ++subscriptionId;
+    pendingSubscriptionId = activeSubscriptionId;
+    const listener = (event: DesktopDaemonEvent): void => {
+      if (
+        activeSubscriptionId !== subscriptionId ||
+        !current(expectedGeneration, expectedDaemonGeneration)
+      ) {
+        return;
+      }
+      if (event.type === "workspaces.changed") {
+        fetchCatalog(expectedGeneration, expectedDaemonGeneration);
+        return;
+      }
+      if (event.type !== "connection.changed") return;
+      if (event.state === "live") {
+        eventLive = true;
+        clearEventRetry();
+        eventRetryAttempts = 0;
+        eventRetryRequested = false;
+        const snapshot = snapshotFromState(state);
+        if (snapshot && daemon) emit({ status: "live", generation, daemon, snapshot });
+        return;
+      }
+      recoverEvents(
+        expectedGeneration,
+        expectedDaemonGeneration,
+        event.error ?? {
+          code: "event-unavailable",
+          reason: "Daemon catalog events are unavailable.",
+        },
+      );
+    };
+    let operation: ReturnType<HostCapabilities["daemon"]["subscribe"]>;
+    try {
+      operation = host.daemon.subscribe({ workspaceNames: [] }, listener);
+    } catch {
+      if (pendingSubscriptionId === activeSubscriptionId) pendingSubscriptionId = null;
+      recoverEvents(expectedGeneration, expectedDaemonGeneration, {
+        code: "event-unavailable",
+        reason: "Desktop host catalog event subscription failed.",
+      });
+      return;
+    }
+    void operation
+      .then((result) => {
+        const wasPending = pendingSubscriptionId === activeSubscriptionId;
+        if (wasPending) pendingSubscriptionId = null;
+        if (
+          activeSubscriptionId !== subscriptionId ||
+          !current(expectedGeneration, expectedDaemonGeneration)
+        ) {
+          if (result.status === "subscribed") {
+            try {
+              result.unsubscribe();
+            } catch {
+              // This logical subscription was already retired.
+            }
+          }
+          if (
+            wasPending &&
+            eventRetryRequested &&
+            current(expectedGeneration, expectedDaemonGeneration)
+          ) {
+            scheduleEventRetry(expectedGeneration, expectedDaemonGeneration);
+          }
+          return;
+        }
+        if (result.status === "subscribed") {
+          unsubscribeHost = result.unsubscribe;
+          return;
+        }
+        recoverEvents(expectedGeneration, expectedDaemonGeneration, result.error);
+      })
+      .catch(() => {
+        const wasPending = pendingSubscriptionId === activeSubscriptionId;
+        if (wasPending) pendingSubscriptionId = null;
+        if (
+          activeSubscriptionId !== subscriptionId ||
+          !current(expectedGeneration, expectedDaemonGeneration)
+        ) {
+          if (
+            wasPending &&
+            eventRetryRequested &&
+            current(expectedGeneration, expectedDaemonGeneration)
+          ) {
+            scheduleEventRetry(expectedGeneration, expectedDaemonGeneration);
+          }
+          return;
+        }
+        recoverEvents(expectedGeneration, expectedDaemonGeneration, {
+          code: "event-unavailable",
+          reason: "Desktop host catalog event subscription failed.",
+        });
+      });
+  }
+
+  const startDaemon = (untrustedDaemon: unknown): void => {
+    const next = connectedIdentity(untrustedDaemon);
+    const nextIdentity = next.status === "connected" ? next.identity : null;
+    if (sameDaemon(daemon, nextIdentity) && next.status === "connected") {
+      clearRequestRetry();
+      requestRetryAttempts = 0;
+      fetchCatalog(generation, daemonGeneration);
+      if (!eventLive) {
+        clearEventRetry();
+        eventRetryAttempts = 0;
+        eventRetryRequested = true;
+        retireSubscription();
+        if (pendingSubscriptionId === null) connectEvents(generation, daemonGeneration);
+      }
+      return;
+    }
+
+    const previousSelection = selectedWorkspaceName;
+    const previousReason = selectedReason;
+    clearRequestRetry();
+    clearEventRetry();
+    retireRequest();
+    retireSubscription(true);
+    generation += 1;
+    daemon = nextIdentity;
+    daemonGeneration = nextIdentity ? daemonKey(nextIdentity) : `unavailable:${generation}`;
+    requestRetryAttempts = 0;
+    eventRetryAttempts = 0;
+    eventRetryRequested = false;
+    if (previousSelection !== null) {
+      pendingSelection = {
+        source: previousReason === "startup" ? "startup" : "persisted",
+        workspaceName: previousSelection,
+      };
+      selectedWorkspaceName = null;
+      selectedReason = null;
+      suppressAutomaticSelection = true;
+    }
+
+    if (next.status !== "connected") {
+      emit({
+        status: "degraded",
+        generation,
+        daemon: null,
+        snapshot: null,
+        code: next.status === "degraded" ? "daemon-degraded" : "daemon-unavailable",
+        reason: next.reason,
+      });
+      return;
+    }
+
+    emit({ status: "loading", generation, daemon, snapshot: null });
+    const expectedGeneration = generation;
+    const expectedDaemonGeneration = daemonGeneration;
+    fetchCatalog(expectedGeneration, expectedDaemonGeneration);
+    connectEvents(expectedGeneration, expectedDaemonGeneration);
+  };
+
+  const store: DesktopWorkspaceCatalogStore = {
+    getState: () => state,
+    subscribe(listener) {
+      if (disposed) {
+        notify(listener, state);
+        return () => undefined;
+      }
+      listeners.add(listener);
+      notify(listener, state);
+      return () => listeners.delete(listener);
+    },
+    select(value) {
+      if (disposed) return false;
+      const workspaceName = exactWorkspaceName(value);
+      const snapshot = snapshotFromState(state);
+      if (
+        workspaceName === null ||
+        snapshot === null ||
+        !snapshot.workspaces.some((workspace) => workspace.workspaceName === workspaceName)
+      ) {
+        return false;
+      }
+      selectedWorkspaceName = workspaceName;
+      selectedReason = "explicit";
+      pendingSelection = null;
+      suppressAutomaticSelection = false;
+      updateSelectionSnapshot();
+      return true;
+    },
+    clearSelection() {
+      if (disposed) return;
+      selectedWorkspaceName = null;
+      selectedReason = null;
+      pendingSelection = null;
+      suppressAutomaticSelection = true;
+      unselectedReason = "explicit-selection-cleared";
+      updateSelectionSnapshot();
+    },
+    refresh() {
+      if (disposed || daemon === null) return;
+      clearRequestRetry();
+      requestRetryAttempts = 0;
+      fetchCatalog(generation, daemonGeneration);
+      if (!eventLive) {
+        clearEventRetry();
+        eventRetryAttempts = 0;
+        eventRetryRequested = true;
+        retireSubscription();
+        if (pendingSubscriptionId === null) connectEvents(generation, daemonGeneration);
+      }
+    },
+    setDaemon(nextDaemon) {
+      if (disposed) return;
+      startDaemon(nextDaemon);
+    },
+    dispose() {
+      if (disposed) return;
+      const retiredListeners = [...listeners];
+      disposed = true;
+      generation += 1;
+      daemon = null;
+      daemonGeneration = `disposed:${generation}`;
+      clearRequestRetry();
+      clearEventRetry();
+      retireRequest();
+      eventRetryRequested = false;
+      retireSubscription(true);
+      state = { status: "disposed", generation, daemon: null, snapshot: null };
+      listeners.clear();
+      for (const listener of retiredListeners) notify(listener, state);
+    },
+  };
+
+  startDaemon(options.daemon);
+  return store;
+}
+
+/** Solid lifecycle adapter; the catalog/selection policy remains framework-independent. */
+export function createSolidDesktopWorkspaceCatalogStore(
+  options: DesktopWorkspaceCatalogStoreOptions,
+): SolidDesktopWorkspaceCatalogStore {
+  const store = createDesktopWorkspaceCatalogStore(options);
+  const [state, setState] = createSignal(store.getState(), { equals: false });
+  const unsubscribe = store.subscribe(setState);
+  let disposed = false;
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    unsubscribe();
+    store.dispose();
+  };
+  onCleanup(dispose);
+  return {
+    state,
+    select: (workspaceName) => store.select(workspaceName),
+    clearSelection: () => store.clearSelection(),
+    refresh: () => store.refresh(),
+    setDaemon: (daemon) => store.setDaemon(daemon),
+    dispose,
+  };
+}

--- a/apps/electron-shell/src/daemon-resource-broker.test.ts
+++ b/apps/electron-shell/src/daemon-resource-broker.test.ts
@@ -75,11 +75,46 @@ class FakeSocket implements BrokerEventSocket {
 
   emit(type: FakeSocketEvent, data?: unknown): void {
     if (type === "open") this.readyState = 1;
+    if (type === "close") this.readyState = 3;
     for (const listener of this.#listeners.get(type) ?? []) listener({ data });
   }
 }
 
 describe("Electron main daemon resource broker", () => {
+  it("keeps one physical socket for an empty catalog-only subscription", async () => {
+    const socket = new FakeSocket();
+    const events: DesktopDaemonEvent[] = [];
+    const broker = new DaemonResourceBroker({
+      daemon: CONNECTED,
+      fetch: async () => json(WORKSPACE_CATALOG),
+      createWebSocket: () => socket,
+    });
+    const result = await broker.subscribe([], (event) => events.push(event));
+    expect(result.status).toBe("subscribed");
+    socket.emit("open");
+    socket.emit("message", JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }));
+    expect(socket.sent).toEqual([]);
+    expect(events).toEqual([{ type: "connection.changed", state: "live", error: null }]);
+
+    socket.emit(
+      "message",
+      JSON.stringify({
+        type: "workspace.added",
+        workspace: {
+          name: "new-workspace",
+          sessionName: "private-route",
+          projectDir: "/private/project",
+          ideConfigPath: null,
+          addedAt: "2026-07-21T00:00:00.000Z",
+        },
+      }),
+    );
+    expect(events.at(-1)).toEqual({ type: "workspaces.changed" });
+    expect(JSON.stringify(events)).not.toMatch(/private-route|private\/project|sessionName/iu);
+    if (result.status === "subscribed") result.unsubscribe();
+    expect(socket.close).toHaveBeenCalledWith(1000, "renderer released");
+  });
+
   it("resolves a semantic workspace through the typed catalog and exposes no daemon route facts", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -449,6 +484,79 @@ describe("Electron main daemon resource broker", () => {
     },
   );
 
+  it.each(["success", "failure"] as const)(
+    "drops a released renderer's rejected-update refresh %s before a replacement renderer",
+    async (settlement) => {
+      let resolveOldRefresh!: (response: Response) => void;
+      let rejectOldRefresh!: (error: unknown) => void;
+      const oldRefresh = new Promise<Response>((resolve, reject) => {
+        resolveOldRefresh = resolve;
+        rejectOldRefresh = reject;
+      });
+      let fetchCalls = 0;
+      const fetch = vi.fn(() => {
+        fetchCalls += 1;
+        return fetchCalls === 2 ? oldRefresh : Promise.resolve(json(WORKSPACE_CATALOG));
+      });
+      const originalSocket = new FakeSocket();
+      const replacementSocket = new FakeSocket();
+      const sockets = [originalSocket, replacementSocket];
+      const createWebSocket = vi.fn(() => sockets.shift()!);
+      const originalEvents: DesktopDaemonEvent[] = [];
+      const replacementEvents: DesktopDaemonEvent[] = [];
+      const broker = new DaemonResourceBroker({
+        daemon: CONNECTED,
+        fetch,
+        createWebSocket,
+      });
+
+      expect((await broker.subscribe(["docs"], (event) => originalEvents.push(event))).status).toBe(
+        "subscribed",
+      );
+      originalSocket.emit("open");
+      originalSocket.emit(
+        "message",
+        JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }),
+      );
+      originalSocket.emit(
+        "message",
+        JSON.stringify({
+          type: "workspace.added",
+          workspace: {
+            name: " docs ",
+            sessionName: "old-private-route",
+            projectDir: "/old/private/project",
+            ideConfigPath: null,
+            addedAt: "2026-07-21T00:00:00.000Z",
+          },
+        }),
+      );
+      expect(fetch).toHaveBeenCalledTimes(2);
+
+      broker.releaseRenderer();
+      expect(
+        (await broker.subscribe(["docs"], (event) => replacementEvents.push(event))).status,
+      ).toBe("subscribed");
+      replacementSocket.emit("open");
+      replacementSocket.emit(
+        "message",
+        JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }),
+      );
+      replacementEvents.length = 0;
+
+      if (settlement === "success") resolveOldRefresh(json(WORKSPACE_CATALOG));
+      else rejectOldRefresh(new Error("private released-renderer failure"));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(replacementEvents).toEqual([]);
+      expect(createWebSocket).toHaveBeenCalledTimes(2);
+      expect(JSON.stringify(replacementEvents)).not.toMatch(/disposed|degraded|private/iu);
+      broker.dispose();
+    },
+  );
+
   it.each([false, true])(
     "bounds the event handshake when socket open=%s and clears it on release",
     async (opened) => {
@@ -506,33 +614,191 @@ describe("Electron main daemon resource broker", () => {
     expect(events.at(-1)).toMatchObject({ error: { code: "event-unavailable" } });
   });
 
+  it("recovers a retained logical subscriber over one physical socket at a time", async () => {
+    vi.useFakeTimers();
+    try {
+      const sockets = [new FakeSocket(), new FakeSocket(), new FakeSocket()];
+      const createWebSocket = vi.fn(() => sockets[createWebSocket.mock.calls.length - 1]!);
+      const events: DesktopDaemonEvent[] = [];
+      const broker = new DaemonResourceBroker({
+        daemon: CONNECTED,
+        fetch: async () => json(WORKSPACE_CATALOG),
+        createWebSocket,
+        eventReconnectInitialDelayMs: 10,
+        eventReconnectMaximumDelayMs: 10,
+        eventReconnectMaximumAttempts: 2,
+      });
+      const result = await broker.subscribe([], (event) => events.push(event));
+      expect(result.status).toBe("subscribed");
+      expect(createWebSocket).toHaveBeenCalledOnce();
+
+      sockets[0]!.emit("close");
+      await vi.advanceTimersByTimeAsync(9);
+      expect(createWebSocket).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(createWebSocket).toHaveBeenCalledTimes(2);
+      sockets[0]!.emit("close");
+      expect(createWebSocket).toHaveBeenCalledTimes(2);
+
+      sockets[1]!.emit("open");
+      sockets[1]!.emit(
+        "message",
+        JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }),
+      );
+      expect(events.at(-1)).toEqual({ type: "connection.changed", state: "live", error: null });
+      sockets[1]!.emit("close");
+      await vi.advanceTimersByTimeAsync(10);
+      expect(createWebSocket).toHaveBeenCalledTimes(3);
+      if (result.status === "subscribed") result.unsubscribe();
+      expect(sockets[2]!.close).toHaveBeenCalledWith(1000, "renderer released");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("derives the default reconnect maximum from a larger initial delay override", async () => {
+    vi.useFakeTimers();
+    try {
+      const first = new FakeSocket();
+      const second = new FakeSocket();
+      const sockets = [first, second];
+      const createWebSocket = vi.fn(() => sockets.shift()!);
+      const broker = new DaemonResourceBroker({
+        daemon: CONNECTED,
+        fetch: async () => json(WORKSPACE_CATALOG),
+        createWebSocket,
+        eventReconnectInitialDelayMs: 5_000,
+        eventReconnectMaximumAttempts: 1,
+      });
+      const result = await broker.subscribe([], vi.fn());
+      first.emit("close");
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(createWebSocket).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(createWebSocket).toHaveBeenCalledTimes(2);
+      if (result.status === "subscribed") result.unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds physical reconnect attempts while logical subscribers remain", async () => {
+    vi.useFakeTimers();
+    try {
+      const sockets: FakeSocket[] = [];
+      const createWebSocket = vi.fn(() => {
+        const socket = new FakeSocket();
+        sockets.push(socket);
+        return socket;
+      });
+      const broker = new DaemonResourceBroker({
+        daemon: CONNECTED,
+        fetch: async () => json(WORKSPACE_CATALOG),
+        createWebSocket,
+        eventReconnectInitialDelayMs: 10,
+        eventReconnectMaximumDelayMs: 10,
+        eventReconnectMaximumAttempts: 2,
+      });
+      const result = await broker.subscribe([], vi.fn());
+      sockets[0]!.emit("close");
+      await vi.advanceTimersByTimeAsync(10);
+      sockets[1]!.emit("close");
+      await vi.advanceTimersByTimeAsync(10);
+      sockets[2]!.emit("close");
+      await vi.advanceTimersByTimeAsync(100);
+      expect(createWebSocket).toHaveBeenCalledTimes(3);
+      if (result.status === "subscribed") result.unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    {
+      label: "protocol error",
+      frame: {
+        type: "protocol.error",
+        code: "invalid-frame",
+        message: "Client frame does not match the daemon event protocol.",
+      },
+      close: [1002, "daemon protocol error"] as const,
+    },
+    {
+      label: "malformed frame",
+      frame: { type: "not-a-frame", private: "/must/not/leak" },
+      close: [1002, "invalid event frame"] as const,
+    },
+  ])("recovers its physical socket after a $label", async ({ frame, close }) => {
+    vi.useFakeTimers();
+    try {
+      const first = new FakeSocket();
+      const second = new FakeSocket();
+      const sockets = [first, second];
+      const createWebSocket = vi.fn(() => sockets.shift()!);
+      const events: DesktopDaemonEvent[] = [];
+      const broker = new DaemonResourceBroker({
+        daemon: CONNECTED,
+        fetch: async () => json(WORKSPACE_CATALOG),
+        createWebSocket,
+        eventReconnectInitialDelayMs: 10,
+        eventReconnectMaximumDelayMs: 10,
+        eventReconnectMaximumAttempts: 1,
+      });
+      const result = await broker.subscribe([], (event) => events.push(event));
+      first.emit("open");
+      first.emit("message", JSON.stringify({ type: "hello", daemon: IDENTITY, sessions: [] }));
+      first.emit("message", JSON.stringify(frame));
+      expect(first.close).toHaveBeenCalledWith(...close);
+      expect(events.at(-1)).toMatchObject({ type: "connection.changed", state: "degraded" });
+      expect(JSON.stringify(events)).not.toMatch(/must\/not\/leak|private/iu);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(createWebSocket).toHaveBeenCalledTimes(2);
+      if (result.status === "subscribed") result.unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects an event peer mismatch and never sends the subscription", async () => {
-    const socket = new FakeSocket();
-    const events: DesktopDaemonEvent[] = [];
-    const broker = new DaemonResourceBroker({
-      daemon: CONNECTED,
-      fetch: async () => json(WORKSPACE_CATALOG),
-      createWebSocket: () => socket,
-    });
-    expect((await broker.subscribe(["docs"], (event) => events.push(event))).status).toBe(
-      "subscribed",
-    );
-    socket.emit("open");
-    socket.emit(
-      "message",
-      JSON.stringify({
-        type: "hello",
-        daemon: { ...IDENTITY, instanceId: "66ab67ed-18fe-431b-913b-70972b78c96f" },
-        sessions: [],
-      }),
-    );
-    expect(socket.sent).toEqual([]);
-    expect(socket.close).toHaveBeenCalledWith(1008, "daemon generation mismatch");
-    expect(events.at(-1)).toMatchObject({
-      type: "connection.changed",
-      state: "degraded",
-      error: { code: "daemon-identity-mismatch" },
-    });
+    vi.useFakeTimers();
+    try {
+      const first = new FakeSocket();
+      const second = new FakeSocket();
+      const sockets = [first, second];
+      const createWebSocket = vi.fn(() => sockets.shift()!);
+      const events: DesktopDaemonEvent[] = [];
+      const broker = new DaemonResourceBroker({
+        daemon: CONNECTED,
+        fetch: async () => json(WORKSPACE_CATALOG),
+        createWebSocket,
+        eventReconnectInitialDelayMs: 10,
+        eventReconnectMaximumDelayMs: 10,
+        eventReconnectMaximumAttempts: 1,
+      });
+      const result = await broker.subscribe(["docs"], (event) => events.push(event));
+      expect(result.status).toBe("subscribed");
+      first.emit("open");
+      first.emit(
+        "message",
+        JSON.stringify({
+          type: "hello",
+          daemon: { ...IDENTITY, instanceId: "66ab67ed-18fe-431b-913b-70972b78c96f" },
+          sessions: [],
+        }),
+      );
+      expect(first.sent).toEqual([]);
+      expect(first.close).toHaveBeenCalledWith(1008, "daemon generation mismatch");
+      expect(events.at(-1)).toMatchObject({
+        type: "connection.changed",
+        state: "degraded",
+        error: { code: "daemon-identity-mismatch" },
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      expect(createWebSocket).toHaveBeenCalledTimes(2);
+      if (result.status === "subscribed") result.unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects event data that arrives before the socket open boundary", async () => {

--- a/apps/electron-shell/src/daemon-resource-broker.ts
+++ b/apps/electron-shell/src/daemon-resource-broker.ts
@@ -24,6 +24,9 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 3_000;
 const DEFAULT_MAX_RESPONSE_BYTES = 1024 * 1024;
 const DEFAULT_MAX_EVENT_BYTES = 512 * 1024;
 const DEFAULT_EVENT_HANDSHAKE_TIMEOUT_MS = 3_000;
+const DEFAULT_EVENT_RECONNECT_INITIAL_DELAY_MS = 250;
+const DEFAULT_EVENT_RECONNECT_MAXIMUM_DELAY_MS = 4_000;
+const DEFAULT_EVENT_RECONNECT_MAXIMUM_ATTEMPTS = 4;
 const WS_CONNECTING = 0;
 const WS_OPEN = 1;
 
@@ -62,6 +65,9 @@ export interface DaemonResourceBrokerDependencies {
   readonly maxResponseBytes?: number;
   readonly maxEventBytes?: number;
   readonly eventHandshakeTimeoutMs?: number;
+  readonly eventReconnectInitialDelayMs?: number;
+  readonly eventReconnectMaximumDelayMs?: number;
+  readonly eventReconnectMaximumAttempts?: number;
 }
 
 export type BrokerSubscriptionResult =
@@ -208,6 +214,9 @@ export class DaemonResourceBroker {
   readonly #maxResponseBytes: number;
   readonly #maxEventBytes: number;
   readonly #eventHandshakeTimeoutMs: number;
+  readonly #eventReconnectInitialDelayMs: number;
+  readonly #eventReconnectMaximumDelayMs: number;
+  readonly #eventReconnectMaximumAttempts: number;
   readonly #controllers = new Set<AbortController>();
   readonly #subscriptions = new Map<number, BrokerSubscription>();
 
@@ -220,6 +229,8 @@ export class DaemonResourceBroker {
   #socketPeerVerified = false;
   #socketOpened = false;
   #socketHandshakeTimer: ReturnType<typeof setTimeout> | null = null;
+  #socketReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  #socketReconnectAttempts = 0;
 
   constructor(dependencies: DaemonResourceBrokerDependencies) {
     this.#daemon = DesktopDaemonHostStateSchemaZ.parse(dependencies.daemon);
@@ -248,6 +259,24 @@ export class DaemonResourceBroker {
       DEFAULT_EVENT_HANDSHAKE_TIMEOUT_MS,
       1,
       30_000,
+    );
+    this.#eventReconnectInitialDelayMs = boundedInteger(
+      dependencies.eventReconnectInitialDelayMs,
+      DEFAULT_EVENT_RECONNECT_INITIAL_DELAY_MS,
+      1,
+      60_000,
+    );
+    this.#eventReconnectMaximumDelayMs = boundedInteger(
+      dependencies.eventReconnectMaximumDelayMs,
+      Math.max(DEFAULT_EVENT_RECONNECT_MAXIMUM_DELAY_MS, this.#eventReconnectInitialDelayMs),
+      this.#eventReconnectInitialDelayMs,
+      60_000,
+    );
+    this.#eventReconnectMaximumAttempts = boundedInteger(
+      dependencies.eventReconnectMaximumAttempts,
+      DEFAULT_EVENT_RECONNECT_MAXIMUM_ATTEMPTS,
+      0,
+      10,
     );
   }
 
@@ -319,6 +348,7 @@ export class DaemonResourceBroker {
         this.#synchronizeSocket();
       } catch {
         this.#subscriptions.delete(id);
+        this.#scheduleSocketReconnect();
         return { status: "error", error: daemonCapabilityError("event-unavailable") };
       }
       if (this.#socket?.readyState === WS_OPEN && this.#socketPeerVerified) {
@@ -335,7 +365,11 @@ export class DaemonResourceBroker {
           if (!active) return;
           active = false;
           this.#subscriptions.delete(id);
-          this.#synchronizeSocket();
+          try {
+            this.#synchronizeSocket();
+          } catch {
+            this.#scheduleSocketReconnect();
+          }
         },
       };
     } catch (error) {
@@ -349,6 +383,7 @@ export class DaemonResourceBroker {
     for (const controller of this.#controllers) controller.abort();
     this.#controllers.clear();
     this.#subscriptions.clear();
+    this.#clearSocketReconnect(true);
     this.#closeSocket();
   }
 
@@ -479,12 +514,14 @@ export class DaemonResourceBroker {
 
   #synchronizeSocket(): void {
     const required = this.#requiredSessions();
-    if (required.size === 0) {
+    if (this.#subscriptions.size === 0) {
+      this.#clearSocketReconnect(true);
       this.#closeSocket();
       return;
     }
     if (!this.#socket) {
       if (this.#daemon.status !== "connected") return;
+      this.#clearSocketReconnect(false);
       const url = new URL("/ws/events", this.#daemon.descriptor.apiBaseUrl);
       url.protocol = "ws:";
       const socket = this.#createWebSocket(url.toString());
@@ -516,7 +553,7 @@ export class DaemonResourceBroker {
         state: "degraded",
         error: daemonCapabilityError("invalid-response"),
       });
-      this.#closeSocket(1002, "event frame before open");
+      this.#closeSocket(1002, "event frame before open", true);
       return;
     }
     if (
@@ -528,7 +565,7 @@ export class DaemonResourceBroker {
         state: "degraded",
         error: daemonCapabilityError("invalid-response"),
       });
-      this.#closeSocket(1009, "invalid event frame");
+      this.#closeSocket(1009, "invalid event frame", true);
       return;
     }
     let raw: unknown;
@@ -540,7 +577,7 @@ export class DaemonResourceBroker {
         state: "degraded",
         error: daemonCapabilityError("invalid-response"),
       });
-      this.#closeSocket(1002, "invalid event frame");
+      this.#closeSocket(1002, "invalid event frame", true);
       return;
     }
     const parsed = DaemonEventServerFrameSchemaZ.safeParse(raw);
@@ -550,7 +587,7 @@ export class DaemonResourceBroker {
         state: "degraded",
         error: daemonCapabilityError("invalid-response"),
       });
-      this.#closeSocket(1002, "invalid event frame");
+      this.#closeSocket(1002, "invalid event frame", true);
       return;
     }
     if (!this.#socketPeerVerified) {
@@ -564,11 +601,12 @@ export class DaemonResourceBroker {
           state: "degraded",
           error: daemonCapabilityError("daemon-identity-mismatch"),
         });
-        this.#closeSocket(1008, "daemon generation mismatch");
+        this.#closeSocket(1008, "daemon generation mismatch", true);
         return;
       }
       this.#socketPeerVerified = true;
       this.#clearSocketHandshakeTimer();
+      this.#clearSocketReconnect(true);
       this.#sendSubscriptionDelta(this.#requiredSessions());
       this.#emit({ type: "connection.changed", state: "live", error: null });
       return;
@@ -579,7 +617,7 @@ export class DaemonResourceBroker {
         state: "degraded",
         error: daemonCapabilityError("invalid-response"),
       });
-      this.#closeSocket(1002, "duplicate hello frame");
+      this.#closeSocket(1002, "duplicate hello frame", true);
       return;
     }
     this.#projectServerFrame(parsed.data);
@@ -643,6 +681,7 @@ export class DaemonResourceBroker {
           state: "degraded",
           error: daemonCapabilityError("protocol-error"),
         });
+        this.#closeSocket(1002, "daemon protocol error", true);
         return;
       default:
         // init output and protocol keepalives are not renderer resources.
@@ -714,6 +753,7 @@ export class DaemonResourceBroker {
       state: "degraded",
       error: daemonCapabilityError("event-unavailable"),
     });
+    this.#scheduleSocketReconnect();
   }
 
   #socketErrored(socket: BrokerEventSocket): void {
@@ -723,7 +763,7 @@ export class DaemonResourceBroker {
       state: "degraded",
       error: daemonCapabilityError("event-unavailable"),
     });
-    this.#closeSocket(1011, "event connection failed");
+    this.#closeSocket(1011, "event connection failed", true);
   }
 
   #startSocketHandshakeTimer(socket: BrokerEventSocket): void {
@@ -735,7 +775,7 @@ export class DaemonResourceBroker {
         state: "degraded",
         error: daemonCapabilityError("event-unavailable"),
       });
-      this.#closeSocket(1008, "event handshake timeout");
+      this.#closeSocket(1008, "event handshake timeout", true);
     }, this.#eventHandshakeTimeoutMs);
     this.#socketHandshakeTimer.unref?.();
   }
@@ -746,26 +786,65 @@ export class DaemonResourceBroker {
     this.#socketHandshakeTimer = null;
   }
 
+  #scheduleSocketReconnect(): void {
+    if (
+      this.#disposed ||
+      this.#subscriptions.size === 0 ||
+      this.#socket !== null ||
+      this.#socketReconnectTimer !== null ||
+      this.#socketReconnectAttempts >= this.#eventReconnectMaximumAttempts
+    ) {
+      return;
+    }
+    const delay = Math.min(
+      this.#eventReconnectMaximumDelayMs,
+      this.#eventReconnectInitialDelayMs * 2 ** this.#socketReconnectAttempts,
+    );
+    this.#socketReconnectAttempts += 1;
+    this.#socketReconnectTimer = setTimeout(() => {
+      this.#socketReconnectTimer = null;
+      if (this.#disposed || this.#subscriptions.size === 0 || this.#socket !== null) return;
+      try {
+        this.#synchronizeSocket();
+      } catch {
+        this.#emit({
+          type: "connection.changed",
+          state: "degraded",
+          error: daemonCapabilityError("event-unavailable"),
+        });
+        this.#scheduleSocketReconnect();
+      }
+    }, delay);
+    this.#socketReconnectTimer.unref?.();
+  }
+
+  #clearSocketReconnect(resetAttempts: boolean): void {
+    if (this.#socketReconnectTimer) clearTimeout(this.#socketReconnectTimer);
+    this.#socketReconnectTimer = null;
+    if (resetAttempts) this.#socketReconnectAttempts = 0;
+  }
+
   #rejectSocketFrame(reason: string): void {
     this.#emit({
       type: "connection.changed",
       state: "degraded",
       error: daemonCapabilityError("invalid-response"),
     });
-    this.#closeSocket(1002, reason);
+    this.#closeSocket(1002, reason, true);
   }
 
   #rejectWorkspaceUpdate(reason: string): void {
     this.#rejectSocketFrame(reason);
-    void this.#refreshCatalogAfterRejectedUpdate();
+    void this.#refreshCatalogAfterRejectedUpdate(this.#rendererGeneration);
   }
 
-  async #refreshCatalogAfterRejectedUpdate(): Promise<void> {
+  async #refreshCatalogAfterRejectedUpdate(expectedRendererGeneration: number): Promise<void> {
     try {
       await this.#loadWorkspaceCatalog();
-      if (!this.#disposed) this.#synchronizeSocket();
+      if (this.#disposed || this.#rendererGeneration !== expectedRendererGeneration) return;
+      this.#synchronizeSocket();
     } catch (error) {
-      if (this.#disposed) return;
+      if (this.#disposed || this.#rendererGeneration !== expectedRendererGeneration) return;
       this.#emit({
         type: "connection.changed",
         state: "degraded",
@@ -774,7 +853,7 @@ export class DaemonResourceBroker {
     }
   }
 
-  #closeSocket(code = 1000, reason = "renderer released"): void {
+  #closeSocket(code = 1000, reason = "renderer released", reconnect = false): void {
     const socket = this.#socket;
     this.#clearSocketHandshakeTimer();
     this.#socket = null;
@@ -784,5 +863,6 @@ export class DaemonResourceBroker {
     if (socket && (socket.readyState === WS_CONNECTING || socket.readyState === WS_OPEN)) {
       socket.close(code, reason);
     }
+    if (reconnect) this.#scheduleSocketReconnect();
   }
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4386,7 +4386,11 @@ var init_desktop_host = __esm({
       z25.object({ status: z25.literal("error"), error: DesktopDaemonCapabilityErrorSchemaZ }).strict()
     ]);
     DesktopDaemonEventSubscriptionRequestSchemaZ = z25.object({
-      workspaceNames: z25.array(DesktopWorkspaceNameSchemaZ).min(1).max(64)
+      /**
+       * Empty subscribes to catalog/connection invalidations only. Non-empty
+       * subscriptions additionally receive events for the named workspaces.
+       */
+      workspaceNames: z25.array(DesktopWorkspaceNameSchemaZ).max(64)
     }).strict().superRefine(({ workspaceNames }, ctx) => {
       if (new Set(workspaceNames).size !== workspaceNames.length) {
         ctx.addIssue({ code: "custom", message: "workspace names must be unique" });

--- a/packages/contracts/src/__tests__/desktop-host.test.ts
+++ b/packages/contracts/src/__tests__/desktop-host.test.ts
@@ -130,6 +130,9 @@ describe("desktop host contract", () => {
         workspaceNames: ["product", "product"],
       }).success,
     ).toBe(false);
+    expect(DesktopDaemonEventSubscriptionRequestSchemaZ.parse({ workspaceNames: [] })).toEqual({
+      workspaceNames: [],
+    });
     expect(
       DesktopDaemonListWorkspacesResultSchemaZ.safeParse({
         status: "ok",

--- a/packages/contracts/src/desktop-host.ts
+++ b/packages/contracts/src/desktop-host.ts
@@ -171,7 +171,11 @@ export const DesktopDaemonFetchApplicationShellResultSchemaZ = z.discriminatedUn
 
 export const DesktopDaemonEventSubscriptionRequestSchemaZ = z
   .object({
-    workspaceNames: z.array(DesktopWorkspaceNameSchemaZ).min(1).max(64),
+    /**
+     * Empty subscribes to catalog/connection invalidations only. Non-empty
+     * subscriptions additionally receive events for the named workspaces.
+     */
+    workspaceNames: z.array(DesktopWorkspaceNameSchemaZ).max(64),
   })
   .strict()
   .superRefine(({ workspaceNames }, ctx) => {


### PR DESCRIPTION
Adds a generation-bound live workspace catalog and explicit 0/1/many selection policy for the Solid desktop renderer. Uses the typed Electron broker only: no renderer URL, fetch, socket, credential, path, session, or raw tmux identity. Adds bounded request/event recovery, one physical broker event socket, exact daemon stamping, stale preservation, same-generation explicit recovery, and cross-renderer teardown isolation.\n\nValidation: 75 focused tests plus contracts/renderer/Electron typechecks and lint, manual identity/subscription/generation probes, and prior full pnpm check. Independent multi-round adversarial review approved with no blocker/high/medium findings.