### PR TITLE
fix(tui): stabilize keyed OpenTUI insertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "check": "pnpm run lint:workspace && pnpm run format:check && pnpm run typecheck:workspace && pnpm run test:unit && pnpm run test:daemon-bun && pnpm run test:tui-renderer && pnpm run test:workbench-dock-package && pnpm run test:pane-frame-package && pnpm run docs:build && pnpm run pack:check && pnpm run test:pack-installed && pnpm run check:native-deps",
     "postinstall": "node scripts/postinstall.js",
     "docs": "turbo run dev --filter=@tmux-ide/docs",
-    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/activity-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/workbench-shell-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/workbench-dock-dual-host-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/command-palette-surface-renderer.test.tsx",
+    "test:tui-renderer": "bun test --preload @opentui/solid/preload ./packages/daemon/src/tui/mirror/missions-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/recipes-gallery-renderer.test.tsx ./packages/daemon/src/tui/mirror/shell-chrome-renderer.test.tsx ./packages/daemon/src/tui/mirror/home-files-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/changes-terminal-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/activity-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/application-shell-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/pane-frame-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/workbench-shell-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/workbench-dock-dual-host-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/agent-terminal-canvas-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/command-palette-surface-renderer.test.tsx ./packages/daemon/src/tui/mirror/workspace/opentui-insertion-stability-renderer.test.tsx",
     "test:tui-smoke": "node scripts/smoke-tui-missions.mjs"
   },
   "keywords": [
@@ -85,16 +85,6 @@
     "solid-js": "1.9.12",
     "ws": "^8.20.0",
     "zod": "^4.3.6"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "esbuild",
-      "node-pty"
-    ],
-    "overrides": {
-      "zod": "^4.3.6"
-    }
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/daemon/src/tui/mirror/workspace/opentui-insertion-stability-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/opentui-insertion-stability-renderer.test.tsx
@@ -1,0 +1,154 @@
+/* @jsxImportSource @opentui/solid */
+import { BoxRenderable } from "@opentui/core";
+import { describe, expect, it } from "bun:test";
+import { For, Show, createSignal, onCleanup } from "solid-js";
+import {
+  destroyTestRenderer,
+  expectFrameBounds,
+  renderForTest,
+  stableFrame,
+} from "../testing/renderer-harness.test.ts";
+
+interface StreamRow {
+  id: "alpha" | "beta";
+  label: string;
+}
+
+interface ChurnState {
+  width: number;
+  outputVersion: number;
+  focusedId: StreamRow["id"];
+  order: readonly StreamRow[];
+  notice: string | null;
+}
+
+const ALPHA: StreamRow = { id: "alpha", label: "Agent alpha" };
+const BETA: StreamRow = { id: "beta", label: "Agent beta" };
+
+describe("OpenTUI Solid insertion stability", () => {
+  it("keeps keyed output rows silent and resident through output, focus, layout, and Show churn", async () => {
+    let drive!: (state: ChurnState) => void;
+    let disposed = 0;
+
+    function Harness() {
+      const [state, setState] = createSignal<ChurnState>({
+        width: 48,
+        outputVersion: 0,
+        focusedId: "alpha",
+        order: [ALPHA, BETA],
+        notice: null,
+      });
+      drive = setState;
+      onCleanup(() => {
+        disposed += 1;
+      });
+      return (
+        <box
+          id="insertion-stability-root"
+          width={state().width}
+          height={6}
+          flexDirection="column"
+          overflow="hidden"
+        >
+          <box height={1} flexDirection="row">
+            <For each={state().order}>
+              {(row) => (
+                <text id={`insertion-stability-row:${row.id}`}>
+                  {`${state().focusedId === row.id ? "●" : "○"} ${row.label} v${state().outputVersion} `}
+                </text>
+              )}
+            </For>
+          </box>
+          <Show when={state().notice} fallback={<text id="insertion-stability-idle">idle</text>}>
+            {(notice) => <text id="insertion-stability-notice">{notice()}</text>}
+          </Show>
+        </box>
+      );
+    }
+
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    const captureDiagnostic = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+    console.warn = captureDiagnostic;
+    console.error = captureDiagnostic;
+    const setup = await renderForTest(() => <Harness />, { width: 48, height: 6 });
+    const initialRows = new Map(
+      ([ALPHA, BETA] as const).map((row) => [
+        row.id,
+        setup.renderer.root.findDescendantById(`insertion-stability-row:${row.id}`),
+      ]),
+    );
+    expect([...initialRows.values()].every(Boolean)).toBe(true);
+
+    try {
+      for (let version = 1; version <= 120; version += 1) {
+        const reversed = version % 2 === 1;
+        const width = version % 3 === 0 ? 64 : 48;
+        const state: ChurnState = {
+          width,
+          outputVersion: version,
+          focusedId: reversed ? "beta" : "alpha",
+          order: reversed ? [BETA, ALPHA] : [ALPHA, BETA],
+          notice: version % 4 === 0 ? `output ${version}` : null,
+        };
+        drive(state);
+        setup.resize(width, 6);
+        await setup.renderOnce();
+
+        const frame = setup.captureCharFrame();
+        const stable = stableFrame(frame);
+        expectFrameBounds(frame, width, 6);
+        expect(stable).toContain(`v${version}`);
+        expect(stable).toContain(state.notice ?? "idle");
+        const alphaOffset = stable.indexOf(`Agent alpha v${version}`);
+        const betaOffset = stable.indexOf(`Agent beta v${version}`);
+        expect(alphaOffset).toBeGreaterThanOrEqual(0);
+        expect(betaOffset).toBeGreaterThanOrEqual(0);
+        expect(reversed ? betaOffset < alphaOffset : alphaOffset < betaOffset).toBe(true);
+        for (const row of [ALPHA, BETA] as const) {
+          expect(setup.renderer.root.findDescendantById(`insertion-stability-row:${row.id}`)).toBe(
+            initialRows.get(row.id),
+          );
+        }
+      }
+    } finally {
+      console.warn = originalWarn;
+      console.error = originalError;
+      destroyTestRenderer(setup);
+    }
+
+    expect(warnings).toEqual([]);
+    expect(disposed).toBe(1);
+  });
+
+  it("continues to report direct same-node and genuinely foreign insertBefore anchors", async () => {
+    const setup = await renderForTest(
+      () => (
+        <box id="valid-parent">
+          <box id="valid-child" />
+        </box>
+      ),
+      { width: 20, height: 4 },
+    );
+    await setup.renderOnce();
+    const parent = setup.renderer.root.findDescendantById("valid-parent")!;
+    const child = setup.renderer.root.findDescendantById("valid-child")!;
+    const foreignAnchor = new BoxRenderable(setup.renderer, { id: "foreign-anchor" });
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+    try {
+      parent.insertBefore(child, child);
+      parent.insertBefore(child, foreignAnchor);
+    } finally {
+      console.warn = originalWarn;
+      foreignAnchor.destroy();
+      destroyTestRenderer(setup);
+    }
+    expect(warnings).toEqual([
+      "Anchor is the same as the node valid-child being inserted, skipping insertBefore",
+      "Anchor with id foreign-anchor does not exist within the parent valid-parent, skipping insertBefore",
+    ]);
+  });
+});

--- a/packages/daemon/src/tui/mirror/workspace/opentui-insertion-stability-renderer.test.tsx
+++ b/packages/daemon/src/tui/mirror/workspace/opentui-insertion-stability-renderer.test.tsx
@@ -1,5 +1,6 @@
 /* @jsxImportSource @opentui/solid */
 import { BoxRenderable } from "@opentui/core";
+import { insertNode } from "@opentui/solid";
 import { describe, expect, it } from "bun:test";
 import { For, Show, createSignal, onCleanup } from "solid-js";
 import {
@@ -122,7 +123,7 @@ describe("OpenTUI Solid insertion stability", () => {
     expect(disposed).toBe(1);
   });
 
-  it("continues to report direct same-node and genuinely foreign insertBefore anchors", async () => {
+  it("forwards nonresident identity anchors while preserving direct Core diagnostics", async () => {
     const setup = await renderForTest(
       () => (
         <box id="valid-parent">
@@ -134,11 +135,17 @@ describe("OpenTUI Solid insertion stability", () => {
     await setup.renderOnce();
     const parent = setup.renderer.root.findDescendantById("valid-parent")!;
     const child = setup.renderer.root.findDescendantById("valid-child")!;
+    const nonresidentIdentity = new BoxRenderable(setup.renderer, {
+      id: "nonresident-identity",
+    });
     const foreignAnchor = new BoxRenderable(setup.renderer, { id: "foreign-anchor" });
     const warnings: string[] = [];
     const originalWarn = console.warn;
     console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
     try {
+      insertNode(parent, nonresidentIdentity, nonresidentIdentity);
+      expect(nonresidentIdentity.parent).toBe(parent);
+      expect(parent.getChildren()).toContain(nonresidentIdentity);
       parent.insertBefore(child, child);
       parent.insertBefore(child, foreignAnchor);
     } finally {

--- a/patches/@opentui__solid@0.4.3.patch
+++ b/patches/@opentui__solid@0.4.3.patch
@@ -1,0 +1,26 @@
+diff --git a/index.bun.js b/index.bun.js
+index 72c8ce7e28f1f724e80ee84fa52961668b8e62dd..ad120aa29820d281e0d758faeaca3b95f519433b 100644
+--- a/index.bun.js
++++ b/index.bun.js
+@@ -568,7 +568,7 @@ function _insertNode(parent, node, anchor) {
+   if (anchorIndex === -1) {
+     log("[INSERT]", "Could not find anchor", logId(parent), logId(anchor), "[children]", ...children.map((c) => c.id));
+   }
+-  parent.add(node, anchorIndex);
++  node !== anchor && parent.add(node, anchorIndex);
+ }
+ function _removeNode(parent, node) {
+   log("Removing node:", logId(node), "from parent:", logId(parent));
+diff --git a/index.js b/index.js
+index 18d70421367d554a9d6a66584b80f0bb46de5ec6..3994fa9f81b9f8d6f6f14c5bba0f9f7537e51612 100644
+--- a/index.js
++++ b/index.js
+@@ -542,7 +542,7 @@ function _insertNode(parent, node, anchor) {
+   if (anchorIndex === -1) {
+     log("[INSERT]", "Could not find anchor", logId(parent), logId(anchor), "[children]", ...children.map((c) => c.id));
+   }
+-  parent.add(node, anchorIndex);
++  node !== anchor && parent.add(node, anchorIndex);
+ }
+ function _removeNode(parent, node) {
+   log("Removing node:", logId(node), "from parent:", logId(parent));

--- a/patches/@opentui__solid@0.4.3.patch
+++ b/patches/@opentui__solid@0.4.3.patch
@@ -1,5 +1,5 @@
 diff --git a/index.bun.js b/index.bun.js
-index 72c8ce7e28f1f724e80ee84fa52961668b8e62dd..ad120aa29820d281e0d758faeaca3b95f519433b 100644
+index 72c8ce7e28f1f724e80ee84fa52961668b8e62dd..2f9edbfe5f3a52f75d1aeb86eb879443e7a99961 100644
 --- a/index.bun.js
 +++ b/index.bun.js
 @@ -568,7 +568,7 @@ function _insertNode(parent, node, anchor) {
@@ -7,12 +7,12 @@ index 72c8ce7e28f1f724e80ee84fa52961668b8e62dd..ad120aa29820d281e0d758faeaca3b95
      log("[INSERT]", "Could not find anchor", logId(parent), logId(anchor), "[children]", ...children.map((c) => c.id));
    }
 -  parent.add(node, anchorIndex);
-+  node !== anchor && parent.add(node, anchorIndex);
++  (node !== anchor || node.parent !== parent) && parent.add(node, anchorIndex);
  }
  function _removeNode(parent, node) {
    log("Removing node:", logId(node), "from parent:", logId(parent));
 diff --git a/index.js b/index.js
-index 18d70421367d554a9d6a66584b80f0bb46de5ec6..3994fa9f81b9f8d6f6f14c5bba0f9f7537e51612 100644
+index 18d70421367d554a9d6a66584b80f0bb46de5ec6..c30cbb50731cef92ee75f984d57e762281303070 100644
 --- a/index.js
 +++ b/index.js
 @@ -542,7 +542,7 @@ function _insertNode(parent, node, anchor) {
@@ -20,7 +20,7 @@ index 18d70421367d554a9d6a66584b80f0bb46de5ec6..3994fa9f81b9f8d6f6f14c5bba0f9f75
      log("[INSERT]", "Could not find anchor", logId(parent), logId(anchor), "[children]", ...children.map((c) => c.id));
    }
 -  parent.add(node, anchorIndex);
-+  node !== anchor && parent.add(node, anchorIndex);
++  (node !== anchor || node.parent !== parent) && parent.add(node, anchorIndex);
  }
  function _removeNode(parent, node) {
    log("Removing node:", logId(node), "from parent:", logId(parent));

--- a/patches/README.md
+++ b/patches/README.md
@@ -9,9 +9,10 @@ that first call is `insertBefore(B, B)`: the DOM-defined, idempotent no-op.
 OpenTUI Core already returns without mutating for this case, but version 0.4.3
 also emits a warning. OpenTUI's renderer console presents that warning inside
 the application, so normal list reordering can cover live terminal content.
-The patch makes the Solid adapter skip only the identical node/anchor call.
-Core's same-node, invalid, destroyed, and foreign-anchor diagnostics remain
-enabled for direct callers.
+The patch makes the Solid adapter skip only an identical node/anchor call when
+that node is already resident under the target parent. Nonresident identity
+inputs still reach `parent.add`, while Core's same-node, invalid, destroyed,
+and foreign-anchor diagnostics remain enabled for direct callers.
 
 The behavior is pinned by
 `opentui-insertion-stability-renderer.test.tsx`. Remove the patch when a future

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,18 @@
+# Dependency patches
+
+## `@opentui/solid@0.4.3`
+
+Solid's universal renderer implements an adjacent keyed-list swap by calling
+`insertBefore(node, getNextSibling(previousNode))`. For `[A, B] -> [B, A]`,
+that first call is `insertBefore(B, B)`: the DOM-defined, idempotent no-op.
+
+OpenTUI Core already returns without mutating for this case, but version 0.4.3
+also emits a warning. OpenTUI's renderer console presents that warning inside
+the application, so normal list reordering can cover live terminal content.
+The patch makes the Solid adapter skip only the identical node/anchor call.
+Core's same-node, invalid, destroyed, and foreign-anchor diagnostics remain
+enabled for direct callers.
+
+The behavior is pinned by
+`opentui-insertion-stability-renderer.test.tsx`. Remove the patch when a future
+OpenTUI release makes same-node insertion silent upstream.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   '@opentui/solid@0.4.3':
-    hash: adf06cc642dd53847fba59a38d4b7c065c5eae9436fdbbafb81caf2b91f6a18c
+    hash: 0b3f46dbad979dced2505fab7aa41bcd7a9606d489e282d251010d80c9600123
     path: patches/@opentui__solid@0.4.3.patch
 
 importers:
@@ -27,7 +27,7 @@ importers:
         version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid':
         specifier: ^0.4.3
-        version: 0.4.3(patch_hash=adf06cc642dd53847fba59a38d4b7c065c5eae9436fdbbafb81caf2b91f6a18c)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.3(patch_hash=0b3f46dbad979dced2505fab7aa41bcd7a9606d489e282d251010d80c9600123)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6
@@ -261,7 +261,7 @@ importers:
         version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid':
         specifier: ^0.4.3
-        version: 0.4.3(patch_hash=adf06cc642dd53847fba59a38d4b7c065c5eae9436fdbbafb81caf2b91f6a18c)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.3(patch_hash=0b3f46dbad979dced2505fab7aa41bcd7a9606d489e282d251010d80c9600123)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6
@@ -4591,7 +4591,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@opentui/solid@0.4.3(patch_hash=adf06cc642dd53847fba59a38d4b7c065c5eae9436fdbbafb81caf2b91f6a18c)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
+  '@opentui/solid@0.4.3(patch_hash=0b3f46dbad979dced2505fab7aa41bcd7a9606d489e282d251010d80c9600123)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   zod: ^4.3.6
 
+patchedDependencies:
+  '@opentui/solid@0.4.3':
+    hash: adf06cc642dd53847fba59a38d4b7c065c5eae9436fdbbafb81caf2b91f6a18c
+    path: patches/@opentui__solid@0.4.3.patch
+
 importers:
 
   .:
@@ -22,7 +27,7 @@ importers:
         version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid':
         specifier: ^0.4.3
-        version: 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.3(patch_hash=adf06cc642dd53847fba59a38d4b7c065c5eae9436fdbbafb81caf2b91f6a18c)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6
@@ -256,7 +261,7 @@ importers:
         version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid':
         specifier: ^0.4.3
-        version: 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.3(patch_hash=adf06cc642dd53847fba59a38d4b7c065c5eae9436fdbbafb81caf2b91f6a18c)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6
@@ -4586,7 +4591,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
+  '@opentui/solid@0.4.3(patch_hash=adf06cc642dd53847fba59a38d4b7c065c5eae9436fdbbafb81caf2b91f6a18c)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,14 @@ packages:
   - apps/*
   - docs
   - packages/*
+
+onlyBuiltDependencies:
+  - "@parcel/watcher"
+  - esbuild
+  - node-pty
+
+overrides:
+  zod: ^4.3.6
+
+patchedDependencies:
+  "@opentui/solid@0.4.3": patches/@opentui__solid@0.4.3.patch


### PR DESCRIPTION
## Summary

- stop the OpenTUI/Solid adapter from forwarding the DOM-style identity no-op `insertBefore(node, node)` into Core
- keep Core diagnostics intact for direct same-node calls and genuinely foreign anchors
- pin 120 keyed swaps under simultaneous output, focus, layout, and conditional-view churn so renderer-console warnings cannot regress onto the terminal canvas
- move the existing pnpm build allowlist and override into `pnpm-workspace.yaml`, where pnpm 10 honors them, and register the version-pinned dependency patch

## Root cause

Solid universal reconciliation implements an adjacent keyed swap `[A, B] -> [B, A]` by calling `insertBefore(B, getNextSibling(A))`, which is `insertBefore(B, B)`. This is a legitimate idempotent no-op. OpenTUI Core safely returned but emitted a warning, and the OpenTUI renderer console painted that warning into the live TUI. The same path remains in OpenTUI 0.4.5 and upstream main, so this PR applies the smallest version-pinned adapter patch rather than changing application identity semantics or suppressing console output.

## Checks

- [x] `pnpm check`
- [x] `pnpm build:tui`
- [x] `pnpm test:tui-smoke`
- [x] `pnpm install --frozen-lockfile --offline`
- [x] `git diff --check`
- [x] docs build, pack dry-run, installed-package smoke, and native dependency loading (included by `pnpm check`)
- [ ] `CHANGELOG.md` updated if release notes changed (not applicable)
- [ ] README/docs updated when the CLI contract changed (not applicable)

## Notes

The full renderer suite still prints the pre-existing `TerminalConsoleCache` EventTarget listener warning during application-shell teardown. That is distinct from this insertion path and intentionally remains out of scope. Remove the patch when a future OpenTUI release makes the adapter identity insertion silent upstream.