### PR TITLE
feat(daemon): add one-time terminal websocket admission

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -164,6 +164,31 @@ export {
   type ReconciledOrphanAttachmentDescriptor,
 } from "./terminal/attachments/lease-manager.ts";
 export {
+  TERMINAL_ATTACHMENT_MAX_CONTROL_BYTES,
+  TERMINAL_ATTACHMENT_MAX_LIVE_CONTROL_FRAMES,
+  TERMINAL_ATTACHMENT_MAX_REDEMPTION_BYTES,
+  TERMINAL_ATTACHMENT_MAX_REDEMPTION_MS,
+  TERMINAL_ATTACHMENT_REDEEM_PATH,
+  TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL,
+  TerminalAttachmentAdmissionCoordinator,
+  TerminalAttachmentAdmissionError,
+  type DirectTerminalAttachmentDescriptor,
+  type DirectTerminalAttachmentIssueContext,
+  type DirectTerminalAttachmentLauncher,
+  type DirectTerminalAttachmentLeaseManager,
+  type DirectTerminalSocket,
+  type TerminalAttachmentAdmissionCoordinatorOptions,
+  type TerminalAttachmentAdmissionErrorCode,
+  type TerminalAttachmentAdmissionSnapshot,
+  type TerminalAttachmentGeometry,
+  type TerminalAttachmentPreAuthAdmission,
+  type TerminalAttachmentUpgradeDecision,
+} from "./terminal/attachments/direct-websocket.ts";
+export {
+  attachTerminalAttachmentWebSocket,
+  type TerminalAttachmentWebSocketBoundary,
+} from "./server/terminal-attachment-upgrade.ts";
+export {
   TmuxAttachmentViewExecutor,
   TmuxAttachmentViewExecutorError,
   TmuxAttachmentClientTransportError,

--- a/packages/daemon/src/server/terminal-attachment-upgrade.ts
+++ b/packages/daemon/src/server/terminal-attachment-upgrade.ts
@@ -1,0 +1,127 @@
+import type { Server } from "node:http";
+import type { Socket } from "node:net";
+import { WebSocketServer } from "ws";
+import {
+  TERMINAL_ATTACHMENT_REDEEM_PATH,
+  TERMINAL_ATTACHMENT_MAX_REDEMPTION_BYTES,
+  TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL,
+  type DirectTerminalSocket,
+  type TerminalAttachmentAdmissionCoordinator,
+} from "../terminal/attachments/direct-websocket.ts";
+
+function protocols(value: string | string[] | undefined): readonly string[] {
+  if (typeof value !== "string") return [];
+  return value.split(",").map((entry) => entry.trim());
+}
+
+function rawHeaderValues(
+  request: import("node:http").IncomingMessage,
+  expectedName: string,
+): readonly string[] {
+  const values: string[] = [];
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    if (request.rawHeaders[index]?.toLowerCase() === expectedName) {
+      values.push(request.rawHeaders[index + 1] ?? "");
+    }
+  }
+  return values;
+}
+
+function rejectUpgrade(socket: Socket, status: number): void {
+  const phrase =
+    status === 403
+      ? "Forbidden"
+      : status === 404
+        ? "Not Found"
+        : status === 426
+          ? "Upgrade Required"
+          : "Service Unavailable";
+  try {
+    socket.end(`HTTP/1.1 ${status} ${phrase}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`);
+  } catch {
+    socket.destroy();
+  }
+}
+
+export interface TerminalAttachmentWebSocketBoundary {
+  close(): Promise<void>;
+}
+
+/**
+ * Thin Node/ws integration for the direct terminal state machine. It performs
+ * all path, protocol, Origin, and pre-auth capacity decisions before calling
+ * `handleUpgrade`, so rejected requests never become WebSockets.
+ */
+export function attachTerminalAttachmentWebSocket(
+  server: Server,
+  coordinator: TerminalAttachmentAdmissionCoordinator,
+): TerminalAttachmentWebSocketBoundary {
+  const wss = new WebSocketServer({
+    noServer: true,
+    clientTracking: false,
+    perMessageDeflate: false,
+    maxPayload: TERMINAL_ATTACHMENT_MAX_REDEMPTION_BYTES,
+    handleProtocols(offered) {
+      return offered.size === 1 && offered.has(TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL)
+        ? TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL
+        : false;
+    },
+  });
+
+  const upgrade = (
+    request: import("node:http").IncomingMessage,
+    socket: Socket,
+    head: Buffer,
+  ): void => {
+    const rawPath = request.url ?? "";
+    const pathname = rawPath.split("?", 1)[0] ?? "";
+    if (!pathname.startsWith("/v1/terminal/attachments/")) return;
+    if (pathname !== TERMINAL_ATTACHMENT_REDEEM_PATH) {
+      rejectUpgrade(socket, 404);
+      return;
+    }
+    const originHeaders = rawHeaderValues(request, "origin");
+    if (originHeaders.length !== 1) {
+      rejectUpgrade(socket, 403);
+      return;
+    }
+    const protocolHeaders = rawHeaderValues(request, "sec-websocket-protocol");
+    if (protocolHeaders.length !== 1) {
+      rejectUpgrade(socket, 426);
+      return;
+    }
+    const decision = coordinator.reserveUpgrade({
+      path: rawPath,
+      protocols: protocols(protocolHeaders[0]),
+      origin: originHeaders[0],
+    });
+    if (!decision.accepted) {
+      rejectUpgrade(socket, decision.httpStatus);
+      return;
+    }
+    const cancelUnbound = (): void => decision.admission.cancelBeforeBind();
+    socket.once("close", cancelUnbound);
+    socket.once("error", cancelUnbound);
+    try {
+      wss.handleUpgrade(request, socket, head, (ws) => {
+        socket.off("close", cancelUnbound);
+        socket.off("error", cancelUnbound);
+        decision.admission.bind(ws as unknown as DirectTerminalSocket);
+      });
+    } catch {
+      socket.off("close", cancelUnbound);
+      socket.off("error", cancelUnbound);
+      decision.admission.cancelBeforeBind();
+      socket.destroy();
+    }
+  };
+
+  server.on("upgrade", upgrade);
+  return {
+    close: async () => {
+      server.off("upgrade", upgrade);
+      await coordinator.shutdown();
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+    },
+  };
+}

--- a/packages/daemon/src/terminal/__tests__/direct-websocket.test.ts
+++ b/packages/daemon/src/terminal/__tests__/direct-websocket.test.ts
@@ -1,0 +1,893 @@
+import { EventEmitter } from "node:events";
+import { createServer } from "node:http";
+import { createConnection } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import type { TerminalAttachRequest } from "@tmux-ide/contracts";
+import {
+  TERMINAL_ATTACHMENT_REDEEM_PATH,
+  TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL,
+  TerminalAttachmentAdmissionCoordinator,
+  TerminalAttachmentAdmissionError,
+  type DirectTerminalAttachmentLeaseManager,
+  type DirectTerminalSocket,
+  type TerminalAttachmentPreAuthAdmission,
+} from "../attachments/direct-websocket.ts";
+import type {
+  AttachmentLeaseBinding,
+  AttachmentLeaseDescriptor,
+  ExecutedAttachmentViewOperation,
+  IssuedAttachmentLease,
+} from "../attachments/lease-manager.ts";
+import type { ClaimedPtyTmuxAttachment } from "../attachments/pty-tmux-attachment-launcher.ts";
+import { attachTerminalAttachmentWebSocket } from "../../server/terminal-attachment-upgrade.ts";
+
+const INSTANCE_ID = "daemon-instance-1";
+const ORIGIN = "tmux-ide://app";
+const OTHER_ORIGIN = "http://127.0.0.1:4173";
+const WS_URL = "ws://127.0.0.1:6070/v1/terminal/attachments/redeem";
+const REQUEST_ID = "2a215cf2-547e-42a2-91c7-454df8e56121";
+const LEASE_ID = "2ddc3f17-723b-4e16-a3d2-ad751fb01b2e";
+const ATTEMPT_ID = "2de42a2f-aa99-4eb5-8e04-4e3d45207d68";
+const TICKET = `ta1_${Buffer.alloc(32, 7).toString("base64url")}`;
+
+function request(viewerMode: "interactive" | "read-only" = "interactive"): TerminalAttachRequest {
+  return {
+    protocolVersion: 1,
+    target: { workspaceName: "workspace.alpha", semanticPaneId: "pane.codex" },
+    viewerMode,
+    viewport: { cols: 120, rows: 40 },
+  };
+}
+
+function descriptor(status: "awaiting-redemption" | "active" = "awaiting-redemption") {
+  return {
+    leaseId: LEASE_ID,
+    requestId: REQUEST_ID,
+    target: request().target,
+    viewerMode: "interactive" as const,
+    status,
+    issuedAt: 1_000,
+    expiresAt: 16_000,
+    graceExpiresAt: null,
+    bindingGeneration: 1,
+    viewGeneration: 0,
+  } satisfies AttachmentLeaseDescriptor;
+}
+
+class FakeLeaseManager implements DirectTerminalAttachmentLeaseManager {
+  readonly calls: string[] = [];
+  readonly releases: Array<{ leaseId: string; binding: AttachmentLeaseBinding }> = [];
+  redeemGate: Promise<void> | null = null;
+  releaseGate: Promise<void> | null = null;
+  renewGate: Promise<void> | null = null;
+  renewFailure = false;
+  renewViewGeneration = 0;
+  issuedTicket = TICKET;
+  nextLeaseId = LEASE_ID;
+  currentLeaseId = LEASE_ID;
+  currentRequestId = REQUEST_ID;
+  active = false;
+  consumed = false;
+
+  async issue(
+    _request: TerminalAttachRequest,
+    context: { requestId: string; projectIdentity: string },
+  ): Promise<IssuedAttachmentLease> {
+    this.calls.push("issue");
+    this.currentLeaseId = this.nextLeaseId;
+    this.currentRequestId = context.requestId;
+    const issued = { descriptor: this.leaseDescriptor() } as IssuedAttachmentLease;
+    Object.defineProperty(issued, "redemptionTicket", { value: this.issuedTicket });
+    return issued;
+  }
+
+  async redeem(ticket: string, _binding: AttachmentLeaseBinding) {
+    this.calls.push("redeem");
+    await this.redeemGate;
+    if (this.consumed || ticket !== this.issuedTicket) throw new Error("invalid ticket");
+    this.consumed = true;
+    this.active = true;
+    return { descriptor: this.leaseDescriptor("active") };
+  }
+
+  async executeViewOperation(
+    _leaseId: string,
+    _binding: AttachmentLeaseBinding,
+    operation: "create" | "attach",
+  ): Promise<ExecutedAttachmentViewOperation> {
+    this.calls.push(operation);
+    if (!this.active) throw new Error("inactive");
+    return {
+      descriptor: this.leaseDescriptor("active"),
+      operation,
+      ...(operation === "attach"
+        ? {
+            clientClaim: {
+              attachmentId: this.currentLeaseId,
+              generation: 0,
+              attemptId: ATTEMPT_ID,
+            },
+          }
+        : {}),
+    };
+  }
+
+  async renew(_leaseId: string, _binding: AttachmentLeaseBinding) {
+    this.calls.push("renew");
+    await this.renewGate;
+    if (this.renewFailure) throw new Error("renewal failed");
+    return {
+      descriptor: {
+        ...this.leaseDescriptor("active"),
+        expiresAt: 31_000,
+        bindingGeneration: 2,
+        viewGeneration: this.renewViewGeneration,
+      },
+    };
+  }
+
+  async release(leaseId: string, binding: AttachmentLeaseBinding) {
+    this.calls.push("release");
+    await this.releaseGate;
+    this.releases.push({ leaseId, binding: { ...binding } });
+    this.active = false;
+    return { released: true, cleanup: "cleaned" };
+  }
+
+  private leaseDescriptor(
+    status: "awaiting-redemption" | "active" = "awaiting-redemption",
+  ): AttachmentLeaseDescriptor {
+    return {
+      ...descriptor(status),
+      leaseId: this.currentLeaseId,
+      requestId: this.currentRequestId,
+    };
+  }
+}
+
+class FakeClient implements ClaimedPtyTmuxAttachment {
+  readonly attemptId = ATTEMPT_ID;
+  readonly attachmentId = LEASE_ID;
+  readonly generation = 0;
+  readonly pid = 1234;
+  readonly resizes: Array<[number, number]> = [];
+  readonly dataListeners = new Set<(data: Buffer) => void>();
+  readonly exitListeners = new Set<
+    (event: { readonly exitCode: number; readonly signal: number | null }) => void
+  >();
+  disposed = 0;
+
+  write(): never {
+    throw new Error("input unavailable");
+  }
+
+  resize(cols: number, rows: number): void {
+    this.resizes.push([cols, rows]);
+  }
+
+  onData(callback: (data: Buffer) => void): () => void {
+    this.dataListeners.add(callback);
+    return () => this.dataListeners.delete(callback);
+  }
+
+  onExit(
+    callback: (event: { readonly exitCode: number; readonly signal: number | null }) => void,
+  ): () => void {
+    this.exitListeners.add(callback);
+    return () => this.exitListeners.delete(callback);
+  }
+
+  dispose(): void {
+    this.disposed += 1;
+  }
+
+  output(bytes: Buffer): void {
+    for (const listener of this.dataListeners) listener(bytes);
+  }
+
+  exit(): void {
+    for (const listener of this.exitListeners) listener({ exitCode: 0, signal: null });
+  }
+}
+
+class FakeSocket extends EventEmitter implements DirectTerminalSocket {
+  readyState = 1;
+  bufferedAmount = 0;
+  readonly sent: Array<{ data: string | Buffer; binary: boolean }> = [];
+  readonly closes: Array<{ code?: number; reason?: string }> = [];
+
+  send(data: string | Buffer, options?: { binary?: boolean }): void {
+    this.sent.push({
+      data: Buffer.isBuffer(data) ? Buffer.from(data) : data,
+      binary: !!options?.binary,
+    });
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closes.push({ code, reason });
+    if (this.readyState !== 1) return;
+    this.readyState = 3;
+    this.emit("close");
+  }
+
+  frame(data: string | Buffer, isBinary = false): void {
+    this.emit("message", data, isBinary);
+  }
+}
+
+function redemption(ticket = TICKET, requestId = REQUEST_ID): string {
+  return JSON.stringify({
+    type: "redeem",
+    protocolVersion: 1,
+    ticket,
+    requestId,
+    daemonInstanceId: INSTANCE_ID,
+  });
+}
+
+function admission(
+  coordinator: TerminalAttachmentAdmissionCoordinator,
+  origin = ORIGIN,
+): TerminalAttachmentPreAuthAdmission {
+  const decision = coordinator.reserveUpgrade({
+    path: TERMINAL_ATTACHMENT_REDEEM_PATH,
+    protocols: [TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL],
+    origin,
+  });
+  if (!decision.accepted) throw new Error(decision.code);
+  return decision.admission;
+}
+
+function rig(
+  overrides: {
+    maxPendingTickets?: number;
+    maxPreAuthSockets?: number;
+    maxLiveConnections?: number;
+    redemptionTimeoutMs?: number;
+    maxBufferedOutputBytes?: number;
+    maxOutputFrameBytes?: number;
+    maxLiveControlFrames?: number;
+    schedule?: (callback: () => void, delayMs: number) => () => void;
+    now?: () => number;
+  } = {},
+) {
+  const manager = new FakeLeaseManager();
+  const client = new FakeClient();
+  const claim = vi.fn(() => client);
+  const resolveGeometry = vi.fn(async () => ({
+    sourceGrid: { cols: 120, rows: 40 },
+    clientViewport: { cols: 118, rows: 38 },
+  }));
+  const coordinator = new TerminalAttachmentAdmissionCoordinator({
+    daemonInstanceId: INSTANCE_ID,
+    webSocketUrl: WS_URL,
+    leaseManager: manager,
+    launcher: { claim },
+    resolveGeometry,
+    now: overrides.now ?? (() => 1_000),
+    ...overrides,
+  });
+  return { coordinator, manager, client, claim, resolveGeometry };
+}
+
+async function issue(coordinator: TerminalAttachmentAdmissionCoordinator, origin = ORIGIN) {
+  return coordinator.issue(request(), {
+    requestId: REQUEST_ID,
+    projectIdentity: "project-alpha",
+    rendererOrigin: origin,
+  });
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function rawUpgradeStatus(port: number, headers: readonly string[]): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const socket = createConnection({ host: "127.0.0.1", port });
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.once("error", reject);
+    socket.on("data", (chunk) => {
+      response += chunk;
+      const match = response.match(/^HTTP\/1\.1 ([0-9]{3})/u);
+      if (match) {
+        socket.destroy();
+        resolve(Number(match[1]));
+      }
+    });
+    socket.once("connect", () => {
+      socket.write(
+        [
+          `GET ${TERMINAL_ATTACHMENT_REDEEM_PATH} HTTP/1.1`,
+          `Host: 127.0.0.1:${port}`,
+          "Connection: Upgrade",
+          "Upgrade: websocket",
+          "Sec-WebSocket-Version: 13",
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+          ...headers,
+          "",
+          "",
+        ].join("\r\n"),
+      );
+    });
+  });
+}
+
+describe("TerminalAttachmentAdmissionCoordinator", () => {
+  it("issues one renderer descriptor while retaining only bounded redacted state", async () => {
+    const { coordinator, manager } = rig();
+    const issued = await issue(coordinator);
+    expect(issued).toEqual({
+      protocolVersion: 1,
+      webSocketUrl: WS_URL,
+      redemptionTicket: TICKET,
+      daemonInstanceId: INSTANCE_ID,
+      requestId: REQUEST_ID,
+      expiresAt: 16_000,
+      effectiveViewerMode: "interactive",
+    });
+    expect(coordinator.toJSON()).toEqual({
+      pendingTickets: 1,
+      preAuthSockets: 0,
+      liveConnections: 0,
+      shuttingDown: false,
+    });
+    expect(JSON.stringify(coordinator)).not.toContain(TICKET);
+    expect(JSON.stringify(coordinator)).not.toContain(LEASE_ID);
+    expect(manager.calls).toEqual(["issue"]);
+    await coordinator.shutdown();
+  });
+
+  it("rejects read-only before lease issue and atomically bounds pending issue", async () => {
+    const { coordinator, manager } = rig({ maxPendingTickets: 1 });
+    await expect(
+      coordinator.issue(request("read-only"), {
+        requestId: REQUEST_ID,
+        projectIdentity: "project-alpha",
+        rendererOrigin: ORIGIN,
+      }),
+    ).rejects.toMatchObject({ code: "read_only_unavailable" });
+    await issue(coordinator);
+    await expect(
+      coordinator.issue(request(), {
+        requestId: "fa8e7197-2236-4a62-bc01-5b64dd18c267",
+        projectIdentity: "project-alpha",
+        rendererOrigin: ORIGIN,
+      }),
+    ).rejects.toMatchObject({ code: "pending-capacity-exhausted" });
+    expect(manager.calls.filter((call) => call === "issue")).toHaveLength(1);
+    await coordinator.shutdown();
+  });
+
+  it("rejects path, protocol, missing/null/wrong Origin and pre-auth saturation before bind", async () => {
+    const { coordinator } = rig({ maxPreAuthSockets: 1 });
+    await issue(coordinator);
+    const attempts = [
+      coordinator.reserveUpgrade({
+        path: `${TERMINAL_ATTACHMENT_REDEEM_PATH}?ticket=forbidden`,
+        protocols: [TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL],
+        origin: ORIGIN,
+      }),
+      coordinator.reserveUpgrade({
+        path: TERMINAL_ATTACHMENT_REDEEM_PATH,
+        protocols: [],
+        origin: ORIGIN,
+      }),
+      coordinator.reserveUpgrade({
+        path: TERMINAL_ATTACHMENT_REDEEM_PATH,
+        protocols: [TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL, "duplicate"],
+        origin: ORIGIN,
+      }),
+      coordinator.reserveUpgrade({
+        path: TERMINAL_ATTACHMENT_REDEEM_PATH,
+        protocols: [TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL],
+        origin: null,
+      }),
+      coordinator.reserveUpgrade({
+        path: TERMINAL_ATTACHMENT_REDEEM_PATH,
+        protocols: [TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL],
+        origin: "null",
+      }),
+      coordinator.reserveUpgrade({
+        path: TERMINAL_ATTACHMENT_REDEEM_PATH,
+        protocols: [TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL],
+        origin: OTHER_ORIGIN,
+      }),
+    ];
+    expect(attempts.map((entry) => (entry.accepted ? "accepted" : entry.code))).toEqual([
+      "invalid-path",
+      "invalid-subprotocol",
+      "invalid-subprotocol",
+      "invalid-origin",
+      "invalid-origin",
+      "origin-rejected",
+    ]);
+    const first = admission(coordinator);
+    expect(coordinator.snapshot().preAuthSockets).toBe(1);
+    expect(
+      coordinator.reserveUpgrade({
+        path: TERMINAL_ATTACHMENT_REDEEM_PATH,
+        protocols: [TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL],
+        origin: ORIGIN,
+      }),
+    ).toEqual({ accepted: false, code: "preauth-capacity-exhausted", httpStatus: 503 });
+    first.cancelBeforeBind();
+    expect(coordinator.snapshot().preAuthSockets).toBe(0);
+    await coordinator.shutdown();
+  });
+
+  it("enforces one text redemption frame, 4 KiB, and the deadline with exact reclamation", async () => {
+    const scheduled: Array<{ callback: () => void; cancelled: boolean; delay: number }> = [];
+    const schedule = (callback: () => void, delay: number) => {
+      const entry = { callback, cancelled: false, delay };
+      scheduled.push(entry);
+      return () => {
+        entry.cancelled = true;
+      };
+    };
+    const { coordinator, manager } = rig({ schedule, redemptionTimeoutMs: 50 });
+    await issue(coordinator);
+
+    const binaryAdmission = admission(coordinator);
+    const binarySocket = new FakeSocket();
+    binaryAdmission.bind(binarySocket);
+    binarySocket.frame(Buffer.from(redemption()), true);
+    expect(binarySocket.closes.at(-1)?.code).toBe(1009);
+
+    const oversizedAdmission = admission(coordinator);
+    const oversizedSocket = new FakeSocket();
+    oversizedAdmission.bind(oversizedSocket);
+    oversizedSocket.frame("x".repeat(4_097));
+    expect(oversizedSocket.closes.at(-1)?.code).toBe(1009);
+
+    const timeoutAdmission = admission(coordinator);
+    const timeoutSocket = new FakeSocket();
+    timeoutAdmission.bind(timeoutSocket);
+    const deadline = scheduled.findLast((entry) => entry.delay === 50 && !entry.cancelled);
+    expect(deadline).toBeDefined();
+    deadline!.callback();
+    expect(timeoutSocket.closes.at(-1)).toEqual({ code: 1008, reason: "redemption-timeout" });
+    expect(coordinator.snapshot().preAuthSockets).toBe(0);
+    expect(coordinator.snapshot().pendingTickets).toBe(1);
+    const pendingExpiry = scheduled.find((entry) => entry.delay === 15_000 && !entry.cancelled);
+    expect(pendingExpiry).toBeDefined();
+    pendingExpiry!.callback();
+    await flush();
+    expect(coordinator.snapshot().pendingTickets).toBe(0);
+    expect(manager.releases).toHaveLength(1);
+    await coordinator.shutdown();
+  });
+
+  it("consumes pending into exactly one live slot, claims once, and streams output directly", async () => {
+    const { coordinator, manager, client, claim } = rig();
+    await issue(coordinator);
+    const pending = admission(coordinator);
+    const socket = new FakeSocket();
+    pending.bind(socket);
+    socket.frame(redemption());
+    await flush();
+    await flush();
+
+    expect(manager.calls.slice(0, 4)).toEqual(["issue", "redeem", "create", "attach"]);
+    expect(claim).toHaveBeenCalledOnce();
+    expect(coordinator.snapshot()).toEqual({
+      pendingTickets: 0,
+      preAuthSockets: 0,
+      liveConnections: 1,
+      shuttingDown: false,
+    });
+    expect(JSON.parse(socket.sent[0]!.data as string)).toMatchObject({
+      type: "ready",
+      effectiveViewerMode: "interactive",
+      inputCapability: "unavailable",
+      sourceGrid: { cols: 120, rows: 40 },
+      clientViewport: { cols: 118, rows: 38 },
+    });
+    client.output(Buffer.from([0, 255, 13, 10]));
+    expect(socket.sent.at(-1)).toEqual({ data: Buffer.from([0, 255, 13, 10]), binary: true });
+
+    socket.frame(Buffer.from("typed input"), true);
+    expect(JSON.parse(socket.sent.at(-1)!.data as string)).toMatchObject({
+      type: "mutation-error",
+      code: "input-backpressure-unavailable",
+    });
+    await flush();
+    expect(client.disposed).toBe(1);
+    expect(coordinator.snapshot().liveConnections).toBe(0);
+    expect(manager.releases).toHaveLength(1);
+    await coordinator.shutdown();
+  });
+
+  it("bounds live control frames and awaits lease release during shutdown", async () => {
+    const { coordinator, manager, client } = rig({ maxLiveControlFrames: 2 });
+    await issue(coordinator);
+    const socket = new FakeSocket();
+    admission(coordinator).bind(socket);
+    socket.frame(redemption());
+    await flush();
+    await flush();
+    const resize = JSON.stringify({
+      type: "resize",
+      protocolVersion: 1,
+      generation: 0,
+      viewport: { cols: 100, rows: 30 },
+    });
+    socket.frame(resize);
+    socket.frame(resize);
+    socket.frame(resize);
+    expect(socket.closes.at(-1)?.reason).toBe("control-frame-limit");
+    expect(client.disposed).toBe(1);
+
+    manager.consumed = false;
+    manager.issuedTicket = `ta1_${Buffer.alloc(32, 9).toString("base64url")}`;
+    manager.nextLeaseId = "96064a6b-478a-4d07-ab83-b1ffdbd6358f";
+    await coordinator.issue(request(), {
+      requestId: "fa8e7197-2236-4a62-bc01-5b64dd18c267",
+      projectIdentity: "project-alpha",
+      rendererOrigin: ORIGIN,
+    });
+    const liveSocket = new FakeSocket();
+    admission(coordinator).bind(liveSocket);
+    liveSocket.frame(redemption(manager.issuedTicket, "fa8e7197-2236-4a62-bc01-5b64dd18c267"));
+    await flush();
+    await flush();
+    expect(coordinator.snapshot().liveConnections).toBe(1);
+    let releaseCleanup!: () => void;
+    manager.releaseGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    let shutdownSettled = false;
+    const shutdown = coordinator.shutdown().then(() => {
+      shutdownSettled = true;
+    });
+    await flush();
+    expect(shutdownSettled).toBe(false);
+    releaseCleanup();
+    await shutdown;
+    expect(shutdownSettled).toBe(true);
+  });
+
+  it("renews a stable live lease before expiry and retires on renewal failure", async () => {
+    let now = 1_000;
+    const scheduled: Array<{ callback: () => void; cancelled: boolean; delay: number }> = [];
+    const schedule = (callback: () => void, delay: number) => {
+      const entry = { callback, cancelled: false, delay };
+      scheduled.push(entry);
+      return () => {
+        entry.cancelled = true;
+      };
+    };
+    const { coordinator, manager, resolveGeometry } = rig({
+      now: () => now,
+      schedule,
+    });
+    await issue(coordinator);
+    const socket = new FakeSocket();
+    admission(coordinator).bind(socket);
+    socket.frame(redemption());
+    await flush();
+    await flush();
+    const firstRenewal = scheduled.find((entry) => entry.delay === 10_000 && !entry.cancelled);
+    expect(firstRenewal).toBeDefined();
+    now = 11_000;
+    firstRenewal!.callback();
+    await flush();
+    await flush();
+    expect(manager.calls.filter((call) => call === "renew")).toHaveLength(1);
+    expect(resolveGeometry).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(socket.sent.at(-1)!.data as string)).toMatchObject({
+      type: "geometry",
+      generation: 0,
+    });
+    expect(scheduled.some((entry) => entry.delay === 20_000 && !entry.cancelled)).toBe(true);
+
+    manager.renewFailure = true;
+    const nextRenewal = scheduled.find((entry) => entry.delay === 13_333 && !entry.cancelled);
+    expect(nextRenewal).toBeDefined();
+    nextRenewal!.callback();
+    await flush();
+    await flush();
+    expect(socket.closes.at(-1)).toEqual({ code: 1012, reason: "attachment-renewal-failed" });
+    expect(coordinator.snapshot().liveConnections).toBe(0);
+    await coordinator.shutdown();
+  });
+
+  it("expires a live connection at the hard lease deadline while renewal is stalled", async () => {
+    let now = 1_000;
+    const scheduled: Array<{ callback: () => void; cancelled: boolean; delay: number }> = [];
+    const schedule = (callback: () => void, delay: number) => {
+      const entry = { callback, cancelled: false, delay };
+      scheduled.push(entry);
+      return () => {
+        entry.cancelled = true;
+      };
+    };
+    const { coordinator, manager, client } = rig({ now: () => now, schedule });
+    let finishRenewal!: () => void;
+    manager.renewGate = new Promise<void>((resolve) => {
+      finishRenewal = resolve;
+    });
+    await issue(coordinator);
+    const socket = new FakeSocket();
+    admission(coordinator).bind(socket);
+    socket.frame(redemption());
+    await flush();
+    await flush();
+    const renewal = scheduled.find((entry) => entry.delay === 10_000 && !entry.cancelled);
+    const expiry = scheduled.find((entry) => entry.delay === 15_000 && !entry.cancelled);
+    expect(renewal).toBeDefined();
+    expect(expiry).toBeDefined();
+    now = 11_000;
+    renewal!.callback();
+    await flush();
+    now = 16_000;
+    expiry!.callback();
+    expect(socket.closes.at(-1)).toEqual({ code: 1008, reason: "attachment-expired" });
+    expect(client.disposed).toBe(1);
+    finishRenewal();
+    await flush();
+    await coordinator.shutdown();
+  });
+
+  it("coalesces resize and reports authoritative geometry without accepting retired generations", async () => {
+    const { coordinator, client, resolveGeometry } = rig();
+    await issue(coordinator);
+    const pending = admission(coordinator);
+    const socket = new FakeSocket();
+    pending.bind(socket);
+    socket.frame(redemption());
+    await flush();
+    await flush();
+    socket.frame(
+      JSON.stringify({
+        type: "resize",
+        protocolVersion: 1,
+        generation: 0,
+        viewport: { cols: 100, rows: 30 },
+      }),
+    );
+    socket.frame(
+      JSON.stringify({
+        type: "resize",
+        protocolVersion: 1,
+        generation: 0,
+        viewport: { cols: 90, rows: 25 },
+      }),
+    );
+    await flush();
+    expect(client.resizes.at(-1)).toEqual([90, 25]);
+    expect(resolveGeometry.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(JSON.parse(socket.sent.at(-1)!.data as string).type).toBe("geometry");
+
+    socket.frame(
+      JSON.stringify({
+        type: "resize",
+        protocolVersion: 1,
+        generation: 1,
+        viewport: { cols: 80, rows: 24 },
+      }),
+    );
+    expect(socket.closes.at(-1)?.reason).toBe("retired-generation");
+    await coordinator.shutdown();
+  });
+
+  it("allows only one of two sockets racing the same ticket and reclaims both pre-auth slots", async () => {
+    const { coordinator, claim } = rig({ maxPreAuthSockets: 2 });
+    await issue(coordinator);
+    const firstSocket = new FakeSocket();
+    const secondSocket = new FakeSocket();
+    admission(coordinator).bind(firstSocket);
+    admission(coordinator).bind(secondSocket);
+    firstSocket.frame(redemption());
+    secondSocket.frame(redemption());
+    await flush();
+    await flush();
+    await flush();
+    expect(claim).toHaveBeenCalledOnce();
+    expect(coordinator.snapshot()).toMatchObject({
+      pendingTickets: 0,
+      preAuthSockets: 0,
+      liveConnections: 1,
+    });
+    expect([firstSocket, secondSocket].filter((socket) => socket.closes.length > 0)).toHaveLength(
+      1,
+    );
+    await coordinator.shutdown();
+  });
+
+  it("retires a socket that sends a second frame while redemption is still pending", async () => {
+    const { coordinator, manager, claim } = rig();
+    let releaseRedeem!: () => void;
+    manager.redeemGate = new Promise<void>((resolve) => {
+      releaseRedeem = resolve;
+    });
+    await issue(coordinator);
+    const socket = new FakeSocket();
+    admission(coordinator).bind(socket);
+    socket.frame(redemption());
+    socket.frame(redemption());
+    expect(socket.closes.at(-1)?.reason).toBe("redemption-frame-rejected");
+    releaseRedeem();
+    await flush();
+    await flush();
+    expect(claim).not.toHaveBeenCalled();
+    expect(coordinator.snapshot()).toMatchObject({
+      pendingTickets: 0,
+      preAuthSockets: 0,
+      liveConnections: 0,
+    });
+    expect(manager.releases).toHaveLength(1);
+    await coordinator.shutdown();
+  });
+
+  it("retires a ticket without spawning when live capacity is saturated", async () => {
+    const { coordinator, manager, claim } = rig({ maxLiveConnections: 1 });
+    await issue(coordinator);
+    const firstSocket = new FakeSocket();
+    admission(coordinator).bind(firstSocket);
+    firstSocket.frame(redemption());
+    await flush();
+    await flush();
+    expect(coordinator.snapshot().liveConnections).toBe(1);
+
+    manager.consumed = false;
+    manager.issuedTicket = `ta1_${Buffer.alloc(32, 8).toString("base64url")}`;
+    manager.nextLeaseId = "96064a6b-478a-4d07-ab83-b1ffdbd6358f";
+    await coordinator.issue(request(), {
+      requestId: "fa8e7197-2236-4a62-bc01-5b64dd18c267",
+      projectIdentity: "project-alpha",
+      rendererOrigin: ORIGIN,
+    });
+    const secondSocket = new FakeSocket();
+    admission(coordinator).bind(secondSocket);
+    secondSocket.frame(redemption(manager.issuedTicket, "fa8e7197-2236-4a62-bc01-5b64dd18c267"));
+    await flush();
+    await flush();
+    expect(secondSocket.closes.at(-1)?.code).toBe(1013);
+    expect(coordinator.snapshot()).toMatchObject({ pendingTickets: 0, liveConnections: 1 });
+    expect(claim).toHaveBeenCalledOnce();
+    expect(manager.releases.some((entry) => entry.leaseId === manager.nextLeaseId)).toBe(true);
+    await coordinator.shutdown();
+  });
+
+  it("closes at output HWM and releases every live resource idempotently", async () => {
+    const { coordinator, manager, client } = rig({
+      maxBufferedOutputBytes: 128,
+      maxOutputFrameBytes: 64,
+    });
+    await issue(coordinator);
+    const socket = new FakeSocket();
+    admission(coordinator).bind(socket);
+    socket.frame(redemption());
+    await flush();
+    await flush();
+    socket.bufferedAmount = 100;
+    client.output(Buffer.alloc(40));
+    await flush();
+    expect(socket.closes.at(-1)).toEqual({ code: 1013, reason: "output-backpressure" });
+    expect(client.disposed).toBe(1);
+    socket.emit("close");
+    expect(client.disposed).toBe(1);
+    expect(manager.releases).toHaveLength(1);
+    expect(coordinator.snapshot().liveConnections).toBe(0);
+    await coordinator.shutdown();
+  });
+
+  it("never includes bearer material in typed errors", () => {
+    const error = new TerminalAttachmentAdmissionError(
+      "redemption-rejected",
+      "Terminal attachment redemption was rejected.",
+    );
+    expect(JSON.stringify(error)).not.toContain(TICKET);
+    expect(error.message).not.toContain(TICKET);
+  });
+
+  it("rejects invalid upgrade metadata before 101 and carries live bytes without Electron", async () => {
+    const { coordinator, client } = rig({ maxPreAuthSockets: 1 });
+    await issue(coordinator);
+    const server = createServer((_request, response) => {
+      response.writeHead(404).end();
+    });
+    const boundary = attachTerminalAttachmentWebSocket(server, coordinator);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("test server did not bind");
+    const url = `ws://127.0.0.1:${address.port}${TERMINAL_ATTACHMENT_REDEEM_PATH}`;
+
+    expect(
+      await rawUpgradeStatus(address.port, [
+        `Origin: ${ORIGIN}`,
+        `Origin: ${ORIGIN}`,
+        `Sec-WebSocket-Protocol: ${TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL}`,
+      ]),
+    ).toBe(403);
+    expect(
+      await rawUpgradeStatus(address.port, [
+        `Origin: ${ORIGIN}`,
+        `Sec-WebSocket-Protocol: ${TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL}`,
+        `Sec-WebSocket-Protocol: ${TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL}`,
+      ]),
+    ).toBe(426);
+
+    const rejectedStatus = await new Promise<number>((resolve, reject) => {
+      const socket = new WebSocket(url, TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL, {
+        origin: OTHER_ORIGIN,
+      });
+      socket.once("unexpected-response", (_request, response) => {
+        resolve(response.statusCode ?? 0);
+        response.destroy();
+      });
+      socket.once("open", () => reject(new Error("wrong Origin reached 101")));
+      socket.once("error", () => undefined);
+    });
+    expect(rejectedStatus).toBe(403);
+
+    const stalled = new WebSocket(url, TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL, { origin: ORIGIN });
+    await new Promise<void>((resolve, reject) => {
+      stalled.once("open", resolve);
+      stalled.once("error", reject);
+    });
+    const saturatedStatus = await new Promise<number>((resolve, reject) => {
+      const socket = new WebSocket(url, TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL, {
+        origin: ORIGIN,
+      });
+      socket.once("unexpected-response", (_request, response) => {
+        resolve(response.statusCode ?? 0);
+        response.destroy();
+      });
+      socket.once("open", () => reject(new Error("saturated pre-auth cap reached 101")));
+      socket.once("error", () => undefined);
+    });
+    expect(saturatedStatus).toBe(503);
+    stalled.close();
+    await new Promise<void>((resolve) => stalled.once("close", resolve));
+
+    const live = new WebSocket(url, TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL, { origin: ORIGIN });
+    const frames: Array<{ data: Buffer; binary: boolean }> = [];
+    live.on("message", (data, binary) =>
+      frames.push({ data: Buffer.from(data as Buffer), binary }),
+    );
+    await new Promise<void>((resolve, reject) => {
+      live.once("open", resolve);
+      live.once("error", reject);
+    });
+    live.send(redemption());
+    await vi.waitFor(() => {
+      expect(
+        frames.some((frame) => !frame.binary && frame.data.toString().includes('"ready"')),
+      ).toBe(true);
+    });
+    client.output(Buffer.from([1, 0, 255, 2]));
+    await vi.waitFor(() => {
+      expect(
+        frames.some((frame) => frame.binary && frame.data.equals(Buffer.from([1, 0, 255, 2]))),
+      ).toBe(true);
+    });
+    live.close();
+    await new Promise<void>((resolve) => live.once("close", resolve));
+    await boundary.close();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  });
+
+  it("refuses non-loopback descriptor endpoints", () => {
+    const { coordinator, ...dependencies } = rig();
+    void coordinator.shutdown();
+    expect(
+      () =>
+        new TerminalAttachmentAdmissionCoordinator({
+          daemonInstanceId: INSTANCE_ID,
+          webSocketUrl: `ws://192.0.2.10:6070${TERMINAL_ATTACHMENT_REDEEM_PATH}`,
+          leaseManager: dependencies.manager,
+          launcher: { claim: dependencies.claim },
+          resolveGeometry: dependencies.resolveGeometry,
+        }),
+    ).toThrow("WebSocket URL is invalid");
+  });
+});

--- a/packages/daemon/src/terminal/__tests__/direct-websocket.test.ts
+++ b/packages/daemon/src/terminal/__tests__/direct-websocket.test.ts
@@ -549,6 +549,68 @@ describe("TerminalAttachmentAdmissionCoordinator", () => {
     expect(shutdownSettled).toBe(true);
   });
 
+  it("awaits a gated lease release that started before shutdown on peer close", async () => {
+    const { coordinator, manager } = rig();
+    await issue(coordinator);
+    const socket = new FakeSocket();
+    admission(coordinator).bind(socket);
+    socket.frame(redemption());
+    await flush();
+    await flush();
+
+    let releaseCleanup!: () => void;
+    manager.releaseGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    socket.readyState = 3;
+    socket.emit("close");
+    expect(coordinator.snapshot().liveConnections).toBe(0);
+    expect(manager.calls.at(-1)).toBe("release");
+
+    let shutdownSettled = false;
+    const shutdown = coordinator.shutdown().then(() => {
+      shutdownSettled = true;
+    });
+    await flush();
+    expect(shutdownSettled).toBe(false);
+
+    releaseCleanup();
+    await shutdown;
+    expect(shutdownSettled).toBe(true);
+    expect(manager.releases).toHaveLength(1);
+  });
+
+  it("returns one shared shutdown barrier to concurrent callers", async () => {
+    const { coordinator, manager } = rig();
+    await issue(coordinator);
+    const socket = new FakeSocket();
+    admission(coordinator).bind(socket);
+    socket.frame(redemption());
+    await flush();
+    await flush();
+
+    let releaseCleanup!: () => void;
+    manager.releaseGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const first = coordinator.shutdown();
+    const second = coordinator.shutdown();
+    expect(second).toBe(first);
+
+    let settled = false;
+    void second.then(() => {
+      settled = true;
+    });
+    await flush();
+    expect(settled).toBe(false);
+    expect(socket.closes.at(-1)).toEqual({ code: 1001, reason: "daemon-shutdown" });
+
+    releaseCleanup();
+    await Promise.all([first, second]);
+    expect(settled).toBe(true);
+    expect(manager.releases).toHaveLength(1);
+  });
+
   it("renews a stable live lease before expiry and retires on renewal failure", async () => {
     let now = 1_000;
     const scheduled: Array<{ callback: () => void; cancelled: boolean; delay: number }> = [];

--- a/packages/daemon/src/terminal/attachments/direct-websocket.ts
+++ b/packages/daemon/src/terminal/attachments/direct-websocket.ts
@@ -363,10 +363,12 @@ export class TerminalAttachmentAdmissionCoordinator {
   readonly #pending = new Map<string, PendingTicket>();
   readonly #preAuth = new Set<PreAuthAdmission>();
   readonly #live = new Set<TerminalAttachmentLiveConnection>();
+  readonly #retiringReleases = new Set<Promise<void>>();
   #pendingReservations = 0;
   #liveReservations = 0;
   #operationTail: Promise<void> = Promise.resolve();
   #shuttingDown = false;
+  #shutdownPromise: Promise<void> | null = null;
 
   constructor(options: TerminalAttachmentAdmissionCoordinatorOptions) {
     this.#instanceId = BindingIdSchemaZ.parse(options.daemonInstanceId);
@@ -558,16 +560,25 @@ export class TerminalAttachmentAdmissionCoordinator {
     return this.snapshot();
   }
 
-  async shutdown(): Promise<void> {
-    if (this.#shuttingDown) return;
+  shutdown(): Promise<void> {
+    if (this.#shutdownPromise) return this.#shutdownPromise;
     this.#shuttingDown = true;
+    this.#shutdownPromise = this.#finishShutdown();
+    return this.#shutdownPromise;
+  }
+
+  async #finishShutdown(): Promise<void> {
     for (const admission of [...this.#preAuth]) admission.close(1001, "daemon-shutdown");
-    const live = [...this.#live];
-    for (const connection of live) connection.close(1001, "daemon-shutdown");
-    await Promise.all(live.map((connection) => connection.waitForRelease()));
     await this.#exclusive(async () => {
+      // Operations admitted before shutdown may have crossed async lease or
+      // launcher boundaries. Sweep only after they have left the serialized
+      // section so a late-created live connection cannot escape teardown.
+      for (const connection of [...this.#live]) {
+        connection.close(1001, "daemon-shutdown");
+      }
       for (const pending of [...this.#pending.values()]) await this.#retirePending(pending);
     });
+    await Promise.all([...this.#retiringReleases]);
   }
 
   #redeem(
@@ -674,7 +685,7 @@ export class TerminalAttachmentAdmissionCoordinator {
           );
         }
         const live = new TerminalAttachmentLiveConnection({
-          onRetire: (connection) => this.#live.delete(connection),
+          onRetire: (connection) => this.#trackRetiringRelease(connection),
           socket,
           client,
           leaseManager: this.#leaseManager,
@@ -756,6 +767,16 @@ export class TerminalAttachmentAdmissionCoordinator {
       // The lease manager may already have retired the one-use lease. No
       // credential, target proof, or terminal bytes are reflected outward.
     }
+  }
+
+  #trackRetiringRelease(connection: TerminalAttachmentLiveConnection): void {
+    this.#live.delete(connection);
+    const release = connection.waitForRelease();
+    this.#retiringReleases.add(release);
+    void release.then(
+      () => this.#retiringReleases.delete(release),
+      () => this.#retiringReleases.delete(release),
+    );
   }
 
   #exclusive<T>(operation: () => Promise<T>): Promise<T> {
@@ -1011,10 +1032,10 @@ class TerminalAttachmentLiveConnection {
     } catch {
       // Lease retirement below remains authoritative.
     }
-    this.#onRetire(this);
     this.#releasePromise = this.#leaseManager
       .release(this.#leaseId, this.#binding)
       .catch(() => undefined);
+    this.#onRetire(this);
     safeClose(this.#socket, code, reason);
   }
 

--- a/packages/daemon/src/terminal/attachments/direct-websocket.ts
+++ b/packages/daemon/src/terminal/attachments/direct-websocket.ts
@@ -1,0 +1,1209 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+import {
+  TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+  TerminalAttachRequestSchemaZ,
+  TerminalAttachmentViewportSchemaZ,
+  type TerminalAttachRequest,
+  type TerminalAttachmentViewport,
+  type TerminalAttachmentViewerMode,
+} from "@tmux-ide/contracts";
+import type {
+  AttachmentIssueContext,
+  AttachmentLeaseBinding,
+  AttachmentLeaseDescriptor,
+  ExecutedAttachmentViewOperation,
+  IssuedAttachmentLease,
+  RedeemedAttachmentLease,
+} from "./lease-manager.ts";
+import type {
+  ClaimedPtyTmuxAttachment,
+  PtyTmuxAttachmentClaimKey,
+} from "./pty-tmux-attachment-launcher.ts";
+
+export const TERMINAL_ATTACHMENT_REDEEM_PATH = "/v1/terminal/attachments/redeem";
+export const TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL = "tmux-ide-terminal.v1";
+export const TERMINAL_ATTACHMENT_MAX_REDEMPTION_BYTES = 4 * 1024;
+export const TERMINAL_ATTACHMENT_MAX_CONTROL_BYTES = 4 * 1024;
+export const TERMINAL_ATTACHMENT_MAX_REDEMPTION_MS = 1_000;
+export const TERMINAL_ATTACHMENT_MAX_LIVE_CONTROL_FRAMES = 1_024;
+
+const WS_OPEN = 1;
+const TicketPattern = /^ta1_[A-Za-z0-9_-]{43}$/u;
+const BindingIdSchemaZ = z
+  .string()
+  .min(1)
+  .max(4096)
+  .refine((value) => !value.includes("\0"));
+const RedemptionFrameSchemaZ = z
+  .object({
+    type: z.literal("redeem"),
+    protocolVersion: z.literal(TERMINAL_ATTACHMENT_PROTOCOL_VERSION),
+    ticket: z.string().regex(TicketPattern),
+    requestId: z.uuid(),
+    daemonInstanceId: BindingIdSchemaZ,
+  })
+  .strict();
+const ResizeFrameSchemaZ = z
+  .object({
+    type: z.literal("resize"),
+    protocolVersion: z.literal(TERMINAL_ATTACHMENT_PROTOCOL_VERSION),
+    generation: z.number().int().nonnegative(),
+    viewport: TerminalAttachmentViewportSchemaZ,
+  })
+  .strict();
+const GridSchemaZ = TerminalAttachmentViewportSchemaZ;
+
+type RedemptionFrame = z.infer<typeof RedemptionFrameSchemaZ>;
+
+export interface TerminalAttachmentGeometry {
+  readonly sourceGrid: TerminalAttachmentViewport;
+  readonly clientViewport: TerminalAttachmentViewport;
+}
+
+export interface DirectTerminalAttachmentDescriptor {
+  readonly protocolVersion: typeof TERMINAL_ATTACHMENT_PROTOCOL_VERSION;
+  readonly webSocketUrl: string;
+  readonly redemptionTicket: string;
+  readonly daemonInstanceId: string;
+  readonly requestId: string;
+  readonly expiresAt: number;
+  readonly effectiveViewerMode: TerminalAttachmentViewerMode;
+}
+
+export interface DirectTerminalAttachmentIssueContext extends AttachmentIssueContext {
+  /** Canonical trusted renderer Origin supplied by the host, never the renderer request body. */
+  readonly rendererOrigin: string;
+}
+
+export interface DirectTerminalAttachmentLeaseManager {
+  issue(
+    request: TerminalAttachRequest,
+    context: AttachmentIssueContext,
+  ): Promise<IssuedAttachmentLease>;
+  redeem(ticket: string, binding: AttachmentLeaseBinding): Promise<RedeemedAttachmentLease>;
+  renew(leaseId: string, binding: AttachmentLeaseBinding): Promise<RedeemedAttachmentLease>;
+  executeViewOperation(
+    leaseId: string,
+    binding: AttachmentLeaseBinding,
+    operation: "create" | "attach",
+  ): Promise<ExecutedAttachmentViewOperation>;
+  release(
+    leaseId: string,
+    binding: AttachmentLeaseBinding,
+  ): Promise<{ released: boolean; cleanup: string }>;
+}
+
+export interface DirectTerminalAttachmentLauncher {
+  claim(key: PtyTmuxAttachmentClaimKey): ClaimedPtyTmuxAttachment | null;
+}
+
+export interface DirectTerminalSocket {
+  readonly readyState: number;
+  readonly bufferedAmount?: number;
+  send(data: string | Buffer, options?: { binary?: boolean }): void;
+  close(code?: number, reason?: string): void;
+  on(
+    event: "message",
+    listener: (data: string | Buffer | ArrayBuffer | readonly Buffer[], isBinary: boolean) => void,
+  ): this;
+  on(event: "close" | "error", listener: () => void): this;
+  off(
+    event: "message",
+    listener: (data: string | Buffer | ArrayBuffer | readonly Buffer[], isBinary: boolean) => void,
+  ): this;
+  off(event: "close" | "error", listener: () => void): this;
+}
+
+export type TerminalAttachmentAdmissionErrorCode =
+  | "daemon-shutting-down"
+  | "invalid-origin"
+  | "origin-rejected"
+  | "invalid-path"
+  | "invalid-subprotocol"
+  | "pending-capacity-exhausted"
+  | "preauth-capacity-exhausted"
+  | "live-capacity-exhausted"
+  | "read_only_unavailable"
+  | "redemption-rejected"
+  | "attachment-unavailable";
+
+export class TerminalAttachmentAdmissionError extends Error {
+  readonly code: TerminalAttachmentAdmissionErrorCode;
+
+  constructor(code: TerminalAttachmentAdmissionErrorCode, message: string) {
+    super(message);
+    this.name = "TerminalAttachmentAdmissionError";
+    this.code = code;
+  }
+}
+
+export type TerminalAttachmentUpgradeDecision =
+  | { readonly accepted: true; readonly admission: TerminalAttachmentPreAuthAdmission }
+  | {
+      readonly accepted: false;
+      readonly code: TerminalAttachmentAdmissionErrorCode;
+      readonly httpStatus: 403 | 404 | 426 | 503;
+    };
+
+export interface TerminalAttachmentPreAuthAdmission {
+  bind(socket: DirectTerminalSocket): void;
+  cancelBeforeBind(): void;
+}
+
+export interface TerminalAttachmentAdmissionSnapshot {
+  readonly pendingTickets: number;
+  readonly preAuthSockets: number;
+  readonly liveConnections: number;
+  readonly shuttingDown: boolean;
+}
+
+export interface TerminalAttachmentAdmissionCoordinatorOptions {
+  readonly daemonInstanceId: string;
+  readonly webSocketUrl: string;
+  readonly leaseManager: DirectTerminalAttachmentLeaseManager;
+  readonly launcher: DirectTerminalAttachmentLauncher;
+  readonly resolveGeometry: (
+    descriptor: AttachmentLeaseDescriptor,
+  ) => Promise<TerminalAttachmentGeometry>;
+  readonly maxPendingTickets?: number;
+  readonly maxPreAuthSockets?: number;
+  readonly maxLiveConnections?: number;
+  readonly redemptionTimeoutMs?: number;
+  readonly maxBufferedOutputBytes?: number;
+  readonly maxOutputFrameBytes?: number;
+  readonly maxLiveControlFrames?: number;
+  readonly now?: () => number;
+  readonly schedule?: (callback: () => void, delayMs: number) => () => void;
+}
+
+interface PendingTicket {
+  readonly leaseId: string;
+  readonly requestId: string;
+  readonly projectIdentity: string;
+  readonly origin: string;
+  readonly ticketDigest: Buffer;
+  readonly descriptor: AttachmentLeaseDescriptor;
+  cancelExpiry: (() => void) | null;
+}
+
+function defaultSchedule(callback: () => void, delayMs: number): () => void {
+  const timer = setTimeout(callback, delayMs);
+  timer.unref?.();
+  return () => clearTimeout(timer);
+}
+
+function boundedInteger(value: number | undefined, fallback: number, maximum: number): number {
+  const selected = value ?? fallback;
+  if (!Number.isSafeInteger(selected) || selected <= 0 || selected > maximum) {
+    throw new TypeError("Terminal attachment admission limit is invalid.");
+  }
+  return selected;
+}
+
+function digestTicket(ticket: string): Buffer {
+  return createHash("sha256").update(ticket, "utf8").digest();
+}
+
+function matchesDigest(left: Buffer, right: Buffer): boolean {
+  return left.byteLength === right.byteLength && timingSafeEqual(left, right);
+}
+
+function canonicalRendererOrigin(value: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length < 4 ||
+    value.length > 2048 ||
+    value === "null" ||
+    value === "*" ||
+    /[\0\r\n\t ]/u.test(value)
+  ) {
+    throw new TerminalAttachmentAdmissionError("invalid-origin", "Renderer Origin is invalid.");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new TerminalAttachmentAdmissionError("invalid-origin", "Renderer Origin is invalid.");
+  }
+  if (
+    !/^[a-z][a-z0-9+.-]*:$/u.test(parsed.protocol) ||
+    parsed.protocol === "file:" ||
+    parsed.username ||
+    parsed.password ||
+    (parsed.pathname !== "" && parsed.pathname !== "/") ||
+    parsed.search ||
+    parsed.hash ||
+    !parsed.hostname
+  ) {
+    throw new TerminalAttachmentAdmissionError("invalid-origin", "Renderer Origin is invalid.");
+  }
+  const canonical = `${parsed.protocol}//${parsed.host}`;
+  if (canonical !== value) {
+    throw new TerminalAttachmentAdmissionError(
+      "invalid-origin",
+      "Renderer Origin must be canonical.",
+    );
+  }
+  return canonical;
+}
+
+function validateWebSocketUrl(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new TypeError("Terminal attachment WebSocket URL is invalid.");
+  }
+  if (
+    (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") ||
+    parsed.username ||
+    parsed.password ||
+    parsed.pathname !== TERMINAL_ATTACHMENT_REDEEM_PATH ||
+    parsed.search ||
+    parsed.hash ||
+    !(
+      parsed.hostname === "localhost" ||
+      parsed.hostname.startsWith("127.") ||
+      parsed.hostname === "[::1]"
+    )
+  ) {
+    throw new TypeError("Terminal attachment WebSocket URL is invalid.");
+  }
+  return parsed.toString();
+}
+
+function rawDataToBuffer(data: string | Buffer | ArrayBuffer | readonly Buffer[]): Buffer {
+  if (typeof data === "string") return Buffer.from(data, "utf8");
+  if (Buffer.isBuffer(data)) return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  return Buffer.concat(data.map((entry) => Buffer.from(entry)));
+}
+
+function rawDataByteLength(
+  data: string | Buffer | ArrayBuffer | readonly Buffer[],
+  maximum: number,
+): number {
+  if (typeof data === "string") return Buffer.byteLength(data, "utf8");
+  if (Buffer.isBuffer(data)) return data.byteLength;
+  if (data instanceof ArrayBuffer) return data.byteLength;
+  let total = 0;
+  for (const entry of data) {
+    if (entry.byteLength > maximum - total) return maximum + 1;
+    total += entry.byteLength;
+  }
+  return total;
+}
+
+function strictJson(bytes: Buffer): unknown {
+  const text = bytes.toString("utf8");
+  if (Buffer.byteLength(text, "utf8") !== bytes.byteLength || text.includes("\uFFFD")) {
+    throw new TypeError("Control frame is not valid UTF-8.");
+  }
+  return JSON.parse(text) as unknown;
+}
+
+function safeClose(socket: DirectTerminalSocket, code: number, reason: string): void {
+  try {
+    if (socket.readyState === WS_OPEN) socket.close(code, reason.slice(0, 123));
+  } catch {
+    // Teardown ownership has already moved to the daemon state machine.
+  }
+}
+
+function sendControl(socket: DirectTerminalSocket, frame: Readonly<Record<string, unknown>>): void {
+  if (socket.readyState !== WS_OPEN) return;
+  const encoded = JSON.stringify(frame);
+  if (Buffer.byteLength(encoded, "utf8") > TERMINAL_ATTACHMENT_MAX_CONTROL_BYTES) {
+    throw new TypeError("Terminal attachment control frame exceeded its bound.");
+  }
+  socket.send(encoded, { binary: false });
+}
+
+function sameTarget(
+  left: AttachmentLeaseDescriptor["target"],
+  right: AttachmentLeaseDescriptor["target"],
+): boolean {
+  return left.workspaceName === right.workspaceName && left.semanticPaneId === right.semanticPaneId;
+}
+
+function validDescriptorIdentity(descriptor: AttachmentLeaseDescriptor): boolean {
+  return (
+    z.uuid().safeParse(descriptor.leaseId).success &&
+    z.uuid().safeParse(descriptor.requestId).success &&
+    Number.isSafeInteger(descriptor.issuedAt) &&
+    Number.isSafeInteger(descriptor.expiresAt) &&
+    Number.isSafeInteger(descriptor.bindingGeneration) &&
+    descriptor.bindingGeneration >= 0 &&
+    Number.isSafeInteger(descriptor.viewGeneration) &&
+    descriptor.viewGeneration >= 0
+  );
+}
+
+/**
+ * In-memory admission authority for one daemon instance. It contains no raw
+ * tmux identity and retains only ticket digests. A daemon restart constructs a
+ * fresh coordinator and makes every prior renderer descriptor inert.
+ */
+export class TerminalAttachmentAdmissionCoordinator {
+  readonly #instanceId: string;
+  readonly #webSocketUrl: string;
+  readonly #leaseManager: DirectTerminalAttachmentLeaseManager;
+  readonly #launcher: DirectTerminalAttachmentLauncher;
+  readonly #resolveGeometry: TerminalAttachmentAdmissionCoordinatorOptions["resolveGeometry"];
+  readonly #maxPending: number;
+  readonly #maxPreAuth: number;
+  readonly #maxLive: number;
+  readonly #redemptionTimeoutMs: number;
+  readonly #maxBufferedOutputBytes: number;
+  readonly #maxOutputFrameBytes: number;
+  readonly #maxLiveControlFrames: number;
+  readonly #now: () => number;
+  readonly #schedule: (callback: () => void, delayMs: number) => () => void;
+  readonly #pending = new Map<string, PendingTicket>();
+  readonly #preAuth = new Set<PreAuthAdmission>();
+  readonly #live = new Set<TerminalAttachmentLiveConnection>();
+  #pendingReservations = 0;
+  #liveReservations = 0;
+  #operationTail: Promise<void> = Promise.resolve();
+  #shuttingDown = false;
+
+  constructor(options: TerminalAttachmentAdmissionCoordinatorOptions) {
+    this.#instanceId = BindingIdSchemaZ.parse(options.daemonInstanceId);
+    this.#webSocketUrl = validateWebSocketUrl(options.webSocketUrl);
+    this.#leaseManager = options.leaseManager;
+    this.#launcher = options.launcher;
+    this.#resolveGeometry = options.resolveGeometry;
+    this.#maxPending = boundedInteger(options.maxPendingTickets, 32, 1_024);
+    this.#maxPreAuth = boundedInteger(options.maxPreAuthSockets, 16, 1_024);
+    this.#maxLive = boundedInteger(options.maxLiveConnections, 16, 1_024);
+    this.#redemptionTimeoutMs = boundedInteger(
+      options.redemptionTimeoutMs,
+      TERMINAL_ATTACHMENT_MAX_REDEMPTION_MS,
+      TERMINAL_ATTACHMENT_MAX_REDEMPTION_MS,
+    );
+    this.#maxBufferedOutputBytes = boundedInteger(
+      options.maxBufferedOutputBytes,
+      1 << 20,
+      16 << 20,
+    );
+    this.#maxOutputFrameBytes = boundedInteger(options.maxOutputFrameBytes, 256 << 10, 1 << 20);
+    if (this.#maxOutputFrameBytes > this.#maxBufferedOutputBytes) {
+      throw new TypeError("Output frame bound must not exceed the WebSocket output bound.");
+    }
+    this.#maxLiveControlFrames = boundedInteger(
+      options.maxLiveControlFrames,
+      TERMINAL_ATTACHMENT_MAX_LIVE_CONTROL_FRAMES,
+      65_536,
+    );
+    this.#now = options.now ?? Date.now;
+    this.#schedule = options.schedule ?? defaultSchedule;
+  }
+
+  issue(
+    request: TerminalAttachRequest,
+    context: DirectTerminalAttachmentIssueContext,
+  ): Promise<DirectTerminalAttachmentDescriptor> {
+    return this.#exclusive(async () => {
+      if (this.#shuttingDown) {
+        throw new TerminalAttachmentAdmissionError(
+          "daemon-shutting-down",
+          "Terminal attachment admission is shutting down.",
+        );
+      }
+      const parsedRequest = TerminalAttachRequestSchemaZ.parse(request);
+      if (parsedRequest.viewerMode === "read-only") {
+        throw new TerminalAttachmentAdmissionError(
+          "read_only_unavailable",
+          "Read-only terminal attachments are not proven geometry-neutral.",
+        );
+      }
+      const origin = canonicalRendererOrigin(context.rendererOrigin);
+      const requestId = z.uuid().parse(context.requestId);
+      const projectIdentity = BindingIdSchemaZ.parse(context.projectIdentity);
+      if (this.#pending.size + this.#pendingReservations >= this.#maxPending) {
+        throw new TerminalAttachmentAdmissionError(
+          "pending-capacity-exhausted",
+          "Terminal attachment ticket capacity is exhausted.",
+        );
+      }
+      this.#pendingReservations += 1;
+      let issued: IssuedAttachmentLease;
+      try {
+        issued = await this.#leaseManager.issue(parsedRequest, { requestId, projectIdentity });
+      } finally {
+        this.#pendingReservations -= 1;
+      }
+      const ticket = issued.redemptionTicket;
+      const issuedDescriptor = issued.descriptor;
+      if (
+        !TicketPattern.test(ticket) ||
+        !validDescriptorIdentity(issuedDescriptor) ||
+        issuedDescriptor.requestId !== requestId ||
+        issuedDescriptor.status !== "awaiting-redemption" ||
+        issuedDescriptor.viewerMode !== parsedRequest.viewerMode ||
+        !sameTarget(issuedDescriptor.target, parsedRequest.target)
+      ) {
+        await this.#releaseLease(issued.descriptor.leaseId, {
+          daemonInstanceId: this.#instanceId,
+          requestId,
+          projectIdentity,
+        });
+        throw new TerminalAttachmentAdmissionError(
+          "attachment-unavailable",
+          "Terminal attachment ticket generation failed.",
+        );
+      }
+      const ticketDigest = digestTicket(ticket);
+      if (
+        [...this.#pending.values()].some((pending) =>
+          matchesDigest(pending.ticketDigest, ticketDigest),
+        )
+      ) {
+        ticketDigest.fill(0);
+        await this.#releaseLease(issuedDescriptor.leaseId, {
+          daemonInstanceId: this.#instanceId,
+          requestId,
+          projectIdentity,
+        });
+        throw new TerminalAttachmentAdmissionError(
+          "attachment-unavailable",
+          "Terminal attachment ticket generation failed.",
+        );
+      }
+      const pending: PendingTicket = {
+        leaseId: issuedDescriptor.leaseId,
+        requestId,
+        projectIdentity,
+        origin,
+        ticketDigest,
+        descriptor: structuredClone(issuedDescriptor),
+        cancelExpiry: null,
+      };
+      const remainingMs = issuedDescriptor.expiresAt - this.#now();
+      if (remainingMs <= 0) {
+        pending.ticketDigest.fill(0);
+        await this.#releaseLease(pending.leaseId, this.#binding(pending));
+        throw new TerminalAttachmentAdmissionError(
+          "attachment-unavailable",
+          "Terminal attachment ticket expired before issue completed.",
+        );
+      }
+      pending.cancelExpiry = this.#schedule(() => {
+        void this.#exclusive(() => this.#retirePending(pending));
+      }, remainingMs);
+      this.#pending.set(pending.leaseId, pending);
+      return Object.freeze({
+        protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+        webSocketUrl: this.#webSocketUrl,
+        redemptionTicket: ticket,
+        daemonInstanceId: this.#instanceId,
+        requestId,
+        expiresAt: issuedDescriptor.expiresAt,
+        effectiveViewerMode: issuedDescriptor.viewerMode,
+      });
+    });
+  }
+
+  reserveUpgrade(input: {
+    readonly path: string;
+    readonly protocols: readonly string[];
+    readonly origin: string | null | undefined;
+  }): TerminalAttachmentUpgradeDecision {
+    if (this.#shuttingDown) {
+      return { accepted: false, code: "daemon-shutting-down", httpStatus: 503 };
+    }
+    if (input.path !== TERMINAL_ATTACHMENT_REDEEM_PATH) {
+      return { accepted: false, code: "invalid-path", httpStatus: 404 };
+    }
+    if (
+      input.protocols.length !== 1 ||
+      input.protocols[0] !== TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL
+    ) {
+      return { accepted: false, code: "invalid-subprotocol", httpStatus: 426 };
+    }
+    let origin: string;
+    try {
+      origin = canonicalRendererOrigin(input.origin ?? "");
+    } catch {
+      return { accepted: false, code: "invalid-origin", httpStatus: 403 };
+    }
+    if (![...this.#pending.values()].some((pending) => pending.origin === origin)) {
+      return { accepted: false, code: "origin-rejected", httpStatus: 403 };
+    }
+    if (this.#preAuth.size >= this.#maxPreAuth) {
+      return { accepted: false, code: "preauth-capacity-exhausted", httpStatus: 503 };
+    }
+    const admission = new PreAuthAdmission({
+      origin,
+      timeoutMs: this.#redemptionTimeoutMs,
+      schedule: this.#schedule,
+      onRelease: (released) => this.#preAuth.delete(released),
+      onRedeem: (active, frame, socket) => this.#redeem(active, frame, socket),
+    });
+    this.#preAuth.add(admission);
+    return { accepted: true, admission };
+  }
+
+  snapshot(): TerminalAttachmentAdmissionSnapshot {
+    return Object.freeze({
+      pendingTickets: this.#pending.size + this.#pendingReservations,
+      preAuthSockets: this.#preAuth.size,
+      liveConnections: this.#live.size + this.#liveReservations,
+      shuttingDown: this.#shuttingDown,
+    });
+  }
+
+  toJSON(): TerminalAttachmentAdmissionSnapshot {
+    return this.snapshot();
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.#shuttingDown) return;
+    this.#shuttingDown = true;
+    for (const admission of [...this.#preAuth]) admission.close(1001, "daemon-shutdown");
+    const live = [...this.#live];
+    for (const connection of live) connection.close(1001, "daemon-shutdown");
+    await Promise.all(live.map((connection) => connection.waitForRelease()));
+    await this.#exclusive(async () => {
+      for (const pending of [...this.#pending.values()]) await this.#retirePending(pending);
+    });
+  }
+
+  #redeem(
+    admission: PreAuthAdmission,
+    frame: RedemptionFrame,
+    socket: DirectTerminalSocket,
+  ): Promise<TerminalAttachmentLiveConnection> {
+    return this.#exclusive(async () => {
+      if (this.#shuttingDown) {
+        throw new TerminalAttachmentAdmissionError(
+          "redemption-rejected",
+          "Terminal attachment redemption was rejected.",
+        );
+      }
+      if (frame.daemonInstanceId !== this.#instanceId) {
+        throw new TerminalAttachmentAdmissionError(
+          "redemption-rejected",
+          "Terminal attachment redemption was rejected.",
+        );
+      }
+      const candidateDigest = digestTicket(frame.ticket);
+      let pending: PendingTicket | undefined;
+      for (const entry of this.#pending.values()) {
+        if (matchesDigest(entry.ticketDigest, candidateDigest)) pending = entry;
+      }
+      candidateDigest.fill(0);
+      if (
+        !pending ||
+        pending.origin !== admission.origin ||
+        pending.requestId !== frame.requestId
+      ) {
+        throw new TerminalAttachmentAdmissionError(
+          "redemption-rejected",
+          "Terminal attachment redemption was rejected.",
+        );
+      }
+      const binding = this.#binding(pending);
+      if (!admission.isOpen()) {
+        this.#removePending(pending);
+        await this.#releaseLease(pending.leaseId, binding);
+        throw new TerminalAttachmentAdmissionError(
+          "redemption-rejected",
+          "Terminal attachment redemption was rejected.",
+        );
+      }
+      this.#removePending(pending);
+      if (this.#live.size + this.#liveReservations >= this.#maxLive) {
+        await this.#releaseLease(pending.leaseId, binding);
+        throw new TerminalAttachmentAdmissionError(
+          "live-capacity-exhausted",
+          "Terminal attachment live capacity is exhausted.",
+        );
+      }
+      let liveReservationHeld = true;
+      this.#liveReservations += 1;
+      try {
+        const redeemed = await this.#leaseManager.redeem(frame.ticket, binding);
+        this.#assertActiveDescriptor(redeemed.descriptor, pending);
+        if (!admission.isOpen()) {
+          throw new TerminalAttachmentAdmissionError(
+            "redemption-rejected",
+            "Terminal attachment redemption was rejected.",
+          );
+        }
+        await this.#leaseManager.executeViewOperation(pending.leaseId, binding, "create");
+        const attached = await this.#leaseManager.executeViewOperation(
+          pending.leaseId,
+          binding,
+          "attach",
+        );
+        if (!attached.clientClaim) {
+          throw new TerminalAttachmentAdmissionError(
+            "attachment-unavailable",
+            "Terminal attachment client was unavailable.",
+          );
+        }
+        const activeDescriptor = this.#assertActiveDescriptor(attached.descriptor, pending);
+        const client = this.#launcher.claim(attached.clientClaim);
+        if (!client) {
+          throw new TerminalAttachmentAdmissionError(
+            "attachment-unavailable",
+            "Terminal attachment client was unavailable.",
+          );
+        }
+        let geometry: TerminalAttachmentGeometry;
+        try {
+          const resolved = await this.#resolveGeometry(activeDescriptor);
+          geometry = {
+            sourceGrid: GridSchemaZ.parse(resolved.sourceGrid),
+            clientViewport: GridSchemaZ.parse(resolved.clientViewport),
+          };
+        } catch {
+          client.dispose();
+          throw new TerminalAttachmentAdmissionError(
+            "attachment-unavailable",
+            "Terminal attachment geometry was unavailable.",
+          );
+        }
+        if (!admission.isOpen()) {
+          client.dispose();
+          throw new TerminalAttachmentAdmissionError(
+            "redemption-rejected",
+            "Terminal attachment redemption was rejected.",
+          );
+        }
+        const live = new TerminalAttachmentLiveConnection({
+          onRetire: (connection) => this.#live.delete(connection),
+          socket,
+          client,
+          leaseManager: this.#leaseManager,
+          leaseId: pending.leaseId,
+          binding,
+          descriptor: activeDescriptor,
+          geometry,
+          resolveGeometry: this.#resolveGeometry,
+          maxBufferedOutputBytes: this.#maxBufferedOutputBytes,
+          maxOutputFrameBytes: this.#maxOutputFrameBytes,
+          maxLiveControlFrames: this.#maxLiveControlFrames,
+          now: this.#now,
+          schedule: this.#schedule,
+        });
+        liveReservationHeld = false;
+        this.#liveReservations -= 1;
+        this.#live.add(live);
+        admission.promote();
+        live.start();
+        return live;
+      } catch (error) {
+        if (liveReservationHeld) {
+          this.#liveReservations -= 1;
+        }
+        await this.#releaseLease(pending.leaseId, binding);
+        throw error;
+      }
+    });
+  }
+
+  #binding(pending: PendingTicket): AttachmentLeaseBinding {
+    return {
+      daemonInstanceId: this.#instanceId,
+      requestId: pending.requestId,
+      projectIdentity: pending.projectIdentity,
+    };
+  }
+
+  #assertActiveDescriptor(
+    descriptor: AttachmentLeaseDescriptor,
+    pending: PendingTicket,
+  ): AttachmentLeaseDescriptor {
+    if (
+      !validDescriptorIdentity(descriptor) ||
+      descriptor.leaseId !== pending.leaseId ||
+      descriptor.requestId !== pending.requestId ||
+      descriptor.status !== "active" ||
+      descriptor.viewerMode !== pending.descriptor.viewerMode ||
+      !sameTarget(descriptor.target, pending.descriptor.target) ||
+      descriptor.expiresAt <= this.#now()
+    ) {
+      throw new TerminalAttachmentAdmissionError(
+        "attachment-unavailable",
+        "Terminal attachment lease identity was unavailable.",
+      );
+    }
+    return structuredClone(descriptor);
+  }
+
+  #removePending(pending: PendingTicket): void {
+    if (this.#pending.get(pending.leaseId) !== pending) return;
+    this.#pending.delete(pending.leaseId);
+    pending.cancelExpiry?.();
+    pending.cancelExpiry = null;
+    pending.ticketDigest.fill(0);
+  }
+
+  async #retirePending(pending: PendingTicket): Promise<void> {
+    if (this.#pending.get(pending.leaseId) !== pending) return;
+    const binding = this.#binding(pending);
+    this.#removePending(pending);
+    await this.#releaseLease(pending.leaseId, binding);
+  }
+
+  async #releaseLease(leaseId: string, binding: AttachmentLeaseBinding): Promise<void> {
+    try {
+      await this.#leaseManager.release(leaseId, binding);
+    } catch {
+      // The lease manager may already have retired the one-use lease. No
+      // credential, target proof, or terminal bytes are reflected outward.
+    }
+  }
+
+  #exclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.#operationTail.then(operation, operation);
+    this.#operationTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+}
+
+interface PreAuthAdmissionOptions {
+  readonly origin: string;
+  readonly timeoutMs: number;
+  readonly schedule: (callback: () => void, delayMs: number) => () => void;
+  readonly onRelease: (admission: PreAuthAdmission) => void;
+  readonly onRedeem: (
+    admission: PreAuthAdmission,
+    frame: RedemptionFrame,
+    socket: DirectTerminalSocket,
+  ) => Promise<TerminalAttachmentLiveConnection>;
+}
+
+class PreAuthAdmission implements TerminalAttachmentPreAuthAdmission {
+  readonly origin: string;
+  readonly #onRelease: PreAuthAdmissionOptions["onRelease"];
+  readonly #onRedeem: PreAuthAdmissionOptions["onRedeem"];
+  readonly #cancelDeadline: () => void;
+  #socket: DirectTerminalSocket | null = null;
+  #frameReceived = false;
+  #open = true;
+  #promoted = false;
+
+  constructor(options: PreAuthAdmissionOptions) {
+    this.origin = options.origin;
+    this.#onRelease = options.onRelease;
+    this.#onRedeem = options.onRedeem;
+    this.#cancelDeadline = options.schedule(
+      () => this.close(1008, "redemption-timeout"),
+      options.timeoutMs,
+    );
+  }
+
+  isOpen(): boolean {
+    return this.#open && !this.#promoted;
+  }
+
+  bind(socket: DirectTerminalSocket): void {
+    if (!this.#open || this.#socket) {
+      safeClose(socket, 1008, "redemption-rejected");
+      return;
+    }
+    this.#socket = socket;
+    socket.on("message", this.#onMessage);
+    socket.on("close", this.#onClose);
+    socket.on("error", this.#onClose);
+  }
+
+  beginRedemption(): void {
+    if (!this.#open || this.#promoted) return;
+    this.#cancelDeadline();
+  }
+
+  cancelBeforeBind(): void {
+    this.close(1008, "upgrade-rejected");
+  }
+
+  promote(): void {
+    if (!this.#open) return;
+    this.#promoted = true;
+    this.#open = false;
+    this.#cancelDeadline();
+    this.#detach();
+    this.#onRelease(this);
+  }
+
+  close(code = 1008, reason = "redemption-rejected"): void {
+    if (!this.#open) return;
+    this.#open = false;
+    this.#cancelDeadline();
+    const socket = this.#socket;
+    this.#detach();
+    this.#onRelease(this);
+    if (socket) safeClose(socket, code, reason);
+  }
+
+  readonly #onMessage = (
+    data: string | Buffer | ArrayBuffer | readonly Buffer[],
+    isBinary: boolean,
+  ): void => {
+    if (!this.#open || this.#frameReceived) {
+      this.close(1008, "redemption-frame-rejected");
+      return;
+    }
+    this.#frameReceived = true;
+    const byteLength = rawDataByteLength(data, TERMINAL_ATTACHMENT_MAX_REDEMPTION_BYTES);
+    if (isBinary || byteLength === 0 || byteLength > TERMINAL_ATTACHMENT_MAX_REDEMPTION_BYTES) {
+      this.close(1009, "redemption-frame-rejected");
+      return;
+    }
+    const bytes = rawDataToBuffer(data);
+    let frame: RedemptionFrame;
+    try {
+      frame = RedemptionFrameSchemaZ.parse(strictJson(bytes));
+    } catch {
+      this.close(1008, "redemption-frame-rejected");
+      return;
+    }
+    const socket = this.#socket;
+    if (!socket) {
+      this.close(1008, "redemption-rejected");
+      return;
+    }
+    this.beginRedemption();
+    void this.#onRedeem(this, frame, socket).catch((error: unknown) => {
+      if (!this.#open) return;
+      const code =
+        error instanceof TerminalAttachmentAdmissionError ? error.code : "attachment-unavailable";
+      try {
+        sendControl(socket, {
+          type: "error",
+          protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+          code,
+          retryable: code === "live-capacity-exhausted",
+        });
+      } catch {
+        // Closing below is the fail-closed response.
+      }
+      this.close(code === "live-capacity-exhausted" ? 1013 : 1008, "redemption-rejected");
+    });
+  };
+
+  readonly #onClose = (): void => this.close(1008, "redemption-rejected");
+
+  #detach(): void {
+    const socket = this.#socket;
+    this.#socket = null;
+    if (!socket) return;
+    socket.off("message", this.#onMessage);
+    socket.off("close", this.#onClose);
+    socket.off("error", this.#onClose);
+  }
+}
+
+interface LiveConnectionOptions {
+  readonly onRetire: (connection: TerminalAttachmentLiveConnection) => void;
+  readonly socket: DirectTerminalSocket;
+  readonly client: ClaimedPtyTmuxAttachment;
+  readonly leaseManager: DirectTerminalAttachmentLeaseManager;
+  readonly leaseId: string;
+  readonly binding: AttachmentLeaseBinding;
+  readonly descriptor: AttachmentLeaseDescriptor;
+  readonly geometry: TerminalAttachmentGeometry;
+  readonly resolveGeometry: (
+    descriptor: AttachmentLeaseDescriptor,
+  ) => Promise<TerminalAttachmentGeometry>;
+  readonly maxBufferedOutputBytes: number;
+  readonly maxOutputFrameBytes: number;
+  readonly maxLiveControlFrames: number;
+  readonly now: () => number;
+  readonly schedule: (callback: () => void, delayMs: number) => () => void;
+}
+
+class TerminalAttachmentLiveConnection {
+  readonly #onRetire: LiveConnectionOptions["onRetire"];
+  readonly #socket: DirectTerminalSocket;
+  readonly #client: ClaimedPtyTmuxAttachment;
+  readonly #leaseManager: DirectTerminalAttachmentLeaseManager;
+  readonly #leaseId: string;
+  readonly #binding: AttachmentLeaseBinding;
+  #descriptor: AttachmentLeaseDescriptor;
+  readonly #initialGeometry: TerminalAttachmentGeometry;
+  readonly #resolveGeometry: LiveConnectionOptions["resolveGeometry"];
+  readonly #maxBufferedOutputBytes: number;
+  readonly #maxOutputFrameBytes: number;
+  readonly #maxLiveControlFrames: number;
+  readonly #now: () => number;
+  readonly #schedule: (callback: () => void, delayMs: number) => () => void;
+  #removeDataListener: (() => void) | null = null;
+  #removeExitListener: (() => void) | null = null;
+  #pendingResize: TerminalAttachmentViewport | null = null;
+  #resizeRunning = false;
+  #controlFrames = 0;
+  #closed = false;
+  #cancelRenewal: (() => void) | null = null;
+  #cancelExpiry: (() => void) | null = null;
+  #renewing = false;
+  #releasePromise: Promise<unknown> | null = null;
+
+  constructor(options: LiveConnectionOptions) {
+    this.#onRetire = options.onRetire;
+    this.#socket = options.socket;
+    this.#client = options.client;
+    this.#leaseManager = options.leaseManager;
+    this.#leaseId = options.leaseId;
+    this.#binding = options.binding;
+    this.#descriptor = structuredClone(options.descriptor);
+    this.#initialGeometry = structuredClone(options.geometry);
+    this.#resolveGeometry = options.resolveGeometry;
+    this.#maxBufferedOutputBytes = options.maxBufferedOutputBytes;
+    this.#maxOutputFrameBytes = options.maxOutputFrameBytes;
+    this.#maxLiveControlFrames = options.maxLiveControlFrames;
+    this.#now = options.now;
+    this.#schedule = options.schedule;
+  }
+
+  start(): void {
+    if (this.#closed || this.#socket.readyState !== WS_OPEN) {
+      this.close(1008, "attachment-retired");
+      return;
+    }
+    this.#socket.on("message", this.#onMessage);
+    this.#socket.on("close", this.#onClose);
+    this.#socket.on("error", this.#onClose);
+    try {
+      sendControl(this.#socket, {
+        type: "ready",
+        protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+        daemonInstanceId: this.#binding.daemonInstanceId,
+        requestId: this.#binding.requestId,
+        generation: this.#descriptor.viewGeneration,
+        effectiveViewerMode: this.#descriptor.viewerMode,
+        inputCapability: "unavailable",
+        sourceGrid: this.#initialGeometry.sourceGrid,
+        clientViewport: this.#initialGeometry.clientViewport,
+      });
+      this.#removeExitListener = this.#client.onExit(this.#onClientExit);
+      this.#removeDataListener = this.#client.onData(this.#onClientData);
+      this.#scheduleLeaseLifecycle();
+    } catch {
+      this.close(1011, "attachment-unavailable");
+    }
+  }
+
+  close(code = 1000, reason = "attachment-closed"): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#cancelRenewal?.();
+    this.#cancelRenewal = null;
+    this.#cancelExpiry?.();
+    this.#cancelExpiry = null;
+    this.#pendingResize = null;
+    this.#socket.off("message", this.#onMessage);
+    this.#socket.off("close", this.#onClose);
+    this.#socket.off("error", this.#onClose);
+    this.#removeDataListener?.();
+    this.#removeDataListener = null;
+    this.#removeExitListener?.();
+    this.#removeExitListener = null;
+    try {
+      this.#client.dispose();
+    } catch {
+      // Lease retirement below remains authoritative.
+    }
+    this.#onRetire(this);
+    this.#releasePromise = this.#leaseManager
+      .release(this.#leaseId, this.#binding)
+      .catch(() => undefined);
+    safeClose(this.#socket, code, reason);
+  }
+
+  async waitForRelease(): Promise<void> {
+    await this.#releasePromise;
+  }
+
+  readonly #onMessage = (
+    data: string | Buffer | ArrayBuffer | readonly Buffer[],
+    isBinary: boolean,
+  ): void => {
+    if (this.#closed) return;
+    this.#controlFrames += 1;
+    if (this.#controlFrames > this.#maxLiveControlFrames) {
+      this.close(1008, "control-frame-limit");
+      return;
+    }
+    const byteLength = rawDataByteLength(data, TERMINAL_ATTACHMENT_MAX_CONTROL_BYTES);
+    if (isBinary) {
+      try {
+        sendControl(this.#socket, {
+          type: "mutation-error",
+          protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+          mutation: "input",
+          code: "input-backpressure-unavailable",
+          retryable: false,
+        });
+      } catch {
+        this.close(1011, "attachment-unavailable");
+        return;
+      }
+      this.close(1008, "input-backpressure-unavailable");
+      return;
+    }
+    if (byteLength === 0 || byteLength > TERMINAL_ATTACHMENT_MAX_CONTROL_BYTES) {
+      this.close(1009, "control-frame-rejected");
+      return;
+    }
+    const bytes = rawDataToBuffer(data);
+    let frame: z.infer<typeof ResizeFrameSchemaZ>;
+    try {
+      frame = ResizeFrameSchemaZ.parse(strictJson(bytes));
+    } catch {
+      this.close(1008, "control-frame-rejected");
+      return;
+    }
+    if (frame.generation !== this.#descriptor.viewGeneration) {
+      this.close(1008, "retired-generation");
+      return;
+    }
+    this.#pendingResize = frame.viewport;
+    this.#flushResize();
+  };
+
+  readonly #onClose = (): void => this.close(1000, "peer-closed");
+
+  readonly #onClientData = (data: Buffer): void => {
+    if (this.#closed || data.byteLength === 0) return;
+    const buffered = this.#socket.bufferedAmount ?? 0;
+    if (
+      !Number.isSafeInteger(buffered) ||
+      buffered < 0 ||
+      data.byteLength > this.#maxOutputFrameBytes ||
+      buffered > this.#maxBufferedOutputBytes - data.byteLength
+    ) {
+      this.close(1013, "output-backpressure");
+      return;
+    }
+    try {
+      this.#socket.send(Buffer.from(data), { binary: true });
+    } catch {
+      this.close(1011, "attachment-unavailable");
+    }
+  };
+
+  readonly #onClientExit = (event: {
+    readonly exitCode: number;
+    readonly signal: number | null;
+  }): void => {
+    if (this.#closed) return;
+    try {
+      sendControl(this.#socket, {
+        type: "exit",
+        protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+        generation: this.#descriptor.viewGeneration,
+        exitCode: Number.isSafeInteger(event.exitCode) ? event.exitCode : 1,
+        signal: Number.isSafeInteger(event.signal) ? event.signal : null,
+      });
+    } finally {
+      this.close(1000, "terminal-exit");
+    }
+  };
+
+  #flushResize(): void {
+    if (this.#closed || this.#resizeRunning || !this.#pendingResize) return;
+    this.#resizeRunning = true;
+    const run = async (): Promise<void> => {
+      while (!this.#closed && this.#pendingResize) {
+        const viewport = this.#pendingResize;
+        this.#pendingResize = null;
+        try {
+          this.#client.resize(viewport.cols, viewport.rows);
+          const geometry = await this.#resolveGeometry(this.#descriptor);
+          if (this.#closed) return;
+          sendControl(this.#socket, {
+            type: "geometry",
+            protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+            generation: this.#descriptor.viewGeneration,
+            sourceGrid: GridSchemaZ.parse(geometry.sourceGrid),
+            clientViewport: GridSchemaZ.parse(geometry.clientViewport),
+          });
+        } catch {
+          this.close(1011, "resize-unavailable");
+          return;
+        }
+      }
+    };
+    void run().finally(() => {
+      this.#resizeRunning = false;
+      this.#flushResize();
+    });
+  }
+
+  #scheduleLeaseLifecycle(): void {
+    this.#cancelRenewal?.();
+    this.#cancelExpiry?.();
+    this.#cancelRenewal = null;
+    this.#cancelExpiry = null;
+    const remaining = this.#descriptor.expiresAt - this.#now();
+    if (remaining <= 0) {
+      this.close(1008, "attachment-expired");
+      return;
+    }
+    this.#cancelExpiry = this.#schedule(() => this.close(1008, "attachment-expired"), remaining);
+    this.#cancelRenewal = this.#schedule(
+      () => {
+        this.#cancelRenewal = null;
+        this.#renewLease();
+      },
+      Math.max(1, Math.floor((remaining * 2) / 3)),
+    );
+  }
+
+  #renewLease(): void {
+    if (this.#closed || this.#renewing) return;
+    this.#renewing = true;
+    void this.#leaseManager
+      .renew(this.#leaseId, this.#binding)
+      .then(async ({ descriptor }) => {
+        if (this.#closed) return;
+        if (
+          descriptor.leaseId !== this.#descriptor.leaseId ||
+          descriptor.requestId !== this.#descriptor.requestId ||
+          descriptor.viewerMode !== this.#descriptor.viewerMode ||
+          descriptor.viewGeneration !== this.#descriptor.viewGeneration ||
+          descriptor.status !== "active" ||
+          descriptor.target.workspaceName !== this.#descriptor.target.workspaceName ||
+          descriptor.target.semanticPaneId !== this.#descriptor.target.semanticPaneId ||
+          descriptor.expiresAt <= this.#now()
+        ) {
+          throw new TypeError("Terminal attachment lease identity changed during renewal.");
+        }
+        const geometry = await this.#resolveGeometry(descriptor);
+        if (this.#closed) return;
+        this.#descriptor = structuredClone(descriptor);
+        sendControl(this.#socket, {
+          type: "geometry",
+          protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+          generation: this.#descriptor.viewGeneration,
+          sourceGrid: GridSchemaZ.parse(geometry.sourceGrid),
+          clientViewport: GridSchemaZ.parse(geometry.clientViewport),
+        });
+        this.#scheduleLeaseLifecycle();
+      })
+      .catch(() => {
+        if (this.#closed) return;
+        try {
+          sendControl(this.#socket, {
+            type: "error",
+            protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+            code: "attachment-renewal-failed",
+            retryable: true,
+          });
+        } finally {
+          this.close(1012, "attachment-renewal-failed");
+        }
+      })
+      .finally(() => {
+        this.#renewing = false;
+      });
+  }
+}


### PR DESCRIPTION
## Outcome

Adds the bounded daemon-side admission and direct WebSocket boundary for native tmux terminal attachments.

## What changed

- Issue-time pending capacity, exact trusted renderer Origin binding, digest-only one-use ticket retention, expiry, and read-only fail-closed gating.
- Exact `/v1/terminal/attachments/redeem` and `tmux-ide-terminal.v1` upgrade admission before 101, including raw duplicate-header rejection and atomic pre-auth capacity.
- One text redemption frame (at most 4 KiB and 1000 ms), serialized pending-to-live transition, first-class PTY launcher claim, direct binary output, bounded/coalesced resize control, HWM close, and typed unavailable input.
- Lease renewal with target/mode/view-generation revalidation, authoritative geometry refresh, hard expiry, reconnect-on-rebind/failure, and awaited idempotent teardown.
- Renderer-safe/redacted snapshots only; no durable daemon credential, raw tmux id, command/cwd/env, Electron byte proxy, or alternate PTY runtime.
- Thin Node/ws integration only; production daemon-embed and host-auth construction remain deliberately deferred.

## Verification

- Focused direct-websocket Vitest: 16/16 passed.
- Daemon TypeScript no-emit check: passed.
- Focused ESLint: passed.
- Focused Prettier check: passed.
- `git diff --check`: passed.
- Full daemon Vitest: 2411/2416 passed under the default 5-second timeout; five host-load timeouts only.
- Isolated timeout reruns: ws-events-protocol 4/4 passed; tmux-view-executor-live 7/7 passed.

## Deliberate boundary

This PR does not mount the route in daemon-embed or add Electron issue IPC. Those require the authenticated durable-credential issue service and production authoritative geometry resolver; placeholder wiring would violate ADR-0002.
