### PR TITLE
feat(daemon): compose native terminal attachment runtime

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -189,6 +189,7 @@ export {
   type TerminalAttachmentAdmissionErrorCode,
   type TerminalAttachmentAdmissionSnapshot,
   type TerminalAttachmentGeometry,
+  type TerminalAttachmentGeometryClientProof,
   type TerminalAttachmentPreAuthAdmission,
   type TerminalAttachmentUpgradeDecision,
 } from "./terminal/attachments/direct-websocket.ts";
@@ -198,6 +199,7 @@ export {
 } from "./server/terminal-attachment-upgrade.ts";
 export {
   TmuxAttachmentViewExecutor,
+  TmuxAttachmentOperationSerializer,
   TmuxAttachmentViewExecutorError,
   TmuxAttachmentClientTransportError,
   planCanonicalTmuxAttachmentClientCommand,
@@ -219,3 +221,12 @@ export {
   type PtyTmuxAttachmentClaimKey,
   type PtyTmuxAttachmentLauncherOptions,
 } from "./terminal/attachments/pty-tmux-attachment-launcher.ts";
+export {
+  NativeTerminalAttachmentRuntime,
+  NativeTerminalAttachmentRuntimeError,
+  createNativeTerminalAttachmentRuntime,
+  type NativeTerminalAttachmentCommandExecutor,
+  type NativeTerminalAttachmentRuntimeErrorCode,
+  type NativeTerminalAttachmentRuntimeOptions,
+  type NativeTerminalAttachmentTmuxAuthority,
+} from "./terminal/attachments/native-runtime.ts";

--- a/packages/daemon/src/terminal/__tests__/native-runtime-live.test.ts
+++ b/packages/daemon/src/terminal/__tests__/native-runtime-live.test.ts
@@ -1,0 +1,145 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { WorkspaceRegistry } from "../../lib/workspace-registry.ts";
+import {
+  TERMINAL_ATTACHMENT_REDEEM_PATH,
+  TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL,
+  type DirectTerminalSocket,
+} from "../attachments/direct-websocket.ts";
+import { createNativeTerminalAttachmentRuntime } from "../attachments/native-runtime.ts";
+
+const hasTmux = spawnSync("tmux", ["-V"], { stdio: "ignore" }).status === 0;
+
+class LiveSocket extends EventEmitter implements DirectTerminalSocket {
+  readyState = 1;
+  bufferedAmount = 0;
+  readonly sent: Array<{ data: string | Buffer; binary: boolean }> = [];
+  readonly closes: Array<{ code?: number; reason?: string }> = [];
+
+  send(data: string | Buffer, options?: { binary?: boolean }): void {
+    this.sent.push({
+      data: Buffer.isBuffer(data) ? Buffer.from(data) : data,
+      binary: !!options?.binary,
+    });
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closes.push({ code, reason });
+    if (this.readyState !== 1) return;
+    this.readyState = 3;
+    this.emit("close");
+  }
+
+  frame(data: string): void {
+    this.emit("message", data, false);
+  }
+}
+
+describe.skipIf(!hasTmux)("native attachment runtime isolated tmux integration", () => {
+  const root = mkdtempSync(join(tmpdir(), "tmux-ide-native-runtime-live-"));
+  const socketName = `tmux-ide-a1-${process.pid}-${randomUUID().slice(0, 8)}`;
+  const sessionName = "native-runtime-source";
+  const workspaceName = "workspace.live-native";
+  const semanticPaneId = "pane.live-agent";
+  const daemonInstanceId = "daemon-native-live";
+  const requestId = "cf59df74-d1fd-456b-afdf-b16f15b7b8ca";
+  const executablePath = realpathSync(execFileSync("which", ["tmux"], { encoding: "utf8" }).trim());
+
+  const run = (argv: readonly string[]): string =>
+    execFileSync(executablePath, ["-L", socketName, ...argv], {
+      cwd: root,
+      encoding: "utf8",
+      maxBuffer: 128 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    }).replace(/(?:\r?\n)+$/u, "");
+
+  beforeAll(() => {
+    run(["-f", "/dev/null", "new-session", "-d", "-s", sessionName, "exec sleep 30"]);
+    run(["set-option", "-p", "-t", `=${sessionName}:0.0`, "@tmux_ide_pane_id", semanticPaneId]);
+  });
+
+  afterAll(() => {
+    spawnSync(executablePath, ["-L", socketName, "kill-server"], { stdio: "ignore" });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("discovers, attaches, correlates geometry, and disposes on its isolated socket", async () => {
+    const audits: Array<{ type: string; reason?: string }> = [];
+    const registry = new WorkspaceRegistry({ dir: join(root, "registry"), listSessions: () => [] });
+    registry.add({ name: workspaceName, sessionName, projectDir: root });
+    const runtime = createNativeTerminalAttachmentRuntime({
+      daemonInstanceId,
+      webSocketUrl: "ws://127.0.0.1:6070/v1/terminal/attachments/redeem",
+      registry,
+      tmuxAuthority: {
+        executablePath,
+        socketSelector: { kind: "name", name: socketName },
+        trustedCwd: root,
+      },
+      lease: { onAudit: (event) => audits.push({ type: event.type, reason: event.reason }) },
+    });
+    const issued = await runtime.admission.issue(
+      {
+        protocolVersion: 1,
+        target: { workspaceName, semanticPaneId },
+        viewerMode: "interactive",
+        viewport: { cols: 100, rows: 30 },
+      },
+      { requestId, projectIdentity: "project-live", rendererOrigin: "tmux-ide://app" },
+    );
+    const upgrade = runtime.admission.reserveUpgrade({
+      path: TERMINAL_ATTACHMENT_REDEEM_PATH,
+      protocols: [TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL],
+      origin: "tmux-ide://app",
+    });
+    if (!upgrade.accepted) throw new Error(upgrade.code);
+    const socket = new LiveSocket();
+    upgrade.admission.bind(socket);
+    socket.frame(
+      JSON.stringify({
+        type: "redeem",
+        protocolVersion: 1,
+        ticket: issued.redemptionTicket,
+        requestId,
+        daemonInstanceId,
+      }),
+    );
+
+    try {
+      await vi.waitFor(
+        () => {
+          const ready = socket.sent
+            .filter((entry) => typeof entry.data === "string")
+            .map((entry) => JSON.parse(entry.data as string) as { type?: string })
+            .find((entry) => entry.type === "ready");
+          expect({ ready, closes: socket.closes, audits }).toMatchObject({
+            ready: {
+              type: "ready",
+              inputCapability: "unavailable",
+              sourceGrid: { cols: expect.any(Number), rows: expect.any(Number) },
+              clientViewport: { cols: expect.any(Number), rows: expect.any(Number) },
+            },
+            closes: [],
+            audits: expect.arrayContaining([
+              expect.objectContaining({ type: "issued" }),
+              expect.objectContaining({ type: "redeemed" }),
+            ]),
+          });
+        },
+        { timeout: 3_000 },
+      );
+      expect(runtime.snapshot().liveConnections).toBe(1);
+    } finally {
+      await runtime.dispose();
+    }
+    expect(runtime.snapshot()).toMatchObject({ liveConnections: 0, shuttingDown: true });
+    expect(run(["list-sessions", "-F", "#{session_name}"])).toBe(sessionName);
+  }, 10_000);
+});

--- a/packages/daemon/src/terminal/__tests__/native-runtime-live.test.ts
+++ b/packages/daemon/src/terminal/__tests__/native-runtime-live.test.ts
@@ -13,6 +13,10 @@ import {
   TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL,
   type DirectTerminalSocket,
 } from "../attachments/direct-websocket.ts";
+import {
+  groupedTmuxViewSessionName,
+  planGroupedTmuxAttachment,
+} from "../attachments/grouped-tmux.ts";
 import { createNativeTerminalAttachmentRuntime } from "../attachments/native-runtime.ts";
 
 const hasTmux = spawnSync("tmux", ["-V"], { stdio: "ignore" }).status === 0;
@@ -61,7 +65,7 @@ describe.skipIf(!hasTmux)("native attachment runtime isolated tmux integration",
     }).replace(/(?:\r?\n)+$/u, "");
 
   beforeAll(() => {
-    run(["-f", "/dev/null", "new-session", "-d", "-s", sessionName, "exec sleep 30"]);
+    run(["-f", "/dev/null", "new-session", "-d", "-s", sessionName, "exec sleep 300"]);
     run(["set-option", "-p", "-t", `=${sessionName}:0.0`, "@tmux_ide_pane_id", semanticPaneId]);
   });
 
@@ -141,5 +145,81 @@ describe.skipIf(!hasTmux)("native attachment runtime isolated tmux integration",
     }
     expect(runtime.snapshot()).toMatchObject({ liveConnections: 0, shuttingDown: true });
     expect(run(["list-sessions", "-F", "#{session_name}"])).toBe(sessionName);
+  }, 10_000);
+
+  it("removes a strictly marked view left by a simulated crash before restart readiness", async () => {
+    const orphanAttachmentId = randomUUID();
+    const [sourceSessionId, sourceWindowId, sourcePaneId, sourcePaneCount] = run([
+      "list-panes",
+      "-t",
+      `=${sessionName}:0.0`,
+      "-F",
+      "#{session_id}\t#{window_id}\t#{pane_id}\t#{window_panes}",
+    ]).split("\t");
+    if (!sourceSessionId || !sourceWindowId || !sourcePaneId || sourcePaneCount !== "1") {
+      throw new Error("isolated source pane discovery failed");
+    }
+    const orphanPlan = planGroupedTmuxAttachment({
+      attachmentId: orphanAttachmentId,
+      generation: 0,
+      target: { workspaceName, semanticPaneId },
+      viewerMode: "interactive",
+      viewport: { cols: 100, rows: 30 },
+      source: {
+        sessionId: sourceSessionId,
+        windowId: sourceWindowId,
+        runtimePaneId: sourcePaneId,
+        paneCount: 1,
+      },
+    });
+    // This is the durable tmux state a daemon process crash leaves behind:
+    // the prior in-memory lease/admission owner is gone, but its strictly
+    // named and marked one-window view remains on the shared tmux socket.
+    run(orphanPlan.create.command.argv);
+    const orphanViewName = groupedTmuxViewSessionName(orphanAttachmentId, 0);
+    const viewExists = (): boolean =>
+      spawnSync(executablePath, ["-L", socketName, "has-session", "-t", `=${orphanViewName}`], {
+        cwd: root,
+        stdio: "ignore",
+      }).status === 0;
+    expect(viewExists()).toBe(true);
+
+    const registry = new WorkspaceRegistry({
+      dir: join(root, "restart-registry"),
+      listSessions: () => [],
+    });
+    registry.add({ name: workspaceName, sessionName, projectDir: root });
+    const restarted = createNativeTerminalAttachmentRuntime({
+      daemonInstanceId: `${daemonInstanceId}-restart`,
+      webSocketUrl: "ws://127.0.0.1:6070/v1/terminal/attachments/redeem",
+      registry,
+      tmuxAuthority: {
+        executablePath,
+        socketSelector: { kind: "name", name: socketName },
+        trustedCwd: root,
+      },
+    });
+
+    // Construction starts reconciliation, but readiness is the publication
+    // barrier. The orphan is still observable until that barrier completes.
+    expect(viewExists()).toBe(true);
+    await expect(restarted.whenReady()).resolves.toBeUndefined();
+    expect(viewExists()).toBe(false);
+    await expect(
+      restarted.admission.issue(
+        {
+          protocolVersion: 1,
+          target: { workspaceName, semanticPaneId },
+          viewerMode: "interactive",
+          viewport: { cols: 100, rows: 30 },
+        },
+        {
+          requestId: randomUUID(),
+          projectIdentity: "project-live-restarted",
+          rendererOrigin: "tmux-ide://app",
+        },
+      ),
+    ).resolves.toMatchObject({ daemonInstanceId: `${daemonInstanceId}-restart` });
+    await restarted.dispose();
   }, 10_000);
 });

--- a/packages/daemon/src/terminal/__tests__/native-runtime.test.ts
+++ b/packages/daemon/src/terminal/__tests__/native-runtime.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -50,6 +51,15 @@ function createRegistry(workspaceName = "workspace.alpha", sessionName = "runtim
   const result = new WorkspaceRegistry({ dir: join(root, "registry"), listSessions: () => [] });
   result.add({ name: workspaceName, sessionName, projectDir: root });
   return { registry: result, root };
+}
+
+function createEmptyRegistry() {
+  const root = mkdtempSync(join(tmpdir(), "tmux-ide-native-runtime-empty-"));
+  roots.push(root);
+  return {
+    registry: new WorkspaceRegistry({ dir: join(root, "registry"), listSessions: () => [] }),
+    root,
+  };
 }
 
 function authority(root: string) {
@@ -350,6 +360,89 @@ class StartupReconciliationTmuxModel {
 }
 
 describe("native terminal attachment runtime lifecycle", () => {
+  it("accepts no default tmux server only for construction with an empty registry", async () => {
+    const { registry, root } = createEmptyRegistry();
+    const calls: string[][] = [];
+    const runtime = createNativeTerminalAttachmentRuntime({
+      daemonInstanceId: INSTANCE_ID,
+      webSocketUrl: WS_URL,
+      registry,
+      tmuxAuthority: {
+        ...authority(root),
+        socketSelector: { kind: "name", name: "default" },
+      },
+      commandExecutor: (_executable, argv) => {
+        calls.push([...argv]);
+        throw new TmuxError("raw default socket detail", "TMUX_UNAVAILABLE");
+      },
+    });
+
+    await expect(runtime.whenReady()).resolves.toBeUndefined();
+    expect(calls).toEqual([
+      ["-L", "default", "list-sessions", "-F", "#{session_name}\t#{session_id}"],
+    ]);
+    await runtime.dispose();
+  });
+
+  it.each([
+    ["a nonempty registry on the default socket", true, "default"],
+    ["an empty registry on a non-default named socket", false, "explicit-runtime"],
+  ])("fails startup closed for %s", async (_label, nonempty, socketName) => {
+    const { registry, root } = nonempty ? createRegistry() : createEmptyRegistry();
+    const runtime = createNativeTerminalAttachmentRuntime({
+      daemonInstanceId: INSTANCE_ID,
+      webSocketUrl: WS_URL,
+      registry,
+      tmuxAuthority: {
+        ...authority(root),
+        socketSelector: { kind: "name", name: socketName },
+      },
+      commandExecutor: () => {
+        throw new TmuxError("raw inaccessible named socket detail", "TMUX_UNAVAILABLE");
+      },
+    });
+
+    await expect(runtime.whenReady()).rejects.toMatchObject({
+      code: "orphan-reconciliation-failed",
+      message: "Daemon-owned terminal view startup reconciliation failed.",
+    });
+    await runtime.dispose();
+  });
+
+  it("fails startup closed for an unavailable explicit socket path", async () => {
+    const { registry, root } = createEmptyRegistry();
+    const socketPath = join(root, "explicit.sock");
+    const server = createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, resolve);
+    });
+    try {
+      const runtime = createNativeTerminalAttachmentRuntime({
+        daemonInstanceId: INSTANCE_ID,
+        webSocketUrl: WS_URL,
+        registry,
+        tmuxAuthority: {
+          ...authority(root),
+          socketSelector: { kind: "path", path: socketPath },
+        },
+        commandExecutor: () => {
+          throw new TmuxError("raw inaccessible path detail", "TMUX_UNAVAILABLE");
+        },
+      });
+
+      await expect(runtime.whenReady()).rejects.toMatchObject({
+        code: "orphan-reconciliation-failed",
+        message: "Daemon-owned terminal view startup reconciliation failed.",
+      });
+      await runtime.dispose();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("cleans strictly marked orphan views before an issue can resolve", async () => {
     const { registry, root } = createRegistry();
     const events: string[] = [];

--- a/packages/daemon/src/terminal/__tests__/native-runtime.test.ts
+++ b/packages/daemon/src/terminal/__tests__/native-runtime.test.ts
@@ -303,7 +303,166 @@ class RuntimeTmuxModel {
   };
 }
 
+class StartupReconciliationTmuxModel {
+  readonly viewName = groupedTmuxViewSessionName(LEASE_ID, 0);
+  readonly marker = `v1:${LEASE_ID}:0`;
+  readonly events: string[];
+  viewExists = true;
+  cleanupFailure = false;
+
+  constructor(events: string[] = []) {
+    this.events = events;
+  }
+
+  execute: NativeTerminalAttachmentCommandExecutor = (_executable, rawArgv) => {
+    const argv = rawArgv.slice(2);
+    const targetIndex = argv.indexOf("-t");
+    const target = targetIndex < 0 ? "" : (argv[targetIndex + 1] ?? "");
+    if (argv[0] === "list-sessions") {
+      this.events.push("enumerate-orphans");
+      return this.viewExists ? `${this.viewName}\t$9\n` : "";
+    }
+    if (argv[0] === "show-environment") {
+      if (!this.viewExists) throw new TmuxError("missing", "SESSION_NOT_FOUND");
+      return `TMUX_IDE_ATTACHMENT_VIEW=${this.marker}\n`;
+    }
+    if (argv[0] === "has-session") {
+      if (!this.viewExists) throw new TmuxError("missing", "SESSION_NOT_FOUND");
+      return "";
+    }
+    if (argv[0] === "list-windows" && target === `=${this.viewName}`) {
+      if (!this.viewExists) throw new TmuxError("missing", "SESSION_NOT_FOUND");
+      return "@2\n";
+    }
+    if (argv[0] === "list-panes" && target === `=${this.viewName}`) {
+      if (!this.viewExists) throw new TmuxError("missing", "SESSION_NOT_FOUND");
+      if (argv.at(-1) === "#{session_id}") return "$9\n";
+      return "$9\t@2\t%3\t1\t1\n";
+    }
+    if (argv[0] === "if-shell" && argv.join(" ").includes("kill-session")) {
+      this.events.push("cleanup-orphan");
+      if (this.cleanupFailure) throw new Error("raw cleanup failure must not escape");
+      this.viewExists = false;
+      return "";
+    }
+    return "";
+  };
+}
+
 describe("native terminal attachment runtime lifecycle", () => {
+  it("cleans strictly marked orphan views before an issue can resolve", async () => {
+    const { registry, root } = createRegistry();
+    const events: string[] = [];
+    const model = new StartupReconciliationTmuxModel(events);
+    const catalog = new SemanticPaneCatalog({
+      discover: () => {
+        events.push("discover-pane-for-issue");
+        return [row()];
+      },
+    });
+    const runtime = createNativeTerminalAttachmentRuntime({
+      daemonInstanceId: INSTANCE_ID,
+      webSocketUrl: WS_URL,
+      registry,
+      tmuxAuthority: authority(root),
+      semanticPaneCatalog: catalog,
+      commandExecutor: model.execute,
+      lease: {
+        createId: () => LEASE_ID,
+        randomBytes: () => Buffer.alloc(32, 7),
+      },
+    });
+
+    const issuing = runtime.admission.issue(request(), {
+      requestId: REQUEST_ID,
+      projectIdentity: "project-alpha",
+      rendererOrigin: ORIGIN,
+    });
+    expect(
+      runtime.admission.reserveUpgrade({
+        path: TERMINAL_ATTACHMENT_REDEEM_PATH,
+        protocols: [TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL],
+        origin: ORIGIN,
+      }),
+    ).toEqual({ accepted: false, code: "attachment-unavailable", httpStatus: 503 });
+
+    await expect(runtime.whenReady()).resolves.toBeUndefined();
+    await expect(issuing).resolves.toMatchObject({ requestId: REQUEST_ID });
+    expect(model.viewExists).toBe(false);
+    expect(events).toEqual(["enumerate-orphans", "cleanup-orphan", "discover-pane-for-issue"]);
+    await runtime.dispose();
+  });
+
+  it("fails readiness and issue admission closed when orphan cleanup fails", async () => {
+    const { registry, root } = createRegistry();
+    const events: string[] = [];
+    const model = new StartupReconciliationTmuxModel(events);
+    model.cleanupFailure = true;
+    const catalog = new SemanticPaneCatalog({
+      discover: () => {
+        events.push("unexpected-pane-discovery");
+        return [row()];
+      },
+    });
+    const runtime = createNativeTerminalAttachmentRuntime({
+      daemonInstanceId: INSTANCE_ID,
+      webSocketUrl: WS_URL,
+      registry,
+      tmuxAuthority: authority(root),
+      semanticPaneCatalog: catalog,
+      commandExecutor: model.execute,
+      lease: {
+        createId: () => LEASE_ID,
+        randomBytes: () => Buffer.alloc(32, 7),
+      },
+    });
+
+    await expect(runtime.whenReady()).rejects.toMatchObject({
+      code: "orphan-reconciliation-failed",
+      message: "Daemon-owned terminal view startup reconciliation failed.",
+    });
+    await expect(
+      runtime.admission.issue(request(), {
+        requestId: REQUEST_ID,
+        projectIdentity: "project-alpha",
+        rendererOrigin: ORIGIN,
+      }),
+    ).rejects.toMatchObject({
+      code: "attachment-unavailable",
+      message: "Terminal attachment startup reconciliation failed.",
+    });
+    expect(events).toEqual(["enumerate-orphans", "cleanup-orphan"]);
+    expect(runtime.snapshot()).toMatchObject({ pendingTickets: 0, liveConnections: 0 });
+    await runtime.dispose();
+  });
+
+  it("disposes through initialization and never reports late readiness", async () => {
+    const { registry, root } = createRegistry();
+    const model = new StartupReconciliationTmuxModel();
+    model.viewExists = false;
+    const runtime = createNativeTerminalAttachmentRuntime({
+      daemonInstanceId: INSTANCE_ID,
+      webSocketUrl: WS_URL,
+      registry,
+      tmuxAuthority: authority(root),
+      semanticPaneCatalog: new SemanticPaneCatalog({ discover: () => [row()] }),
+      commandExecutor: model.execute,
+    });
+
+    const readiness = runtime.whenReady();
+    const disposing = runtime.dispose();
+    expect(runtime.dispose()).toBe(disposing);
+    await expect(readiness).rejects.toMatchObject({ code: "runtime-disposed" });
+    await disposing;
+    expect(model.events).toEqual(["enumerate-orphans"]);
+    expect(runtime.snapshot()).toEqual({
+      pendingTickets: 0,
+      preAuthSockets: 0,
+      liveConnections: 0,
+      shuttingDown: true,
+    });
+  });
+
   it("does not finish an issue across shutdown and returns one complete dispose barrier", async () => {
     const { registry, root } = createRegistry();
     let releaseDiscovery!: () => void;

--- a/packages/daemon/src/terminal/__tests__/native-runtime.test.ts
+++ b/packages/daemon/src/terminal/__tests__/native-runtime.test.ts
@@ -1,0 +1,418 @@
+import { EventEmitter } from "node:events";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TerminalAttachRequest } from "@tmux-ide/contracts";
+import { TmuxError } from "@tmux-ide/tmux-bridge";
+
+import { WorkspaceRegistry } from "../../lib/workspace-registry.ts";
+import type { DirectTerminalSocket } from "../attachments/direct-websocket.ts";
+import {
+  TERMINAL_ATTACHMENT_REDEEM_PATH,
+  TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL,
+} from "../attachments/direct-websocket.ts";
+import { groupedTmuxViewSessionName, type TmuxArgvPlan } from "../attachments/grouped-tmux.ts";
+import type { AttachmentLeaseDescriptor } from "../attachments/lease-manager.ts";
+import {
+  NativeTerminalAttachmentGeometryResolver,
+  NativeTerminalAttachmentRuntimeError,
+  createNativeTerminalAttachmentRuntime,
+  discoverWorkspaceRegistrySemanticPanes,
+  type NativeTerminalAttachmentCommandExecutor,
+} from "../attachments/native-runtime.ts";
+import {
+  SemanticPaneCatalog,
+  type TrustedSemanticPaneSnapshot,
+} from "../attachments/semantic-pane-catalog.ts";
+import {
+  TmuxAttachmentOperationSerializer,
+  type TmuxAttachmentCommandRunner,
+} from "../attachments/tmux-view-executor.ts";
+import { MockPtyAdapter } from "./MockPtyAdapter.ts";
+
+const INSTANCE_ID = "daemon-instance-a1";
+const REQUEST_ID = "25f3e0c9-00eb-434a-9c90-d59f6f62facf";
+const LEASE_ID = "f3d8bc0b-460c-458c-b9c0-dbc2536d1486";
+const ATTEMPT_ID = "a45072f8-5a82-4930-8bed-0959c617e60b";
+const ORIGIN = "tmux-ide://app";
+const WS_URL = "ws://127.0.0.1:6070/v1/terminal/attachments/redeem";
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function createRegistry(workspaceName = "workspace.alpha", sessionName = "runtime-session") {
+  const root = mkdtempSync(join(tmpdir(), "tmux-ide-native-runtime-"));
+  roots.push(root);
+  const result = new WorkspaceRegistry({ dir: join(root, "registry"), listSessions: () => [] });
+  result.add({ name: workspaceName, sessionName, projectDir: root });
+  return { registry: result, root };
+}
+
+function authority(root: string) {
+  const executablePath = join(root, "trusted-tmux");
+  writeFileSync(executablePath, "#!/bin/sh\nexit 0\n");
+  chmodSync(executablePath, 0o755);
+  return {
+    executablePath,
+    socketSelector: { kind: "name" as const, name: "native-runtime-test" },
+    trustedCwd: root,
+    environment: {
+      TERM: "screen-256color",
+      LANG: "C",
+      PATH: `${root}:/hostile`,
+      TMUX: "/tmp/hostile,1,2",
+      BASH_ENV: "/tmp/hostile-hook",
+      SECRET_TOKEN: "must-not-cross",
+    },
+  };
+}
+
+function row(overrides: Partial<TrustedSemanticPaneSnapshot> = {}): TrustedSemanticPaneSnapshot {
+  return {
+    workspaceName: "workspace.alpha",
+    semanticPaneId: "pane.agent",
+    sessionId: "$1",
+    windowId: "@2",
+    runtimePaneId: "%3",
+    windowPaneCount: 1,
+    sessionWindowCount: 2,
+    ...overrides,
+  };
+}
+
+function request(): TerminalAttachRequest {
+  return {
+    protocolVersion: 1,
+    target: { workspaceName: "workspace.alpha", semanticPaneId: "pane.agent" },
+    viewerMode: "interactive",
+    viewport: { cols: 120, rows: 40 },
+  };
+}
+
+function descriptor(overrides: Partial<AttachmentLeaseDescriptor> = {}): AttachmentLeaseDescriptor {
+  return {
+    leaseId: LEASE_ID,
+    requestId: REQUEST_ID,
+    target: request().target,
+    viewerMode: "interactive",
+    status: "active",
+    issuedAt: 1_000,
+    expiresAt: 61_000,
+    graceExpiresAt: null,
+    bindingGeneration: 0,
+    viewGeneration: 0,
+    ...overrides,
+  };
+}
+
+describe("workspace-registry semantic pane discovery", () => {
+  it("maps semantic workspace name to a distinct exact tmux session name", async () => {
+    const { registry } = createRegistry("workspace.alpha", "runtime-session-different");
+    const calls: string[][] = [];
+    const runner: TmuxAttachmentCommandRunner = {
+      run(command) {
+        calls.push([...command.argv]);
+        return {
+          status: "ok",
+          stdout: "runtime-session-different\t$1\t@2\t%3\t1\t2\tpane.agent\n",
+        };
+      },
+    };
+    const catalog = new SemanticPaneCatalog({
+      discover: () => discoverWorkspaceRegistrySemanticPanes(registry, runner),
+    });
+
+    await expect(catalog.resolve(request().target)).resolves.toMatchObject({
+      target: request().target,
+      source: { sessionId: "$1", windowId: "@2", runtimePaneId: "%3" },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("=runtime-session-different");
+    expect(calls[0]).not.toContain("=workspace.alpha");
+  });
+
+  it.each([
+    ["missing stamp", "runtime-session\t$1\t@2\t%3\t1\t2\t\n", "missing-semantic-stamp"],
+    [
+      "duplicate stamp",
+      "runtime-session\t$1\t@2\t%3\t1\t2\tpane.agent\nruntime-session\t$1\t@4\t%5\t1\t2\tpane.agent\n",
+      "duplicate-semantic-stamp",
+    ],
+  ])("rejects %s from exact registry-backed discovery", async (_label, stdout, code) => {
+    const { registry } = createRegistry();
+    const catalog = new SemanticPaneCatalog({
+      discover: () =>
+        discoverWorkspaceRegistrySemanticPanes(registry, {
+          run: () => ({ status: "ok", stdout }),
+        }),
+    });
+    await expect(catalog.resolve(request().target)).rejects.toMatchObject({ code });
+  });
+});
+
+describe("native terminal attachment geometry", () => {
+  function geometryRig(output: (viewName: string) => string) {
+    let discovered = row();
+    const catalog = new SemanticPaneCatalog({ discover: () => [discovered] });
+    const calls: TmuxArgvPlan[] = [];
+    const runner: TmuxAttachmentCommandRunner = {
+      run(command) {
+        calls.push({ executable: "tmux", argv: [...command.argv] });
+        return { status: "ok", stdout: output(groupedTmuxViewSessionName(LEASE_ID, 0)) };
+      },
+    };
+    const resolver = new NativeTerminalAttachmentGeometryResolver({
+      catalog,
+      runner,
+      operationSerializer: new TmuxAttachmentOperationSerializer(),
+    });
+    return {
+      catalog,
+      resolver,
+      calls,
+      mutate(next: TrustedSemanticPaneSnapshot) {
+        discovered = next;
+      },
+    };
+  }
+
+  const claim = { attemptId: ATTEMPT_ID, attachmentId: LEASE_ID, generation: 0, pid: 4321 };
+
+  it("returns geometry only after one exact view client matches the claimed PTY pid", async () => {
+    const rig = geometryRig(
+      (viewName) => `source\t$1\t@2\t%3\t1\t120\t40\nclient\t4321\t${viewName}\t118\t38\n`,
+    );
+    await expect(rig.resolver.resolve(descriptor(), claim)).resolves.toEqual({
+      sourceGrid: { cols: 120, rows: 40 },
+      clientViewport: { cols: 118, rows: 38 },
+    });
+    const serialized = rig.calls[0]!.argv.join(" ");
+    expect(serialized).toContain("$1:@2.%3");
+    expect(serialized).toContain(groupedTmuxViewSessionName(LEASE_ID, 0));
+    expect(serialized).toContain(`v1:${LEASE_ID}:0`);
+  });
+
+  it.each([
+    [
+      "wrong pid",
+      (view: string) => `source\t$1\t@2\t%3\t1\t120\t40\nclient\t9999\t${view}\t118\t38\n`,
+    ],
+    ["wrong view", () => "source\t$1\t@2\t%3\t1\t120\t40\nclient\t4321\tforeign-view\t118\t38\n"],
+    [
+      "multiple clients",
+      (view: string) =>
+        `source\t$1\t@2\t%3\t1\t120\t40\nclient\t4321\t${view}\t118\t38\nclient\t5555\t${view}\t80\t24\n`,
+    ],
+    [
+      "source guard mismatch",
+      (view: string) => `source\t$8\t@2\t%3\t1\t120\t40\nclient\t4321\t${view}\t118\t38\n`,
+    ],
+    ["view guard mismatch", () => "__tmux_ide_geometry_view_mismatch_v1__\n"],
+  ])("fails closed for %s", async (_label, output) => {
+    const rig = geometryRig(output);
+    await expect(rig.resolver.resolve(descriptor(), claim)).rejects.toBeInstanceOf(
+      NativeTerminalAttachmentRuntimeError,
+    );
+  });
+
+  it("rejects external source rebinding after the descriptor generation was issued", async () => {
+    const rig = geometryRig(
+      (viewName) => `source\t$1\t@2\t%3\t1\t120\t40\nclient\t4321\t${viewName}\t118\t38\n`,
+    );
+    await rig.catalog.resolve(request().target);
+    rig.mutate(row({ sessionId: "$8", windowId: "@9", runtimePaneId: "%10" }));
+    await expect(rig.resolver.resolve(descriptor(), claim)).rejects.toMatchObject({
+      code: "geometry-mismatch",
+    });
+    expect(rig.calls).toHaveLength(0);
+  });
+});
+
+class FakeSocket extends EventEmitter implements DirectTerminalSocket {
+  readyState = 1;
+  bufferedAmount = 0;
+
+  send(): void {}
+
+  close(): void {
+    if (this.readyState !== 1) return;
+    this.readyState = 3;
+    this.emit("close");
+  }
+
+  frame(data: string): void {
+    this.emit("message", data, false);
+  }
+}
+
+class RuntimeTmuxModel {
+  viewName = "";
+  marker = "";
+  viewExists = false;
+  proofReady = false;
+  readonly environments: NodeJS.ProcessEnv[] = [];
+
+  constructor(readonly adapter: MockPtyAdapter) {}
+
+  execute: NativeTerminalAttachmentCommandExecutor = (_executable, rawArgv, options) => {
+    this.environments.push({ ...options.env });
+    const argv = rawArgv.slice(2);
+    const serialized = argv.join(" ");
+    if (argv[0] === "has-session") {
+      if (!this.viewExists) throw new TmuxError("missing", "SESSION_NOT_FOUND");
+      return "";
+    }
+    if (argv[0] === "show-environment") {
+      if (!this.viewExists) throw new TmuxError("missing", "SESSION_NOT_FOUND");
+      return `TMUX_IDE_ATTACHMENT_VIEW=${this.marker}\n`;
+    }
+    if (argv[0] === "list-windows") return this.viewExists ? "@2\n" : "";
+    if (argv[0] === "list-sessions") return "";
+    if (argv[0] === "list-panes") {
+      const target = argv[argv.indexOf("-t") + 1] ?? "";
+      if (target.startsWith("=")) {
+        if (argv.at(-1) === "#{session_id}") return "$9\n";
+        return "$9\t@2\t%3\t1\t1\n";
+      }
+      return "$1\t@2\t%3\t1\n";
+    }
+    if (argv[0] === "if-shell" && serialized.includes("new-session")) {
+      const match = /_tmux-ide-view-v1-[0-9a-f]{32}-[0-9a-z]+/u.exec(serialized);
+      if (!match) throw new Error("missing view name");
+      this.viewName = match[0];
+      this.marker = `v1:${LEASE_ID}:0`;
+      this.viewExists = true;
+      return "";
+    }
+    if (argv[0] === "if-shell" && serialized.includes("kill-session")) {
+      this.viewExists = false;
+      return "";
+    }
+    if (argv[0] === "if-shell" && serialized.includes("client\\t#{client_pid}")) {
+      return `source\t$1\t@2\t%3\t1\t120\t40\nclient\t${this.adapter.lastSpawned()!.pid}\t${this.viewName}\t118\t38\n`;
+    }
+    if (argv[0] === "if-shell" && serialized.includes("list-clients")) {
+      if (!this.proofReady) return "";
+      return `${this.adapter.lastSpawned()!.pid}\t${this.viewName}\n`;
+    }
+    return "";
+  };
+}
+
+describe("native terminal attachment runtime lifecycle", () => {
+  it("does not finish an issue across shutdown and returns one complete dispose barrier", async () => {
+    const { registry, root } = createRegistry();
+    let releaseDiscovery!: () => void;
+    let discoveryStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      discoveryStarted = resolve;
+    });
+    const discoveryGate = new Promise<void>((resolve) => {
+      releaseDiscovery = resolve;
+    });
+    const catalog = new SemanticPaneCatalog({
+      discover: async () => {
+        discoveryStarted();
+        await discoveryGate;
+        return [row()];
+      },
+    });
+    const runtime = createNativeTerminalAttachmentRuntime({
+      daemonInstanceId: INSTANCE_ID,
+      webSocketUrl: WS_URL,
+      registry,
+      tmuxAuthority: authority(root),
+      semanticPaneCatalog: catalog,
+      commandExecutor: () => "",
+      lease: {
+        createId: () => LEASE_ID,
+        randomBytes: () => Buffer.alloc(32, 7),
+      },
+    });
+    const issuing = runtime.admission.issue(request(), {
+      requestId: REQUEST_ID,
+      projectIdentity: "project-alpha",
+      rendererOrigin: ORIGIN,
+    });
+    await started;
+    const firstDispose = runtime.dispose();
+    expect(runtime.dispose()).toBe(firstDispose);
+    releaseDiscovery();
+
+    await expect(issuing).rejects.toMatchObject({ code: "daemon-shutting-down" });
+    await firstDispose;
+    expect(runtime.snapshot()).toEqual({
+      pendingTickets: 0,
+      preAuthSockets: 0,
+      liveConnections: 0,
+      shuttingDown: true,
+    });
+  });
+
+  it("kills a launch awaiting readiness and cannot publish a late live PTY after dispose", async () => {
+    const { registry, root } = createRegistry();
+    const adapter = new MockPtyAdapter({ startingPid: 4321 });
+    const model = new RuntimeTmuxModel(adapter);
+    const catalog = new SemanticPaneCatalog({ discover: () => [row()] });
+    const runtime = createNativeTerminalAttachmentRuntime({
+      daemonInstanceId: INSTANCE_ID,
+      webSocketUrl: WS_URL,
+      registry,
+      tmuxAuthority: authority(root),
+      semanticPaneCatalog: catalog,
+      commandExecutor: model.execute,
+      ptyAdapter: adapter,
+      lease: {
+        createId: () => LEASE_ID,
+        randomBytes: () => Buffer.alloc(32, 7),
+      },
+      launcher: { readinessTimeoutMs: 5_000, readinessPollIntervalMs: 10 },
+    });
+    const issued = await runtime.admission.issue(request(), {
+      requestId: REQUEST_ID,
+      projectIdentity: "project-alpha",
+      rendererOrigin: ORIGIN,
+    });
+    expect(JSON.stringify(runtime)).toBe(
+      '{"pendingTickets":1,"preAuthSockets":0,"liveConnections":0,"shuttingDown":false}',
+    );
+    const upgrade = runtime.admission.reserveUpgrade({
+      path: TERMINAL_ATTACHMENT_REDEEM_PATH,
+      protocols: [TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL],
+      origin: ORIGIN,
+    });
+    if (!upgrade.accepted) throw new Error(upgrade.code);
+    const socket = new FakeSocket();
+    upgrade.admission.bind(socket);
+    socket.frame(
+      JSON.stringify({
+        type: "redeem",
+        protocolVersion: 1,
+        ticket: issued.redemptionTicket,
+        requestId: REQUEST_ID,
+        daemonInstanceId: INSTANCE_ID,
+      }),
+    );
+    await vi.waitFor(() => expect(adapter.spawnCount).toBe(1));
+    const process = adapter.lastSpawned()!;
+    const disposing = runtime.dispose();
+    model.proofReady = true;
+    await disposing;
+
+    expect(process.killed).toBe("SIGTERM");
+    expect(adapter.spawnCount).toBe(1);
+    expect(runtime.snapshot()).toMatchObject({
+      pendingTickets: 0,
+      preAuthSockets: 0,
+      liveConnections: 0,
+      shuttingDown: true,
+    });
+    for (const environment of model.environments) {
+      expect(environment).toEqual({ TERM: "screen-256color", LANG: "C" });
+    }
+  });
+});

--- a/packages/daemon/src/terminal/__tests__/tmux-view-executor.test.ts
+++ b/packages/daemon/src/terminal/__tests__/tmux-view-executor.test.ts
@@ -13,6 +13,7 @@ import type {
 } from "../attachments/lease-manager.ts";
 import {
   TmuxAttachmentClientTransportError,
+  TmuxAttachmentOperationSerializer,
   TmuxAttachmentViewExecutor,
   TmuxAttachmentViewExecutorError,
   planCanonicalTmuxAttachmentClientCommand,
@@ -660,8 +661,17 @@ describe("TmuxAttachmentViewExecutor guarded cleanup", () => {
     const firstPlan = plan();
     const secondPlan = plan(secondAttachmentId);
     seed(runner, secondPlan);
-    const first = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
-    const second = new TmuxAttachmentViewExecutor({ runner, now: () => 1_000 });
+    const operationSerializer = new TmuxAttachmentOperationSerializer();
+    const first = new TmuxAttachmentViewExecutor({
+      runner,
+      operationSerializer,
+      now: () => 1_000,
+    });
+    const second = new TmuxAttachmentViewExecutor({
+      runner,
+      operationSerializer,
+      now: () => 1_000,
+    });
 
     const creating = first.executeGuardedViewOperation(operation("create", firstPlan));
     const cleaning = second.guardedCleanup(cleanup(secondPlan));

--- a/packages/daemon/src/terminal/attachments/direct-websocket.ts
+++ b/packages/daemon/src/terminal/attachments/direct-websocket.ts
@@ -171,6 +171,12 @@ export interface TerminalAttachmentAdmissionCoordinatorOptions {
   readonly webSocketUrl: string;
   readonly leaseManager: DirectTerminalAttachmentLeaseManager;
   readonly launcher: DirectTerminalAttachmentLauncher;
+  /**
+   * Daemon-owned startup work which must complete before any descriptor or
+   * WebSocket admission can be published. Rejections are deliberately
+   * collapsed to the static attachment-unavailable domain error.
+   */
+  readonly startupBarrier?: PromiseLike<void>;
   readonly resolveGeometry: (
     descriptor: AttachmentLeaseDescriptor,
     client: TerminalAttachmentGeometryClientProof,
@@ -359,6 +365,7 @@ export class TerminalAttachmentAdmissionCoordinator {
   readonly #webSocketUrl: string;
   readonly #leaseManager: DirectTerminalAttachmentLeaseManager;
   readonly #launcher: DirectTerminalAttachmentLauncher;
+  readonly #startupBarrier: Promise<void>;
   readonly #resolveGeometry: TerminalAttachmentAdmissionCoordinatorOptions["resolveGeometry"];
   readonly #maxPending: number;
   readonly #maxPreAuth: number;
@@ -376,6 +383,7 @@ export class TerminalAttachmentAdmissionCoordinator {
   #pendingReservations = 0;
   #liveReservations = 0;
   #operationTail: Promise<void> = Promise.resolve();
+  #startupState: "pending" | "ready" | "failed";
   #shuttingDown = false;
   #shutdownPromise: Promise<void> | null = null;
 
@@ -384,6 +392,27 @@ export class TerminalAttachmentAdmissionCoordinator {
     this.#webSocketUrl = validateWebSocketUrl(options.webSocketUrl);
     this.#leaseManager = options.leaseManager;
     this.#launcher = options.launcher;
+    if (options.startupBarrier) {
+      this.#startupState = "pending";
+      this.#startupBarrier = Promise.resolve(options.startupBarrier).then(
+        () => {
+          this.#startupState = "ready";
+        },
+        () => {
+          this.#startupState = "failed";
+          throw new TerminalAttachmentAdmissionError(
+            "attachment-unavailable",
+            "Terminal attachment startup reconciliation failed.",
+          );
+        },
+      );
+      // The same rejection remains observable through issue(); this handler
+      // only prevents a constructor-started barrier from becoming unhandled.
+      void this.#startupBarrier.catch(() => undefined);
+    } else {
+      this.#startupState = "ready";
+      this.#startupBarrier = Promise.resolve();
+    }
     this.#resolveGeometry = options.resolveGeometry;
     this.#maxPending = boundedInteger(options.maxPendingTickets, 32, 1_024);
     this.#maxPreAuth = boundedInteger(options.maxPreAuthSockets, 16, 1_024);
@@ -416,6 +445,20 @@ export class TerminalAttachmentAdmissionCoordinator {
     context: DirectTerminalAttachmentIssueContext,
   ): Promise<DirectTerminalAttachmentDescriptor> {
     return this.#exclusive(async () => {
+      try {
+        await this.#startupBarrier;
+      } catch {
+        if (this.#shuttingDown) {
+          throw new TerminalAttachmentAdmissionError(
+            "daemon-shutting-down",
+            "Terminal attachment admission is shutting down.",
+          );
+        }
+        throw new TerminalAttachmentAdmissionError(
+          "attachment-unavailable",
+          "Terminal attachment startup reconciliation failed.",
+        );
+      }
       if (this.#shuttingDown) {
         throw new TerminalAttachmentAdmissionError(
           "daemon-shutting-down",
@@ -534,6 +577,9 @@ export class TerminalAttachmentAdmissionCoordinator {
   }): TerminalAttachmentUpgradeDecision {
     if (this.#shuttingDown) {
       return { accepted: false, code: "daemon-shutting-down", httpStatus: 503 };
+    }
+    if (this.#startupState !== "ready") {
+      return { accepted: false, code: "attachment-unavailable", httpStatus: 503 };
     }
     if (input.path !== TERMINAL_ATTACHMENT_REDEEM_PATH) {
       return { accepted: false, code: "invalid-path", httpStatus: 404 };

--- a/packages/daemon/src/terminal/attachments/direct-websocket.ts
+++ b/packages/daemon/src/terminal/attachments/direct-websocket.ts
@@ -61,6 +61,14 @@ export interface TerminalAttachmentGeometry {
   readonly clientViewport: TerminalAttachmentViewport;
 }
 
+/** Narrow, non-capability proof retained only inside the daemon runtime. */
+export interface TerminalAttachmentGeometryClientProof {
+  readonly attemptId: string;
+  readonly attachmentId: string;
+  readonly generation: number;
+  readonly pid: number;
+}
+
 export interface DirectTerminalAttachmentDescriptor {
   readonly protocolVersion: typeof TERMINAL_ATTACHMENT_PROTOCOL_VERSION;
   readonly webSocketUrl: string;
@@ -165,6 +173,7 @@ export interface TerminalAttachmentAdmissionCoordinatorOptions {
   readonly launcher: DirectTerminalAttachmentLauncher;
   readonly resolveGeometry: (
     descriptor: AttachmentLeaseDescriptor,
+    client: TerminalAttachmentGeometryClientProof,
   ) => Promise<TerminalAttachmentGeometry>;
   readonly maxPendingTickets?: number;
   readonly maxPreAuthSockets?: number;
@@ -436,6 +445,17 @@ export class TerminalAttachmentAdmissionCoordinator {
       } finally {
         this.#pendingReservations -= 1;
       }
+      if (this.#shuttingDown) {
+        await this.#releaseLease(issued.descriptor.leaseId, {
+          daemonInstanceId: this.#instanceId,
+          requestId,
+          projectIdentity,
+        });
+        throw new TerminalAttachmentAdmissionError(
+          "daemon-shutting-down",
+          "Terminal attachment admission is shutting down.",
+        );
+      }
       const ticket = issued.redemptionTicket;
       const issuedDescriptor = issued.descriptor;
       if (
@@ -665,7 +685,7 @@ export class TerminalAttachmentAdmissionCoordinator {
         }
         let geometry: TerminalAttachmentGeometry;
         try {
-          const resolved = await this.#resolveGeometry(activeDescriptor);
+          const resolved = await this.#resolveGeometry(activeDescriptor, client);
           geometry = {
             sourceGrid: GridSchemaZ.parse(resolved.sourceGrid),
             clientViewport: GridSchemaZ.parse(resolved.clientViewport),
@@ -933,6 +953,7 @@ interface LiveConnectionOptions {
   readonly geometry: TerminalAttachmentGeometry;
   readonly resolveGeometry: (
     descriptor: AttachmentLeaseDescriptor,
+    client: TerminalAttachmentGeometryClientProof,
   ) => Promise<TerminalAttachmentGeometry>;
   readonly maxBufferedOutputBytes: number;
   readonly maxOutputFrameBytes: number;
@@ -1138,7 +1159,7 @@ class TerminalAttachmentLiveConnection {
         this.#pendingResize = null;
         try {
           this.#client.resize(viewport.cols, viewport.rows);
-          const geometry = await this.#resolveGeometry(this.#descriptor);
+          const geometry = await this.#resolveGeometry(this.#descriptor, this.#client);
           if (this.#closed) return;
           sendControl(this.#socket, {
             type: "geometry",
@@ -1198,7 +1219,7 @@ class TerminalAttachmentLiveConnection {
         ) {
           throw new TypeError("Terminal attachment lease identity changed during renewal.");
         }
-        const geometry = await this.#resolveGeometry(descriptor);
+        const geometry = await this.#resolveGeometry(descriptor, this.#client);
         if (this.#closed) return;
         this.#descriptor = structuredClone(descriptor);
         sendControl(this.#socket, {

--- a/packages/daemon/src/terminal/attachments/native-runtime.ts
+++ b/packages/daemon/src/terminal/attachments/native-runtime.ts
@@ -1,0 +1,558 @@
+import { accessSync, constants, realpathSync, statSync } from "node:fs";
+import { isAbsolute } from "node:path";
+
+import {
+  TerminalAttachmentSemanticTargetSchemaZ,
+  TerminalAttachmentViewportSchemaZ,
+} from "@tmux-ide/contracts";
+import { runTmuxBinary, TmuxError } from "@tmux-ide/tmux-bridge";
+import { z } from "zod";
+
+import type { WorkspaceRegistry } from "../../lib/workspace-registry.ts";
+import type { PtyAdapter } from "../PtyAdapter.ts";
+import {
+  TerminalAttachmentAdmissionCoordinator,
+  type TerminalAttachmentAdmissionCoordinatorOptions,
+  type TerminalAttachmentAdmissionSnapshot,
+  type TerminalAttachmentGeometry,
+  type TerminalAttachmentGeometryClientProof,
+} from "./direct-websocket.ts";
+import {
+  GROUPED_TMUX_MAX_GENERATION,
+  GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
+  groupedTmuxViewSessionName,
+  type TmuxArgvPlan,
+} from "./grouped-tmux.ts";
+import {
+  AttachmentLeaseManager,
+  type AttachmentLeaseManagerOptions,
+  type AttachmentLeaseDescriptor,
+} from "./lease-manager.ts";
+import {
+  PtyTmuxAttachmentLauncher,
+  type DaemonTmuxSocketSelector,
+  type PtyTmuxAttachmentLauncherOptions,
+} from "./pty-tmux-attachment-launcher.ts";
+import { SemanticPaneCatalog, type TrustedSemanticPaneSnapshot } from "./semantic-pane-catalog.ts";
+import {
+  TmuxAttachmentOperationSerializer,
+  TmuxAttachmentViewExecutor,
+  type TmuxAttachmentCommandResult,
+  type TmuxAttachmentCommandRunner,
+} from "./tmux-view-executor.ts";
+
+const MAX_TMUX_OUTPUT_BYTES = 128 * 1024;
+const MAX_DISCOVERED_WORKSPACES = 128;
+const MAX_DISCOVERED_PANES = 4_096;
+const MAX_GEOMETRY_CLIENTS = 32;
+const SAFE_SESSION_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/u;
+const SAFE_TERMINAL_VALUE = /^(?:xterm|screen|tmux|rxvt|vt100|ansi)[A-Za-z0-9+._-]{0,58}$/u;
+const SAFE_COLOR_TERMINAL_VALUE = /^(?:truecolor|24bit)$/u;
+const SAFE_LOCALE_VALUE = /^[A-Za-z0-9][A-Za-z0-9_.@-]{0,127}$/u;
+const INTEGER = /^(?:0|[1-9][0-9]*)$/u;
+const VIEW_MISMATCH = "__tmux_ide_geometry_view_mismatch_v1__";
+
+export type NativeTerminalAttachmentRuntimeErrorCode =
+  | "invalid-authority"
+  | "discovery-failed"
+  | "invalid-tmux-output"
+  | "geometry-mismatch";
+
+const ERROR_MESSAGES: Readonly<Record<NativeTerminalAttachmentRuntimeErrorCode, string>> = {
+  "invalid-authority": "The daemon tmux authority is invalid.",
+  "discovery-failed": "Trusted semantic pane discovery failed.",
+  "invalid-tmux-output": "Trusted tmux discovery returned invalid output.",
+  "geometry-mismatch": "Terminal attachment geometry no longer matches its proof.",
+};
+
+export class NativeTerminalAttachmentRuntimeError extends Error {
+  readonly code: NativeTerminalAttachmentRuntimeErrorCode;
+
+  constructor(code: NativeTerminalAttachmentRuntimeErrorCode) {
+    super(ERROR_MESSAGES[code]);
+    this.name = "NativeTerminalAttachmentRuntimeError";
+    this.code = code;
+  }
+}
+
+export interface NativeTerminalAttachmentTmuxAuthority {
+  readonly executablePath: string;
+  readonly socketSelector: DaemonTmuxSocketSelector;
+  readonly trustedCwd: string;
+  /** Captured once at factory construction; only validated presentation fields survive. */
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+export interface NativeTerminalAttachmentCommandExecutor {
+  (
+    executable: string,
+    argv: readonly string[],
+    options: {
+      readonly cwd: string;
+      readonly env: NodeJS.ProcessEnv;
+      readonly maxBuffer: number;
+    },
+  ): string | Buffer;
+}
+
+interface CanonicalTmuxAuthority {
+  readonly executablePath: string;
+  readonly socketSelector: DaemonTmuxSocketSelector;
+  readonly socketArgv: readonly string[];
+  readonly trustedCwd: string;
+  readonly environment: NodeJS.ProcessEnv;
+}
+
+function presentationEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    TERM: SAFE_TERMINAL_VALUE.test(source.TERM ?? "") ? source.TERM : "xterm-256color",
+  };
+  if (SAFE_COLOR_TERMINAL_VALUE.test(source.COLORTERM ?? "")) {
+    environment.COLORTERM = source.COLORTERM;
+  }
+  for (const name of ["LANG", "LC_ALL", "LC_CTYPE"] as const) {
+    const value = source[name];
+    if (value && SAFE_LOCALE_VALUE.test(value)) environment[name] = value;
+  }
+  return environment;
+}
+
+function canonicalAuthority(input: NativeTerminalAttachmentTmuxAuthority): CanonicalTmuxAuthority {
+  try {
+    if (!isAbsolute(input.executablePath) || !isAbsolute(input.trustedCwd)) throw new Error();
+    const executablePath = realpathSync(input.executablePath);
+    const trustedCwd = realpathSync(input.trustedCwd);
+    accessSync(executablePath, constants.X_OK);
+    if (!statSync(executablePath).isFile() || !statSync(trustedCwd).isDirectory())
+      throw new Error();
+    let socketSelector: DaemonTmuxSocketSelector;
+    let socketArgv: readonly string[];
+    if (input.socketSelector.kind === "path") {
+      if (!isAbsolute(input.socketSelector.path)) throw new Error();
+      const path = realpathSync(input.socketSelector.path);
+      if (!statSync(path).isSocket()) throw new Error();
+      socketSelector = { kind: "path", path };
+      socketArgv = ["-S", path];
+    } else {
+      if (!SAFE_SESSION_NAME.test(input.socketSelector.name)) throw new Error();
+      socketSelector = { kind: "name", name: input.socketSelector.name };
+      socketArgv = ["-L", input.socketSelector.name];
+    }
+    return Object.freeze({
+      executablePath,
+      socketSelector: Object.freeze(socketSelector),
+      socketArgv: Object.freeze([...socketArgv]),
+      trustedCwd,
+      environment: Object.freeze(presentationEnvironment(input.environment ?? process.env)),
+    });
+  } catch {
+    throw new NativeTerminalAttachmentRuntimeError("invalid-authority");
+  }
+}
+
+function defaultCommandExecutor(
+  executable: string,
+  argv: readonly string[],
+  options: { readonly cwd: string; readonly env: NodeJS.ProcessEnv; readonly maxBuffer: number },
+): string | Buffer {
+  return runTmuxBinary(executable, [...argv], {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: options.env,
+    maxBuffer: options.maxBuffer,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function pinnedRunner(
+  authority: CanonicalTmuxAuthority,
+  execute: NativeTerminalAttachmentCommandExecutor,
+): TmuxAttachmentCommandRunner {
+  return Object.freeze({
+    run(command: TmuxArgvPlan): TmuxAttachmentCommandResult {
+      if (command.executable !== "tmux") return { status: "failed" };
+      try {
+        const stdout = execute(
+          authority.executablePath,
+          [...authority.socketArgv, ...command.argv],
+          {
+            cwd: authority.trustedCwd,
+            env: authority.environment,
+            maxBuffer: MAX_TMUX_OUTPUT_BYTES,
+          },
+        );
+        const value = String(stdout);
+        if (value.includes("\0") || Buffer.byteLength(value, "utf8") > MAX_TMUX_OUTPUT_BYTES) {
+          return { status: "failed" };
+        }
+        return { status: "ok", stdout: value };
+      } catch (error) {
+        if (error instanceof TmuxError && error.code === "SESSION_NOT_FOUND") {
+          return { status: "not-found" };
+        }
+        if (error instanceof TmuxError && error.code === "ENVIRONMENT_VARIABLE_NOT_FOUND") {
+          return { status: "variable-not-found" };
+        }
+        return { status: "failed" };
+      }
+    },
+  });
+}
+
+function strictLines(stdout: string, maximum: number): readonly string[] {
+  if (
+    typeof stdout !== "string" ||
+    stdout.includes("\0") ||
+    Buffer.byteLength(stdout, "utf8") > MAX_TMUX_OUTPUT_BYTES
+  ) {
+    throw new NativeTerminalAttachmentRuntimeError("invalid-tmux-output");
+  }
+  const normalized = stdout.replace(/(?:\r?\n)+$/u, "");
+  if (normalized === "") return [];
+  const lines = normalized.split("\n");
+  if (lines.length > maximum || lines.some((line) => line.includes("\r"))) {
+    throw new NativeTerminalAttachmentRuntimeError("invalid-tmux-output");
+  }
+  return lines;
+}
+
+function positiveInteger(value: string): number {
+  if (!INTEGER.test(value)) throw new NativeTerminalAttachmentRuntimeError("invalid-tmux-output");
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new NativeTerminalAttachmentRuntimeError("invalid-tmux-output");
+  }
+  return parsed;
+}
+
+function viewport(cols: string, rows: string): TerminalAttachmentGeometry["sourceGrid"] {
+  try {
+    return TerminalAttachmentViewportSchemaZ.parse({
+      cols: positiveInteger(cols),
+      rows: positiveInteger(rows),
+    });
+  } catch {
+    throw new NativeTerminalAttachmentRuntimeError("invalid-tmux-output");
+  }
+}
+
+/** Internal raw-id discovery; callers expose only SemanticPaneCatalog resolution. */
+export async function discoverWorkspaceRegistrySemanticPanes(
+  registry: WorkspaceRegistry,
+  runner: TmuxAttachmentCommandRunner,
+): Promise<readonly TrustedSemanticPaneSnapshot[]> {
+  const workspaces = registry.list();
+  if (workspaces.length > MAX_DISCOVERED_WORKSPACES) {
+    throw new NativeTerminalAttachmentRuntimeError("discovery-failed");
+  }
+  const rows: TrustedSemanticPaneSnapshot[] = [];
+  for (const workspace of workspaces) {
+    if (!SAFE_SESSION_NAME.test(workspace.sessionName)) {
+      throw new NativeTerminalAttachmentRuntimeError("discovery-failed");
+    }
+    const result = runner.run({
+      executable: "tmux",
+      argv: [
+        "list-panes",
+        "-s",
+        "-t",
+        `=${workspace.sessionName}`,
+        "-F",
+        "#{session_name}\t#{session_id}\t#{window_id}\t#{pane_id}\t#{window_panes}\t#{session_windows}\t#{@tmux_ide_pane_id}",
+      ],
+    });
+    if (result.status === "not-found") continue;
+    if (result.status !== "ok") {
+      throw new NativeTerminalAttachmentRuntimeError("discovery-failed");
+    }
+    for (const line of strictLines(result.stdout, MAX_DISCOVERED_PANES)) {
+      const fields = line.split("\t");
+      if (fields.length !== 7 || fields[0] !== workspace.sessionName) {
+        throw new NativeTerminalAttachmentRuntimeError("invalid-tmux-output");
+      }
+      const [, sessionId, windowId, runtimePaneId, paneCount, windowCount, stamp] = fields;
+      rows.push({
+        workspaceName: workspace.name,
+        semanticPaneId: stamp === "" ? null : stamp!,
+        sessionId: sessionId!,
+        windowId: windowId!,
+        runtimePaneId: runtimePaneId!,
+        windowPaneCount: positiveInteger(paneCount!),
+        sessionWindowCount: positiveInteger(windowCount!),
+      });
+      if (rows.length > MAX_DISCOVERED_PANES) {
+        throw new NativeTerminalAttachmentRuntimeError("discovery-failed");
+      }
+    }
+  }
+  return rows;
+}
+
+function quoteArgument(value: string): string {
+  if (/\0|\r|\n/u.test(value)) {
+    throw new NativeTerminalAttachmentRuntimeError("geometry-mismatch");
+  }
+  return JSON.stringify(value);
+}
+
+function commandString(argv: readonly string[]): string {
+  return argv.map((value) => (value === ";" ? ";" : quoteArgument(value))).join(" ");
+}
+
+function geometryDescriptorIsValid(
+  descriptor: AttachmentLeaseDescriptor,
+  client: TerminalAttachmentGeometryClientProof,
+): boolean {
+  return (
+    z.uuid().safeParse(descriptor.leaseId).success &&
+    z.uuid().safeParse(descriptor.requestId).success &&
+    TerminalAttachmentSemanticTargetSchemaZ.safeParse(descriptor.target).success &&
+    descriptor.status === "active" &&
+    Number.isSafeInteger(descriptor.bindingGeneration) &&
+    descriptor.bindingGeneration >= 0 &&
+    Number.isSafeInteger(descriptor.viewGeneration) &&
+    descriptor.viewGeneration >= 0 &&
+    descriptor.viewGeneration <= GROUPED_TMUX_MAX_GENERATION &&
+    z.uuid().safeParse(client.attemptId).success &&
+    client.attachmentId === descriptor.leaseId &&
+    client.generation === descriptor.viewGeneration &&
+    Number.isSafeInteger(client.pid) &&
+    client.pid > 0
+  );
+}
+
+export class NativeTerminalAttachmentGeometryResolver {
+  readonly #catalog: SemanticPaneCatalog;
+  readonly #runner: TmuxAttachmentCommandRunner;
+  readonly #serializer: TmuxAttachmentOperationSerializer;
+
+  constructor(options: {
+    catalog: SemanticPaneCatalog;
+    runner: TmuxAttachmentCommandRunner;
+    operationSerializer: TmuxAttachmentOperationSerializer;
+  }) {
+    this.#catalog = options.catalog;
+    this.#runner = options.runner;
+    this.#serializer = options.operationSerializer;
+  }
+
+  resolve(
+    descriptor: AttachmentLeaseDescriptor,
+    client: TerminalAttachmentGeometryClientProof,
+  ): Promise<TerminalAttachmentGeometry> {
+    return this.#serializer.run(() => this.#resolve(descriptor, client));
+  }
+
+  async #resolve(
+    descriptor: AttachmentLeaseDescriptor,
+    client: TerminalAttachmentGeometryClientProof,
+  ): Promise<TerminalAttachmentGeometry> {
+    if (!geometryDescriptorIsValid(descriptor, client)) {
+      throw new NativeTerminalAttachmentRuntimeError("geometry-mismatch");
+    }
+    let resolution;
+    try {
+      resolution = await this.#catalog.resolve(descriptor.target);
+    } catch {
+      throw new NativeTerminalAttachmentRuntimeError("geometry-mismatch");
+    }
+    if (
+      resolution.bindingGeneration !== descriptor.bindingGeneration ||
+      resolution.target.workspaceName !== descriptor.target.workspaceName ||
+      resolution.target.semanticPaneId !== descriptor.target.semanticPaneId
+    ) {
+      throw new NativeTerminalAttachmentRuntimeError("geometry-mismatch");
+    }
+    const source = resolution.source;
+    const viewName = groupedTmuxViewSessionName(descriptor.leaseId, descriptor.viewGeneration);
+    const marker = `v1:${descriptor.leaseId.toLowerCase()}:${descriptor.viewGeneration}`;
+    const sourceTarget = `${source.sessionId}:${source.windowId}.${source.runtimePaneId}`;
+    const viewTarget = `=${viewName}:${source.windowId}.${source.runtimePaneId}`;
+    // The `=name` target is exact. The session-local marker then proves that
+    // exact view's ownership while the linked global window id and
+    // one-window/one-pane topology prove its contents. The exact target
+    // already selects the expected global pane id; tmux does not populate
+    // `pane_id` in this if-shell format context on all supported versions.
+    const viewGuard = `#{&&:#{==:#{window_id},${source.windowId}},#{&&:#{==:#{window_panes},1},#{&&:#{==:#{session_windows},1},#{==:#{${GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT}},${marker}}}}}`;
+    const payload = commandString([
+      "display-message",
+      "-p",
+      "-t",
+      sourceTarget,
+      "source\t#{session_id}\t#{window_id}\t#{pane_id}\t#{window_panes}\t#{pane_width}\t#{pane_height}",
+      ";",
+      "list-clients",
+      "-t",
+      `=${viewName}`,
+      "-F",
+      "client\t#{client_pid}\t#{session_name}\t#{client_width}\t#{client_height}",
+    ]);
+    const result = this.#runner.run({
+      executable: "tmux",
+      argv: [
+        "if-shell",
+        "-F",
+        "-t",
+        viewTarget,
+        viewGuard,
+        payload,
+        commandString(["display-message", "-p", VIEW_MISMATCH]),
+      ],
+    });
+    if (result.status !== "ok") {
+      throw new NativeTerminalAttachmentRuntimeError("geometry-mismatch");
+    }
+    const lines = strictLines(result.stdout, MAX_GEOMETRY_CLIENTS + 1);
+    if (lines.length < 2 || lines[0] === VIEW_MISMATCH) {
+      throw new NativeTerminalAttachmentRuntimeError("geometry-mismatch");
+    }
+    const sourceFields = lines[0]!.split("\t");
+    if (
+      sourceFields.length !== 7 ||
+      sourceFields[0] !== "source" ||
+      sourceFields[1] !== source.sessionId ||
+      sourceFields[2] !== source.windowId ||
+      sourceFields[3] !== source.runtimePaneId ||
+      sourceFields[4] !== "1"
+    ) {
+      throw new NativeTerminalAttachmentRuntimeError("geometry-mismatch");
+    }
+    const sourceGrid = viewport(sourceFields[5]!, sourceFields[6]!);
+    const clients = lines.slice(1).map((line) => line.split("\t"));
+    if (
+      clients.length !== 1 ||
+      clients[0]!.length !== 5 ||
+      clients[0]![0] !== "client" ||
+      !INTEGER.test(clients[0]![1]!) ||
+      Number(clients[0]![1]) !== client.pid ||
+      clients[0]![2] !== viewName
+    ) {
+      throw new NativeTerminalAttachmentRuntimeError("geometry-mismatch");
+    }
+    const clientViewport = viewport(clients[0]![3]!, clients[0]![4]!);
+    return Object.freeze({ sourceGrid, clientViewport });
+  }
+}
+
+type LeaseRuntimeOptions = Omit<
+  AttachmentLeaseManagerOptions,
+  "daemonInstanceId" | "catalog" | "viewExecutor"
+>;
+type LauncherRuntimeOptions = Omit<
+  PtyTmuxAttachmentLauncherOptions,
+  | "socketSelector"
+  | "trustedCwd"
+  | "tmuxExecutable"
+  | "environment"
+  | "ptyAdapter"
+  | "proofRunner"
+  | "proofCommandExecutor"
+>;
+type AdmissionRuntimeOptions = Omit<
+  TerminalAttachmentAdmissionCoordinatorOptions,
+  "daemonInstanceId" | "webSocketUrl" | "leaseManager" | "launcher" | "resolveGeometry"
+>;
+
+export interface NativeTerminalAttachmentRuntimeOptions {
+  readonly daemonInstanceId: string;
+  readonly webSocketUrl: string;
+  readonly registry: WorkspaceRegistry;
+  readonly tmuxAuthority: NativeTerminalAttachmentTmuxAuthority;
+  readonly ptyAdapter?: PtyAdapter;
+  readonly commandExecutor?: NativeTerminalAttachmentCommandExecutor;
+  /** Narrow deterministic seam; production omits it and uses registry-backed discovery. */
+  readonly semanticPaneCatalog?: SemanticPaneCatalog;
+  readonly lease?: LeaseRuntimeOptions;
+  readonly launcher?: LauncherRuntimeOptions;
+  readonly admission?: AdmissionRuntimeOptions;
+}
+
+/** One daemon-generation owner for catalog, grouped view, PTY, lease and admission state. */
+export class NativeTerminalAttachmentRuntime {
+  readonly admission: TerminalAttachmentAdmissionCoordinator;
+  readonly #launcher: PtyTmuxAttachmentLauncher;
+  readonly #serializer: TmuxAttachmentOperationSerializer;
+  #disposePromise: Promise<void> | null = null;
+
+  constructor(options: NativeTerminalAttachmentRuntimeOptions) {
+    const authority = canonicalAuthority(options.tmuxAuthority);
+    const execute = options.commandExecutor ?? defaultCommandExecutor;
+    const runner = pinnedRunner(authority, execute);
+    const serializer = new TmuxAttachmentOperationSerializer();
+    const catalog =
+      options.semanticPaneCatalog ??
+      new SemanticPaneCatalog({
+        discover: () => discoverWorkspaceRegistrySemanticPanes(options.registry, runner),
+      });
+    const launcher = new PtyTmuxAttachmentLauncher({
+      ...options.launcher,
+      socketSelector: authority.socketSelector,
+      trustedCwd: authority.trustedCwd,
+      tmuxExecutable: authority.executablePath,
+      environment: authority.environment,
+      ptyAdapter: options.ptyAdapter,
+      proofCommandExecutor: (executable, argv, executionOptions) =>
+        execute(executable, argv, {
+          cwd: executionOptions.cwd,
+          env: executionOptions.env,
+          maxBuffer: MAX_TMUX_OUTPUT_BYTES,
+        }),
+    });
+    const viewExecutor = new TmuxAttachmentViewExecutor({
+      runner,
+      clientTransport: launcher,
+      operationSerializer: serializer,
+      now: options.lease?.now,
+    });
+    const leaseManager = new AttachmentLeaseManager({
+      ...options.lease,
+      daemonInstanceId: options.daemonInstanceId,
+      catalog,
+      viewExecutor,
+    });
+    const geometry = new NativeTerminalAttachmentGeometryResolver({
+      catalog,
+      runner,
+      operationSerializer: serializer,
+    });
+    this.admission = new TerminalAttachmentAdmissionCoordinator({
+      ...options.admission,
+      daemonInstanceId: options.daemonInstanceId,
+      webSocketUrl: options.webSocketUrl,
+      leaseManager,
+      launcher,
+      resolveGeometry: (descriptor, client) => geometry.resolve(descriptor, client),
+    });
+    this.#launcher = launcher;
+    this.#serializer = serializer;
+  }
+
+  snapshot(): TerminalAttachmentAdmissionSnapshot {
+    return this.admission.snapshot();
+  }
+
+  toJSON(): TerminalAttachmentAdmissionSnapshot {
+    return this.snapshot();
+  }
+
+  dispose(): Promise<void> {
+    this.#disposePromise ??= this.#finishDispose();
+    return this.#disposePromise;
+  }
+
+  async #finishDispose(): Promise<void> {
+    const admissionBarrier = this.admission.shutdown();
+    // Cancel an attach readiness wait immediately; the coordinator barrier
+    // then retires the associated lease/view before this method resolves.
+    this.#launcher.disposeAll();
+    await admissionBarrier;
+    this.#launcher.disposeAll();
+    await this.#serializer.barrier();
+  }
+}
+
+export function createNativeTerminalAttachmentRuntime(
+  options: NativeTerminalAttachmentRuntimeOptions,
+): NativeTerminalAttachmentRuntime {
+  return new NativeTerminalAttachmentRuntime(options);
+}

--- a/packages/daemon/src/terminal/attachments/native-runtime.ts
+++ b/packages/daemon/src/terminal/attachments/native-runtime.ts
@@ -171,6 +171,7 @@ function defaultCommandExecutor(
 function pinnedRunner(
   authority: CanonicalTmuxAuthority,
   execute: NativeTerminalAttachmentCommandExecutor,
+  startupPolicy: { allowUnavailableDefaultEnumeration: boolean },
 ): TmuxAttachmentCommandRunner {
   return Object.freeze({
     run(command: TmuxArgvPlan): TmuxAttachmentCommandResult {
@@ -192,6 +193,22 @@ function pinnedRunner(
         return { status: "ok", stdout: value };
       } catch (error) {
         if (error instanceof TmuxError && error.code === "SESSION_NOT_FOUND") {
+          return { status: "not-found" };
+        }
+        if (
+          error instanceof TmuxError &&
+          error.code === "TMUX_UNAVAILABLE" &&
+          startupPolicy.allowUnavailableDefaultEnumeration &&
+          authority.socketSelector.kind === "name" &&
+          authority.socketSelector.name === "default" &&
+          command.argv.length === 3 &&
+          command.argv[0] === "list-sessions" &&
+          command.argv[1] === "-F" &&
+          command.argv[2] === "#{session_name}\t#{session_id}"
+        ) {
+          // A first-run project may have no default tmux server yet. This
+          // one construction-time orphan enumeration is equivalent to zero
+          // sessions; every other command/socket/registry state stays strict.
           return { status: "not-found" };
         }
         if (error instanceof TmuxError && error.code === "ENVIRONMENT_VARIABLE_NOT_FOUND") {
@@ -488,7 +505,13 @@ export class NativeTerminalAttachmentRuntime {
   constructor(options: NativeTerminalAttachmentRuntimeOptions) {
     const authority = canonicalAuthority(options.tmuxAuthority);
     const execute = options.commandExecutor ?? defaultCommandExecutor;
-    const runner = pinnedRunner(authority, execute);
+    const startupPolicy = {
+      allowUnavailableDefaultEnumeration:
+        authority.socketSelector.kind === "name" &&
+        authority.socketSelector.name === "default" &&
+        options.registry.list().length === 0,
+    };
+    const runner = pinnedRunner(authority, execute, startupPolicy);
     const serializer = new TmuxAttachmentOperationSerializer();
     const catalog =
       options.semanticPaneCatalog ??
@@ -529,6 +552,7 @@ export class NativeTerminalAttachmentRuntime {
     this.#startupBarrier = leaseManager
       .reconcileOrphanViews()
       .then((result) => {
+        startupPolicy.allowUnavailableDefaultEnumeration = false;
         if (result.failed.length > 0) {
           throw new NativeTerminalAttachmentRuntimeError("orphan-reconciliation-failed");
         }
@@ -538,6 +562,7 @@ export class NativeTerminalAttachmentRuntime {
         this.#lifecycle = "ready";
       })
       .catch((error: unknown) => {
+        startupPolicy.allowUnavailableDefaultEnumeration = false;
         if (this.#lifecycle === "initializing") this.#lifecycle = "failed";
         if (error instanceof NativeTerminalAttachmentRuntimeError) throw error;
         throw new NativeTerminalAttachmentRuntimeError("orphan-reconciliation-failed");

--- a/packages/daemon/src/terminal/attachments/native-runtime.ts
+++ b/packages/daemon/src/terminal/attachments/native-runtime.ts
@@ -56,13 +56,17 @@ export type NativeTerminalAttachmentRuntimeErrorCode =
   | "invalid-authority"
   | "discovery-failed"
   | "invalid-tmux-output"
-  | "geometry-mismatch";
+  | "geometry-mismatch"
+  | "orphan-reconciliation-failed"
+  | "runtime-disposed";
 
 const ERROR_MESSAGES: Readonly<Record<NativeTerminalAttachmentRuntimeErrorCode, string>> = {
   "invalid-authority": "The daemon tmux authority is invalid.",
   "discovery-failed": "Trusted semantic pane discovery failed.",
   "invalid-tmux-output": "Trusted tmux discovery returned invalid output.",
   "geometry-mismatch": "Terminal attachment geometry no longer matches its proof.",
+  "orphan-reconciliation-failed": "Daemon-owned terminal view startup reconciliation failed.",
+  "runtime-disposed": "The native terminal attachment runtime was disposed during startup.",
 };
 
 export class NativeTerminalAttachmentRuntimeError extends Error {
@@ -450,7 +454,12 @@ type LauncherRuntimeOptions = Omit<
 >;
 type AdmissionRuntimeOptions = Omit<
   TerminalAttachmentAdmissionCoordinatorOptions,
-  "daemonInstanceId" | "webSocketUrl" | "leaseManager" | "launcher" | "resolveGeometry"
+  | "daemonInstanceId"
+  | "webSocketUrl"
+  | "leaseManager"
+  | "launcher"
+  | "resolveGeometry"
+  | "startupBarrier"
 >;
 
 export interface NativeTerminalAttachmentRuntimeOptions {
@@ -471,7 +480,9 @@ export interface NativeTerminalAttachmentRuntimeOptions {
 export class NativeTerminalAttachmentRuntime {
   readonly admission: TerminalAttachmentAdmissionCoordinator;
   readonly #launcher: PtyTmuxAttachmentLauncher;
+  readonly #startupBarrier: Promise<void>;
   readonly #serializer: TmuxAttachmentOperationSerializer;
+  #lifecycle: "initializing" | "ready" | "failed" | "disposing" | "disposed" = "initializing";
   #disposePromise: Promise<void> | null = null;
 
   constructor(options: NativeTerminalAttachmentRuntimeOptions) {
@@ -515,12 +526,34 @@ export class NativeTerminalAttachmentRuntime {
       runner,
       operationSerializer: serializer,
     });
+    this.#startupBarrier = leaseManager
+      .reconcileOrphanViews()
+      .then((result) => {
+        if (result.failed.length > 0) {
+          throw new NativeTerminalAttachmentRuntimeError("orphan-reconciliation-failed");
+        }
+        if (this.#lifecycle !== "initializing") {
+          throw new NativeTerminalAttachmentRuntimeError("runtime-disposed");
+        }
+        this.#lifecycle = "ready";
+      })
+      .catch((error: unknown) => {
+        if (this.#lifecycle === "initializing") this.#lifecycle = "failed";
+        if (error instanceof NativeTerminalAttachmentRuntimeError) throw error;
+        throw new NativeTerminalAttachmentRuntimeError("orphan-reconciliation-failed");
+      });
+    // Startup begins at construction so no caller can expose admission before
+    // reconciliation starts. The rejection remains observable via whenReady()
+    // and admission.issue(); this prevents an unawaited runtime from emitting
+    // a process-level unhandled rejection first.
+    void this.#startupBarrier.catch(() => undefined);
     this.admission = new TerminalAttachmentAdmissionCoordinator({
       ...options.admission,
       daemonInstanceId: options.daemonInstanceId,
       webSocketUrl: options.webSocketUrl,
       leaseManager,
       launcher,
+      startupBarrier: this.#startupBarrier,
       resolveGeometry: (descriptor, client) => geometry.resolve(descriptor, client),
     });
     this.#launcher = launcher;
@@ -535,19 +568,31 @@ export class NativeTerminalAttachmentRuntime {
     return this.snapshot();
   }
 
+  /** A2 must await this barrier before exposing HTTP or WebSocket listeners. */
+  whenReady(): Promise<void> {
+    return this.#startupBarrier;
+  }
+
   dispose(): Promise<void> {
-    this.#disposePromise ??= this.#finishDispose();
+    if (!this.#disposePromise) {
+      this.#lifecycle = "disposing";
+      this.#disposePromise = this.#finishDispose();
+    }
     return this.#disposePromise;
   }
 
   async #finishDispose(): Promise<void> {
-    const admissionBarrier = this.admission.shutdown();
-    // Cancel an attach readiness wait immediately; the coordinator barrier
-    // then retires the associated lease/view before this method resolves.
-    this.#launcher.disposeAll();
-    await admissionBarrier;
-    this.#launcher.disposeAll();
-    await this.#serializer.barrier();
+    try {
+      const admissionBarrier = this.admission.shutdown();
+      // Cancel an attach readiness wait immediately; the coordinator barrier
+      // then retires the associated lease/view before this method resolves.
+      this.#launcher.disposeAll();
+      await Promise.all([admissionBarrier, this.#startupBarrier.catch(() => undefined)]);
+      this.#launcher.disposeAll();
+      await this.#serializer.barrier();
+    } finally {
+      this.#lifecycle = "disposed";
+    }
   }
 }
 

--- a/packages/daemon/src/terminal/attachments/tmux-view-executor.ts
+++ b/packages/daemon/src/terminal/attachments/tmux-view-executor.ts
@@ -157,6 +157,7 @@ export class TmuxAttachmentViewExecutorError extends Error {
 export interface TmuxAttachmentViewExecutorOptions {
   readonly runner?: TmuxAttachmentCommandRunner;
   readonly clientTransport?: TmuxAttachmentClientTransport;
+  readonly operationSerializer?: TmuxAttachmentOperationSerializer;
   readonly now?: () => number;
 }
 
@@ -176,20 +177,22 @@ interface ViewServerGuard {
   readonly format: string;
 }
 
-/*
- * One queue is shared by every executor instance in this daemon process. A
- * lease manager has its own queue, but that is not enough when more than one
- * manager is alive during lifecycle transitions or tests.
- */
-let serverWideAttachmentOperationTail: Promise<void> = Promise.resolve();
+/** Instance-owned queue shared explicitly by attachment executors for one tmux authority. */
+export class TmuxAttachmentOperationSerializer {
+  #tail: Promise<void> = Promise.resolve();
 
-function serializeServerWide<T>(operation: () => T | PromiseLike<T>): Promise<T> {
-  const run: Promise<T> = serverWideAttachmentOperationTail.then(operation, operation);
-  serverWideAttachmentOperationTail = run.then(
-    () => undefined,
-    () => undefined,
-  );
-  return run;
+  run<T>(operation: () => T | PromiseLike<T>): Promise<T> {
+    const run: Promise<T> = this.#tail.then(operation, operation);
+    this.#tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  barrier(): Promise<void> {
+    return this.#tail;
+  }
 }
 
 const productionRunner: TmuxAttachmentCommandRunner = {
@@ -437,29 +440,34 @@ function canonicalPlanFor(operation: GuardedAttachmentViewOperation): GroupedTmu
 export class TmuxAttachmentViewExecutor implements AttachmentViewExecutor {
   readonly #runner: TmuxAttachmentCommandRunner;
   readonly #clientTransport: TmuxAttachmentClientTransport | null;
+  readonly #operationSerializer: TmuxAttachmentOperationSerializer;
   readonly #now: () => number;
 
   constructor(options: TmuxAttachmentViewExecutorOptions = {}) {
     this.#runner = options.runner ?? productionRunner;
     this.#clientTransport = options.clientTransport ?? null;
+    this.#operationSerializer =
+      options.operationSerializer ?? new TmuxAttachmentOperationSerializer();
     this.#now = options.now ?? Date.now;
   }
 
   guardedCleanup(cleanup: GuardedAttachmentCleanup): Promise<GuardedAttachmentCleanupResult> {
-    return serializeServerWide(() => this.#guardedCleanup(cleanup));
+    return this.#operationSerializer.run(() => this.#guardedCleanup(cleanup));
   }
 
   executeGuardedViewOperation(
     operation: GuardedAttachmentViewOperation,
   ): Promise<GuardedAttachmentViewOperationResult> {
-    return serializeServerWide(() => this.#executeGuardedViewOperation(operation));
+    return this.#operationSerializer.run(() => this.#executeGuardedViewOperation(operation));
   }
 
   enumerateMarkedViews(
     prefix: typeof GROUPED_TMUX_VIEW_SESSION_PREFIX,
     markerEnvironment: typeof GROUPED_TMUX_VIEW_MARKER_ENVIRONMENT,
   ): Promise<readonly EnumeratedMarkedAttachmentView[]> {
-    return serializeServerWide(() => this.#enumerateMarkedViews(prefix, markerEnvironment));
+    return this.#operationSerializer.run(() =>
+      this.#enumerateMarkedViews(prefix, markerEnvironment),
+    );
   }
 
   #command(command: TmuxArgvPlan): TmuxAttachmentStandardCommandResult;


### PR DESCRIPTION
## Summary

- compose one daemon-instance-owned native attachment runtime across semantic discovery, grouped tmux views, node-pty launch, leases, geometry, and direct WebSocket admission
- pin tmux executable, socket authority, cwd, and allowlisted terminal environment while replacing the process-global mutation queue with an explicit instance serializer
- re-resolve semantic pane generations and fail closed unless the exact marked one-window view has exactly one client whose PID matches the claimed PTY
- add complete disposal barriers, shutdown-during-issue protection, strict public snapshots, deterministic adversarial coverage, and an isolated real-tmux integration smoke

## Deliberate boundary

This PR adds no HTTP route, Electron wiring, renderer UI, terminal input, or public raw tmux identifiers. Those remain follow-up integration slices.

## Verification

- 8 attachment-focused files / 126 tests passed after rebasing onto current main
- isolated native-runtime live tmux + real node-pty test passed
- daemon typecheck passed
- lint and format passed
- git diff --check passed
- full pnpm check passed on prior main e61c10e0

Current base note: after rebasing onto 9508f452, the full gate reaches the newly merged OpenTUI insertion-stability test and fails there with 122 existing insertBefore diagnostics. That test also fails in isolation and this PR changes no TUI files. All A1-owned and daemon TypeScript gates remain green.

Base proof: origin/main 9508f4528a3ec05ae9f30d13076039647d3c7099; PR head a241f7912bc728ee821ba15af0d734eeaa482480.