### PR TITLE
docs(terminal): accept native tmux attachment architecture

### DIFF
--- a/docs/adr/0002-native-tmux-terminal-attachments.md
+++ b/docs/adr/0002-native-tmux-terminal-attachments.md
@@ -52,9 +52,9 @@ terminal lifecycle events.**
 policy, builds a proof-bound ephemeral one-window tmux view, and uses its existing
 `PtyAdapter`/`node-pty` boundary to launch a fixed argv-safe real
 `tmux attach-session`. Effective interactive mode reserves the sole writer; effective
-read-only mode reserves reader/live capacity and depends on a separately proven
-continuous interactive geometry owner. tmux remains the sole process, session, pane,
-history, and framebuffer authority.**
+read-only mode reserves reader authority and depends on a separately proven continuous
+interactive geometry owner. Live-connection capacity is reserved once, at redemption.
+tmux remains the sole process, session, pane, history, and framebuffer authority.**
 
 ### Data flow
 
@@ -75,16 +75,19 @@ sequenceDiagram
     H-->>X: typed read_only_unavailable; no ticket or capacity retained
   end
   alt effective interactive
-    D->>D: reserve sole writer + live capacity
+    D->>D: reserve pending-ticket capacity + sole writer authority
   else effective read-only
-    D->>D: prove continuous interactive geometry owner + reserve reader/live capacity
+    D->>D: reserve pending-ticket capacity + reader authority + geometry-owner dependency
   end
   D->>D: mint mode-bound single-use ticket
   D-->>H: ephemeral attachment descriptor
   H-->>X: descriptor only (no durable credential or raw pane id)
-  X->>D: WebSocket upgrade (exact Origin)
+  X->>D: Upgrade request (exact path, subprotocol, Origin)
+  D->>D: atomically reserve pre-auth socket capacity
+  D-->>X: 101 Switching Protocols
   X->>D: redeem(ticket, requestId, daemonInstanceId)
-  D->>D: atomically consume ticket and revalidate proof
+  D->>D: atomically revalidate; consume ticket; pending→live; activate mode authority
+  D->>D: release pre-auth socket capacity
   D->>P: spawn(fixed tmux executable, fixed argv, safe env, viewport)
   P->>T: real PTY-backed attach to ephemeral one-window view
   T-->>P: full tmux redraw
@@ -124,14 +127,15 @@ for one immediate connection:
 
 The ticket is bound server-side to the exact daemon instance, host-issued request,
 canonical renderer Origin, semantic target proof, resource generation, effective viewer
-mode, and its mode-specific admission. Interactive binds the sole writer plus live
-capacity. Read-only binds reader/live capacity plus proof of a separately held,
-continuous interactive geometry owner; inability to establish that proof returns typed
-`read_only_unavailable` before ticket issue. It has a short fixed TTL, is consumed
-atomically before the tmux client starts, and cannot be retried or transferred to
-another origin. Cancellation, target retirement, daemon restart, and expiry release
-only that mode's reservation. Reconnect always requires a new host issue call and a new
-ticket.
+mode, pending-ticket capacity, and its mode authority. Interactive binds the sole writer
+authority. Read-only binds reader authority plus proof of a separately held, continuous
+interactive geometry owner; inability to establish that proof returns typed
+`read_only_unavailable` before ticket issue. Neither mode reserves live-connection
+capacity at issue. The ticket has a short fixed TTL, is consumed atomically before the
+tmux client starts, and cannot be retried or transferred to another origin.
+Cancellation, target retirement, daemon restart, and expiry release pending-ticket
+capacity and only that mode's authority/dependency. Reconnect always requires a new host
+issue call and a new ticket.
 
 The descriptor may expose the daemon's WebSocket URL because the URL alone grants no
 terminal access. The renderer must never receive the durable daemon credential or a
@@ -172,10 +176,13 @@ rejected without allocating a WebSocket. An admitted socket gets at most 1,000 m
 send exactly one redemption control frame of at most 4 KiB. Binary data, a second frame,
 an oversized frame, malformed redemption, or any other message before `ready` closes
 the socket. The slot is released on every rejection, timeout, peer close, parser error,
-successful transition to separately reserved live capacity, and daemon shutdown. The
-redeem transition atomically consumes the ticket and reserves live capacity before it
-releases pre-auth capacity; if either operation loses a race, the socket closes without
-spawning a PTY. Pending-ticket capacity remains independently bounded and expires even
+successful transition to live-connection capacity, and daemon shutdown. On valid
+redemption one critical section revalidates proof, consumes the ticket, releases its
+pending-ticket slot, reserves exactly one live-connection slot, and activates the
+already-held mode authority; only then does it release pre-auth capacity. If live
+capacity is unavailable or any proof loses a race, that critical section retires the
+ticket, releases its pending and mode reservations/dependency, closes the socket, and
+spawns no PTY. Pending-ticket capacity remains independently bounded and expires even
 when no socket ever presents the ticket.
 
 The desktop renderer keeps context isolation enabled, Node integration disabled, remote
@@ -201,11 +208,13 @@ mode are not supported.
 
 The daemon resolves the semantic pane identity to a current tmux proof that includes
 the server/socket identity, daemon generation, session/window/pane lineage, and current
-resource revision. Before awaiting work it reserves either the sole interactive writer
-and live capacity, or read-only reader/live capacity tied to a separately reserved
-continuous interactive geometry owner. A read-only reservation never consumes or
-creates writer authority. The daemon revalidates topology, effective mode, capacity,
-and (for read-only) continuous geometry-owner proof immediately before PTY spawn.
+resource revision. At issue, before awaiting work, it reserves pending-ticket capacity
+plus either the sole interactive writer authority, or read-only reader authority tied to
+a separately reserved continuous interactive geometry-owner dependency. A read-only
+reservation never consumes or creates writer authority. At redeem, the daemon consumes
+the ticket and reserves live-connection capacity once; it does not reserve either mode
+authority again. It revalidates topology, effective mode, authority, capacity, and (for
+read-only) continuous geometry-owner proof immediately before PTY spawn.
 
 For each attachment, the daemon creates an ephemeral tmux view containing exactly one
 linked target window, selects the proof-resolved pane, and attaches a normal tmux client
@@ -298,11 +307,15 @@ queue in the bound; JS-array accounting alone is insufficient. A slow, detached,
 non-reading renderer therefore cannot grow daemon or native-process memory without
 limit.
 
-Capacity is reserved atomically before asynchronous issue/redeem work. Limits cover
-pending descriptors, live attachments, pending bytes, frames, control messages,
-per-pane interactive writers, read-only readers, and mode-specific live capacity.
-Teardown is idempotent and removes every timer, listener, writer/reader/live reservation,
-geometry-owner dependency, ephemeral view, and PTY client.
+Capacity transitions are explicit and atomic. Issue reserves one pending-ticket slot
+plus mode authority (interactive writer, or read-only reader and geometry-owner
+dependency). Upgrade reserves one pre-auth socket slot. Redeem consumes the ticket,
+releases the pending slot, reserves one live-connection slot, activates rather than
+re-reserves mode authority, then releases pre-auth. Limits also cover pending bytes,
+frames, and control messages. Teardown is idempotent: an unredeemed ticket releases
+pending plus mode authority/dependency; a redeemed attachment releases live plus the
+same authority/dependency, along with every timer, listener, ephemeral view, and PTY
+client.
 
 ### Redraw and reconnect
 
@@ -410,9 +423,11 @@ The native terminal path is not complete until all gates are implemented:
 2. Electron exposes only `issueTerminalAttachment(...)`; no terminal byte/resize/ACK
    IPC channels or main-process stream queues exist.
 3. The daemon authenticates issue with the durable credential and atomically issues,
-   reserves, redeems, expires, and retires mode-bound tickets. Only effective
-   interactive reserves writer authority; effective read-only reserves reader/live
-   capacity plus continuous interactive geometry-owner proof or fails typed.
+   reserves, redeems, expires, and retires mode-bound tickets. Issue reserves
+   pending-ticket capacity plus writer authority for effective interactive, or reader
+   authority and continuous interactive geometry-owner dependency for effective
+   read-only. Redeem alone reserves live-connection capacity and never re-reserves mode
+   authority.
 4. Upgrade and redemption enforce exact Origin, daemon instance, request, target proof,
    resource generation, TTL, one-time use, and mode-specific capacity. The exact path
    and subprotocol, atomic pre-auth socket cap, 1,000 ms redemption deadline, and one
@@ -447,12 +462,13 @@ Required automated evidence includes:
    concurrent redemption, and log/snapshot/crash-report redaction.
 3. Capacity tests race concurrent issue/redeem calls and prove atomic caps for pending
    tickets, pre-auth sockets, live connections, per-pane interactive writers, read-only
-   readers, mode-specific live capacity, frame count, and bytes. They prove read-only
-   never consumes writer capacity and cannot issue without continuous interactive
-   geometry-owner proof. They cover saturation before `101`, no first frame,
-   slow/oversized/multiple first frames, close-before-frame, timeout-versus-redeem,
-   redeem-versus-expiry, and two sockets racing one ticket; all reservations and timers
-   are reclaimed.
+   readers, frame count, and bytes. They prove issue reserves no live slot, redeem
+   reserves exactly one, mode authority is never double-reserved, and read-only never
+   consumes writer capacity or issues without continuous interactive geometry-owner
+   proof. They cover saturation before `101`, no first frame, slow/oversized/multiple
+   first frames, close-before-frame, timeout-versus-redeem, redeem-versus-expiry, and
+   two sockets racing one ticket; every pending/pre-auth/live/mode reservation,
+   dependency, and timer is reclaimed exactly once.
 4. `PtyAdapter` unit tests assert the exact executable/argv/env/cwd shape and prove no
    shell interpolation or renderer-authored launch field can reach spawn.
 5. Live tmux tests prove an existing full-screen/alternate-screen pane redraws on

--- a/docs/adr/0002-native-tmux-terminal-attachments.md
+++ b/docs/adr/0002-native-tmux-terminal-attachments.md
@@ -85,9 +85,13 @@ sequenceDiagram
 ```
 
 The host issue call is a privilege transition, not a stream transport. It accepts only
-a daemon-issued semantic pane identity, the current resource/generation proof, and a
-validated viewport. It does not accept an executable, argv, shell fragment, working
-directory, environment, daemon URL, expected Origin, raw tmux `%pane_id`, or ticket.
+a daemon-issued semantic pane identity, requested viewer mode, opaque resource revision,
+request generation, and a validated viewport. It does not accept an executable, argv,
+shell fragment, working directory, environment, daemon URL, expected Origin, raw tmux
+`%pane_id`, or ticket. The daemon resolves and validates all topology proof after the
+call. Raw tmux runtime identities and their resolution proof are strictly daemon-only.
+Electron main owns no product-state correlation and never receives or caches
+`%pane_id`, runtime session/window ids, socket proof, or tmux topology.
 
 ### Attachment descriptor
 
@@ -135,18 +139,32 @@ crash reports, URLs, command descriptors, or persisted workspace data.
 ### Origin and CSP admission
 
 Production desktop builds use a stable, registered secure application scheme and a
-canonical renderer Origin. The daemon rejects `null`, missing, wildcard, file, and
-unexpected origins for terminal upgrades. It checks the upgrade Origin before allowing
-the bounded redemption frame and checks that the same Origin was bound by the trusted
-host at issue time. The renderer does not supply or override its expected Origin.
+canonical renderer Origin. The only terminal upgrade route is the exact versioned path
+`/v1/terminal/attachments/redeem` with subprotocol `tmux-ide-terminal.v1`. The daemon
+rejects every other path/subprotocol and rejects `null`, missing, wildcard, file, and
+unexpected origins before returning `101 Switching Protocols`. It checks that the exact
+Origin was bound by the trusted host at issue time. The renderer does not supply or
+override its expected Origin.
+
+Admission is bounded before authentication. The upgrade handler atomically reserves a
+slot from a separate pre-auth socket cap before returning `101`; a saturated cap is
+rejected without allocating a WebSocket. An admitted socket gets at most 1,000 ms to
+send exactly one redemption control frame of at most 4 KiB. Binary data, a second frame,
+an oversized frame, malformed redemption, or any other message before `ready` closes
+the socket. The slot is released on every rejection, timeout, peer close, parser error,
+successful transition to separately reserved live capacity, and daemon shutdown. The
+redeem transition atomically consumes the ticket and reserves live capacity before it
+releases pre-auth capacity; if either operation loses a race, the socket closes without
+spawning a PTY. Pending-ticket capacity remains independently bounded and expires even
+when no socket ever presents the ticket.
 
 The desktop renderer keeps context isolation enabled, Node integration disabled, remote
 navigation disabled, and a restrictive Content Security Policy. `connect-src` admits
 only the resolved local daemon origin needed for the current instance plus explicitly
 declared development services. No remote document is allowed to inherit terminal
-capabilities. A fixed WebSocket subprotocol identifies the protocol version; the first
-small control frame carries the one-time ticket. After ready, terminal input and output
-use binary frames. Ticket material is never encoded in a WebSocket URL.
+capabilities. The first bounded control frame carries the one-time ticket. After ready,
+terminal input and output use binary frames. Ticket material is never encoded in a
+WebSocket URL.
 
 Development has two honest modes:
 
@@ -190,6 +208,40 @@ Electron main process, dock surface, agent card, or daemon attachment handler ma
 to launch a shell, agent harness, or arbitrary program. Those processes are created by
 semantic tmux mutations and remain tmux-owned.
 
+### Viewer mode and geometry authority
+
+The issue request contains `requestedViewerMode`; it is intent, not authority. On
+successful redemption the daemon sends `ready` with `effectiveViewerMode`, the
+authoritative source/window grid, and the attached client viewport. The renderer does
+not infer effective mode from what it requested.
+
+- `interactive` is the only input and shared-size owner. It accepts terminal input and
+  its coalesced viewport changes may drive tmux geometry. The daemon confirms the new
+  authoritative grid after tmux applies it; optimistic DOM/xterm size is not truth.
+- `read-only` rejects every input frame and ignores resize as shared tmux authority. A
+  local viewport change may alter only clipping, scrolling, padding, or presentation.
+  It cannot resize the PTY client in a way that participates in tmux window sizing.
+- `ready` and later geometry events carry both `sourceGrid` (the daemon-read tmux
+  window/pane grid) and `clientViewport` (the visible terminal-cell viewport). When
+  they differ, xterm renders the source grid and the tile clips/scrolls honestly. It
+  does not stretch cells, claim a false fit, or resize shared tmux state.
+
+Read-only support is gated by installed tmux behavior and a continuously held,
+daemon-managed interactive size owner for the same linked window. In tmux 3.1, a
+read-only client is ignored for size only while a non-read-only attached client exists.
+From tmux 3.2, `attach -r` sets both `READONLY` and `IGNORESIZE`, but an ignore-size
+client is likewise ignored only while a size-participating client exists. Therefore a
+read-only request must fail with a typed `read_only_unavailable` error rather than
+silently become interactive whenever version/proof is unknown, no interactive owner is
+reserved, or owner-loss ordering cannot be proved safe. The first implementation keeps
+read-only disabled until a live tmux gate proves attach, viewport mismatch, owner
+teardown, crash, and reconnect cannot alter the shared grid.
+
+An interactive attachment may return an effective viewport different from its request
+while tmux converges. Initial attach and reconnect both wait for authoritative
+`sourceGrid`/`clientViewport` evidence before reporting `ready`; recovery never assumes
+the pre-disconnect size survived.
+
 ### Stream, resize, and backpressure
 
 The daemon and renderer use a versioned direct protocol with strict frame kinds and
@@ -200,10 +252,28 @@ of this protocol.
 Both directions have byte, frame-count, and per-frame limits. Input writes are ordered;
 empty writes are ignored. Resize keeps only the latest uncommitted viewport and is
 serialized with terminal mutations so it cannot create an unbounded resize queue.
-Output observes WebSocket/transport high- and low-water marks. The daemon pauses the PTY
-source where the adapter supports it; otherwise it fails closed and retires the
-attachment before a bounded buffer can overflow. A slow, detached, or non-reading
-renderer cannot grow daemon memory without limit.
+
+The legacy `PtyProcess.write(...): void` and `node-pty` private write queue are not an
+acceptable backpressure proof for this path. Before native attachment ships,
+`PtyAdapter` must expose either:
+
+1. an input completion/drain primitive whose completion means the adapter/native queue
+   released the accounted bytes; or
+2. a demonstrably bounded `tryWrite`/fail-closed primitive that refuses bytes before
+   any unobservable native queue can grow.
+
+The bridge reserves input bytes before calling the adapter, permits only the bounded
+number of in-flight writes specified by the protocol, and releases accounting only on
+that completion/drain proof. If the adapter cannot accept within its fixed deadline,
+the bridge closes the attachment and tmux client; it does not enqueue another write.
+
+Output uses an adapter-level pause/resume contract tied to WebSocket high/low water
+marks. If the platform adapter cannot suspend output before the fixed HWM, the bridge
+synchronously retires the attachment at the HWM and discards no additional output into
+an application queue. The implementation gate must include the native binding's own
+queue in the bound; JS-array accounting alone is insufficient. A slow, detached, or
+non-reading renderer therefore cannot grow daemon or native-process memory without
+limit.
 
 Capacity is reserved atomically before asynchronous issue/redeem work. Limits cover
 pending descriptors, live attachments, pending bytes, frames, control messages, and
@@ -318,18 +388,27 @@ The native terminal path is not complete until all gates are implemented:
 3. The daemon authenticates issue with the durable credential and atomically issues,
    reserves, redeems, expires, and retires tickets.
 4. Upgrade and redemption enforce exact Origin, daemon instance, request, target proof,
-   resource generation, TTL, one-time use, and one-writer capacity.
+   resource generation, TTL, one-time use, and one-writer capacity. The exact path and
+   subprotocol, atomic pre-auth socket cap, 1,000 ms redemption deadline, and one 4 KiB
+   first-frame limit are enforced before live allocation.
 5. A daemon-owned fixed argv builder creates and cleans a proof-bound one-window view,
    rejects sibling-pane exposure, then spawns only a real `tmux attach-session` through
    `PtyAdapter`.
-6. Renderer xterm connects directly, handles binary data, coalesces resize, preserves a
-   recovery overlay, and resets for a fresh real redraw on reconnect.
-7. Production CSP/custom-origin and exact Vite-in-Electron development origin are
+6. Requested/effective viewer mode and geometry are explicit. Interactive owns input
+   and shared size; read-only is typed-failure gated until its installed tmux version,
+   continuous owner, mismatch, and owner-loss behavior are proven geometry-neutral.
+7. `PtyAdapter` provides measurable input completion/drain or demonstrably bounded
+   fail-closed input plus output pause/resume or HWM close; the legacy void-write/private
+   queue is not used as proof.
+8. Renderer xterm connects directly, handles binary data, clips/scrolls a mismatched
+   source grid honestly, coalesces interactive resize, preserves a recovery overlay,
+   and resets for a fresh real redraw on reconnect.
+9. Production CSP/custom-origin and exact Vite-in-Electron development origin are
    configured; standalone browser preview remains non-live.
-8. WSL2 discovery resolves the daemon without changing process authority; remote use is
-   refused unless an authenticated host-owned tunnel is configured.
-9. Metrics expose counts and sizes without tickets, terminal bytes, commands, cwd,
-   environment secrets, or raw tmux correlation.
+10. WSL2 discovery resolves the daemon without changing process authority; remote use is
+    refused unless an authenticated host-owned tunnel is configured.
+11. Metrics expose counts and sizes without tickets, terminal bytes, commands, cwd,
+    environment secrets, or raw tmux correlation.
 
 ## Test gates
 
@@ -338,28 +417,38 @@ Required automated evidence includes:
 1. Contract tests reject executable/cwd/env/raw-pane fields, malformed descriptors,
    oversized frames, retired generations, and protocol-version mismatch.
 2. Security tests cover missing/wrong durable credential; missing/`null`/wrong Origin;
-   ticket reuse, expiry, transfer, daemon restart, target change, concurrent redemption,
-   and log/snapshot/crash-report redaction.
+   wrong path/subprotocol; ticket reuse, expiry, transfer, daemon restart, target change,
+   concurrent redemption, and log/snapshot/crash-report redaction.
 3. Capacity tests race concurrent issue/redeem calls and prove atomic caps for pending
-   tickets, connections, per-pane writers, frame count, and bytes.
+   tickets, pre-auth sockets, live connections, per-pane writers, frame count, and
+   bytes. They cover saturation before `101`, no first frame, slow/oversized/multiple
+   first frames, close-before-frame, timeout-versus-redeem, redeem-versus-expiry, and
+   two sockets racing one ticket; all reservations and timers are reclaimed.
 4. `PtyAdapter` unit tests assert the exact executable/argv/env/cwd shape and prove no
    shell interpolation or renderer-authored launch field can reach spawn.
 5. Live tmux tests prove an existing full-screen/alternate-screen pane redraws on
-   attach; subsequent output arrives exactly once; input and `Ctrl-C` reach the tmux
-   process; resize reaches the attached client; multi-pane sources fail closed; and
-   disconnect leaves tmux alive.
-6. Reconnect tests prove a new ticket and client, fresh redraw without cached-tail
-   duplication, last-frame recovery overlay, disabled input while stale, and rejection
-   of late old-connection events.
-7. Backpressure tests use slow/non-reading peers, oversized/zero-byte frame floods,
-   resize storms, PTY write failure, socket close races, and teardown during pending
-   writes; memory and queue bounds remain fixed.
-8. Boundary/source tests prove Electron has no terminal streaming IPC and that
-   `node-pty` imports exist only behind the daemon `PtyAdapter` implementation.
-9. CSP/navigation tests prove production and Vite-in-Electron live development connect
-   only to the intended daemon; standalone browser preview and remote documents cannot
-   issue or redeem live attachments.
-10. WSL2 integration tests cover discovery/address rotation and fresh issue; remote
+   attach; subsequent output arrives exactly once; interactive input and `Ctrl-C` reach
+   the tmux process; resize reaches the attached client; multi-pane sources fail closed;
+   and disconnect leaves tmux alive.
+6. Viewer-mode tests prove requested/effective reporting, read-only input rejection,
+   version gating, a continuous interactive size owner, owner teardown/crash, and
+   initial/recovery viewport mismatches. Source grid never changes from a read-only
+   attach/resize/disconnect; the renderer clips/scrolls to the reported client viewport.
+7. Reconnect tests prove a new ticket and client, fresh redraw without cached-tail
+   duplication, authoritative post-reconnect source/client grids, last-frame recovery
+   overlay, disabled input while stale, and rejection of late old-connection events.
+8. Backpressure tests use slow/non-reading peers, stalled tmux input, oversized/zero-byte
+   frame floods, resize storms, PTY write failure, socket close races, and teardown
+   during pending writes. They assert adapter/native queue telemetry and daemon/tmux RSS
+   remain within fixed bounds over time, not only that JavaScript arrays are bounded.
+9. Boundary/source tests prove Electron has no terminal streaming IPC or raw tmux
+   identity/proof in host capabilities, issue request/response, retained state, events,
+   or diagnostics; `node-pty` imports exist only behind the daemon `PtyAdapter`
+   implementation.
+10. CSP/navigation tests prove production and Vite-in-Electron live development connect
+    only to the intended daemon; standalone browser preview and remote documents cannot
+    issue or redeem live attachments.
+11. WSL2 integration tests cover discovery/address rotation and fresh issue; remote
     network tests reject unauthenticated/non-tunnel exposure.
 
 ## Clean-room reference boundary

--- a/docs/adr/0002-native-tmux-terminal-attachments.md
+++ b/docs/adr/0002-native-tmux-terminal-attachments.md
@@ -1,0 +1,372 @@
+# ADR-0002 — Native tmux terminal attachments
+
+- **Status**: Accepted
+- **Date**: 2026-07-22
+- **Decision drivers**: tmux authority, native terminal fidelity, renderer
+  isolation, bounded streaming, reconnect correctness, desktop/web development
+  parity, and a portable daemon boundary.
+- **Supersedes**: terminal-transport assumptions in
+  `docs/product/native-tmux-ide-ux-contract.md` that prohibited every renderer
+  endpoint, one-time ticket, and use of `node-pty`.
+- **Superseded by**: none
+- **References**: `docs/product/native-tmux-ide-ux-contract.md`,
+  `packages/daemon/src/terminal/PtyAdapter.ts`,
+  `packages/daemon/src/terminal/attachments/grouped-tmux.ts`, and
+  `apps/desktop-renderer/src/terminal/native-terminal-transport.ts`.
+
+## Context
+
+The desktop renderer needs the behavior of a native terminal: a full tmux redraw on
+attach, byte-accurate input and output, resize propagation, terminal control sequences,
+and recovery after a renderer or daemon interruption. tmux must remain the only owner
+of shells, agent processes, sessions, windows, panes, history, and framebuffer truth.
+
+Earlier design work protected that authority by keeping daemon endpoints and tickets
+out of the renderer and by excluding `node-pty` from the native terminal path. Those
+rules prevented obvious parallel runtimes, but they also forced terminal bytes through
+Electron main or toward tmux control mode. Both alternatives are the wrong boundary:
+
+- Electron main becomes a high-volume byte proxy and must invent input, resize, output,
+  acknowledgement, queue, and teardown semantics unrelated to its host role.
+- tmux control mode reports protocol events; it does not behave like a terminal client
+  attached to a PTY. Reconstructing a terminal from `%output`, `capture-pane`, or a
+  replay tail produces a synthetic snapshot and diverges from tmux's real redraw.
+- A renderer-created shell or renderer-authored command/cwd would create terminal
+  authority outside tmux and expand the renderer's privilege.
+
+The daemon already owns a testable `PtyAdapter`, backed in production by `node-pty`.
+The safe use of that adapter is narrow: allocate a PTY for a real, fixed-argument tmux
+client that attaches to an already proof-resolved pane view. The PTY does not launch or
+own the shell shown in the tile; tmux does.
+
+## Decision
+
+**A Solid/xterm terminal surface obtains a short-lived, single-use, daemon-instance,
+request, target, and renderer-origin-bound attachment descriptor through one narrow
+Electron host issue call. After issue, terminal bytes and resize/control messages flow
+directly between the renderer and daemon over a binary WebSocket. Electron main never
+proxies terminal input, output, resize messages, flow-control acknowledgements, or
+terminal lifecycle events.**
+
+**The daemon redeems the descriptor once, verifies its proof and one-writer policy,
+builds a proof-bound ephemeral one-window tmux view, and uses its existing
+`PtyAdapter`/`node-pty` boundary to launch a fixed argv-safe real
+`tmux attach-session`. tmux remains the sole process, session, pane, history, and
+framebuffer authority.**
+
+### Data flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant X as Solid + xterm renderer
+  participant H as Electron host issue boundary
+  participant D as tmux-ide daemon
+  participant P as daemon PtyAdapter / node-pty
+  participant T as real tmux client + server
+
+  X->>H: issue(semanticPane, viewport, requestGeneration)
+  H->>D: POST issue + durable daemon credential + canonical renderer origin
+  D->>D: resolve proof, reserve writer, mint single-use ticket
+  D-->>H: ephemeral attachment descriptor
+  H-->>X: descriptor only (no durable credential or raw pane id)
+  X->>D: WebSocket upgrade (exact Origin)
+  X->>D: redeem(ticket, requestId, daemonInstanceId)
+  D->>D: atomically consume ticket and revalidate proof
+  D->>P: spawn(fixed tmux executable, fixed argv, safe env, viewport)
+  P->>T: real PTY-backed attach to ephemeral one-window view
+  T-->>P: full tmux redraw
+  P-->>D: PTY output
+  D-->>X: binary terminal output
+  X->>D: binary input or bounded resize/control
+  D->>P: ordered PTY write or coalesced resize
+  P->>T: real terminal input/resize
+  Note over X,D: Direct stream; Electron main is absent from the byte path
+```
+
+The host issue call is a privilege transition, not a stream transport. It accepts only
+a daemon-issued semantic pane identity, the current resource/generation proof, and a
+validated viewport. It does not accept an executable, argv, shell fragment, working
+directory, environment, daemon URL, expected Origin, raw tmux `%pane_id`, or ticket.
+
+### Attachment descriptor
+
+The descriptor is a renderer-safe, versioned value with only the information needed
+for one immediate connection:
+
+- protocol version;
+- a WebSocket URL for the selected daemon instance;
+- an opaque one-time ticket, delivered separately from the URL and never placed in a
+  query string;
+- daemon instance and request identifiers used for retirement checks;
+- expiry; and
+- non-secret display/retry metadata where useful.
+
+The ticket is bound server-side to the exact daemon instance, host-issued request,
+canonical renderer Origin, semantic target proof, resource generation, and writer
+reservation. It has a short fixed TTL, is consumed atomically before the tmux client
+starts, and cannot be retried or transferred to another origin. Cancellation, target
+retirement, daemon restart, and expiry release the reservation. Reconnect always
+requires a new host issue call and a new ticket.
+
+The descriptor may expose the daemon's WebSocket URL because the URL alone grants no
+terminal access. The renderer must never receive the durable daemon credential or a
+reusable, directly admissible terminal URL.
+
+### Durable credential versus ephemeral ticket
+
+The two credentials have deliberately different trust and lifetime boundaries:
+
+| Property            | Durable daemon credential                           | Ephemeral attachment ticket                             |
+| ------------------- | --------------------------------------------------- | ------------------------------------------------------- |
+| Holder              | daemon and trusted Electron host only               | one isolated renderer request                           |
+| Purpose             | authorize descriptor issue                          | redeem one exact terminal attachment                    |
+| Scope               | current daemon instance                             | instance + request + origin + target proof + generation |
+| Lifetime            | daemon lifetime; rotate on restart                  | short TTL; single atomic use                            |
+| Storage             | canonical daemon record with owner-only permissions | memory only                                             |
+| Renderer visibility | forbidden                                           | allowed only for immediate redemption                   |
+| Logging/URL use     | forbidden                                           | forbidden                                               |
+
+The issue endpoint requires the durable credential even on loopback. Loopback and CORS
+are not authentication. The issue response is `no-store`, ticket values are redacted
+from errors and telemetry, and neither credential may enter renderer state snapshots,
+crash reports, URLs, command descriptors, or persisted workspace data.
+
+### Origin and CSP admission
+
+Production desktop builds use a stable, registered secure application scheme and a
+canonical renderer Origin. The daemon rejects `null`, missing, wildcard, file, and
+unexpected origins for terminal upgrades. It checks the upgrade Origin before allowing
+the bounded redemption frame and checks that the same Origin was bound by the trusted
+host at issue time. The renderer does not supply or override its expected Origin.
+
+The desktop renderer keeps context isolation enabled, Node integration disabled, remote
+navigation disabled, and a restrictive Content Security Policy. `connect-src` admits
+only the resolved local daemon origin needed for the current instance plus explicitly
+declared development services. No remote document is allowed to inherit terminal
+capabilities. A fixed WebSocket subprotocol identifies the protocol version; the first
+small control frame carries the one-time ticket. After ready, terminal input and output
+use binary frames. Ticket material is never encoded in a WebSocket URL.
+
+Development has two honest modes:
+
+1. A standalone browser preview uses preview/unavailable transports and cannot issue a
+   live attachment.
+2. Live desktop development runs the Vite renderer inside Electron. The host binds the
+   descriptor to that exact loopback development Origin and CSP admits the exact daemon
+   origin plus the known Vite/HMR endpoints.
+
+Arbitrary browser tabs, wildcard dev origins, and a public unauthenticated live-terminal
+mode are not supported.
+
+### Real tmux client and proof-bound view
+
+The daemon resolves the semantic pane identity to a current tmux proof that includes
+the server/socket identity, daemon generation, session/window/pane lineage, and current
+resource revision. It reserves the single writer before awaiting work and revalidates
+the proof immediately before PTY spawn.
+
+For each attachment, the daemon creates an ephemeral tmux view containing exactly one
+linked target window, selects the proof-resolved pane, and attaches a normal tmux client
+to that view. The view changes presentation only: it does not clone a pane, start a new
+shell, copy history, or become durable workspace topology. It is removed when the
+attachment exits. A daemon-owned fixed command builder supplies the tmux executable,
+socket/server selector, `attach-session`, and generated view target as separate argv
+values. Spawning through a shell is forbidden.
+
+The view proof must also prevent sibling-pane disclosure. The current grouped-view
+planner therefore admits only a source window proven to contain the target pane alone;
+it fails closed for a multi-pane source window. Supporting an arbitrary pane later
+requires a tmux-native isolation plan that preserves process and topology identity and
+passes the same proof gates. It must not fall back to a synthetic snapshot or mutate
+durable layout as a side effect of viewing.
+
+The renderer cannot author the command, cwd, environment, socket path, session name, or
+view name. Environment is a small daemon-owned allowlist needed for terminal fidelity
+(for example `TERM`/color/locale), with secrets and renderer values excluded.
+
+`PtyAdapter`/`node-pty` is allowed only around this real tmux client. No renderer,
+Electron main process, dock surface, agent card, or daemon attachment handler may use it
+to launch a shell, agent harness, or arbitrary program. Those processes are created by
+semantic tmux mutations and remain tmux-owned.
+
+### Stream, resize, and backpressure
+
+The daemon and renderer use a versioned direct protocol with strict frame kinds and
+size limits. Terminal input/output is binary. Small bounded control frames cover
+redemption, ready, viewport resize, exit, and typed failure. Electron IPC is not part
+of this protocol.
+
+Both directions have byte, frame-count, and per-frame limits. Input writes are ordered;
+empty writes are ignored. Resize keeps only the latest uncommitted viewport and is
+serialized with terminal mutations so it cannot create an unbounded resize queue.
+Output observes WebSocket/transport high- and low-water marks. The daemon pauses the PTY
+source where the adapter supports it; otherwise it fails closed and retires the
+attachment before a bounded buffer can overflow. A slow, detached, or non-reading
+renderer cannot grow daemon memory without limit.
+
+Capacity is reserved atomically before asynchronous issue/redeem work. Limits cover
+pending descriptors, live attachments, pending bytes, frames, control messages, and
+per-pane writers. Teardown is idempotent and removes every timer, listener, writer
+reservation, ephemeral view, and PTY client.
+
+### Redraw and reconnect
+
+The initial screen is the redraw emitted by the real tmux client on attach. The daemon
+does not synthesize it from control-mode `%output`, `capture-pane`, persisted logs, or a
+replay tail. Those sources may support diagnostics or explicit history tools but are
+not terminal framebuffer initialization.
+
+On interruption, xterm may retain the last validated frame behind a recovery overlay,
+with input disabled. Reconnect retires the old attachment, obtains a fresh descriptor,
+resets the terminal parser/display for a fresh attach, and accepts the new real tmux
+redraw exactly once. It does not prepend cached output or merge an old tail into the new
+stream. Daemon-instance and request generations reject late bytes, exit events, and
+control messages from retired connections.
+
+### WSL2 and remote Windows
+
+tmux is not replaced by a native Windows shell runtime. On Windows, the supported local
+shape is:
+
+- tmux, the daemon, and `PtyAdapter`/`node-pty` run inside one WSL2 Linux distribution;
+- Electron may run on Windows and reach the daemon through a resolved WSL2 loopback
+  forwarding address; and
+- the daemon still launches Linux `tmux attach-session` directly. It never launches a
+  separate PowerShell, `cmd.exe`, or agent process through ConPTY for a terminal tile.
+
+The daemon descriptor records the canonical reachable address for that instance, but
+the issue call and exact-Origin checks remain unchanged. If the WSL2 address changes,
+the host rediscovers the daemon and requests a fresh descriptor; old tickets fail by
+instance binding.
+
+Remote Windows clients do not expose the daemon on `0.0.0.0` with bearer tickets. A
+remote setup must place the daemon behind an authenticated, encrypted, host-owned tunnel
+(for example an SSH loopback forward), preserve exact Origin admission, and still run
+the daemon next to tmux on the Linux/WSL2 side. Native Windows without WSL2/tmux and a
+general remote transport are outside this ADR; any future remote broker must preserve
+this authority and credential split.
+
+## Explicitly rejected alternatives
+
+### tmux control mode as the terminal renderer
+
+Rejected. Control mode is useful for topology/events and proof resolution, but a
+control-mode reconstruction or synthetic snapshot is not a real terminal attachment.
+
+### `capture-pane` or replay tail as the initial framebuffer
+
+Rejected. A snapshot/tail has ordering, truncation, mode, cursor, and alternate-screen
+ambiguities. The real attached tmux client owns initial redraw.
+
+### Electron main as terminal byte proxy
+
+Rejected. Main may discover the daemon and authorize descriptor issue, but it never
+carries terminal input, output, resize, acknowledgements, or streaming lifecycle.
+
+### Renderer-authored command or cwd
+
+Rejected. The renderer selects a semantic resource, never an executable context. A
+command/cwd terminal API would be a renderer shell-spawn primitive.
+
+### Renderer or parallel PTY runtime
+
+Rejected. `node-pty` is used only by the daemon's existing `PtyAdapter`, and only to
+host the fixed real tmux client. It never becomes a second shell, process, history, or
+session authority.
+
+### Reusable renderer terminal credential or endpoint
+
+Rejected. The renderer receives one expiring ticket and a URL that is inert without
+valid issue/redemption authority. Durable credentials and directly reusable terminal
+admission remain outside the renderer.
+
+## Consequences
+
+### Positive
+
+- xterm consumes the output of a real tmux terminal client, including native initial
+  redraw, modes, cursor, alternate screen, input, and resize behavior.
+- tmux remains the sole process and terminal-history authority.
+- Electron main stays a low-volume capability broker instead of a streaming runtime.
+- The durable daemon secret never crosses into the renderer, while direct streaming
+  avoids an unnecessary IPC hop.
+- `PtyAdapter` remains mockable and platform-local, and the narrow use of `node-pty` is
+  enforceable by dependency/import tests.
+
+### Negative
+
+- The renderer sees a short-lived bearer ticket and daemon URL. CSP, Origin checks,
+  short TTL, single-use redemption, and redaction are therefore mandatory, not defense
+  in depth that may be deferred.
+- Each attachment creates a small ephemeral tmux view and a real tmux client, requiring
+  strict cleanup and capacity limits.
+- Production custom-scheme, Vite-in-Electron development, WSL2 forwarding, and future
+  remote tunnels need explicit origin discovery rather than wildcard CORS.
+- Reconnect deliberately redraws rather than attempting seamless byte-tail replay, so
+  selection/local viewport state may be retired while tmux process/history state stays
+  intact.
+
+## Implementation gates
+
+The native terminal path is not complete until all gates are implemented:
+
+1. Versioned contracts define the issue request, renderer-safe descriptor, direct WS
+   protocol, typed failures, limits, and generation retirement.
+2. Electron exposes only `issueTerminalAttachment(...)`; no terminal byte/resize/ACK
+   IPC channels or main-process stream queues exist.
+3. The daemon authenticates issue with the durable credential and atomically issues,
+   reserves, redeems, expires, and retires tickets.
+4. Upgrade and redemption enforce exact Origin, daemon instance, request, target proof,
+   resource generation, TTL, one-time use, and one-writer capacity.
+5. A daemon-owned fixed argv builder creates and cleans a proof-bound one-window view,
+   rejects sibling-pane exposure, then spawns only a real `tmux attach-session` through
+   `PtyAdapter`.
+6. Renderer xterm connects directly, handles binary data, coalesces resize, preserves a
+   recovery overlay, and resets for a fresh real redraw on reconnect.
+7. Production CSP/custom-origin and exact Vite-in-Electron development origin are
+   configured; standalone browser preview remains non-live.
+8. WSL2 discovery resolves the daemon without changing process authority; remote use is
+   refused unless an authenticated host-owned tunnel is configured.
+9. Metrics expose counts and sizes without tickets, terminal bytes, commands, cwd,
+   environment secrets, or raw tmux correlation.
+
+## Test gates
+
+Required automated evidence includes:
+
+1. Contract tests reject executable/cwd/env/raw-pane fields, malformed descriptors,
+   oversized frames, retired generations, and protocol-version mismatch.
+2. Security tests cover missing/wrong durable credential; missing/`null`/wrong Origin;
+   ticket reuse, expiry, transfer, daemon restart, target change, concurrent redemption,
+   and log/snapshot/crash-report redaction.
+3. Capacity tests race concurrent issue/redeem calls and prove atomic caps for pending
+   tickets, connections, per-pane writers, frame count, and bytes.
+4. `PtyAdapter` unit tests assert the exact executable/argv/env/cwd shape and prove no
+   shell interpolation or renderer-authored launch field can reach spawn.
+5. Live tmux tests prove an existing full-screen/alternate-screen pane redraws on
+   attach; subsequent output arrives exactly once; input and `Ctrl-C` reach the tmux
+   process; resize reaches the attached client; multi-pane sources fail closed; and
+   disconnect leaves tmux alive.
+6. Reconnect tests prove a new ticket and client, fresh redraw without cached-tail
+   duplication, last-frame recovery overlay, disabled input while stale, and rejection
+   of late old-connection events.
+7. Backpressure tests use slow/non-reading peers, oversized/zero-byte frame floods,
+   resize storms, PTY write failure, socket close races, and teardown during pending
+   writes; memory and queue bounds remain fixed.
+8. Boundary/source tests prove Electron has no terminal streaming IPC and that
+   `node-pty` imports exist only behind the daemon `PtyAdapter` implementation.
+9. CSP/navigation tests prove production and Vite-in-Electron live development connect
+   only to the intended daemon; standalone browser preview and remote documents cannot
+   issue or redeem live attachments.
+10. WSL2 integration tests cover discovery/address rotation and fresh issue; remote
+    network tests reject unauthenticated/non-tunnel exposure.
+
+## Clean-room reference boundary
+
+NodeTerm and Gloomberb remain behavioral references only. No source, assets, names,
+glyph sequences, styling values, storage model, terminal runtime, or transport code is
+copied. Allowing tmux-ide's pre-existing daemon `PtyAdapter` around a real tmux client
+does not adopt either reference project's architecture: the authority, protocol,
+security split, proof model, view lifecycle, and implementation remain native tmux-ide
+designs.

--- a/docs/adr/0002-native-tmux-terminal-attachments.md
+++ b/docs/adr/0002-native-tmux-terminal-attachments.md
@@ -48,11 +48,13 @@ directly between the renderer and daemon over a binary WebSocket. Electron main 
 proxies terminal input, output, resize messages, flow-control acknowledgements, or
 terminal lifecycle events.**
 
-**The daemon redeems the descriptor once, verifies its proof and one-writer policy,
-builds a proof-bound ephemeral one-window tmux view, and uses its existing
+**The daemon redeems the descriptor once, verifies its proof and mode-specific admission
+policy, builds a proof-bound ephemeral one-window tmux view, and uses its existing
 `PtyAdapter`/`node-pty` boundary to launch a fixed argv-safe real
-`tmux attach-session`. tmux remains the sole process, session, pane, history, and
-framebuffer authority.**
+`tmux attach-session`. Effective interactive mode reserves the sole writer; effective
+read-only mode reserves reader/live capacity and depends on a separately proven
+continuous interactive geometry owner. tmux remains the sole process, session, pane,
+history, and framebuffer authority.**
 
 ### Data flow
 
@@ -65,9 +67,19 @@ sequenceDiagram
   participant P as daemon PtyAdapter / node-pty
   participant T as real tmux client + server
 
-  X->>H: issue(semanticPane, viewport, requestGeneration)
+  X->>H: issue(semanticPane, requestedViewerMode, viewport, requestGeneration)
   H->>D: POST issue + durable daemon credential + canonical renderer origin
-  D->>D: resolve proof, reserve writer, mint single-use ticket
+  D->>D: resolve proof and effective mode
+  break requested read-only cannot be proven safe
+    D-->>H: typed read_only_unavailable
+    H-->>X: typed read_only_unavailable; no ticket or capacity retained
+  end
+  alt effective interactive
+    D->>D: reserve sole writer + live capacity
+  else effective read-only
+    D->>D: prove continuous interactive geometry owner + reserve reader/live capacity
+  end
+  D->>D: mint mode-bound single-use ticket
   D-->>H: ephemeral attachment descriptor
   H-->>X: descriptor only (no durable credential or raw pane id)
   X->>D: WebSocket upgrade (exact Origin)
@@ -78,9 +90,13 @@ sequenceDiagram
   T-->>P: full tmux redraw
   P-->>D: PTY output
   D-->>X: binary terminal output
-  X->>D: binary input or bounded resize/control
-  D->>P: ordered PTY write or coalesced resize
-  P->>T: real terminal input/resize
+  alt effective interactive
+    X->>D: binary input or bounded resize/control
+    D->>P: ordered PTY write or coalesced resize
+    P->>T: real terminal input/resize
+  else effective read-only
+    Note over X,D: output only; input rejected and viewport is presentation-only
+  end
   Note over X,D: Direct stream; Electron main is absent from the byte path
 ```
 
@@ -107,11 +123,15 @@ for one immediate connection:
 - non-secret display/retry metadata where useful.
 
 The ticket is bound server-side to the exact daemon instance, host-issued request,
-canonical renderer Origin, semantic target proof, resource generation, and writer
-reservation. It has a short fixed TTL, is consumed atomically before the tmux client
-starts, and cannot be retried or transferred to another origin. Cancellation, target
-retirement, daemon restart, and expiry release the reservation. Reconnect always
-requires a new host issue call and a new ticket.
+canonical renderer Origin, semantic target proof, resource generation, effective viewer
+mode, and its mode-specific admission. Interactive binds the sole writer plus live
+capacity. Read-only binds reader/live capacity plus proof of a separately held,
+continuous interactive geometry owner; inability to establish that proof returns typed
+`read_only_unavailable` before ticket issue. It has a short fixed TTL, is consumed
+atomically before the tmux client starts, and cannot be retried or transferred to
+another origin. Cancellation, target retirement, daemon restart, and expiry release
+only that mode's reservation. Reconnect always requires a new host issue call and a new
+ticket.
 
 The descriptor may expose the daemon's WebSocket URL because the URL alone grants no
 terminal access. The renderer must never receive the durable daemon credential or a
@@ -181,8 +201,11 @@ mode are not supported.
 
 The daemon resolves the semantic pane identity to a current tmux proof that includes
 the server/socket identity, daemon generation, session/window/pane lineage, and current
-resource revision. It reserves the single writer before awaiting work and revalidates
-the proof immediately before PTY spawn.
+resource revision. Before awaiting work it reserves either the sole interactive writer
+and live capacity, or read-only reader/live capacity tied to a separately reserved
+continuous interactive geometry owner. A read-only reservation never consumes or
+creates writer authority. The daemon revalidates topology, effective mode, capacity,
+and (for read-only) continuous geometry-owner proof immediately before PTY spawn.
 
 For each attachment, the daemon creates an ephemeral tmux view containing exactly one
 linked target window, selects the proof-resolved pane, and attaches a normal tmux client
@@ -276,9 +299,10 @@ non-reading renderer therefore cannot grow daemon or native-process memory witho
 limit.
 
 Capacity is reserved atomically before asynchronous issue/redeem work. Limits cover
-pending descriptors, live attachments, pending bytes, frames, control messages, and
-per-pane writers. Teardown is idempotent and removes every timer, listener, writer
-reservation, ephemeral view, and PTY client.
+pending descriptors, live attachments, pending bytes, frames, control messages,
+per-pane interactive writers, read-only readers, and mode-specific live capacity.
+Teardown is idempotent and removes every timer, listener, writer/reader/live reservation,
+geometry-owner dependency, ephemeral view, and PTY client.
 
 ### Redraw and reconnect
 
@@ -386,11 +410,13 @@ The native terminal path is not complete until all gates are implemented:
 2. Electron exposes only `issueTerminalAttachment(...)`; no terminal byte/resize/ACK
    IPC channels or main-process stream queues exist.
 3. The daemon authenticates issue with the durable credential and atomically issues,
-   reserves, redeems, expires, and retires tickets.
+   reserves, redeems, expires, and retires mode-bound tickets. Only effective
+   interactive reserves writer authority; effective read-only reserves reader/live
+   capacity plus continuous interactive geometry-owner proof or fails typed.
 4. Upgrade and redemption enforce exact Origin, daemon instance, request, target proof,
-   resource generation, TTL, one-time use, and one-writer capacity. The exact path and
-   subprotocol, atomic pre-auth socket cap, 1,000 ms redemption deadline, and one 4 KiB
-   first-frame limit are enforced before live allocation.
+   resource generation, TTL, one-time use, and mode-specific capacity. The exact path
+   and subprotocol, atomic pre-auth socket cap, 1,000 ms redemption deadline, and one
+   4 KiB first-frame limit are enforced before live allocation.
 5. A daemon-owned fixed argv builder creates and cleans a proof-bound one-window view,
    rejects sibling-pane exposure, then spawns only a real `tmux attach-session` through
    `PtyAdapter`.
@@ -420,10 +446,13 @@ Required automated evidence includes:
    wrong path/subprotocol; ticket reuse, expiry, transfer, daemon restart, target change,
    concurrent redemption, and log/snapshot/crash-report redaction.
 3. Capacity tests race concurrent issue/redeem calls and prove atomic caps for pending
-   tickets, pre-auth sockets, live connections, per-pane writers, frame count, and
-   bytes. They cover saturation before `101`, no first frame, slow/oversized/multiple
-   first frames, close-before-frame, timeout-versus-redeem, redeem-versus-expiry, and
-   two sockets racing one ticket; all reservations and timers are reclaimed.
+   tickets, pre-auth sockets, live connections, per-pane interactive writers, read-only
+   readers, mode-specific live capacity, frame count, and bytes. They prove read-only
+   never consumes writer capacity and cannot issue without continuous interactive
+   geometry-owner proof. They cover saturation before `101`, no first frame,
+   slow/oversized/multiple first frames, close-before-frame, timeout-versus-redeem,
+   redeem-versus-expiry, and two sockets racing one ticket; all reservations and timers
+   are reclaimed.
 4. `PtyAdapter` unit tests assert the exact executable/argv/env/cwd shape and prove no
    shell interpolation or renderer-authored launch field can reach spawn.
 5. Live tmux tests prove an existing full-screen/alternate-screen pane redraws on

--- a/docs/product/native-tmux-ide-ux-contract.md
+++ b/docs/product/native-tmux-ide-ux-contract.md
@@ -30,14 +30,17 @@ architecture vocabulary only:
 | Reference                     | Transferable pattern                                                                                                                   | Explicitly not transferred                                                       |
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | Gloomberb                     | Dense app bar, focused pane chrome, command-first navigation, dock/float/zoom verbs, shared behavior across terminal and desktop hosts | Source, names, assets, glyph sequences, theme values, finance-specific layout    |
-| NodeTerm                      | Immediate terminal/agent creation, spatial orientation, helpful empty canvas, one visible creation locus                               | Source or assets; `node-pty`; React Flow; its storage, node, or terminal runtime |
+| NodeTerm                      | Immediate terminal/agent creation, spatial orientation, helpful empty canvas, one visible creation locus                               | Source/assets; React Flow; storage; renderer-owned or parallel shell/PTY runtime |
 | T3 Code                       | Typed renderer/host boundary, honest startup readiness, a reusable web renderer inside a desktop shell                                 | Source, visual design, provider runtime, application state model                 |
 | tuiboard / tuiparts / OpenTUI | Responsive zones, behavior-versus-style separation, keyboard/focus primitives, headless snapshots                                      | Board data model, component source, or styling recipes                           |
 
-NodeTerm is BUSL-1.1 and is treated as a behavioral reference only. This design does
-not introduce it as a dependency and does not reproduce its code or assets. All
-tmux-ide components and interaction details below are original and use the existing
-tmux-ide contracts.
+NodeTerm is BUSL-1.1 and is treated as a behavioral reference only. Gloomberb is also
+used only as an observable behavioral reference. This design does not introduce either
+application as a dependency and does not reproduce their source, assets, terminal
+runtime, or transport. All tmux-ide components and interaction details below are
+original and use native tmux-ide contracts. ADR-0002 permits the existing daemon
+`PtyAdapter` solely around a fixed real tmux client; it does not permit a reference
+runtime or a second shell authority.
 
 “Parity” in this document means product-quality capability parity: coherent chrome,
 navigation, onboarding, recovery, and pane manipulation. It does not mean pixel
@@ -49,9 +52,11 @@ copying or making tmux-ide impersonate another product.
 flowchart TB
   Person[Person]
   TUI[OpenTUI / Solid host]
-  Desktop[Solid / Electron host]
+  Desktop[Solid renderer]
+  Host[Electron issue boundary]
   Kernel[Shared experience contracts\ncommands · focus · tokens · projections]
-  Daemon[tmux-ide daemon\ntyped resources · leases · mutations]
+  Daemon[tmux-ide daemon\ntyped resources · descriptors · mutations]
+  Client[proof-bound real tmux client\ndaemon PtyAdapter]
   Tmux[tmux server\nPTYs · sessions · windows · panes · history]
   Native[Native app surfaces\nFiles · Changes · Missions · Activity]
 
@@ -59,23 +64,36 @@ flowchart TB
   Person --> Desktop
   TUI --> Kernel
   Desktop --> Kernel
+  Desktop --> Host
+  Host -. issue one-time descriptor .-> Daemon
   Kernel --> Daemon
   Daemon --> Tmux
+  Desktop == direct binary terminal stream ==> Daemon
+  Daemon --> Client
+  Client --> Tmux
   Kernel --> Native
-  Tmux -. terminal bytes and pane events .-> Daemon
+  Tmux -. pane events and authority .-> Daemon
   Daemon -. validated projections .-> Kernel
 ```
 
 Hard boundaries:
 
-- A renderer cannot spawn a PTY, invent a semantic pane identity, or receive a raw
-  tmux `%pane_id`. Raw correlation stays inside the daemon/trusted host.
-- A terminal tile attaches through a validated, generation-bound lease and the
-  one-writer transport contract.
+- A renderer cannot spawn a PTY, invent a semantic pane identity, author a terminal
+  command/cwd, or receive a raw tmux `%pane_id`. Raw correlation stays inside the
+  daemon/trusted host.
+- A terminal tile obtains a short-lived, single-use, daemon-instance/request/origin-
+  bound attachment descriptor through the narrow Electron host issue call, then
+  streams bytes directly to the daemon. Electron main never proxies terminal input,
+  output, resize, acknowledgements, or lifecycle events.
+- The daemon may reuse its existing `PtyAdapter`/`node-pty` boundary only to host a
+  fixed argv-safe real `tmux attach-session` into a proof-bound ephemeral one-window
+  view. That view creates no shell, agent, pane history, or parallel process authority.
 - App layout state may describe how panes are presented, but terminal existence,
   command execution, scrollback, and lifecycle always resolve back to tmux.
-- Electron secrets, daemon endpoints, tickets, and transport credentials remain in
-  the trusted host. Renderer state contains semantic resources only.
+- Durable daemon credentials and reusable, directly admissible terminal endpoints
+  remain in the trusted host. The renderer may receive only the expiring one-use
+  attachment descriptor defined by ADR-0002; it is memory-only, redacted, and inert
+  after atomic redemption or expiry.
 - A stale or invalid resource fails visibly. Electron never substitutes preview
   fixtures for live state.
 - Mission data may be displayed as history or capability state. The app must not
@@ -267,19 +285,19 @@ Requirements:
 Every blocking state answers four questions: what happened, what remains safe, what
 the user can do now, and where details live.
 
-| State               | Preserve                                                          | Primary action                            | Never do                                     |
-| ------------------- | ----------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------- |
-| Discovering         | Window chrome and recent identity                                 | Wait/cancel only if genuinely cancellable | Show fake workspace content                  |
-| No workspace        | Folder choice and detected system readiness                       | Use/Open folder                           | Demand YAML                                  |
-| Workspace chooser   | Search and keyboard selection                                     | Open selected                             | Auto-open an ambiguous project               |
-| Starting            | Selected project and progress stage                               | Cancel if safe                            | Spawn duplicate sessions on retry            |
-| Live                | Full app                                                          | Contextual                                | Hide degraded resources                      |
-| Stale snapshot      | Last validated content, visibly marked                            | Refresh                                   | Present stale data as current                |
-| Reconnecting        | Last validated terminal frame, input disabled until lease returns | Retry now                                 | Clear the terminal or create a second writer |
-| Daemon unavailable  | Project identity and diagnostics                                  | Start/reconnect daemon                    | Replace live mode with preview fixtures      |
-| Incompatible daemon | Version facts                                                     | Restart/update the older side             | Retry forever                                |
-| Mutation failed     | Last daemon-confirmed layout/state                                | Retry or dismiss                          | Leave optimistic geometry as truth           |
-| Terminal exited     | Scrollback and exit status                                        | Restart/new terminal                      | Discard evidence automatically               |
+| State               | Preserve                                                                               | Primary action                            | Never do                                       |
+| ------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------- |
+| Discovering         | Window chrome and recent identity                                                      | Wait/cancel only if genuinely cancellable | Show fake workspace content                    |
+| No workspace        | Folder choice and detected system readiness                                            | Use/Open folder                           | Demand YAML                                    |
+| Workspace chooser   | Search and keyboard selection                                                          | Open selected                             | Auto-open an ambiguous project                 |
+| Starting            | Selected project and progress stage                                                    | Cancel if safe                            | Spawn duplicate sessions on retry              |
+| Live                | Full app                                                                               | Contextual                                | Hide degraded resources                        |
+| Stale snapshot      | Last validated content, visibly marked                                                 | Refresh                                   | Present stale data as current                  |
+| Reconnecting        | Last validated terminal frame, input disabled until a fresh descriptor and tmux redraw | Retry now                                 | Replay a cached tail or create a second writer |
+| Daemon unavailable  | Project identity and diagnostics                                                       | Start/reconnect daemon                    | Replace live mode with preview fixtures        |
+| Incompatible daemon | Version facts                                                                          | Restart/update the older side             | Retry forever                                  |
+| Mutation failed     | Last daemon-confirmed layout/state                                                     | Retry or dismiss                          | Leave optimistic geometry as truth             |
+| Terminal exited     | Scrollback and exit status                                                             | Restart/new terminal                      | Discard evidence automatically                 |
 
 Additional rules:
 
@@ -288,6 +306,10 @@ Additional rules:
 - A same-daemon refresh preserves subscriptions and known-safe content. A daemon
   identity change retires the previous connection before the new one becomes
   authoritative.
+- Terminal reconnect always issues a fresh one-time descriptor, resets the emulator
+  for the real tmux client's fresh redraw, and rejects late bytes from the retired
+  request. Control-mode output, `capture-pane`, and replay tails are not terminal
+  framebuffer initialization.
 - Retry is idempotent and visibly busy. Repeated activation cannot create overlapping
   connections or tmux panes.
 - Technical detail is copyable from an expandable diagnostics section. The primary
@@ -385,15 +407,21 @@ Requirements:
 ### UX-01 — Real terminal body in the shared PaneFrame
 
 Highest impact. Replace the desktop placeholder pane body with the validated native
-tmux attachment stream already being built by the terminal transport cards.
+tmux attachment stream defined by ADR-0002.
 
 Acceptance:
 
 - At least one live tmux pane renders, accepts input, resizes, reconnects, and preserves
   scrollback across status-only rerenders.
-- The renderer cannot access tmux credentials or spawn a PTY.
-- One-writer lease, expiry, daemon generation, and detach behavior have adversarial
-  tests.
+- The renderer cannot access durable daemon/tmux credentials, author command/cwd, or
+  spawn a PTY; its one-use descriptor is request/origin/instance/proof-bound.
+- Electron main has no terminal input/output/resize/ACK byte path. Renderer and daemon
+  use the bounded direct binary WebSocket after descriptor issue.
+- The daemon `PtyAdapter` launches only fixed argv-safe real `tmux attach-session` in a
+  proof-bound ephemeral one-window view; tmux owns process, history, and redraw truth.
+- One-writer reservation, atomic issue/redeem, expiry, daemon generation, Origin/CSP,
+  bounded backpressure, fresh-redraw reconnect, and detach behavior have adversarial
+  and live tmux tests.
 - `Ctrl-C` reaches the foreground process; app shutdown remains separate.
 - Desktop tests prove the terminal mount sentinel is not replaced when chrome/status
   changes.
@@ -485,8 +513,9 @@ Acceptance:
   processes without exposing raw tmux correlation to Solid.
 - Camera, placement, fit/focus, empty guidance, persistence, recovery, and one resize
   authority have dedicated tests.
-- Dependency audit confirms no NodeTerm source/assets, `node-pty`, or parallel terminal
-  runtime entered the product.
+- Dependency audit confirms no NodeTerm/Gloomberb source, assets, transport, or runtime
+  entered the product; `node-pty` remains isolated behind the daemon `PtyAdapter` and
+  can launch only the real tmux client, never a parallel shell/runtime.
 
 ## Quality gate
 

--- a/docs/product/native-tmux-ide-ux-contract.md
+++ b/docs/product/native-tmux-ide-ux-contract.md
@@ -80,7 +80,8 @@ Hard boundaries:
 
 - A renderer cannot spawn a PTY, invent a semantic pane identity, author a terminal
   command/cwd, or receive a raw tmux `%pane_id`. Raw correlation stays inside the
-  daemon/trusted host.
+  daemon only; Electron main holds neither raw tmux proof nor product-state
+  correlation.
 - A terminal tile obtains a short-lived, single-use, daemon-instance/request/origin-
   bound attachment descriptor through the narrow Electron host issue call, then
   streams bytes directly to the daemon. Electron main never proxies terminal input,
@@ -387,10 +388,10 @@ surface is complete. It is a tmux-ide feature, not an embedded reference app.
 
 Requirements:
 
-- Every tile is keyed by a daemon-issued semantic pane identity. The daemon/trusted
-  host correlates that identity to the current raw tmux `%pane_id`; the renderer never
-  receives or persists the raw correlation. Switching between grid and map cannot
-  create, clone, or replace a terminal process.
+- Every tile is keyed by a daemon-issued semantic pane identity. The daemon alone
+  correlates that identity to the current raw tmux `%pane_id`; neither Electron main
+  nor the renderer receives or persists the raw correlation. Switching between grid
+  and map cannot create, clone, or replace a terminal process.
 - Pan/zoom/placement are app presentation state. Create, split, close, restart, rename,
   and focus remain daemon-owned semantic tmux mutations.
 - The camera can fit all panes or focus one pane. The current zoom percentage and a
@@ -419,9 +420,14 @@ Acceptance:
   use the bounded direct binary WebSocket after descriptor issue.
 - The daemon `PtyAdapter` launches only fixed argv-safe real `tmux attach-session` in a
   proof-bound ephemeral one-window view; tmux owns process, history, and redraw truth.
+- Issue records requested viewer mode; daemon `ready` reports effective mode,
+  authoritative shared-window grid, and client viewport. Read-only rejects input and
+  resize authority; mismatched viewports clip/scroll instead of changing shared tmux
+  geometry.
 - One-writer reservation, atomic issue/redeem, expiry, daemon generation, Origin/CSP,
-  bounded backpressure, fresh-redraw reconnect, and detach behavior have adversarial
-  and live tmux tests.
+  atomic pre-auth socket capacity, bounded redemption, implementable PTY
+  completion/drain or fail-closed flow control, fresh-redraw reconnect, and detach
+  behavior have adversarial and live tmux tests.
 - `Ctrl-C` reaches the foreground process; app shutdown remains separate.
 - Desktop tests prove the terminal mount sentinel is not replaced when chrome/status
   changes.

--- a/docs/product/native-tmux-ide-ux-contract.md
+++ b/docs/product/native-tmux-ide-ux-contract.md
@@ -424,10 +424,12 @@ Acceptance:
   authoritative shared-window grid, and client viewport. Read-only rejects input and
   resize authority; mismatched viewports clip/scroll instead of changing shared tmux
   geometry.
-- One-writer reservation, atomic issue/redeem, expiry, daemon generation, Origin/CSP,
-  atomic pre-auth socket capacity, bounded redemption, implementable PTY
-  completion/drain or fail-closed flow control, fresh-redraw reconnect, and detach
-  behavior have adversarial and live tmux tests.
+- Mode-specific admission reserves the sole writer only for effective interactive;
+  read-only reserves reader/live capacity plus proven continuous interactive geometry
+  ownership or fails typed. Atomic issue/redeem, expiry, daemon generation, Origin/CSP,
+  pre-auth socket capacity, bounded redemption, implementable PTY completion/drain or
+  fail-closed flow control, fresh-redraw reconnect, and detach behavior have adversarial
+  and live tmux tests.
 - `Ctrl-C` reaches the foreground process; app shutdown remains separate.
 - Desktop tests prove the terminal mount sentinel is not replaced when chrome/status
   changes.

--- a/docs/product/native-tmux-ide-ux-contract.md
+++ b/docs/product/native-tmux-ide-ux-contract.md
@@ -425,11 +425,13 @@ Acceptance:
   resize authority; mismatched viewports clip/scroll instead of changing shared tmux
   geometry.
 - Mode-specific admission reserves the sole writer only for effective interactive;
-  read-only reserves reader/live capacity plus proven continuous interactive geometry
-  ownership or fails typed. Atomic issue/redeem, expiry, daemon generation, Origin/CSP,
-  pre-auth socket capacity, bounded redemption, implementable PTY completion/drain or
-  fail-closed flow control, fresh-redraw reconnect, and detach behavior have adversarial
-  and live tmux tests.
+  read-only reserves reader authority plus proven continuous interactive geometry
+  ownership or fails typed. Issue also reserves pending-ticket capacity; redeem alone
+  swaps that pending slot for one live-connection slot and activates—never
+  re-reserves—the mode authority. Atomic issue/redeem, expiry, daemon generation,
+  Origin/CSP, pre-auth socket capacity, bounded redemption, implementable PTY
+  completion/drain or fail-closed flow control, fresh-redraw reconnect, and detach
+  behavior have adversarial and live tmux tests.
 - `Ctrl-C` reaches the foreground process; app shutdown remains separate.
 - Desktop tests prove the terminal mount sentinel is not replaced when chrome/status
   changes.


### PR DESCRIPTION
## Summary
- accept the real tmux PTY attachment architecture in ADR-0002
- define the one-time descriptor, durable credential split, direct renderer-to-daemon binary stream, Origin/CSP, reconnect, backpressure, WSL2, and remote boundaries
- align the native UX contract without importing NodeTerm or Gloomberb runtime designs

## Decision
Electron only issues a short-lived attachment descriptor. It never proxies terminal bytes. The daemon uses the existing PtyAdapter solely to run fixed argv-safe real tmux attach-session clients in proof-bound one-window views; tmux remains sole process, history, and framebuffer authority.

## Validation
- pnpm docs:build
- pnpm format:check
- git diff --check

No production code changed. This PR is intentionally left unmerged.