### PR TITLE
feat(desktop): compose the live workspace app

### DIFF
--- a/apps/desktop-renderer/src/App.test.tsx
+++ b/apps/desktop-renderer/src/App.test.tsx
@@ -2,7 +2,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "solid-js/web";
 import {
+  APPLICATION_SHELL_RESOURCE_VERSION,
+  ApplicationShellProjectionInputV1SchemaZ,
   DESKTOP_HOST_API_VERSION,
+  type ApplicationShellProjectionInputV1,
+  type DaemonInstanceIdentity,
+  type DesktopDaemonEvent,
+  type DesktopDaemonFetchApplicationShellResult,
+  type DesktopDaemonListWorkspacesResult,
+  type DesktopDaemonRefreshConnectionResult,
   type DesktopHostBootstrap,
   type DesktopThemeState,
   type DesktopWindowState,
@@ -10,22 +18,223 @@ import {
 } from "@tmux-ide/contracts";
 
 import { App } from "./App.tsx";
+import { createDefaultDomShellInput } from "./experience/dom-shell.ts";
 import styles from "./styles.css?raw";
 
 interface Deferred<T> {
   readonly promise: Promise<T>;
+  reject(error: unknown): void;
   resolve(value: T): void;
 }
 
 function deferred<T>(): Deferred<T> {
+  let rejectPromise: ((error: unknown) => void) | undefined;
   let resolvePromise: ((value: T) => void) | undefined;
-  const promise = new Promise<T>((resolve) => {
+  const promise = new Promise<T>((resolve, reject) => {
+    rejectPromise = reject;
     resolvePromise = resolve;
   });
   return {
     promise,
+    reject(error) {
+      rejectPromise?.(error);
+    },
     resolve(value) {
       resolvePromise?.(value);
+    },
+  };
+}
+
+const DAEMON_A: DaemonInstanceIdentity = {
+  protocolVersion: 1,
+  productVersion: "test-a",
+  instanceId: "00000000-0000-4000-8000-000000000001",
+  startedAt: "2026-07-22T00:00:00.000Z",
+};
+
+const DAEMON_B: DaemonInstanceIdentity = {
+  protocolVersion: 1,
+  productVersion: "test-b",
+  instanceId: "00000000-0000-4000-8000-000000000002",
+  startedAt: "2026-07-22T00:01:00.000Z",
+};
+
+const INITIAL_WINDOW: DesktopWindowState = {
+  maximized: false,
+  fullscreen: false,
+  focused: true,
+};
+
+function bootstrap(daemon: DaemonInstanceIdentity = DAEMON_A): DesktopHostBootstrap {
+  return {
+    apiVersion: DESKTOP_HOST_API_VERSION,
+    runtime: "electron",
+    platform: "linux",
+    appVersion: "test",
+    theme: { mode: "light", highContrast: false, reducedMotion: false },
+    window: INITIAL_WINDOW,
+    daemon: { status: "connected", identity: daemon },
+  };
+}
+
+function shellInput(projectName: string): ApplicationShellProjectionInputV1 {
+  const input = createDefaultDomShellInput();
+  return ApplicationShellProjectionInputV1SchemaZ.parse({
+    ...input,
+    project: { ...input.project, name: projectName, rootLabel: `${projectName} workspace` },
+    workspace: { ...input.workspace, name: projectName },
+  });
+}
+
+function withDuplicatePaneIdentity(
+  input: ApplicationShellProjectionInputV1,
+): ApplicationShellProjectionInputV1 {
+  const firstPaneId = input.workspace.sidebar.agents[0]!.paneId;
+  return {
+    ...input,
+    workspace: {
+      ...input.workspace,
+      sidebar: {
+        ...input.workspace.sidebar,
+        agents: input.workspace.sidebar.agents.map((agent, index) =>
+          index === 1 ? { ...agent, paneId: firstPaneId } : agent,
+        ),
+      },
+    },
+  };
+}
+
+function withDuplicateSidebarIdentities(
+  input: ApplicationShellProjectionInputV1,
+): ApplicationShellProjectionInputV1 {
+  const firstSessionId = input.workspace.sidebar.sessions[0]!.id;
+  const firstAgentId = input.workspace.sidebar.agents[0]!.id;
+  return {
+    ...input,
+    workspace: {
+      ...input.workspace,
+      sidebar: {
+        sessions: input.workspace.sidebar.sessions.map((session, index) =>
+          index === 1 ? { ...session, id: firstSessionId } : session,
+        ),
+        agents: input.workspace.sidebar.agents.map((agent, index) =>
+          index === 1 ? { ...agent, id: firstAgentId } : agent,
+        ),
+      },
+    },
+  };
+}
+
+interface HostSubscription {
+  readonly workspaceNames: readonly string[];
+  readonly listener: (event: DesktopDaemonEvent) => void;
+  readonly unsubscribe: ReturnType<typeof vi.fn>;
+}
+
+function createHostHarness() {
+  let activeBootstrap = bootstrap();
+  let activeDaemon = DAEMON_A;
+  let workspaceNames: string[] = [];
+  let publishTheme: ((state: DesktopThemeState) => void) | undefined;
+  let publishWindow: ((state: DesktopWindowState) => void) | undefined;
+  const subscriptions: HostSubscription[] = [];
+  const shellInputs = new Map<string, ApplicationShellProjectionInputV1>();
+
+  const stopTheme = vi.fn();
+  const stopWindow = vi.fn();
+  const host: HostCapabilities = {
+    apiVersion: DESKTOP_HOST_API_VERSION,
+    bootstrap: vi.fn(async () => activeBootstrap),
+    lifecycle: { requestQuit: async () => undefined },
+    window: {
+      getState: async () => INITIAL_WINDOW,
+      minimize: async () => INITIAL_WINDOW,
+      toggleMaximized: async () => INITIAL_WINDOW,
+      close: async () => undefined,
+      onStateChanged(listener) {
+        publishWindow = listener;
+        return stopWindow;
+      },
+    },
+    menu: { showApplicationMenu: async () => ({ status: "unavailable" }) },
+    dialog: { selectProjectDirectory: vi.fn(async () => null) },
+    theme: {
+      getState: async () => ({ mode: "light", highContrast: false, reducedMotion: false }),
+      onChanged(listener) {
+        publishTheme = listener;
+        return stopTheme;
+      },
+    },
+    daemon: {
+      refreshConnection: vi.fn(
+        async (): Promise<DesktopDaemonRefreshConnectionResult> => ({
+          outcome: "unchanged",
+          daemon: { status: "connected", identity: activeDaemon },
+        }),
+      ),
+      listWorkspaces: vi.fn(
+        async (): Promise<DesktopDaemonListWorkspacesResult> => ({
+          status: "ok",
+          daemon: activeDaemon,
+          workspaces: workspaceNames.map((workspaceName) => ({ workspaceName })),
+        }),
+      ),
+      fetchApplicationShell: vi.fn(async ({ workspaceName }) => ({
+        status: "ok" as const,
+        envelope: {
+          version: APPLICATION_SHELL_RESOURCE_VERSION,
+          daemon: activeDaemon,
+          resource: shellInputs.get(workspaceName) ?? shellInput(workspaceName),
+        },
+      })),
+      subscribe: vi.fn(async (request, listener) => {
+        const subscription: HostSubscription = {
+          workspaceNames: [...request.workspaceNames],
+          listener,
+          unsubscribe: vi.fn(),
+        };
+        subscriptions.push(subscription);
+        return {
+          status: "subscribed" as const,
+          unsubscribe: subscription.unsubscribe as () => void,
+        };
+      }),
+    },
+  };
+
+  return {
+    host,
+    subscriptions,
+    stopTheme,
+    stopWindow,
+    setBootstrap(next: DesktopHostBootstrap) {
+      activeBootstrap = next;
+      if (next.daemon.status === "connected") activeDaemon = next.daemon.identity;
+    },
+    setDaemon(next: DaemonInstanceIdentity) {
+      activeDaemon = next;
+    },
+    setWorkspaces(...names: string[]) {
+      workspaceNames = names;
+    },
+    setShell(name: string, input: ApplicationShellProjectionInputV1) {
+      shellInputs.set(name, input);
+    },
+    emit(workspaceNames: readonly string[], event: DesktopDaemonEvent) {
+      for (const subscription of subscriptions) {
+        if (
+          subscription.workspaceNames.length === workspaceNames.length &&
+          subscription.workspaceNames.every((name, index) => name === workspaceNames[index])
+        ) {
+          subscription.listener(event);
+        }
+      }
+    },
+    publishTheme(next: DesktopThemeState) {
+      publishTheme?.(next);
+    },
+    publishWindow(next: DesktopWindowState) {
+      publishWindow?.(next);
     },
   };
 }
@@ -46,110 +255,539 @@ function installLightMediaPreference(): void {
   );
 }
 
+function mount(app: () => ReturnType<typeof App>) {
+  const root = document.createElement("div");
+  document.body.append(root);
+  return { root, dispose: render(app, root) };
+}
+
+async function markLive(harness: ReturnType<typeof createHostHarness>, names: readonly string[]) {
+  await vi.waitFor(() => {
+    expect(
+      harness.subscriptions.some(
+        (subscription) =>
+          subscription.workspaceNames.length === names.length &&
+          subscription.workspaceNames.every((name, index) => name === names[index]),
+      ),
+    ).toBe(true);
+  });
+  harness.emit(names, { type: "connection.changed", state: "live", error: null });
+}
+
+async function mountResourceIdentityMismatch(
+  refresh: Promise<DesktopDaemonRefreshConnectionResult>,
+) {
+  const harness = createHostHarness();
+  harness.setWorkspaces("alpha");
+  harness.setShell("alpha", shellInput("Recovered workspace"));
+  const mismatched = deferred<DesktopDaemonFetchApplicationShellResult>();
+  vi.mocked(harness.host.daemon.fetchApplicationShell).mockReturnValueOnce(mismatched.promise);
+  vi.mocked(harness.host.daemon.refreshConnection).mockReturnValueOnce(refresh);
+  const mounted = mount(() => <App host={harness.host} />);
+  await markLive(harness, []);
+  await vi.waitFor(() =>
+    expect(harness.host.daemon.fetchApplicationShell).toHaveBeenCalledTimes(1),
+  );
+  mismatched.resolve({
+    status: "ok",
+    envelope: {
+      version: APPLICATION_SHELL_RESOURCE_VERSION,
+      daemon: DAEMON_B,
+      resource: shellInput("Rejected mismatched workspace"),
+    },
+  });
+  await vi.waitFor(() => expect(harness.host.daemon.refreshConnection).toHaveBeenCalledOnce());
+  return { harness, ...mounted };
+}
+
+function retryButton(root: HTMLElement): HTMLButtonElement | null {
+  return (
+    [...root.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Try again",
+    ) ?? null
+  );
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
+  delete window.tmuxIdeHost;
   document.body.replaceChildren();
 });
 
-describe("desktop App host lifecycle", () => {
-  it("paints the synchronous light seed, reacts to deferred bootstrap/events, and unsubscribes", async () => {
+describe("desktop App live composition", () => {
+  it("keeps the browser/Vite surface explicitly preview-only and performs no network work", async () => {
     installLightMediaPreference();
-    const pendingBootstrap = deferred<DesktopHostBootstrap>();
-    const stopTheme = vi.fn();
-    const stopWindow = vi.fn();
-    let publishTheme: ((state: DesktopThemeState) => void) | undefined;
-    let publishWindow: ((state: DesktopWindowState) => void) | undefined;
-    const initialWindow: DesktopWindowState = {
-      maximized: false,
-      fullscreen: false,
-      focused: true,
-    };
-    const host: HostCapabilities = {
-      apiVersion: DESKTOP_HOST_API_VERSION,
-      bootstrap: () => pendingBootstrap.promise,
-      lifecycle: { requestQuit: async () => undefined },
-      window: {
-        getState: async () => initialWindow,
-        minimize: async () => initialWindow,
-        toggleMaximized: async () => initialWindow,
-        close: async () => undefined,
-        onStateChanged(listener) {
-          publishWindow = listener;
-          return stopWindow;
-        },
-      },
-      menu: { showApplicationMenu: async () => ({ status: "unavailable" }) },
-      dialog: { selectProjectDirectory: async () => null },
-      theme: {
-        getState: async () => ({ mode: "light", highContrast: false, reducedMotion: false }),
-        onChanged(listener) {
-          publishTheme = listener;
-          return stopTheme;
-        },
-      },
-      daemon: {
-        refreshConnection: async () => ({
-          outcome: "unchanged",
-          daemon: { status: "unavailable", code: "preview-only", reason: "test boundary" },
-        }),
-        listWorkspaces: async () => ({
-          status: "error",
-          error: { code: "preview-only", reason: "test boundary" },
-        }),
-        fetchApplicationShell: async () => ({
-          status: "error",
-          error: { code: "preview-only", reason: "test boundary" },
-        }),
-        subscribe: async () => ({
-          status: "error",
-          error: { code: "preview-only", reason: "test boundary" },
-        }),
-      },
-    };
-    const root = document.createElement("div");
-    document.body.append(root);
-    const dispose = render(() => <App host={host} />, root);
-    const app = root.querySelector<HTMLElement>(".app")!;
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { root, dispose } = mount(() => <App />);
 
-    expect(app.dataset.theme).toBe("light");
-    expect(app.style.getPropertyValue("--tmux-ide-surface-canvas")).toBe("rgb(245 245 247)");
-    expect(app.dataset.increasedContrast).toBe("false");
-    expect(app.dataset.shellSource).toBe("preview");
+    expect(root.querySelector<HTMLElement>(".app")?.dataset.shellSource).toBe("preview");
     expect(root.querySelector(".titlebar__preview-badge")?.textContent).toBe("Preview data");
-    expect(root.querySelector(".status-strip")?.getAttribute("data-shell-source")).toBe("preview");
-    expect(root.querySelector(".window-controls")).toBeNull();
+    expect(root.querySelector(".shell-workbench")?.getAttribute("data-shell-source")).toBe(
+      "preview",
+    );
+    expect(root.textContent).not.toContain("Open another folder");
+    await Promise.resolve();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    dispose();
+  });
 
-    pendingBootstrap.resolve({
-      apiVersion: DESKTOP_HOST_API_VERSION,
-      runtime: "electron",
-      platform: "linux",
-      appVersion: "test",
-      theme: { mode: "light", highContrast: true, reducedMotion: false },
-      window: initialWindow,
-      daemon: { status: "unavailable", code: "preview-only", reason: "test boundary" },
-    });
+  it("hard-fails an invalid present bridge instead of falling back to preview", () => {
+    installLightMediaPreference();
+    window.tmuxIdeHost = { apiVersion: DESKTOP_HOST_API_VERSION } as HostCapabilities;
+    const { root, dispose } = mount(() => <App />);
+
+    expect(root.querySelector<HTMLElement>(".app")?.dataset.shellSource).toBe("hard-error");
+    expect(root.querySelector(".runtime-state-surface")?.getAttribute("data-state")).toBe(
+      "hard-error",
+    );
+    expect(root.querySelector('[role="alert"]')?.textContent).toContain(
+      "desktop bridge is incompatible",
+    );
+    expect(root.querySelector(".titlebar__preview-badge")).toBeNull();
+    expect(root.querySelector(".shell-workbench")).toBeNull();
+    dispose();
+  });
+
+  it("hard-fails an invalid Electron bootstrap without substituting preview data", async () => {
+    installLightMediaPreference();
+    const harness = createHostHarness();
+    vi.mocked(harness.host.bootstrap).mockResolvedValueOnce({
+      ...bootstrap(),
+      runtime: "invalid-runtime",
+    } as unknown as DesktopHostBootstrap);
+    const { root, dispose } = mount(() => <App host={harness.host} />);
+
     await vi.waitFor(() => {
-      expect(app.dataset.increasedContrast).toBe("true");
-      expect(app.dataset.reducedMotion).toBe("false");
-      expect(root.querySelector(".window-controls")).not.toBeNull();
-      expect(root.querySelector(".status-strip__connection")?.textContent).toContain(
-        "Daemon unavailable — test boundary",
+      expect(root.querySelector('[role="alert"]')?.textContent).toContain(
+        "desktop host could not be verified",
       );
     });
-    expect(styles).toMatch(
-      /\.window-controls button \{[\s\S]*?transition:\s*color var\(--tmux-ide-motion-fast\) linear,\s*background-color var\(--tmux-ide-motion-fast\) linear;/u,
+    expect(root.querySelector(".runtime-state-surface")?.getAttribute("data-state")).toBe(
+      "hard-error",
     );
+    expect(root.querySelector(".titlebar__preview-badge")).toBeNull();
+    expect(harness.host.daemon.listWorkspaces).not.toHaveBeenCalled();
+    dispose();
+  });
 
-    publishTheme?.({ mode: "dark", highContrast: false, reducedMotion: false });
-    publishWindow?.({ ...initialWindow, maximized: true });
+  it("shows pending, zero-workspace onboarding, and preserves theme/window lifecycle", async () => {
+    installLightMediaPreference();
+    const pendingBootstrap = deferred<DesktopHostBootstrap>();
+    const harness = createHostHarness();
+    vi.mocked(harness.host.bootstrap).mockReturnValueOnce(pendingBootstrap.promise);
+    const { root, dispose } = mount(() => <App host={harness.host} />);
+    const app = root.querySelector<HTMLElement>(".app")!;
+
+    expect(app.dataset.shellSource).toBe("runtime");
+    expect(root.querySelector(".runtime-state-surface")?.getAttribute("data-state")).toBe(
+      "pending",
+    );
+    expect(root.textContent).toContain("No preview data is substituted");
+
+    pendingBootstrap.resolve(bootstrap());
+    await markLive(harness, []);
     await vi.waitFor(() => {
-      expect(app.dataset.theme).toBe("dark");
-      expect(app.style.getPropertyValue("--tmux-ide-surface-canvas")).toBe("rgb(14 14 18)");
-      expect(root.querySelector('[aria-label="Restore"]')).not.toBeNull();
+      expect(root.querySelector(".runtime-state-surface")?.getAttribute("data-state")).toBe(
+        "onboarding",
+      );
+      expect(root.textContent).toContain("Start tmux-ide in a project");
+      expect(root.querySelector('[aria-label="Minimize"]')).not.toBeNull();
     });
 
+    harness.publishTheme({ mode: "dark", highContrast: true, reducedMotion: true });
+    harness.publishWindow({ ...INITIAL_WINDOW, maximized: true });
+    await vi.waitFor(() => {
+      expect(app.dataset.theme).toBe("dark");
+      expect(app.dataset.increasedContrast).toBe("true");
+      expect(app.dataset.reducedMotion).toBe("true");
+      expect(root.querySelector('[aria-label="Restore"]')).not.toBeNull();
+    });
+    expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(styles).toContain("var(--tmux-ide-motion-easing-standard)");
+    expect(root.querySelector(".runtime-action")).toBeNull();
+    expect(harness.host.dialog.selectProjectDirectory).not.toHaveBeenCalled();
+
     dispose();
-    expect(stopTheme).toHaveBeenCalledOnce();
-    expect(stopWindow).toHaveBeenCalledOnce();
+    expect(harness.stopTheme).toHaveBeenCalledOnce();
+    expect(harness.stopWindow).toHaveBeenCalledOnce();
+    expect(harness.subscriptions[0]?.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("requires explicit selection for many workspaces and renders the live semantic shell", async () => {
+    installLightMediaPreference();
+    const harness = createHostHarness();
+    harness.setWorkspaces("alpha", "beta");
+    harness.setShell("beta", shellInput("Beta project"));
+    const { root, dispose } = mount(() => <App host={harness.host} />);
+
+    await markLive(harness, []);
+    await vi.waitFor(() => {
+      expect(root.querySelector(".runtime-state-surface")?.getAttribute("data-state")).toBe(
+        "chooser",
+      );
+    });
+    expect(harness.host.daemon.fetchApplicationShell).not.toHaveBeenCalled();
+    const options = root.querySelectorAll<HTMLButtonElement>('[role="option"]');
+    expect([...options].map((option) => option.textContent)).toEqual([
+      expect.stringContaining("alpha"),
+      expect.stringContaining("beta"),
+    ]);
+    expect(root.querySelector('[role="listbox"]')).not.toBeNull();
+    expect(options[0]?.tabIndex).toBe(0);
+    expect(options[1]?.tabIndex).toBe(-1);
+    options[0]?.focus();
+    options[0]?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(document.activeElement).toBe(options[1]);
+    expect(options[0]?.tabIndex).toBe(-1);
+    expect(options[0]?.getAttribute("aria-selected")).toBe("false");
+    expect(options[1]?.tabIndex).toBe(0);
+    expect(options[1]?.getAttribute("aria-selected")).toBe("true");
+    options[1]?.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+    expect(document.activeElement).toBe(options[0]);
+    options[0]?.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    expect(document.activeElement).toBe(options[1]);
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    outside.focus();
+    expect(options[1]?.tabIndex).toBe(0);
+    options[1]?.focus();
+    expect(document.activeElement).toBe(options[1]);
+
+    options[1]?.click();
+    await markLive(harness, ["beta"]);
+    await vi.waitFor(() => {
+      expect(root.querySelector(".shell-workbench")?.getAttribute("data-shell-source")).toBe(
+        "runtime",
+      );
+      expect(root.querySelector(".titlebar__brand")?.textContent).toContain("Beta project");
+      expect(root.querySelector(".titlebar__preview-badge")).toBeNull();
+    });
+    expect(harness.host.daemon.fetchApplicationShell).toHaveBeenCalledWith({
+      workspaceName: "beta",
+    });
+    const workspaceSubscription = harness.subscriptions.find(
+      ({ workspaceNames }) => workspaceNames[0] === "beta",
+    );
+    expect(harness.host.dialog.selectProjectDirectory).not.toHaveBeenCalled();
+    dispose();
+    expect(workspaceSubscription?.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("preserves a live shell as stale and cleans it up when the selected workspace disappears", async () => {
+    installLightMediaPreference();
+    const harness = createHostHarness();
+    harness.setWorkspaces("alpha", "beta");
+    harness.setShell("alpha", shellInput("Alpha project"));
+    const { root, dispose } = mount(() => <App host={harness.host} />);
+
+    await markLive(harness, []);
+    await vi.waitFor(() => expect(root.querySelectorAll('[role="option"]')).toHaveLength(2));
+    root.querySelectorAll<HTMLButtonElement>('[role="option"]')[0]?.click();
+    await markLive(harness, ["alpha"]);
+    await vi.waitFor(() => expect(root.textContent).toContain("Alpha project"));
+
+    harness.emit(["alpha"], {
+      type: "connection.changed",
+      state: "degraded",
+      error: { code: "event-unavailable", reason: "Live events are recovering." },
+    });
+    await vi.waitFor(() => {
+      expect(root.textContent).toContain("Alpha project");
+      expect(root.querySelector(".runtime-resource-notice")?.textContent).toContain(
+        "Showing last live workspace",
+      );
+    });
+
+    harness.setWorkspaces("beta");
+    harness.emit([], { type: "workspaces.changed" });
+    await vi.waitFor(() => {
+      expect(root.querySelector(".runtime-state-surface")?.getAttribute("data-state")).toBe(
+        "chooser",
+      );
+      expect(root.textContent).not.toContain("Alpha project");
+    });
+    const remainingOption = root.querySelector<HTMLButtonElement>('[role="option"]');
+    expect(remainingOption?.textContent).toContain("beta");
+    expect(remainingOption?.tabIndex).toBe(0);
+    expect(remainingOption?.getAttribute("aria-selected")).toBe("true");
+    const alphaSubscription = harness.subscriptions.find(
+      ({ workspaceNames }) => workspaceNames[0] === "alpha",
+    );
+    expect(alphaSubscription?.unsubscribe).toHaveBeenCalledOnce();
+
+    dispose();
+    expect(
+      harness.subscriptions.find(({ workspaceNames }) => workspaceNames.length === 0)?.unsubscribe,
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("retires the old generation before accepting a replacement daemon catalog", async () => {
+    installLightMediaPreference();
+    const harness = createHostHarness();
+    const lateA = deferred<DesktopDaemonListWorkspacesResult>();
+    vi.mocked(harness.host.daemon.listWorkspaces)
+      .mockReturnValueOnce(lateA.promise)
+      .mockResolvedValueOnce({
+        status: "ok",
+        daemon: DAEMON_B,
+        workspaces: [{ workspaceName: "new-workspace" }],
+      });
+    harness.setShell("new-workspace", shellInput("New generation"));
+    vi.mocked(harness.host.daemon.refreshConnection).mockImplementationOnce(async () => {
+      harness.setDaemon(DAEMON_B);
+      return {
+        outcome: "generation-replaced",
+        previousIdentity: DAEMON_A,
+        daemon: { status: "connected", identity: DAEMON_B },
+      };
+    });
+    const { root, dispose } = mount(() => <App host={harness.host} />);
+
+    await markLive(harness, []);
+    harness.emit([], {
+      type: "connection.changed",
+      state: "degraded",
+      error: {
+        code: "daemon-identity-mismatch",
+        reason: "The daemon generation changed.",
+      },
+    });
+    await vi.waitFor(() => expect(harness.host.daemon.refreshConnection).toHaveBeenCalledOnce());
+    expect(harness.host.bootstrap).toHaveBeenCalledOnce();
+    await markLive(harness, []);
+    await markLive(harness, ["new-workspace"]);
+    await vi.waitFor(() => expect(root.textContent).toContain("New generation"));
+
+    lateA.resolve({
+      status: "ok",
+      daemon: DAEMON_A,
+      workspaces: [{ workspaceName: "old-workspace" }],
+    });
+    await Promise.resolve();
+    expect(root.textContent).not.toContain("old-workspace");
+    expect(harness.host.daemon.fetchApplicationShell).toHaveBeenCalledWith({
+      workspaceName: "new-workspace",
+    });
+    expect(harness.host.daemon.fetchApplicationShell).not.toHaveBeenCalledWith({
+      workspaceName: "old-workspace",
+    });
+    dispose();
+  });
+
+  it.each([
+    ["duplicate pane identity", withDuplicatePaneIdentity],
+    ["duplicate sidebar DOM identities", withDuplicateSidebarIdentities],
+  ])("rejects %s at the controlled semantic projection boundary", async (_label, corrupt) => {
+    installLightMediaPreference();
+    const harness = createHostHarness();
+    harness.setWorkspaces("unsafe");
+    harness.setShell("unsafe", corrupt(shellInput("Unsafe resource")));
+    const { root, dispose } = mount(() => <App host={harness.host} />);
+
+    await markLive(harness, []);
+    await markLive(harness, ["unsafe"]);
+    await vi.waitFor(() => {
+      expect(root.querySelector(".runtime-state-surface")?.getAttribute("data-state")).toBe(
+        "degraded",
+      );
+      expect(root.textContent).toContain("rejected an incoherent semantic workspace update");
+    });
+    expect(root.querySelector(".shell-workbench")).toBeNull();
+    expect(root.querySelector(".titlebar__preview-badge")).toBeNull();
+    expect(root.querySelectorAll('[id^="sidebar-agent-"]')).toHaveLength(0);
+    expect(root.querySelectorAll('[id^="sidebar-session-"]')).toHaveLength(0);
+    dispose();
+  });
+
+  it("revalidates a resource identity mismatch exactly once and retires late callbacks", async () => {
+    installLightMediaPreference();
+    const harness = createHostHarness();
+    harness.setWorkspaces("alpha");
+    harness.setShell("alpha", shellInput("Replacement generation"));
+    const mismatched = deferred<DesktopDaemonFetchApplicationShellResult>();
+    const nextRefresh = deferred<DesktopDaemonRefreshConnectionResult>();
+    vi.mocked(harness.host.daemon.fetchApplicationShell).mockReturnValueOnce(mismatched.promise);
+    vi.mocked(harness.host.daemon.refreshConnection).mockReturnValueOnce(nextRefresh.promise);
+    const { root, dispose } = mount(() => <App host={harness.host} />);
+
+    await markLive(harness, []);
+    await vi.waitFor(() =>
+      expect(harness.host.daemon.fetchApplicationShell).toHaveBeenCalledTimes(1),
+    );
+    await vi.waitFor(() =>
+      expect(
+        harness.subscriptions.filter(({ workspaceNames }) => workspaceNames[0] === "alpha"),
+      ).toHaveLength(1),
+    );
+    const retired = harness.subscriptions.find(
+      ({ workspaceNames }) => workspaceNames[0] === "alpha",
+    )!;
+    harness.setDaemon(DAEMON_B);
+    mismatched.resolve({
+      status: "ok",
+      envelope: {
+        version: APPLICATION_SHELL_RESOURCE_VERSION,
+        daemon: DAEMON_B,
+        resource: shellInput("Mismatched resource"),
+      },
+    });
+
+    await vi.waitFor(() => expect(harness.host.daemon.refreshConnection).toHaveBeenCalledOnce());
+    expect(root.textContent).toContain("Revalidating the daemon");
+    expect(
+      [...root.querySelectorAll("button")].some((button) => button.textContent === "Try again"),
+    ).toBe(false);
+    harness.emit([], {
+      type: "daemon-generation.changed",
+      previousIdentity: DAEMON_A,
+      daemon: { status: "connected", identity: DAEMON_B },
+    });
+    harness.emit(["alpha"], {
+      type: "daemon-generation.changed",
+      previousIdentity: DAEMON_A,
+      daemon: { status: "connected", identity: DAEMON_B },
+    });
+    nextRefresh.resolve({
+      outcome: "generation-replaced",
+      previousIdentity: DAEMON_A,
+      daemon: { status: "connected", identity: DAEMON_B },
+    });
+    await vi.waitFor(() =>
+      expect(
+        harness.subscriptions.filter(({ workspaceNames }) => workspaceNames.length === 0).length,
+      ).toBeGreaterThanOrEqual(2),
+    );
+    harness.emit([], { type: "connection.changed", state: "live", error: null });
+    await vi.waitFor(() =>
+      expect(
+        harness.subscriptions.filter(({ workspaceNames }) => workspaceNames[0] === "alpha").length,
+      ).toBeGreaterThanOrEqual(2),
+    );
+    harness.emit(["alpha"], { type: "connection.changed", state: "live", error: null });
+    await vi.waitFor(() => expect(root.textContent).toContain("Replacement generation"));
+    expect(retired.unsubscribe).toHaveBeenCalledOnce();
+
+    const fetchCount = vi.mocked(harness.host.daemon.fetchApplicationShell).mock.calls.length;
+    retired.listener({ type: "application-shell.changed", workspaceName: "alpha" });
+    retired.listener({
+      type: "connection.changed",
+      state: "degraded",
+      error: { code: "event-unavailable", reason: "Late old-generation callback." },
+    });
+    await Promise.resolve();
+    expect(harness.host.bootstrap).toHaveBeenCalledOnce();
+    expect(harness.host.daemon.refreshConnection).toHaveBeenCalledOnce();
+    expect(harness.host.daemon.fetchApplicationShell).toHaveBeenCalledTimes(fetchCount);
+    expect(root.textContent).toContain("Replacement generation");
+    expect(root.querySelector(".runtime-resource-notice")).toBeNull();
+    dispose();
+  });
+
+  it("leaves same-generation refresh in an honest retryable recovery state", async () => {
+    installLightMediaPreference();
+    const refresh = deferred<DesktopDaemonRefreshConnectionResult>();
+    const { harness, root, dispose } = await mountResourceIdentityMismatch(refresh.promise);
+    expect(root.textContent).toContain("Revalidating the daemon");
+    expect(retryButton(root)).toBeNull();
+
+    refresh.resolve({
+      outcome: "unchanged",
+      daemon: { status: "connected", identity: DAEMON_A },
+    });
+    await vi.waitFor(() => expect(root.textContent).toContain("daemon generation is unchanged"));
+    expect(root.textContent).not.toContain("Revalidating the daemon");
+    expect(retryButton(root)).not.toBeNull();
+    expect(harness.host.bootstrap).toHaveBeenCalledOnce();
+
+    retryButton(root)?.click();
+    await vi.waitFor(() => expect(harness.host.daemon.refreshConnection).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(root.textContent).toContain("daemon generation is unchanged"));
+    dispose();
+  });
+
+  it("retires live stores when refresh reports the daemon authority unavailable", async () => {
+    installLightMediaPreference();
+    const refresh = deferred<DesktopDaemonRefreshConnectionResult>();
+    const { harness, root, dispose } = await mountResourceIdentityMismatch(refresh.promise);
+    const oldWorkspaceSubscription = harness.subscriptions.find(
+      ({ workspaceNames }) => workspaceNames[0] === "alpha",
+    )!;
+    refresh.resolve({
+      outcome: "authority-retired",
+      previousIdentity: DAEMON_A,
+      daemon: {
+        status: "unavailable",
+        code: "process-not-running",
+        reason: "The canonical daemon is not running.",
+      },
+    });
+
+    await vi.waitFor(() => expect(root.textContent).toContain("The daemon is unavailable"));
+    expect(root.textContent).toContain("canonical daemon is not running");
+    expect(root.textContent).not.toContain("Revalidating the daemon");
+    expect(root.querySelector(".shell-workbench")).toBeNull();
+    expect(oldWorkspaceSubscription.unsubscribe).toHaveBeenCalledOnce();
+    expect(harness.host.bootstrap).toHaveBeenCalledOnce();
+    dispose();
+  });
+
+  it("coalesces concurrent recovery and handles superseded authority without getting stuck", async () => {
+    installLightMediaPreference();
+    const refresh = deferred<DesktopDaemonRefreshConnectionResult>();
+    const { harness, root, dispose } = await mountResourceIdentityMismatch(refresh.promise);
+    harness.emit([], {
+      type: "connection.changed",
+      state: "degraded",
+      error: { code: "daemon-identity-mismatch", reason: "Concurrent catalog mismatch." },
+    });
+    await Promise.resolve();
+    expect(harness.host.daemon.refreshConnection).toHaveBeenCalledOnce();
+
+    refresh.resolve({
+      outcome: "superseded",
+      daemon: { status: "connected", identity: DAEMON_A },
+    });
+    await vi.waitFor(() => expect(root.textContent).toContain("recovery was superseded"));
+    expect(root.textContent).not.toContain("Revalidating the daemon");
+    expect(retryButton(root)).not.toBeNull();
+
+    vi.mocked(harness.host.daemon.refreshConnection).mockImplementationOnce(async () => {
+      harness.setDaemon(DAEMON_B);
+      return {
+        outcome: "generation-replaced",
+        previousIdentity: DAEMON_A,
+        daemon: { status: "connected", identity: DAEMON_B },
+      };
+    });
+    retryButton(root)?.click();
+    await vi.waitFor(() => expect(harness.host.daemon.refreshConnection).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(
+        harness.subscriptions.filter(({ workspaceNames }) => workspaceNames[0] === "alpha").length,
+      ).toBeGreaterThanOrEqual(2),
+    );
+    harness.emit(["alpha"], { type: "connection.changed", state: "live", error: null });
+    await vi.waitFor(() => expect(root.textContent).toContain("Recovered workspace"));
+    expect(root.textContent).not.toContain("Revalidating the daemon");
+    expect(harness.host.bootstrap).toHaveBeenCalledOnce();
+    dispose();
+  });
+
+  it("surfaces refresh failure and allows a typed recovery retry", async () => {
+    installLightMediaPreference();
+    const refresh = deferred<DesktopDaemonRefreshConnectionResult>();
+    const { harness, root, dispose } = await mountResourceIdentityMismatch(refresh.promise);
+    refresh.reject(new Error("private host failure"));
+    await vi.waitFor(() => expect(root.textContent).toContain("Daemon verification failed"));
+    expect(root.textContent).not.toContain("private host failure");
+    expect(root.textContent).not.toContain("Revalidating the daemon");
+    expect(retryButton(root)).not.toBeNull();
+
+    retryButton(root)?.click();
+    await vi.waitFor(() => expect(harness.host.daemon.refreshConnection).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(root.textContent).toContain("daemon generation is unchanged"));
+    expect(root.textContent).not.toContain("Revalidating the daemon");
+    expect(harness.host.bootstrap).toHaveBeenCalledOnce();
+    dispose();
   });
 });

--- a/apps/desktop-renderer/src/App.tsx
+++ b/apps/desktop-renderer/src/App.tsx
@@ -1,11 +1,13 @@
-import { createMemo, createResource, createSignal, onCleanup, onMount } from "solid-js";
+import { Show, createMemo, createSignal, onCleanup, onMount } from "solid-js";
 import type {
   ApplicationShellCommandInvocation,
   ApplicationShellProjectionInputV1,
+  DesktopHostBootstrap,
   DesktopThemeState,
   DesktopWindowState,
   HostCapabilities,
 } from "@tmux-ide/contracts";
+import { DesktopDaemonRefreshConnectionResultSchemaZ } from "@tmux-ide/contracts";
 
 import {
   parseThemeState,
@@ -15,6 +17,11 @@ import {
   resolveHostCapabilities,
 } from "./host-capabilities.ts";
 import { DomApplicationShell, createDomExperience } from "./experience/index.ts";
+import {
+  DesktopConnectionSurface,
+  DesktopLiveApplication,
+  type DesktopDaemonRecoveryPhase,
+} from "./runtime/live-app-composition.tsx";
 import type {
   PaneFrameActionIntent,
   PaneFrameActivationSource,
@@ -35,19 +42,95 @@ export interface AppProps {
   readonly onPaneGrip?: (intent: PaneFrameGripIntent, source: PaneFrameActivationSource) => void;
 }
 
+function daemonCapabilityReason(value: DesktopHostBootstrap["daemon"]): string {
+  return value.status === "connected" ? "The daemon connection changed." : value.reason;
+}
+
 export function App(props: AppProps = {}) {
-  const host = props.host ?? resolveHostCapabilities();
+  const browserPreview =
+    props.host === undefined && (typeof window === "undefined" || window.tmuxIdeHost === undefined);
+  let host: HostCapabilities | null = null;
+  let hostResolutionError = false;
+  try {
+    host = resolveHostCapabilities(props.host);
+  } catch {
+    hostResolutionError = true;
+  }
   const initialTheme = props.initialTheme ?? readInitialThemeState();
-  const [bootstrap] = createResource(() => readHostBootstrap(host));
+  const [bootstrap, setBootstrap] = createSignal<DesktopHostBootstrap | null>(null);
+  const [bootstrapError, setBootstrapError] = createSignal(false);
+  const [daemonRecovery, setDaemonRecovery] = createSignal<DesktopDaemonRecoveryPhase>("idle");
   const [theme, setTheme] = createSignal<DesktopThemeState | null>(null);
   const [windowState, setWindowState] = createSignal<DesktopWindowState | null>(null);
+  let bootstrapRequest = 0;
+  let daemonRefreshFlight: Promise<void> | null = null;
+  let disposed = false;
+
+  const loadBootstrap = (): void => {
+    if (!host || disposed) return;
+    const request = ++bootstrapRequest;
+    setBootstrapError(false);
+    void readHostBootstrap(host)
+      .then((next) => {
+        if (disposed || request !== bootstrapRequest) return;
+        setBootstrap(next);
+      })
+      .catch(() => {
+        if (disposed || request !== bootstrapRequest) return;
+        setBootstrap(null);
+        setBootstrapError(true);
+      });
+  };
+
+  const refreshDaemonConnection = (): void => {
+    if (!host || disposed || !bootstrap() || daemonRefreshFlight) return;
+    setDaemonRecovery("refreshing");
+    const operation = host.daemon
+      .refreshConnection()
+      .then((rawResult) => DesktopDaemonRefreshConnectionResultSchemaZ.parse(rawResult))
+      .then((result) => {
+        if (disposed || daemonRefreshFlight !== operation) return;
+        const previousDaemon = bootstrap()?.daemon ?? null;
+        setBootstrap((current) => (current ? { ...current, daemon: result.daemon } : current));
+        const identityChanged =
+          previousDaemon?.status === "connected" &&
+          result.daemon.status === "connected" &&
+          (previousDaemon.identity.instanceId !== result.daemon.identity.instanceId ||
+            previousDaemon.identity.startedAt !== result.daemon.identity.startedAt ||
+            previousDaemon.identity.protocolVersion !== result.daemon.identity.protocolVersion ||
+            previousDaemon.identity.productVersion !== result.daemon.identity.productVersion);
+        if (
+          result.outcome === "generation-replaced" ||
+          result.outcome === "authority-retired" ||
+          result.outcome === "state-changed" ||
+          identityChanged ||
+          result.daemon.status !== "connected"
+        ) {
+          setDaemonRecovery("idle");
+          return;
+        }
+        setDaemonRecovery(result.outcome === "superseded" ? "superseded" : "unchanged");
+      })
+      .catch(() => {
+        if (!disposed && daemonRefreshFlight === operation) setDaemonRecovery("failed");
+      })
+      .finally(() => {
+        if (daemonRefreshFlight === operation) daemonRefreshFlight = null;
+      });
+    daemonRefreshFlight = operation;
+  };
 
   onMount(() => {
+    if (!host) return;
+    loadBootstrap();
     const stopTheme = host.theme.onChanged((next) => setTheme(parseThemeState(next)));
     const stopWindow = host.window.onStateChanged((next) => setWindowState(parseWindowState(next)));
     onCleanup(() => {
       stopTheme();
       stopWindow();
+      disposed = true;
+      bootstrapRequest += 1;
+      daemonRefreshFlight = null;
     });
   });
 
@@ -63,22 +146,137 @@ export function App(props: AppProps = {}) {
       data-reduced-motion={String(experience().accessibility.reducedMotion)}
       data-increased-contrast={String(experience().accessibility.increasedContrast)}
       data-accessibility-conflicts={experience().accessibility.conflicts.join(" ") || undefined}
-      data-shell-source={props.shellInput === undefined ? "preview" : "runtime"}
+      data-shell-source={
+        hostResolutionError
+          ? "hard-error"
+          : props.shellInput !== undefined
+            ? "injected"
+            : browserPreview
+              ? "preview"
+              : "runtime"
+      }
       style={experience().variables}
     >
-      <DomApplicationShell
-        host={host}
-        daemonState={bootstrap()?.daemon}
-        runtime={bootstrap()?.runtime}
-        platform={bootstrap()?.platform}
-        windowState={effectiveWindow()}
-        input={props.shellInput}
-        dataMode={props.shellInput === undefined ? "preview" : "runtime"}
-        onCommand={props.onCommand}
-        paneFrames={props.paneFrames}
-        onPaneAction={props.onPaneAction}
-        onPaneGrip={props.onPaneGrip}
-      />
+      <Show
+        when={!hostResolutionError && host}
+        fallback={
+          <DesktopConnectionSurface
+            state="hard-error"
+            eyebrow="Desktop host boundary"
+            title="The desktop bridge is incompatible"
+            description="tmux-ide stopped before loading preview or live workspace data."
+            guidance="Update the desktop host and reopen tmux-ide"
+            alert
+          />
+        }
+      >
+        {(activeHost) => (
+          <Show
+            when={props.shellInput}
+            fallback={
+              <Show
+                when={!browserPreview}
+                fallback={
+                  <DomApplicationShell
+                    host={activeHost()}
+                    daemonState={bootstrap()?.daemon}
+                    runtime={bootstrap()?.runtime}
+                    platform={bootstrap()?.platform}
+                    windowState={effectiveWindow()}
+                    dataMode="preview"
+                    onCommand={props.onCommand}
+                    paneFrames={props.paneFrames}
+                    onPaneAction={props.onPaneAction}
+                    onPaneGrip={props.onPaneGrip}
+                  />
+                }
+              >
+                <Show
+                  when={!bootstrapError()}
+                  fallback={
+                    <DesktopConnectionSurface
+                      host={activeHost()}
+                      runtime="electron"
+                      windowState={effectiveWindow()}
+                      state="hard-error"
+                      eyebrow="Desktop host boundary"
+                      title="The desktop host could not be verified"
+                      description="tmux-ide rejected the host bootstrap response."
+                      guidance="Reopen tmux-ide after updating the desktop host"
+                      alert
+                      onRetry={loadBootstrap}
+                    />
+                  }
+                >
+                  <Show
+                    when={bootstrap()}
+                    fallback={
+                      <DesktopConnectionSurface
+                        host={activeHost()}
+                        state="pending"
+                        eyebrow="Native tmux workspace"
+                        title="Connecting to tmux-ide"
+                        description="Verifying the desktop host and daemon generation."
+                        guidance="No preview data is substituted"
+                      />
+                    }
+                  >
+                    {(ready) => (
+                      <Show
+                        when={ready().daemon.status === "connected"}
+                        fallback={
+                          <DesktopConnectionSurface
+                            host={activeHost()}
+                            runtime={ready().runtime}
+                            platform={ready().platform}
+                            windowState={effectiveWindow()}
+                            state="degraded"
+                            eyebrow="Native tmux workspace"
+                            title="The daemon is unavailable"
+                            description={daemonCapabilityReason(ready().daemon)}
+                            guidance="Start tmux-ide and try again"
+                            onRetry={refreshDaemonConnection}
+                          />
+                        }
+                      >
+                        <DesktopLiveApplication
+                          host={activeHost()}
+                          daemon={ready().daemon}
+                          runtime={ready().runtime}
+                          platform={ready().platform}
+                          windowState={effectiveWindow()}
+                          daemonRecovery={daemonRecovery()}
+                          onRetryDaemonConnection={refreshDaemonConnection}
+                          onDaemonIdentityMismatch={refreshDaemonConnection}
+                          onCommand={props.onCommand}
+                          onPaneAction={props.onPaneAction}
+                          onPaneGrip={props.onPaneGrip}
+                        />
+                      </Show>
+                    )}
+                  </Show>
+                </Show>
+              </Show>
+            }
+          >
+            {(injectedInput) => (
+              <DomApplicationShell
+                host={activeHost()}
+                daemonState={bootstrap()?.daemon}
+                runtime={bootstrap()?.runtime}
+                platform={bootstrap()?.platform}
+                windowState={effectiveWindow()}
+                input={injectedInput()}
+                dataMode="runtime"
+                onCommand={props.onCommand}
+                paneFrames={props.paneFrames}
+                onPaneAction={props.onPaneAction}
+                onPaneGrip={props.onPaneGrip}
+              />
+            )}
+          </Show>
+        )}
+      </Show>
     </div>
   );
 }

--- a/apps/desktop-renderer/src/experience/application-shell.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.tsx
@@ -600,9 +600,9 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
               <span class="eyebrow">Project workspace</span>
               <h1>{shell().project.name}</h1>
               <p>{shell().project.readiness.facts.join(" ")}</p>
-              <button type="button" onClick={() => void props.host.dialog.selectProjectDirectory()}>
-                Open another folder
-              </button>
+              <small class="home-canvas__workspace-guidance">
+                Additional workspaces appear after tmux-ide is started in their project.
+              </small>
             </div>
             <section class="readiness-card" aria-labelledby="readiness-heading">
               <header>

--- a/apps/desktop-renderer/src/runtime/index.ts
+++ b/apps/desktop-renderer/src/runtime/index.ts
@@ -9,3 +9,4 @@ export type {
 export { createHostDaemonTransport } from "./host-daemon-transport.ts";
 export * from "./desktop-resource-store.ts";
 export * from "./workspace-catalog-store.ts";
+export * from "./live-app-composition.tsx";

--- a/apps/desktop-renderer/src/runtime/live-app-composition.tsx
+++ b/apps/desktop-renderer/src/runtime/live-app-composition.tsx
@@ -1,0 +1,659 @@
+import {
+  projectApplicationShellV1,
+  type ApplicationShellCommandInvocation,
+  type ApplicationShellProjectionInputV1,
+  type DaemonInstanceIdentity,
+  type DesktopDaemonCapabilityState,
+  type DesktopPlatform,
+  type DesktopWindowState,
+  type HostCapabilities,
+} from "@tmux-ide/contracts";
+import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
+
+import { paneFrameModelsFromApplicationShellAgents } from "../../../../packages/daemon/src/ui/pane-frame/model.ts";
+import type {
+  PaneFrameActionIntent,
+  PaneFrameActivationSource,
+  PaneFrameGripIntent,
+  PaneFrameModel,
+} from "../../../../packages/daemon/src/ui/pane-frame/presenter.tsx";
+import { DomApplicationShell } from "../experience/application-shell.tsx";
+import { DomIcon } from "../experience/dom-icon.tsx";
+import type { DesktopApplicationShellResourceState } from "./connection-state.ts";
+import { createSolidDesktopApplicationShellResourceStore } from "./desktop-resource-store.ts";
+import { createHostDaemonTransport } from "./host-daemon-transport.ts";
+import {
+  createSolidDesktopWorkspaceCatalogStore,
+  type DesktopWorkspaceCatalogState,
+} from "./workspace-catalog-store.ts";
+
+export type DesktopDaemonRecoveryPhase =
+  | "idle"
+  | "refreshing"
+  | "unchanged"
+  | "superseded"
+  | "failed";
+
+export interface DesktopLiveApplicationProps {
+  readonly host: HostCapabilities;
+  readonly daemon: DesktopDaemonCapabilityState;
+  readonly runtime?: string;
+  readonly platform?: DesktopPlatform;
+  readonly windowState?: DesktopWindowState | null;
+  readonly onDaemonIdentityMismatch?: () => void;
+  readonly daemonRecovery?: DesktopDaemonRecoveryPhase;
+  readonly onRetryDaemonConnection?: () => void;
+  readonly onCommand?: (invocation: ApplicationShellCommandInvocation) => void;
+  readonly onPaneAction?: (
+    intent: PaneFrameActionIntent,
+    source: PaneFrameActivationSource,
+  ) => void;
+  readonly onPaneGrip?: (intent: PaneFrameGripIntent, source: PaneFrameActivationSource) => void;
+}
+
+interface DesktopConnectionSurfaceProps {
+  readonly host?: HostCapabilities;
+  readonly runtime?: string;
+  readonly platform?: DesktopPlatform;
+  readonly windowState?: DesktopWindowState | null;
+  readonly state:
+    | "pending"
+    | "loading"
+    | "onboarding"
+    | "chooser"
+    | "degraded"
+    | "error"
+    | "hard-error";
+  readonly eyebrow: string;
+  readonly title: string;
+  readonly description: string;
+  readonly guidance: string;
+  readonly alert?: boolean;
+  readonly onRetry?: () => void;
+  readonly workspaces?: readonly string[];
+  readonly onSelectWorkspace?: (workspaceName: string) => void;
+}
+
+function WindowControls(props: {
+  readonly host?: HostCapabilities;
+  readonly runtime?: string;
+  readonly platform?: DesktopPlatform;
+  readonly windowState?: DesktopWindowState | null;
+}) {
+  return (
+    <Show when={props.host && props.runtime === "electron" && props.platform !== "darwin"}>
+      <nav class="window-controls" aria-label="Window controls">
+        <button
+          type="button"
+          aria-label="Minimize"
+          onClick={() => void props.host?.window.minimize()}
+        >
+          <DomIcon id="minimize" usage="nativeWindow" />
+        </button>
+        <button
+          type="button"
+          aria-label={props.windowState?.maximized ? "Restore" : "Maximize"}
+          onClick={() => void props.host?.window.toggleMaximized()}
+        >
+          <DomIcon
+            id={props.windowState?.maximized ? "restore" : "maximize"}
+            usage="nativeWindow"
+          />
+        </button>
+        <button type="button" aria-label="Close" onClick={() => void props.host?.window.close()}>
+          <DomIcon id="close" usage="nativeWindow" />
+        </button>
+      </nav>
+    </Show>
+  );
+}
+
+function focusWorkspaceOption(
+  container: HTMLElement,
+  current: HTMLElement,
+  direction: "previous" | "next" | "first" | "last",
+): void {
+  const options = Array.from(container.querySelectorAll<HTMLElement>('[role="option"]'));
+  if (options.length === 0) return;
+  const currentIndex = Math.max(0, options.indexOf(current));
+  const nextIndex =
+    direction === "first"
+      ? 0
+      : direction === "last"
+        ? options.length - 1
+        : direction === "next"
+          ? (currentIndex + 1) % options.length
+          : (currentIndex - 1 + options.length) % options.length;
+  options[nextIndex]?.focus();
+}
+
+/** Product-native non-workspace state. It never displays host paths or runtime ids. */
+export function DesktopConnectionSurface(props: DesktopConnectionSurfaceProps) {
+  const [activeWorkspace, setActiveWorkspace] = createSignal<string | null>(
+    props.workspaces?.[0] ?? null,
+  );
+  createEffect(() => {
+    const workspaces = props.workspaces ?? [];
+    if (workspaces.length === 0) {
+      setActiveWorkspace(null);
+      return;
+    }
+    if (!activeWorkspace() || !workspaces.includes(activeWorkspace()!)) {
+      setActiveWorkspace(workspaces[0]!);
+    }
+  });
+
+  const handleChooserKeyDown = (event: KeyboardEvent): void => {
+    if (!(event.currentTarget instanceof HTMLElement) || !(event.target instanceof HTMLElement)) {
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      focusWorkspaceOption(
+        event.currentTarget,
+        event.target,
+        event.key === "ArrowDown" ? "next" : "previous",
+      );
+      return;
+    }
+    if (event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      focusWorkspaceOption(
+        event.currentTarget,
+        event.target,
+        event.key === "Home" ? "first" : "last",
+      );
+    }
+  };
+
+  return (
+    <>
+      <header class="titlebar runtime-titlebar" data-focus-zone="application-bar">
+        <div class="titlebar__brand">
+          <DomIcon id="terminals" usage="tab" />
+          <strong>tmux-ide</strong>
+          <span>workspace</span>
+        </div>
+        <div class="titlebar__drag titlebar__spacer" />
+        <WindowControls
+          host={props.host}
+          runtime={props.runtime}
+          platform={props.platform}
+          windowState={props.windowState}
+        />
+      </header>
+
+      <main
+        class="runtime-state-surface"
+        data-state={props.state}
+        role={props.alert ? "alert" : undefined}
+        aria-live={props.alert ? "assertive" : "polite"}
+        aria-busy={props.state === "pending" || props.state === "loading"}
+      >
+        <section class="runtime-state-card" aria-labelledby="runtime-state-title">
+          <div class="runtime-state-card__signal" aria-hidden="true">
+            <i />
+            <span>{props.state}</span>
+          </div>
+          <span class="eyebrow">{props.eyebrow}</span>
+          <h1 id="runtime-state-title">{props.title}</h1>
+          <p>{props.description}</p>
+
+          <Show when={props.workspaces && props.workspaces.length > 0}>
+            <div
+              class="workspace-chooser"
+              role="listbox"
+              aria-label="Available workspaces"
+              onKeyDown={handleChooserKeyDown}
+            >
+              <For each={props.workspaces}>
+                {(workspaceName) => (
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={workspaceName === activeWorkspace()}
+                    tabIndex={workspaceName === activeWorkspace() ? 0 : -1}
+                    onFocus={() => setActiveWorkspace(workspaceName)}
+                    onClick={() => props.onSelectWorkspace?.(workspaceName)}
+                  >
+                    <span class="workspace-chooser__mark" aria-hidden="true">
+                      {workspaceName.slice(0, 2)}
+                    </span>
+                    <span>
+                      <strong>{workspaceName}</strong>
+                      <small>Live tmux workspace</small>
+                    </span>
+                    <DomIcon id="terminals" usage="action" />
+                  </button>
+                )}
+              </For>
+            </div>
+          </Show>
+
+          <Show when={props.onRetry}>
+            <div class="runtime-state-card__actions">
+              <button class="runtime-action" type="button" onClick={() => props.onRetry?.()}>
+                Try again
+              </button>
+            </div>
+          </Show>
+        </section>
+      </main>
+
+      <footer class="status-strip runtime-status-strip" role="status">
+        <span class="status-strip__connection" data-state={props.state}>
+          <i />
+          <span>{props.description}</span>
+        </span>
+        <span class="status-strip__guidance">{props.guidance}</span>
+      </footer>
+    </>
+  );
+}
+
+function catalogReason(state: DesktopWorkspaceCatalogState): string | null {
+  if (state.status === "stale" || state.status === "degraded" || state.status === "error") {
+    return state.reason;
+  }
+  return null;
+}
+
+function daemonCapabilityKey(state: DesktopDaemonCapabilityState): string {
+  if (state.status !== "connected")
+    return `${state.status}\u0000${state.code}\u0000${state.reason}`;
+  const identity = state.identity;
+  return [
+    state.status,
+    identity.protocolVersion,
+    identity.productVersion,
+    identity.instanceId,
+    identity.startedAt,
+  ].join("\u0000");
+}
+
+function ResourceNotice(props: {
+  readonly tone: "stale" | "degraded";
+  readonly label: string;
+  readonly reason: string;
+}) {
+  return (
+    <div class="runtime-resource-notice" data-tone={props.tone} role="status" aria-live="polite">
+      <i aria-hidden="true" />
+      <strong>{props.label}</strong>
+      <span>{props.reason}</span>
+    </div>
+  );
+}
+
+interface LiveWorkspaceProps extends Omit<DesktopLiveApplicationProps, "daemon"> {
+  readonly target: {
+    readonly daemon: DaemonInstanceIdentity;
+    readonly workspaceName: string;
+  };
+  readonly catalogState: DesktopWorkspaceCatalogState;
+}
+
+type LiveWorkspaceProjection =
+  | {
+      readonly status: "ready";
+      readonly input: ApplicationShellProjectionInputV1;
+      readonly paneFrames: readonly PaneFrameModel[];
+    }
+  | { readonly status: "rejected" };
+
+function assertUniqueSemanticIds(label: string, ids: readonly string[]): void {
+  if (new Set(ids).size !== ids.length) {
+    throw new Error(`Live workspace ${label} identities are incoherent.`);
+  }
+}
+
+/** Strict rendering boundary. Failures are intentionally sanitized by the caller. */
+function projectLiveWorkspace(input: ApplicationShellProjectionInputV1): LiveWorkspaceProjection {
+  try {
+    const shell = projectApplicationShellV1(input);
+    const sessionIds = shell.sidebar.sessions.map(({ id }) => id);
+    const agentIds = shell.sidebar.agents.map(({ id }) => id);
+    assertUniqueSemanticIds("session", sessionIds);
+    assertUniqueSemanticIds("agent", agentIds);
+    assertUniqueSemanticIds("sidebar resource", [...sessionIds, ...agentIds]);
+    if (!sessionIds.includes(shell.sidebar.activeSessionId)) {
+      throw new Error("Live workspace active session identity is incoherent.");
+    }
+    const paneFrames = paneFrameModelsFromApplicationShellAgents(shell);
+    return { status: "ready", input, paneFrames };
+  } catch {
+    return { status: "rejected" };
+  }
+}
+
+function resourceData(state: DesktopApplicationShellResourceState) {
+  return "data" in state ? state.data : null;
+}
+
+function resourceReason(state: DesktopApplicationShellResourceState): string {
+  return "reason" in state ? state.reason : "Reading the live semantic workspace from tmux-ide.";
+}
+
+function recoveryPresentation(phase: DesktopDaemonRecoveryPhase): {
+  readonly title: string;
+  readonly description: string;
+  readonly guidance: string;
+} {
+  if (phase === "refreshing") {
+    return {
+      title: "Revalidating the daemon",
+      description: "The desktop host is checking the canonical daemon authority.",
+      guidance: "The current workspace generation is retired",
+    };
+  }
+  if (phase === "unchanged") {
+    return {
+      title: "The daemon generation is unchanged",
+      description: "The workspace stream could not be re-established against this generation.",
+      guidance: "Restart tmux-ide or verify the daemon, then try again",
+    };
+  }
+  if (phase === "superseded") {
+    return {
+      title: "Daemon recovery was superseded",
+      description: "A newer desktop authority operation replaced this recovery attempt.",
+      guidance: "Try again to read the current daemon authority",
+    };
+  }
+  if (phase === "failed") {
+    return {
+      title: "Daemon verification failed",
+      description: "The desktop host could not complete canonical daemon verification.",
+      guidance: "Check tmux-ide, then try the verified connection again",
+    };
+  }
+  return {
+    title: "The workspace generation changed",
+    description: "The live resource no longer matches the verified daemon authority.",
+    guidance: "Start verified daemon recovery",
+  };
+}
+
+function LiveWorkspace(props: LiveWorkspaceProps) {
+  const store = createSolidDesktopApplicationShellResourceStore({
+    target: props.target,
+    transport: createHostDaemonTransport(props.host),
+  });
+  createEffect(() => store.setTarget(props.target));
+
+  const input = createMemo(() => resourceData(store.state()));
+  const projection = createMemo<LiveWorkspaceProjection | null>(() => {
+    const snapshot = input();
+    return snapshot ? projectLiveWorkspace(snapshot) : null;
+  });
+
+  let mismatchGeneration = -1;
+  createEffect(() => {
+    const state = store.state();
+    if (
+      state.status === "degraded" &&
+      state.code === "daemon-identity-mismatch" &&
+      state.generation !== mismatchGeneration
+    ) {
+      mismatchGeneration = state.generation;
+      props.onDaemonIdentityMismatch?.();
+    }
+  });
+  const notice = createMemo(() => {
+    const resource = store.state();
+    if (resource.status === "stale") {
+      return {
+        tone: "stale" as const,
+        label: "Showing last live workspace",
+        reason: resource.reason,
+      };
+    }
+    if (resource.status === "degraded" && resource.data !== null) {
+      return {
+        tone: "degraded" as const,
+        label: "Workspace connection degraded",
+        reason: resource.reason,
+      };
+    }
+    const reason = catalogReason(props.catalogState);
+    return reason
+      ? { tone: "stale" as const, label: "Workspace catalog is recovering", reason }
+      : null;
+  });
+
+  const renderFallback = () => {
+    const projected = projection();
+    if (projected?.status === "rejected") {
+      return (
+        <DesktopConnectionSurface
+          host={props.host}
+          runtime={props.runtime}
+          platform={props.platform}
+          windowState={props.windowState}
+          state="degraded"
+          eyebrow="Native tmux workspace"
+          title="Workspace data could not be displayed"
+          description="tmux-ide rejected an incoherent semantic workspace update."
+          guidance="No preview or partial workspace data is shown"
+          onRetry={() => store.refresh()}
+        />
+      );
+    }
+    const resource = store.state();
+    const identityMismatch =
+      resource.status === "degraded" && resource.code === "daemon-identity-mismatch";
+    const recovery = recoveryPresentation(props.daemonRecovery ?? "idle");
+    return (
+      <DesktopConnectionSurface
+        host={props.host}
+        runtime={props.runtime}
+        platform={props.platform}
+        windowState={props.windowState}
+        state={
+          resource.status === "loading"
+            ? "loading"
+            : resource.status === "error"
+              ? "error"
+              : "degraded"
+        }
+        eyebrow="Native tmux workspace"
+        title={
+          resource.status === "loading"
+            ? "Loading the workspace"
+            : identityMismatch
+              ? recovery.title
+              : "The workspace is unavailable"
+        }
+        description={identityMismatch ? recovery.description : resourceReason(resource)}
+        guidance={identityMismatch ? recovery.guidance : "tmux remains the source of truth"}
+        alert={resource.status === "error"}
+        onRetry={
+          identityMismatch
+            ? props.daemonRecovery === "refreshing"
+              ? undefined
+              : props.onRetryDaemonConnection
+            : () => store.refresh()
+        }
+      />
+    );
+  };
+
+  const readyProjection = createMemo(() => {
+    const projected = projection();
+    return projected?.status === "ready" ? projected : null;
+  });
+
+  return (
+    <Show when={readyProjection()} fallback={renderFallback()}>
+      {(ready) => (
+        <>
+          <DomApplicationShell
+            host={props.host}
+            daemonState={{ status: "connected", identity: props.target.daemon }}
+            runtime={props.runtime}
+            platform={props.platform}
+            windowState={props.windowState}
+            input={ready().input}
+            dataMode="runtime"
+            onCommand={props.onCommand}
+            paneFrames={ready().paneFrames}
+            onPaneAction={props.onPaneAction}
+            onPaneGrip={props.onPaneGrip}
+          />
+          <Show when={notice()}>
+            {(current) => (
+              <ResourceNotice
+                tone={current().tone}
+                label={current().label}
+                reason={current().reason}
+              />
+            )}
+          </Show>
+        </>
+      )}
+    </Show>
+  );
+}
+
+/**
+ * Electron-only semantic composition. All daemon I/O stays behind the injected
+ * host facade; this component owns neither URLs, sockets, terminal bytes nor tmux ids.
+ */
+export function DesktopLiveApplication(props: DesktopLiveApplicationProps) {
+  const catalog = createSolidDesktopWorkspaceCatalogStore({
+    host: props.host,
+    daemon: props.daemon,
+  });
+  // The constructor already owns the initial daemon. Only a genuinely new
+  // capability generation should retire catalog work and start another read.
+  let activeDaemonKey = daemonCapabilityKey(props.daemon);
+  createEffect(() => {
+    const nextDaemon = props.daemon;
+    const nextKey = daemonCapabilityKey(nextDaemon);
+    if (nextKey === activeDaemonKey) return;
+    activeDaemonKey = nextKey;
+    catalog.setDaemon(nextDaemon);
+  });
+
+  let mismatchGeneration = -1;
+  createEffect(() => {
+    const state = catalog.state();
+    if (
+      state.status === "degraded" &&
+      state.code === "daemon-identity-mismatch" &&
+      state.generation !== mismatchGeneration
+    ) {
+      mismatchGeneration = state.generation;
+      props.onDaemonIdentityMismatch?.();
+    }
+  });
+
+  const selectedTarget = createMemo(() => {
+    const state = catalog.state();
+    const selection = state.snapshot?.selection;
+    if (!state.daemon || selection?.view !== "workspace") return null;
+    return { daemon: state.daemon, workspaceName: selection.workspaceName };
+  });
+
+  const fallback = () => {
+    const state = catalog.state();
+    const selection = state.snapshot?.selection;
+    if (selection?.view === "onboarding") {
+      return (
+        <DesktopConnectionSurface
+          host={props.host}
+          runtime={props.runtime}
+          platform={props.platform}
+          windowState={props.windowState}
+          state="onboarding"
+          eyebrow="Workspace discovery"
+          title="No live workspaces yet"
+          description="Start tmux-ide in a project to make its live workspace available here."
+          guidance="Workspace opening is not available in this build yet"
+        />
+      );
+    }
+    if (selection?.view === "chooser" && state.snapshot) {
+      return (
+        <DesktopConnectionSurface
+          host={props.host}
+          runtime={props.runtime}
+          platform={props.platform}
+          windowState={props.windowState}
+          state="chooser"
+          eyebrow="Live tmux workspaces"
+          title="Choose a workspace"
+          description="Multiple workspaces are available. tmux-ide never picks one arbitrarily."
+          guidance="Arrow keys move · Enter opens"
+          workspaces={state.snapshot.workspaces.map(({ workspaceName }) => workspaceName)}
+          onSelectWorkspace={(workspaceName) => catalog.select(workspaceName)}
+        />
+      );
+    }
+    const identityMismatch =
+      state.status === "degraded" && state.code === "daemon-identity-mismatch";
+    const recovery = recoveryPresentation(props.daemonRecovery ?? "idle");
+    const surfaceState =
+      state.status === "loading"
+        ? "loading"
+        : state.status === "error" || state.status === "disposed"
+          ? "error"
+          : "degraded";
+    return (
+      <DesktopConnectionSurface
+        host={props.host}
+        runtime={props.runtime}
+        platform={props.platform}
+        windowState={props.windowState}
+        state={surfaceState}
+        eyebrow="Native tmux workspace"
+        title={
+          state.status === "loading"
+            ? "Finding your workspaces"
+            : identityMismatch
+              ? recovery.title
+              : "Workspace connection needs attention"
+        }
+        description={
+          identityMismatch
+            ? recovery.description
+            : "reason" in state
+              ? state.reason
+              : "Reading the live workspace catalog from tmux-ide."
+        }
+        guidance={identityMismatch ? recovery.guidance : "tmux remains the source of truth"}
+        alert={state.status === "error"}
+        onRetry={
+          state.status === "loading"
+            ? undefined
+            : identityMismatch
+              ? props.daemonRecovery === "refreshing"
+                ? undefined
+                : props.onRetryDaemonConnection
+              : () => catalog.refresh()
+        }
+      />
+    );
+  };
+
+  return (
+    <Show when={selectedTarget()} fallback={fallback()}>
+      {(target) => (
+        <LiveWorkspace
+          host={props.host}
+          target={target()}
+          catalogState={catalog.state()}
+          runtime={props.runtime}
+          platform={props.platform}
+          windowState={props.windowState}
+          onCommand={props.onCommand}
+          onPaneAction={props.onPaneAction}
+          onPaneGrip={props.onPaneGrip}
+          onDaemonIdentityMismatch={props.onDaemonIdentityMismatch}
+          daemonRecovery={props.daemonRecovery}
+          onRetryDaemonConnection={props.onRetryDaemonConnection}
+        />
+      )}
+    </Show>
+  );
+}

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -47,6 +47,7 @@ select:focus-visible,
 }
 
 .app {
+  position: relative;
   display: grid;
   grid-template-rows: 28px minmax(0, 1fr) 18px;
   width: 100%;
@@ -217,6 +218,234 @@ kbd {
 .window-controls button:last-child:hover {
   color: var(--tmux-ide-text-bright);
   background: var(--tmux-ide-status-danger);
+}
+
+.runtime-titlebar {
+  grid-row: 1;
+}
+
+.runtime-state-surface {
+  grid-row: 2;
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  place-items: center;
+  padding: clamp(22px, 5vw, 64px);
+  overflow: auto;
+  background:
+    linear-gradient(
+      90deg,
+      transparent 0,
+      transparent calc(100% - 1px),
+      var(--tmux-ide-border-subtle) calc(100% - 1px)
+    ),
+    var(--tmux-ide-surface-canvas);
+  background-size: min(72px, 8vw) 100%;
+}
+
+.runtime-state-card {
+  width: min(620px, 100%);
+  padding: clamp(20px, 4vw, 40px);
+  border: 1px solid var(--tmux-ide-border-default);
+  border-radius: var(--tmux-ide-shape-panel);
+  background: var(--tmux-ide-surface-panel);
+  box-shadow: var(--tmux-ide-elevation-floating-shadow);
+}
+
+.runtime-state-card__signal {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 24px;
+  color: var(--tmux-ide-text-muted);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.runtime-state-card__signal i {
+  width: 7px;
+  height: 7px;
+  border: 1px solid var(--tmux-ide-status-info);
+  border-radius: 50%;
+}
+
+.runtime-state-surface[data-state="pending"] .runtime-state-card__signal i,
+.runtime-state-surface[data-state="loading"] .runtime-state-card__signal i {
+  background: var(--tmux-ide-status-info);
+  animation: runtime-signal 1.4s linear infinite;
+}
+
+.runtime-state-surface[data-state="onboarding"] .runtime-state-card__signal i,
+.runtime-state-surface[data-state="chooser"] .runtime-state-card__signal i {
+  border-color: var(--tmux-ide-status-success);
+  background: var(--tmux-ide-status-success);
+}
+
+.runtime-state-surface[data-state="degraded"] .runtime-state-card__signal i,
+.runtime-state-surface[data-state="error"] .runtime-state-card__signal i,
+.runtime-state-surface[data-state="hard-error"] .runtime-state-card__signal i {
+  border-color: var(--tmux-ide-status-warning);
+  background: var(--tmux-ide-status-warning);
+}
+
+.runtime-state-surface[data-state="error"] .runtime-state-card__signal i,
+.runtime-state-surface[data-state="hard-error"] .runtime-state-card__signal i {
+  border-color: var(--tmux-ide-status-danger);
+  background: var(--tmux-ide-status-danger);
+}
+
+@keyframes runtime-signal {
+  50% {
+    opacity: 0.34;
+  }
+}
+
+.runtime-state-card h1 {
+  margin: 7px 0 10px;
+  color: var(--tmux-ide-text-bright);
+  font-size: clamp(22px, 4vw, 38px);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.runtime-state-card > p {
+  max-width: 520px;
+  margin: 0;
+  color: var(--tmux-ide-text-secondary);
+  font-size: 12px;
+  line-height: 19px;
+}
+
+.runtime-state-card__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.runtime-action {
+  min-height: 30px;
+  padding: 0 11px;
+  border: 1px solid var(--tmux-ide-border-default);
+  border-radius: var(--tmux-ide-shape-control);
+  color: var(--tmux-ide-text-primary);
+  background: var(--tmux-ide-surface-panel-raised);
+  cursor: pointer;
+  transition:
+    color var(--tmux-ide-motion-fast) var(--tmux-ide-motion-easing-standard),
+    background-color var(--tmux-ide-motion-fast) var(--tmux-ide-motion-easing-standard),
+    border-color var(--tmux-ide-motion-fast) var(--tmux-ide-motion-easing-standard);
+}
+
+@media (hover: hover) {
+  .runtime-action:hover,
+  .workspace-chooser button:hover {
+    border-color: var(--tmux-ide-border-focused);
+    color: var(--tmux-ide-text-bright);
+    background: var(--tmux-ide-selection-hover);
+  }
+}
+
+.workspace-chooser {
+  display: grid;
+  gap: 6px;
+  max-height: min(312px, 38vh);
+  margin-top: 22px;
+  padding-right: 3px;
+  overflow: auto;
+}
+
+.workspace-chooser button {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr) auto;
+  min-height: 48px;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 9px;
+  border: 1px solid var(--tmux-ide-border-subtle);
+  border-radius: var(--tmux-ide-shape-control);
+  color: var(--tmux-ide-text-secondary);
+  background: var(--tmux-ide-surface-panel-raised);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    color var(--tmux-ide-motion-fast) var(--tmux-ide-motion-easing-standard),
+    background-color var(--tmux-ide-motion-fast) var(--tmux-ide-motion-easing-standard),
+    border-color var(--tmux-ide-motion-fast) var(--tmux-ide-motion-easing-standard);
+}
+
+.workspace-chooser button > span:nth-child(2) {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.workspace-chooser button strong,
+.workspace-chooser button small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-chooser button small {
+  color: var(--tmux-ide-text-muted);
+  font-size: 9px;
+}
+
+.workspace-chooser__mark {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid var(--tmux-ide-border-default);
+  color: var(--tmux-ide-text-link);
+  background: var(--tmux-ide-surface-terminal);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.runtime-status-strip {
+  grid-row: 3;
+  justify-content: space-between;
+}
+
+.runtime-resource-notice {
+  position: absolute;
+  z-index: 40;
+  top: 34px;
+  left: 50%;
+  display: flex;
+  max-width: min(680px, calc(100vw - 48px));
+  align-items: center;
+  gap: 7px;
+  padding: 4px 9px;
+  overflow: hidden;
+  border: 1px solid var(--tmux-ide-border-attention);
+  border-radius: var(--tmux-ide-shape-status-radius);
+  color: var(--tmux-ide-text-primary);
+  background: var(--tmux-ide-surface-command);
+  box-shadow: var(--tmux-ide-elevation-floating-shadow);
+  font-size: 10px;
+  transform: translateX(-50%);
+}
+
+.runtime-resource-notice i {
+  flex: 0 0 6px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--tmux-ide-status-warning);
+}
+
+.runtime-resource-notice strong,
+.runtime-resource-notice span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runtime-resource-notice span {
+  color: var(--tmux-ide-text-muted);
 }
 
 .shell-workbench {
@@ -429,14 +658,10 @@ kbd {
   color: var(--tmux-ide-text-secondary);
 }
 
-.home-canvas button {
-  height: 28px;
-  margin-top: 10px;
-  padding: 0 10px;
-  border: 1px solid var(--tmux-ide-border-focused);
-  border-radius: var(--tmux-ide-shape-control);
-  color: var(--tmux-ide-selection-selection-text);
-  background: var(--tmux-ide-selection-selection);
+.home-canvas__workspace-guidance {
+  display: block;
+  margin-top: 12px;
+  color: var(--tmux-ide-text-muted);
 }
 
 .readiness-card {


### PR DESCRIPTION
Connects the Electron Solid App to the merged HostCapabilities v4 daemon refresh, live workspace catalog, live application-shell resource store, and canonical pane-frame adapter. Electron has explicit pending/onboarding/chooser/live/stale/degraded/error states and never falls back to preview fixtures; browser preview remains an explicit no-network mode. Daemon generation recovery uses daemon.refreshConnection rather than bootstrap, semantic corruption is contained, and old resource/catalog callbacks are retired.\n\nValidation: 123 renderer tests, typecheck, lint, production build, formatting, diff check, and production-bundle HostCapabilities v4 probes. Independent review approved with no blocker/high/medium findings.