### PR TITLE
feat(daemon): bound opaque PTY input generations

### DIFF
--- a/docs/adr/0003-bounded-pty-input.md
+++ b/docs/adr/0003-bounded-pty-input.md
@@ -1,0 +1,266 @@
+# ADR-0003 — Bounded input for opaque PTY writers
+
+- **Status**: Proposed; primitive implemented, native attachment input remains gated
+- **Date**: 2026-07-22
+- **Decision drivers**: no unbounded native queue, byte fidelity, explicit failure,
+  npm-installable distribution, macOS/Linux/WSL2 support, and honest delivery semantics
+- **Depends on**: `docs/adr/0002-native-tmux-terminal-attachments.md`
+
+## Decision summary
+
+The current `node-pty` public API cannot prove that an input byte left its internal
+writer queue. tmux-ide therefore must not estimate drain from elapsed time, terminal
+echo, output, or private fields.
+
+We will use two layers:
+
+1. **Now: a monotonic fail-closed capability.** Each fresh `PtyProcess` owns a fixed
+   lifetime byte budget, frame budget, and single-frame limit. It snapshots and reserves
+   each accepted binary frame before calling `node-pty.write`, never returns capacity,
+   and permanently rejects after any limit/backend failure. This bounds the opaque
+   queue by assuming the worst case: every accepted byte and task remains forever.
+2. **For lossless long-lived input: a maintained public completion API.** Prefer an
+   upstream `node-pty` API; otherwise publish a scoped fork with the same prebuild
+   matrix. A native helper is the fallback if a maintained fork is not viable.
+
+The monotonic primitive is implemented by
+`packages/daemon/src/terminal/MonotonicPtyInput.ts` and exposed as
+`PtyProcess.boundedInput`. It is not wired into `ClaimedPtyTmuxAttachment.write` in this
+card. The launcher continues to throw `input-backpressure-unavailable` until the direct
+WebSocket transport owns typed retirement/re-attach behavior and is structurally given
+only the bounded capability, never `PtyProcess.write`.
+
+## Evidence
+
+The installed dependency is `node-pty@1.2.0-beta.12`. Its public declaration exposes
+`IPty.write(data): void` and no pending-byte, completion, callback, or drain primitive.
+The current upstream beta, `1.2.0-beta.14`, has the same public shape.
+
+On Unix, `CustomWriteStream.write` copies every frame into a private array, while an
+asynchronous `fs.write` callback advances the head. `EAGAIN` retries later, but callers
+cannot observe queue size or completion. On Windows, `inSocket.write(data)` is called
+without returning its boolean or callback; calls made before ConPTY readiness are also
+stored in a private deferred array. WSL2 uses the Linux/Unix path because tmux and the
+daemon run inside WSL2.
+
+Primary evidence:
+
+- [`IPty.write` in v1.2.0-beta.12](https://github.com/microsoft/node-pty/blob/v1.2.0-beta.12/typings/node-pty.d.ts)
+- [Unix `CustomWriteStream` in v1.2.0-beta.12](https://github.com/microsoft/node-pty/blob/v1.2.0-beta.12/src/unixTerminal.ts)
+- [Windows write/deferred path in v1.2.0-beta.12](https://github.com/microsoft/node-pty/blob/v1.2.0-beta.12/src/windowsTerminal.ts)
+- [Upstream issue #939: indefinite input queue when write completions stall](https://github.com/microsoft/node-pty/issues/939)
+- [Unmerged callback/return-value PR #186](https://github.com/microsoft/node-pty/pull/186)
+
+`@lydell/node-pty` does not solve the contract: it is a smaller distribution of the
+same upstream package, not an independent writer API. Upgrading or changing package
+names therefore cannot unlock input.
+
+## Monotonic capability contract
+
+```ts
+interface PtyBoundedInput {
+  write(data: Uint8Array): PtyInputWriteReceipt;
+  snapshot(): PtyInputSnapshot;
+  close(): void;
+}
+
+interface PtyInputLimits {
+  maxFrameBytes: number;
+  maxAcceptedBytes: number;
+  maxAcceptedFrames: number;
+}
+```
+
+The default policy for one PTY generation is:
+
+| Limit           | Default | Hard configurable ceiling | Purpose                                    |
+| --------------- | ------: | ------------------------: | ------------------------------------------ |
+| Single frame    |  16 KiB |                    64 KiB | bounds the snapshot before the opaque call |
+| Lifetime bytes  | 256 KiB |                     4 MiB | bounds all payload ever handed to node-pty |
+| Lifetime frames |   8,192 |                    16,384 | bounds private queue/task metadata         |
+
+The ceilings are unit-specific. A large byte ceiling cannot be exchanged for tens of
+millions of one-byte tasks. `NodePtyAdapter` validates and freezes its daemon-owned
+policy in its constructor, before any spawn.
+
+### Invariants
+
+For every non-empty input frame:
+
+1. Validate the original byte length against the single-frame and remaining lifetime
+   limits. A refused frame is never copied into or passed to the backend.
+2. Copy to a new `Buffer`, preventing later mutation of a renderer/WS-owned view.
+3. Increment lifetime byte and frame counters before calling the opaque writer.
+4. Call `node-pty.write` once with that immutable snapshot.
+5. Never decrement either counter, including after success, synchronous throw, exit, or
+   close.
+
+An empty frame is ignored without spending capacity. Every non-empty refusal throws a
+typed `PtyInputRejectedError` without input content. Limit refusal changes state to
+`exhausted`; backend throw changes it to `failed`; explicit close/PTY exit changes it
+to `closed`. None can return to `open`.
+
+Only spawning and proof-claiming a new tmux-client PTY creates a fresh budget. Reconnect
+must retire the old generation and reject its late frames. There is no reset API and no
+input replay across generations, because replay could execute a command twice.
+
+### What “accepted” means
+
+An accepted receipt means only: “the daemon copied this frame into a bounded opaque
+writer budget.” It does **not** mean tmux read the byte, the foreground process handled
+it, or output corresponding to it exists. A direct transport may release its temporary
+WebSocket-frame allocation after acceptance, but must not label the receipt as a PTY
+drain/completion acknowledgement.
+
+If an accepted frame exactly reaches a limit, its receipt reports `state: exhausted`.
+The transport must disable further input and replace the attachment. If the next frame
+finds the limit first, it gets a typed rejection and the transport retires immediately.
+The UI must never silently drop or automatically resend the uncertain frame.
+
+This finite-generation behavior is memory-safe but can require the user to verify the
+last interaction after replacement. That tradeoff is why the native launcher remains
+gated until the direct transport and recovery UX are implemented and reviewed.
+
+## Memory bound
+
+The proof does not read node-pty private fields at runtime. It counts the only values
+tmux-ide can cause the opaque API to retain: calls and bytes handed across the boundary.
+
+At the default policy, one generation can allocate at most:
+
+- 256 KiB of accepted payload in tmux-ide snapshots over its lifetime;
+- 256 KiB of queued payload copies in the audited Unix node-pty implementation;
+- 8,192 opaque write-task records; and
+- one temporary caller/WS frame no larger than 16 KiB outside the capability.
+
+The conservative reachable/pool-retained payload allowance is therefore 512 KiB plus
+one 16 KiB caller frame per attachment. V8 object, allocator, and libuv request overhead
+is implementation dependent, so this ADR does not pretend it has a byte-exact static
+size. Instead, the supported-platform stress gate caps the measured post-GC RSS delta
+at 8 MiB per stalled default-policy attachment. With the launcher's existing maximum
+of 32 owned attempts, the corresponding admission-planning ceiling is 256 MiB RSS and
+16 MiB accounted payload copies. The direct transport may choose a lower live cap; it
+must not raise either input default without re-running the matrix and updating this ADR.
+
+The hard configurable ceilings exist for isolated future use, not as direct-transport
+defaults. Running every live attachment at the 4 MiB/16,384-frame ceiling requires a
+separate aggregate capacity review.
+
+## Direct transport requirements
+
+The future binary WebSocket bridge must:
+
+1. receive only `PtyBoundedInput`, output pause/resume, resize, and dispose capabilities;
+   it must not receive `PtyProcess` or legacy `PtyProcess.write`;
+2. limit the WebSocket input frame before creating a second copy;
+3. serialize input and reserve its own per-socket/global temporary frame capacity;
+4. call `boundedInput.write` exactly once per admitted frame;
+5. on `PtyInputRejectedError`, disable input, retire that PTY/view generation, surface a
+   typed recovery state, and issue a fresh descriptor/client;
+6. on an accepted receipt whose snapshot is already exhausted, complete the same
+   retirement path before accepting another frame;
+7. never automatically replay input after reconnect; and
+8. treat `Ctrl-C`, escape sequences, UTF-8, NUL, and high bytes as ordinary binary input.
+
+Paste larger than 16 KiB must be chunked before the adapter, remain inside the socket's
+temporary capacity, and stop at the first typed rejection. The renderer should show an
+explicit reconnect/review state rather than report the full paste as delivered.
+
+## Path to measurable completion
+
+The preferred upstream/scoped-fork API is conceptually:
+
+```ts
+interface BoundedPtyWriter {
+  tryWrite(
+    data: Buffer,
+  ):
+    | { accepted: true; writeId: bigint; pendingBytes: number; pendingFrames: number }
+    | { accepted: false; reason: "capacity" | "closed" };
+  onWriteSettled(
+    listener: (event: {
+      writeId: bigint;
+      status: "written" | "failed" | "closed";
+      pendingBytes: number;
+      pendingFrames: number;
+    }) => void,
+  ): Disposable;
+}
+```
+
+Acceptance must occur inside the same public queue that owns the buffer, before copying.
+Settlement must fire only after the whole frame leaves that queue or is failed/closed.
+Unix must account partial writes and `EAGAIN`; Windows must expose `net.Socket.write`
+completion and bound pre-ready deferred calls. Close must settle every outstanding id,
+and a stalled completion watchdog must fail/close rather than retain forever.
+
+If upstream does not accept this API, the fallback is a published scoped fork with
+macOS arm64/x64 and Linux arm64/x64 prebuilds (WSL2 consumes Linux). A pnpm patch is not
+acceptable because npm consumers of the published tmux-ide package would install the
+unpatched dependency. A native `forkpty` helper with a bounded framed stdin protocol is
+the second fallback; it needs its own signed/prebuilt distribution and resize/signal
+lifecycle and is materially larger.
+
+Estimated effort after the monotonic primitive:
+
+| Option                               | Engineering estimate | Release/maintenance risk                               |
+| ------------------------------------ | -------------------: | ------------------------------------------------------ |
+| Upstream API + temporary scoped fork |             5–8 days | medium; upstream timing and prebuild publishing        |
+| Permanent scoped fork                |            7–12 days | high; security updates and platform matrix become ours |
+| Dedicated native helper              |           10–15 days | high initially; cleanest long-term ownership           |
+
+## Test gates
+
+The primitive/card is mergeable when:
+
+- deterministic fake-never-drains tests prove byte, frame, and single-frame refusal
+  occurs before another opaque call;
+- tests prove input is snapshotted, backend throws retain accounting, close is permanent,
+  and a new process—not a reset—creates fresh capacity;
+- NUL and high bytes remain byte-exact;
+- invalid policy is rejected at `NodePtyAdapter` construction;
+- source/boundary review confirms native attachment code cannot call legacy `write`; and
+- the launcher still throws `input-backpressure-unavailable` in production.
+
+Before enabling direct input, additionally require:
+
+- a live stalled-reader/SIGSTOP stress on macOS arm64/x64 and Linux arm64/x64 (including
+  WSL2) that holds the process at its limits, repeatedly refuses more data, forces GC,
+  and stays within the 8 MiB per-attachment RSS delta over time;
+- aggregate stress at the chosen live-attachment cap;
+- exhaustion/reconnect UX and no-auto-replay tests, including remote 16 KiB+ paste; and
+- either explicit product acceptance of uncertain final-frame delivery or the public
+  completion API above.
+
+The opt-in runner is
+`packages/daemon/scripts/stress-bounded-pty-input.mjs`. On 2026-07-22, its first local
+macOS arm64 run under Node 26.5.0 filled 256 KiB behind a SIGSTOP reader, performed
+4,096 typed refusals across eight GC/sample rounds, and measured a 416 KiB peak RSS
+delta against the 8 MiB gate. That is one platform sample, not the required release
+matrix.
+
+## Risk register
+
+- **Blocker for enabling interactive attachments**: the direct WebSocket retirement and
+  recovery path is not implemented, and the current launcher intentionally exposes no
+  input capability.
+- **High**: monotonic fail-closed input bounds memory but cannot prove final-frame
+  delivery before retirement. It is not equivalent to completion/drain.
+- **High**: a local package-manager patch would disappear for npm consumers; do not use
+  it as a production fix.
+- **Medium**: V8/libuv metadata size and RSS retention vary by platform; the empirical
+  supported-platform gate must stay tied to dependency/runtime upgrades.
+- **Medium**: 16 KiB paste chunking and finite generation quotas need explicit UX to
+  avoid appearing as silent truncation.
+- **Medium**: current node-pty source is audited evidence, not a stable memory-layout
+  contract. Dependency upgrades require re-auditing write copies and re-running stress.
+
+## Rejected shortcuts
+
+- Reading `_writeQueue`, `_agent.inSocket`, `_fd`, or other private fields in production.
+- Assuming one event-loop tick, timeout, echo, prompt, or output frame means input drained.
+- Calling void `write` slowly and subtracting guessed capacity.
+- Sending terminal input through Electron main.
+- Replacing terminal input with `tmux send-keys`; it bypasses real-client key/prefix/mouse
+  semantics and is not byte-equivalent.
+- Resetting a budget on the same PTY or replaying uncertain bytes after reconnect.

--- a/packages/daemon/scripts/stress-bounded-pty-input.mjs
+++ b/packages/daemon/scripts/stress-bounded-pty-input.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * Opt-in live stress for ADR-0003.
+ *
+ * Usage (Node 20+):
+ *   node --experimental-strip-types --expose-gc \
+ *     packages/daemon/scripts/stress-bounded-pty-input.mjs
+ *
+ * The PTY child SIGSTOPs before reading. The adapter fills its entire default
+ * lifetime budget, then repeatedly refuses more frames. This script never
+ * inspects node-pty private fields; it asserts public accounting and a coarse
+ * process RSS ceiling. Run it in the macOS/Linux/WSL2 release matrix before
+ * enabling native attachment input.
+ */
+
+import { setTimeout as delay } from "node:timers/promises";
+import { Buffer } from "node:buffer";
+import console from "node:console";
+import process from "node:process";
+import { NodePtyAdapter } from "../src/terminal/NodePtyAdapter.ts";
+import { DEFAULT_PTY_INPUT_LIMITS } from "../src/terminal/MonotonicPtyInput.ts";
+import { PtyInputRejectedError } from "../src/terminal/PtyAdapter.ts";
+
+if (process.platform === "win32") {
+  console.error("Run this inside WSL2; native Windows is outside ADR-0002.");
+  process.exit(2);
+}
+if (typeof globalThis.gc !== "function") {
+  console.error("This stress requires --expose-gc.");
+  process.exit(2);
+}
+
+const RSS_DELTA_LIMIT = 8 * 1024 * 1024;
+const adapter = new NodePtyAdapter();
+const proc = adapter.spawnSync({
+  shell: "/bin/sh",
+  args: ["-c", "kill -STOP $$; while :; do sleep 1; done"],
+  cwd: process.cwd(),
+  cols: 80,
+  rows: 24,
+  env: { TERM: "xterm-256color", LANG: process.env.LANG },
+  encoding: null,
+});
+
+function collect() {
+  globalThis.gc();
+  return process.memoryUsage();
+}
+
+try {
+  await delay(50);
+  const before = collect();
+  const frame = Buffer.alloc(DEFAULT_PTY_INPUT_LIMITS.maxFrameBytes, 0x61);
+  const acceptedFrameCount =
+    DEFAULT_PTY_INPUT_LIMITS.maxAcceptedBytes / DEFAULT_PTY_INPUT_LIMITS.maxFrameBytes;
+  if (!Number.isInteger(acceptedFrameCount)) {
+    throw new Error("default input bytes must be divisible by default frame bytes");
+  }
+
+  for (let index = 0; index < acceptedFrameCount; index += 1) {
+    proc.boundedInput.write(frame);
+  }
+  const full = proc.boundedInput.snapshot();
+  if (
+    full.state !== "exhausted" ||
+    full.acceptedBytes !== DEFAULT_PTY_INPUT_LIMITS.maxAcceptedBytes ||
+    full.acceptedFrames !== acceptedFrameCount
+  ) {
+    throw new Error(`unexpected full-budget snapshot: ${JSON.stringify(full)}`);
+  }
+
+  const samples = [];
+  let rejectionCount = 0;
+  for (let round = 0; round < 8; round += 1) {
+    for (let index = 0; index < 512; index += 1) {
+      try {
+        proc.boundedInput.write(Uint8Array.of(0x62));
+      } catch (error) {
+        if (!(error instanceof PtyInputRejectedError)) throw error;
+        rejectionCount += 1;
+      }
+    }
+    await delay(25);
+    samples.push(collect());
+  }
+
+  const maxRss = Math.max(...samples.map((sample) => sample.rss));
+  const rssDelta = Math.max(0, maxRss - before.rss);
+  const result = {
+    platform: process.platform,
+    arch: process.arch,
+    pid: proc.pid,
+    limits: DEFAULT_PTY_INPUT_LIMITS,
+    rejectionCount,
+    before,
+    samples,
+    rssDelta,
+    rssDeltaLimit: RSS_DELTA_LIMIT,
+  };
+  console.log(JSON.stringify(result, null, 2));
+  if (rssDelta > RSS_DELTA_LIMIT) {
+    throw new Error(`stalled PTY input RSS delta ${rssDelta} exceeded ${RSS_DELTA_LIMIT}`);
+  }
+} finally {
+  proc.kill("SIGKILL");
+}

--- a/packages/daemon/src/terminal/MonotonicPtyInput.ts
+++ b/packages/daemon/src/terminal/MonotonicPtyInput.ts
@@ -1,0 +1,154 @@
+import {
+  PtyInputRejectedError,
+  type PtyBoundedInput,
+  type PtyInputLimits,
+  type PtyInputRejectionReason,
+  type PtyInputSnapshot,
+  type PtyInputState,
+  type PtyInputWriteReceipt,
+} from "./PtyAdapter.ts";
+
+/**
+ * Conservative defaults for one real tmux-client PTY generation.
+ *
+ * 256 KiB bounds opaque payload retention while 8,192 frames bounds private
+ * queue/task metadata when a renderer sends one key per frame. A 16 KiB frame
+ * admits ordinary bracketed paste but makes larger paste an explicit transport
+ * operation that must be chunked before it reaches this boundary.
+ */
+export const DEFAULT_PTY_INPUT_LIMITS: PtyInputLimits = Object.freeze({
+  maxFrameBytes: 16 * 1024,
+  maxAcceptedBytes: 256 * 1024,
+  maxAcceptedFrames: 8_192,
+});
+
+/** Hard implementation ceilings; callers cannot trade a byte cap for task explosion. */
+export const MAX_PTY_INPUT_FRAME_BYTES = 64 * 1024;
+export const MAX_PTY_INPUT_ACCEPTED_BYTES = 4 * 1024 * 1024;
+export const MAX_PTY_INPUT_ACCEPTED_FRAMES = 16_384;
+
+export function validatePtyInputLimits(limits: PtyInputLimits): PtyInputLimits {
+  validateLimit("maxFrameBytes", limits.maxFrameBytes, MAX_PTY_INPUT_FRAME_BYTES);
+  validateLimit("maxAcceptedBytes", limits.maxAcceptedBytes, MAX_PTY_INPUT_ACCEPTED_BYTES);
+  validateLimit("maxAcceptedFrames", limits.maxAcceptedFrames, MAX_PTY_INPUT_ACCEPTED_FRAMES);
+  if (limits.maxFrameBytes > limits.maxAcceptedBytes) {
+    throw new RangeError("maxFrameBytes cannot exceed maxAcceptedBytes");
+  }
+  return Object.freeze({ ...limits });
+}
+
+function validateLimit(name: string, value: number, maximum: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0 || value > maximum) {
+    throw new RangeError(`${name} must be a positive safe integer no greater than ${maximum}`);
+  }
+}
+
+/**
+ * Bounds an opaque PTY writer by assuming the worst case: every byte and task
+ * ever accepted remains queued for this process's entire lifetime.
+ *
+ * This deliberately does not inspect node-pty private fields and does not
+ * infer progress from time or terminal echo. Capacity is reserved before the
+ * sink call and is never reclaimed, including when that call throws.
+ */
+export class MonotonicPtyInput implements PtyBoundedInput {
+  readonly #limits: PtyInputLimits;
+  readonly #sink: (frame: Buffer) => void;
+  #acceptedBytes = 0;
+  #acceptedFrames = 0;
+  #state: PtyInputState = "open";
+  #terminalReason: PtyInputRejectionReason | null = null;
+
+  constructor(limits: PtyInputLimits, sink: (frame: Buffer) => void) {
+    this.#limits = validatePtyInputLimits(limits);
+    this.#sink = sink;
+  }
+
+  write(data: Uint8Array): PtyInputWriteReceipt {
+    if (!(data instanceof Uint8Array)) {
+      throw new TypeError("bounded PTY input must be a Uint8Array");
+    }
+    if (data.byteLength === 0) {
+      return { status: "ignored", reason: "empty", snapshot: this.snapshot() };
+    }
+    if (this.#state === "exhausted") {
+      const reason =
+        this.#terminalReason ??
+        (this.#acceptedFrames >= this.#limits.maxAcceptedFrames
+          ? "lifetime_frames_exhausted"
+          : "lifetime_bytes_exhausted");
+      this.#reject(reason, "exhausted");
+    }
+    if (this.#state !== "open") {
+      this.#reject("process_closed", this.#state);
+    }
+    if (data.byteLength > this.#limits.maxFrameBytes) {
+      this.#reject("frame_too_large", "exhausted");
+    }
+    if (this.#acceptedFrames >= this.#limits.maxAcceptedFrames) {
+      this.#reject("lifetime_frames_exhausted", "exhausted");
+    }
+    if (data.byteLength > this.#limits.maxAcceptedBytes - this.#acceptedBytes) {
+      this.#reject("lifetime_bytes_exhausted", "exhausted");
+    }
+
+    // Copy before accounting and before crossing the opaque boundary. This
+    // prevents a renderer-owned ArrayBuffer (including a shared view) from
+    // changing after the exact byteLength has been reserved.
+    const frame = Buffer.from(data);
+    this.#acceptedBytes += frame.byteLength;
+    this.#acceptedFrames += 1;
+    if (
+      this.#acceptedBytes === this.#limits.maxAcceptedBytes ||
+      this.#acceptedFrames === this.#limits.maxAcceptedFrames
+    ) {
+      this.#state = "exhausted";
+      this.#terminalReason =
+        this.#acceptedFrames === this.#limits.maxAcceptedFrames
+          ? "lifetime_frames_exhausted"
+          : "lifetime_bytes_exhausted";
+    }
+
+    try {
+      this.#sink(frame);
+    } catch (cause) {
+      this.#state = "failed";
+      this.#terminalReason = "backend_write_failed";
+      throw new PtyInputRejectedError({
+        reason: "backend_write_failed",
+        snapshot: this.snapshot(),
+        cause,
+      });
+    }
+
+    return {
+      status: "accepted",
+      byteLength: frame.byteLength,
+      snapshot: this.snapshot(),
+    };
+  }
+
+  snapshot(): PtyInputSnapshot {
+    return Object.freeze({
+      ...this.#limits,
+      state: this.#state,
+      acceptedBytes: this.#acceptedBytes,
+      acceptedFrames: this.#acceptedFrames,
+      remainingBytes: this.#limits.maxAcceptedBytes - this.#acceptedBytes,
+      remainingFrames: this.#limits.maxAcceptedFrames - this.#acceptedFrames,
+    });
+  }
+
+  close(): void {
+    if (this.#state === "open" || this.#state === "exhausted") {
+      this.#state = "closed";
+      this.#terminalReason = "process_closed";
+    }
+  }
+
+  #reject(reason: PtyInputRejectionReason, state: PtyInputState): never {
+    this.#state = state;
+    this.#terminalReason = reason;
+    throw new PtyInputRejectedError({ reason, snapshot: this.snapshot() });
+  }
+}

--- a/packages/daemon/src/terminal/MonotonicPtyInput.ts
+++ b/packages/daemon/src/terminal/MonotonicPtyInput.ts
@@ -111,13 +111,12 @@ export class MonotonicPtyInput implements PtyBoundedInput {
 
     try {
       this.#sink(frame);
-    } catch (cause) {
+    } catch {
       this.#state = "failed";
       this.#terminalReason = "backend_write_failed";
       throw new PtyInputRejectedError({
         reason: "backend_write_failed",
         snapshot: this.snapshot(),
-        cause,
       });
     }
 
@@ -140,7 +139,7 @@ export class MonotonicPtyInput implements PtyBoundedInput {
   }
 
   close(): void {
-    if (this.#state === "open" || this.#state === "exhausted") {
+    if (this.#state !== "closed") {
       this.#state = "closed";
       this.#terminalReason = "process_closed";
     }

--- a/packages/daemon/src/terminal/NodePtyAdapter.ts
+++ b/packages/daemon/src/terminal/NodePtyAdapter.ts
@@ -19,10 +19,16 @@ import {
   PtySpawnError,
   type PtyAdapter,
   type PtyExitEvent,
+  type PtyInputLimits,
   type PtyProcess,
   type PtySpawnInput,
   type PtySpawnListeners,
 } from "./PtyAdapter.ts";
+import {
+  DEFAULT_PTY_INPUT_LIMITS,
+  MonotonicPtyInput,
+  validatePtyInputLimits,
+} from "./MonotonicPtyInput.ts";
 
 const ADAPTER_ID = "node-pty";
 let helperEnsured = false;
@@ -102,9 +108,15 @@ class NodePtyProcess implements PtyProcess {
   private readonly child: pty.IPty;
   private readonly dataListeners = new Set<(data: Buffer) => void>();
   private readonly exitListeners = new Set<(event: PtyExitEvent) => void>();
+  readonly boundedInput: MonotonicPtyInput;
 
-  constructor(child: pty.IPty, listeners: PtySpawnListeners = {}) {
+  constructor(
+    child: pty.IPty,
+    listeners: PtySpawnListeners = {},
+    inputLimits: PtyInputLimits = DEFAULT_PTY_INPUT_LIMITS,
+  ) {
     this.child = child;
+    this.boundedInput = new MonotonicPtyInput(inputLimits, (frame) => this.child.write(frame));
     if (listeners.onData) this.dataListeners.add(listeners.onData);
     if (listeners.onExit) this.exitListeners.add(listeners.onExit);
     // node-pty hands us strings by default; we want raw buffers for
@@ -116,6 +128,7 @@ class NodePtyProcess implements PtyProcess {
     });
     this.child.onExit((evt) => {
       this.exited = true;
+      this.boundedInput.close();
       const event: PtyExitEvent = {
         exitCode: evt.exitCode ?? 0,
         signal: typeof evt.signal === "number" ? evt.signal : null,
@@ -132,6 +145,8 @@ class NodePtyProcess implements PtyProcess {
   }
 
   write(data: string | Uint8Array): void {
+    // Legacy bridge only. Native attachments receive `boundedInput`, not this
+    // process method, because node-pty exposes no completion/capacity signal.
     if (this.exited) return;
     if (typeof data === "string") this.child.write(data);
     else this.child.write(Buffer.from(data));
@@ -161,6 +176,7 @@ class NodePtyProcess implements PtyProcess {
 
   kill(signal?: NodeJS.Signals | number): void {
     if (this.exited) return;
+    this.boundedInput.close();
     try {
       this.child.kill(typeof signal === "number" ? String(signal) : signal);
     } catch {
@@ -200,6 +216,11 @@ export interface NodePtyAdapterOptions {
   statCwd?: (cwd: string) => Stats;
   /** Skip the spawn-helper chmod (test isolation). */
   skipHelperEnsure?: boolean;
+  /**
+   * Daemon-owned monotonic native-input limits. They are copied into each
+   * fresh process and cannot be reset for that process generation.
+   */
+  boundedInputLimits?: PtyInputLimits;
 }
 
 export class NodePtyAdapter implements PtyAdapter {
@@ -207,11 +228,15 @@ export class NodePtyAdapter implements PtyAdapter {
   private readonly spawnPty: typeof pty.spawn;
   private readonly statCwd: (cwd: string) => Stats;
   private readonly skipHelperEnsure: boolean;
+  private readonly boundedInputLimits: PtyInputLimits;
 
   constructor(options: NodePtyAdapterOptions = {}) {
     this.spawnPty = options.spawnPty ?? pty.spawn;
     this.statCwd = options.statCwd ?? statSync;
     this.skipHelperEnsure = options.skipHelperEnsure ?? false;
+    this.boundedInputLimits = validatePtyInputLimits(
+      options.boundedInputLimits ?? DEFAULT_PTY_INPUT_LIMITS,
+    );
   }
 
   async spawn(input: PtySpawnInput, listeners?: PtySpawnListeners): Promise<PtyProcess> {
@@ -280,7 +305,7 @@ export class NodePtyAdapter implements PtyAdapter {
         cause: err,
       });
     }
-    return new NodePtyProcess(child, listeners);
+    return new NodePtyProcess(child, listeners, this.boundedInputLimits);
   }
 }
 

--- a/packages/daemon/src/terminal/PtyAdapter.ts
+++ b/packages/daemon/src/terminal/PtyAdapter.ts
@@ -106,15 +106,8 @@ export class PtyInputRejectedError extends Error {
   readonly reason: PtyInputRejectionReason;
   readonly snapshot: PtyInputSnapshot;
 
-  constructor(args: {
-    reason: PtyInputRejectionReason;
-    snapshot: PtyInputSnapshot;
-    cause?: unknown;
-  }) {
-    super(
-      `bounded PTY input rejected: ${args.reason}`,
-      args.cause !== undefined ? { cause: args.cause } : undefined,
-    );
+  constructor(args: { reason: PtyInputRejectionReason; snapshot: PtyInputSnapshot }) {
+    super(`bounded PTY input rejected: ${args.reason}`);
     this.name = "PtyInputRejectedError";
     this.reason = args.reason;
     this.snapshot = args.snapshot;

--- a/packages/daemon/src/terminal/PtyAdapter.ts
+++ b/packages/daemon/src/terminal/PtyAdapter.ts
@@ -60,6 +60,95 @@ export interface PtyExitEvent {
 }
 
 /**
+ * Fixed, daemon-owned limits for the fail-closed PTY input capability.
+ *
+ * These are lifetime limits, not watermarks. Accepted capacity is never
+ * returned because the public node-pty API cannot prove that its private
+ * writer queue released any particular byte. A fresh budget therefore
+ * requires a fresh {@link PtyProcess}; callers cannot reset one in place.
+ */
+export interface PtyInputLimits {
+  /** Largest single binary frame that can cross the adapter boundary. */
+  readonly maxFrameBytes: number;
+  /** Total bytes that can ever be handed to the opaque backend process. */
+  readonly maxAcceptedBytes: number;
+  /** Total non-empty frames that can ever be handed to the opaque backend. */
+  readonly maxAcceptedFrames: number;
+}
+
+export type PtyInputState = "open" | "exhausted" | "failed" | "closed";
+
+/** Immutable accounting snapshot; it never contains terminal input bytes. */
+export interface PtyInputSnapshot extends PtyInputLimits {
+  readonly state: PtyInputState;
+  readonly acceptedBytes: number;
+  readonly acceptedFrames: number;
+  readonly remainingBytes: number;
+  readonly remainingFrames: number;
+}
+
+export type PtyInputRejectionReason =
+  | "frame_too_large"
+  | "lifetime_bytes_exhausted"
+  | "lifetime_frames_exhausted"
+  | "process_closed"
+  | "backend_write_failed";
+
+/**
+ * Typed fail-closed rejection from {@link PtyBoundedInput.write}.
+ *
+ * The rejected payload is deliberately absent. Capacity/backend failures
+ * retire the capability permanently so a caller cannot ignore one rejected
+ * frame and continue with a divergent terminal input stream.
+ */
+export class PtyInputRejectedError extends Error {
+  readonly code = "pty_input_rejected" as const;
+  readonly reason: PtyInputRejectionReason;
+  readonly snapshot: PtyInputSnapshot;
+
+  constructor(args: {
+    reason: PtyInputRejectionReason;
+    snapshot: PtyInputSnapshot;
+    cause?: unknown;
+  }) {
+    super(
+      `bounded PTY input rejected: ${args.reason}`,
+      args.cause !== undefined ? { cause: args.cause } : undefined,
+    );
+    this.name = "PtyInputRejectedError";
+    this.reason = args.reason;
+    this.snapshot = args.snapshot;
+  }
+}
+
+export type PtyInputWriteReceipt =
+  | {
+      readonly status: "accepted";
+      readonly byteLength: number;
+      readonly snapshot: PtyInputSnapshot;
+    }
+  | {
+      readonly status: "ignored";
+      readonly reason: "empty";
+      readonly snapshot: PtyInputSnapshot;
+    };
+
+/**
+ * A bounded binary-only input capability for native attachment transports.
+ *
+ * `write` snapshots accepted input and reserves its byte+frame quota before
+ * invoking the opaque backend. It either returns an accepted/empty receipt or
+ * throws {@link PtyInputRejectedError}; it never silently drops a non-empty
+ * frame. There is intentionally no reset method.
+ */
+export interface PtyBoundedInput {
+  write(data: Uint8Array): PtyInputWriteReceipt;
+  snapshot(): PtyInputSnapshot;
+  /** Permanently reject future writes without releasing accepted capacity. */
+  close(): void;
+}
+
+/**
  * Optional listeners installed on the adapter's process wrapper before that
  * wrapper subscribes to the native child. This closes the post-spawn handle
  * handoff gap and captures even a child implementation which emits
@@ -82,7 +171,17 @@ export interface PtySpawnListeners {
 export interface PtyProcess {
   /** Underlying OS PID (or a synthetic positive integer for mocks). */
   readonly pid: number;
-  /** Write raw bytes (string is interpreted as UTF-8) into the child stdin. */
+  /**
+   * Fail-closed input for native attachment transports. This is the only PTY
+   * input surface whose opaque-backend memory can be bounded without a public
+   * node-pty drain callback.
+   */
+  readonly boundedInput: PtyBoundedInput;
+  /**
+   * Legacy, non-authoritative input with no completion or capacity proof.
+   * Native attachment transports MUST receive only `boundedInput`, never this
+   * process or method. Retained solely for the historical shell bridge.
+   */
   write(data: string | Uint8Array): void;
   /** Resize the controlling terminal. */
   resize(cols: number, rows: number): void;

--- a/packages/daemon/src/terminal/README.md
+++ b/packages/daemon/src/terminal/README.md
@@ -90,13 +90,15 @@ we register there.
   This is enforced by `pty-bridge.ts` now consuming `PtyAdapter` and is
   the gate G14-T10 will tighten further.
 - Native PTY input is intentionally not exposed by the grouped attachment
-  launcher yet. Installed node-pty's public `IPty.write(): void` offers no
-  drain/completion or pending-capacity signal while its Unix implementation
-  has a private asynchronous queue. Until an adapter/native helper provides a
-  real bounded-write contract, interactive writes fail with
-  `input-backpressure-unavailable`; this prevents stalled tmux readers from
-  growing an unobservable queue without bound. Output uses public
-  `IPty.pause()`/`resume()` and byte+frame caps.
+  launcher yet. `PtyProcess.boundedInput` now provides a monotonic fail-closed
+  primitive: it snapshots and accounts a fixed lifetime byte+frame budget
+  before each opaque node-pty call and never reclaims it. That bounds the
+  private queue without reading private fields, but it does not prove delivery.
+  Interactive attachment writes therefore continue to fail with
+  `input-backpressure-unavailable` until the direct stream owns typed
+  exhaustion/re-attach behavior. Legacy `PtyProcess.write()` is explicitly
+  non-authoritative and must never reach that stream. See ADR-0003. Output uses
+  public `IPty.pause()`/`resume()` and byte+frame caps.
 - Read-only attachment clients are also fail-closed in this first launcher
   slice. They fail before PTY spawn with `read_only_unavailable` until the
   daemon proves the installed tmux version and continuously holds an

--- a/packages/daemon/src/terminal/__tests__/MockPtyAdapter.test.ts
+++ b/packages/daemon/src/terminal/__tests__/MockPtyAdapter.test.ts
@@ -75,6 +75,30 @@ describe("MockPtyAdapter", () => {
     expect(proc.writeLog[1]).toEqual(new Uint8Array([1, 2, 3]));
   });
 
+  it("gives every fresh process an independent monotonic bounded-input generation", async () => {
+    const adapter = new MockPtyAdapter({
+      boundedInputLimits: {
+        maxFrameBytes: 2,
+        maxAcceptedBytes: 2,
+        maxAcceptedFrames: 1,
+      },
+    });
+    const first = (await adapter.spawn(baseInput)) as MockPtyProcess;
+    first.boundedInput.write(Uint8Array.of(1, 2));
+    expect(first.boundedInput.snapshot().state).toBe("exhausted");
+
+    const second = (await adapter.spawn(baseInput)) as MockPtyProcess;
+    second.boundedInput.write(Uint8Array.of(3, 4));
+
+    expect(first.boundedWriteLog).toEqual([Buffer.from([1, 2])]);
+    expect(second.boundedWriteLog).toEqual([Buffer.from([3, 4])]);
+    expect(second.boundedInput.snapshot()).toMatchObject({
+      state: "exhausted",
+      acceptedBytes: 2,
+      acceptedFrames: 1,
+    });
+  });
+
   it("resize logs every dimension change", async () => {
     const adapter = new MockPtyAdapter();
     const proc = (await adapter.spawn(baseInput)) as MockPtyProcess;

--- a/packages/daemon/src/terminal/__tests__/MockPtyAdapter.ts
+++ b/packages/daemon/src/terminal/__tests__/MockPtyAdapter.ts
@@ -19,10 +19,12 @@ import {
   PtySpawnError,
   type PtyAdapter,
   type PtyExitEvent,
+  type PtyInputLimits,
   type PtyProcess,
   type PtySpawnInput,
   type PtySpawnListeners,
 } from "../PtyAdapter.ts";
+import { DEFAULT_PTY_INPUT_LIMITS, MonotonicPtyInput } from "../MonotonicPtyInput.ts";
 
 export interface MockPtyOptions {
   /** Force `spawn` to reject with this error. Used by error-path tests. */
@@ -31,12 +33,16 @@ export interface MockPtyOptions {
   syncUnsupported?: boolean;
   /** Synthetic starting pid for spawned processes; auto-increments. */
   startingPid?: number;
+  /** Override the fresh monotonic input budget assigned to each mock process. */
+  boundedInputLimits?: PtyInputLimits;
 }
 
 export class MockPtyProcess implements PtyProcess {
   readonly pid: number;
   /** Append-only log of every `write(...)` call so tests can assert input. */
   readonly writeLog: Array<string | Uint8Array> = [];
+  /** Frames accepted through the fail-closed monotonic capability. */
+  readonly boundedWriteLog: Buffer[] = [];
   /** Append-only log of every `resize(...)` call. */
   readonly resizeLog: Array<{ cols: number; rows: number }> = [];
   /** Records the last signal observed by `kill(...)`. */
@@ -46,10 +52,19 @@ export class MockPtyProcess implements PtyProcess {
   private readonly dataListeners = new Set<(data: Buffer) => void>();
   private readonly exitListeners = new Set<(event: PtyExitEvent) => void>();
   private readonly _input: PtySpawnInput;
+  readonly boundedInput: MonotonicPtyInput;
 
-  constructor(pid: number, input: PtySpawnInput, listeners: PtySpawnListeners = {}) {
+  constructor(
+    pid: number,
+    input: PtySpawnInput,
+    listeners: PtySpawnListeners = {},
+    inputLimits: PtyInputLimits = DEFAULT_PTY_INPUT_LIMITS,
+  ) {
     this.pid = pid;
     this._input = input;
+    this.boundedInput = new MonotonicPtyInput(inputLimits, (frame) => {
+      this.boundedWriteLog.push(Buffer.from(frame));
+    });
     if (listeners.onData) this.dataListeners.add(listeners.onData);
     if (listeners.onExit) this.exitListeners.add(listeners.onExit);
   }
@@ -82,6 +97,7 @@ export class MockPtyProcess implements PtyProcess {
   kill(signal?: NodeJS.Signals | number): void {
     if (this.exited) return;
     this.killed = signal ?? "SIGTERM";
+    this.boundedInput.close();
     // Synthesize an exit so subscribers detach cleanly — matches the
     // node-pty fallback inside NodePtyAdapter.
     this.emitExit({ exitCode: 0, signal: typeof signal === "number" ? signal : null });
@@ -122,6 +138,7 @@ export class MockPtyProcess implements PtyProcess {
   emitExit(event: PtyExitEvent): void {
     if (this.exited) return;
     this.exited = true;
+    this.boundedInput.close();
     const listeners = [...this.exitListeners];
     this.dataListeners.clear();
     this.exitListeners.clear();
@@ -146,11 +163,13 @@ export class MockPtyAdapter implements PtyAdapter {
   private nextPid: number;
   private _failNext: MockPtyOptions["failNext"];
   private readonly syncUnsupported: boolean;
+  private readonly boundedInputLimits: PtyInputLimits;
 
   constructor(options: MockPtyOptions = {}) {
     this.nextPid = options.startingPid ?? 100_000;
     this._failNext = options.failNext;
     this.syncUnsupported = options.syncUnsupported ?? false;
+    this.boundedInputLimits = options.boundedInputLimits ?? DEFAULT_PTY_INPUT_LIMITS;
   }
 
   /** Arm the next spawn to throw a typed error. */
@@ -165,7 +184,7 @@ export class MockPtyAdapter implements PtyAdapter {
       throw new PtySpawnError({ adapter: this.id, code: err.code, message: err.message });
     }
     this.spawnLog.push(input);
-    const proc = new MockPtyProcess(this.nextPid++, input, listeners);
+    const proc = new MockPtyProcess(this.nextPid++, input, listeners, this.boundedInputLimits);
     this.spawned.push(proc);
     return proc;
   }
@@ -184,7 +203,7 @@ export class MockPtyAdapter implements PtyAdapter {
       throw new PtySpawnError({ adapter: this.id, code: err.code, message: err.message });
     }
     this.spawnLog.push(input);
-    const proc = new MockPtyProcess(this.nextPid++, input, listeners);
+    const proc = new MockPtyProcess(this.nextPid++, input, listeners, this.boundedInputLimits);
     this.spawned.push(proc);
     return proc;
   }

--- a/packages/daemon/src/terminal/__tests__/MonotonicPtyInput.test.ts
+++ b/packages/daemon/src/terminal/__tests__/MonotonicPtyInput.test.ts
@@ -63,7 +63,7 @@ describe("MonotonicPtyInput", () => {
 
     const first = rejection(() => input.write(Uint8Array.of(1, 2, 3)));
     expect(first.reason).toBe("backend_write_failed");
-    expect(first.cause).toBe(backendError);
+    expect(first.cause).toBeUndefined();
     expect(first.snapshot).toMatchObject({
       state: "failed",
       acceptedBytes: 3,
@@ -75,6 +75,30 @@ describe("MonotonicPtyInput", () => {
     expect(second.reason).toBe("process_closed");
     expect(second.snapshot.acceptedBytes).toBe(3);
     expect(sink).toHaveBeenCalledOnce();
+  });
+
+  it("redacts a backend failure and transitions the failed generation to closed", () => {
+    const payload = Buffer.from("sec");
+    const sensitiveBackendMessage = "opaque writer retained secret terminal input";
+    const input = new MonotonicPtyInput(limits, () => {
+      throw new Error(sensitiveBackendMessage);
+    });
+
+    const failure = rejection(() => input.write(payload));
+    expect(failure).toMatchObject({
+      reason: "backend_write_failed",
+      snapshot: { state: "failed", acceptedBytes: payload.byteLength, acceptedFrames: 1 },
+    });
+    expect(failure.cause).toBeUndefined();
+    expect(failure.message).not.toContain(sensitiveBackendMessage);
+
+    input.close();
+    expect(input.snapshot()).toMatchObject({
+      state: "closed",
+      acceptedBytes: payload.byteLength,
+      acceptedFrames: 1,
+    });
+    expect(rejection(() => input.write(Uint8Array.of(1))).reason).toBe("process_closed");
   });
 
   it("caps task metadata independently with a lifetime frame count", () => {

--- a/packages/daemon/src/terminal/__tests__/MonotonicPtyInput.test.ts
+++ b/packages/daemon/src/terminal/__tests__/MonotonicPtyInput.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import { MonotonicPtyInput, validatePtyInputLimits } from "../MonotonicPtyInput.ts";
+import { PtyInputRejectedError, type PtyInputLimits } from "../PtyAdapter.ts";
+
+const limits: PtyInputLimits = {
+  maxFrameBytes: 4,
+  maxAcceptedBytes: 6,
+  maxAcceptedFrames: 3,
+};
+
+function rejection(run: () => unknown): PtyInputRejectedError {
+  try {
+    run();
+  } catch (error) {
+    expect(error).toBeInstanceOf(PtyInputRejectedError);
+    return error as PtyInputRejectedError;
+  }
+  throw new Error("expected bounded PTY input rejection");
+}
+
+describe("MonotonicPtyInput", () => {
+  it("snapshots each frame before reserving it and crossing the opaque boundary", () => {
+    const held: Buffer[] = [];
+    const input = new MonotonicPtyInput(limits, (frame) => held.push(frame));
+    const source = Uint8Array.from([0x00, 0x80, 0xff]);
+
+    const receipt = input.write(source);
+    source.fill(0x41);
+
+    expect(held).toEqual([Buffer.from([0x00, 0x80, 0xff])]);
+    expect(receipt).toMatchObject({
+      status: "accepted",
+      byteLength: 3,
+      snapshot: { state: "open", acceptedBytes: 3, acceptedFrames: 1 },
+    });
+  });
+
+  it("bounds a fake backend that never drains by monotonic bytes and never calls it after refusal", () => {
+    const sink = vi.fn();
+    const input = new MonotonicPtyInput(limits, sink);
+
+    input.write(Uint8Array.of(1, 2, 3, 4));
+    input.write(Uint8Array.of(5, 6));
+    expect(input.snapshot()).toMatchObject({
+      state: "exhausted",
+      acceptedBytes: 6,
+      acceptedFrames: 2,
+      remainingBytes: 0,
+    });
+
+    const error = rejection(() => input.write(Uint8Array.of(7)));
+    expect(error.reason).toBe("lifetime_bytes_exhausted");
+    expect(error.snapshot.acceptedBytes).toBe(6);
+    expect(sink).toHaveBeenCalledTimes(2);
+  });
+
+  it("reserves a backend-throwing frame permanently and fails the capability closed", () => {
+    const backendError = new Error("opaque writer failed");
+    const sink = vi.fn(() => {
+      throw backendError;
+    });
+    const input = new MonotonicPtyInput(limits, sink);
+
+    const first = rejection(() => input.write(Uint8Array.of(1, 2, 3)));
+    expect(first.reason).toBe("backend_write_failed");
+    expect(first.cause).toBe(backendError);
+    expect(first.snapshot).toMatchObject({
+      state: "failed",
+      acceptedBytes: 3,
+      acceptedFrames: 1,
+      remainingBytes: 3,
+    });
+
+    const second = rejection(() => input.write(Uint8Array.of(4)));
+    expect(second.reason).toBe("process_closed");
+    expect(second.snapshot.acceptedBytes).toBe(3);
+    expect(sink).toHaveBeenCalledOnce();
+  });
+
+  it("caps task metadata independently with a lifetime frame count", () => {
+    const frameLimits: PtyInputLimits = {
+      maxFrameBytes: 4,
+      maxAcceptedBytes: 20,
+      maxAcceptedFrames: 2,
+    };
+    const sink = vi.fn();
+    const input = new MonotonicPtyInput(frameLimits, sink);
+
+    input.write(Uint8Array.of(1));
+    input.write(Uint8Array.of(2));
+    const error = rejection(() => input.write(Uint8Array.of(3)));
+
+    expect(error.reason).toBe("lifetime_frames_exhausted");
+    expect(error.snapshot).toMatchObject({
+      state: "exhausted",
+      acceptedBytes: 2,
+      acceptedFrames: 2,
+      remainingFrames: 0,
+    });
+    expect(sink).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects an oversized frame before copying it into the opaque writer", () => {
+    const sink = vi.fn();
+    const input = new MonotonicPtyInput(limits, sink);
+
+    const error = rejection(() => input.write(new Uint8Array(5)));
+
+    expect(error.reason).toBe("frame_too_large");
+    expect(error.snapshot).toMatchObject({ acceptedBytes: 0, acceptedFrames: 0 });
+    expect(sink).not.toHaveBeenCalled();
+    expect(rejection(() => input.write(Uint8Array.of(1))).reason).toBe("frame_too_large");
+  });
+
+  it("ignores zero bytes without spending byte or frame capacity", () => {
+    const sink = vi.fn();
+    const input = new MonotonicPtyInput(limits, sink);
+
+    expect(input.write(new Uint8Array())).toMatchObject({ status: "ignored", reason: "empty" });
+    expect(input.snapshot()).toMatchObject({ acceptedBytes: 0, acceptedFrames: 0 });
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it("closes permanently without releasing any accepted capacity", () => {
+    const input = new MonotonicPtyInput(limits, () => undefined);
+    input.write(Uint8Array.of(1, 2));
+    input.close();
+
+    const error = rejection(() => input.write(Uint8Array.of(3)));
+    expect(error.reason).toBe("process_closed");
+    expect(error.snapshot).toMatchObject({
+      state: "closed",
+      acceptedBytes: 2,
+      acceptedFrames: 1,
+    });
+  });
+
+  it("validates daemon-owned limits before accepting any input", () => {
+    expect(() =>
+      validatePtyInputLimits({
+        maxFrameBytes: 5,
+        maxAcceptedBytes: 4,
+        maxAcceptedFrames: 1,
+      }),
+    ).toThrow(/maxFrameBytes/u);
+    expect(() => validatePtyInputLimits({ ...limits, maxAcceptedFrames: 0 })).toThrow(
+      /maxAcceptedFrames/u,
+    );
+    expect(() =>
+      validatePtyInputLimits({
+        maxFrameBytes: 1,
+        maxAcceptedBytes: 1,
+        maxAcceptedFrames: 16_385,
+      }),
+    ).toThrow(/maxAcceptedFrames/u);
+    expect(validatePtyInputLimits(limits)).toEqual(limits);
+  });
+});

--- a/packages/daemon/src/terminal/__tests__/NodePtyAdapter.test.ts
+++ b/packages/daemon/src/terminal/__tests__/NodePtyAdapter.test.ts
@@ -23,7 +23,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { IPty, IPtyForkOptions } from "node-pty";
 import { NodePtyAdapter, ensureNodePtySpawnHelperExecutable } from "../NodePtyAdapter.ts";
-import { PtySpawnError } from "../PtyAdapter.ts";
+import { PtyInputRejectedError, PtySpawnError } from "../PtyAdapter.ts";
 
 const skipOnWin = process.platform === "win32";
 // node-pty's `onData` callback never fires under bun's runtime. This
@@ -50,6 +50,20 @@ function stubNodePty(write: IPty["write"]): IPty {
 }
 
 describe("NodePtyAdapter input encoding", () => {
+  it("rejects invalid bounded-input policy at adapter construction, before spawn", () => {
+    expect(
+      () =>
+        new NodePtyAdapter({
+          skipHelperEnsure: true,
+          boundedInputLimits: {
+            maxFrameBytes: 1,
+            maxAcceptedBytes: 1,
+            maxAcceptedFrames: 16_385,
+          },
+        }),
+    ).toThrow(/maxAcceptedFrames/u);
+  });
+
   it("passes raw bytes to node-pty without string transcoding and preserves UTF-8 strings", () => {
     const writes: Array<string | Buffer> = [];
     let spawnOptions: IPtyForkOptions | undefined;
@@ -140,6 +154,76 @@ describe("NodePtyAdapter input encoding", () => {
 
     expect(child.pause).toHaveBeenCalledOnce();
     expect(child.resume).toHaveBeenCalledOnce();
+  });
+
+  it("bounds an opaque node-pty writer that never reports drain", () => {
+    const writes: Array<string | Buffer> = [];
+    const child = stubNodePty((data) => writes.push(data));
+    const adapter = new NodePtyAdapter({
+      skipHelperEnsure: true,
+      spawnPty: () => child,
+      boundedInputLimits: {
+        maxFrameBytes: 3,
+        maxAcceptedBytes: 4,
+        maxAcceptedFrames: 2,
+      },
+    });
+    const proc = adapter.spawnSync({
+      shell: "/trusted/tmux",
+      cwd: process.cwd(),
+      cols: 80,
+      rows: 24,
+      env: { TERM: "xterm-256color" },
+      encoding: null,
+    });
+
+    proc.boundedInput.write(Uint8Array.of(0x00, 0x80, 0xff));
+    expect(() => proc.boundedInput.write(Uint8Array.of(1, 2))).toThrowError(
+      expect.objectContaining<Partial<PtyInputRejectedError>>({
+        reason: "lifetime_bytes_exhausted",
+      }),
+    );
+
+    expect(writes).toEqual([Buffer.from([0x00, 0x80, 0xff])]);
+    expect(proc.boundedInput.snapshot()).toMatchObject({
+      state: "exhausted",
+      acceptedBytes: 3,
+      acceptedFrames: 1,
+    });
+  });
+
+  it("does not reclaim reserved capacity when node-pty write throws", () => {
+    const backendError = new Error("write queue unavailable");
+    const child = stubNodePty(() => {
+      throw backendError;
+    });
+    const adapter = new NodePtyAdapter({
+      skipHelperEnsure: true,
+      spawnPty: () => child,
+      boundedInputLimits: {
+        maxFrameBytes: 4,
+        maxAcceptedBytes: 4,
+        maxAcceptedFrames: 2,
+      },
+    });
+    const proc = adapter.spawnSync({
+      shell: "/trusted/tmux",
+      cwd: process.cwd(),
+      cols: 80,
+      rows: 24,
+      env: { TERM: "xterm-256color" },
+    });
+
+    expect(() => proc.boundedInput.write(Uint8Array.of(1, 2, 3))).toThrowError(
+      expect.objectContaining<Partial<PtyInputRejectedError>>({
+        reason: "backend_write_failed",
+      }),
+    );
+    expect(proc.boundedInput.snapshot()).toMatchObject({
+      state: "failed",
+      acceptedBytes: 3,
+      acceptedFrames: 1,
+    });
   });
 });
 

--- a/packages/daemon/src/terminal/__tests__/PtyAdapter.contract.test.ts
+++ b/packages/daemon/src/terminal/__tests__/PtyAdapter.contract.test.ts
@@ -13,7 +13,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NodePtyAdapter } from "../NodePtyAdapter.ts";
-import { PtySpawnError, type PtyAdapter } from "../PtyAdapter.ts";
+import { PtyInputRejectedError, PtySpawnError, type PtyAdapter } from "../PtyAdapter.ts";
 import { MockPtyAdapter } from "./MockPtyAdapter.ts";
 
 interface AdapterCase {
@@ -83,6 +83,26 @@ for (const ctx of CASES) {
       });
       expect(proc.pid).toBeGreaterThan(0);
       proc.kill();
+    });
+
+    it("gives each process a binary bounded-input capability that closes with it", () => {
+      const adapter = ctx.make();
+      const proc = adapter.spawnSync({
+        shell: "/bin/cat",
+        cwd: workDir,
+        cols: 80,
+        rows: 24,
+        env: { ...process.env },
+        encoding: null,
+      });
+
+      expect(proc.boundedInput.write(Uint8Array.of(0x00, 0x80, 0xff))).toMatchObject({
+        status: "accepted",
+        byteLength: 3,
+        snapshot: { acceptedBytes: 3, acceptedFrames: 1 },
+      });
+      proc.kill();
+      expect(() => proc.boundedInput.write(Uint8Array.of(1))).toThrowError(PtyInputRejectedError);
     });
 
     it("spawn() rejects with PtySpawnError on an invalid cwd", async () => {


### PR DESCRIPTION
## Outcome

Adds a binary-only, monotonic PTY input capability that safely bounds the opaque node-pty writer without inspecting private fields or claiming drain completion.

- reserves bytes and frame count before every opaque write
- never reclaims capacity, including after backend failure
- typed fail-closed exhaustion with no input content in errors
- fresh quota only from a fresh PTY process generation
- default limits: 16 KiB frame, 256 KiB lifetime bytes, 8,192 lifetime frames
- hard unit-specific ceilings prevent task-metadata explosions
- keeps native attachment write gated; no launcher or Electron input path is enabled
- documents upstream fork/native-helper options and exact enablement gates in ADR-0003

## Verification

- 150 daemon test files, 2,414 tests passed with a 15s harness timeout on this loaded machine
- daemon typecheck passed
- focused terminal suite: 12 files, 163 tests passed
- Prettier, ESLint, and git diff check passed
- opt-in live SIGSTOP reader stress passed twice on macOS arm64 / Node 26.5.0; latest RSS delta 320 KiB against the 8 MiB gate after 4,096 typed refusals

## Deliberate gate

ClaimedPtyTmuxAttachment.write still throws input-backpressure-unavailable. Direct input must not be enabled until the binary WebSocket layer receives only PtyBoundedInput, retires and reattaches on typed exhaustion without replay, and the stalled-reader RSS matrix passes on macOS arm64/x64, Linux arm64/x64, and WSL2. Lossless long-lived input still benefits from a maintained public node-pty completion API as detailed in ADR-0003.