### PR TITLE
feat(terminal): execute guarded tmux attachments

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -161,3 +161,11 @@ export {
   type RedeemedAttachmentLease,
   type ReconciledOrphanAttachmentDescriptor,
 } from "./terminal/attachments/lease-manager.ts";
+export {
+  TmuxAttachmentViewExecutor,
+  TmuxAttachmentViewExecutorError,
+  type TmuxAttachmentCommandResult,
+  type TmuxAttachmentCommandRunner,
+  type TmuxAttachmentViewExecutorErrorCode,
+  type TmuxAttachmentViewExecutorOptions,
+} from "./terminal/attachments/tmux-view-executor.ts";

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -166,6 +166,8 @@ export {
   TmuxAttachmentViewExecutorError,
   type TmuxAttachmentCommandResult,
   type TmuxAttachmentCommandRunner,
+  type TmuxAttachmentClientTransport,
+  type TmuxAttachmentClientTransportResult,
   type TmuxAttachmentViewExecutorErrorCode,
   type TmuxAttachmentViewExecutorOptions,
 } from "./terminal/attachments/tmux-view-executor.ts";

--- a/packages/daemon/src/terminal/__tests__/grouped-tmux-plan.test.ts
+++ b/packages/daemon/src/terminal/__tests__/grouped-tmux-plan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  GROUPED_TMUX_VIEW_MARKER_OPTION,
+  GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
   GROUPED_TMUX_VIEW_SESSION_PREFIX,
   GroupedTmuxAttachmentPlanInputSchemaZ,
   groupedTmuxViewSessionName,
@@ -66,7 +66,7 @@ describe("grouped tmux attachment planner", () => {
         "-s",
         view,
         "__tmux_ide_attachment_placeholder",
-        GROUPED_TMUX_VIEW_MARKER_OPTION,
+        GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
         plan.identity.markerValue,
         "link-window",
         "$12:@34",
@@ -127,7 +127,9 @@ describe("grouped tmux attachment planner", () => {
     const second = planGroupedTmuxAttachment(input());
     expect(second).toEqual(first);
     expect(first.recover.attach).toBe(first.attach);
-    expect(first.cleanup.ownership.expectedStdout).toBe(first.identity.markerValue);
+    expect(first.cleanup.ownership.expectedStdout).toBe(
+      `${GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT}=${first.identity.markerValue}`,
+    );
     expect(first.recover.topology.expectedStdout).toBe(first.identity.durableSource.windowId);
     expect(first.cleanup.command.argv).toEqual([
       "kill-session",
@@ -139,13 +141,14 @@ describe("grouped tmux attachment planner", () => {
   it("can clean only the exact daemon-marked view and never the durable source", () => {
     const plan = planGroupedTmuxAttachment(input());
     expect(plan.cleanup.ownership.query.argv).toEqual([
-      "show-options",
-      "-qv",
+      "show-environment",
       "-t",
-      plan.identity.viewSessionName,
-      GROUPED_TMUX_VIEW_MARKER_OPTION,
+      `=${plan.identity.viewSessionName}`,
+      GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
     ]);
-    expect(plan.cleanup.ownership.expectedStdout).toBe(plan.identity.markerValue);
+    expect(plan.cleanup.ownership.expectedStdout).toBe(
+      `${GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT}=${plan.identity.markerValue}`,
+    );
     expect(plan.cleanup.command.argv.at(-1)).toBe(`=${plan.identity.viewSessionName}`);
 
     const argv = everyArgv(plan);

--- a/packages/daemon/src/terminal/__tests__/tmux-view-executor-live.test.ts
+++ b/packages/daemon/src/terminal/__tests__/tmux-view-executor-live.test.ts
@@ -1,21 +1,24 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
-  GROUPED_TMUX_VIEW_MARKER_OPTION,
+  GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
   GROUPED_TMUX_VIEW_SESSION_PREFIX,
   planGroupedTmuxAttachment,
   type TmuxArgvPlan,
 } from "../attachments/grouped-tmux.ts";
 import {
   TmuxAttachmentViewExecutor,
+  type TmuxAttachmentClientTransportResult,
   type TmuxAttachmentCommandResult,
   type TmuxAttachmentCommandRunner,
+  type TmuxAttachmentClientTransport,
 } from "../attachments/tmux-view-executor.ts";
 
 const hasTmux = spawnSync("tmux", ["-V"], { stdio: "ignore" }).status === 0;
 const socketName = `tmux-ide-executor-${process.pid}-${randomUUID().slice(0, 8)}`;
 const sleepCommand = "exec sleep 2147483647";
+const legacyPaneMarkerOption = "@tmux_ide_attachment_view";
 
 function runOnSocket(argv: readonly string[]): string {
   return execFileSync("tmux", ["-L", socketName, "-f", "/dev/null", ...argv], {
@@ -39,11 +42,58 @@ class LiveSocketRunner implements TmuxAttachmentCommandRunner {
       return result;
     } catch (error) {
       const stderr = String((error as { stderr?: string | Buffer }).stderr ?? "").toLowerCase();
-      const result: TmuxAttachmentCommandResult =
-        /(?:can't find|no such|not found|no server running)/u.test(stderr)
+      const result: TmuxAttachmentCommandResult = stderr.includes("unknown variable:")
+        ? { status: "variable-not-found" }
+        : /(?:can't find|no such|not found|no server running)/u.test(stderr)
           ? { status: "not-found" }
           : { status: "failed" };
       return result;
+    }
+  }
+}
+
+class LiveControlClientTransport implements TmuxAttachmentClientTransport {
+  detachTarget = "";
+
+  runGuardedAttach(command: TmuxArgvPlan): TmuxAttachmentClientTransportResult {
+    const detachTarget = this.detachTarget;
+    if (!detachTarget) return { status: "failed" };
+    const detachScript = [
+      'const { execFileSync } = require("node:child_process");',
+      "const [socketName, target] = process.argv.slice(1);",
+      "let attempts = 0;",
+      "const timer = setInterval(() => {",
+      "  try {",
+      '    execFileSync("tmux", ["-L", socketName, "detach-client", "-s", target], { stdio: "ignore" });',
+      "    clearInterval(timer);",
+      "  } catch {",
+      "    attempts += 1;",
+      "    if (attempts >= 100) { clearInterval(timer); process.exitCode = 1; }",
+      "  }",
+      "}, 20);",
+    ].join("\n");
+    const detacher = spawn(process.execPath, ["-e", detachScript, socketName, detachTarget], {
+      stdio: "ignore",
+    });
+    try {
+      const stdout = execFileSync("tmux", ["-L", socketName, "-C", ...command.argv], {
+        encoding: "utf8",
+        maxBuffer: 128 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 5_000,
+      });
+      if (stdout.includes("__tmux_ide_source_proof_mismatch_v1__")) {
+        return { status: "source-proof-mismatch" };
+      }
+      if (stdout.includes("__tmux_ide_view_proof_mismatch_v1__")) {
+        return { status: "view-proof-mismatch" };
+      }
+      return { status: "executed" };
+    } catch {
+      return { status: "failed" };
+    } finally {
+      detacher.unref();
+      this.detachTarget = "";
     }
   }
 }
@@ -88,9 +138,12 @@ describe.skipIf(!hasTmux)("TmuxAttachmentViewExecutor live server guards", () =>
     });
   }
 
-  function liveOperation(selectedPlan: ReturnType<typeof livePlan>) {
+  function liveOperation(
+    selectedPlan: ReturnType<typeof livePlan>,
+    operation: "create" | "attach" | "recover" = "create",
+  ) {
     return {
-      operation: "create" as const,
+      operation,
       exactViewSessionTarget: `=${selectedPlan.identity.viewSessionName}` as const,
       deadline: 2_000,
       source: { sessionId, windowId, runtimePaneId: paneId, paneCount: 1 as const },
@@ -108,7 +161,7 @@ describe.skipIf(!hasTmux)("TmuxAttachmentViewExecutor live server guards", () =>
     await expect(
       executor.enumerateMarkedViews(
         GROUPED_TMUX_VIEW_SESSION_PREFIX,
-        GROUPED_TMUX_VIEW_MARKER_OPTION,
+        GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
       ),
     ).resolves.toContainEqual({
       viewSessionName: selectedPlan.identity.viewSessionName,
@@ -117,7 +170,7 @@ describe.skipIf(!hasTmux)("TmuxAttachmentViewExecutor live server guards", () =>
     });
     const cleanupResult = await executor.guardedCleanup({
       exactViewSessionTarget: `=${selectedPlan.identity.viewSessionName}`,
-      markerOption: GROUPED_TMUX_VIEW_MARKER_OPTION,
+      markerEnvironment: GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
       expectedMarkerValue: selectedPlan.identity.markerValue,
       expectedWindowId: windowId,
     });
@@ -126,6 +179,160 @@ describe.skipIf(!hasTmux)("TmuxAttachmentViewExecutor live server guards", () =>
       runOnSocket(["has-session", "-t", `=${selectedPlan.identity.viewSessionName}`]),
     ).toThrow();
     expect(runOnSocket(["display-message", "-p", "-t", paneId, "#{pane_dead}"]).trim()).toBe("0");
+  });
+
+  it("does not accept a pane-only legacy option when the session marker is absent", async () => {
+    const selectedPlan = livePlan("677b4096-7e25-43bb-a01d-3fa7d9b93ce8");
+    const exactTarget = `=${selectedPlan.identity.viewSessionName}` as const;
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    await executor.executeGuardedViewOperation(liveOperation(selectedPlan));
+    runOnSocket(["set-environment", "-u", "-t", exactTarget, GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT]);
+    runOnSocket([
+      "set-option",
+      "-p",
+      "-t",
+      paneId,
+      legacyPaneMarkerOption,
+      selectedPlan.identity.markerValue,
+    ]);
+
+    await expect(
+      executor.guardedCleanup({
+        exactViewSessionTarget: exactTarget,
+        markerEnvironment: GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
+        expectedMarkerValue: selectedPlan.identity.markerValue,
+        expectedWindowId: windowId,
+      }),
+    ).resolves.toBe("ownership-mismatch");
+    expect(runOnSocket(["has-session", "-t", exactTarget])).toBe("");
+
+    runOnSocket(["set-option", "-p", "-u", "-t", paneId, legacyPaneMarkerOption]);
+    runOnSocket(["kill-session", "-t", exactTarget]);
+  });
+
+  it("treats an exact missing marker as unowned despite a marker-looking multiline value", async () => {
+    const selectedPlan = livePlan("80805d88-9e3f-4d8e-99ae-0a16941e72e1");
+    const exactTarget = `=${selectedPlan.identity.viewSessionName}` as const;
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    await executor.executeGuardedViewOperation(liveOperation(selectedPlan));
+    runOnSocket(["set-environment", "-u", "-t", exactTarget, GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT]);
+    runOnSocket([
+      "set-environment",
+      "-t",
+      exactTarget,
+      "UNRELATED_MULTILINE",
+      `before\n${GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT}=${selectedPlan.identity.markerValue}\nafter`,
+    ]);
+
+    await expect(
+      executor.enumerateMarkedViews(
+        GROUPED_TMUX_VIEW_SESSION_PREFIX,
+        GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
+      ),
+    ).resolves.toContainEqual({
+      viewSessionName: selectedPlan.identity.viewSessionName,
+      markerValue: null,
+      windowIds: [windowId],
+    });
+    await expect(
+      executor.guardedCleanup({
+        exactViewSessionTarget: exactTarget,
+        markerEnvironment: GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
+        expectedMarkerValue: selectedPlan.identity.markerValue,
+        expectedWindowId: windowId,
+      }),
+    ).resolves.toBe("ownership-mismatch");
+    expect(runOnSocket(["has-session", "-t", exactTarget])).toBe("");
+    runOnSocket(["kill-session", "-t", exactTarget]);
+  });
+
+  it("recognizes the exact valid marker despite a conflicting multiline value", async () => {
+    const selectedPlan = livePlan("0b3283cc-9e16-4d68-9ffd-dd1521e9c028");
+    const exactTarget = `=${selectedPlan.identity.viewSessionName}` as const;
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    await executor.executeGuardedViewOperation(liveOperation(selectedPlan));
+    runOnSocket([
+      "set-environment",
+      "-t",
+      exactTarget,
+      "UNRELATED_MULTILINE",
+      `before\n${GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT}=v1:00000000-0000-4000-8000-000000000000:0\nafter`,
+    ]);
+
+    await expect(
+      executor.enumerateMarkedViews(
+        GROUPED_TMUX_VIEW_SESSION_PREFIX,
+        GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
+      ),
+    ).resolves.toContainEqual({
+      viewSessionName: selectedPlan.identity.viewSessionName,
+      markerValue: selectedPlan.identity.markerValue,
+      windowIds: [windowId],
+    });
+    await expect(
+      executor.guardedCleanup({
+        exactViewSessionTarget: exactTarget,
+        markerEnvironment: GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
+        expectedMarkerValue: selectedPlan.identity.markerValue,
+        expectedWindowId: windowId,
+      }),
+    ).resolves.toBe("cleaned");
+  });
+
+  it("uses the session environment marker despite a conflicting pane user option", async () => {
+    const selectedPlan = livePlan("187efac9-a928-4ccb-bf71-10fb3c3cdf59");
+    const exactTarget = `=${selectedPlan.identity.viewSessionName}` as const;
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    await executor.executeGuardedViewOperation(liveOperation(selectedPlan));
+    runOnSocket([
+      "set-option",
+      "-p",
+      "-t",
+      paneId,
+      legacyPaneMarkerOption,
+      "conflicting-pane-value",
+    ]);
+
+    await expect(
+      executor.guardedCleanup({
+        exactViewSessionTarget: exactTarget,
+        markerEnvironment: GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
+        expectedMarkerValue: selectedPlan.identity.markerValue,
+        expectedWindowId: windowId,
+      }),
+    ).resolves.toBe("cleaned");
+    runOnSocket(["set-option", "-p", "-u", "-t", paneId, legacyPaneMarkerOption]);
+  });
+
+  it("runs attach and recover only through an explicit real tmux client transport", async () => {
+    const selectedPlan = livePlan("2fd6f699-416f-4258-b5f2-0bd9933e8f50");
+    const exactTarget = `=${selectedPlan.identity.viewSessionName}` as const;
+    const prepareExecutor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    await prepareExecutor.executeGuardedViewOperation(liveOperation(selectedPlan));
+
+    const transport = new LiveControlClientTransport();
+    const executor = new TmuxAttachmentViewExecutor({
+      runner,
+      clientTransport: transport,
+      now: () => 1_000,
+    });
+    transport.detachTarget = exactTarget;
+    await expect(
+      executor.executeGuardedViewOperation(liveOperation(selectedPlan, "attach")),
+    ).resolves.toBe("executed");
+    transport.detachTarget = exactTarget;
+    await expect(
+      executor.executeGuardedViewOperation(liveOperation(selectedPlan, "recover")),
+    ).resolves.toBe("executed");
+
+    await expect(
+      executor.guardedCleanup({
+        exactViewSessionTarget: exactTarget,
+        markerEnvironment: GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
+        expectedMarkerValue: selectedPlan.identity.markerValue,
+        expectedWindowId: windowId,
+      }),
+    ).resolves.toBe("cleaned");
   });
 
   it("falsifies the server guard when an external client splits after daemon proof", async () => {

--- a/packages/daemon/src/terminal/__tests__/tmux-view-executor-live.test.ts
+++ b/packages/daemon/src/terminal/__tests__/tmux-view-executor-live.test.ts
@@ -1,0 +1,160 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  GROUPED_TMUX_VIEW_MARKER_OPTION,
+  GROUPED_TMUX_VIEW_SESSION_PREFIX,
+  planGroupedTmuxAttachment,
+  type TmuxArgvPlan,
+} from "../attachments/grouped-tmux.ts";
+import {
+  TmuxAttachmentViewExecutor,
+  type TmuxAttachmentCommandResult,
+  type TmuxAttachmentCommandRunner,
+} from "../attachments/tmux-view-executor.ts";
+
+const hasTmux = spawnSync("tmux", ["-V"], { stdio: "ignore" }).status === 0;
+const socketName = `tmux-ide-executor-${process.pid}-${randomUUID().slice(0, 8)}`;
+const sleepCommand = "exec sleep 2147483647";
+
+function runOnSocket(argv: readonly string[]): string {
+  return execFileSync("tmux", ["-L", socketName, "-f", "/dev/null", ...argv], {
+    encoding: "utf8",
+    maxBuffer: 128 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+class LiveSocketRunner implements TmuxAttachmentCommandRunner {
+  beforeServerGuard: (() => void) | undefined;
+
+  run(command: TmuxArgvPlan): TmuxAttachmentCommandResult {
+    try {
+      if (command.argv[0] === "if-shell" && !command.argv[3]?.startsWith("=")) {
+        const mutate = this.beforeServerGuard;
+        this.beforeServerGuard = undefined;
+        mutate?.();
+      }
+      const result = { status: "ok" as const, stdout: runOnSocket(command.argv) };
+      return result;
+    } catch (error) {
+      const stderr = String((error as { stderr?: string | Buffer }).stderr ?? "").toLowerCase();
+      const result: TmuxAttachmentCommandResult =
+        /(?:can't find|no such|not found|no server running)/u.test(stderr)
+          ? { status: "not-found" }
+          : { status: "failed" };
+      return result;
+    }
+  }
+}
+
+describe.skipIf(!hasTmux)("TmuxAttachmentViewExecutor live server guards", () => {
+  const runner = new LiveSocketRunner();
+  let sessionId = "";
+  let windowId = "";
+  let paneId = "";
+
+  beforeAll(() => {
+    runOnSocket(["new-session", "-d", "-s", "durable-source", "-n", "authorized", sleepCommand]);
+    sessionId = runOnSocket([
+      "display-message",
+      "-p",
+      "-t",
+      "durable-source",
+      "#{session_id}",
+    ]).trim();
+    windowId = runOnSocket([
+      "display-message",
+      "-p",
+      "-t",
+      "durable-source",
+      "#{window_id}",
+    ]).trim();
+    paneId = runOnSocket(["display-message", "-p", "-t", "durable-source", "#{pane_id}"]).trim();
+  });
+
+  afterAll(() => {
+    spawnSync("tmux", ["-L", socketName, "kill-server"], { stdio: "ignore" });
+  });
+
+  function livePlan(attachmentId: string) {
+    return planGroupedTmuxAttachment({
+      attachmentId,
+      generation: 0,
+      target: { workspaceName: "workspace.live", semanticPaneId: "pane.authorized" },
+      viewerMode: "read-only",
+      viewport: { cols: 120, rows: 40 },
+      source: { sessionId, windowId, runtimePaneId: paneId, paneCount: 1 },
+    });
+  }
+
+  function liveOperation(selectedPlan: ReturnType<typeof livePlan>) {
+    return {
+      operation: "create" as const,
+      exactViewSessionTarget: `=${selectedPlan.identity.viewSessionName}` as const,
+      deadline: 2_000,
+      source: { sessionId, windowId, runtimePaneId: paneId, paneCount: 1 as const },
+      plan: selectedPlan,
+    };
+  }
+
+  it("creates, strictly enumerates, and atomically cleans a real grouped tmux view", async () => {
+    const selectedPlan = livePlan("7ff5a4a4-998f-4ee9-9b8b-b90ddf449c62");
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+
+    await expect(executor.executeGuardedViewOperation(liveOperation(selectedPlan))).resolves.toBe(
+      "executed",
+    );
+    await expect(
+      executor.enumerateMarkedViews(
+        GROUPED_TMUX_VIEW_SESSION_PREFIX,
+        GROUPED_TMUX_VIEW_MARKER_OPTION,
+      ),
+    ).resolves.toContainEqual({
+      viewSessionName: selectedPlan.identity.viewSessionName,
+      markerValue: selectedPlan.identity.markerValue,
+      windowIds: [windowId],
+    });
+    const cleanupResult = await executor.guardedCleanup({
+      exactViewSessionTarget: `=${selectedPlan.identity.viewSessionName}`,
+      markerOption: GROUPED_TMUX_VIEW_MARKER_OPTION,
+      expectedMarkerValue: selectedPlan.identity.markerValue,
+      expectedWindowId: windowId,
+    });
+    expect(cleanupResult).toBe("cleaned");
+    expect(() =>
+      runOnSocket(["has-session", "-t", `=${selectedPlan.identity.viewSessionName}`]),
+    ).toThrow();
+    expect(runOnSocket(["display-message", "-p", "-t", paneId, "#{pane_dead}"]).trim()).toBe("0");
+  });
+
+  it("falsifies the server guard when an external client splits after daemon proof", async () => {
+    const selectedPlan = livePlan("ea7d29fa-9b57-42a8-bdd0-3b4c22aee962");
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    let addedPane = "";
+    runner.beforeServerGuard = () => {
+      addedPane = runOnSocket([
+        "split-window",
+        "-d",
+        "-t",
+        paneId,
+        "-P",
+        "-F",
+        "#{pane_id}",
+        sleepCommand,
+      ]).trim();
+    };
+
+    await expect(executor.executeGuardedViewOperation(liveOperation(selectedPlan))).resolves.toBe(
+      "source-proof-mismatch",
+    );
+    expect(() =>
+      runOnSocket(["has-session", "-t", `=${selectedPlan.identity.viewSessionName}`]),
+    ).toThrow();
+    expect(addedPane).toMatch(/^%(?:0|[1-9][0-9]*)$/u);
+    runOnSocket(["kill-pane", "-t", addedPane]);
+    expect(runOnSocket(["display-message", "-p", "-t", paneId, "#{window_panes}"]).trim()).toBe(
+      "1",
+    );
+  });
+});

--- a/packages/daemon/src/terminal/__tests__/tmux-view-executor.test.ts
+++ b/packages/daemon/src/terminal/__tests__/tmux-view-executor.test.ts
@@ -1,0 +1,517 @@
+import { inspect } from "node:util";
+import { describe, expect, it } from "vitest";
+import {
+  GROUPED_TMUX_VIEW_MARKER_OPTION,
+  GROUPED_TMUX_VIEW_SESSION_PREFIX,
+  planGroupedTmuxAttachment,
+  type GroupedTmuxAttachmentPlan,
+  type TmuxArgvPlan,
+} from "../attachments/grouped-tmux.ts";
+import type {
+  GuardedAttachmentCleanup,
+  GuardedAttachmentViewOperation,
+} from "../attachments/lease-manager.ts";
+import {
+  TmuxAttachmentViewExecutor,
+  TmuxAttachmentViewExecutorError,
+  type TmuxAttachmentCommandResult,
+  type TmuxAttachmentCommandRunner,
+} from "../attachments/tmux-view-executor.ts";
+
+const attachmentId = "f3d8bc0b-460c-458c-b9c0-dbc2536d1486";
+const secondAttachmentId = "a45072f8-5a82-4930-8bed-0959c617e60b";
+
+interface FakeView {
+  marker: string | null;
+  windows: string[];
+}
+
+class FakeRunner implements TmuxAttachmentCommandRunner {
+  readonly calls: string[][] = [];
+  readonly views = new Map<string, FakeView>();
+  sourceOutput = "$12\t@34\t%56\t1\n";
+  sessionsOutput: string | null = null;
+  rawOutput: ((argv: readonly string[]) => string | null) | undefined;
+  fail: ((argv: readonly string[]) => "not-found" | "failed" | "throw" | null) | undefined;
+  before: ((argv: readonly string[]) => void) | undefined;
+  partialCreateFailure = false;
+  mutationCount = 0;
+  serverSourceGuardMatches = true;
+  serverViewGuardMatches = true;
+
+  #parseCommandString(value: string): string[][] {
+    const commands: string[][] = [[]];
+    let offset = 0;
+    while (offset < value.length) {
+      while (value[offset] === " ") offset += 1;
+      if (offset >= value.length) break;
+      if (value[offset] === ";") {
+        commands.push([]);
+        offset += 1;
+        continue;
+      }
+      if (value[offset] !== '"') throw new Error("invalid fake command string");
+      let end = offset + 1;
+      let escaped = false;
+      for (; end < value.length; end += 1) {
+        const character = value[end]!;
+        if (!escaped && character === '"') break;
+        if (!escaped && character === "\\") escaped = true;
+        else escaped = false;
+      }
+      if (end >= value.length) throw new Error("unterminated fake command string");
+      commands.at(-1)!.push(JSON.parse(value.slice(offset, end + 1)) as string);
+      offset = end + 1;
+    }
+    return commands.filter((command) => command.length > 0);
+  }
+
+  #runCommandString(value: string): TmuxAttachmentCommandResult {
+    const commands = this.#parseCommandString(value);
+    const creation = commands.find((command) => command[0] === "new-session");
+    if (creation) {
+      for (const command of commands) this.calls.push(command);
+      const name = creation[creation.indexOf("-s") + 1]!;
+      const markerCommand = commands.find(
+        (command) =>
+          command[0] === "set-option" && command.includes(GROUPED_TMUX_VIEW_MARKER_OPTION),
+      );
+      const markerIndex = markerCommand?.indexOf(GROUPED_TMUX_VIEW_MARKER_OPTION) ?? -1;
+      const link = commands.find((command) => command[0] === "link-window");
+      const source = link?.[link.indexOf("-s") + 1] ?? "";
+      this.views.set(name, {
+        marker: markerCommand?.[markerIndex + 1] ?? null,
+        windows: [source.slice(source.indexOf(":") + 1)],
+      });
+      this.mutationCount += 1;
+      return this.partialCreateFailure ? { status: "failed" } : { status: "ok", stdout: "" };
+    }
+    let result: TmuxAttachmentCommandResult = { status: "ok", stdout: "" };
+    for (const command of commands) {
+      result = this.run({ executable: "tmux", argv: command });
+      if (result.status !== "ok") return result;
+    }
+    return result;
+  }
+
+  run(command: TmuxArgvPlan): TmuxAttachmentCommandResult {
+    const argv = [...command.argv];
+    this.calls.push(argv);
+    this.before?.(argv);
+    const raw = this.rawOutput?.(argv);
+    if (raw !== undefined && raw !== null) return { status: "ok", stdout: raw };
+    const requestedFailure = this.fail?.(argv);
+    if (requestedFailure === "throw") {
+      throw new Error("raw-secret-%999-$888-@777");
+    }
+    if (requestedFailure) return { status: requestedFailure };
+
+    switch (argv[0]) {
+      case "if-shell": {
+        const target = argv[argv.indexOf("-t") + 1] ?? "";
+        const isViewGuard =
+          target.startsWith("=") || argv[4]?.includes(GROUPED_TMUX_VIEW_MARKER_OPTION);
+        const matches = isViewGuard ? this.serverViewGuardMatches : this.serverSourceGuardMatches;
+        return this.#runCommandString(argv[matches ? 5 : 6]!);
+      }
+      case "has-session": {
+        const name = argv.at(-1)?.replace(/^=/u, "") ?? "";
+        return this.views.has(name) ? { status: "ok", stdout: "" } : { status: "not-found" };
+      }
+      case "show-options": {
+        const target = argv[argv.indexOf("-t") + 1]?.replace(/^=/u, "") ?? "";
+        const view = this.views.get(target);
+        if (!view) return { status: "not-found" };
+        return { status: "ok", stdout: `${view.marker ?? ""}\n` };
+      }
+      case "list-windows": {
+        const target = argv[argv.indexOf("-t") + 1]?.replace(/^=/u, "") ?? "";
+        const view = this.views.get(target);
+        if (!view) return { status: "not-found" };
+        return { status: "ok", stdout: `${view.windows.join("\n")}\n` };
+      }
+      case "list-panes": {
+        const target = argv[argv.indexOf("-t") + 1] ?? "";
+        if (!target.startsWith("=")) return { status: "ok", stdout: this.sourceOutput };
+        const view = this.views.get(target.slice(1));
+        if (!view) return { status: "not-found" };
+        if (argv.at(-1) === `#{${GROUPED_TMUX_VIEW_MARKER_OPTION}}`) {
+          return { status: "ok", stdout: `${view.marker ?? ""}\n` };
+        }
+        return {
+          status: "ok",
+          stdout: `$90\t${view.windows[0] ?? "@0"}\t%91\t${view.windows.length === 1 ? "1" : "2"}\t1\t${view.marker ?? ""}\n`,
+        };
+      }
+      case "list-sessions":
+        return {
+          status: "ok",
+          stdout:
+            this.sessionsOutput ??
+            [...this.views.entries()]
+              .map(([name, view]) => `${name}\t${view.marker ?? ""}`)
+              .join("\n"),
+        };
+      case "kill-session": {
+        const name = argv.at(-1)?.replace(/^=/u, "") ?? "";
+        if (!this.views.has(name)) return { status: "not-found" };
+        this.views.delete(name);
+        this.mutationCount += 1;
+        return { status: "ok", stdout: "" };
+      }
+      case "attach-session":
+      case "select-window":
+      case "set-option":
+        this.mutationCount += 1;
+        return { status: "ok", stdout: "" };
+      case "display-message":
+        return { status: "ok", stdout: `${argv.at(-1)}\n` };
+      default:
+        return { status: "failed" };
+    }
+  }
+}
+
+function plan(id = attachmentId, generation = 0): GroupedTmuxAttachmentPlan {
+  return planGroupedTmuxAttachment({
+    attachmentId: id,
+    generation,
+    target: { workspaceName: "workspace.alpha", semanticPaneId: "pane.worker" },
+    viewerMode: "interactive",
+    viewport: { cols: 120, rows: 40 },
+    source: {
+      sessionId: "$12",
+      windowId: "@34",
+      runtimePaneId: "%56",
+      paneCount: 1,
+    },
+  });
+}
+
+function operation(
+  selected: GuardedAttachmentViewOperation["operation"] = "create",
+  selectedPlan = plan(),
+  deadline = 2_000,
+): GuardedAttachmentViewOperation {
+  return {
+    operation: selected,
+    exactViewSessionTarget: `=${selectedPlan.identity.viewSessionName}`,
+    deadline,
+    source: {
+      sessionId: "$12",
+      windowId: "@34",
+      runtimePaneId: "%56",
+      paneCount: 1,
+    },
+    plan: selectedPlan,
+  };
+}
+
+function cleanup(selectedPlan = plan()): GuardedAttachmentCleanup {
+  return {
+    exactViewSessionTarget: `=${selectedPlan.identity.viewSessionName}`,
+    markerOption: GROUPED_TMUX_VIEW_MARKER_OPTION,
+    expectedMarkerValue: selectedPlan.identity.markerValue,
+    expectedWindowId: selectedPlan.identity.durableSource.windowId,
+  };
+}
+
+function seed(runner: FakeRunner, selectedPlan = plan(), overrides: Partial<FakeView> = {}): void {
+  runner.views.set(selectedPlan.identity.viewSessionName, {
+    marker: selectedPlan.identity.markerValue,
+    windows: [selectedPlan.identity.durableSource.windowId],
+    ...overrides,
+  });
+}
+
+function exposed(error: unknown): string {
+  return `${JSON.stringify(error)} ${inspect(error)}`;
+}
+
+describe("TmuxAttachmentViewExecutor guarded execution", () => {
+  it("revalidates the exact source tuple and creates only the canonical server plan", async () => {
+    const runner = new FakeRunner();
+    const selectedPlan = plan();
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_999 });
+
+    await expect(executor.executeGuardedViewOperation(operation())).resolves.toBe("executed");
+    expect(runner.views.get(selectedPlan.identity.viewSessionName)).toEqual({
+      marker: selectedPlan.identity.markerValue,
+      windows: ["@34"],
+    });
+    expect(runner.calls).toContainEqual([
+      "list-panes",
+      "-t",
+      "$12:@34",
+      "-F",
+      "#{session_id}\t#{window_id}\t#{pane_id}\t#{window_panes}",
+    ]);
+    expect(runner.calls).toContainEqual(selectedPlan.create.command.argv.slice(0, 7));
+    expect(runner.calls.some((argv) => argv[0] === "if-shell")).toBe(true);
+    expect(runner.mutationCount).toBe(1);
+  });
+
+  it("checks the immutable deadline after the final proof with zero exact-deadline mutation", async () => {
+    const runner = new FakeRunner();
+    let now = 1_999;
+    runner.before = (argv) => {
+      if (argv[0] === "list-panes") now = 2_000;
+    };
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => now });
+
+    await expect(executor.executeGuardedViewOperation(operation())).resolves.toBe("lease-expired");
+    expect(runner.mutationCount).toBe(0);
+    expect(runner.calls.some((argv) => argv[0] === "new-session")).toBe(false);
+  });
+
+  it.each([
+    ["session churn", "$99\t@34\t%56\t1\n"],
+    ["window churn", "$12\t@99\t%56\t1\n"],
+    ["pane churn", "$12\t@34\t%99\t1\n"],
+    ["split window", "$12\t@34\t%56\t2\n"],
+    ["duplicate source rows", "$12\t@34\t%56\t1\n$12\t@34\t%56\t1\n"],
+  ])("returns a proof mismatch without mutation on %s", async (_label, sourceOutput) => {
+    const runner = new FakeRunner();
+    runner.sourceOutput = sourceOutput;
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    await expect(executor.executeGuardedViewOperation(operation())).resolves.toBe(
+      "source-proof-mismatch",
+    );
+    expect(runner.mutationCount).toBe(0);
+  });
+
+  it("proves the durable session/window tuple even when a linked view shares the global pane id", async () => {
+    const runner = new FakeRunner();
+    const selectedPlan = plan();
+    seed(runner, selectedPlan);
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+
+    await expect(
+      executor.executeGuardedViewOperation(operation("attach", selectedPlan)),
+    ).resolves.toBe("executed");
+    const proofCall = runner.calls.find(
+      (argv) => argv[0] === "list-panes" && argv[2] === "$12:@34",
+    );
+    expect(proofCall?.[2]).toBe("$12:@34");
+    expect(proofCall).not.toContain("%56");
+    expect(runner.calls.at(-1)).toEqual(selectedPlan.attach.argv);
+  });
+
+  it("rechecks source inside the tmux server queue and fails closed on last-moment churn", async () => {
+    const runner = new FakeRunner();
+    runner.before = (argv) => {
+      if (argv[0] === "list-panes") runner.serverSourceGuardMatches = false;
+    };
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+
+    await expect(executor.executeGuardedViewOperation(operation())).resolves.toBe(
+      "source-proof-mismatch",
+    );
+    expect(runner.mutationCount).toBe(0);
+    expect(runner.calls.some((argv) => argv[0] === "new-session")).toBe(false);
+  });
+
+  it("rejects injected or noncanonical argv before touching tmux", async () => {
+    const runner = new FakeRunner();
+    const hostile = structuredClone(plan()) as GroupedTmuxAttachmentPlan & {
+      create: { command: { argv: string[] } };
+    };
+    hostile.create.command.argv.push(";", "run-shell", "touch /tmp/owned");
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+
+    await expect(
+      executor.executeGuardedViewOperation(operation("create", hostile)),
+    ).rejects.toEqual(new TmuxAttachmentViewExecutorError("invalid-request"));
+    expect(runner.calls).toHaveLength(0);
+  });
+
+  it("validates ownership/topology before attach and recover", async () => {
+    const runner = new FakeRunner();
+    const selectedPlan = plan();
+    seed(runner, selectedPlan, { marker: "v1:00000000-0000-4000-8000-000000000000:0" });
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    await expect(
+      executor.executeGuardedViewOperation(operation("attach", selectedPlan)),
+    ).rejects.toMatchObject({ code: "view-state-mismatch" });
+    expect(runner.mutationCount).toBe(0);
+
+    seed(runner, selectedPlan, { windows: ["@35"] });
+    await expect(
+      executor.executeGuardedViewOperation(operation("recover", selectedPlan)),
+    ).rejects.toMatchObject({ code: "view-state-mismatch" });
+    expect(runner.mutationCount).toBe(0);
+  });
+
+  it("reports a partial mutation as uncertain, rolls back only a canonical view, and leaks nothing", async () => {
+    const runner = new FakeRunner();
+    runner.partialCreateFailure = true;
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    try {
+      await executor.executeGuardedViewOperation(operation());
+      throw new Error("expected uncertain mutation");
+    } catch (error) {
+      expect(error).toBeInstanceOf(TmuxAttachmentViewExecutorError);
+      expect(error).toMatchObject({ code: "mutation-outcome-uncertain" });
+      expect((error as Error).cause).toBeUndefined();
+      expect(exposed(error)).not.toMatch(/raw-secret|%999|\$888|@777/u);
+    }
+    expect(runner.views.size).toBe(0);
+    expect(runner.calls.some((argv) => argv[0] === "kill-session")).toBe(true);
+  });
+
+  it("sanitizes arbitrary runner exceptions without retaining a cause", async () => {
+    const runner = new FakeRunner();
+    runner.fail = (argv) => (argv[0] === "list-panes" ? "throw" : null);
+    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    try {
+      await executor.executeGuardedViewOperation(operation());
+      throw new Error("expected command failure");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "tmux-command-failed" });
+      expect((error as Error).cause).toBeUndefined();
+      expect(exposed(error)).not.toMatch(/raw-secret|%999|\$888|@777/u);
+    }
+  });
+});
+
+describe("TmuxAttachmentViewExecutor guarded cleanup", () => {
+  it("kills only an exact canonical marked one-window view", async () => {
+    const runner = new FakeRunner();
+    const selectedPlan = plan();
+    seed(runner, selectedPlan);
+    const executor = new TmuxAttachmentViewExecutor({ runner });
+
+    await expect(executor.guardedCleanup(cleanup(selectedPlan))).resolves.toBe("cleaned");
+    expect(runner.views.has(selectedPlan.identity.viewSessionName)).toBe(false);
+    const viewCommands = runner.calls.filter((argv) =>
+      ["has-session", "show-options", "list-windows", "kill-session"].includes(argv[0]!),
+    );
+    for (const argv of viewCommands) {
+      const target = argv[argv.indexOf("-t") + 1];
+      expect(target).toBe(`=${selectedPlan.identity.viewSessionName}`);
+    }
+  });
+
+  it("rechecks marker/topology in the final tmux queue and does not kill after churn", async () => {
+    const runner = new FakeRunner();
+    seed(runner);
+    runner.serverViewGuardMatches = false;
+    const executor = new TmuxAttachmentViewExecutor({ runner });
+
+    await expect(executor.guardedCleanup(cleanup())).resolves.toBe("topology-mismatch");
+    expect(runner.views.has(plan().identity.viewSessionName)).toBe(true);
+    expect(runner.mutationCount).toBe(0);
+  });
+
+  it.each([
+    ["ownership-mismatch", { marker: "v1:00000000-0000-4000-8000-000000000000:0" }],
+    ["topology-mismatch", { windows: ["@35"] }],
+    ["topology-mismatch", { windows: ["@34", "@35"] }],
+  ] as const)("returns %s without mutation", async (expected, overrides) => {
+    const runner = new FakeRunner();
+    seed(runner, plan(), overrides);
+    const executor = new TmuxAttachmentViewExecutor({ runner });
+    await expect(executor.guardedCleanup(cleanup())).resolves.toBe(expected);
+    expect(runner.mutationCount).toBe(0);
+  });
+
+  it("serializes execute and cleanup across distinct executor/lease-manager boundaries", async () => {
+    const runner = new FakeRunner();
+    const firstPlan = plan();
+    const secondPlan = plan(secondAttachmentId);
+    seed(runner, secondPlan);
+    const first = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    const second = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+
+    const creating = first.executeGuardedViewOperation(operation("create", firstPlan));
+    const cleaning = second.guardedCleanup(cleanup(secondPlan));
+    await expect(Promise.all([creating, cleaning])).resolves.toEqual(["executed", "cleaned"]);
+
+    const createIndex = runner.calls.findIndex((argv) => argv[0] === "new-session");
+    const secondProbeIndex = runner.calls.findIndex(
+      (argv) =>
+        argv[0] === "has-session" && argv.at(-1) === `=${secondPlan.identity.viewSessionName}`,
+    );
+    expect(createIndex).toBeGreaterThanOrEqual(0);
+    expect(secondProbeIndex).toBeGreaterThan(createIndex);
+  });
+});
+
+describe("TmuxAttachmentViewExecutor marked-view enumeration", () => {
+  it("returns only validated bounded identities and queries each view by exact name", async () => {
+    const runner = new FakeRunner();
+    const first = plan();
+    const second = plan(secondAttachmentId, 2);
+    seed(runner, first);
+    seed(runner, second, { marker: null });
+    runner.sessionsOutput = [
+      `durable-source\t${first.identity.markerValue}`,
+      `${first.identity.viewSessionName}\t${first.identity.markerValue}`,
+      `${second.identity.viewSessionName}\t`,
+    ].join("\n");
+    const executor = new TmuxAttachmentViewExecutor({ runner });
+
+    await expect(
+      executor.enumerateMarkedViews(
+        GROUPED_TMUX_VIEW_SESSION_PREFIX,
+        GROUPED_TMUX_VIEW_MARKER_OPTION,
+      ),
+    ).resolves.toEqual([
+      {
+        viewSessionName: first.identity.viewSessionName,
+        markerValue: first.identity.markerValue,
+        windowIds: ["@34"],
+      },
+      {
+        viewSessionName: second.identity.viewSessionName,
+        markerValue: null,
+        windowIds: ["@34"],
+      },
+    ]);
+    for (const argv of runner.calls.filter((entry) => entry[0] === "list-windows")) {
+      expect(argv[argv.indexOf("-t") + 1]).toMatch(/^=_tmux-ide-view-v1-/u);
+    }
+  });
+
+  it.each([
+    ["malformed row", `${plan().identity.viewSessionName}`],
+    [
+      "duplicate row",
+      `${plan().identity.viewSessionName}\t${plan().identity.markerValue}\n${plan().identity.viewSessionName}\t${plan().identity.markerValue}`,
+    ],
+    ["noncanonical generated name", `${GROUPED_TMUX_VIEW_SESSION_PREFIX}not-an-id-0\t`],
+    ["oversized output", "x".repeat(128 * 1024 + 1)],
+  ])("fails closed with a static error for %s", async (_label, sessionsOutput) => {
+    const runner = new FakeRunner();
+    runner.sessionsOutput = sessionsOutput;
+    const executor = new TmuxAttachmentViewExecutor({ runner });
+    try {
+      await executor.enumerateMarkedViews(
+        GROUPED_TMUX_VIEW_SESSION_PREFIX,
+        GROUPED_TMUX_VIEW_MARKER_OPTION,
+      );
+      throw new Error("expected invalid output");
+    } catch (error) {
+      expect(error).toBeInstanceOf(TmuxAttachmentViewExecutorError);
+      expect(error).toMatchObject({ code: "invalid-tmux-output" });
+      expect((error as Error).cause).toBeUndefined();
+      expect((error as Error).message).toBe(
+        "Trusted tmux attachment discovery returned invalid output.",
+      );
+    }
+  });
+
+  it("rejects duplicate, malformed, and overlarge per-view window output", async () => {
+    const runner = new FakeRunner();
+    const selectedPlan = plan();
+    seed(runner, selectedPlan);
+    runner.rawOutput = (argv) => (argv[0] === "list-windows" ? "@34\n@34\n" : null);
+    const executor = new TmuxAttachmentViewExecutor({ runner });
+    await expect(
+      executor.enumerateMarkedViews(
+        GROUPED_TMUX_VIEW_SESSION_PREFIX,
+        GROUPED_TMUX_VIEW_MARKER_OPTION,
+      ),
+    ).rejects.toMatchObject({ code: "invalid-tmux-output" });
+  });
+});

--- a/packages/daemon/src/terminal/__tests__/tmux-view-executor.test.ts
+++ b/packages/daemon/src/terminal/__tests__/tmux-view-executor.test.ts
@@ -1,7 +1,7 @@
 import { inspect } from "node:util";
 import { describe, expect, it } from "vitest";
 import {
-  GROUPED_TMUX_VIEW_MARKER_OPTION,
+  GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
   GROUPED_TMUX_VIEW_SESSION_PREFIX,
   planGroupedTmuxAttachment,
   type GroupedTmuxAttachmentPlan,
@@ -14,6 +14,7 @@ import type {
 import {
   TmuxAttachmentViewExecutor,
   TmuxAttachmentViewExecutorError,
+  type TmuxAttachmentClientTransportResult,
   type TmuxAttachmentCommandResult,
   type TmuxAttachmentCommandRunner,
 } from "../attachments/tmux-view-executor.ts";
@@ -29,6 +30,7 @@ interface FakeView {
 class FakeRunner implements TmuxAttachmentCommandRunner {
   readonly calls: string[][] = [];
   readonly views = new Map<string, FakeView>();
+  readonly sessionIds = new Map<string, string>();
   sourceOutput = "$12\t@34\t%56\t1\n";
   sessionsOutput: string | null = null;
   rawOutput: ((argv: readonly string[]) => string | null) | undefined;
@@ -38,6 +40,14 @@ class FakeRunner implements TmuxAttachmentCommandRunner {
   mutationCount = 0;
   serverSourceGuardMatches = true;
   serverViewGuardMatches = true;
+
+  sessionId(name: string): string {
+    const existing = this.sessionIds.get(name);
+    if (existing) return existing;
+    const allocated = `$${90 + this.sessionIds.size}`;
+    this.sessionIds.set(name, allocated);
+    return allocated;
+  }
 
   #parseCommandString(value: string): string[][] {
     const commands: string[][] = [[]];
@@ -74,15 +84,17 @@ class FakeRunner implements TmuxAttachmentCommandRunner {
       const name = creation[creation.indexOf("-s") + 1]!;
       const markerCommand = commands.find(
         (command) =>
-          command[0] === "set-option" && command.includes(GROUPED_TMUX_VIEW_MARKER_OPTION),
+          command[0] === "set-environment" &&
+          command.includes(GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT),
       );
-      const markerIndex = markerCommand?.indexOf(GROUPED_TMUX_VIEW_MARKER_OPTION) ?? -1;
+      const markerIndex = markerCommand?.indexOf(GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT) ?? -1;
       const link = commands.find((command) => command[0] === "link-window");
       const source = link?.[link.indexOf("-s") + 1] ?? "";
       this.views.set(name, {
         marker: markerCommand?.[markerIndex + 1] ?? null,
         windows: [source.slice(source.indexOf(":") + 1)],
       });
+      this.sessionId(name);
       this.mutationCount += 1;
       return this.partialCreateFailure ? { status: "failed" } : { status: "ok", stdout: "" };
     }
@@ -110,7 +122,7 @@ class FakeRunner implements TmuxAttachmentCommandRunner {
       case "if-shell": {
         const target = argv[argv.indexOf("-t") + 1] ?? "";
         const isViewGuard =
-          target.startsWith("=") || argv[4]?.includes(GROUPED_TMUX_VIEW_MARKER_OPTION);
+          target.startsWith("=") || argv[4]?.includes(GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT);
         const matches = isViewGuard ? this.serverViewGuardMatches : this.serverSourceGuardMatches;
         return this.#runCommandString(argv[matches ? 5 : 6]!);
       }
@@ -118,11 +130,19 @@ class FakeRunner implements TmuxAttachmentCommandRunner {
         const name = argv.at(-1)?.replace(/^=/u, "") ?? "";
         return this.views.has(name) ? { status: "ok", stdout: "" } : { status: "not-found" };
       }
-      case "show-options": {
-        const target = argv[argv.indexOf("-t") + 1]?.replace(/^=/u, "") ?? "";
-        const view = this.views.get(target);
+      case "show-environment": {
+        const sessionId = argv[argv.indexOf("-t") + 1] ?? "";
+        const name = [...this.sessionIds.entries()].find((entry) => entry[1] === sessionId)?.[0];
+        const view = name ? this.views.get(name) : undefined;
         if (!view) return { status: "not-found" };
-        return { status: "ok", stdout: `${view.marker ?? ""}\n` };
+        if (argv.at(-1) !== GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT) {
+          return { status: "failed" };
+        }
+        if (view.marker === null) return { status: "variable-not-found" };
+        return {
+          status: "ok",
+          stdout: `${GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT}=${view.marker}\n`,
+        };
       }
       case "list-windows": {
         const target = argv[argv.indexOf("-t") + 1]?.replace(/^=/u, "") ?? "";
@@ -135,12 +155,12 @@ class FakeRunner implements TmuxAttachmentCommandRunner {
         if (!target.startsWith("=")) return { status: "ok", stdout: this.sourceOutput };
         const view = this.views.get(target.slice(1));
         if (!view) return { status: "not-found" };
-        if (argv.at(-1) === `#{${GROUPED_TMUX_VIEW_MARKER_OPTION}}`) {
-          return { status: "ok", stdout: `${view.marker ?? ""}\n` };
+        if (argv.at(-1) === "#{session_id}") {
+          return { status: "ok", stdout: `${this.sessionId(target.slice(1))}\n` };
         }
         return {
           status: "ok",
-          stdout: `$90\t${view.windows[0] ?? "@0"}\t%91\t${view.windows.length === 1 ? "1" : "2"}\t1\t${view.marker ?? ""}\n`,
+          stdout: `${this.sessionId(target.slice(1))}\t${view.windows[0] ?? "@0"}\t%91\t${view.windows.length === 1 ? "1" : "2"}\t1\n`,
         };
       }
       case "list-sessions":
@@ -149,19 +169,21 @@ class FakeRunner implements TmuxAttachmentCommandRunner {
           stdout:
             this.sessionsOutput ??
             [...this.views.entries()]
-              .map(([name, view]) => `${name}\t${view.marker ?? ""}`)
+              .map(([name]) => `${name}\t${this.sessionId(name)}`)
               .join("\n"),
         };
       case "kill-session": {
         const name = argv.at(-1)?.replace(/^=/u, "") ?? "";
         if (!this.views.has(name)) return { status: "not-found" };
         this.views.delete(name);
+        this.sessionIds.delete(name);
         this.mutationCount += 1;
         return { status: "ok", stdout: "" };
       }
       case "attach-session":
       case "select-window":
       case "set-option":
+      case "set-environment":
         this.mutationCount += 1;
         return { status: "ok", stdout: "" };
       case "display-message":
@@ -210,7 +232,7 @@ function operation(
 function cleanup(selectedPlan = plan()): GuardedAttachmentCleanup {
   return {
     exactViewSessionTarget: `=${selectedPlan.identity.viewSessionName}`,
-    markerOption: GROUPED_TMUX_VIEW_MARKER_OPTION,
+    markerEnvironment: GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
     expectedMarkerValue: selectedPlan.identity.markerValue,
     expectedWindowId: selectedPlan.identity.durableSource.windowId,
   };
@@ -222,6 +244,23 @@ function seed(runner: FakeRunner, selectedPlan = plan(), overrides: Partial<Fake
     windows: [selectedPlan.identity.durableSource.windowId],
     ...overrides,
   });
+  runner.sessionId(selectedPlan.identity.viewSessionName);
+}
+
+function clientTransport(runner: FakeRunner) {
+  return {
+    runGuardedAttach: (command: TmuxArgvPlan): TmuxAttachmentClientTransportResult => {
+      const result = runner.run(command);
+      if (result.status !== "ok") return { status: "failed" };
+      if (result.stdout.trim() === "__tmux_ide_source_proof_mismatch_v1__") {
+        return { status: "source-proof-mismatch" };
+      }
+      if (result.stdout.trim() === "__tmux_ide_view_proof_mismatch_v1__") {
+        return { status: "view-proof-mismatch" };
+      }
+      return { status: "executed" };
+    },
+  };
 }
 
 function exposed(error: unknown): string {
@@ -284,7 +323,11 @@ describe("TmuxAttachmentViewExecutor guarded execution", () => {
     const runner = new FakeRunner();
     const selectedPlan = plan();
     seed(runner, selectedPlan);
-    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    const executor = new TmuxAttachmentViewExecutor({
+      runner,
+      clientTransport: clientTransport(runner),
+      now: () => 1_000,
+    });
 
     await expect(
       executor.executeGuardedViewOperation(operation("attach", selectedPlan)),
@@ -311,6 +354,44 @@ describe("TmuxAttachmentViewExecutor guarded execution", () => {
     expect(runner.calls.some((argv) => argv[0] === "new-session")).toBe(false);
   });
 
+  it("preserves a last-moment source guard failure through the client transport", async () => {
+    const runner = new FakeRunner();
+    const selectedPlan = plan();
+    seed(runner, selectedPlan);
+    runner.before = (argv) => {
+      if (argv[0] === "list-panes" && argv[2] === "$12:@34") {
+        runner.serverSourceGuardMatches = false;
+      }
+    };
+    const executor = new TmuxAttachmentViewExecutor({
+      runner,
+      clientTransport: clientTransport(runner),
+      now: () => 1_000,
+    });
+
+    await expect(
+      executor.executeGuardedViewOperation(operation("attach", selectedPlan)),
+    ).resolves.toBe("source-proof-mismatch");
+    expect(runner.mutationCount).toBe(0);
+  });
+
+  it("preserves a last-moment view guard failure through the client transport", async () => {
+    const runner = new FakeRunner();
+    const selectedPlan = plan();
+    seed(runner, selectedPlan);
+    runner.serverViewGuardMatches = false;
+    const executor = new TmuxAttachmentViewExecutor({
+      runner,
+      clientTransport: clientTransport(runner),
+      now: () => 1_000,
+    });
+
+    await expect(
+      executor.executeGuardedViewOperation(operation("recover", selectedPlan)),
+    ).rejects.toMatchObject({ code: "view-state-mismatch" });
+    expect(runner.mutationCount).toBe(0);
+  });
+
   it("rejects injected or noncanonical argv before touching tmux", async () => {
     const runner = new FakeRunner();
     const hostile = structuredClone(plan()) as GroupedTmuxAttachmentPlan & {
@@ -329,7 +410,11 @@ describe("TmuxAttachmentViewExecutor guarded execution", () => {
     const runner = new FakeRunner();
     const selectedPlan = plan();
     seed(runner, selectedPlan, { marker: "v1:00000000-0000-4000-8000-000000000000:0" });
-    const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    const executor = new TmuxAttachmentViewExecutor({
+      runner,
+      clientTransport: clientTransport(runner),
+      now: () => 1_000,
+    });
     await expect(
       executor.executeGuardedViewOperation(operation("attach", selectedPlan)),
     ).rejects.toMatchObject({ code: "view-state-mismatch" });
@@ -341,6 +426,25 @@ describe("TmuxAttachmentViewExecutor guarded execution", () => {
     ).rejects.toMatchObject({ code: "view-state-mismatch" });
     expect(runner.mutationCount).toBe(0);
   });
+
+  it.each(["attach", "recover"] as const)(
+    "rejects %s without an explicit client transport before any command or mutation",
+    async (selected) => {
+      const runner = new FakeRunner();
+      seed(runner);
+      runner.calls.length = 0;
+      const executor = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+
+      await expect(executor.executeGuardedViewOperation(operation(selected))).rejects.toMatchObject(
+        {
+          code: "attachment-transport-unavailable",
+          message: "A tmux client transport is required for this attachment operation.",
+        },
+      );
+      expect(runner.calls).toHaveLength(0);
+      expect(runner.mutationCount).toBe(0);
+    },
+  );
 
   it("reports a partial mutation as uncertain, rolls back only a canonical view, and leaks nothing", async () => {
     const runner = new FakeRunner();
@@ -371,6 +475,28 @@ describe("TmuxAttachmentViewExecutor guarded execution", () => {
       expect((error as Error).cause).toBeUndefined();
       expect(exposed(error)).not.toMatch(/raw-secret|%999|\$888|@777/u);
     }
+  });
+
+  it("sanitizes exact marker-query failures without retaining tmux output", async () => {
+    const runner = new FakeRunner();
+    seed(runner);
+    runner.fail = (argv) => (argv[0] === "show-environment" ? "throw" : null);
+    const executor = new TmuxAttachmentViewExecutor({ runner });
+
+    try {
+      await executor.guardedCleanup(cleanup());
+      throw new Error("expected command failure");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "tmux-command-failed" });
+      expect((error as Error).cause).toBeUndefined();
+      expect(exposed(error)).not.toMatch(/raw-secret|%999|\$888|@777/u);
+    }
+    expect(runner.calls).toContainEqual([
+      "show-environment",
+      "-t",
+      runner.sessionId(plan().identity.viewSessionName),
+      GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
+    ]);
   });
 });
 
@@ -445,16 +571,16 @@ describe("TmuxAttachmentViewExecutor marked-view enumeration", () => {
     seed(runner, first);
     seed(runner, second, { marker: null });
     runner.sessionsOutput = [
-      `durable-source\t${first.identity.markerValue}`,
-      `${first.identity.viewSessionName}\t${first.identity.markerValue}`,
-      `${second.identity.viewSessionName}\t`,
+      "durable-source\t$1",
+      `${first.identity.viewSessionName}\t${runner.sessionId(first.identity.viewSessionName)}`,
+      `${second.identity.viewSessionName}\t${runner.sessionId(second.identity.viewSessionName)}`,
     ].join("\n");
     const executor = new TmuxAttachmentViewExecutor({ runner });
 
     await expect(
       executor.enumerateMarkedViews(
         GROUPED_TMUX_VIEW_SESSION_PREFIX,
-        GROUPED_TMUX_VIEW_MARKER_OPTION,
+        GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
       ),
     ).resolves.toEqual([
       {
@@ -471,15 +597,19 @@ describe("TmuxAttachmentViewExecutor marked-view enumeration", () => {
     for (const argv of runner.calls.filter((entry) => entry[0] === "list-windows")) {
       expect(argv[argv.indexOf("-t") + 1]).toMatch(/^=_tmux-ide-view-v1-/u);
     }
+    for (const argv of runner.calls.filter((entry) => entry[0] === "show-environment")) {
+      expect(argv).toHaveLength(4);
+      expect(argv.at(-1)).toBe(GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT);
+    }
   });
 
   it.each([
     ["malformed row", `${plan().identity.viewSessionName}`],
     [
       "duplicate row",
-      `${plan().identity.viewSessionName}\t${plan().identity.markerValue}\n${plan().identity.viewSessionName}\t${plan().identity.markerValue}`,
+      `${plan().identity.viewSessionName}\t$90\n${plan().identity.viewSessionName}\t$90`,
     ],
-    ["noncanonical generated name", `${GROUPED_TMUX_VIEW_SESSION_PREFIX}not-an-id-0\t`],
+    ["noncanonical generated name", `${GROUPED_TMUX_VIEW_SESSION_PREFIX}not-an-id-0\t$90`],
     ["oversized output", "x".repeat(128 * 1024 + 1)],
   ])("fails closed with a static error for %s", async (_label, sessionsOutput) => {
     const runner = new FakeRunner();
@@ -488,7 +618,7 @@ describe("TmuxAttachmentViewExecutor marked-view enumeration", () => {
     try {
       await executor.enumerateMarkedViews(
         GROUPED_TMUX_VIEW_SESSION_PREFIX,
-        GROUPED_TMUX_VIEW_MARKER_OPTION,
+        GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
       );
       throw new Error("expected invalid output");
     } catch (error) {
@@ -510,7 +640,7 @@ describe("TmuxAttachmentViewExecutor marked-view enumeration", () => {
     await expect(
       executor.enumerateMarkedViews(
         GROUPED_TMUX_VIEW_SESSION_PREFIX,
-        GROUPED_TMUX_VIEW_MARKER_OPTION,
+        GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
       ),
     ).rejects.toMatchObject({ code: "invalid-tmux-output" });
   });

--- a/packages/daemon/src/terminal/attachments/grouped-tmux.ts
+++ b/packages/daemon/src/terminal/attachments/grouped-tmux.ts
@@ -10,8 +10,12 @@ import {
 
 /** Namespace reserved for daemon-owned, disposable grouped view sessions. */
 export const GROUPED_TMUX_VIEW_SESSION_PREFIX = "_tmux-ide-view-v1-" as const;
-/** Session-local proof that cleanup owns a view rather than a durable session. */
-export const GROUPED_TMUX_VIEW_MARKER_OPTION = "@tmux_ide_attachment_view" as const;
+/**
+ * Session-local ownership proof. tmux has no pane/window scope for environment
+ * entries, unlike `@` user options whose effective format value can be
+ * shadowed by a linked pane or window.
+ */
+export const GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT = "TMUX_IDE_ATTACHMENT_VIEW" as const;
 export const GROUPED_TMUX_MAX_GENERATION = 65_535;
 const GROUPED_TMUX_PLACEHOLDER_WINDOW = "__tmux_ide_attachment_placeholder" as const;
 const GROUPED_TMUX_PLACEHOLDER_COMMAND = "exec sleep 2147483647" as const;
@@ -68,7 +72,7 @@ export interface GroupedTmuxAttachmentPlan {
     readonly attachmentId: string;
     readonly generation: number;
     readonly viewSessionName: string;
-    readonly markerOption: typeof GROUPED_TMUX_VIEW_MARKER_OPTION;
+    readonly markerEnvironment: typeof GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT;
     readonly markerValue: string;
     readonly semanticTarget: TerminalAttachmentSemanticTarget;
     readonly durableSource: {
@@ -157,7 +161,7 @@ function attachCommand(
  * session would expose every source window through next/previous navigation.
  *
  * The linked window's contents and window options are shared with the durable
- * source. This planner therefore mutates session-scoped view options only;
+ * source. This planner therefore mutates session-scoped view state only;
  * especially, read-only setup never writes `window-size` or resizes a window.
  */
 export function planGroupedTmuxAttachment(
@@ -169,8 +173,8 @@ export function planGroupedTmuxAttachment(
   const exactViewTarget = `=${viewSessionName}`;
   const existenceProbe = tmux(["has-session", "-t", exactViewTarget]);
   const ownership: TmuxOutputGate = {
-    query: tmux(["show-options", "-qv", "-t", viewSessionName, GROUPED_TMUX_VIEW_MARKER_OPTION]),
-    expectedStdout: viewMarkerValue,
+    query: tmux(["show-environment", "-t", exactViewTarget, GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT]),
+    expectedStdout: `${GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT}=${viewMarkerValue}`,
   };
   const topology: TmuxOutputGate = {
     query: tmux(["list-windows", "-t", exactViewTarget, "-F", "#{window_id}"]),
@@ -191,10 +195,10 @@ export function planGroupedTmuxAttachment(
     GROUPED_TMUX_PLACEHOLDER_WINDOW,
     GROUPED_TMUX_PLACEHOLDER_COMMAND,
     ";",
-    "set-option",
+    "set-environment",
     "-t",
     viewSessionName,
-    GROUPED_TMUX_VIEW_MARKER_OPTION,
+    GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
     viewMarkerValue,
     ";",
     "set-option",
@@ -226,7 +230,7 @@ export function planGroupedTmuxAttachment(
       attachmentId: parsed.attachmentId,
       generation: parsed.generation,
       viewSessionName,
-      markerOption: GROUPED_TMUX_VIEW_MARKER_OPTION,
+      markerEnvironment: GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
       markerValue: viewMarkerValue,
       semanticTarget: parsed.target,
       durableSource: {

--- a/packages/daemon/src/terminal/attachments/lease-manager.ts
+++ b/packages/daemon/src/terminal/attachments/lease-manager.ts
@@ -8,7 +8,7 @@ import {
 } from "@tmux-ide/contracts";
 import {
   GROUPED_TMUX_MAX_GENERATION,
-  GROUPED_TMUX_VIEW_MARKER_OPTION,
+  GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
   GROUPED_TMUX_VIEW_SESSION_PREFIX,
   groupedTmuxViewSessionName,
   planGroupedTmuxAttachment,
@@ -58,7 +58,7 @@ export type GuardedAttachmentCleanupResult =
 export interface GuardedAttachmentCleanup {
   /** Exact-name tmux target. Never a caller-authored prefix or pattern. */
   readonly exactViewSessionTarget: `=${string}`;
-  readonly markerOption: typeof GROUPED_TMUX_VIEW_MARKER_OPTION;
+  readonly markerEnvironment: typeof GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT;
   readonly expectedMarkerValue: string;
   readonly expectedWindowId: string;
 }
@@ -107,7 +107,7 @@ export interface AttachmentViewExecutor {
   ) => Promise<GuardedAttachmentViewOperationResult>;
   readonly enumerateMarkedViews: (
     prefix: typeof GROUPED_TMUX_VIEW_SESSION_PREFIX,
-    markerOption: typeof GROUPED_TMUX_VIEW_MARKER_OPTION,
+    markerEnvironment: typeof GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
   ) => Promise<readonly EnumeratedMarkedAttachmentView[]>;
 }
 
@@ -677,7 +677,7 @@ export class AttachmentLeaseManager {
       try {
         const enumerated = await this.#viewExecutor.enumerateMarkedViews(
           GROUPED_TMUX_VIEW_SESSION_PREFIX,
-          GROUPED_TMUX_VIEW_MARKER_OPTION,
+          GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
         );
         if (!Array.isArray(enumerated)) throw new TypeError("Invalid marked view enumeration.");
         candidates = [...enumerated];
@@ -713,7 +713,7 @@ export class AttachmentLeaseManager {
         try {
           const result = await this.#viewExecutor.guardedCleanup({
             exactViewSessionTarget: `=${parsed.viewSessionName}`,
-            markerOption: GROUPED_TMUX_VIEW_MARKER_OPTION,
+            markerEnvironment: GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
             expectedMarkerValue: parsed.markerValue,
             expectedWindowId: parsed.windowId,
           });
@@ -932,7 +932,7 @@ export class AttachmentLeaseManager {
     try {
       const status = await this.#viewExecutor.guardedCleanup({
         exactViewSessionTarget: exactViewSessionTarget(state.plan),
-        markerOption: state.plan.identity.markerOption,
+        markerEnvironment: state.plan.identity.markerEnvironment,
         expectedMarkerValue: state.plan.identity.markerValue,
         expectedWindowId: state.plan.recover.topology.expectedStdout,
       });

--- a/packages/daemon/src/terminal/attachments/tmux-view-executor.ts
+++ b/packages/daemon/src/terminal/attachments/tmux-view-executor.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { runTmux, TmuxError } from "@tmux-ide/tmux-bridge";
 import {
   GROUPED_TMUX_MAX_GENERATION,
-  GROUPED_TMUX_VIEW_MARKER_OPTION,
+  GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
   GROUPED_TMUX_VIEW_SESSION_PREFIX,
   groupedTmuxViewSessionName,
   planGroupedTmuxAttachment,
@@ -23,6 +23,7 @@ const MAX_TMUX_OUTPUT_BYTES = 128 * 1024;
 const MAX_ENUMERATED_VIEWS = 256;
 const MAX_ENUMERATED_WINDOWS_PER_VIEW = 16;
 const MAX_SOURCE_PROOF_ROWS = 8;
+const MAX_MARKER_OUTPUT_ROWS = 1;
 const SOURCE_PROOF_MISMATCH_SENTINEL = "__tmux_ide_source_proof_mismatch_v1__";
 const VIEW_PROOF_MISMATCH_SENTINEL = "__tmux_ide_view_proof_mismatch_v1__";
 
@@ -45,7 +46,12 @@ const ViewNamePattern = /^_tmux-ide-view-v1-([0-9a-f]{32})-([0-9a-z]+)$/u;
 export type TmuxAttachmentCommandResult =
   | { readonly status: "ok"; readonly stdout: string }
   | { readonly status: "not-found" }
+  | { readonly status: "variable-not-found" }
   | { readonly status: "failed" };
+type TmuxAttachmentStandardCommandResult = Exclude<
+  TmuxAttachmentCommandResult,
+  { readonly status: "variable-not-found" }
+>;
 
 /**
  * Synchronous by design. The final source proof, deadline decision, and tmux
@@ -55,10 +61,28 @@ export interface TmuxAttachmentCommandRunner {
   readonly run: (command: TmuxArgvPlan) => TmuxAttachmentCommandResult;
 }
 
+export type TmuxAttachmentClientTransportResult =
+  | { readonly status: "executed" }
+  | { readonly status: "source-proof-mismatch" }
+  | { readonly status: "view-proof-mismatch" }
+  | { readonly status: "failed" };
+
+/**
+ * Explicit capability for commands which create a live tmux client. The
+ * ordinary daemon command runner is intentionally not treated as this
+ * capability: `attach-session` requires a PTY or control-client owner. The
+ * transport also owns decoding its terminal/control protocol and must not
+ * report `executed` unless the guarded mutation branch ran.
+ */
+export interface TmuxAttachmentClientTransport {
+  readonly runGuardedAttach: (command: TmuxArgvPlan) => TmuxAttachmentClientTransportResult;
+}
+
 export type TmuxAttachmentViewExecutorErrorCode =
   | "invalid-request"
   | "invalid-tmux-output"
   | "tmux-command-failed"
+  | "attachment-transport-unavailable"
   | "view-state-mismatch"
   | "mutation-outcome-uncertain";
 
@@ -66,6 +90,8 @@ const ERROR_MESSAGES: Record<TmuxAttachmentViewExecutorErrorCode, string> = {
   "invalid-request": "The guarded tmux attachment request is invalid.",
   "invalid-tmux-output": "Trusted tmux attachment discovery returned invalid output.",
   "tmux-command-failed": "The guarded tmux attachment command failed.",
+  "attachment-transport-unavailable":
+    "A tmux client transport is required for this attachment operation.",
   "view-state-mismatch": "The guarded tmux attachment view no longer matches its proof.",
   "mutation-outcome-uncertain": "The guarded tmux attachment mutation outcome is uncertain.",
 };
@@ -83,6 +109,7 @@ export class TmuxAttachmentViewExecutorError extends Error {
 
 export interface TmuxAttachmentViewExecutorOptions {
   readonly runner?: TmuxAttachmentCommandRunner;
+  readonly clientTransport?: TmuxAttachmentClientTransport;
   readonly now?: () => number;
 }
 
@@ -127,6 +154,9 @@ const productionRunner: TmuxAttachmentCommandRunner = {
     } catch (error) {
       if (error instanceof TmuxError && error.code === "SESSION_NOT_FOUND") {
         return { status: "not-found" };
+      }
+      if (error instanceof TmuxError && error.code === "ENVIRONMENT_VARIABLE_NOT_FOUND") {
+        return { status: "variable-not-found" };
       }
       return { status: "failed" };
     }
@@ -226,7 +256,7 @@ function canonicalMarker(attachmentId: string, generation: number): string {
 
 function parseCleanupIdentity(cleanup: GuardedAttachmentCleanup): ParsedViewIdentity {
   if (
-    cleanup.markerOption !== GROUPED_TMUX_VIEW_MARKER_OPTION ||
+    cleanup.markerEnvironment !== GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT ||
     !cleanup.exactViewSessionTarget.startsWith("=")
   ) {
     throw new TmuxAttachmentViewExecutorError("invalid-request");
@@ -278,10 +308,12 @@ function canonicalPlanFor(operation: GuardedAttachmentViewOperation): GroupedTmu
  */
 export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
   readonly #runner: TmuxAttachmentCommandRunner;
+  readonly #clientTransport: TmuxAttachmentClientTransport | null;
   readonly #now: () => number;
 
   constructor(options: TmuxAttachmentViewExecutorOptions = {}) {
     this.#runner = options.runner ?? productionRunner;
+    this.#clientTransport = options.clientTransport ?? null;
     this.#now = options.now ?? Date.now;
   }
 
@@ -297,25 +329,59 @@ export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
 
   enumerateMarkedViews(
     prefix: typeof GROUPED_TMUX_VIEW_SESSION_PREFIX,
-    markerOption: typeof GROUPED_TMUX_VIEW_MARKER_OPTION,
+    markerEnvironment: typeof GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
   ): Promise<readonly EnumeratedMarkedAttachmentView[]> {
-    return serializeServerWide(() => this.#enumerateMarkedViews(prefix, markerOption));
+    return serializeServerWide(() => this.#enumerateMarkedViews(prefix, markerEnvironment));
   }
 
-  #command(command: TmuxArgvPlan): TmuxAttachmentCommandResult {
+  #command(command: TmuxArgvPlan): TmuxAttachmentStandardCommandResult;
+  #command(
+    command: TmuxArgvPlan,
+    options: { readonly allowVariableNotFound: true },
+  ): TmuxAttachmentCommandResult;
+  #command(
+    command: TmuxArgvPlan,
+    options: { readonly allowVariableNotFound?: boolean } = {},
+  ): TmuxAttachmentCommandResult {
     if (command.executable !== "tmux") {
       throw new TmuxAttachmentViewExecutorError("invalid-request");
     }
     try {
       const result = this.#runner.run({ executable: "tmux", argv: [...command.argv] });
       if (result.status === "ok") boundedOutput(result.stdout);
-      if (!["ok", "not-found", "failed"].includes(result.status)) {
+      if (
+        !["ok", "not-found", "variable-not-found", "failed"].includes(result.status) ||
+        (result.status === "variable-not-found" && !options.allowVariableNotFound)
+      ) {
         throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
       }
       return result;
     } catch (error) {
       if (error instanceof TmuxAttachmentViewExecutorError) throw error;
       throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
+    }
+  }
+
+  #clientCommand(command: TmuxArgvPlan): TmuxAttachmentClientTransportResult {
+    if (!this.#clientTransport) {
+      throw new TmuxAttachmentViewExecutorError("attachment-transport-unavailable");
+    }
+    try {
+      const result = this.#clientTransport.runGuardedAttach({
+        executable: "tmux",
+        argv: [...command.argv],
+      });
+      if (
+        !["executed", "source-proof-mismatch", "view-proof-mismatch", "failed"].includes(
+          result.status,
+        )
+      ) {
+        throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
+      }
+      return result;
+    } catch (error) {
+      if (error instanceof TmuxAttachmentViewExecutorError) throw error;
+      throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
     }
   }
 
@@ -328,20 +394,42 @@ export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
     return true;
   }
 
-  #marker(exactTarget: `=${string}`): string | null {
+  #sessionMarker(sessionId: string): string | null {
+    if (!RuntimeSessionIdSchemaZ.safeParse(sessionId).success) {
+      throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+    }
     const result = this.#command(
-      tmux(["list-panes", "-t", exactTarget, "-F", `#{${GROUPED_TMUX_VIEW_MARKER_OPTION}}`]),
+      tmux(["show-environment", "-t", sessionId, GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT]),
+      { allowVariableNotFound: true },
     );
+    if (result.status === "not-found") return null;
+    if (result.status === "variable-not-found") return null;
+    if (result.status === "failed") {
+      throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
+    }
+    const rows = strictLines(result.stdout, MAX_MARKER_OUTPUT_ROWS);
+    const assignmentPrefix = `${GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT}=`;
+    if (rows.length !== 1 || !rows[0]!.startsWith(assignmentPrefix)) {
+      throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+    }
+    return rows[0]!.slice(assignmentPrefix.length);
+  }
+
+  #marker(exactTarget: `=${string}`): string | null {
+    const result = this.#command(tmux(["list-panes", "-t", exactTarget, "-F", "#{session_id}"]));
     if (result.status === "not-found") return null;
     if (result.status === "failed") {
       throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
     }
-    const markers = strictLines(result.stdout, MAX_SOURCE_PROOF_ROWS);
-    if (markers.length === 0) return "";
-    if (new Set(markers).size !== 1) {
+    const sessionIds = strictLines(result.stdout, MAX_SOURCE_PROOF_ROWS);
+    if (
+      sessionIds.length === 0 ||
+      new Set(sessionIds).size !== 1 ||
+      !RuntimeSessionIdSchemaZ.safeParse(sessionIds[0]).success
+    ) {
       throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
     }
-    return markers[0]!;
+    return this.#sessionMarker(sessionIds[0]!);
   }
 
   #windowIds(exactTarget: `=${string}`): readonly string[] | null {
@@ -371,7 +459,7 @@ export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
         "-t",
         exactTarget,
         "-F",
-        `#{session_id}\t#{window_id}\t#{pane_id}\t#{window_panes}\t#{session_windows}\t#{${GROUPED_TMUX_VIEW_MARKER_OPTION}}`,
+        "#{session_id}\t#{window_id}\t#{pane_id}\t#{window_panes}\t#{session_windows}",
       ]),
     );
     if (result.status === "not-found") return null;
@@ -381,10 +469,10 @@ export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
     const rows = strictLines(result.stdout, MAX_SOURCE_PROOF_ROWS);
     if (rows.length !== 1) return null;
     const fields = rows[0]!.split("\t");
-    if (fields.length !== 6) {
+    if (fields.length !== 5) {
       throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
     }
-    const [sessionId, windowId, paneId, paneCount, sessionWindowCount, marker] = fields;
+    const [sessionId, windowId, paneId, paneCount, sessionWindowCount] = fields;
     if (
       !RuntimeSessionIdSchemaZ.safeParse(sessionId).success ||
       !RuntimeWindowIdSchemaZ.safeParse(windowId).success ||
@@ -398,13 +486,13 @@ export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
       windowId !== expectedWindowId ||
       paneCount !== "1" ||
       sessionWindowCount !== "1" ||
-      marker !== expectedMarker
+      this.#sessionMarker(sessionId!) !== expectedMarker
     ) {
       return null;
     }
     return {
       target: `${sessionId}:${windowId}.${paneId}`,
-      format: `#{&&:#{==:#{session_id},${sessionId}},#{&&:#{==:#{window_id},${windowId}},#{&&:#{==:#{window_panes},1},#{&&:#{==:#{session_windows},1},#{==:#{${GROUPED_TMUX_VIEW_MARKER_OPTION}},${expectedMarker}}}}}}`,
+      format: `#{&&:#{==:#{session_id},${sessionId}},#{&&:#{==:#{window_id},${windowId}},#{&&:#{==:#{window_panes},1},#{&&:#{==:#{session_windows},1},#{==:#{${GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT}},${expectedMarker}}}}}}`,
     };
   }
 
@@ -412,7 +500,9 @@ export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
     const identity = parseCleanupIdentity(cleanup);
     if (!this.#viewExists(identity.exactTarget)) return "absent";
     const marker = this.#marker(identity.exactTarget);
-    if (marker === null) return "absent";
+    if (marker === null) {
+      return this.#viewExists(identity.exactTarget) ? "ownership-mismatch" : "absent";
+    }
     if (marker !== identity.markerValue) return "ownership-mismatch";
     const windows = this.#windowIds(identity.exactTarget);
     if (windows === null) return "absent";
@@ -548,28 +638,47 @@ export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
       viewGuardedMutation,
       tmuxCommandString(tmux(["display-message", "-p", SOURCE_PROOF_MISMATCH_SENTINEL])),
     ]);
-    let result: TmuxAttachmentCommandResult;
+    if (operation.operation === "create") {
+      let result: TmuxAttachmentCommandResult;
+      try {
+        result = this.#command(guarded);
+      } catch {
+        throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
+      }
+      if (result.status !== "ok") {
+        throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
+      }
+      const output = boundedOutput(result.stdout);
+      if (output === SOURCE_PROOF_MISMATCH_SENTINEL) return "source-proof-mismatch";
+      if (output === VIEW_PROOF_MISMATCH_SENTINEL) {
+        throw new TmuxAttachmentViewExecutorError("view-state-mismatch");
+      }
+      return "executed";
+    }
+
+    let result: TmuxAttachmentClientTransportResult;
     try {
-      result = this.#command(guarded);
+      result = this.#clientCommand(guarded);
     } catch {
       throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
     }
-    if (result.status !== "ok") {
-      throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
+    switch (result.status) {
+      case "executed":
+        return "executed";
+      case "source-proof-mismatch":
+        return "source-proof-mismatch";
+      case "view-proof-mismatch":
+        throw new TmuxAttachmentViewExecutorError("view-state-mismatch");
+      case "failed":
+        throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
     }
-    const output = boundedOutput(result.stdout);
-    if (output === SOURCE_PROOF_MISMATCH_SENTINEL) return "source-proof-mismatch";
-    if (output === VIEW_PROOF_MISMATCH_SENTINEL) {
-      throw new TmuxAttachmentViewExecutorError("view-state-mismatch");
-    }
-    return "executed";
   }
 
   #bestEffortRollbackCreate(plan: GroupedTmuxAttachmentPlan): void {
     try {
       this.#guardedCleanup({
         exactViewSessionTarget: `=${plan.identity.viewSessionName}`,
-        markerOption: GROUPED_TMUX_VIEW_MARKER_OPTION,
+        markerEnvironment: GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
         expectedMarkerValue: plan.identity.markerValue,
         expectedWindowId: plan.identity.durableSource.windowId,
       });
@@ -582,6 +691,9 @@ export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
     operation: GuardedAttachmentViewOperation,
   ): GuardedAttachmentViewOperationResult {
     const plan = canonicalPlanFor(operation);
+    if (operation.operation !== "create" && !this.#clientTransport) {
+      throw new TmuxAttachmentViewExecutorError("attachment-transport-unavailable");
+    }
     let viewGuard: ViewServerGuard | null = null;
 
     if (operation.operation === "create") {
@@ -623,23 +735,22 @@ export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
 
   #enumerateMarkedViews(
     prefix: typeof GROUPED_TMUX_VIEW_SESSION_PREFIX,
-    markerOption: typeof GROUPED_TMUX_VIEW_MARKER_OPTION,
+    markerEnvironment: typeof GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
   ): readonly EnumeratedMarkedAttachmentView[] {
     if (
       prefix !== GROUPED_TMUX_VIEW_SESSION_PREFIX ||
-      markerOption !== GROUPED_TMUX_VIEW_MARKER_OPTION
+      markerEnvironment !== GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT
     ) {
       throw new TmuxAttachmentViewExecutorError("invalid-request");
     }
-    const result = this.#command(
-      tmux(["list-sessions", "-F", `#{session_name}\t#{${GROUPED_TMUX_VIEW_MARKER_OPTION}}`]),
-    );
+    const result = this.#command(tmux(["list-sessions", "-F", "#{session_name}\t#{session_id}"]));
     if (result.status === "not-found") return [];
     if (result.status === "failed") {
       throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
     }
     const rows = strictLines(result.stdout, MAX_ENUMERATED_VIEWS * 4);
     const found = new Map<string, { identity: ParsedViewIdentity; markerValue: string | null }>();
+    const runtimeSessionIds = new Set<string>();
     for (const row of rows) {
       const separator = row.indexOf("\t");
       if (separator < 0 || row.indexOf("\t", separator + 1) >= 0) {
@@ -651,10 +762,18 @@ export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
       if (!parsedName || found.has(sessionName)) {
         throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
       }
-      const rawMarker = row.slice(separator + 1);
+      const sessionId = row.slice(separator + 1);
+      if (
+        !RuntimeSessionIdSchemaZ.safeParse(sessionId).success ||
+        runtimeSessionIds.has(sessionId)
+      ) {
+        throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+      }
+      runtimeSessionIds.add(sessionId);
+      const rawMarker = this.#sessionMarker(sessionId);
       let markerValue: string | null = null;
-      const markerMatch = MarkerPattern.exec(rawMarker);
-      if (markerMatch) {
+      const markerMatch = rawMarker === null ? null : MarkerPattern.exec(rawMarker);
+      if (rawMarker !== null && markerMatch) {
         const generation = Number.parseInt(markerMatch[2]!, 10);
         if (
           Number.isSafeInteger(generation) &&

--- a/packages/daemon/src/terminal/attachments/tmux-view-executor.ts
+++ b/packages/daemon/src/terminal/attachments/tmux-view-executor.ts
@@ -1,0 +1,691 @@
+import { isDeepStrictEqual } from "node:util";
+import { z } from "zod";
+import { runTmux, TmuxError } from "@tmux-ide/tmux-bridge";
+import {
+  GROUPED_TMUX_MAX_GENERATION,
+  GROUPED_TMUX_VIEW_MARKER_OPTION,
+  GROUPED_TMUX_VIEW_SESSION_PREFIX,
+  groupedTmuxViewSessionName,
+  planGroupedTmuxAttachment,
+  type GroupedTmuxAttachmentPlan,
+  type TmuxArgvPlan,
+} from "./grouped-tmux.ts";
+import type {
+  AttachmentViewExecutor,
+  EnumeratedMarkedAttachmentView,
+  GuardedAttachmentCleanup,
+  GuardedAttachmentCleanupResult,
+  GuardedAttachmentViewOperation,
+  GuardedAttachmentViewOperationResult,
+} from "./lease-manager.ts";
+
+const MAX_TMUX_OUTPUT_BYTES = 128 * 1024;
+const MAX_ENUMERATED_VIEWS = 256;
+const MAX_ENUMERATED_WINDOWS_PER_VIEW = 16;
+const MAX_SOURCE_PROOF_ROWS = 8;
+const SOURCE_PROOF_MISMATCH_SENTINEL = "__tmux_ide_source_proof_mismatch_v1__";
+const VIEW_PROOF_MISMATCH_SENTINEL = "__tmux_ide_view_proof_mismatch_v1__";
+
+const RuntimeSessionIdSchemaZ = z
+  .string()
+  .max(32)
+  .regex(/^\$(?:0|[1-9][0-9]*)$/u);
+const RuntimeWindowIdSchemaZ = z
+  .string()
+  .max(32)
+  .regex(/^@(?:0|[1-9][0-9]*)$/u);
+const RuntimePaneIdSchemaZ = z
+  .string()
+  .max(32)
+  .regex(/^%(?:0|[1-9][0-9]*)$/u);
+const MarkerPattern =
+  /^v1:([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}):(0|[1-9][0-9]*)$/u;
+const ViewNamePattern = /^_tmux-ide-view-v1-([0-9a-f]{32})-([0-9a-z]+)$/u;
+
+export type TmuxAttachmentCommandResult =
+  | { readonly status: "ok"; readonly stdout: string }
+  | { readonly status: "not-found" }
+  | { readonly status: "failed" };
+
+/**
+ * Synchronous by design. The final source proof, deadline decision, and tmux
+ * process spawn must remain in one uninterrupted JavaScript critical section.
+ */
+export interface TmuxAttachmentCommandRunner {
+  readonly run: (command: TmuxArgvPlan) => TmuxAttachmentCommandResult;
+}
+
+export type TmuxAttachmentViewExecutorErrorCode =
+  | "invalid-request"
+  | "invalid-tmux-output"
+  | "tmux-command-failed"
+  | "view-state-mismatch"
+  | "mutation-outcome-uncertain";
+
+const ERROR_MESSAGES: Record<TmuxAttachmentViewExecutorErrorCode, string> = {
+  "invalid-request": "The guarded tmux attachment request is invalid.",
+  "invalid-tmux-output": "Trusted tmux attachment discovery returned invalid output.",
+  "tmux-command-failed": "The guarded tmux attachment command failed.",
+  "view-state-mismatch": "The guarded tmux attachment view no longer matches its proof.",
+  "mutation-outcome-uncertain": "The guarded tmux attachment mutation outcome is uncertain.",
+};
+
+/** Static, serialization-safe errors: raw tmux stderr/stdout is never retained. */
+export class TmuxAttachmentViewExecutorError extends Error {
+  readonly code: TmuxAttachmentViewExecutorErrorCode;
+
+  constructor(code: TmuxAttachmentViewExecutorErrorCode) {
+    super(ERROR_MESSAGES[code]);
+    this.name = "TmuxAttachmentViewExecutorError";
+    this.code = code;
+  }
+}
+
+export interface TmuxAttachmentViewExecutorOptions {
+  readonly runner?: TmuxAttachmentCommandRunner;
+  readonly now?: () => number;
+}
+
+interface ParsedViewIdentity {
+  readonly attachmentId: string;
+  readonly generation: number;
+  readonly viewSessionName: string;
+  readonly markerValue: string;
+  readonly exactTarget: `=${string}`;
+}
+
+interface ViewServerGuard {
+  readonly target: string;
+  readonly format: string;
+}
+
+/*
+ * One queue is shared by every executor instance in this daemon process. A
+ * lease manager has its own queue, but that is not enough when more than one
+ * manager is alive during lifecycle transitions or tests.
+ */
+let serverWideAttachmentOperationTail: Promise<void> = Promise.resolve();
+
+function serializeServerWide<T>(operation: () => T): Promise<T> {
+  const run = serverWideAttachmentOperationTail.then(operation, operation);
+  serverWideAttachmentOperationTail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+const productionRunner: TmuxAttachmentCommandRunner = {
+  run(command) {
+    try {
+      const stdout = runTmux([...command.argv], {
+        encoding: "utf8",
+        maxBuffer: MAX_TMUX_OUTPUT_BYTES,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      return { status: "ok", stdout: String(stdout) };
+    } catch (error) {
+      if (error instanceof TmuxError && error.code === "SESSION_NOT_FOUND") {
+        return { status: "not-found" };
+      }
+      return { status: "failed" };
+    }
+  },
+};
+
+function tmux(argv: readonly string[]): TmuxArgvPlan {
+  return { executable: "tmux", argv };
+}
+
+function quoteTmuxCommandArgument(value: string): string {
+  if (value.includes("\0") || value.includes("\n") || value.includes("\r")) {
+    throw new TmuxAttachmentViewExecutorError("invalid-request");
+  }
+  // JSON's double-quoted escaping is a strict subset of tmux's command parser
+  // for the bounded ASCII argv produced by the canonical planner. Quoting
+  // every token also keeps runtime ids such as `$12` literal.
+  return JSON.stringify(value);
+}
+
+function tmuxCommandString(command: TmuxArgvPlan): string {
+  if (command.executable !== "tmux") {
+    throw new TmuxAttachmentViewExecutorError("invalid-request");
+  }
+  return command.argv
+    .map((argument) => (argument === ";" ? ";" : quoteTmuxCommandArgument(argument)))
+    .join(" ");
+}
+
+function tmuxCommandListString(commands: readonly TmuxArgvPlan[]): string {
+  return commands.map(tmuxCommandString).join(" ; ");
+}
+
+function sourcePaneTarget(operation: GuardedAttachmentViewOperation): string {
+  return `${operation.source.sessionId}:${operation.source.windowId}.${operation.source.runtimePaneId}`;
+}
+
+function sourceProofFormat(operation: GuardedAttachmentViewOperation): string {
+  const source = operation.source;
+  // The target itself includes the globally unique runtime pane id. tmux's
+  // format comparator treats a `%N` rhs specially, so re-check the enclosing
+  // session/window/count while target resolution proves the pane identity.
+  return `#{&&:#{==:#{session_id},${source.sessionId}},#{&&:#{==:#{window_id},${source.windowId}},#{==:#{window_panes},1}}}`;
+}
+
+function boundedOutput(stdout: string): string {
+  if (
+    typeof stdout !== "string" ||
+    stdout.includes("\0") ||
+    Buffer.byteLength(stdout, "utf8") > MAX_TMUX_OUTPUT_BYTES
+  ) {
+    throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+  }
+  return stdout.replace(/(?:\r?\n)+$/u, "");
+}
+
+function strictLines(stdout: string, maximum: number): readonly string[] {
+  const normalized = boundedOutput(stdout);
+  if (normalized === "") return [];
+  const lines = normalized.split("\n");
+  if (lines.length > maximum || lines.some((line) => line.includes("\r"))) {
+    throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+  }
+  return lines;
+}
+
+function uuidFromCompactHex(value: string): string {
+  return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}`;
+}
+
+function parseViewSessionName(value: string): Omit<ParsedViewIdentity, "markerValue"> | null {
+  const match = ViewNamePattern.exec(value);
+  if (!match) return null;
+  const attachmentId = uuidFromCompactHex(match[1]!);
+  if (!z.uuid().safeParse(attachmentId).success) return null;
+  const generation = Number.parseInt(match[2]!, 36);
+  if (
+    !Number.isSafeInteger(generation) ||
+    generation < 0 ||
+    generation > GROUPED_TMUX_MAX_GENERATION ||
+    generation.toString(36) !== match[2]
+  ) {
+    return null;
+  }
+  if (groupedTmuxViewSessionName(attachmentId, generation) !== value) return null;
+  return {
+    attachmentId,
+    generation,
+    viewSessionName: value,
+    exactTarget: `=${value}`,
+  };
+}
+
+function canonicalMarker(attachmentId: string, generation: number): string {
+  return `v1:${attachmentId}:${generation}`;
+}
+
+function parseCleanupIdentity(cleanup: GuardedAttachmentCleanup): ParsedViewIdentity {
+  if (
+    cleanup.markerOption !== GROUPED_TMUX_VIEW_MARKER_OPTION ||
+    !cleanup.exactViewSessionTarget.startsWith("=")
+  ) {
+    throw new TmuxAttachmentViewExecutorError("invalid-request");
+  }
+  const parsedName = parseViewSessionName(cleanup.exactViewSessionTarget.slice(1));
+  if (!parsedName) throw new TmuxAttachmentViewExecutorError("invalid-request");
+  const markerValue = canonicalMarker(parsedName.attachmentId, parsedName.generation);
+  if (
+    cleanup.expectedMarkerValue !== markerValue ||
+    !RuntimeWindowIdSchemaZ.safeParse(cleanup.expectedWindowId).success
+  ) {
+    throw new TmuxAttachmentViewExecutorError("invalid-request");
+  }
+  return { ...parsedName, markerValue };
+}
+
+function canonicalPlanFor(operation: GuardedAttachmentViewOperation): GroupedTmuxAttachmentPlan {
+  try {
+    if (
+      !Number.isSafeInteger(operation.deadline) ||
+      operation.deadline < 0 ||
+      !["create", "attach", "recover"].includes(operation.operation)
+    ) {
+      throw new TmuxAttachmentViewExecutorError("invalid-request");
+    }
+    const canonical = planGroupedTmuxAttachment({
+      attachmentId: operation.plan.identity.attachmentId,
+      generation: operation.plan.identity.generation,
+      target: operation.plan.identity.semanticTarget,
+      viewerMode: operation.plan.viewerMode,
+      viewport: operation.plan.viewport,
+      source: operation.source,
+    });
+    if (
+      operation.exactViewSessionTarget !== `=${canonical.identity.viewSessionName}` ||
+      !isDeepStrictEqual(operation.plan, canonical)
+    ) {
+      throw new TmuxAttachmentViewExecutorError("invalid-request");
+    }
+    return canonical;
+  } catch {
+    throw new TmuxAttachmentViewExecutorError("invalid-request");
+  }
+}
+
+/**
+ * Production executor for the grouped-tmux attachment lease boundary. It does
+ * not create a second PTY/runtime model: every command targets tmux itself.
+ */
+export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
+  readonly #runner: TmuxAttachmentCommandRunner;
+  readonly #now: () => number;
+
+  constructor(options: TmuxAttachmentViewExecutorOptions = {}) {
+    this.#runner = options.runner ?? productionRunner;
+    this.#now = options.now ?? Date.now;
+  }
+
+  guardedCleanup(cleanup: GuardedAttachmentCleanup): Promise<GuardedAttachmentCleanupResult> {
+    return serializeServerWide(() => this.#guardedCleanup(cleanup));
+  }
+
+  executeGuardedViewOperation(
+    operation: GuardedAttachmentViewOperation,
+  ): Promise<GuardedAttachmentViewOperationResult> {
+    return serializeServerWide(() => this.#executeGuardedViewOperation(operation));
+  }
+
+  enumerateMarkedViews(
+    prefix: typeof GROUPED_TMUX_VIEW_SESSION_PREFIX,
+    markerOption: typeof GROUPED_TMUX_VIEW_MARKER_OPTION,
+  ): Promise<readonly EnumeratedMarkedAttachmentView[]> {
+    return serializeServerWide(() => this.#enumerateMarkedViews(prefix, markerOption));
+  }
+
+  #command(command: TmuxArgvPlan): TmuxAttachmentCommandResult {
+    if (command.executable !== "tmux") {
+      throw new TmuxAttachmentViewExecutorError("invalid-request");
+    }
+    try {
+      const result = this.#runner.run({ executable: "tmux", argv: [...command.argv] });
+      if (result.status === "ok") boundedOutput(result.stdout);
+      if (!["ok", "not-found", "failed"].includes(result.status)) {
+        throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
+      }
+      return result;
+    } catch (error) {
+      if (error instanceof TmuxAttachmentViewExecutorError) throw error;
+      throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
+    }
+  }
+
+  #viewExists(exactTarget: `=${string}`): boolean {
+    const result = this.#command(tmux(["has-session", "-t", exactTarget]));
+    if (result.status === "not-found") return false;
+    if (result.status === "failed") {
+      throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
+    }
+    return true;
+  }
+
+  #marker(exactTarget: `=${string}`): string | null {
+    const result = this.#command(
+      tmux(["list-panes", "-t", exactTarget, "-F", `#{${GROUPED_TMUX_VIEW_MARKER_OPTION}}`]),
+    );
+    if (result.status === "not-found") return null;
+    if (result.status === "failed") {
+      throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
+    }
+    const markers = strictLines(result.stdout, MAX_SOURCE_PROOF_ROWS);
+    if (markers.length === 0) return "";
+    if (new Set(markers).size !== 1) {
+      throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+    }
+    return markers[0]!;
+  }
+
+  #windowIds(exactTarget: `=${string}`): readonly string[] | null {
+    const result = this.#command(tmux(["list-windows", "-t", exactTarget, "-F", "#{window_id}"]));
+    if (result.status === "not-found") return null;
+    if (result.status === "failed") {
+      throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
+    }
+    const lines = strictLines(result.stdout, MAX_ENUMERATED_WINDOWS_PER_VIEW);
+    if (
+      lines.some((line) => !RuntimeWindowIdSchemaZ.safeParse(line).success) ||
+      new Set(lines).size !== lines.length
+    ) {
+      throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+    }
+    return lines;
+  }
+
+  #viewServerGuard(
+    exactTarget: `=${string}`,
+    expectedMarker: string,
+    expectedWindowId: string,
+  ): ViewServerGuard | null {
+    const result = this.#command(
+      tmux([
+        "list-panes",
+        "-t",
+        exactTarget,
+        "-F",
+        `#{session_id}\t#{window_id}\t#{pane_id}\t#{window_panes}\t#{session_windows}\t#{${GROUPED_TMUX_VIEW_MARKER_OPTION}}`,
+      ]),
+    );
+    if (result.status === "not-found") return null;
+    if (result.status === "failed") {
+      throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
+    }
+    const rows = strictLines(result.stdout, MAX_SOURCE_PROOF_ROWS);
+    if (rows.length !== 1) return null;
+    const fields = rows[0]!.split("\t");
+    if (fields.length !== 6) {
+      throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+    }
+    const [sessionId, windowId, paneId, paneCount, sessionWindowCount, marker] = fields;
+    if (
+      !RuntimeSessionIdSchemaZ.safeParse(sessionId).success ||
+      !RuntimeWindowIdSchemaZ.safeParse(windowId).success ||
+      !RuntimePaneIdSchemaZ.safeParse(paneId).success ||
+      !/^(?:0|[1-9][0-9]*)$/u.test(paneCount!) ||
+      !/^(?:0|[1-9][0-9]*)$/u.test(sessionWindowCount!)
+    ) {
+      throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+    }
+    if (
+      windowId !== expectedWindowId ||
+      paneCount !== "1" ||
+      sessionWindowCount !== "1" ||
+      marker !== expectedMarker
+    ) {
+      return null;
+    }
+    return {
+      target: `${sessionId}:${windowId}.${paneId}`,
+      format: `#{&&:#{==:#{session_id},${sessionId}},#{&&:#{==:#{window_id},${windowId}},#{&&:#{==:#{window_panes},1},#{&&:#{==:#{session_windows},1},#{==:#{${GROUPED_TMUX_VIEW_MARKER_OPTION}},${expectedMarker}}}}}}`,
+    };
+  }
+
+  #guardedCleanup(cleanup: GuardedAttachmentCleanup): GuardedAttachmentCleanupResult {
+    const identity = parseCleanupIdentity(cleanup);
+    if (!this.#viewExists(identity.exactTarget)) return "absent";
+    const marker = this.#marker(identity.exactTarget);
+    if (marker === null) return "absent";
+    if (marker !== identity.markerValue) return "ownership-mismatch";
+    const windows = this.#windowIds(identity.exactTarget);
+    if (windows === null) return "absent";
+    if (windows.length !== 1 || windows[0] !== cleanup.expectedWindowId) {
+      return "topology-mismatch";
+    }
+    const viewGuard = this.#viewServerGuard(
+      identity.exactTarget,
+      identity.markerValue,
+      cleanup.expectedWindowId,
+    );
+    if (!viewGuard) return "topology-mismatch";
+
+    // `if-shell -F` inserts the selected command immediately after itself in
+    // the same tmux client command queue; both guard and branch are synchronous
+    // queue items. This removes the daemon-side check/use gap. The process-wide
+    // queue above separately serializes every in-daemon manager/executor.
+    let killed: TmuxAttachmentCommandResult;
+    try {
+      killed = this.#command(
+        tmux([
+          "if-shell",
+          "-F",
+          "-t",
+          viewGuard.target,
+          viewGuard.format,
+          tmuxCommandString(tmux(["kill-session", "-t", identity.exactTarget])),
+          tmuxCommandString(tmux(["display-message", "-p", VIEW_PROOF_MISMATCH_SENTINEL])),
+        ]),
+      );
+    } catch {
+      throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
+    }
+    if (killed.status === "not-found") return "absent";
+    if (killed.status !== "ok") {
+      throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
+    }
+    if (boundedOutput(killed.stdout) === VIEW_PROOF_MISMATCH_SENTINEL) {
+      if (this.#marker(identity.exactTarget) !== identity.markerValue) {
+        return "ownership-mismatch";
+      }
+      return "topology-mismatch";
+    }
+    return "cleaned";
+  }
+
+  #sourceProofMatches(operation: GuardedAttachmentViewOperation): boolean {
+    const source = operation.source;
+    if (
+      !RuntimeSessionIdSchemaZ.safeParse(source.sessionId).success ||
+      !RuntimeWindowIdSchemaZ.safeParse(source.windowId).success ||
+      !RuntimePaneIdSchemaZ.safeParse(source.runtimePaneId).success ||
+      source.paneCount !== 1
+    ) {
+      throw new TmuxAttachmentViewExecutorError("invalid-request");
+    }
+    const result = this.#command(
+      tmux([
+        "list-panes",
+        "-t",
+        `${source.sessionId}:${source.windowId}`,
+        "-F",
+        "#{session_id}\t#{window_id}\t#{pane_id}\t#{window_panes}",
+      ]),
+    );
+    if (result.status === "not-found") return false;
+    if (result.status === "failed") {
+      throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
+    }
+    const rows = strictLines(result.stdout, MAX_SOURCE_PROOF_ROWS);
+    if (rows.length !== 1) return false;
+    const fields = rows[0]!.split("\t");
+    if (fields.length !== 4) {
+      throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+    }
+    const [sessionId, windowId, paneId, paneCount] = fields;
+    if (
+      !RuntimeSessionIdSchemaZ.safeParse(sessionId).success ||
+      !RuntimeWindowIdSchemaZ.safeParse(windowId).success ||
+      !RuntimePaneIdSchemaZ.safeParse(paneId).success ||
+      !/^(?:0|[1-9][0-9]*)$/u.test(paneCount!)
+    ) {
+      throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+    }
+    return (
+      sessionId === source.sessionId &&
+      windowId === source.windowId &&
+      paneId === source.runtimePaneId &&
+      paneCount === "1"
+    );
+  }
+
+  #viewMatchesPlan(plan: GroupedTmuxAttachmentPlan): ViewServerGuard | null {
+    const exactTarget = `=${plan.identity.viewSessionName}` as const;
+    if (!this.#viewExists(exactTarget)) return null;
+    if (this.#marker(exactTarget) !== plan.identity.markerValue) return null;
+    const windows = this.#windowIds(exactTarget);
+    if (windows?.length !== 1 || windows[0] !== plan.identity.durableSource.windowId) return null;
+    return this.#viewServerGuard(
+      exactTarget,
+      plan.identity.markerValue,
+      plan.identity.durableSource.windowId,
+    );
+  }
+
+  #runServerGuardedMutation(
+    operation: GuardedAttachmentViewOperation,
+    plan: GroupedTmuxAttachmentPlan,
+    commands: readonly TmuxArgvPlan[],
+    viewGuard: ViewServerGuard | null,
+  ): GuardedAttachmentViewOperationResult {
+    const mutation = tmuxCommandListString(commands);
+    const viewGuardedMutation =
+      operation.operation === "create"
+        ? mutation
+        : tmuxCommandString(
+            tmux([
+              "if-shell",
+              "-F",
+              "-t",
+              viewGuard!.target,
+              viewGuard!.format,
+              mutation,
+              tmuxCommandString(tmux(["display-message", "-p", VIEW_PROOF_MISMATCH_SENTINEL])),
+            ]),
+          );
+    const guarded = tmux([
+      "if-shell",
+      "-F",
+      "-t",
+      sourcePaneTarget(operation),
+      sourceProofFormat(operation),
+      viewGuardedMutation,
+      tmuxCommandString(tmux(["display-message", "-p", SOURCE_PROOF_MISMATCH_SENTINEL])),
+    ]);
+    let result: TmuxAttachmentCommandResult;
+    try {
+      result = this.#command(guarded);
+    } catch {
+      throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
+    }
+    if (result.status !== "ok") {
+      throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
+    }
+    const output = boundedOutput(result.stdout);
+    if (output === SOURCE_PROOF_MISMATCH_SENTINEL) return "source-proof-mismatch";
+    if (output === VIEW_PROOF_MISMATCH_SENTINEL) {
+      throw new TmuxAttachmentViewExecutorError("view-state-mismatch");
+    }
+    return "executed";
+  }
+
+  #bestEffortRollbackCreate(plan: GroupedTmuxAttachmentPlan): void {
+    try {
+      this.#guardedCleanup({
+        exactViewSessionTarget: `=${plan.identity.viewSessionName}`,
+        markerOption: GROUPED_TMUX_VIEW_MARKER_OPTION,
+        expectedMarkerValue: plan.identity.markerValue,
+        expectedWindowId: plan.identity.durableSource.windowId,
+      });
+    } catch {
+      // The original static uncertain-outcome error is the only observable result.
+    }
+  }
+
+  #executeGuardedViewOperation(
+    operation: GuardedAttachmentViewOperation,
+  ): GuardedAttachmentViewOperationResult {
+    const plan = canonicalPlanFor(operation);
+    let viewGuard: ViewServerGuard | null = null;
+
+    if (operation.operation === "create") {
+      if (this.#viewExists(operation.exactViewSessionTarget)) {
+        throw new TmuxAttachmentViewExecutorError("view-state-mismatch");
+      }
+    } else {
+      viewGuard = this.#viewMatchesPlan(plan);
+      if (!viewGuard) throw new TmuxAttachmentViewExecutorError("view-state-mismatch");
+    }
+
+    if (!this.#sourceProofMatches(operation)) return "source-proof-mismatch";
+    if (this.#now() >= operation.deadline) return "lease-expired";
+
+    // The validated command call is immediate: there is no await between the
+    // proof/deadline decision above and spawning a single tmux command list.
+    // That server-side list repeats source proof (and, for attach/recover, view
+    // proof) immediately before the selected mutation in the same queue.
+    try {
+      switch (operation.operation) {
+        case "create":
+          return this.#runServerGuardedMutation(operation, plan, [plan.create.command], null);
+        case "attach":
+          return this.#runServerGuardedMutation(operation, plan, [plan.attach], viewGuard);
+        case "recover":
+          return this.#runServerGuardedMutation(
+            operation,
+            plan,
+            [...plan.recover.reconcile, plan.recover.attach],
+            viewGuard,
+          );
+      }
+    } catch (error) {
+      if (operation.operation === "create") this.#bestEffortRollbackCreate(plan);
+      if (error instanceof TmuxAttachmentViewExecutorError) throw error;
+      throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
+    }
+  }
+
+  #enumerateMarkedViews(
+    prefix: typeof GROUPED_TMUX_VIEW_SESSION_PREFIX,
+    markerOption: typeof GROUPED_TMUX_VIEW_MARKER_OPTION,
+  ): readonly EnumeratedMarkedAttachmentView[] {
+    if (
+      prefix !== GROUPED_TMUX_VIEW_SESSION_PREFIX ||
+      markerOption !== GROUPED_TMUX_VIEW_MARKER_OPTION
+    ) {
+      throw new TmuxAttachmentViewExecutorError("invalid-request");
+    }
+    const result = this.#command(
+      tmux(["list-sessions", "-F", `#{session_name}\t#{${GROUPED_TMUX_VIEW_MARKER_OPTION}}`]),
+    );
+    if (result.status === "not-found") return [];
+    if (result.status === "failed") {
+      throw new TmuxAttachmentViewExecutorError("tmux-command-failed");
+    }
+    const rows = strictLines(result.stdout, MAX_ENUMERATED_VIEWS * 4);
+    const found = new Map<string, { identity: ParsedViewIdentity; markerValue: string | null }>();
+    for (const row of rows) {
+      const separator = row.indexOf("\t");
+      if (separator < 0 || row.indexOf("\t", separator + 1) >= 0) {
+        throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+      }
+      const sessionName = row.slice(0, separator);
+      if (!sessionName.startsWith(prefix)) continue;
+      const parsedName = parseViewSessionName(sessionName);
+      if (!parsedName || found.has(sessionName)) {
+        throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+      }
+      const rawMarker = row.slice(separator + 1);
+      let markerValue: string | null = null;
+      const markerMatch = MarkerPattern.exec(rawMarker);
+      if (markerMatch) {
+        const generation = Number.parseInt(markerMatch[2]!, 10);
+        if (
+          Number.isSafeInteger(generation) &&
+          generation <= GROUPED_TMUX_MAX_GENERATION &&
+          canonicalMarker(markerMatch[1]!, generation) === rawMarker
+        ) {
+          markerValue = rawMarker;
+        }
+      }
+      found.set(sessionName, {
+        identity: {
+          ...parsedName,
+          markerValue: canonicalMarker(parsedName.attachmentId, parsedName.generation),
+        },
+        markerValue,
+      });
+      if (found.size > MAX_ENUMERATED_VIEWS) {
+        throw new TmuxAttachmentViewExecutorError("invalid-tmux-output");
+      }
+    }
+
+    const enumerated: EnumeratedMarkedAttachmentView[] = [];
+    for (const candidate of found.values()) {
+      const windowIds = this.#windowIds(candidate.identity.exactTarget);
+      if (windowIds === null) continue;
+      enumerated.push({
+        viewSessionName: candidate.identity.viewSessionName,
+        markerValue: candidate.markerValue,
+        windowIds,
+      });
+    }
+    return enumerated;
+  }
+}

--- a/packages/tmux-bridge/src/runner.test.ts
+++ b/packages/tmux-bridge/src/runner.test.ts
@@ -20,6 +20,7 @@ import {
   setSessionEnvironment,
   attachSession,
   runSessionCommand,
+  runTmux,
 } from "./index.ts";
 
 let mockExec;
@@ -447,6 +448,19 @@ describe("debug logging", () => {
 // --- Error classification edge cases ---
 
 describe("error classification", () => {
+  it('classifies an exact show-environment "unknown variable" separately', () => {
+    mockExec.mockImplementation(() => {
+      throw makeExecError("unknown variable: TMUX_IDE_ATTACHMENT_VIEW");
+    });
+
+    expect(() => runTmux(["show-environment", "-t", "$12", "TMUX_IDE_ATTACHMENT_VIEW"])).toThrow(
+      expect.objectContaining({
+        code: "ENVIRONMENT_VARIABLE_NOT_FOUND",
+        message: "tmux environment variable was not found",
+      }),
+    );
+  });
+
   it('classifies "can\'t find window" as SESSION_NOT_FOUND', () => {
     mockExec.mockImplementation(() => {
       throw makeExecError("can't find window: proj:0");

--- a/packages/tmux-bridge/src/runner.ts
+++ b/packages/tmux-bridge/src/runner.ts
@@ -4,6 +4,7 @@ import { TmuxError } from "./errors.ts";
 const DEBUG = process.env.TMUX_IDE_DEBUG === "1";
 
 const SESSION_NOT_FOUND_PATTERNS = ["can't find session", "can't find window", "unknown target"];
+const ENVIRONMENT_VARIABLE_NOT_FOUND_PATTERNS = ["unknown variable:"];
 
 const TMUX_UNAVAILABLE_PATTERNS = [
   "failed to connect to server",
@@ -70,6 +71,14 @@ function classifyTmuxError(error: unknown): TmuxError {
     return new TmuxError("tmux session was not found", "SESSION_NOT_FOUND", {
       cause: error as Error,
     });
+  }
+
+  if (ENVIRONMENT_VARIABLE_NOT_FOUND_PATTERNS.some((pattern) => detail.includes(pattern))) {
+    return new TmuxError(
+      "tmux environment variable was not found",
+      "ENVIRONMENT_VARIABLE_NOT_FOUND",
+      { cause: error as Error },
+    );
   }
 
   if (TMUX_UNAVAILABLE_PATTERNS.some((pattern) => detail.includes(pattern))) {


### PR DESCRIPTION
Implements the daemon-owned tmux AttachmentViewExecutor. It regenerates canonical plans, re-proves source/view identity in the tmux server command queue, checks exact lease deadlines, serializes managers, uses a session-local ownership environment marker, performs exact guarded cleanup and bounded enumeration, and sanitizes failures. Attach/recover require an explicit control-client transport; no sync non-PTY fallback, NodeTerm runtime, or node-pty is added.\n\nValidation: 85 post-rebase focused daemon tests, 62 tmux-bridge tests, daemon and bridge typechecks, prior isolated 2,371-test daemon aggregate, and live tmux mutation/marker/control-client probes. Independent multi-round correctness review approved with no blocker/high/medium findings.