### PR TITLE
fix(terminal): prepare portable real tmux PTY attach

### DIFF
--- a/packages/daemon/src/terminal/NodePtyAdapter.ts
+++ b/packages/daemon/src/terminal/NodePtyAdapter.ts
@@ -128,7 +128,7 @@ class NodePtyProcess implements PtyProcess {
   write(data: string | Uint8Array): void {
     if (this.exited) return;
     if (typeof data === "string") this.child.write(data);
-    else this.child.write(Buffer.from(data).toString("binary"));
+    else this.child.write(Buffer.from(data));
   }
 
   resize(cols: number, rows: number): void {
@@ -236,7 +236,7 @@ export class NodePtyAdapter implements PtyAdapter {
         rows: input.rows,
         cwd: input.cwd,
         env,
-        encoding: input.encoding === "utf8" ? "utf8" : (null as unknown as undefined),
+        encoding: input.encoding === "utf8" ? "utf8" : null,
       });
     } catch (err) {
       const errno = (err as NodeJS.ErrnoException | undefined)?.code;

--- a/packages/daemon/src/terminal/__tests__/NodePtyAdapter.test.ts
+++ b/packages/daemon/src/terminal/__tests__/NodePtyAdapter.test.ts
@@ -17,10 +17,11 @@
  * tsx-via-node instead of bun in `src/lib/tmux.ts`).
  */
 
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { chmodSync, existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { IPty, IPtyForkOptions } from "node-pty";
 import { NodePtyAdapter, ensureNodePtySpawnHelperExecutable } from "../NodePtyAdapter.ts";
 import { PtySpawnError } from "../PtyAdapter.ts";
 
@@ -29,6 +30,61 @@ const skipOnWin = process.platform === "win32";
 // suite is a vitest-only integration test; under `bun test` we skip
 // the entire describe block. See file header.
 const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+
+function stubNodePty(write: IPty["write"]): IPty {
+  return {
+    pid: 123,
+    cols: 80,
+    rows: 24,
+    process: "tmux",
+    handleFlowControl: false,
+    onData: () => ({ dispose: () => undefined }),
+    onExit: () => ({ dispose: () => undefined }),
+    resize: () => undefined,
+    clear: () => undefined,
+    write,
+    kill: () => undefined,
+    pause: () => undefined,
+    resume: () => undefined,
+  };
+}
+
+describe("NodePtyAdapter input encoding", () => {
+  it("passes raw bytes to node-pty without string transcoding and preserves UTF-8 strings", () => {
+    const writes: Array<string | Buffer> = [];
+    let spawnOptions: IPtyForkOptions | undefined;
+    const child = stubNodePty((data) => writes.push(data));
+    const spawnPty = vi.fn((_file: string, _args: string[], options: IPtyForkOptions) => {
+      spawnOptions = options;
+      return child;
+    });
+    const adapter = new NodePtyAdapter({
+      skipHelperEnsure: true,
+      spawnPty,
+    });
+    const proc = adapter.spawnSync({
+      shell: "tmux",
+      args: ["attach-session", "-E", "-r", "-t", "=tmux-ide-view"],
+      cwd: process.cwd(),
+      cols: 80,
+      rows: 24,
+      env: { ...process.env },
+      encoding: null,
+    });
+
+    const raw = Uint8Array.from([0x00, 0x7f, 0x80, 0xff]);
+    const text = "tmux 🙂";
+    proc.write(raw);
+    proc.write(text);
+
+    expect(spawnOptions?.encoding).toBeNull();
+    expect(Buffer.isBuffer(writes[0])).toBe(true);
+    expect(writes[0]).toEqual(Buffer.from(raw));
+    expect(typeof writes[0]).not.toBe("string");
+    expect(writes[1]).toBe(text);
+    expect(Buffer.from(writes[1] as string, "utf8")).toEqual(Buffer.from(text, "utf8"));
+  });
+});
 
 describe.skipIf(skipOnWin || isBun)("NodePtyAdapter", () => {
   let workDir: string;

--- a/packages/daemon/src/terminal/__tests__/grouped-tmux-plan.test.ts
+++ b/packages/daemon/src/terminal/__tests__/grouped-tmux-plan.test.ts
@@ -99,21 +99,26 @@ describe("grouped tmux attachment planner", () => {
     ).toBe(true);
   });
 
-  it("models interactive and read-only input/size ownership separately", () => {
+  it("uses exact safe interactive and read-only client argv for attach and recovery", () => {
     const interactive = planGroupedTmuxAttachment(input());
     const readOnly = planGroupedTmuxAttachment(input({ viewerMode: "read-only" }));
-    expect(interactive.attach.argv).toEqual([
+    const interactiveAttachArgv = [
       "attach-session",
+      "-E",
       "-t",
       `=${interactive.identity.viewSessionName}`,
-    ]);
-    expect(readOnly.attach.argv).toEqual([
+    ];
+    const readOnlyAttachArgv = [
       "attach-session",
-      "-f",
-      "read-only,ignore-size",
+      "-E",
+      "-r",
       "-t",
       `=${readOnly.identity.viewSessionName}`,
-    ]);
+    ];
+    expect(interactive.attach.argv).toEqual(interactiveAttachArgv);
+    expect(interactive.recover.attach.argv).toEqual(interactiveAttachArgv);
+    expect(readOnly.attach.argv).toEqual(readOnlyAttachArgv);
+    expect(readOnly.recover.attach.argv).toEqual(readOnlyAttachArgv);
     for (const argv of everyArgv(readOnly)) {
       expect(argv).not.toContain("set-window-option");
       expect(argv).not.toContain("resize-window");

--- a/packages/daemon/src/terminal/attachments/grouped-tmux.ts
+++ b/packages/daemon/src/terminal/attachments/grouped-tmux.ts
@@ -148,9 +148,11 @@ function attachCommand(
   viewerMode: TerminalAttachmentViewerMode,
 ): TmuxArgvPlan {
   const target = `=${viewSessionName}`;
+  // `-E` keeps daemon-client environment values out of the view session by
+  // disabling tmux's update-environment behavior during every attachment.
   return viewerMode === "read-only"
-    ? tmux(["attach-session", "-f", "read-only,ignore-size", "-t", target])
-    : tmux(["attach-session", "-t", target]);
+    ? tmux(["attach-session", "-E", "-r", "-t", target])
+    : tmux(["attach-session", "-E", "-t", target]);
 }
 
 /**


### PR DESCRIPTION
## Summary

- use portable tmux 3.1+ safe client attachment: `attach-session -E -t =<view>` for interactive and `attach-session -E -r -t =<view>` for read-only
- prevent daemon environment values and secrets from being copied into the grouped session through `update-environment`
- pass `Uint8Array` input to node-pty as a `Buffer`, preserving NUL and bytes above 0x7f without string transcoding
- keep string input on node-pty's UTF-8 string path and make the raw-output `encoding: null` contract explicit

## Runtime boundary

The PTY launches the real `tmux attach-session` client for the daemon-owned grouped view. It does not launch a project shell or create a second terminal/session authority: the durable pane, process, history, focus, and lifecycle remain owned by tmux. node-pty is only the native byte-and-resize transport around that tmux client.

## Verification

- official tmux 3.1 manual verified: attach `-E` prevents the `update-environment` option from being applied; attach `-r` makes the client read-only
- installed node-pty 1.2.0-beta.12 typings and Unix runtime inspected; `IPty.write` accepts `string | Buffer`, buffers are copied byte-for-byte, and strings use UTF-8 when encoding is null
- real node-pty probe observed `00 80 ff 0a` byte-exactly with `encoding: null`
- terminal test suite: 10 files, 129 tests passed
- daemon typecheck passed
- daemon lint passed
- focused Prettier check passed
- `git diff --check` passed