### PR TITLE
feat(desktop): add native tmux terminal surface

### DIFF
--- a/apps/desktop-renderer/package.json
+++ b/apps/desktop-renderer/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@tmux-ide/contracts": "workspace:*",
+    "@xterm/addon-fit": "0.11.0",
+    "@xterm/xterm": "6.0.0",
     "solid-js": "1.9.12"
   },
   "devDependencies": {

--- a/apps/desktop-renderer/src/App.tsx
+++ b/apps/desktop-renderer/src/App.tsx
@@ -22,6 +22,7 @@ import {
   DesktopLiveApplication,
   type DesktopDaemonRecoveryPhase,
 } from "./runtime/live-app-composition.tsx";
+import type { NativeTerminalTransport } from "./terminal/native-terminal-transport.ts";
 import type {
   PaneFrameActionIntent,
   PaneFrameActivationSource,
@@ -35,6 +36,7 @@ export interface AppProps {
   readonly shellInput?: ApplicationShellProjectionInputV1;
   readonly onCommand?: (invocation: ApplicationShellCommandInvocation) => void;
   readonly paneFrames?: readonly PaneFrameModel[];
+  readonly terminalTransport?: NativeTerminalTransport | null;
   readonly onPaneAction?: (
     intent: PaneFrameActionIntent,
     source: PaneFrameActivationSource,
@@ -137,6 +139,10 @@ export function App(props: AppProps = {}) {
   const effectiveTheme = () => theme() ?? bootstrap()?.theme ?? initialTheme;
   const effectiveWindow = () => windowState() ?? bootstrap()?.window ?? null;
   const experience = createMemo(() => createDomExperience({ hostTheme: effectiveTheme() }));
+  const terminalThemeKey = createMemo(() => {
+    const current = effectiveTheme();
+    return `${current?.mode ?? "system"}:${current?.highContrast ?? false}`;
+  });
 
   return (
     <div
@@ -184,6 +190,9 @@ export function App(props: AppProps = {}) {
                     platform={bootstrap()?.platform}
                     windowState={effectiveWindow()}
                     dataMode="preview"
+                    terminalTransport={props.terminalTransport}
+                    reducedMotion={experience().accessibility.reducedMotion}
+                    terminalThemeKey={terminalThemeKey()}
                     onCommand={props.onCommand}
                     paneFrames={props.paneFrames}
                     onPaneAction={props.onPaneAction}
@@ -246,6 +255,9 @@ export function App(props: AppProps = {}) {
                           platform={ready().platform}
                           windowState={effectiveWindow()}
                           daemonRecovery={daemonRecovery()}
+                          terminalTransport={props.terminalTransport}
+                          reducedMotion={experience().accessibility.reducedMotion}
+                          terminalThemeKey={terminalThemeKey()}
                           onRetryDaemonConnection={refreshDaemonConnection}
                           onDaemonIdentityMismatch={refreshDaemonConnection}
                           onCommand={props.onCommand}
@@ -268,6 +280,9 @@ export function App(props: AppProps = {}) {
                 windowState={effectiveWindow()}
                 input={injectedInput()}
                 dataMode="runtime"
+                terminalTransport={props.terminalTransport}
+                reducedMotion={experience().accessibility.reducedMotion}
+                terminalThemeKey={terminalThemeKey()}
                 onCommand={props.onCommand}
                 paneFrames={props.paneFrames}
                 onPaneAction={props.onPaneAction}

--- a/apps/desktop-renderer/src/experience/application-shell.test.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.test.tsx
@@ -293,6 +293,104 @@ describe("visible DOM application shell", () => {
     );
   });
 
+  it("keeps terminal mount identity while semantic focus and daemon-confirmed zoom change", () => {
+    const onCommand = vi.fn<(invocation: ApplicationShellCommandInvocation) => void>();
+    const onPaneAction = vi.fn<NonNullable<DomApplicationShellProps["onPaneAction"]>>();
+    const [paneFrames, setPaneFrames] = createSignal<
+      NonNullable<DomApplicationShellProps["paneFrames"]>
+    >(
+      createDefaultDomPaneFrames().map((model) => ({
+        ...model,
+        appearance: { ...model.appearance, structure: "docked" as const },
+      })),
+    );
+    const root = document.createElement("div");
+    document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <DomApplicationShell
+            host={host()}
+            runtime="browser"
+            platform="darwin"
+            windowState={WINDOW_STATE}
+            input={createDefaultDomShellInput()}
+            dataMode="runtime"
+            onCommand={onCommand}
+            paneFrames={paneFrames()}
+            onPaneAction={onPaneAction}
+          />
+        ),
+        root,
+      ),
+    );
+    const pane = root.querySelector<HTMLElement>('[data-pane-id="pane.pm"]')!;
+    const otherPane = root.querySelector<HTMLElement>('[data-pane-id="pane.implementer"]')!;
+    const zoom = pane.querySelector<HTMLButtonElement>('[data-command-id="pane.maximize.toggle"]')!;
+    const terminalMount = pane.querySelector(".terminal-surface__viewport");
+
+    expect(zoom.getAttribute("aria-label")).toBe("Maximize or restore");
+    zoom.click();
+    expect(onPaneAction).toHaveBeenCalledWith(
+      {
+        kind: "action",
+        paneId: "pane.pm",
+        actionId: "maximize-toggle",
+        commandId: "pane.maximize.toggle",
+      },
+      "keyboard",
+    );
+    expect(pane.getAttribute("data-structure")).toBe("docked");
+
+    setPaneFrames((current) =>
+      current.map((model) =>
+        model.pane.id === "pane.pm"
+          ? {
+              ...model,
+              appearance: { ...model.appearance, structure: "maximized" as const },
+              actions: model.actions.map((action) =>
+                action.commandId === "pane.maximize.toggle"
+                  ? {
+                      ...action,
+                      icon: "restore" as const,
+                      label: "Restore",
+                      description: "Restore pane layout",
+                      pressed: true,
+                    }
+                  : action,
+              ),
+            }
+          : model,
+      ),
+    );
+    expect(pane.getAttribute("data-structure")).toBe("maximized");
+    expect(root.querySelector(".agent-grid")?.getAttribute("data-has-maximized")).toBe("true");
+    expect(otherPane.getAttribute("data-structure")).toBe("docked");
+    expect(zoom.getAttribute("aria-label")).toBe("Restore pane layout");
+    expect(zoom.getAttribute("aria-pressed")).toBe("true");
+    expect(pane.querySelector(".terminal-surface__viewport")).toBe(terminalMount);
+
+    pane
+      .querySelector(".terminal-surface")!
+      .dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    expect(onCommand).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: APPLICATION_SHELL_COMMAND_IDS.moveFocus,
+        args: { target: { kind: "pane", paneId: "pane.pm", input: "terminal" } },
+        source: { kind: "mouse", surface: "application-shell" },
+      }),
+    );
+    expect(pane.getAttribute("data-border-role")).toBe("focused");
+    expect(pane.getAttribute("data-terminal-input-owner")).toBe("true");
+    expect(otherPane.getAttribute("data-terminal-input-owner")).toBe("false");
+    expect(pane.querySelector(".terminal-surface__viewport")).toBe(terminalMount);
+    expect(styles).toContain(
+      '.agent-grid[data-has-maximized="true"] > .web-pane-frame:not([data-structure="maximized"])',
+    );
+    expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(styles).not.toContain("transition-all");
+  });
+
   it("keeps compact session identity and connection state accessible at 720px", () => {
     vi.spyOn(window, "innerWidth", "get").mockReturnValue(720);
     vi.spyOn(window, "innerHeight", "get").mockReturnValue(480);

--- a/apps/desktop-renderer/src/experience/application-shell.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.tsx
@@ -12,6 +12,7 @@ import {
   type DesktopWindowState,
   type FocusZone,
   type HostCapabilities,
+  type PaneAppearance,
   type ProductSurfaceId,
   type SemanticFocusTarget,
   resolvePaneAppearance,
@@ -44,6 +45,8 @@ import type {
 } from "../../../../packages/daemon/src/ui/workbench-dock/presenter.tsx";
 import { CommandPalette } from "./command-palette.tsx";
 import { DomIcon } from "./dom-icon.tsx";
+import { TerminalSurface } from "../terminal/terminal-surface.tsx";
+import type { NativeTerminalTransport } from "../terminal/native-terminal-transport.ts";
 import {
   createDefaultDomShellInput,
   createDefaultDomPaneFrames,
@@ -68,6 +71,10 @@ export interface DomApplicationShellProps {
   readonly windowState?: DesktopWindowState | null;
   readonly input?: ApplicationShellProjectionInputV1;
   readonly dataMode?: "runtime" | "preview";
+  readonly terminalWorkspaceName?: string;
+  readonly terminalTransport?: NativeTerminalTransport | null;
+  readonly reducedMotion?: boolean;
+  readonly terminalThemeKey?: string;
   readonly onCommand?: (invocation: ApplicationShellCommandInvocation) => void;
   readonly paneFrames?: readonly PaneFrameModel[];
   readonly onPaneAction?: (
@@ -244,6 +251,49 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
       ];
     });
   });
+  const appearanceWithSemanticFocus = (
+    appearance: PaneAppearance,
+    focused: boolean,
+  ): PaneAppearance =>
+    resolvePaneAppearance({
+      structure: appearance.structure,
+      applicationFocus: {
+        pane: focused,
+        terminalInput: focused,
+        windowActive: appearance.header.windowActive,
+      },
+      agentActivity: appearance.header.agentActivity,
+      domainStatus: appearance.status.domainStatus,
+      attention: appearance.status.attention,
+      layoutInteraction: {
+        editable: true,
+        selected: appearance.accessibility.layoutSelected,
+        dragging: false,
+        resizing: false,
+        previewing: false,
+      },
+      controlInteraction: {
+        hover: appearance.action.hover,
+        focusVisible: appearance.action.focusVisible,
+        pressed: appearance.action.pressed,
+        disabled: appearance.action.disabled,
+        loading: appearance.action.loading,
+      },
+    });
+  const renderedPaneFrames = createMemo<readonly PaneFrameModel[]>(() => {
+    const localTerminalFocus = shell().focus.terminalInputPaneId;
+    if (!localTerminalFocus) return paneFrames();
+    return paneFrames().map((model) => ({
+      ...model,
+      appearance: appearanceWithSemanticFocus(
+        model.appearance,
+        localTerminalFocus === model.pane.id,
+      ),
+    }));
+  });
+  const hasMaximizedPane = createMemo(() =>
+    renderedPaneFrames().some(({ appearance }) => appearance.structure === "maximized"),
+  );
   const dock = createMemo(() => projectDomWorkbenchDock(shell(), viewport()));
   const paletteEntries = createMemo(() => createDomPaletteEntries(shell()));
   const statusStrip = createMemo(() => {
@@ -645,8 +695,8 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
               </span>
               <span>{shell().sidebar.agents.length} agents</span>
             </header>
-            <div class="agent-grid">
-              <Index each={paneFrames()}>
+            <div class="agent-grid" data-has-maximized={hasMaximizedPane()}>
+              <Index each={renderedPaneFrames()}>
                 {(paneFrame) => {
                   const agent = createMemo(() =>
                     shell().sidebar.agents.find((item) => item.paneId === paneFrame().pane.id),
@@ -661,11 +711,36 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
                       renderGripIcon={(icon) => <DomIcon id={icon} usage="action" />}
                     >
                       <div class="agent-pane__body" data-focus-zone="terminal">
-                        <span class="agent-prompt">
-                          {agent()?.harness ?? paneFrame().subtitle ?? paneFrame().pane.kind}
+                        <TerminalSurface
+                          target={{
+                            workspaceName: props.terminalWorkspaceName ?? input().workspace.id,
+                            semanticPaneId: paneFrame().pane.id,
+                          }}
+                          title={paneFrame().title}
+                          transport={props.terminalTransport}
+                          focused={paneFrame().appearance.accessibility.terminalInputOwner}
+                          reducedMotion={props.reducedMotion}
+                          themeKey={props.terminalThemeKey}
+                          onFocus={(source) =>
+                            dispatch(
+                              applicationShellCommandInvocation(
+                                APPLICATION_SHELL_COMMAND_IDS.moveFocus,
+                                {
+                                  target: {
+                                    kind: "pane",
+                                    paneId: paneFrame().pane.id,
+                                    input: "terminal",
+                                  },
+                                },
+                                { kind: source, surface: "application-shell" },
+                              ),
+                            )
+                          }
+                        />
+                        <span class="sr-only">
+                          {agent()?.harness ?? paneFrame().subtitle ?? paneFrame().pane.kind} ·
+                          Activity: {agent()?.activity ?? paneFrame().status?.label ?? "idle"}
                         </span>
-                        <p>Activity: {agent()?.activity ?? paneFrame().status?.label ?? "idle"}</p>
-                        <small>{paneFrame().pane.id}</small>
                       </div>
                     </WebPaneFrame>
                   );

--- a/apps/desktop-renderer/src/runtime/live-app-composition.tsx
+++ b/apps/desktop-renderer/src/runtime/live-app-composition.tsx
@@ -22,6 +22,7 @@ import { DomIcon } from "../experience/dom-icon.tsx";
 import type { DesktopApplicationShellResourceState } from "./connection-state.ts";
 import { createSolidDesktopApplicationShellResourceStore } from "./desktop-resource-store.ts";
 import { createHostDaemonTransport } from "./host-daemon-transport.ts";
+import type { NativeTerminalTransport } from "../terminal/native-terminal-transport.ts";
 import {
   createSolidDesktopWorkspaceCatalogStore,
   type DesktopWorkspaceCatalogState,
@@ -49,6 +50,9 @@ export interface DesktopLiveApplicationProps {
     source: PaneFrameActivationSource,
   ) => void;
   readonly onPaneGrip?: (intent: PaneFrameGripIntent, source: PaneFrameActivationSource) => void;
+  readonly terminalTransport?: NativeTerminalTransport | null;
+  readonly reducedMotion?: boolean;
+  readonly terminalThemeKey?: string;
 }
 
 interface DesktopConnectionSurfaceProps {
@@ -495,6 +499,10 @@ function LiveWorkspace(props: LiveWorkspaceProps) {
             windowState={props.windowState}
             input={ready().input}
             dataMode="runtime"
+            terminalWorkspaceName={props.target.workspaceName}
+            terminalTransport={props.terminalTransport}
+            reducedMotion={props.reducedMotion}
+            terminalThemeKey={props.terminalThemeKey}
             onCommand={props.onCommand}
             paneFrames={ready().paneFrames}
             onPaneAction={props.onPaneAction}
@@ -646,6 +654,9 @@ export function DesktopLiveApplication(props: DesktopLiveApplicationProps) {
           runtime={props.runtime}
           platform={props.platform}
           windowState={props.windowState}
+          terminalTransport={props.terminalTransport}
+          reducedMotion={props.reducedMotion}
+          terminalThemeKey={props.terminalThemeKey}
           onCommand={props.onCommand}
           onPaneAction={props.onPaneAction}
           onPaneGrip={props.onPaneGrip}

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -1,3 +1,5 @@
+@import "@xterm/xterm/css/xterm.css";
+
 :root {
   font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
   color: CanvasText;
@@ -743,10 +745,19 @@ kbd {
   min-height: 0;
 }
 
+.agent-grid[data-has-maximized="true"] > .web-pane-frame:not([data-structure="maximized"]) {
+  display: none;
+}
+
+.agent-grid > .web-pane-frame[data-structure="maximized"] {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+}
+
 .agent-pane__body {
   height: 100%;
-  padding: 9px;
-  overflow: auto;
+  padding: 0;
+  overflow: hidden;
   color: var(--tmux-ide-text-secondary);
 }
 
@@ -760,6 +771,134 @@ kbd {
 
 .agent-prompt {
   color: var(--tmux-ide-text-link);
+}
+
+.terminal-surface {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--tmux-ide-surface-terminal);
+}
+
+.terminal-surface__viewport {
+  position: absolute;
+  inset: 0;
+  min-width: 0;
+  min-height: 0;
+  padding: 6px 7px;
+  overflow: hidden;
+}
+
+.terminal-surface__viewport .xterm {
+  width: 100%;
+  height: 100%;
+}
+
+.terminal-surface__viewport .xterm-viewport {
+  scrollbar-color: var(--tmux-ide-border-default) transparent;
+  scrollbar-width: thin;
+}
+
+.terminal-surface__state {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  grid-template-rows: auto auto;
+  gap: 2px 8px;
+  align-content: center;
+  padding: 14px;
+  color: var(--tmux-ide-text-muted);
+  background: var(--tmux-ide-surface-terminal);
+}
+
+.terminal-surface[data-preserves-frame="true"] .terminal-surface__state {
+  inset: auto 8px 8px;
+  border: 1px solid var(--tmux-ide-border-default);
+  border-radius: var(--tmux-ide-shape-panel);
+  background: var(--tmux-ide-surface-panel);
+  box-shadow: var(--tmux-ide-elevation-floating-shadow);
+}
+
+.terminal-surface__state > i {
+  grid-row: 1 / span 2;
+  width: 6px;
+  height: 6px;
+  margin-top: 6px;
+  border: 1px solid var(--tmux-ide-text-muted);
+  border-radius: 50%;
+}
+
+.terminal-surface[data-phase="connecting"] .terminal-surface__state > i,
+.terminal-surface[data-phase="measuring"] .terminal-surface__state > i {
+  border-color: var(--tmux-ide-status-info);
+  background: var(--tmux-ide-status-info);
+  animation: terminal-surface-signal 1.4s linear infinite;
+}
+
+.terminal-surface[data-phase="disconnected"] .terminal-surface__state > i {
+  border-color: var(--tmux-ide-status-warning);
+  background: var(--tmux-ide-status-warning);
+}
+
+.terminal-surface[data-phase="error"] .terminal-surface__state > i {
+  border-color: var(--tmux-ide-status-danger);
+  background: var(--tmux-ide-status-danger);
+}
+
+.terminal-surface__state strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--tmux-ide-text-primary);
+  font-size: 11px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.terminal-surface__state span {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--tmux-ide-text-muted);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.terminal-surface__state button {
+  grid-column: 3;
+  grid-row: 1 / span 2;
+  align-self: center;
+  height: 24px;
+  padding: 0 8px;
+  border: 1px solid var(--tmux-ide-border-default);
+  border-radius: var(--tmux-ide-shape-control);
+  color: var(--tmux-ide-text-primary);
+  background: var(--tmux-ide-surface-header);
+  cursor: pointer;
+}
+
+.terminal-surface__state button:hover {
+  border-color: var(--tmux-ide-border-focused);
+  background: var(--tmux-ide-selection-hover);
+}
+
+@keyframes terminal-surface-signal {
+  50% {
+    opacity: 0.34;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .terminal-surface__state > i,
+  .terminal-surface__state button {
+    animation: none !important;
+    transition: none !important;
+  }
 }
 
 .workspace-dock,

--- a/apps/desktop-renderer/src/terminal/__snapshots__/terminal-surface.test.tsx.snap
+++ b/apps/desktop-renderer/src/terminal/__snapshots__/terminal-surface.test.tsx.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TerminalSurface > renders an explicit unavailable surface without a production transport 1`] = `"<div class="terminal-surface" data-phase="unavailable" data-focused="false" data-reduced-motion="false" data-preserves-frame="false"><div class="terminal-surface__viewport" aria-label="Codex terminal"></div><div class="terminal-surface__state" aria-live="polite" role="status"><i aria-hidden="true"></i><strong>Native terminal unavailable</strong><span>The verified desktop terminal transport is not present in this build.</span></div></div>"`;

--- a/apps/desktop-renderer/src/terminal/native-terminal-transport.ts
+++ b/apps/desktop-renderer/src/terminal/native-terminal-transport.ts
@@ -1,0 +1,66 @@
+import {
+  TerminalAttachRequestSchemaZ,
+  TerminalAttachmentViewportSchemaZ,
+  type TerminalAttachRequest,
+  type TerminalAttachmentViewport,
+} from "@tmux-ide/contracts";
+
+export type NativeTerminalConnectionState = "connected" | "disconnected";
+
+export type NativeTerminalEvent =
+  | { readonly type: "output"; readonly bytes: Uint8Array }
+  | {
+      readonly type: "state";
+      readonly state: NativeTerminalConnectionState;
+      readonly error: NativeTerminalTransportError | null;
+    };
+
+export interface NativeTerminalTransportError {
+  readonly code: string;
+  readonly reason: string;
+  readonly retryable: boolean;
+}
+
+export interface NativeTerminalAttachment {
+  write(bytes: Uint8Array): Promise<NativeTerminalMutationResult>;
+  resize(viewport: TerminalAttachmentViewport): Promise<NativeTerminalMutationResult>;
+  dispose(): void;
+}
+
+export type NativeTerminalMutationResult =
+  | { readonly status: "ok" }
+  | { readonly status: "error"; readonly error: NativeTerminalTransportError };
+
+export type NativeTerminalConnectResult =
+  | { readonly status: "connected"; readonly attachment: NativeTerminalAttachment }
+  | { readonly status: "error"; readonly error: NativeTerminalTransportError };
+
+/**
+ * Renderer-owned adapter target for the versioned desktop host capability.
+ * It is deliberately semantic: private tmux ids, daemon locations, lease
+ * tickets and connection ids cannot be represented here.
+ */
+export interface NativeTerminalTransport {
+  connect(
+    request: TerminalAttachRequest,
+    listener: (event: NativeTerminalEvent) => void | Promise<void>,
+  ): Promise<NativeTerminalConnectResult>;
+}
+
+export function validateNativeTerminalRequest(
+  request: TerminalAttachRequest,
+): TerminalAttachRequest {
+  return TerminalAttachRequestSchemaZ.parse(request);
+}
+
+export function validateNativeTerminalViewport(
+  viewport: TerminalAttachmentViewport,
+): TerminalAttachmentViewport {
+  return TerminalAttachmentViewportSchemaZ.parse(viewport);
+}
+
+export function isNativeTerminalOutput(
+  event: NativeTerminalEvent,
+): event is Extract<NativeTerminalEvent, { readonly type: "output" }> {
+  return event.type === "output" && event.bytes instanceof Uint8Array;
+}

--- a/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
@@ -394,10 +394,14 @@ describe("TerminalSurface", () => {
     await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
     dispose();
 
-    (listener as ((event: NativeTerminalEvent) => void) | null)?.({
-      type: "output",
-      bytes: new Uint8Array([1]),
-    });
+    await expect(
+      Promise.resolve(
+        (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+          type: "output",
+          bytes: new Uint8Array([1]),
+        }),
+      ),
+    ).rejects.toThrow("Terminal output was not consumed by the renderer.");
     renderer.emitInput(new Uint8Array([2]));
     ResizeObserverHarness.active[0]!.trigger();
     connection.resolve({ status: "connected", attachment });
@@ -407,7 +411,7 @@ describe("TerminalSurface", () => {
     expect(attachment.resize).not.toHaveBeenCalled();
   });
 
-  it("releases a pending renderer acknowledgement during unmount", async () => {
+  it("rejects a pending renderer acknowledgement during unmount", async () => {
     const blockedWrite = deferred<void>();
     const attachment = attachmentHarness();
     let listener: ((event: NativeTerminalEvent) => void | Promise<void>) | null = null;
@@ -430,12 +434,14 @@ describe("TerminalSurface", () => {
       root,
     );
     await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
-    const acknowledgment = Promise.resolve(
-      (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
-        type: "output",
-        bytes: new Uint8Array([1]),
-      }),
-    );
+    const acknowledgment = expect(
+      Promise.resolve(
+        (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+          type: "output",
+          bytes: new Uint8Array([1]),
+        }),
+      ),
+    ).rejects.toThrow("Terminal output was not consumed by the renderer.");
     await vi.waitFor(() => expect(renderer.renderer.write).toHaveBeenCalledOnce());
     dispose();
     await acknowledgment;
@@ -467,9 +473,9 @@ describe("TerminalSurface", () => {
       root,
     );
     await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
-    const oldAcknowledgment = Promise.resolve(
-      listeners[0]!({ type: "output", bytes: new Uint8Array([1]) }),
-    );
+    const oldAcknowledgment = expect(
+      Promise.resolve(listeners[0]!({ type: "output", bytes: new Uint8Array([1]) })),
+    ).rejects.toThrow("Terminal output was not consumed by the renderer.");
     await vi.waitFor(() => expect(renderer.renderer.write).toHaveBeenCalledOnce());
     setTarget(TARGET_B);
     await oldAcknowledgment;
@@ -479,6 +485,103 @@ describe("TerminalSurface", () => {
       expect.objectContaining({ target: TARGET_B }),
       expect.any(Function),
     );
+    blockedWrite.resolve();
+    dispose();
+  });
+
+  it("rejects failed renderer output without validating a frame", async () => {
+    const attachment = attachmentHarness();
+    let listener: ((event: NativeTerminalEvent) => void | Promise<void>) | null = null;
+    const transport = transportHarness(async (_request, nextListener) => {
+      listener = nextListener;
+      return { status: "connected", attachment };
+    });
+    const renderer = rendererHarness();
+    vi.mocked(renderer.renderer.write).mockRejectedValue(new Error("renderer failed"));
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    await vi.waitFor(() =>
+      expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("connected"),
+    );
+
+    await expect(
+      Promise.resolve(
+        (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+          type: "output",
+          bytes: new Uint8Array([1]),
+        }),
+      ),
+    ).rejects.toThrow("Terminal output was not consumed by the renderer.");
+
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-preserves-frame")).toBe(
+      "false",
+    );
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("error");
+    expect(attachment.dispose).toHaveBeenCalledOnce();
+    dispose();
+  });
+
+  it("rejects every unconsumed output acknowledgement when the queue overloads", async () => {
+    const blockedWrite = deferred<void>();
+    const attachment = attachmentHarness();
+    let listener: ((event: NativeTerminalEvent) => void | Promise<void>) | null = null;
+    const transport = transportHarness(async (_request, nextListener) => {
+      listener = nextListener;
+      return { status: "connected", attachment };
+    });
+    const renderer = rendererHarness();
+    vi.mocked(renderer.renderer.write).mockImplementation(async () => blockedWrite.promise);
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+
+    const acknowledgements = Array.from({ length: 65 }, (_, index) =>
+      Promise.resolve(
+        (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+          type: "output",
+          bytes: new Uint8Array([index]),
+        }),
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      ),
+    );
+    const outcomes = await Promise.all(acknowledgements);
+
+    expect(outcomes).toHaveLength(65);
+    for (const outcome of outcomes) {
+      expect(outcome).toEqual(
+        expect.objectContaining({
+          message: "Terminal output was not consumed by the renderer.",
+        }),
+      );
+    }
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-preserves-frame")).toBe(
+      "false",
+    );
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("error");
+    expect(attachment.dispose).toHaveBeenCalledOnce();
     blockedWrite.resolve();
     dispose();
   });

--- a/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
@@ -62,6 +62,7 @@ function rendererHarness(initialViewport: TerminalAttachmentViewport = { cols: 8
   let viewport = initialViewport;
   let input: ((bytes: Uint8Array) => void) | null = null;
   const writes: Uint8Array[] = [];
+  const disposeInput = vi.fn(() => (input = null));
   const renderer: TerminalRenderer = {
     open: vi.fn(),
     write: vi.fn(async (bytes) => {
@@ -73,7 +74,7 @@ function rendererHarness(initialViewport: TerminalAttachmentViewport = { cols: 8
     setReducedMotion: vi.fn(),
     onInput: vi.fn((listener) => {
       input = listener;
-      return { dispose: vi.fn(() => (input = null)) };
+      return { dispose: disposeInput };
     }),
     dispose: vi.fn(),
   };
@@ -82,6 +83,7 @@ function rendererHarness(initialViewport: TerminalAttachmentViewport = { cols: 8
     renderer,
     factory,
     writes,
+    disposeInput,
     emitInput(bytes: Uint8Array) {
       input?.(bytes);
     },
@@ -89,6 +91,18 @@ function rendererHarness(initialViewport: TerminalAttachmentViewport = { cols: 8
       viewport = next;
     },
   };
+}
+
+function rendererFleetHarness(
+  initialViewport: TerminalAttachmentViewport = { cols: 80, rows: 24 },
+) {
+  const instances: Array<ReturnType<typeof rendererHarness>> = [];
+  const factory: TerminalRendererFactory = vi.fn(() => {
+    const instance = rendererHarness(initialViewport);
+    instances.push(instance);
+    return instance.renderer;
+  });
+  return { factory, instances };
 }
 
 function attachmentHarness(overrides: Partial<NativeTerminalAttachment> = {}) {
@@ -370,6 +384,103 @@ describe("TerminalSurface", () => {
     dispose();
   });
 
+  it("ignores zero-byte input without calling the host", async () => {
+    const attachment = attachmentHarness();
+    const transport = transportHarness(async () => ({ status: "connected", attachment }));
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+
+    renderer.emitInput(new Uint8Array());
+    await Promise.resolve();
+
+    expect(attachment.write).not.toHaveBeenCalled();
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("connected");
+    dispose();
+  });
+
+  it("fails closed at a bounded input entry count behind a stalled host write", async () => {
+    const firstWrite = deferred<void>();
+    const attachment = attachmentHarness({
+      write: vi.fn(async () => {
+        await firstWrite.promise;
+        return { status: "ok" as const };
+      }),
+    });
+    const transport = transportHarness(async () => ({ status: "connected", attachment }));
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+
+    renderer.emitInput(new Uint8Array([0]));
+    await vi.waitFor(() => expect(attachment.write).toHaveBeenCalledOnce());
+    for (let index = 1; index <= 64; index += 1) {
+      renderer.emitInput(new Uint8Array([index]));
+    }
+    await vi.waitFor(() =>
+      expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("error"),
+    );
+
+    expect(root.textContent).toContain("Terminal input exceeded the native forwarding buffer.");
+    expect(attachment.dispose).toHaveBeenCalledOnce();
+    expect(attachment.write).toHaveBeenCalledOnce();
+    firstWrite.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(attachment.write).toHaveBeenCalledOnce();
+    dispose();
+  });
+
+  it("fails closed before copying an input payload beyond the byte budget", async () => {
+    const attachment = attachmentHarness();
+    const transport = transportHarness(async () => ({ status: "connected", attachment }));
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+
+    renderer.emitInput(new Uint8Array(256 * 1024 + 1));
+    await vi.waitFor(() =>
+      expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("error"),
+    );
+
+    expect(attachment.write).not.toHaveBeenCalled();
+    expect(attachment.dispose).toHaveBeenCalledOnce();
+    dispose();
+  });
+
   it("retires late connect, output, input, and resize work after unmount", async () => {
     const connection = deferred<NativeTerminalConnectResult>();
     const attachment = attachmentHarness();
@@ -456,9 +567,8 @@ describe("TerminalSurface", () => {
       listeners.push(listener);
       return { status: "connected", attachment: attachments[connectionIndex++]! };
     });
-    const renderer = rendererHarness();
+    const rendererFleet = rendererFleetHarness();
     const blockedWrite = deferred<void>();
-    vi.mocked(renderer.renderer.write).mockImplementation(async () => blockedWrite.promise);
     const [target, setTarget] = createSignal(TARGET_A);
     const root = document.body.appendChild(document.createElement("div"));
     const dispose = render(
@@ -467,25 +577,96 @@ describe("TerminalSurface", () => {
           target={target()}
           title="Codex"
           transport={transport}
-          rendererFactory={renderer.factory}
+          rendererFactory={rendererFleet.factory}
         />
       ),
       root,
     );
     await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    const oldRenderer = rendererFleet.instances[0]!;
+    vi.mocked(oldRenderer.renderer.write).mockImplementation(async () => blockedWrite.promise);
     const oldAcknowledgment = expect(
       Promise.resolve(listeners[0]!({ type: "output", bytes: new Uint8Array([1]) })),
     ).rejects.toThrow("Terminal output was not consumed by the renderer.");
-    await vi.waitFor(() => expect(renderer.renderer.write).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(oldRenderer.renderer.write).toHaveBeenCalledOnce());
     setTarget(TARGET_B);
     await oldAcknowledgment;
     await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(rendererFleet.instances).toHaveLength(2));
+    const newRenderer = rendererFleet.instances[1]!;
     expect(attachments[0]!.dispose).toHaveBeenCalledOnce();
+    expect(oldRenderer.renderer.dispose).toHaveBeenCalledOnce();
+    expect(oldRenderer.disposeInput).toHaveBeenCalledOnce();
+    expect(ResizeObserverHarness.active[0]!.disconnect).toHaveBeenCalledOnce();
     expect(transport.connect).toHaveBeenLastCalledWith(
       expect.objectContaining({ target: TARGET_B }),
       expect.any(Function),
     );
+    await Promise.resolve(listeners[1]!({ type: "output", bytes: new Uint8Array([2]) }));
+    expect(newRenderer.writes).toEqual([new Uint8Array([2])]);
     blockedWrite.resolve();
+    await Promise.resolve();
+    expect(newRenderer.writes).toEqual([new Uint8Array([2])]);
+    dispose();
+  });
+
+  it("replaces the renderer when terminal transport authority changes", async () => {
+    const attachments = [attachmentHarness(), attachmentHarness()];
+    let oldListener: ((event: NativeTerminalEvent) => void | Promise<void>) | null = null;
+    let newListener: ((event: NativeTerminalEvent) => void | Promise<void>) | null = null;
+    const oldTransport = transportHarness(async (_request, listener) => {
+      oldListener = listener;
+      return { status: "connected", attachment: attachments[0]! };
+    });
+    const newTransport = transportHarness(async (_request, listener) => {
+      newListener = listener;
+      return { status: "connected", attachment: attachments[1]! };
+    });
+    const [transport, setTransport] = createSignal<NativeTerminalTransport>(oldTransport);
+    const rendererFleet = rendererFleetHarness();
+    const blockedWrite = deferred<void>();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport()}
+          rendererFactory={rendererFleet.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(oldTransport.connect).toHaveBeenCalledOnce());
+    const oldRenderer = rendererFleet.instances[0]!;
+    vi.mocked(oldRenderer.renderer.write).mockImplementation(async () => blockedWrite.promise);
+    const oldAcknowledgment = expect(
+      Promise.resolve(
+        (oldListener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+          type: "output",
+          bytes: new Uint8Array([1]),
+        }),
+      ),
+    ).rejects.toThrow("Terminal output was not consumed by the renderer.");
+    await vi.waitFor(() => expect(oldRenderer.renderer.write).toHaveBeenCalledOnce());
+
+    setTransport(newTransport);
+    await oldAcknowledgment;
+    await vi.waitFor(() => expect(newTransport.connect).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(rendererFleet.instances).toHaveLength(2));
+    const newRenderer = rendererFleet.instances[1]!;
+    expect(attachments[0]!.dispose).toHaveBeenCalledOnce();
+    expect(oldRenderer.renderer.dispose).toHaveBeenCalledOnce();
+    await Promise.resolve(
+      (newListener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+        type: "output",
+        bytes: new Uint8Array([2]),
+      }),
+    );
+    expect(newRenderer.writes).toEqual([new Uint8Array([2])]);
+    blockedWrite.resolve();
+    await Promise.resolve();
+    expect(newRenderer.writes).toEqual([new Uint8Array([2])]);
     dispose();
   });
 
@@ -621,13 +802,14 @@ describe("TerminalSurface", () => {
 
   it("requires an explicit retry after disconnect instead of reconnecting on resize", async () => {
     const attachments = [attachmentHarness(), attachmentHarness()];
-    const listeners: Array<(event: NativeTerminalEvent) => void> = [];
+    const listeners: Array<(event: NativeTerminalEvent) => void | Promise<void>> = [];
     let connectionIndex = 0;
     const transport = transportHarness(async (_request, listener) => {
       listeners.push(listener);
       return { status: "connected", attachment: attachments[connectionIndex++]! };
     });
-    const renderer = rendererHarness();
+    const rendererFleet = rendererFleetHarness();
+    const blockedWrite = deferred<void>();
     const root = document.body.appendChild(document.createElement("div"));
     const dispose = render(
       () => (
@@ -635,14 +817,21 @@ describe("TerminalSurface", () => {
           target={TARGET_A}
           title="Codex"
           transport={transport}
-          rendererFactory={renderer.factory}
+          rendererFactory={rendererFleet.factory}
         />
       ),
       root,
     );
     await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    const oldRenderer = rendererFleet.instances[0]!;
+    vi.mocked(oldRenderer.renderer.write).mockImplementation(async () => blockedWrite.promise);
+    const oldAcknowledgment = expect(
+      Promise.resolve(listeners[0]!({ type: "output", bytes: new Uint8Array([1]) })),
+    ).rejects.toThrow("Terminal output was not consumed by the renderer.");
+    await vi.waitFor(() => expect(oldRenderer.renderer.write).toHaveBeenCalledOnce());
     listeners[0]!({ type: "state", state: "disconnected", error: null });
-    renderer.setViewport({ cols: 120, rows: 40 });
+    await oldAcknowledgment;
+    oldRenderer.setViewport({ cols: 120, rows: 40 });
     ResizeObserverHarness.active[0]!.trigger();
     await Promise.resolve();
     expect(transport.connect).toHaveBeenCalledOnce();
@@ -650,6 +839,17 @@ describe("TerminalSurface", () => {
     root.querySelector<HTMLButtonElement>(".terminal-surface__state button")!.click();
     expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("measuring");
     await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(rendererFleet.instances).toHaveLength(2));
+    const newRenderer = rendererFleet.instances[1]!;
+    expect(oldRenderer.renderer.dispose).toHaveBeenCalledOnce();
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-preserves-frame")).toBe(
+      "false",
+    );
+    await Promise.resolve(listeners[1]!({ type: "output", bytes: new Uint8Array([2]) }));
+    expect(newRenderer.writes).toEqual([new Uint8Array([2])]);
+    blockedWrite.resolve();
+    await Promise.resolve();
+    expect(newRenderer.writes).toEqual([new Uint8Array([2])]);
     dispose();
   });
 

--- a/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
@@ -354,6 +354,49 @@ describe("TerminalSurface", () => {
     dispose();
   });
 
+  it("coalesces viewport measurements while connect is delayed", async () => {
+    const connection = deferred<NativeTerminalConnectResult>();
+    const attachment = attachmentHarness();
+    const transport = transportHarness(async () => connection.promise);
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    expect(transport.connect).toHaveBeenCalledWith(
+      expect.objectContaining({ viewport: { cols: 80, rows: 24 } }),
+      expect.any(Function),
+    );
+
+    let fitCalls = vi.mocked(renderer.renderer.fit).mock.calls.length;
+    renderer.setViewport({ cols: 100, rows: 30 });
+    ResizeObserverHarness.active[0]!.trigger();
+    await vi.waitFor(() => expect(renderer.renderer.fit).toHaveBeenCalledTimes(fitCalls + 1));
+    fitCalls += 1;
+    renderer.setViewport({ cols: 120, rows: 40 });
+    ResizeObserverHarness.active[0]!.trigger();
+    await vi.waitFor(() => expect(renderer.renderer.fit).toHaveBeenCalledTimes(fitCalls + 1));
+    expect(attachment.resize).not.toHaveBeenCalled();
+
+    connection.resolve({ status: "connected", attachment });
+    await vi.waitFor(() => expect(attachment.resize).toHaveBeenCalledWith({ cols: 120, rows: 40 }));
+    expect(attachment.resize).toHaveBeenCalledOnce();
+
+    ResizeObserverHarness.active[0]!.trigger();
+    await Promise.resolve();
+    expect(attachment.resize).toHaveBeenCalledOnce();
+    dispose();
+  });
+
   it("fails closed on a typed host input rejection without starting a second writer", async () => {
     const attachment = attachmentHarness({
       write: vi.fn(async () => ({
@@ -797,6 +840,79 @@ describe("TerminalSurface", () => {
     connection.resolve({ status: "connected", attachment });
     await vi.waitFor(() => expect(attachment.dispose).toHaveBeenCalledOnce());
     expect(root.textContent).toContain("Terminal disconnected");
+    dispose();
+  });
+
+  it("retires a typed connect failure before rejecting late output", async () => {
+    let listener: ((event: NativeTerminalEvent) => void | Promise<void>) | null = null;
+    const transport = transportHarness(async (_request, nextListener) => {
+      listener = nextListener;
+      return {
+        status: "error",
+        error: { code: "attach-failed", reason: "tmux attach failed", retryable: true },
+      };
+    });
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() =>
+      expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("error"),
+    );
+
+    await expect(
+      Promise.resolve(
+        (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+          type: "output",
+          bytes: new Uint8Array([1]),
+        }),
+      ),
+    ).rejects.toThrow("Terminal output was not consumed by the renderer.");
+    expect(renderer.renderer.write).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("retires a rejected connect before rejecting late output", async () => {
+    let listener: ((event: NativeTerminalEvent) => void | Promise<void>) | null = null;
+    const transport = transportHarness((_request, nextListener) => {
+      listener = nextListener;
+      return Promise.reject(new Error("transport rejected"));
+    });
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() =>
+      expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("error"),
+    );
+
+    await expect(
+      Promise.resolve(
+        (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+          type: "output",
+          bytes: new Uint8Array([1]),
+        }),
+      ),
+    ).rejects.toThrow("Terminal output was not consumed by the renderer.");
+    expect(renderer.renderer.write).not.toHaveBeenCalled();
     dispose();
   });
 

--- a/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
@@ -1,0 +1,563 @@
+/* @vitest-environment happy-dom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSignal } from "solid-js";
+import { render } from "solid-js/web";
+import type {
+  TerminalAttachmentSemanticTarget,
+  TerminalAttachmentViewport,
+} from "@tmux-ide/contracts";
+
+import { TerminalSurface } from "./terminal-surface.tsx";
+import type {
+  NativeTerminalAttachment,
+  NativeTerminalConnectResult,
+  NativeTerminalEvent,
+  NativeTerminalTransport,
+} from "./native-terminal-transport.ts";
+import type { TerminalRenderer, TerminalRendererFactory } from "./xterm-renderer.ts";
+import surfaceSource from "./terminal-surface.tsx?raw";
+import transportSource from "./native-terminal-transport.ts?raw";
+import xtermSource from "./xterm-renderer.ts?raw";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: (value) => resolvePromise?.(value) };
+}
+
+const TARGET_A: TerminalAttachmentSemanticTarget = {
+  workspaceName: "workspace-a",
+  semanticPaneId: "agent-a",
+};
+const TARGET_B: TerminalAttachmentSemanticTarget = {
+  workspaceName: "workspace-b",
+  semanticPaneId: "agent-b",
+};
+
+class ResizeObserverHarness {
+  static readonly active: ResizeObserverHarness[] = [];
+  readonly callback: ResizeObserverCallback;
+  readonly disconnect = vi.fn();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    ResizeObserverHarness.active.push(this);
+  }
+
+  observe(): void {}
+  unobserve(): void {}
+  trigger(): void {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+function rendererHarness(initialViewport: TerminalAttachmentViewport = { cols: 80, rows: 24 }) {
+  let viewport = initialViewport;
+  let input: ((bytes: Uint8Array) => void) | null = null;
+  const writes: Uint8Array[] = [];
+  const renderer: TerminalRenderer = {
+    open: vi.fn(),
+    write: vi.fn(async (bytes) => {
+      writes.push(bytes);
+    }),
+    focus: vi.fn(),
+    fit: vi.fn(() => viewport),
+    refreshTheme: vi.fn(),
+    setReducedMotion: vi.fn(),
+    onInput: vi.fn((listener) => {
+      input = listener;
+      return { dispose: vi.fn(() => (input = null)) };
+    }),
+    dispose: vi.fn(),
+  };
+  const factory: TerminalRendererFactory = vi.fn(() => renderer);
+  return {
+    renderer,
+    factory,
+    writes,
+    emitInput(bytes: Uint8Array) {
+      input?.(bytes);
+    },
+    setViewport(next: TerminalAttachmentViewport) {
+      viewport = next;
+    },
+  };
+}
+
+function attachmentHarness(overrides: Partial<NativeTerminalAttachment> = {}) {
+  return {
+    write: vi.fn(async () => ({ status: "ok" as const })),
+    resize: vi.fn(async () => ({ status: "ok" as const })),
+    dispose: vi.fn(),
+    ...overrides,
+  } satisfies NativeTerminalAttachment;
+}
+
+function transportHarness(connect: NativeTerminalTransport["connect"]): NativeTerminalTransport {
+  return { connect: vi.fn(connect) };
+}
+
+beforeEach(() => {
+  ResizeObserverHarness.active.length = 0;
+  let nextFrame = 0;
+  vi.stubGlobal("ResizeObserver", ResizeObserverHarness);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    const id = ++nextFrame;
+    queueMicrotask(() => callback(id));
+    return id;
+  });
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.replaceChildren();
+});
+
+describe("TerminalSurface", () => {
+  it("renders an explicit unavailable surface without a production transport", () => {
+    const root = document.body.appendChild(document.createElement("div"));
+    const renderer = rendererHarness();
+    const dispose = render(
+      () => <TerminalSurface target={TARGET_A} title="Codex" rendererFactory={renderer.factory} />,
+      root,
+    );
+
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("unavailable");
+    expect(root.textContent).toContain("Native terminal unavailable");
+    expect(root.innerHTML).toMatchSnapshot();
+    dispose();
+    expect(renderer.renderer.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("forwards early binary output and serializes terminal input writes", async () => {
+    const connection = deferred<NativeTerminalConnectResult>();
+    const firstWrite = deferred<void>();
+    const writeOrder: number[] = [];
+    const attachment = attachmentHarness({
+      write: vi.fn(async (bytes: Uint8Array) => {
+        writeOrder.push(bytes[0]!);
+        if (writeOrder.length === 1) await firstWrite.promise;
+        return { status: "ok" as const };
+      }),
+    });
+    let listener: ((event: NativeTerminalEvent) => void) | null = null;
+    const transport = transportHarness(async (_request, nextListener) => {
+      listener = nextListener;
+      return connection.promise;
+    });
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    expect(transport.connect).toHaveBeenCalledWith(
+      {
+        protocolVersion: 1,
+        target: TARGET_A,
+        viewerMode: "interactive",
+        viewport: { cols: 80, rows: 24 },
+      },
+      expect.any(Function),
+    );
+    await Promise.resolve(
+      (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+        type: "output",
+        bytes: new Uint8Array([27, 91, 65]),
+      }),
+    );
+    expect(renderer.writes).toEqual([new Uint8Array([27, 91, 65])]);
+
+    connection.resolve({ status: "connected", attachment });
+    await vi.waitFor(() =>
+      expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("connected"),
+    );
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-preserves-frame")).toBe(
+      "true",
+    );
+    renderer.emitInput(new Uint8Array([1]));
+    renderer.emitInput(new Uint8Array([2]));
+    await vi.waitFor(() => expect(writeOrder).toEqual([1]));
+    firstWrite.resolve();
+    await vi.waitFor(() => expect(writeOrder).toEqual([1, 2]));
+
+    dispose();
+    expect(attachment.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("acknowledges ordered output only after the renderer write callback settles", async () => {
+    const firstWrite = deferred<void>();
+    const writeOrder: number[] = [];
+    const attachment = attachmentHarness();
+    let listener: ((event: NativeTerminalEvent) => void | Promise<void>) | null = null;
+    const transport = transportHarness(async (_request, nextListener) => {
+      listener = nextListener;
+      return { status: "connected", attachment };
+    });
+    const renderer = rendererHarness();
+    vi.mocked(renderer.renderer.write).mockImplementation(async (bytes) => {
+      writeOrder.push(bytes[0]!);
+      if (writeOrder.length === 1) await firstWrite.promise;
+    });
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+
+    let firstAcknowledged = false;
+    let secondAcknowledged = false;
+    const firstAck = Promise.resolve(
+      (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+        type: "output",
+        bytes: new Uint8Array([1]),
+      }),
+    ).then(() => {
+      firstAcknowledged = true;
+    });
+    const secondAck = Promise.resolve(
+      (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+        type: "output",
+        bytes: new Uint8Array([2]),
+      }),
+    ).then(() => {
+      secondAcknowledged = true;
+    });
+    await vi.waitFor(() => expect(writeOrder).toEqual([1]));
+    expect(firstAcknowledged).toBe(false);
+    expect(secondAcknowledged).toBe(false);
+
+    firstWrite.resolve();
+    await firstAck;
+    await vi.waitFor(() => expect(writeOrder).toEqual([1, 2]));
+    await secondAck;
+    expect(firstAcknowledged).toBe(true);
+    expect(secondAcknowledged).toBe(true);
+    dispose();
+  });
+
+  it("focuses the renderer when semantic focus changes", async () => {
+    const attachment = attachmentHarness();
+    const transport = transportHarness(async () => ({ status: "connected", attachment }));
+    const renderer = rendererHarness();
+    const [focused, setFocused] = createSignal(false);
+    const [reducedMotion, setReducedMotion] = createSignal(false);
+    const [themeKey, setThemeKey] = createSignal("dark:false");
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          focused={focused()}
+          reducedMotion={reducedMotion()}
+          themeKey={themeKey()}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    expect(renderer.renderer.focus).not.toHaveBeenCalled();
+    setFocused(true);
+    await vi.waitFor(() => expect(renderer.renderer.focus).toHaveBeenCalledOnce());
+    const themeRefreshesBeforeChange = vi.mocked(renderer.renderer.refreshTheme).mock.calls.length;
+    setReducedMotion(true);
+    setThemeKey("light:true");
+    await vi.waitFor(() =>
+      expect(renderer.renderer.setReducedMotion).toHaveBeenLastCalledWith(true),
+    );
+    expect(renderer.renderer.refreshTheme).toHaveBeenCalledTimes(themeRefreshesBeforeChange + 1);
+    dispose();
+  });
+
+  it("coalesces viewport changes behind one ordered resize flight", async () => {
+    const firstResize = deferred<void>();
+    const resizeOrder: TerminalAttachmentViewport[] = [];
+    const attachment = attachmentHarness({
+      resize: vi.fn(async (viewport: TerminalAttachmentViewport) => {
+        resizeOrder.push(viewport);
+        if (resizeOrder.length === 1) await firstResize.promise;
+        return { status: "ok" as const };
+      }),
+    });
+    const transport = transportHarness(async () => ({ status: "connected", attachment }));
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+
+    renderer.setViewport({ cols: 100, rows: 30 });
+    ResizeObserverHarness.active[0]!.trigger();
+    await vi.waitFor(() => expect(resizeOrder).toEqual([{ cols: 100, rows: 30 }]));
+    renderer.setViewport({ cols: 120, rows: 40 });
+    ResizeObserverHarness.active[0]!.trigger();
+    expect(resizeOrder).toEqual([{ cols: 100, rows: 30 }]);
+    firstResize.resolve();
+    await vi.waitFor(() =>
+      expect(resizeOrder).toEqual([
+        { cols: 100, rows: 30 },
+        { cols: 120, rows: 40 },
+      ]),
+    );
+    dispose();
+  });
+
+  it("fails closed on a typed host input rejection without starting a second writer", async () => {
+    const attachment = attachmentHarness({
+      write: vi.fn(async () => ({
+        status: "error" as const,
+        error: { code: "read-only", reason: "This terminal is read-only.", retryable: false },
+      })),
+    });
+    const transport = transportHarness(async () => ({ status: "connected", attachment }));
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    renderer.emitInput(new Uint8Array([3]));
+    await vi.waitFor(() => expect(root.textContent).toContain("This terminal is read-only."));
+    renderer.emitInput(new Uint8Array([4]));
+    expect(attachment.write).toHaveBeenCalledOnce();
+    expect(attachment.dispose).toHaveBeenCalledOnce();
+    dispose();
+  });
+
+  it("retires late connect, output, input, and resize work after unmount", async () => {
+    const connection = deferred<NativeTerminalConnectResult>();
+    const attachment = attachmentHarness();
+    let listener: ((event: NativeTerminalEvent) => void) | null = null;
+    const transport = transportHarness(async (_request, nextListener) => {
+      listener = nextListener;
+      return connection.promise;
+    });
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    dispose();
+
+    (listener as ((event: NativeTerminalEvent) => void) | null)?.({
+      type: "output",
+      bytes: new Uint8Array([1]),
+    });
+    renderer.emitInput(new Uint8Array([2]));
+    ResizeObserverHarness.active[0]!.trigger();
+    connection.resolve({ status: "connected", attachment });
+    await vi.waitFor(() => expect(attachment.dispose).toHaveBeenCalledOnce());
+    expect(renderer.writes).toEqual([]);
+    expect(attachment.write).not.toHaveBeenCalled();
+    expect(attachment.resize).not.toHaveBeenCalled();
+  });
+
+  it("releases a pending renderer acknowledgement during unmount", async () => {
+    const blockedWrite = deferred<void>();
+    const attachment = attachmentHarness();
+    let listener: ((event: NativeTerminalEvent) => void | Promise<void>) | null = null;
+    const transport = transportHarness(async (_request, nextListener) => {
+      listener = nextListener;
+      return { status: "connected", attachment };
+    });
+    const renderer = rendererHarness();
+    vi.mocked(renderer.renderer.write).mockImplementation(async () => blockedWrite.promise);
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    const acknowledgment = Promise.resolve(
+      (listener as ((event: NativeTerminalEvent) => void | Promise<void>) | null)?.({
+        type: "output",
+        bytes: new Uint8Array([1]),
+      }),
+    );
+    await vi.waitFor(() => expect(renderer.renderer.write).toHaveBeenCalledOnce());
+    dispose();
+    await acknowledgment;
+    blockedWrite.resolve();
+  });
+
+  it("retires the old attachment and reconnects when the semantic target changes", async () => {
+    const attachments = [attachmentHarness(), attachmentHarness()];
+    const listeners: Array<(event: NativeTerminalEvent) => void | Promise<void>> = [];
+    let connectionIndex = 0;
+    const transport = transportHarness(async (_request, listener) => {
+      listeners.push(listener);
+      return { status: "connected", attachment: attachments[connectionIndex++]! };
+    });
+    const renderer = rendererHarness();
+    const blockedWrite = deferred<void>();
+    vi.mocked(renderer.renderer.write).mockImplementation(async () => blockedWrite.promise);
+    const [target, setTarget] = createSignal(TARGET_A);
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={target()}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    const oldAcknowledgment = Promise.resolve(
+      listeners[0]!({ type: "output", bytes: new Uint8Array([1]) }),
+    );
+    await vi.waitFor(() => expect(renderer.renderer.write).toHaveBeenCalledOnce());
+    setTarget(TARGET_B);
+    await oldAcknowledgment;
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledTimes(2));
+    expect(attachments[0]!.dispose).toHaveBeenCalledOnce();
+    expect(transport.connect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ target: TARGET_B }),
+      expect.any(Function),
+    );
+    blockedWrite.resolve();
+    dispose();
+  });
+
+  it("rejects a late success after a pre-resolution disconnect", async () => {
+    const connection = deferred<NativeTerminalConnectResult>();
+    const attachment = attachmentHarness();
+    let listener: ((event: NativeTerminalEvent) => void) | null = null;
+    const transport = transportHarness(async (_request, nextListener) => {
+      listener = nextListener;
+      return connection.promise;
+    });
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    (listener as ((event: NativeTerminalEvent) => void) | null)?.({
+      type: "state",
+      state: "disconnected",
+      error: null,
+    });
+    connection.resolve({ status: "connected", attachment });
+    await vi.waitFor(() => expect(attachment.dispose).toHaveBeenCalledOnce());
+    expect(root.textContent).toContain("Terminal disconnected");
+    dispose();
+  });
+
+  it("requires an explicit retry after disconnect instead of reconnecting on resize", async () => {
+    const attachments = [attachmentHarness(), attachmentHarness()];
+    const listeners: Array<(event: NativeTerminalEvent) => void> = [];
+    let connectionIndex = 0;
+    const transport = transportHarness(async (_request, listener) => {
+      listeners.push(listener);
+      return { status: "connected", attachment: attachments[connectionIndex++]! };
+    });
+    const renderer = rendererHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={TARGET_A}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    listeners[0]!({ type: "state", state: "disconnected", error: null });
+    renderer.setViewport({ cols: 120, rows: 40 });
+    ResizeObserverHarness.active[0]!.trigger();
+    await Promise.resolve();
+    expect(transport.connect).toHaveBeenCalledOnce();
+
+    root.querySelector<HTMLButtonElement>(".terminal-surface__state button")!.click();
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("measuring");
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledTimes(2));
+    dispose();
+  });
+
+  it("keeps process, tmux, daemon, and network authority out of the Solid renderer", () => {
+    const rendererSources = `${surfaceSource}\n${transportSource}\n${xtermSource}`;
+    expect(rendererSources).not.toMatch(
+      /(?:from\s+["']node:|node-pty|ipcRenderer|child_process|\bfetch\s*\(|new\s+WebSocket|\.spawn\s*\()/u,
+    );
+    expect(transportSource).not.toMatch(
+      /(?:apiBaseUrl|redemptionTicket|connectionId|tmuxPaneId|runtimePaneId)/u,
+    );
+    expect(xtermSource).toContain("terminal.write(bytes, resolve)");
+  });
+});

--- a/apps/desktop-renderer/src/terminal/terminal-surface.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.tsx
@@ -27,6 +27,8 @@ export type TerminalSurfacePhase =
 
 const MAX_PENDING_OUTPUT_WRITES = 64;
 const OUTPUT_WRITE_TIMEOUT_MS = 15_000;
+const MAX_PENDING_INPUT_WRITES = 64;
+const MAX_PENDING_INPUT_BYTES = 256 * 1024;
 
 export interface TerminalSurfaceProps {
   readonly target: TerminalAttachmentSemanticTarget;
@@ -72,12 +74,32 @@ interface OutputEpoch {
   pending: number;
 }
 
+interface InputEpoch {
+  readonly queue: Uint8Array[];
+  retired: boolean;
+  inFlight: boolean;
+  inFlightBytes: number;
+  pendingEntries: number;
+  pendingBytes: number;
+}
+
 function outputEpoch(): OutputEpoch {
   let retire = (): void => undefined;
   const retired = new Promise<void>((resolve) => {
     retire = resolve;
   });
   return { retired, retire, pending: 0 };
+}
+
+function inputEpoch(): InputEpoch {
+  return {
+    queue: [],
+    retired: false,
+    inFlight: false,
+    inFlightBytes: 0,
+    pendingEntries: 0,
+    pendingBytes: 0,
+  };
 }
 
 const OUTPUT_NOT_CONSUMED = new Error("Terminal output was not consumed by the renderer.");
@@ -100,7 +122,7 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
   let animationFrame: number | null = null;
   let disposed = false;
   let generation = 0;
-  let writeTail = Promise.resolve();
+  let activeInputEpoch = inputEpoch();
   let outputTail = Promise.resolve();
   let activeOutputEpoch = outputEpoch();
   let observedTarget = `${props.target.workspaceName}\0${props.target.semanticPaneId}`;
@@ -111,8 +133,13 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
   let pointerFocus = false;
   let rendererLoadGeneration = 0;
 
-  const retireWrites = (): void => {
-    writeTail = Promise.resolve();
+  const retireInput = (): void => {
+    const epoch = activeInputEpoch;
+    epoch.retired = true;
+    epoch.queue.length = 0;
+    epoch.pendingEntries = epoch.inFlight ? 1 : 0;
+    epoch.pendingBytes = epoch.inFlightBytes;
+    activeInputEpoch = inputEpoch();
   };
 
   const retireOutput = (): void => {
@@ -134,9 +161,41 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
     attachment = null;
     pendingResize = null;
     resizeFlight = null;
-    retireWrites();
+    retireInput();
     retireOutput();
     if (active) safelyDispose(active);
+  };
+
+  const disposeRenderer = (): void => {
+    rendererLoadGeneration += 1;
+    if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+    animationFrame = null;
+    const activeObserver = observer;
+    observer = null;
+    try {
+      activeObserver?.disconnect();
+    } catch {
+      // A stale observer cannot retain renderer ownership after invalidation.
+    }
+    const activeInputSubscription = inputSubscription;
+    inputSubscription = null;
+    try {
+      activeInputSubscription?.dispose();
+    } catch {
+      // A stale input callback is generation-gated even if teardown is broken.
+    }
+    const activeRenderer = renderer;
+    renderer = null;
+    try {
+      activeRenderer?.dispose();
+    } catch {
+      // Renderer teardown is best-effort; authority has already been retired.
+    }
+    try {
+      mount?.replaceChildren();
+    } catch {
+      // The replacement renderer still receives a fresh generation and instance.
+    }
   };
 
   const flushResize = (): void => {
@@ -330,51 +389,103 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
   const retry = (): void => {
     generation += 1;
     disposeAttachment();
+    disposeRenderer();
     currentViewport = null;
     pendingResize = null;
-    if (animationFrame !== null) cancelAnimationFrame(animationFrame);
-    animationFrame = null;
+    setHasValidatedFrame(false);
     setPhase(props.transport ? "measuring" : "unavailable");
     ensureRenderer();
     scheduleFit();
   };
 
-  const queueInput = (bytes: Uint8Array): void => {
+  const failInput = (message: string): void => {
+    setReason(message);
+    setPhase("error");
+    generation += 1;
+    disposeAttachment();
+  };
+
+  const drainInput = (epoch: InputEpoch): void => {
+    if (
+      disposed ||
+      epoch !== activeInputEpoch ||
+      epoch.retired ||
+      epoch.inFlight ||
+      epoch.queue.length === 0
+    ) {
+      return;
+    }
     const activeAttachment = attachment;
     const activeGeneration = generation;
     if (!activeAttachment || phase() !== "connected") return;
-    const payload = bytes.slice();
-    writeTail = writeTail
-      .catch(() => undefined)
-      .then(async () => {
+    const payload = epoch.queue.shift();
+    if (!payload) return;
+    epoch.inFlight = true;
+    epoch.inFlightBytes = payload.byteLength;
+    void Promise.resolve()
+      .then(() => {
         if (
           disposed ||
+          epoch.retired ||
+          epoch !== activeInputEpoch ||
           generation !== activeGeneration ||
           attachment !== activeAttachment ||
           phase() !== "connected"
         ) {
+          return null;
+        }
+        return activeAttachment.write(payload);
+      })
+      .then((result) => {
+        if (
+          !result ||
+          result.status !== "error" ||
+          disposed ||
+          epoch.retired ||
+          epoch !== activeInputEpoch ||
+          generation !== activeGeneration ||
+          attachment !== activeAttachment
+        ) {
           return;
         }
-        const result = await activeAttachment.write(payload);
-        if (result.status === "error") {
-          if (disposed || generation !== activeGeneration || attachment !== activeAttachment) {
-            return;
-          }
-          setReason(validatedTransportReason(result.error.reason));
-          setPhase("error");
-          generation += 1;
-          disposeAttachment();
-        }
+        failInput(validatedTransportReason(result.error.reason));
       })
       .catch(() => {
-        if (disposed || generation !== activeGeneration || attachment !== activeAttachment) {
+        if (
+          disposed ||
+          epoch.retired ||
+          epoch !== activeInputEpoch ||
+          generation !== activeGeneration ||
+          attachment !== activeAttachment
+        ) {
           return;
         }
-        setReason("The desktop host could not forward terminal input.");
-        setPhase("error");
-        generation += 1;
-        disposeAttachment();
+        failInput("The desktop host could not forward terminal input.");
+      })
+      .finally(() => {
+        epoch.inFlight = false;
+        epoch.inFlightBytes = 0;
+        epoch.pendingEntries -= 1;
+        epoch.pendingBytes -= payload.byteLength;
+        if (epoch === activeInputEpoch && !epoch.retired) drainInput(epoch);
       });
+  };
+
+  const queueInput = (bytes: Uint8Array): void => {
+    if (bytes.byteLength === 0 || !attachment || phase() !== "connected") return;
+    const epoch = activeInputEpoch;
+    if (
+      epoch.pendingEntries >= MAX_PENDING_INPUT_WRITES ||
+      bytes.byteLength > MAX_PENDING_INPUT_BYTES - epoch.pendingBytes
+    ) {
+      failInput("Terminal input exceeded the native forwarding buffer.");
+      return;
+    }
+    const payload = bytes.slice();
+    epoch.queue.push(payload);
+    epoch.pendingEntries += 1;
+    epoch.pendingBytes += payload.byteLength;
+    drainInput(epoch);
   };
 
   const activateRenderer = (nextRenderer: TerminalRenderer, activeLoad: number): void => {
@@ -387,8 +498,12 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
     renderer.refreshTheme();
     renderer.setReducedMotion(props.reducedMotion ?? false);
     if (props.focused) renderer.focus();
-    inputSubscription = renderer.onInput(queueInput);
-    observer = new ResizeObserver(scheduleFit);
+    inputSubscription = renderer.onInput((bytes) => {
+      if (activeLoad === rendererLoadGeneration && renderer === nextRenderer) queueInput(bytes);
+    });
+    observer = new ResizeObserver(() => {
+      if (activeLoad === rendererLoadGeneration && renderer === nextRenderer) scheduleFit();
+    });
     observer.observe(mount);
     scheduleFit();
   };
@@ -419,15 +534,8 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
     onCleanup(() => {
       disposed = true;
       generation += 1;
-      rendererLoadGeneration += 1;
-      if (animationFrame !== null) cancelAnimationFrame(animationFrame);
-      observer?.disconnect();
-      inputSubscription?.dispose();
       disposeAttachment();
-      renderer?.dispose();
-      observer = null;
-      inputSubscription = null;
-      renderer = null;
+      disposeRenderer();
     });
   });
 
@@ -454,6 +562,7 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
     if (disposed) return;
     generation += 1;
     disposeAttachment();
+    disposeRenderer();
     currentViewport = null;
     pendingResize = null;
     setReason(null);

--- a/apps/desktop-renderer/src/terminal/terminal-surface.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.tsx
@@ -80,6 +80,8 @@ function outputEpoch(): OutputEpoch {
   return { retired, retire, pending: 0 };
 }
 
+const OUTPUT_NOT_CONSUMED = new Error("Terminal output was not consumed by the renderer.");
+
 /**
  * Native Solid terminal leaf. This component renders bytes and forwards input;
  * it never creates a process, resolves a tmux target, or opens a network path.
@@ -175,7 +177,7 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
       setPhase("error");
       generation += 1;
       disposeAttachment();
-      return Promise.resolve();
+      return Promise.reject(OUTPUT_NOT_CONSUMED);
     }
     epoch.pending += 1;
     const payload = bytes.slice();
@@ -188,13 +190,13 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
           renderer !== activeRenderer ||
           epoch !== activeOutputEpoch
         ) {
-          return;
+          throw OUTPUT_NOT_CONSUMED;
         }
         let timer: ReturnType<typeof setTimeout> | undefined;
         try {
-          await Promise.race([
-            activeRenderer.write(payload),
-            epoch.retired,
+          const outcome = await Promise.race([
+            activeRenderer.write(payload).then(() => "written" as const),
+            epoch.retired.then(() => "retired" as const),
             new Promise<never>((_resolve, reject) => {
               timer = setTimeout(
                 () => reject(new Error("terminal renderer write timed out")),
@@ -202,23 +204,24 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
               );
             }),
           ]);
+          if (outcome === "retired") throw OUTPUT_NOT_CONSUMED;
         } finally {
           if (timer !== undefined) clearTimeout(timer);
         }
       })
       .catch(() => {
-        if (
+        const retiredOrStale =
           disposed ||
           generation !== activeGeneration ||
           renderer !== activeRenderer ||
-          epoch !== activeOutputEpoch
-        ) {
-          return;
+          epoch !== activeOutputEpoch;
+        if (!retiredOrStale) {
+          setReason("The terminal renderer could not consume native output.");
+          setPhase("error");
+          generation += 1;
+          disposeAttachment();
         }
-        setReason("The terminal renderer could not consume native output.");
-        setPhase("error");
-        generation += 1;
-        disposeAttachment();
+        throw OUTPUT_NOT_CONSUMED;
       })
       .finally(() => {
         epoch.pending -= 1;
@@ -231,7 +234,9 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
     event: NativeTerminalEvent,
     activeGeneration: number,
   ): void | Promise<void> => {
-    if (disposed || activeGeneration !== generation) return;
+    if (disposed || activeGeneration !== generation) {
+      return event.type === "output" ? Promise.reject(OUTPUT_NOT_CONSUMED) : undefined;
+    }
     if (isNativeTerminalOutput(event)) {
       return queueOutput(event.bytes, activeGeneration).then(() => {
         if (!disposed && activeGeneration === generation) setHasValidatedFrame(true);
@@ -289,7 +294,6 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
         }
         attachment = result.attachment;
         currentViewport = viewport;
-        setHasValidatedFrame(true);
         setPhase("connected");
         if (props.focused) renderer?.focus();
       })

--- a/apps/desktop-renderer/src/terminal/terminal-surface.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.tsx
@@ -128,6 +128,7 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
   let observedTarget = `${props.target.workspaceName}\0${props.target.semanticPaneId}`;
   let observedTransport = props.transport;
   let currentViewport: TerminalAttachmentViewport | null = null;
+  let latestMeasuredViewport: TerminalAttachmentViewport | null = null;
   let pendingResize: TerminalAttachmentViewport | null = null;
   let resizeFlight: Promise<void> | null = null;
   let pointerFocus = false;
@@ -319,6 +320,14 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
     disposeAttachment();
   };
 
+  const failConnect = (message: string, activeGeneration: number): void => {
+    if (disposed || activeGeneration !== generation) return;
+    generation += 1;
+    disposeAttachment();
+    setReason(message);
+    setPhase("error");
+  };
+
   const connect = (viewport: TerminalAttachmentViewport): void => {
     if (!props.transport || attachment || phase() === "connecting" || disposed) return;
     const activeGeneration = ++generation;
@@ -333,8 +342,7 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
         viewport,
       });
     } catch {
-      setReason("The semantic terminal target or viewport is invalid.");
-      setPhase("error");
+      failConnect("The semantic terminal target or viewport is invalid.", activeGeneration);
       return;
     }
     void props.transport
@@ -347,19 +355,22 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
           return;
         }
         if (result.status === "error") {
-          setReason(validatedTransportReason(result.error.reason));
-          setPhase("error");
+          failConnect(validatedTransportReason(result.error.reason), activeGeneration);
           return;
         }
         attachment = result.attachment;
         currentViewport = viewport;
         setPhase("connected");
+        const latestViewport = latestMeasuredViewport;
+        if (latestViewport && !sameViewport(currentViewport, latestViewport)) {
+          currentViewport = latestViewport;
+          pendingResize = latestViewport;
+          flushResize();
+        }
         if (props.focused) renderer?.focus();
       })
       .catch(() => {
-        if (disposed || activeGeneration !== generation) return;
-        setReason("The native terminal transport could not attach this pane.");
-        setPhase("error");
+        failConnect("The native terminal transport could not attach this pane.", activeGeneration);
       });
   };
 
@@ -371,6 +382,7 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
       if (!attachment && props.transport) setPhase("measuring");
       return;
     }
+    latestMeasuredViewport = viewport;
     if (!attachment) {
       if (phase() === "measuring") connect(viewport);
       return;
@@ -391,6 +403,7 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
     disposeAttachment();
     disposeRenderer();
     currentViewport = null;
+    latestMeasuredViewport = null;
     pendingResize = null;
     setHasValidatedFrame(false);
     setPhase(props.transport ? "measuring" : "unavailable");
@@ -564,6 +577,7 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
     disposeAttachment();
     disposeRenderer();
     currentViewport = null;
+    latestMeasuredViewport = null;
     pendingResize = null;
     setReason(null);
     setHasValidatedFrame(false);

--- a/apps/desktop-renderer/src/terminal/terminal-surface.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.tsx
@@ -1,0 +1,526 @@
+import {
+  TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+  TerminalAttachmentViewportSchemaZ,
+  type TerminalAttachRequest,
+  type TerminalAttachmentSemanticTarget,
+  type TerminalAttachmentViewport,
+} from "@tmux-ide/contracts";
+import { Match, Show, Switch, createEffect, createSignal, onCleanup, onMount } from "solid-js";
+
+import {
+  isNativeTerminalOutput,
+  validateNativeTerminalRequest,
+  validateNativeTerminalViewport,
+  type NativeTerminalAttachment,
+  type NativeTerminalEvent,
+  type NativeTerminalTransport,
+} from "./native-terminal-transport.ts";
+import type { TerminalRenderer, TerminalRendererFactory } from "./xterm-renderer.ts";
+
+export type TerminalSurfacePhase =
+  | "unavailable"
+  | "measuring"
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "error";
+
+const MAX_PENDING_OUTPUT_WRITES = 64;
+const OUTPUT_WRITE_TIMEOUT_MS = 15_000;
+
+export interface TerminalSurfaceProps {
+  readonly target: TerminalAttachmentSemanticTarget;
+  readonly title: string;
+  readonly transport?: NativeTerminalTransport | null;
+  readonly focused?: boolean;
+  readonly reducedMotion?: boolean;
+  readonly themeKey?: string;
+  readonly onFocus?: (source: "keyboard" | "mouse") => void;
+  readonly rendererFactory?: TerminalRendererFactory;
+}
+
+function sameViewport(
+  left: TerminalAttachmentViewport | null,
+  right: TerminalAttachmentViewport,
+): boolean {
+  return left?.cols === right.cols && left.rows === right.rows;
+}
+
+function usableViewport(
+  value: TerminalAttachmentViewport | null,
+): TerminalAttachmentViewport | null {
+  if (!value) return null;
+  const parsed = TerminalAttachmentViewportSchemaZ.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function validatedTransportReason(value: string): string {
+  const reason = value.trim();
+  const hasControlCharacter = [...reason].some((character) => {
+    const code = character.charCodeAt(0);
+    return code < 32 || code === 127;
+  });
+  if (reason.length === 0 || reason.length > 240 || hasControlCharacter) {
+    return "The native terminal transport reported an invalid error.";
+  }
+  return reason;
+}
+
+interface OutputEpoch {
+  readonly retired: Promise<void>;
+  readonly retire: () => void;
+  pending: number;
+}
+
+function outputEpoch(): OutputEpoch {
+  let retire = (): void => undefined;
+  const retired = new Promise<void>((resolve) => {
+    retire = resolve;
+  });
+  return { retired, retire, pending: 0 };
+}
+
+/**
+ * Native Solid terminal leaf. This component renders bytes and forwards input;
+ * it never creates a process, resolves a tmux target, or opens a network path.
+ */
+export function TerminalSurface(props: TerminalSurfaceProps) {
+  const [phase, setPhase] = createSignal<TerminalSurfacePhase>(
+    props.transport ? "measuring" : "unavailable",
+  );
+  const [reason, setReason] = createSignal<string | null>(null);
+  const [hasValidatedFrame, setHasValidatedFrame] = createSignal(false);
+  let mount: HTMLDivElement | undefined;
+  let renderer: TerminalRenderer | null = null;
+  let attachment: NativeTerminalAttachment | null = null;
+  let observer: ResizeObserver | null = null;
+  let inputSubscription: { dispose(): void } | null = null;
+  let animationFrame: number | null = null;
+  let disposed = false;
+  let generation = 0;
+  let writeTail = Promise.resolve();
+  let outputTail = Promise.resolve();
+  let activeOutputEpoch = outputEpoch();
+  let observedTarget = `${props.target.workspaceName}\0${props.target.semanticPaneId}`;
+  let observedTransport = props.transport;
+  let currentViewport: TerminalAttachmentViewport | null = null;
+  let pendingResize: TerminalAttachmentViewport | null = null;
+  let resizeFlight: Promise<void> | null = null;
+  let pointerFocus = false;
+  let rendererLoadGeneration = 0;
+
+  const retireWrites = (): void => {
+    writeTail = Promise.resolve();
+  };
+
+  const retireOutput = (): void => {
+    activeOutputEpoch.retire();
+    activeOutputEpoch = outputEpoch();
+    outputTail = Promise.resolve();
+  };
+
+  const safelyDispose = (active: NativeTerminalAttachment): void => {
+    try {
+      active.dispose();
+    } catch {
+      // A broken host cleanup cannot revive or retain renderer authority.
+    }
+  };
+
+  const disposeAttachment = (): void => {
+    const active = attachment;
+    attachment = null;
+    pendingResize = null;
+    resizeFlight = null;
+    retireWrites();
+    retireOutput();
+    if (active) safelyDispose(active);
+  };
+
+  const flushResize = (): void => {
+    if (!attachment || !pendingResize || resizeFlight || disposed) return;
+    const next = pendingResize;
+    pendingResize = null;
+    const activeAttachment = attachment;
+    const operation = activeAttachment
+      .resize(validateNativeTerminalViewport(next))
+      .then((result) => {
+        if (result.status !== "error" || disposed || attachment !== activeAttachment) {
+          return;
+        }
+        setReason(validatedTransportReason(result.error.reason));
+        setPhase("error");
+        generation += 1;
+        disposeAttachment();
+      })
+      .catch(() => {
+        if (disposed || attachment !== activeAttachment) return;
+        setReason("The desktop host could not resize this terminal.");
+        setPhase("error");
+        generation += 1;
+        disposeAttachment();
+      })
+      .finally(() => {
+        if (resizeFlight === operation) resizeFlight = null;
+        flushResize();
+      });
+    resizeFlight = operation;
+  };
+
+  const queueOutput = (bytes: Uint8Array, activeGeneration: number): Promise<void> => {
+    const activeRenderer = renderer;
+    const epoch = activeOutputEpoch;
+    if (!activeRenderer || epoch.pending >= MAX_PENDING_OUTPUT_WRITES) {
+      setReason("The terminal renderer could not keep up with the native output stream.");
+      setPhase("error");
+      generation += 1;
+      disposeAttachment();
+      return Promise.resolve();
+    }
+    epoch.pending += 1;
+    const payload = bytes.slice();
+    const operation = outputTail
+      .catch(() => undefined)
+      .then(async () => {
+        if (
+          disposed ||
+          generation !== activeGeneration ||
+          renderer !== activeRenderer ||
+          epoch !== activeOutputEpoch
+        ) {
+          return;
+        }
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([
+            activeRenderer.write(payload),
+            epoch.retired,
+            new Promise<never>((_resolve, reject) => {
+              timer = setTimeout(
+                () => reject(new Error("terminal renderer write timed out")),
+                OUTPUT_WRITE_TIMEOUT_MS,
+              );
+            }),
+          ]);
+        } finally {
+          if (timer !== undefined) clearTimeout(timer);
+        }
+      })
+      .catch(() => {
+        if (
+          disposed ||
+          generation !== activeGeneration ||
+          renderer !== activeRenderer ||
+          epoch !== activeOutputEpoch
+        ) {
+          return;
+        }
+        setReason("The terminal renderer could not consume native output.");
+        setPhase("error");
+        generation += 1;
+        disposeAttachment();
+      })
+      .finally(() => {
+        epoch.pending -= 1;
+      });
+    outputTail = operation;
+    return operation;
+  };
+
+  const handleEvent = (
+    event: NativeTerminalEvent,
+    activeGeneration: number,
+  ): void | Promise<void> => {
+    if (disposed || activeGeneration !== generation) return;
+    if (isNativeTerminalOutput(event)) {
+      return queueOutput(event.bytes, activeGeneration).then(() => {
+        if (!disposed && activeGeneration === generation) setHasValidatedFrame(true);
+      });
+    }
+    if (event.type !== "state") return;
+    if (event.state === "connected") {
+      if (attachment) {
+        setReason(null);
+        setPhase("connected");
+      }
+      return;
+    }
+    setReason(
+      event.error
+        ? validatedTransportReason(event.error.reason)
+        : "The native tmux attachment closed.",
+    );
+    setPhase("disconnected");
+    generation += 1;
+    disposeAttachment();
+  };
+
+  const connect = (viewport: TerminalAttachmentViewport): void => {
+    if (!props.transport || attachment || phase() === "connecting" || disposed) return;
+    const activeGeneration = ++generation;
+    setReason(null);
+    setPhase("connecting");
+    let request: TerminalAttachRequest;
+    try {
+      request = validateNativeTerminalRequest({
+        protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+        target: props.target,
+        viewerMode: "interactive",
+        viewport,
+      });
+    } catch {
+      setReason("The semantic terminal target or viewport is invalid.");
+      setPhase("error");
+      return;
+    }
+    void props.transport
+      .connect(request, (event) => handleEvent(event, activeGeneration))
+      .then((result) => {
+        if (disposed || activeGeneration !== generation) {
+          if (result.status === "connected") {
+            safelyDispose(result.attachment);
+          }
+          return;
+        }
+        if (result.status === "error") {
+          setReason(validatedTransportReason(result.error.reason));
+          setPhase("error");
+          return;
+        }
+        attachment = result.attachment;
+        currentViewport = viewport;
+        setHasValidatedFrame(true);
+        setPhase("connected");
+        if (props.focused) renderer?.focus();
+      })
+      .catch(() => {
+        if (disposed || activeGeneration !== generation) return;
+        setReason("The native terminal transport could not attach this pane.");
+        setPhase("error");
+      });
+  };
+
+  const fit = (): void => {
+    animationFrame = null;
+    if (disposed) return;
+    const viewport = usableViewport(renderer?.fit() ?? null);
+    if (!viewport) {
+      if (!attachment && props.transport) setPhase("measuring");
+      return;
+    }
+    if (!attachment) {
+      if (phase() === "measuring") connect(viewport);
+      return;
+    }
+    if (sameViewport(currentViewport, viewport)) return;
+    currentViewport = viewport;
+    pendingResize = viewport;
+    flushResize();
+  };
+
+  const scheduleFit = (): void => {
+    if (disposed || animationFrame !== null) return;
+    animationFrame = requestAnimationFrame(fit);
+  };
+
+  const retry = (): void => {
+    generation += 1;
+    disposeAttachment();
+    currentViewport = null;
+    pendingResize = null;
+    if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+    animationFrame = null;
+    setPhase(props.transport ? "measuring" : "unavailable");
+    ensureRenderer();
+    scheduleFit();
+  };
+
+  const queueInput = (bytes: Uint8Array): void => {
+    const activeAttachment = attachment;
+    const activeGeneration = generation;
+    if (!activeAttachment || phase() !== "connected") return;
+    const payload = bytes.slice();
+    writeTail = writeTail
+      .catch(() => undefined)
+      .then(async () => {
+        if (
+          disposed ||
+          generation !== activeGeneration ||
+          attachment !== activeAttachment ||
+          phase() !== "connected"
+        ) {
+          return;
+        }
+        const result = await activeAttachment.write(payload);
+        if (result.status === "error") {
+          if (disposed || generation !== activeGeneration || attachment !== activeAttachment) {
+            return;
+          }
+          setReason(validatedTransportReason(result.error.reason));
+          setPhase("error");
+          generation += 1;
+          disposeAttachment();
+        }
+      })
+      .catch(() => {
+        if (disposed || generation !== activeGeneration || attachment !== activeAttachment) {
+          return;
+        }
+        setReason("The desktop host could not forward terminal input.");
+        setPhase("error");
+        generation += 1;
+        disposeAttachment();
+      });
+  };
+
+  const activateRenderer = (nextRenderer: TerminalRenderer, activeLoad: number): void => {
+    if (disposed || activeLoad !== rendererLoadGeneration || !mount) {
+      nextRenderer.dispose();
+      return;
+    }
+    renderer = nextRenderer;
+    renderer.open(mount);
+    renderer.refreshTheme();
+    renderer.setReducedMotion(props.reducedMotion ?? false);
+    if (props.focused) renderer.focus();
+    inputSubscription = renderer.onInput(queueInput);
+    observer = new ResizeObserver(scheduleFit);
+    observer.observe(mount);
+    scheduleFit();
+  };
+
+  const ensureRenderer = (): void => {
+    if (renderer || disposed || !mount || (!props.transport && !props.rendererFactory)) return;
+    const activeLoad = ++rendererLoadGeneration;
+    const options = {
+      reducedMotion: props.reducedMotion ?? false,
+      label: `${props.title} terminal`,
+    };
+    if (props.rendererFactory) {
+      activateRenderer(props.rendererFactory(options), activeLoad);
+      return;
+    }
+    void import("./xterm-renderer.ts")
+      .then(({ createXtermRenderer }) => activateRenderer(createXtermRenderer(options), activeLoad))
+      .catch(() => {
+        if (disposed || activeLoad !== rendererLoadGeneration) return;
+        setReason("The native terminal renderer could not be loaded.");
+        setPhase("error");
+      });
+  };
+
+  onMount(() => {
+    ensureRenderer();
+
+    onCleanup(() => {
+      disposed = true;
+      generation += 1;
+      rendererLoadGeneration += 1;
+      if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+      observer?.disconnect();
+      inputSubscription?.dispose();
+      disposeAttachment();
+      renderer?.dispose();
+      observer = null;
+      inputSubscription = null;
+      renderer = null;
+    });
+  });
+
+  createEffect(() => {
+    if (props.focused) renderer?.focus();
+  });
+
+  createEffect(() => {
+    const themeKey = props.themeKey;
+    renderer?.refreshTheme();
+    return themeKey;
+  });
+
+  createEffect(() => {
+    renderer?.setReducedMotion(props.reducedMotion ?? false);
+  });
+
+  createEffect(() => {
+    const nextTarget = `${props.target.workspaceName}\0${props.target.semanticPaneId}`;
+    const nextTransport = props.transport;
+    if (nextTarget === observedTarget && nextTransport === observedTransport) return;
+    observedTarget = nextTarget;
+    observedTransport = nextTransport;
+    if (disposed) return;
+    generation += 1;
+    disposeAttachment();
+    currentViewport = null;
+    pendingResize = null;
+    setReason(null);
+    setHasValidatedFrame(false);
+    setPhase(nextTransport ? "measuring" : "unavailable");
+    ensureRenderer();
+    scheduleFit();
+  });
+
+  return (
+    <div
+      class="terminal-surface"
+      data-phase={phase()}
+      data-focused={props.focused ?? false}
+      data-reduced-motion={props.reducedMotion ?? false}
+      data-preserves-frame={hasValidatedFrame()}
+      onPointerDown={() => {
+        pointerFocus = true;
+        props.onFocus?.("mouse");
+        queueMicrotask(() => {
+          pointerFocus = false;
+        });
+      }}
+      onFocusIn={() => {
+        if (!pointerFocus) props.onFocus?.("keyboard");
+      }}
+    >
+      <div
+        ref={(element) => {
+          mount = element;
+        }}
+        class="terminal-surface__viewport"
+        aria-label={`${props.title} terminal`}
+      />
+      <Show when={phase() !== "connected"}>
+        <div
+          class="terminal-surface__state"
+          role={phase() === "error" || phase() === "disconnected" ? "alert" : "status"}
+          aria-live="polite"
+        >
+          <i aria-hidden="true" />
+          <Switch>
+            <Match when={phase() === "unavailable"}>
+              <strong>Native terminal unavailable</strong>
+              <span>The verified desktop terminal transport is not present in this build.</span>
+            </Match>
+            <Match when={phase() === "measuring"}>
+              <strong>Preparing terminal</strong>
+              <span>Waiting for enough pane space to attach safely.</span>
+            </Match>
+            <Match when={phase() === "connecting"}>
+              <strong>Connecting to tmux</strong>
+              <span>The desktop host is attaching this semantic pane.</span>
+            </Match>
+            <Match when={phase() === "disconnected"}>
+              <strong>Terminal disconnected</strong>
+              <span>{reason()}</span>
+              <button type="button" onClick={retry}>
+                Reconnect
+              </button>
+            </Match>
+            <Match when={phase() === "error"}>
+              <strong>Terminal could not attach</strong>
+              <span>{reason()}</span>
+              <button type="button" onClick={retry}>
+                Try again
+              </button>
+            </Match>
+          </Switch>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/apps/desktop-renderer/src/terminal/xterm-renderer.ts
+++ b/apps/desktop-renderer/src/terminal/xterm-renderer.ts
@@ -1,0 +1,108 @@
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+import type { TerminalAttachmentViewport } from "@tmux-ide/contracts";
+
+export interface TerminalRendererDisposable {
+  dispose(): void;
+}
+
+export interface TerminalRenderer {
+  open(container: HTMLElement): void;
+  write(bytes: Uint8Array): Promise<void>;
+  focus(): void;
+  fit(): TerminalAttachmentViewport | null;
+  refreshTheme(): void;
+  setReducedMotion(reducedMotion: boolean): void;
+  onInput(listener: (bytes: Uint8Array) => void): TerminalRendererDisposable;
+  dispose(): void;
+}
+
+export type TerminalRendererFactory = (options: {
+  readonly reducedMotion: boolean;
+  readonly label: string;
+}) => TerminalRenderer;
+
+function color(style: CSSStyleDeclaration, property: string, fallback: string): string {
+  return style.getPropertyValue(property).trim() || fallback;
+}
+
+/** xterm is a VT renderer only here; the desktop host remains the terminal runtime. */
+export const createXtermRenderer: TerminalRendererFactory = ({ reducedMotion, label }) => {
+  let container: HTMLElement | null = null;
+  let fitAddon: FitAddon | null = null;
+  const encoder = new TextEncoder();
+  const terminal = new Terminal({
+    allowProposedApi: false,
+    convertEol: false,
+    cursorBlink: !reducedMotion,
+    cursorStyle: "block",
+    drawBoldTextInBrightColors: false,
+    fontFamily: '"SFMono-Regular", Menlo, Monaco, Consolas, monospace',
+    fontSize: 12,
+    lineHeight: 1.2,
+    minimumContrastRatio: 4.5,
+    rightClickSelectsWord: true,
+    screenReaderMode: true,
+    scrollback: 10_000,
+    tabStopWidth: 4,
+  });
+
+  const applyTheme = (): void => {
+    if (!container) return;
+    const style = getComputedStyle(container);
+    terminal.options.fontFamily = style.fontFamily || "monospace";
+    terminal.options.theme = {
+      background: color(style, "--tmux-ide-surface-terminal", "#11121a"),
+      foreground: color(style, "--tmux-ide-text-primary", "#f2f3f7"),
+      cursor: color(style, "--tmux-ide-text-bright", "#ffffff"),
+      cursorAccent: color(style, "--tmux-ide-surface-terminal", "#11121a"),
+      selectionBackground: color(style, "--tmux-ide-selection-selection", "#293149"),
+    };
+  };
+
+  return {
+    open(nextContainer) {
+      container = nextContainer;
+      applyTheme();
+      fitAddon = new FitAddon();
+      terminal.loadAddon(fitAddon);
+      terminal.open(nextContainer);
+      terminal.textarea?.setAttribute("aria-label", label);
+    },
+    write(bytes) {
+      return new Promise<void>((resolve) => terminal.write(bytes, resolve));
+    },
+    focus() {
+      terminal.focus();
+    },
+    fit() {
+      if (!container || !fitAddon || container.clientWidth <= 0 || container.clientHeight <= 0) {
+        return null;
+      }
+      try {
+        const dimensions = fitAddon.proposeDimensions();
+        if (!dimensions || dimensions.cols < 1 || dimensions.rows < 1) return null;
+        if (dimensions.cols !== terminal.cols || dimensions.rows !== terminal.rows) {
+          terminal.resize(dimensions.cols, dimensions.rows);
+        }
+        return { cols: dimensions.cols, rows: dimensions.rows };
+      } catch {
+        return null;
+      }
+    },
+    refreshTheme() {
+      applyTheme();
+    },
+    setReducedMotion(nextReducedMotion) {
+      terminal.options.cursorBlink = !nextReducedMotion;
+    },
+    onInput(listener) {
+      return terminal.onData((data) => listener(encoder.encode(data)));
+    },
+    dispose() {
+      container = null;
+      fitAddon = null;
+      terminal.dispose();
+    },
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,12 @@ importers:
       '@tmux-ide/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
+      '@xterm/addon-fit':
+        specifier: 0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: 6.0.0
+        version: 6.0.0
       solid-js:
         specifier: 1.9.12
         version: 1.9.12
@@ -2122,8 +2128,14 @@ packages:
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
   '@xterm/headless@6.0.0':
     resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -5585,7 +5597,11 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@xterm/addon-fit@0.11.0': {}
+
   '@xterm/headless@6.0.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:


### PR DESCRIPTION
## Summary
- replace desktop terminal placeholders with a stable Solid/xterm renderer leaf inside the existing PaneFrame
- add a strict semantic NativeTerminalTransport seam aligned with the forthcoming HostCapabilities v5 stream while keeping missing production transport explicit
- serialize renderer output and ACK only after xterm consumes it; reject ACK on renderer failure, overload, unmount, failed connect, or authority replacement
- replace unbounded input promise chaining with one in-flight host write and a queue capped by both entry count and byte count; zero-byte input is a no-op and overflow fails closed
- make xterm, its input subscription, ResizeObserver, output epoch, and attachment generation-owned; retry and semantic target/transport changes dispose and clear the old renderer before reconnecting
- coalesce viewport measurements during delayed attachment and resize exactly once to the newest measured viewport after connect
- follow daemon-confirmed focus/zoom PaneFrame state without creating a CSS-only terminal runtime
- lazy-load xterm and apply tmux-ide theme, accessibility, and reduced-motion state

## Boundaries
- tmux remains the sole process, PTY, topology, and history authority
- Solid receives no daemon URL, ticket, connection id, raw tmux pane id, or credentials
- no node-pty, direct network, daemon, or Electron IPC access is introduced
- Electron without the typed terminal capability shows an explicit unavailable state; there is no production mock

## Proof
- `pnpm --filter @tmux-ide/desktop-renderer test` — 12 files, 145 tests passed
- `pnpm --filter @tmux-ide/desktop-renderer typecheck` — passed
- `pnpm --filter @tmux-ide/desktop-renderer lint` — passed
- `pnpm --filter @tmux-ide/desktop-renderer build` — passed; xterm emitted as a lazy chunk
- `git diff --check origin/main...HEAD` — passed

## Adversarial coverage
- ordered output success waits for the renderer callback; renderer failure, overload, unmount, failed connect, target replacement, and transport replacement reject unconsumed ACKs
- both typed connect errors and rejected connect promises retire their captured listener before late output can render
- stalled first input write plus a burst cannot exceed 64 pending entries; oversized input beyond 256 KiB fails before copying; zero-byte input never reaches the host
- blocked old renderer output across retry, semantic target replacement, and transport replacement cannot enter the fresh renderer or carry old scrollback forward
- multiple viewport measurements during delayed connect collapse into one resize to the latest dimensions
