### PR TITLE
feat(desktop): add bounded native terminal websocket transport

### DIFF
--- a/apps/desktop-renderer/README.md
+++ b/apps/desktop-renderer/README.md
@@ -12,3 +12,26 @@ SolidJS/Vite application and must remain runnable without Electron.
 Run `pnpm --filter @tmux-ide/desktop-renderer dev` for browser development.
 The browser fallback implements the same narrow host shape with safe no-op
 native capabilities.
+
+## Native terminal transport boundary
+
+`src/terminal/native-terminal-websocket-transport.ts` is the renderer-owned
+direct WebSocket adapter for a future native terminal issue capability. Its
+only privileged dependency is an injected `issueAttachment(request)` function:
+
+- the request is validated by the shared semantic terminal-attachment contract;
+- the result remains `unknown` and is accepted only by a card-local untrusted
+  parser; this does not establish a new shared/public wire contract;
+- the parsed value must be an exact, short-lived
+  loopback `ws:`/`wss:` descriptor with the one supported subprotocol;
+- the one-use ticket is sent in exactly one bounded first control frame and is
+  never placed in the URL, an error, retained attachment state, or reconnect;
+- binary daemon output crosses directly to the Solid terminal listener through
+  a fixed frame/count/byte queue;
+- resize is a bounded, latest-value-coalesced control operation; and
+- `write()` remains fail-closed with `input-backpressure-unavailable` until the
+  daemon recovery/no-replay gate is enabled in a separate reviewed change.
+
+The adapter has no Electron import, host capability implementation, daemon
+credential, raw tmux identity, process API, or automatic reconnect loop. A
+retry creates a new issue request, ticket, socket, and real tmux redraw.

--- a/apps/desktop-renderer/src/terminal/native-terminal-transport.ts
+++ b/apps/desktop-renderer/src/terminal/native-terminal-transport.ts
@@ -7,11 +7,28 @@ import {
 
 export type NativeTerminalConnectionState = "connected" | "disconnected";
 
+export interface NativeTerminalGeometry {
+  readonly sourceGrid: TerminalAttachmentViewport;
+  readonly clientViewport: TerminalAttachmentViewport;
+}
+
 export type NativeTerminalEvent =
   | { readonly type: "output"; readonly bytes: Uint8Array }
   | {
       readonly type: "state";
-      readonly state: NativeTerminalConnectionState;
+      readonly state: "connected";
+      readonly error: null;
+      readonly sourceGrid: TerminalAttachmentViewport;
+      readonly clientViewport: TerminalAttachmentViewport;
+    }
+  | {
+      readonly type: "geometry";
+      readonly sourceGrid: TerminalAttachmentViewport;
+      readonly clientViewport: TerminalAttachmentViewport;
+    }
+  | {
+      readonly type: "state";
+      readonly state: "disconnected";
       readonly error: NativeTerminalTransportError | null;
     };
 
@@ -23,6 +40,7 @@ export interface NativeTerminalTransportError {
 
 export interface NativeTerminalAttachment {
   write(bytes: Uint8Array): Promise<NativeTerminalMutationResult>;
+  /** Resolves `ok` only after daemon-authoritative geometry matches this viewport. */
   resize(viewport: TerminalAttachmentViewport): Promise<NativeTerminalMutationResult>;
   dispose(): void;
 }
@@ -69,11 +87,16 @@ export {
   NATIVE_TERMINAL_DEFAULT_ISSUE_TIMEOUT_MS,
   NATIVE_TERMINAL_MAX_CONTROL_BYTES,
   NATIVE_TERMINAL_MAX_CONTROL_FRAMES,
+  NATIVE_TERMINAL_MAX_CONNECTION_LIFETIME_MS,
   NATIVE_TERMINAL_MAX_DESCRIPTOR_LIFETIME_MS,
+  NATIVE_TERMINAL_MAX_INBOUND_CONTROL_FRAMES_PER_WINDOW,
+  NATIVE_TERMINAL_MAX_INBOUND_FRAMES_PER_WINDOW,
   NATIVE_TERMINAL_MAX_OUTPUT_FRAME_BYTES,
   NATIVE_TERMINAL_MAX_QUEUED_EVENT_BYTES,
   NATIVE_TERMINAL_MAX_QUEUED_EVENTS,
   NATIVE_TERMINAL_MAX_SOCKET_BUFFERED_BYTES,
+  NATIVE_TERMINAL_RATE_WINDOW_MS,
+  NATIVE_TERMINAL_RESIZE_ACK_TIMEOUT_MS,
   NATIVE_TERMINAL_WEBSOCKET_PROTOCOL,
   createNativeTerminalWebSocketTransport,
   type NativeTerminalIssueAttachment,

--- a/apps/desktop-renderer/src/terminal/native-terminal-transport.ts
+++ b/apps/desktop-renderer/src/terminal/native-terminal-transport.ts
@@ -64,3 +64,22 @@ export function isNativeTerminalOutput(
 ): event is Extract<NativeTerminalEvent, { readonly type: "output" }> {
   return event.type === "output" && event.bytes instanceof Uint8Array;
 }
+
+export {
+  NATIVE_TERMINAL_DEFAULT_ISSUE_TIMEOUT_MS,
+  NATIVE_TERMINAL_MAX_CONTROL_BYTES,
+  NATIVE_TERMINAL_MAX_CONTROL_FRAMES,
+  NATIVE_TERMINAL_MAX_DESCRIPTOR_LIFETIME_MS,
+  NATIVE_TERMINAL_MAX_OUTPUT_FRAME_BYTES,
+  NATIVE_TERMINAL_MAX_QUEUED_EVENT_BYTES,
+  NATIVE_TERMINAL_MAX_QUEUED_EVENTS,
+  NATIVE_TERMINAL_MAX_SOCKET_BUFFERED_BYTES,
+  NATIVE_TERMINAL_WEBSOCKET_PROTOCOL,
+  createNativeTerminalWebSocketTransport,
+  type NativeTerminalIssueAttachment,
+  type NativeTerminalSocketEvent,
+  type NativeTerminalSocketListener,
+  type NativeTerminalWebSocket,
+  type NativeTerminalWebSocketFactory,
+  type NativeTerminalWebSocketTransportDependencies,
+} from "./native-terminal-websocket-transport.ts";

--- a/apps/desktop-renderer/src/terminal/native-terminal-websocket-transport.test.ts
+++ b/apps/desktop-renderer/src/terminal/native-terminal-websocket-transport.test.ts
@@ -4,8 +4,15 @@ import type {
   NativeTerminalTransportError,
 } from "./native-terminal-transport.ts";
 import {
+  NATIVE_TERMINAL_MAX_CONNECTION_LIFETIME_MS,
+  NATIVE_TERMINAL_MAX_CONTROL_BYTES,
+  NATIVE_TERMINAL_MAX_INBOUND_CONTROL_FRAMES_PER_WINDOW,
+  NATIVE_TERMINAL_MAX_INBOUND_FRAMES_PER_WINDOW,
+  NATIVE_TERMINAL_MAX_OUTPUT_FRAME_BYTES,
   NATIVE_TERMINAL_MAX_QUEUED_EVENTS,
   NATIVE_TERMINAL_MAX_SOCKET_BUFFERED_BYTES,
+  NATIVE_TERMINAL_RATE_WINDOW_MS,
+  NATIVE_TERMINAL_RESIZE_ACK_TIMEOUT_MS,
   NATIVE_TERMINAL_WEBSOCKET_PROTOCOL,
   createNativeTerminalWebSocketTransport,
   type NativeTerminalSocketEvent,
@@ -56,13 +63,14 @@ function ready(overrides: Record<string, unknown> = {}): string {
   });
 }
 
-function geometry(generation = 0): string {
+function geometry(overrides: Record<string, unknown> = {}): string {
   return JSON.stringify({
     type: "geometry",
     protocolVersion: 1,
-    generation,
+    generation: 0,
     sourceGrid: { cols: 100, rows: 30 },
     clientViewport: { cols: 98, rows: 28 },
+    ...overrides,
   });
 }
 
@@ -127,6 +135,7 @@ interface RigOptions {
   readonly descriptors?: readonly unknown[];
   readonly schedule?: NativeTerminalWebSocketTransportDependencies["schedule"];
   readonly issueAttachment?: NativeTerminalWebSocketTransportDependencies["issueAttachment"];
+  readonly now?: () => number;
 }
 
 function rig(options: RigOptions = {}) {
@@ -143,7 +152,7 @@ function rig(options: RigOptions = {}) {
   const transport = createNativeTerminalWebSocketTransport({
     issueAttachment,
     createWebSocket,
-    now: () => NOW,
+    now: options.now ?? (() => NOW),
     schedule: options.schedule,
   });
   return { transport, issueAttachment, createWebSocket, sockets };
@@ -227,6 +236,15 @@ describe("NativeTerminalTransport direct WebSocket adapter", () => {
     const result = await connection;
     expect(result.status).toBe("connected");
     if (result.status !== "connected") return;
+    await vi.waitFor(() =>
+      expect(events).toContainEqual({
+        type: "state",
+        state: "connected",
+        error: null,
+        sourceGrid: { cols: 120, rows: 40 },
+        clientViewport: { cols: 118, rows: 38 },
+      }),
+    );
 
     socket.message(Uint8Array.of(0x00, 0x80, 0xff).buffer);
     await vi.waitFor(() => expect(events.some((event) => event.type === "output")).toBe(true));
@@ -277,7 +295,7 @@ describe("NativeTerminalTransport direct WebSocket adapter", () => {
     });
   });
 
-  it("coalesces resize to the latest bounded control frame and retires at socket HWM", async () => {
+  it("settles only the latest coalesced resize after matching authoritative geometry", async () => {
     const events: NativeTerminalEvent[] = [];
     const harness = rig();
     const { socket, attachment } = await connectLive(harness, (event) => {
@@ -286,13 +304,19 @@ describe("NativeTerminalTransport direct WebSocket adapter", () => {
     const first = attachment.resize({ cols: 80, rows: 24 });
     const second = attachment.resize({ cols: 90, rows: 25 });
     const third = attachment.resize({ cols: 100, rows: 30 });
-    expect(second).toBe(first);
-    expect(third).toBe(first);
-    await expect(Promise.all([first, second, third])).resolves.toEqual([
-      { status: "ok" },
-      { status: "ok" },
-      { status: "ok" },
-    ]);
+    await expect(first).resolves.toMatchObject({
+      status: "error",
+      error: { code: "resize-superseded" },
+    });
+    await expect(second).resolves.toMatchObject({
+      status: "error",
+      error: { code: "resize-superseded" },
+    });
+    let thirdSettled = false;
+    void third.then(() => {
+      thirdSettled = true;
+    });
+    await Promise.resolve();
     expect(socket.sent).toHaveLength(2);
     expect(JSON.parse(socket.sent[1] as string)).toMatchObject({
       type: "resize",
@@ -300,6 +324,22 @@ describe("NativeTerminalTransport direct WebSocket adapter", () => {
       viewport: { cols: 100, rows: 30 },
     });
     socket.message(geometry());
+    await Promise.resolve();
+    expect(thirdSettled).toBe(false);
+    socket.message(
+      geometry({
+        sourceGrid: { cols: 102, rows: 32 },
+        clientViewport: { cols: 100, rows: 30 },
+      }),
+    );
+    await expect(third).resolves.toEqual({ status: "ok" });
+    await vi.waitFor(() =>
+      expect(events).toContainEqual({
+        type: "geometry",
+        sourceGrid: { cols: 102, rows: 32 },
+        clientViewport: { cols: 100, rows: 30 },
+      }),
+    );
 
     socket.bufferedAmount = NATIVE_TERMINAL_MAX_SOCKET_BUFFERED_BYTES;
     await expect(attachment.resize({ cols: 110, rows: 35 })).resolves.toMatchObject({
@@ -314,6 +354,28 @@ describe("NativeTerminalTransport direct WebSocket adapter", () => {
         error: expect.objectContaining({ code: "socket-backpressure" }),
       }),
     );
+  });
+
+  it("serializes sent resize correlation and supersedes older promises deterministically", async () => {
+    const harness = rig();
+    const { socket, attachment } = await connectLive(harness);
+    const first = attachment.resize({ cols: 80, rows: 24 });
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(2));
+    const latest = attachment.resize({ cols: 100, rows: 30 });
+    await expect(first).resolves.toMatchObject({
+      status: "error",
+      error: { code: "resize-superseded" },
+    });
+    expect(socket.sent).toHaveLength(2);
+
+    socket.message(geometry({ clientViewport: { cols: 80, rows: 24 } }));
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(3));
+    expect(JSON.parse(socket.sent[2] as string)).toMatchObject({
+      type: "resize",
+      viewport: { cols: 100, rows: 30 },
+    });
+    socket.message(geometry({ clientViewport: { cols: 100, rows: 30 } }));
+    await expect(latest).resolves.toEqual({ status: "ok" });
   });
 
   it("bounds asynchronous output delivery and retires instead of growing an event queue", async () => {
@@ -346,6 +408,164 @@ describe("NativeTerminalTransport direct WebSocket adapter", () => {
       }),
     );
     expect(events.filter((event) => event.type === "output")).toHaveLength(1);
+  });
+
+  it("rejects oversized text and binary frames before encoding or copying payloads", async () => {
+    const textHarness = rig();
+    const text = await connectLive(textHarness);
+    const encode = vi.spyOn(TextEncoder.prototype, "encode");
+    text.socket.message("x".repeat(NATIVE_TERMINAL_MAX_CONTROL_BYTES + 1));
+    expect(encode).not.toHaveBeenCalled();
+    expect(text.socket.closes.at(-1)).toEqual({
+      code: 1009,
+      reason: "control-frame-too-large",
+    });
+    encode.mockRestore();
+
+    const encodedHarness = rig();
+    const encoded = await connectLive(encodedHarness);
+    const encodedByteCheck = vi.spyOn(TextEncoder.prototype, "encode");
+    encoded.socket.message("€".repeat(Math.floor(NATIVE_TERMINAL_MAX_CONTROL_BYTES / 3) + 1));
+    expect(encodedByteCheck).toHaveBeenCalledOnce();
+    expect(encoded.socket.closes.at(-1)).toEqual({
+      code: 1009,
+      reason: "control-frame-too-large",
+    });
+    encodedByteCheck.mockRestore();
+
+    const bufferHarness = rig();
+    const buffer = await connectLive(bufferHarness);
+    const arrayBufferSlice = vi.spyOn(ArrayBuffer.prototype, "slice");
+    buffer.socket.message(new ArrayBuffer(NATIVE_TERMINAL_MAX_OUTPUT_FRAME_BYTES + 1));
+    expect(arrayBufferSlice).not.toHaveBeenCalled();
+    expect(buffer.socket.closes.at(-1)).toEqual({
+      code: 1009,
+      reason: "output-frame-too-large",
+    });
+    arrayBufferSlice.mockRestore();
+
+    const viewHarness = rig();
+    const view = await connectLive(viewHarness);
+    const typedArraySlice = vi.spyOn(Uint8Array.prototype, "slice");
+    view.socket.message(new Uint8Array(NATIVE_TERMINAL_MAX_OUTPUT_FRAME_BYTES + 1));
+    expect(typedArraySlice).not.toHaveBeenCalled();
+    expect(view.socket.closes.at(-1)).toEqual({
+      code: 1009,
+      reason: "output-frame-too-large",
+    });
+    typedArraySlice.mockRestore();
+  });
+
+  it("retires typed on bounded control and total inbound frame-rate exhaustion", async () => {
+    let clock = NOW;
+    const controlHarness = rig({ now: () => clock });
+    const control = await connectLive(controlHarness);
+    for (
+      let index = 1;
+      index <= NATIVE_TERMINAL_MAX_INBOUND_CONTROL_FRAMES_PER_WINDOW;
+      index += 1
+    ) {
+      control.socket.message(geometry());
+      await Promise.resolve();
+      await Promise.resolve();
+      if (control.socket.readyState === 3) break;
+    }
+    expect(control.socket.closes.at(-1)).toEqual({
+      code: 1008,
+      reason: "control-frame-rate-limit",
+    });
+
+    clock = NOW;
+    const frameHarness = rig({ now: () => clock });
+    const frames = await connectLive(frameHarness);
+    for (let index = 1; index <= NATIVE_TERMINAL_MAX_INBOUND_FRAMES_PER_WINDOW; index += 1) {
+      frames.socket.message(new ArrayBuffer(0));
+      if (frames.socket.readyState === 3) break;
+    }
+    expect(frames.socket.closes.at(-1)).toEqual({
+      code: 1008,
+      reason: "inbound-frame-rate-limit",
+    });
+
+    clock = NOW;
+    const renewalHarness = rig({ now: () => clock });
+    const renewal = await connectLive(renewalHarness);
+    for (let index = 0; index < 4; index += 1) {
+      clock += NATIVE_TERMINAL_RATE_WINDOW_MS;
+      renewal.socket.message(geometry());
+      await Promise.resolve();
+    }
+    expect(renewal.socket.closes).toEqual([]);
+  });
+
+  it("bounds connection lifetime and resize acknowledgement, settling outstanding callers", async () => {
+    const scheduled: Array<{ callback: () => void; active: boolean; delay: number }> = [];
+    const schedule = (callback: () => void, delay: number) => {
+      const entry = { callback, active: true, delay };
+      scheduled.push(entry);
+      return () => {
+        entry.active = false;
+      };
+    };
+
+    const resizeHarness = rig({ schedule });
+    const resize = await connectLive(resizeHarness);
+    const pending = resize.attachment.resize({ cols: 100, rows: 30 });
+    await vi.waitFor(() => expect(resize.socket.sent).toHaveLength(2));
+    const resizeTimeout = scheduled.find(
+      (entry) => entry.active && entry.delay === NATIVE_TERMINAL_RESIZE_ACK_TIMEOUT_MS,
+    );
+    expect(resizeTimeout).toBeDefined();
+    resizeTimeout!.callback();
+    await expect(pending).resolves.toMatchObject({
+      status: "error",
+      error: { code: "resize-ack-timeout" },
+    });
+    expect(resize.socket.closes.at(-1)).toEqual({ code: 1008, reason: "resize-ack-timeout" });
+
+    const lifetimeHarness = rig({ schedule });
+    const lifetimeEvents: NativeTerminalEvent[] = [];
+    const lifetime = await connectLive(lifetimeHarness, (event) => {
+      lifetimeEvents.push(event);
+    });
+    const lifetimeLimit = [...scheduled]
+      .reverse()
+      .find((entry) => entry.active && entry.delay === NATIVE_TERMINAL_MAX_CONNECTION_LIFETIME_MS);
+    expect(lifetimeLimit).toBeDefined();
+    lifetimeLimit!.callback();
+    expect(lifetime.socket.closes.at(-1)).toEqual({
+      code: 1008,
+      reason: "connection-lifetime-limit",
+    });
+    await vi.waitFor(() =>
+      expect(lifetimeEvents).toContainEqual({
+        type: "state",
+        state: "disconnected",
+        error: expect.objectContaining({ code: "connection-lifetime-limit" }),
+      }),
+    );
+  });
+
+  it("settles an outstanding resize with typed close and socket errors", async () => {
+    const closeHarness = rig();
+    const closed = await connectLive(closeHarness);
+    const closedResize = closed.attachment.resize({ cols: 100, rows: 30 });
+    await vi.waitFor(() => expect(closed.socket.sent).toHaveLength(2));
+    closed.socket.peerClose();
+    await expect(closedResize).resolves.toMatchObject({
+      status: "error",
+      error: { code: "attachment-closed" },
+    });
+
+    const errorHarness = rig();
+    const errored = await connectLive(errorHarness);
+    const erroredResize = errored.attachment.resize({ cols: 100, rows: 30 });
+    await vi.waitFor(() => expect(errored.socket.sent).toHaveLength(2));
+    errored.socket.error();
+    await expect(erroredResize).resolves.toMatchObject({
+      status: "error",
+      error: { code: "socket-unavailable" },
+    });
   });
 
   it("translates typed daemon failures and emits one disconnected state", async () => {

--- a/apps/desktop-renderer/src/terminal/native-terminal-websocket-transport.test.ts
+++ b/apps/desktop-renderer/src/terminal/native-terminal-websocket-transport.test.ts
@@ -1,0 +1,497 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  NativeTerminalEvent,
+  NativeTerminalTransportError,
+} from "./native-terminal-transport.ts";
+import {
+  NATIVE_TERMINAL_MAX_QUEUED_EVENTS,
+  NATIVE_TERMINAL_MAX_SOCKET_BUFFERED_BYTES,
+  NATIVE_TERMINAL_WEBSOCKET_PROTOCOL,
+  createNativeTerminalWebSocketTransport,
+  type NativeTerminalSocketEvent,
+  type NativeTerminalSocketListener,
+  type NativeTerminalWebSocket,
+  type NativeTerminalWebSocketTransportDependencies,
+} from "./native-terminal-websocket-transport.ts";
+
+const NOW = 1_000;
+const URL = "ws://127.0.0.1:6070/v1/terminal/attachments/redeem";
+const REQUEST_ID = "2a215cf2-547e-42a2-91c7-454df8e56121";
+const DAEMON_ID = "daemon-instance-1";
+const TICKET = `ta1_${"a".repeat(43)}`;
+const TARGET = { workspaceName: "workspace.alpha", semanticPaneId: "pane.codex" };
+const REQUEST = {
+  protocolVersion: 1 as const,
+  target: TARGET,
+  viewerMode: "interactive" as const,
+  viewport: { cols: 120, rows: 40 },
+};
+
+function issueDescriptor(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    protocolVersion: 1,
+    webSocketUrl: URL,
+    webSocketProtocol: NATIVE_TERMINAL_WEBSOCKET_PROTOCOL,
+    redemptionTicket: TICKET,
+    daemonInstanceId: DAEMON_ID,
+    requestId: REQUEST_ID,
+    expiresAt: NOW + 15_000,
+    effectiveViewerMode: "interactive",
+    ...overrides,
+  };
+}
+
+function ready(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type: "ready",
+    protocolVersion: 1,
+    daemonInstanceId: DAEMON_ID,
+    requestId: REQUEST_ID,
+    generation: 0,
+    effectiveViewerMode: "interactive",
+    inputCapability: "unavailable",
+    sourceGrid: { cols: 120, rows: 40 },
+    clientViewport: { cols: 118, rows: 38 },
+    ...overrides,
+  });
+}
+
+function geometry(generation = 0): string {
+  return JSON.stringify({
+    type: "geometry",
+    protocolVersion: 1,
+    generation,
+    sourceGrid: { cols: 100, rows: 30 },
+    clientViewport: { cols: 98, rows: 28 },
+  });
+}
+
+class FakeWebSocket implements NativeTerminalWebSocket {
+  readyState = 0;
+  bufferedAmount = 0;
+  protocol: string;
+  binaryType: BinaryType = "blob";
+  readonly url: string;
+  readonly sent: Array<string | ArrayBuffer | ArrayBufferView> = [];
+  readonly closes: Array<{ code?: number; reason?: string }> = [];
+  private readonly listeners = new Map<string, Set<NativeTerminalSocketListener>>();
+
+  constructor(url: string, protocol: string) {
+    this.url = url;
+    this.protocol = protocol;
+  }
+
+  addEventListener(type: string, listener: NativeTerminalSocketListener): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: NativeTerminalSocketListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  send(data: string | ArrayBuffer | ArrayBufferView): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closes.push({ code, reason });
+    this.readyState = 3;
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.emit("open");
+  }
+
+  message(data: unknown): void {
+    this.emit("message", { data });
+  }
+
+  peerClose(): void {
+    this.readyState = 3;
+    this.emit("close");
+  }
+
+  error(): void {
+    this.emit("error");
+  }
+
+  private emit(type: string, event: NativeTerminalSocketEvent = {}): void {
+    for (const listener of [...(this.listeners.get(type) ?? [])]) listener(event);
+  }
+}
+
+interface RigOptions {
+  readonly descriptors?: readonly unknown[];
+  readonly schedule?: NativeTerminalWebSocketTransportDependencies["schedule"];
+  readonly issueAttachment?: NativeTerminalWebSocketTransportDependencies["issueAttachment"];
+}
+
+function rig(options: RigOptions = {}) {
+  const descriptors = [...(options.descriptors ?? [issueDescriptor()])];
+  const sockets: FakeWebSocket[] = [];
+  const issueAttachment = vi.fn(
+    options.issueAttachment ?? (async () => descriptors.shift() ?? issueDescriptor()),
+  );
+  const createWebSocket = vi.fn((url: string, protocol: string) => {
+    const socket = new FakeWebSocket(url, protocol);
+    sockets.push(socket);
+    return socket;
+  });
+  const transport = createNativeTerminalWebSocketTransport({
+    issueAttachment,
+    createWebSocket,
+    now: () => NOW,
+    schedule: options.schedule,
+  });
+  return { transport, issueAttachment, createWebSocket, sockets };
+}
+
+async function waitForSocket(sockets: FakeWebSocket[], index = 0): Promise<FakeWebSocket> {
+  await vi.waitFor(() => expect(sockets.length).toBeGreaterThan(index));
+  return sockets[index]!;
+}
+
+async function connectLive(
+  harness: ReturnType<typeof rig>,
+  listener: (event: NativeTerminalEvent) => void | Promise<void> = () => undefined,
+  socketIndex = 0,
+) {
+  const connection = harness.transport.connect(REQUEST, listener);
+  const socket = await waitForSocket(harness.sockets, socketIndex);
+  socket.open();
+  socket.message(ready());
+  const result = await connection;
+  if (result.status !== "connected") throw new Error(result.error.reason);
+  await Promise.resolve();
+  return { socket, attachment: result.attachment };
+}
+
+describe("NativeTerminalTransport direct WebSocket adapter", () => {
+  it("validates semantic requests before issue and rejects unsafe issue descriptors", async () => {
+    const invalidRequest = rig();
+    await expect(
+      invalidRequest.transport.connect(
+        { ...REQUEST, target: { ...TARGET, workspaceName: "%7" } },
+        () => undefined,
+      ),
+    ).resolves.toMatchObject({ status: "error", error: { code: "invalid-request" } });
+    expect(invalidRequest.issueAttachment).not.toHaveBeenCalled();
+
+    for (const descriptor of [
+      issueDescriptor({ webSocketUrl: "ws://192.0.2.1:6070/v1/terminal/attachments/redeem" }),
+      issueDescriptor({
+        webSocketUrl: `ws://secret@127.0.0.1:6070${URL.slice(URL.indexOf("/v1"))}`,
+      }),
+      issueDescriptor({ webSocketUrl: `${URL}?ticket=${TICKET}` }),
+      issueDescriptor({ webSocketProtocol: "other-terminal.v1" }),
+      issueDescriptor({ expiresAt: NOW }),
+      issueDescriptor({ tmuxPaneId: "%7" }),
+    ]) {
+      const harness = rig({ descriptors: [descriptor] });
+      await expect(harness.transport.connect(REQUEST, () => undefined)).resolves.toMatchObject({
+        status: "error",
+        error: { code: "invalid-descriptor" },
+      });
+      expect(harness.createWebSocket).not.toHaveBeenCalled();
+    }
+  });
+
+  it("opens the exact subprotocol, redeems once first, streams binary, and never sends input", async () => {
+    const events: NativeTerminalEvent[] = [];
+    const harness = rig();
+    const connection = harness.transport.connect(REQUEST, (event) => {
+      events.push(event);
+    });
+    const socket = await waitForSocket(harness.sockets);
+
+    expect(harness.issueAttachment).toHaveBeenCalledWith(REQUEST);
+    expect(harness.createWebSocket).toHaveBeenCalledWith(URL, NATIVE_TERMINAL_WEBSOCKET_PROTOCOL);
+    expect(socket.binaryType).toBe("arraybuffer");
+    expect(socket.sent).toEqual([]);
+    expect(socket.url).not.toContain(TICKET);
+
+    socket.open();
+    socket.open();
+    expect(socket.sent).toHaveLength(1);
+    expect(JSON.parse(socket.sent[0] as string)).toEqual({
+      type: "redeem",
+      protocolVersion: 1,
+      ticket: TICKET,
+      requestId: REQUEST_ID,
+      daemonInstanceId: DAEMON_ID,
+    });
+    socket.message(ready());
+    const result = await connection;
+    expect(result.status).toBe("connected");
+    if (result.status !== "connected") return;
+
+    socket.message(Uint8Array.of(0x00, 0x80, 0xff).buffer);
+    await vi.waitFor(() => expect(events.some((event) => event.type === "output")).toBe(true));
+    expect(events).toContainEqual({ type: "output", bytes: Uint8Array.of(0x00, 0x80, 0xff) });
+    await expect(result.attachment.write(Uint8Array.of(3, 0, 255))).resolves.toEqual({
+      status: "error",
+      error: {
+        code: "input-backpressure-unavailable",
+        reason: "Terminal input is unavailable until the daemon enables bounded input recovery.",
+        retryable: false,
+      },
+    });
+    expect(socket.sent).toHaveLength(1);
+    expect(JSON.stringify(result.attachment)).not.toContain(TICKET);
+  });
+
+  it("rejects pre-ready frames, wrong ready identity, and close-versus-ready races", async () => {
+    const preReady = rig();
+    const first = preReady.transport.connect(REQUEST, () => undefined);
+    const firstSocket = await waitForSocket(preReady.sockets);
+    firstSocket.open();
+    firstSocket.message(geometry());
+    await expect(first).resolves.toMatchObject({
+      status: "error",
+      error: { code: "protocol-error" },
+    });
+    expect(firstSocket.closes.at(-1)).toEqual({ code: 1002, reason: "protocol-error" });
+
+    const wrongIdentity = rig();
+    const second = wrongIdentity.transport.connect(REQUEST, () => undefined);
+    const secondSocket = await waitForSocket(wrongIdentity.sockets);
+    secondSocket.open();
+    secondSocket.message(ready({ requestId: "fa8e7197-2236-4a62-bc01-5b64dd18c267" }));
+    await expect(second).resolves.toMatchObject({
+      status: "error",
+      error: { code: "protocol-error" },
+    });
+
+    const closed = rig();
+    const third = closed.transport.connect(REQUEST, () => undefined);
+    const thirdSocket = await waitForSocket(closed.sockets);
+    thirdSocket.open();
+    thirdSocket.peerClose();
+    thirdSocket.message(ready());
+    await expect(third).resolves.toMatchObject({
+      status: "error",
+      error: { code: "attachment-closed" },
+    });
+  });
+
+  it("coalesces resize to the latest bounded control frame and retires at socket HWM", async () => {
+    const events: NativeTerminalEvent[] = [];
+    const harness = rig();
+    const { socket, attachment } = await connectLive(harness, (event) => {
+      events.push(event);
+    });
+    const first = attachment.resize({ cols: 80, rows: 24 });
+    const second = attachment.resize({ cols: 90, rows: 25 });
+    const third = attachment.resize({ cols: 100, rows: 30 });
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    await expect(Promise.all([first, second, third])).resolves.toEqual([
+      { status: "ok" },
+      { status: "ok" },
+      { status: "ok" },
+    ]);
+    expect(socket.sent).toHaveLength(2);
+    expect(JSON.parse(socket.sent[1] as string)).toMatchObject({
+      type: "resize",
+      generation: 0,
+      viewport: { cols: 100, rows: 30 },
+    });
+    socket.message(geometry());
+
+    socket.bufferedAmount = NATIVE_TERMINAL_MAX_SOCKET_BUFFERED_BYTES;
+    await expect(attachment.resize({ cols: 110, rows: 35 })).resolves.toMatchObject({
+      status: "error",
+      error: { code: "socket-backpressure" },
+    });
+    expect(socket.closes.at(-1)).toEqual({ code: 1013, reason: "socket-backpressure" });
+    await vi.waitFor(() =>
+      expect(events).toContainEqual({
+        type: "state",
+        state: "disconnected",
+        error: expect.objectContaining({ code: "socket-backpressure" }),
+      }),
+    );
+  });
+
+  it("bounds asynchronous output delivery and retires instead of growing an event queue", async () => {
+    let releaseOutput!: () => void;
+    const outputGate = new Promise<void>((resolve) => {
+      releaseOutput = resolve;
+    });
+    const events: NativeTerminalEvent[] = [];
+    const harness = rig();
+    const { socket } = await connectLive(harness, async (event) => {
+      events.push(event);
+      if (
+        event.type === "output" &&
+        events.filter((entry) => entry.type === "output").length === 1
+      ) {
+        await outputGate;
+      }
+    });
+
+    for (let index = 0; index <= NATIVE_TERMINAL_MAX_QUEUED_EVENTS; index += 1) {
+      socket.message(Uint8Array.of(index & 0xff).buffer);
+    }
+    expect(socket.closes.at(-1)).toEqual({ code: 1013, reason: "renderer-backpressure" });
+    releaseOutput();
+    await vi.waitFor(() =>
+      expect(events).toContainEqual({
+        type: "state",
+        state: "disconnected",
+        error: expect.objectContaining({ code: "renderer-backpressure" }),
+      }),
+    );
+    expect(events.filter((event) => event.type === "output")).toHaveLength(1);
+  });
+
+  it("translates typed daemon failures and emits one disconnected state", async () => {
+    const events: NativeTerminalEvent[] = [];
+    const harness = rig();
+    const { socket } = await connectLive(harness, (event) => {
+      events.push(event);
+    });
+    socket.message(
+      JSON.stringify({
+        type: "error",
+        protocolVersion: 1,
+        code: "attachment-renewal-failed",
+        retryable: true,
+      }),
+    );
+    socket.peerClose();
+    await vi.waitFor(() =>
+      expect(events.filter((event) => event.type === "state")).toHaveLength(2),
+    );
+    const disconnected = events.filter(
+      (event): event is Extract<NativeTerminalEvent, { type: "state" }> =>
+        event.type === "state" && event.state === "disconnected",
+    );
+    expect(disconnected).toEqual([
+      {
+        type: "state",
+        state: "disconnected",
+        error: {
+          code: "attachment-renewal-failed",
+          reason: "The terminal attachment could not renew its lease.",
+          retryable: true,
+        },
+      },
+    ]);
+  });
+
+  it("tears down idempotently and rejects late socket events and resize", async () => {
+    const events: NativeTerminalEvent[] = [];
+    const harness = rig();
+    const { socket, attachment } = await connectLive(harness, (event) => {
+      events.push(event);
+    });
+    attachment.dispose();
+    attachment.dispose();
+    socket.message(Uint8Array.of(9).buffer);
+    socket.peerClose();
+
+    expect(socket.closes).toEqual([{ code: 1000, reason: "renderer-disposed" }]);
+    await expect(attachment.resize({ cols: 100, rows: 30 })).resolves.toMatchObject({
+      status: "error",
+      error: { code: "resize-unavailable" },
+    });
+    expect(events.filter((event) => event.type === "output")).toEqual([]);
+    expect(
+      events.filter((event) => event.type === "state" && event.state === "disconnected"),
+    ).toEqual([]);
+  });
+
+  it("bounds issue/open lifetime and ignores late completion after expiry", async () => {
+    const scheduled: Array<{ callback: () => void; active: boolean; delay: number }> = [];
+    const schedule = (callback: () => void, delay: number) => {
+      const entry = { callback, active: true, delay };
+      scheduled.push(entry);
+      return () => {
+        entry.active = false;
+      };
+    };
+    const never = new Promise<unknown>(() => undefined);
+    const issueTimeout = rig({ issueAttachment: async () => never, schedule });
+    const timed = issueTimeout.transport.connect(REQUEST, () => undefined);
+    await vi.waitFor(() => expect(scheduled.some((entry) => entry.active)).toBe(true));
+    scheduled.find((entry) => entry.active)!.callback();
+    await expect(timed).resolves.toMatchObject({
+      status: "error",
+      error: { code: "attachment-issue-failed" },
+    });
+    expect(issueTimeout.sockets).toHaveLength(0);
+
+    const openExpiry = rig({ schedule });
+    const opening = openExpiry.transport.connect(REQUEST, () => undefined);
+    const socket = await waitForSocket(openExpiry.sockets);
+    const expiry = [...scheduled].reverse().find((entry) => entry.active);
+    expect(expiry?.delay).toBe(15_000);
+    expiry!.callback();
+    socket.open();
+    socket.message(ready());
+    await expect(opening).resolves.toMatchObject({
+      status: "error",
+      error: { code: "attachment-expired" },
+    });
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  it("requires a fresh issue/ticket on reconnect and rejects late retired output", async () => {
+    const secondTicket = `ta1_${"b".repeat(43)}`;
+    const secondRequest = "fa8e7197-2236-4a62-bc01-5b64dd18c267";
+    const harness = rig({
+      descriptors: [
+        issueDescriptor(),
+        issueDescriptor({ redemptionTicket: secondTicket, requestId: secondRequest }),
+      ],
+    });
+    const firstEvents: NativeTerminalEvent[] = [];
+    const first = await connectLive(harness, (event) => {
+      firstEvents.push(event);
+    });
+    first.socket.message(Uint8Array.of(1).buffer);
+    await vi.waitFor(() => expect(firstEvents.some((event) => event.type === "output")).toBe(true));
+    first.socket.peerClose();
+    first.socket.message(Uint8Array.of(9).buffer);
+
+    const secondEvents: NativeTerminalEvent[] = [];
+    const secondConnection = harness.transport.connect(REQUEST, (event) => {
+      secondEvents.push(event);
+    });
+    const secondSocket = await waitForSocket(harness.sockets, 1);
+    secondSocket.open();
+    secondSocket.message(ready({ requestId: secondRequest }));
+    const second = await secondConnection;
+    expect(second.status).toBe("connected");
+    secondSocket.message(Uint8Array.of(2).buffer);
+    await vi.waitFor(() =>
+      expect(secondEvents.some((event) => event.type === "output")).toBe(true),
+    );
+
+    expect(harness.issueAttachment).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(first.socket.sent[0] as string).ticket).toBe(TICKET);
+    expect(JSON.parse(secondSocket.sent[0] as string).ticket).toBe(secondTicket);
+    expect(firstEvents.filter((event) => event.type === "output")).toEqual([
+      { type: "output", bytes: Uint8Array.of(1) },
+    ]);
+    expect(secondEvents.filter((event) => event.type === "output")).toEqual([
+      { type: "output", bytes: Uint8Array.of(2) },
+    ]);
+  });
+
+  it("does not reflect bearer material through typed failures", async () => {
+    const secret = `${TICKET}-must-not-reflect`;
+    const harness = rig({ issueAttachment: async () => Promise.reject(new Error(secret)) });
+    const result = await harness.transport.connect(REQUEST, () => undefined);
+    expect(result.status).toBe("error");
+    if (result.status !== "error") return;
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect((result.error satisfies NativeTerminalTransportError).code).toBe(
+      "attachment-issue-failed",
+    );
+  });
+});

--- a/apps/desktop-renderer/src/terminal/native-terminal-websocket-transport.ts
+++ b/apps/desktop-renderer/src/terminal/native-terminal-websocket-transport.ts
@@ -26,6 +26,11 @@ export const NATIVE_TERMINAL_MAX_CONTROL_FRAMES = 1_024;
 export const NATIVE_TERMINAL_MAX_SOCKET_BUFFERED_BYTES = 64 * 1024;
 export const NATIVE_TERMINAL_MAX_DESCRIPTOR_LIFETIME_MS = 60_000;
 export const NATIVE_TERMINAL_DEFAULT_ISSUE_TIMEOUT_MS = 5_000;
+export const NATIVE_TERMINAL_RATE_WINDOW_MS = 1_000;
+export const NATIVE_TERMINAL_MAX_INBOUND_FRAMES_PER_WINDOW = 4_096;
+export const NATIVE_TERMINAL_MAX_INBOUND_CONTROL_FRAMES_PER_WINDOW = 256;
+export const NATIVE_TERMINAL_MAX_CONNECTION_LIFETIME_MS = 24 * 60 * 60 * 1_000;
+export const NATIVE_TERMINAL_RESIZE_ACK_TIMEOUT_MS = 5_000;
 
 const REDEEM_PATH = "/v1/terminal/attachments/redeem";
 const WS_CONNECTING = 0;
@@ -91,11 +96,15 @@ interface ReadyFrame {
   readonly requestId: string;
   readonly generation: number;
   readonly effectiveViewerMode: TerminalAttachmentViewerMode;
+  readonly sourceGrid: TerminalAttachmentViewport;
+  readonly clientViewport: TerminalAttachmentViewport;
 }
 
 interface GeometryFrame {
   readonly type: "geometry";
   readonly generation: number;
+  readonly sourceGrid: TerminalAttachmentViewport;
+  readonly clientViewport: TerminalAttachmentViewport;
 }
 
 interface ExitFrame {
@@ -116,6 +125,19 @@ type ServerControlFrame = ReadyFrame | GeometryFrame | ExitFrame | ErrorFrame;
 interface QueuedEvent {
   readonly event: NativeTerminalEvent;
   readonly byteLength: number;
+}
+
+interface ResizeRequest {
+  readonly viewport: TerminalAttachmentViewport;
+  readonly promise: Promise<NativeTerminalMutationResult>;
+  readonly resolve: (result: NativeTerminalMutationResult) => void;
+  settled: boolean;
+}
+
+interface SentResize {
+  readonly viewport: TerminalAttachmentViewport;
+  request: ResizeRequest | null;
+  cancelTimeout: () => void;
 }
 
 function defaultCreateWebSocket(url: string, protocol: string): NativeTerminalWebSocket {
@@ -167,8 +189,12 @@ function safeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value);
 }
 
-function controlByteLength(value: string): number {
-  return new TextEncoder().encode(value).byteLength;
+function boundedControlByteLength(value: string): number | null {
+  // A UTF-16 code unit always contributes at least one UTF-8 byte. Reject on
+  // that allocation-free lower bound before TextEncoder can copy hostile text.
+  if (value.length === 0 || value.length > NATIVE_TERMINAL_MAX_CONTROL_BYTES) return null;
+  const byteLength = new TextEncoder().encode(value).byteLength;
+  return byteLength <= NATIVE_TERMINAL_MAX_CONTROL_BYTES ? byteLength : null;
 }
 
 function validateLoopbackWebSocketUrl(value: unknown): string | null {
@@ -233,7 +259,7 @@ function validateIssueDescriptor(
     requestId: value.requestId,
     daemonInstanceId: value.daemonInstanceId,
   });
-  if (controlByteLength(redemptionFrame) > NATIVE_TERMINAL_MAX_CONTROL_BYTES) return null;
+  if (boundedControlByteLength(redemptionFrame) === null) return null;
 
   // A mode change is allowed only when it is explicit in both issue and ready;
   // the renderer never infers authority from the requested mode.
@@ -250,7 +276,6 @@ function validateIssueDescriptor(
 }
 
 function parseControlFrame(text: string): ServerControlFrame | null {
-  if (text.length === 0 || controlByteLength(text) > NATIVE_TERMINAL_MAX_CONTROL_BYTES) return null;
   let value: unknown;
   try {
     value = JSON.parse(text);
@@ -293,6 +318,8 @@ function parseControlFrame(text: string): ServerControlFrame | null {
       requestId: value.requestId,
       generation: value.generation,
       effectiveViewerMode: viewerMode.data,
+      sourceGrid: TerminalAttachmentViewportSchemaZ.parse(value.sourceGrid),
+      clientViewport: TerminalAttachmentViewportSchemaZ.parse(value.clientViewport),
     };
   }
 
@@ -312,7 +339,12 @@ function parseControlFrame(text: string): ServerControlFrame | null {
     ) {
       return null;
     }
-    return { type: "geometry", generation: value.generation };
+    return {
+      type: "geometry",
+      generation: value.generation,
+      sourceGrid: TerminalAttachmentViewportSchemaZ.parse(value.sourceGrid),
+      clientViewport: TerminalAttachmentViewportSchemaZ.parse(value.clientViewport),
+    };
   }
 
   if (value.type === "exit") {
@@ -374,12 +406,17 @@ function controlError(frame: ErrorFrame): NativeTerminalTransportError {
   );
 }
 
-function binaryBytes(value: unknown): Uint8Array | null {
+function binaryByteLength(value: unknown): number | null {
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return value.byteLength;
+  return null;
+}
+
+function copyBinaryBytes(value: ArrayBuffer | ArrayBufferView): Uint8Array {
   if (value instanceof ArrayBuffer) return new Uint8Array(value.slice(0));
   if (ArrayBuffer.isView(value)) {
     return new Uint8Array(value.buffer, value.byteOffset, value.byteLength).slice();
   }
-  return null;
+  throw new TypeError("Terminal output frame is not binary.");
 }
 
 function boundedIssueTimeout(value: number | undefined): number {
@@ -388,6 +425,21 @@ function boundedIssueTimeout(value: number | undefined): number {
     throw new TypeError("Native terminal issue timeout is invalid.");
   }
   return selected;
+}
+
+function sameViewport(
+  left: TerminalAttachmentViewport,
+  right: TerminalAttachmentViewport,
+): boolean {
+  return left.cols === right.cols && left.rows === right.rows;
+}
+
+function resizeRequest(viewport: TerminalAttachmentViewport): ResizeRequest {
+  let resolve!: (result: NativeTerminalMutationResult) => void;
+  const promise = new Promise<NativeTerminalMutationResult>((settle) => {
+    resolve = settle;
+  });
+  return { viewport, promise, resolve, settled: false };
 }
 
 class NativeTerminalWebSocketSession {
@@ -402,6 +454,7 @@ class NativeTerminalWebSocketSession {
   #resolveConnect!: (result: NativeTerminalConnectResult) => void;
   #redemptionFrame: string | null;
   #cancelExpiry: (() => void) | null = null;
+  #cancelLifetime: (() => void) | null = null;
   #phase: "opening" | "redeeming" | "live" | "closed" = "opening";
   #generation: number | null = null;
   #connectSettled = false;
@@ -409,9 +462,13 @@ class NativeTerminalWebSocketSession {
   #eventCount = 0;
   #eventBytes = 0;
   #delivering = false;
-  #pendingResize: TerminalAttachmentViewport | null = null;
-  #resizePromise: Promise<NativeTerminalMutationResult> | null = null;
-  #controlFrames = 0;
+  #queuedResize: ResizeRequest | null = null;
+  #sentResize: SentResize | null = null;
+  #resizeFlushScheduled = false;
+  #outboundControlFrames = 0;
+  #rateWindowStartedAt: number;
+  #inboundFrames = 0;
+  #inboundControlFrames = 0;
 
   constructor(options: {
     readonly descriptor: SafeIssueDescriptor;
@@ -424,6 +481,7 @@ class NativeTerminalWebSocketSession {
     this.#listener = options.listener;
     this.#schedule = options.schedule;
     this.#now = options.now;
+    this.#rateWindowStartedAt = options.now();
     const { redemptionFrame, ...identity } = options.descriptor;
     this.#redemptionFrame = redemptionFrame;
     this.#identity = identity;
@@ -505,7 +563,21 @@ class NativeTerminalWebSocketSession {
       if (this.#phase === "opening") this.#protocolFailure();
       return;
     }
+    if (!this.#acceptInboundFrame(typeof event.data === "string")) return;
     if (typeof event.data === "string") {
+      if (boundedControlByteLength(event.data) === null) {
+        this.#retire(
+          transportError(
+            "control-frame-too-large",
+            "The daemon sent an oversized terminal control frame.",
+            true,
+          ),
+          this.#phase === "live",
+          1009,
+          "control-frame-too-large",
+        );
+        return;
+      }
       const frame = parseControlFrame(event.data);
       if (!frame) {
         this.#protocolFailure();
@@ -514,13 +586,13 @@ class NativeTerminalWebSocketSession {
       this.#handleControl(frame);
       return;
     }
-    const bytes = binaryBytes(event.data);
-    if (!bytes || this.#phase !== "live") {
+    const byteLength = binaryByteLength(event.data);
+    if (byteLength === null || this.#phase !== "live") {
       this.#protocolFailure();
       return;
     }
-    if (bytes.byteLength === 0) return;
-    if (bytes.byteLength > NATIVE_TERMINAL_MAX_OUTPUT_FRAME_BYTES) {
+    if (byteLength === 0) return;
+    if (byteLength > NATIVE_TERMINAL_MAX_OUTPUT_FRAME_BYTES) {
       this.#retire(
         transportError(
           "output-frame-too-large",
@@ -533,8 +605,41 @@ class NativeTerminalWebSocketSession {
       );
       return;
     }
-    this.#queueEvent({ type: "output", bytes }, bytes.byteLength);
+    const bytes = copyBinaryBytes(event.data as ArrayBuffer | ArrayBufferView);
+    this.#queueEvent({ type: "output", bytes }, byteLength);
   };
+
+  #acceptInboundFrame(control: boolean): boolean {
+    const now = this.#now();
+    if (
+      !Number.isSafeInteger(now) ||
+      now < this.#rateWindowStartedAt ||
+      now - this.#rateWindowStartedAt >= NATIVE_TERMINAL_RATE_WINDOW_MS
+    ) {
+      this.#rateWindowStartedAt = Number.isSafeInteger(now) ? now : this.#rateWindowStartedAt;
+      this.#inboundFrames = 0;
+      this.#inboundControlFrames = 0;
+    }
+    this.#inboundFrames += 1;
+    if (control) this.#inboundControlFrames += 1;
+    if (
+      this.#inboundFrames <= NATIVE_TERMINAL_MAX_INBOUND_FRAMES_PER_WINDOW &&
+      this.#inboundControlFrames <= NATIVE_TERMINAL_MAX_INBOUND_CONTROL_FRAMES_PER_WINDOW
+    ) {
+      return true;
+    }
+    const controlExhausted =
+      this.#inboundControlFrames > NATIVE_TERMINAL_MAX_INBOUND_CONTROL_FRAMES_PER_WINDOW;
+    const error = transportError(
+      controlExhausted ? "control-frame-rate-limit" : "inbound-frame-rate-limit",
+      controlExhausted
+        ? "The daemon exceeded the terminal control-frame rate limit."
+        : "The daemon exceeded the terminal inbound frame-rate limit.",
+      true,
+    );
+    this.#retire(error, this.#phase === "live", 1008, error.code);
+    return false;
+  }
 
   readonly #onClose = (): void => {
     if (this.#phase === "closed") return;
@@ -573,8 +678,32 @@ class NativeTerminalWebSocketSession {
       this.#phase = "live";
       this.#cancelExpiry?.();
       this.#cancelExpiry = null;
+      this.#cancelLifetime = this.#schedule(
+        () =>
+          this.#retire(
+            transportError(
+              "connection-lifetime-limit",
+              "The terminal attachment reached its maximum connection lifetime.",
+              true,
+            ),
+            true,
+            1008,
+            "connection-lifetime-limit",
+          ),
+        NATIVE_TERMINAL_MAX_CONNECTION_LIFETIME_MS,
+      );
+      if (this.#phase !== "live") return;
       this.#settleConnect({ status: "connected", attachment: this.#attachment });
-      this.#queueEvent({ type: "state", state: "connected", error: null }, 0);
+      this.#queueEvent(
+        {
+          type: "state",
+          state: "connected",
+          error: null,
+          sourceGrid: frame.sourceGrid,
+          clientViewport: frame.clientViewport,
+        },
+        0,
+      );
       return;
     }
 
@@ -587,7 +716,19 @@ class NativeTerminalWebSocketSession {
       return;
     }
     if (frame.type === "geometry") {
-      if (frame.generation !== this.#generation) this.#protocolFailure();
+      if (frame.generation !== this.#generation) {
+        this.#protocolFailure();
+        return;
+      }
+      this.#queueEvent(
+        {
+          type: "geometry",
+          sourceGrid: frame.sourceGrid,
+          clientViewport: frame.clientViewport,
+        },
+        0,
+      );
+      this.#acknowledgeResize(frame.clientViewport);
       return;
     }
     if (frame.type === "exit") {
@@ -644,47 +785,130 @@ class NativeTerminalWebSocketSession {
         errorResult(transportError("resize-unavailable", "Terminal resize is unavailable.", true)),
       );
     }
-    this.#pendingResize = parsed.data;
-    if (this.#resizePromise) return this.#resizePromise;
-    this.#resizePromise = Promise.resolve().then(() => {
-      const next = this.#pendingResize;
-      this.#pendingResize = null;
-      this.#resizePromise = null;
-      if (this.#phase !== "live" || this.#generation === null || !next) {
-        return errorResult(
-          transportError("resize-unavailable", "Terminal resize is unavailable.", true),
-        );
-      }
-      if (this.#controlFrames >= NATIVE_TERMINAL_MAX_CONTROL_FRAMES) {
-        const error = transportError(
+    const next = parsed.data;
+    if (this.#queuedResize && sameViewport(this.#queuedResize.viewport, next)) {
+      return this.#queuedResize.promise;
+    }
+    if (this.#sentResize && sameViewport(this.#sentResize.viewport, next)) {
+      this.#supersedeResize(this.#queuedResize);
+      this.#queuedResize = null;
+      if (this.#sentResize.request) return this.#sentResize.request.promise;
+      const request = resizeRequest(next);
+      this.#sentResize.request = request;
+      return request.promise;
+    }
+
+    if (this.#sentResize?.request) {
+      this.#supersedeResize(this.#sentResize.request);
+      this.#sentResize.request = null;
+    }
+    this.#supersedeResize(this.#queuedResize);
+    const request = resizeRequest(next);
+    this.#queuedResize = request;
+    this.#scheduleResizeFlush();
+    return request.promise;
+  }
+
+  #supersedeResize(request: ResizeRequest | null): void {
+    if (!request || request.settled) return;
+    request.settled = true;
+    request.resolve(
+      errorResult(
+        transportError(
+          "resize-superseded",
+          "A newer terminal viewport superseded this resize request.",
+          true,
+        ),
+      ),
+    );
+  }
+
+  #settleResize(request: ResizeRequest | null, result: NativeTerminalMutationResult): void {
+    if (!request || request.settled) return;
+    request.settled = true;
+    request.resolve(result);
+  }
+
+  #scheduleResizeFlush(): void {
+    if (this.#resizeFlushScheduled) return;
+    this.#resizeFlushScheduled = true;
+    void Promise.resolve().then(() => {
+      this.#resizeFlushScheduled = false;
+      this.#flushResize();
+    });
+  }
+
+  #flushResize(): void {
+    if (this.#sentResize || !this.#queuedResize) return;
+    if (this.#phase !== "live" || this.#generation === null) {
+      const request = this.#queuedResize;
+      this.#queuedResize = null;
+      this.#settleResize(
+        request,
+        errorResult(transportError("resize-unavailable", "Terminal resize is unavailable.", true)),
+      );
+      return;
+    }
+    if (this.#outboundControlFrames >= NATIVE_TERMINAL_MAX_CONTROL_FRAMES) {
+      this.#retire(
+        transportError(
           "control-frame-limit",
           "The terminal control-frame limit was exhausted.",
           true,
-        );
-        this.#retire(error, true, 1008, "control-frame-limit");
-        return errorResult(error);
-      }
-      const frame = JSON.stringify({
-        type: "resize",
-        protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
-        generation: this.#generation,
-        viewport: next,
-      });
-      const sendError = this.#sendControl(frame);
-      if (sendError) return errorResult(sendError);
-      this.#controlFrames += 1;
-      return { status: "ok" };
+        ),
+        true,
+        1008,
+        "control-frame-limit",
+      );
+      return;
+    }
+    const request = this.#queuedResize;
+    const frame = JSON.stringify({
+      type: "resize",
+      protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+      generation: this.#generation,
+      viewport: request.viewport,
     });
-    return this.#resizePromise;
+    const sendError = this.#sendControl(frame);
+    if (sendError) return;
+    this.#queuedResize = null;
+    this.#outboundControlFrames += 1;
+    const sent: SentResize = {
+      viewport: request.viewport,
+      request,
+      cancelTimeout: () => undefined,
+    };
+    this.#sentResize = sent;
+    sent.cancelTimeout = this.#schedule(() => {
+      if (this.#sentResize !== sent) return;
+      this.#retire(
+        transportError(
+          "resize-ack-timeout",
+          "The daemon did not confirm the terminal viewport in time.",
+          true,
+        ),
+        true,
+        1008,
+        "resize-ack-timeout",
+      );
+    }, NATIVE_TERMINAL_RESIZE_ACK_TIMEOUT_MS);
+  }
+
+  #acknowledgeResize(viewport: TerminalAttachmentViewport): void {
+    const sent = this.#sentResize;
+    if (!sent || !sameViewport(sent.viewport, viewport)) return;
+    sent.cancelTimeout();
+    this.#sentResize = null;
+    this.#settleResize(sent.request, { status: "ok" });
+    this.#scheduleResizeFlush();
   }
 
   #sendControl(frame: string): NativeTerminalTransportError | null {
-    const byteLength = controlByteLength(frame);
+    const byteLength = boundedControlByteLength(frame);
     const buffered = this.#socket.bufferedAmount;
     if (
       this.#socket.readyState !== WS_OPEN ||
-      byteLength === 0 ||
-      byteLength > NATIVE_TERMINAL_MAX_CONTROL_BYTES ||
+      byteLength === null ||
       !Number.isSafeInteger(buffered) ||
       buffered < 0 ||
       buffered > NATIVE_TERMINAL_MAX_SOCKET_BUFFERED_BYTES - byteLength
@@ -793,9 +1017,17 @@ class NativeTerminalWebSocketSession {
     const wasLive = this.#phase === "live";
     this.#phase = "closed";
     this.#redemptionFrame = null;
-    this.#pendingResize = null;
+    const queuedResize = this.#queuedResize;
+    const sentResize = this.#sentResize;
+    this.#queuedResize = null;
+    this.#sentResize = null;
+    sentResize?.cancelTimeout();
+    this.#settleResize(sentResize?.request ?? null, errorResult(error));
+    this.#settleResize(queuedResize, errorResult(error));
     this.#cancelExpiry?.();
     this.#cancelExpiry = null;
+    this.#cancelLifetime?.();
+    this.#cancelLifetime = null;
     this.#socket.removeEventListener("open", this.#onOpen);
     this.#socket.removeEventListener("message", this.#onMessage);
     this.#socket.removeEventListener("close", this.#onClose);

--- a/apps/desktop-renderer/src/terminal/native-terminal-websocket-transport.ts
+++ b/apps/desktop-renderer/src/terminal/native-terminal-websocket-transport.ts
@@ -1,0 +1,949 @@
+import {
+  TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+  TerminalAttachRequestSchemaZ,
+  TerminalAttachmentViewerModeSchemaZ,
+  TerminalAttachmentViewportSchemaZ,
+  type TerminalAttachRequest,
+  type TerminalAttachmentViewerMode,
+  type TerminalAttachmentViewport,
+} from "@tmux-ide/contracts";
+
+import type {
+  NativeTerminalAttachment,
+  NativeTerminalConnectResult,
+  NativeTerminalEvent,
+  NativeTerminalMutationResult,
+  NativeTerminalTransport,
+  NativeTerminalTransportError,
+} from "./native-terminal-transport.ts";
+
+export const NATIVE_TERMINAL_WEBSOCKET_PROTOCOL = "tmux-ide-terminal.v1";
+export const NATIVE_TERMINAL_MAX_CONTROL_BYTES = 4 * 1024;
+export const NATIVE_TERMINAL_MAX_OUTPUT_FRAME_BYTES = 256 * 1024;
+export const NATIVE_TERMINAL_MAX_QUEUED_EVENT_BYTES = 1024 * 1024;
+export const NATIVE_TERMINAL_MAX_QUEUED_EVENTS = 32;
+export const NATIVE_TERMINAL_MAX_CONTROL_FRAMES = 1_024;
+export const NATIVE_TERMINAL_MAX_SOCKET_BUFFERED_BYTES = 64 * 1024;
+export const NATIVE_TERMINAL_MAX_DESCRIPTOR_LIFETIME_MS = 60_000;
+export const NATIVE_TERMINAL_DEFAULT_ISSUE_TIMEOUT_MS = 5_000;
+
+const REDEEM_PATH = "/v1/terminal/attachments/redeem";
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
+const WS_CLOSING = 2;
+const RequestIdPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+const ErrorCodePattern = /^[a-z][a-z0-9_-]{0,79}$/u;
+
+type SocketEventType = "open" | "message" | "close" | "error";
+
+export interface NativeTerminalSocketEvent {
+  readonly data?: unknown;
+}
+
+export type NativeTerminalSocketListener = (event: NativeTerminalSocketEvent) => void;
+
+/** Browser WebSocket subset used by the renderer-only transport and deterministic tests. */
+export interface NativeTerminalWebSocket {
+  readonly readyState: number;
+  readonly bufferedAmount: number;
+  readonly protocol: string;
+  binaryType: BinaryType;
+  addEventListener(type: SocketEventType, listener: NativeTerminalSocketListener): void;
+  removeEventListener(type: SocketEventType, listener: NativeTerminalSocketListener): void;
+  send(data: string | ArrayBuffer | ArrayBufferView): void;
+  close(code?: number, reason?: string): void;
+}
+
+export type NativeTerminalWebSocketFactory = (
+  url: string,
+  protocol: string,
+) => NativeTerminalWebSocket;
+
+/** The unreviewed host result stays unknown until this card-local parser accepts it. */
+export type NativeTerminalIssueAttachment = (request: TerminalAttachRequest) => Promise<unknown>;
+
+export interface NativeTerminalWebSocketTransportDependencies {
+  /** Privileged issue call injected by a future host adapter; never a stream proxy. */
+  readonly issueAttachment: NativeTerminalIssueAttachment;
+  readonly createWebSocket?: NativeTerminalWebSocketFactory;
+  readonly now?: () => number;
+  readonly schedule?: (callback: () => void, delayMs: number) => () => void;
+  readonly issueTimeoutMs?: number;
+}
+
+interface SafeIssueDescriptor {
+  readonly webSocketUrl: string;
+  readonly webSocketProtocol: typeof NATIVE_TERMINAL_WEBSOCKET_PROTOCOL;
+  readonly daemonInstanceId: string;
+  readonly requestId: string;
+  readonly expiresAt: number;
+  readonly effectiveViewerMode: TerminalAttachmentViewerMode;
+  readonly redemptionFrame: string;
+}
+
+// Card-local projections of untrusted daemon frames. They deliberately are
+// not exported as a public wire contract; every field is checked below before
+// it can affect renderer state.
+interface ReadyFrame {
+  readonly type: "ready";
+  readonly daemonInstanceId: string;
+  readonly requestId: string;
+  readonly generation: number;
+  readonly effectiveViewerMode: TerminalAttachmentViewerMode;
+}
+
+interface GeometryFrame {
+  readonly type: "geometry";
+  readonly generation: number;
+}
+
+interface ExitFrame {
+  readonly type: "exit";
+  readonly generation: number;
+  readonly exitCode: number;
+  readonly signal: number | null;
+}
+
+interface ErrorFrame {
+  readonly type: "error" | "mutation-error";
+  readonly code: string;
+  readonly retryable: boolean;
+}
+
+type ServerControlFrame = ReadyFrame | GeometryFrame | ExitFrame | ErrorFrame;
+
+interface QueuedEvent {
+  readonly event: NativeTerminalEvent;
+  readonly byteLength: number;
+}
+
+function defaultCreateWebSocket(url: string, protocol: string): NativeTerminalWebSocket {
+  return new globalThis.WebSocket(url, protocol) as unknown as NativeTerminalWebSocket;
+}
+
+function defaultSchedule(callback: () => void, delayMs: number): () => void {
+  const timer = globalThis.setTimeout(callback, delayMs);
+  return () => globalThis.clearTimeout(timer);
+}
+
+function transportError(
+  code: string,
+  reason: string,
+  retryable: boolean,
+): NativeTerminalTransportError {
+  return Object.freeze({ code, reason, retryable });
+}
+
+const INPUT_UNAVAILABLE = transportError(
+  "input-backpressure-unavailable",
+  "Terminal input is unavailable until the daemon enables bounded input recovery.",
+  false,
+);
+
+function errorResult(error: NativeTerminalTransportError): NativeTerminalMutationResult {
+  return { status: "error", error };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const keys = Object.keys(value).sort();
+  return keys.length === expected.length && keys.every((key, index) => key === expected[index]);
+}
+
+function safeIdentity(value: unknown, maximum: number): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= maximum &&
+    !/[\0\r\n]/u.test(value)
+  );
+}
+
+function safeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value);
+}
+
+function controlByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function validateLoopbackWebSocketUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0 || value.length > 2_048) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (
+    (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") ||
+    !["127.0.0.1", "localhost", "[::1]"].includes(parsed.hostname) ||
+    parsed.username.length > 0 ||
+    parsed.password.length > 0 ||
+    parsed.pathname !== REDEEM_PATH ||
+    parsed.search.length > 0 ||
+    parsed.hash.length > 0
+  ) {
+    return null;
+  }
+  return parsed.toString();
+}
+
+function validateIssueDescriptor(
+  value: unknown,
+  request: TerminalAttachRequest,
+  now: number,
+): SafeIssueDescriptor | null {
+  if (!isRecord(value)) return null;
+  if (
+    !hasExactKeys(value, [
+      "daemonInstanceId",
+      "effectiveViewerMode",
+      "expiresAt",
+      "protocolVersion",
+      "redemptionTicket",
+      "requestId",
+      "webSocketProtocol",
+      "webSocketUrl",
+    ]) ||
+    value.protocolVersion !== TERMINAL_ATTACHMENT_PROTOCOL_VERSION ||
+    value.webSocketProtocol !== NATIVE_TERMINAL_WEBSOCKET_PROTOCOL ||
+    !safeIdentity(value.daemonInstanceId, 4_096) ||
+    typeof value.requestId !== "string" ||
+    !RequestIdPattern.test(value.requestId) ||
+    !safeInteger(value.expiresAt) ||
+    value.expiresAt <= now ||
+    value.expiresAt - now > NATIVE_TERMINAL_MAX_DESCRIPTOR_LIFETIME_MS ||
+    !safeIdentity(value.redemptionTicket, 4_096)
+  ) {
+    return null;
+  }
+  const webSocketUrl = validateLoopbackWebSocketUrl(value.webSocketUrl);
+  const viewerMode = TerminalAttachmentViewerModeSchemaZ.safeParse(value.effectiveViewerMode);
+  if (!webSocketUrl || !viewerMode.success) return null;
+
+  const redemptionFrame = JSON.stringify({
+    type: "redeem",
+    protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+    ticket: value.redemptionTicket,
+    requestId: value.requestId,
+    daemonInstanceId: value.daemonInstanceId,
+  });
+  if (controlByteLength(redemptionFrame) > NATIVE_TERMINAL_MAX_CONTROL_BYTES) return null;
+
+  // A mode change is allowed only when it is explicit in both issue and ready;
+  // the renderer never infers authority from the requested mode.
+  void request;
+  return {
+    webSocketUrl,
+    webSocketProtocol: NATIVE_TERMINAL_WEBSOCKET_PROTOCOL,
+    daemonInstanceId: value.daemonInstanceId,
+    requestId: value.requestId,
+    expiresAt: value.expiresAt,
+    effectiveViewerMode: viewerMode.data,
+    redemptionFrame,
+  };
+}
+
+function parseControlFrame(text: string): ServerControlFrame | null {
+  if (text.length === 0 || controlByteLength(text) > NATIVE_TERMINAL_MAX_CONTROL_BYTES) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!isRecord(value) || value.protocolVersion !== TERMINAL_ATTACHMENT_PROTOCOL_VERSION) {
+    return null;
+  }
+
+  if (value.type === "ready") {
+    if (
+      !hasExactKeys(value, [
+        "clientViewport",
+        "daemonInstanceId",
+        "effectiveViewerMode",
+        "generation",
+        "inputCapability",
+        "protocolVersion",
+        "requestId",
+        "sourceGrid",
+        "type",
+      ]) ||
+      !safeInteger(value.generation) ||
+      value.generation < 0 ||
+      value.inputCapability !== "unavailable" ||
+      !safeIdentity(value.daemonInstanceId, 4_096) ||
+      typeof value.requestId !== "string" ||
+      !RequestIdPattern.test(value.requestId) ||
+      !TerminalAttachmentViewportSchemaZ.safeParse(value.sourceGrid).success ||
+      !TerminalAttachmentViewportSchemaZ.safeParse(value.clientViewport).success
+    ) {
+      return null;
+    }
+    const viewerMode = TerminalAttachmentViewerModeSchemaZ.safeParse(value.effectiveViewerMode);
+    if (!viewerMode.success) return null;
+    return {
+      type: "ready",
+      daemonInstanceId: value.daemonInstanceId,
+      requestId: value.requestId,
+      generation: value.generation,
+      effectiveViewerMode: viewerMode.data,
+    };
+  }
+
+  if (value.type === "geometry") {
+    if (
+      !hasExactKeys(value, [
+        "clientViewport",
+        "generation",
+        "protocolVersion",
+        "sourceGrid",
+        "type",
+      ]) ||
+      !safeInteger(value.generation) ||
+      value.generation < 0 ||
+      !TerminalAttachmentViewportSchemaZ.safeParse(value.sourceGrid).success ||
+      !TerminalAttachmentViewportSchemaZ.safeParse(value.clientViewport).success
+    ) {
+      return null;
+    }
+    return { type: "geometry", generation: value.generation };
+  }
+
+  if (value.type === "exit") {
+    if (
+      !hasExactKeys(value, ["exitCode", "generation", "protocolVersion", "signal", "type"]) ||
+      !safeInteger(value.generation) ||
+      value.generation < 0 ||
+      !safeInteger(value.exitCode) ||
+      !(value.signal === null || safeInteger(value.signal))
+    ) {
+      return null;
+    }
+    return {
+      type: "exit",
+      generation: value.generation,
+      exitCode: value.exitCode,
+      signal: value.signal,
+    };
+  }
+
+  if (value.type === "error") {
+    if (
+      !hasExactKeys(value, ["code", "protocolVersion", "retryable", "type"]) ||
+      typeof value.code !== "string" ||
+      !ErrorCodePattern.test(value.code) ||
+      typeof value.retryable !== "boolean"
+    ) {
+      return null;
+    }
+    return { type: "error", code: value.code, retryable: value.retryable };
+  }
+
+  if (value.type === "mutation-error") {
+    if (
+      !hasExactKeys(value, ["code", "mutation", "protocolVersion", "retryable", "type"]) ||
+      value.mutation !== "input" ||
+      typeof value.code !== "string" ||
+      !ErrorCodePattern.test(value.code) ||
+      typeof value.retryable !== "boolean"
+    ) {
+      return null;
+    }
+    return { type: "mutation-error", code: value.code, retryable: value.retryable };
+  }
+
+  return null;
+}
+
+function controlError(frame: ErrorFrame): NativeTerminalTransportError {
+  const reasons: Readonly<Record<string, string>> = {
+    "attachment-renewal-failed": "The terminal attachment could not renew its lease.",
+    "input-backpressure-unavailable": INPUT_UNAVAILABLE.reason,
+    "resize-unavailable": "The daemon could not resize this terminal attachment.",
+  };
+  return transportError(
+    frame.code,
+    reasons[frame.code] ?? "The daemon retired this terminal attachment.",
+    frame.retryable,
+  );
+}
+
+function binaryBytes(value: unknown): Uint8Array | null {
+  if (value instanceof ArrayBuffer) return new Uint8Array(value.slice(0));
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength).slice();
+  }
+  return null;
+}
+
+function boundedIssueTimeout(value: number | undefined): number {
+  const selected = value ?? NATIVE_TERMINAL_DEFAULT_ISSUE_TIMEOUT_MS;
+  if (!Number.isSafeInteger(selected) || selected <= 0 || selected > 30_000) {
+    throw new TypeError("Native terminal issue timeout is invalid.");
+  }
+  return selected;
+}
+
+class NativeTerminalWebSocketSession {
+  readonly #socket: NativeTerminalWebSocket;
+  readonly #listener: (event: NativeTerminalEvent) => void | Promise<void>;
+  readonly #identity: Omit<SafeIssueDescriptor, "redemptionFrame">;
+  readonly #schedule: (callback: () => void, delayMs: number) => () => void;
+  readonly #now: () => number;
+  readonly #eventQueue: QueuedEvent[] = [];
+  readonly #attachment: NativeTerminalAttachment;
+  readonly #connectPromise: Promise<NativeTerminalConnectResult>;
+  #resolveConnect!: (result: NativeTerminalConnectResult) => void;
+  #redemptionFrame: string | null;
+  #cancelExpiry: (() => void) | null = null;
+  #phase: "opening" | "redeeming" | "live" | "closed" = "opening";
+  #generation: number | null = null;
+  #connectSettled = false;
+  #notifiedDisconnected = false;
+  #eventCount = 0;
+  #eventBytes = 0;
+  #delivering = false;
+  #pendingResize: TerminalAttachmentViewport | null = null;
+  #resizePromise: Promise<NativeTerminalMutationResult> | null = null;
+  #controlFrames = 0;
+
+  constructor(options: {
+    readonly descriptor: SafeIssueDescriptor;
+    readonly socket: NativeTerminalWebSocket;
+    readonly listener: (event: NativeTerminalEvent) => void | Promise<void>;
+    readonly schedule: (callback: () => void, delayMs: number) => () => void;
+    readonly now: () => number;
+  }) {
+    this.#socket = options.socket;
+    this.#listener = options.listener;
+    this.#schedule = options.schedule;
+    this.#now = options.now;
+    const { redemptionFrame, ...identity } = options.descriptor;
+    this.#redemptionFrame = redemptionFrame;
+    this.#identity = identity;
+    this.#connectPromise = new Promise((resolve) => {
+      this.#resolveConnect = resolve;
+    });
+    this.#attachment = Object.freeze({
+      write: (bytes: Uint8Array) => this.#write(bytes),
+      resize: (viewport: TerminalAttachmentViewport) => this.#resize(viewport),
+      dispose: () => this.#dispose(),
+    });
+  }
+
+  start(): Promise<NativeTerminalConnectResult> {
+    this.#socket.binaryType = "arraybuffer";
+    this.#socket.addEventListener("open", this.#onOpen);
+    this.#socket.addEventListener("message", this.#onMessage);
+    this.#socket.addEventListener("close", this.#onClose);
+    this.#socket.addEventListener("error", this.#onError);
+    const remaining = this.#identity.expiresAt - this.#now();
+    if (remaining <= 0) {
+      this.#retire(
+        transportError("attachment-expired", "The terminal attachment ticket expired.", true),
+        false,
+        1008,
+        "attachment-expired",
+      );
+    } else {
+      this.#cancelExpiry = this.#schedule(
+        () =>
+          this.#retire(
+            transportError("attachment-expired", "The terminal attachment ticket expired.", true),
+            false,
+            1008,
+            "attachment-expired",
+          ),
+        remaining,
+      );
+    }
+    return this.#connectPromise;
+  }
+
+  readonly #onOpen = (): void => {
+    if (this.#phase !== "opening") return;
+    if (
+      this.#socket.protocol !== this.#identity.webSocketProtocol ||
+      this.#socket.readyState !== WS_OPEN
+    ) {
+      this.#retire(
+        transportError(
+          "subprotocol-mismatch",
+          "The terminal WebSocket negotiated an unexpected protocol.",
+          false,
+        ),
+        false,
+        1002,
+        "subprotocol-mismatch",
+      );
+      return;
+    }
+    if (this.#now() >= this.#identity.expiresAt || !this.#redemptionFrame) {
+      this.#retire(
+        transportError("attachment-expired", "The terminal attachment ticket expired.", true),
+        false,
+        1008,
+        "attachment-expired",
+      );
+      return;
+    }
+    const frame = this.#redemptionFrame;
+    this.#redemptionFrame = null;
+    this.#phase = "redeeming";
+    const sendError = this.#sendControl(frame);
+    if (sendError) return;
+  };
+
+  readonly #onMessage = (event: NativeTerminalSocketEvent): void => {
+    if (this.#phase === "closed" || this.#phase === "opening") {
+      if (this.#phase === "opening") this.#protocolFailure();
+      return;
+    }
+    if (typeof event.data === "string") {
+      const frame = parseControlFrame(event.data);
+      if (!frame) {
+        this.#protocolFailure();
+        return;
+      }
+      this.#handleControl(frame);
+      return;
+    }
+    const bytes = binaryBytes(event.data);
+    if (!bytes || this.#phase !== "live") {
+      this.#protocolFailure();
+      return;
+    }
+    if (bytes.byteLength === 0) return;
+    if (bytes.byteLength > NATIVE_TERMINAL_MAX_OUTPUT_FRAME_BYTES) {
+      this.#retire(
+        transportError(
+          "output-frame-too-large",
+          "The daemon sent an oversized terminal output frame.",
+          true,
+        ),
+        true,
+        1009,
+        "output-frame-too-large",
+      );
+      return;
+    }
+    this.#queueEvent({ type: "output", bytes }, bytes.byteLength);
+  };
+
+  readonly #onClose = (): void => {
+    if (this.#phase === "closed") return;
+    this.#retire(
+      transportError("attachment-closed", "The native tmux attachment closed.", true),
+      this.#phase === "live",
+      undefined,
+      undefined,
+      true,
+    );
+  };
+
+  readonly #onError = (): void => {
+    if (this.#phase === "closed") return;
+    this.#retire(
+      transportError("socket-unavailable", "The terminal WebSocket became unavailable.", true),
+      this.#phase === "live",
+      1011,
+      "socket-unavailable",
+    );
+  };
+
+  #handleControl(frame: ServerControlFrame): void {
+    if (frame.type === "ready") {
+      if (
+        this.#phase !== "redeeming" ||
+        frame.generation < 0 ||
+        frame.effectiveViewerMode !== this.#identity.effectiveViewerMode ||
+        frame.daemonInstanceId !== this.#identity.daemonInstanceId ||
+        frame.requestId !== this.#identity.requestId
+      ) {
+        this.#protocolFailure();
+        return;
+      }
+      this.#generation = frame.generation;
+      this.#phase = "live";
+      this.#cancelExpiry?.();
+      this.#cancelExpiry = null;
+      this.#settleConnect({ status: "connected", attachment: this.#attachment });
+      this.#queueEvent({ type: "state", state: "connected", error: null }, 0);
+      return;
+    }
+
+    if (this.#phase !== "live") {
+      if (frame.type === "error") {
+        this.#retire(controlError(frame), false, 1008, "attachment-unavailable");
+      } else {
+        this.#protocolFailure();
+      }
+      return;
+    }
+    if (frame.type === "geometry") {
+      if (frame.generation !== this.#generation) this.#protocolFailure();
+      return;
+    }
+    if (frame.type === "exit") {
+      if (frame.generation !== this.#generation) {
+        this.#protocolFailure();
+        return;
+      }
+      this.#retire(
+        transportError(
+          "terminal-exit",
+          frame.signal === null
+            ? `The tmux client exited with status ${frame.exitCode}.`
+            : "The tmux client exited after a signal.",
+          false,
+        ),
+        true,
+        1000,
+        "terminal-exit",
+        true,
+      );
+      return;
+    }
+    this.#retire(controlError(frame), true, 1008, "attachment-unavailable", true);
+  }
+
+  #protocolFailure(): void {
+    this.#retire(
+      transportError("protocol-error", "The terminal WebSocket protocol was invalid.", false),
+      this.#phase === "live",
+      1002,
+      "protocol-error",
+    );
+  }
+
+  #write(_bytes: Uint8Array): Promise<NativeTerminalMutationResult> {
+    // Input remains deliberately unavailable even though the daemon now owns a
+    // bounded primitive. Recovery/no-replay enablement is a separate reviewed card.
+    return Promise.resolve(errorResult(INPUT_UNAVAILABLE));
+  }
+
+  #resize(viewport: TerminalAttachmentViewport): Promise<NativeTerminalMutationResult> {
+    const parsed = TerminalAttachmentViewportSchemaZ.safeParse(viewport);
+    if (!parsed.success) {
+      return Promise.resolve(
+        errorResult(transportError("invalid-viewport", "The terminal viewport is invalid.", false)),
+      );
+    }
+    if (
+      this.#phase !== "live" ||
+      this.#generation === null ||
+      this.#identity.effectiveViewerMode !== "interactive"
+    ) {
+      return Promise.resolve(
+        errorResult(transportError("resize-unavailable", "Terminal resize is unavailable.", true)),
+      );
+    }
+    this.#pendingResize = parsed.data;
+    if (this.#resizePromise) return this.#resizePromise;
+    this.#resizePromise = Promise.resolve().then(() => {
+      const next = this.#pendingResize;
+      this.#pendingResize = null;
+      this.#resizePromise = null;
+      if (this.#phase !== "live" || this.#generation === null || !next) {
+        return errorResult(
+          transportError("resize-unavailable", "Terminal resize is unavailable.", true),
+        );
+      }
+      if (this.#controlFrames >= NATIVE_TERMINAL_MAX_CONTROL_FRAMES) {
+        const error = transportError(
+          "control-frame-limit",
+          "The terminal control-frame limit was exhausted.",
+          true,
+        );
+        this.#retire(error, true, 1008, "control-frame-limit");
+        return errorResult(error);
+      }
+      const frame = JSON.stringify({
+        type: "resize",
+        protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
+        generation: this.#generation,
+        viewport: next,
+      });
+      const sendError = this.#sendControl(frame);
+      if (sendError) return errorResult(sendError);
+      this.#controlFrames += 1;
+      return { status: "ok" };
+    });
+    return this.#resizePromise;
+  }
+
+  #sendControl(frame: string): NativeTerminalTransportError | null {
+    const byteLength = controlByteLength(frame);
+    const buffered = this.#socket.bufferedAmount;
+    if (
+      this.#socket.readyState !== WS_OPEN ||
+      byteLength === 0 ||
+      byteLength > NATIVE_TERMINAL_MAX_CONTROL_BYTES ||
+      !Number.isSafeInteger(buffered) ||
+      buffered < 0 ||
+      buffered > NATIVE_TERMINAL_MAX_SOCKET_BUFFERED_BYTES - byteLength
+    ) {
+      const error = transportError(
+        "socket-backpressure",
+        "The terminal WebSocket could not accept another control frame.",
+        true,
+      );
+      this.#retire(error, this.#phase === "live", 1013, "socket-backpressure");
+      return error;
+    }
+    try {
+      this.#socket.send(frame);
+      return null;
+    } catch {
+      const error = transportError(
+        "socket-unavailable",
+        "The terminal WebSocket became unavailable.",
+        true,
+      );
+      this.#retire(error, this.#phase === "live", 1011, "socket-unavailable");
+      return error;
+    }
+  }
+
+  #queueEvent(event: NativeTerminalEvent, byteLength: number): void {
+    if (this.#phase === "closed" && event.type === "output") return;
+    if (
+      this.#eventCount >= NATIVE_TERMINAL_MAX_QUEUED_EVENTS ||
+      byteLength > NATIVE_TERMINAL_MAX_QUEUED_EVENT_BYTES - this.#eventBytes
+    ) {
+      this.#retire(
+        transportError(
+          "renderer-backpressure",
+          "The renderer could not keep up with terminal output.",
+          true,
+        ),
+        true,
+        1013,
+        "renderer-backpressure",
+      );
+      return;
+    }
+    this.#eventQueue.push({ event, byteLength });
+    this.#eventCount += 1;
+    this.#eventBytes += byteLength;
+    this.#drainEvents();
+  }
+
+  #drainEvents(): void {
+    if (this.#delivering) return;
+    this.#delivering = true;
+    const run = async (): Promise<void> => {
+      while (this.#eventQueue.length > 0) {
+        const entry = this.#eventQueue.shift()!;
+        try {
+          await this.#listener(entry.event);
+        } catch {
+          this.#clearQueuedEvents();
+          this.#retire(
+            transportError(
+              "renderer-consumer-failed",
+              "The renderer could not consume terminal output.",
+              true,
+            ),
+            false,
+            1013,
+            "renderer-consumer-failed",
+          );
+          return;
+        } finally {
+          this.#eventCount -= 1;
+          this.#eventBytes -= entry.byteLength;
+        }
+      }
+    };
+    void run().finally(() => {
+      this.#delivering = false;
+      if (this.#eventQueue.length > 0) this.#drainEvents();
+    });
+  }
+
+  #clearQueuedEvents(): void {
+    for (const entry of this.#eventQueue) {
+      this.#eventCount -= 1;
+      this.#eventBytes -= entry.byteLength;
+    }
+    this.#eventQueue.length = 0;
+  }
+
+  #settleConnect(result: NativeTerminalConnectResult): void {
+    if (this.#connectSettled) return;
+    this.#connectSettled = true;
+    this.#resolveConnect(result);
+  }
+
+  #retire(
+    error: NativeTerminalTransportError,
+    notify: boolean,
+    closeCode?: number,
+    closeReason?: string,
+    preserveQueue = false,
+  ): void {
+    if (this.#phase === "closed") return;
+    const wasLive = this.#phase === "live";
+    this.#phase = "closed";
+    this.#redemptionFrame = null;
+    this.#pendingResize = null;
+    this.#cancelExpiry?.();
+    this.#cancelExpiry = null;
+    this.#socket.removeEventListener("open", this.#onOpen);
+    this.#socket.removeEventListener("message", this.#onMessage);
+    this.#socket.removeEventListener("close", this.#onClose);
+    this.#socket.removeEventListener("error", this.#onError);
+    if (!preserveQueue) this.#clearQueuedEvents();
+    if (!this.#connectSettled) {
+      this.#settleConnect({ status: "error", error });
+    } else if (notify && wasLive && !this.#notifiedDisconnected) {
+      this.#notifiedDisconnected = true;
+      if (this.#eventCount >= NATIVE_TERMINAL_MAX_QUEUED_EVENTS) {
+        this.#clearQueuedEvents();
+      }
+      this.#queueEvent({ type: "state", state: "disconnected", error }, 0);
+    }
+    if (
+      closeCode !== undefined &&
+      (this.#socket.readyState === WS_CONNECTING ||
+        this.#socket.readyState === WS_OPEN ||
+        this.#socket.readyState === WS_CLOSING)
+    ) {
+      try {
+        this.#socket.close(closeCode, closeReason?.slice(0, 123));
+      } catch {
+        // Local authority is already retired.
+      }
+    }
+  }
+
+  #dispose(): void {
+    this.#retire(
+      transportError("disposed", "The terminal attachment was disposed.", false),
+      false,
+      1000,
+      "renderer-disposed",
+    );
+  }
+}
+
+function issueWithTimeout(
+  issueAttachment: NativeTerminalIssueAttachment,
+  request: TerminalAttachRequest,
+  timeoutMs: number,
+  schedule: (callback: () => void, delayMs: number) => () => void,
+): Promise<{ readonly status: "ok"; readonly value: unknown } | { readonly status: "error" }> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let cancelTimeout = (): void => undefined;
+    const finish = (
+      result: { readonly status: "ok"; readonly value: unknown } | { readonly status: "error" },
+    ): void => {
+      if (settled) return;
+      settled = true;
+      cancelTimeout();
+      resolve(result);
+    };
+    const scheduledCancellation = schedule(() => finish({ status: "error" }), timeoutMs);
+    cancelTimeout = scheduledCancellation;
+    if (settled) scheduledCancellation();
+    void Promise.resolve()
+      .then(() => issueAttachment(request))
+      .then(
+        (value) => finish({ status: "ok", value }),
+        () => finish({ status: "error" }),
+      );
+  });
+}
+
+/**
+ * Renderer-owned direct WebSocket adapter. The injected issue function is the
+ * only privileged seam; Electron/host code is intentionally absent from bytes,
+ * resize, lifecycle, and terminal state.
+ */
+export function createNativeTerminalWebSocketTransport(
+  dependencies: NativeTerminalWebSocketTransportDependencies,
+): NativeTerminalTransport {
+  if (typeof dependencies.issueAttachment !== "function") {
+    throw new TypeError("Native terminal transport requires an issueAttachment function.");
+  }
+  const now = dependencies.now ?? Date.now;
+  const schedule = dependencies.schedule ?? defaultSchedule;
+  const createWebSocket = dependencies.createWebSocket ?? defaultCreateWebSocket;
+  const issueTimeoutMs = boundedIssueTimeout(dependencies.issueTimeoutMs);
+
+  return Object.freeze({
+    connect: async (
+      request: TerminalAttachRequest,
+      listener: (event: NativeTerminalEvent) => void | Promise<void>,
+    ): Promise<NativeTerminalConnectResult> => {
+      const parsedRequest = TerminalAttachRequestSchemaZ.safeParse(request);
+      if (!parsedRequest.success || typeof listener !== "function") {
+        return {
+          status: "error",
+          error: transportError(
+            "invalid-request",
+            "The semantic terminal attachment request is invalid.",
+            false,
+          ),
+        };
+      }
+
+      const issued = await issueWithTimeout(
+        dependencies.issueAttachment,
+        parsedRequest.data,
+        issueTimeoutMs,
+        schedule,
+      );
+      if (issued.status === "error") {
+        return {
+          status: "error",
+          error: transportError(
+            "attachment-issue-failed",
+            "The desktop host could not issue a terminal attachment.",
+            true,
+          ),
+        };
+      }
+      const descriptor = validateIssueDescriptor(issued.value, parsedRequest.data, now());
+      if (!descriptor) {
+        return {
+          status: "error",
+          error: transportError(
+            "invalid-descriptor",
+            "The desktop host returned an invalid terminal attachment descriptor.",
+            false,
+          ),
+        };
+      }
+
+      let socket: NativeTerminalWebSocket;
+      try {
+        socket = createWebSocket(descriptor.webSocketUrl, descriptor.webSocketProtocol);
+      } catch {
+        return {
+          status: "error",
+          error: transportError(
+            "socket-unavailable",
+            "The terminal WebSocket could not be created.",
+            true,
+          ),
+        };
+      }
+      return new NativeTerminalWebSocketSession({
+        descriptor,
+        socket,
+        listener,
+        schedule,
+        now,
+      }).start();
+    },
+  });
+}

--- a/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
@@ -41,6 +41,13 @@ const TARGET_B: TerminalAttachmentSemanticTarget = {
   semanticPaneId: "agent-b",
 };
 
+function connectedState(
+  clientViewport: TerminalAttachmentViewport = { cols: 80, rows: 24 },
+  sourceGrid: TerminalAttachmentViewport = clientViewport,
+): NativeTerminalEvent {
+  return { type: "state", state: "connected", error: null, sourceGrid, clientViewport };
+}
+
 class ResizeObserverHarness {
   static readonly active: ResizeObserverHarness[] = [];
   readonly callback: ResizeObserverCallback;
@@ -322,7 +329,10 @@ describe("TerminalSurface", () => {
         return { status: "ok" as const };
       }),
     });
-    const transport = transportHarness(async () => ({ status: "connected", attachment }));
+    const transport = transportHarness(async (_request, listener) => {
+      await listener(connectedState());
+      return { status: "connected", attachment };
+    });
     const renderer = rendererHarness();
     const root = document.body.appendChild(document.createElement("div"));
     const dispose = render(
@@ -356,8 +366,21 @@ describe("TerminalSurface", () => {
 
   it("coalesces viewport measurements while connect is delayed", async () => {
     const connection = deferred<NativeTerminalConnectResult>();
-    const attachment = attachmentHarness();
-    const transport = transportHarness(async () => connection.promise);
+    let listener: ((event: NativeTerminalEvent) => void | Promise<void>) | null = null;
+    const attachment = attachmentHarness({
+      resize: vi.fn(async (viewport: TerminalAttachmentViewport) => {
+        await (listener as (event: NativeTerminalEvent) => void | Promise<void>)({
+          type: "geometry",
+          sourceGrid: viewport,
+          clientViewport: viewport,
+        });
+        return { status: "ok" as const };
+      }),
+    });
+    const transport = transportHarness(async (_request, nextListener) => {
+      listener = nextListener;
+      return connection.promise;
+    });
     const renderer = rendererHarness();
     const root = document.body.appendChild(document.createElement("div"));
     const dispose = render(
@@ -387,9 +410,19 @@ describe("TerminalSurface", () => {
     await vi.waitFor(() => expect(renderer.renderer.fit).toHaveBeenCalledTimes(fitCalls + 1));
     expect(attachment.resize).not.toHaveBeenCalled();
 
+    await (listener as unknown as (event: NativeTerminalEvent) => void | Promise<void>)(
+      connectedState(),
+    );
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-source-grid")).toBe("80x24");
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-client-viewport")).toBe(
+      "80x24",
+    );
     connection.resolve({ status: "connected", attachment });
     await vi.waitFor(() => expect(attachment.resize).toHaveBeenCalledWith({ cols: 120, rows: 40 }));
     expect(attachment.resize).toHaveBeenCalledOnce();
+    expect(root.querySelector(".terminal-surface")?.getAttribute("data-client-viewport")).toBe(
+      "120x40",
+    );
 
     ResizeObserverHarness.active[0]!.trigger();
     await Promise.resolve();

--- a/apps/desktop-renderer/src/terminal/terminal-surface.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.tsx
@@ -114,6 +114,8 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
   );
   const [reason, setReason] = createSignal<string | null>(null);
   const [hasValidatedFrame, setHasValidatedFrame] = createSignal(false);
+  const [sourceGrid, setSourceGrid] = createSignal<TerminalAttachmentViewport | null>(null);
+  const [clientViewport, setClientViewport] = createSignal<TerminalAttachmentViewport | null>(null);
   let mount: HTMLDivElement | undefined;
   let renderer: TerminalRenderer | null = null;
   let attachment: NativeTerminalAttachment | null = null;
@@ -302,11 +304,30 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
         if (!disposed && activeGeneration === generation) setHasValidatedFrame(true);
       });
     }
+    if (event.type === "geometry") {
+      currentViewport = event.clientViewport;
+      setSourceGrid(event.sourceGrid);
+      setClientViewport(event.clientViewport);
+      const measured = latestMeasuredViewport;
+      if (attachment && measured && !sameViewport(event.clientViewport, measured)) {
+        pendingResize = measured;
+        flushResize();
+      }
+      return;
+    }
     if (event.type !== "state") return;
     if (event.state === "connected") {
+      currentViewport = event.clientViewport;
+      setSourceGrid(event.sourceGrid);
+      setClientViewport(event.clientViewport);
       if (attachment) {
         setReason(null);
         setPhase("connected");
+        const measured = latestMeasuredViewport;
+        if (measured && !sameViewport(event.clientViewport, measured)) {
+          pendingResize = measured;
+          flushResize();
+        }
       }
       return;
     }
@@ -359,11 +380,9 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
           return;
         }
         attachment = result.attachment;
-        currentViewport = viewport;
         setPhase("connected");
         const latestViewport = latestMeasuredViewport;
-        if (latestViewport && !sameViewport(currentViewport, latestViewport)) {
-          currentViewport = latestViewport;
+        if (currentViewport && latestViewport && !sameViewport(currentViewport, latestViewport)) {
           pendingResize = latestViewport;
           flushResize();
         }
@@ -387,8 +406,8 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
       if (phase() === "measuring") connect(viewport);
       return;
     }
+    if (!currentViewport) return;
     if (sameViewport(currentViewport, viewport)) return;
-    currentViewport = viewport;
     pendingResize = viewport;
     flushResize();
   };
@@ -405,6 +424,8 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
     currentViewport = null;
     latestMeasuredViewport = null;
     pendingResize = null;
+    setSourceGrid(null);
+    setClientViewport(null);
     setHasValidatedFrame(false);
     setPhase(props.transport ? "measuring" : "unavailable");
     ensureRenderer();
@@ -579,6 +600,8 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
     currentViewport = null;
     latestMeasuredViewport = null;
     pendingResize = null;
+    setSourceGrid(null);
+    setClientViewport(null);
     setReason(null);
     setHasValidatedFrame(false);
     setPhase(nextTransport ? "measuring" : "unavailable");
@@ -593,6 +616,10 @@ export function TerminalSurface(props: TerminalSurfaceProps) {
       data-focused={props.focused ?? false}
       data-reduced-motion={props.reducedMotion ?? false}
       data-preserves-frame={hasValidatedFrame()}
+      data-source-grid={sourceGrid() ? `${sourceGrid()!.cols}x${sourceGrid()!.rows}` : undefined}
+      data-client-viewport={
+        clientViewport() ? `${clientViewport()!.cols}x${clientViewport()!.rows}` : undefined
+      }
       onPointerDown={() => {
         pointerFocus = true;
         props.onFocus?.("mouse");


### PR DESCRIPTION
## Summary

- add a renderer-only `NativeTerminalTransport` WebSocket adapter behind an injected one-use attachment-issuance seam
- validate semantic attach requests through shared contracts while parsing the private untrusted descriptor/control envelope locally, without declaring a new public wire contract
- enforce exact loopback URL/protocol/ticket-first admission, bounded output and resize queues, deterministic teardown, and fresh-ticket reconnects
- keep input truthfully disabled with `input-backpressure-unavailable` until backend input enablement lands
- document the native tmux-ide boundary and add deterministic fake-WebSocket lifecycle, race, expiry, queue, resize, and backpressure tests

## Scope boundary

Renderer/runtime files and tests only. This does not add Electron host capability, embedded daemon ownership, UI composition, tmux mutation, raw tmux identifiers, durable credentials, or input enablement. It is a native tmux-ide implementation; no NodeTerm runtime or source was incorporated.

## Verification

- `pnpm --filter @tmux-ide/desktop-renderer test` — 13 files / 155 tests passed
- `pnpm --filter @tmux-ide/desktop-renderer typecheck` — passed
- `pnpm --filter @tmux-ide/desktop-renderer lint` — passed
- targeted Prettier check — passed
- `git diff --check` — passed
- `pnpm check` — passed (including contracts 146, renderer 155, Electron 84, daemon 151 files / 2433 tests, daemon-bun 44, TUI renderer 97, packaging/docs/install/native dependency gates)