### PR TITLE
feat(desktop): add secure packaged renderer origin

### DIFF
--- a/apps/desktop-renderer/index.html
+++ b/apps/desktop-renderer/index.html
@@ -3,10 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
-    />
     <meta name="color-scheme" content="dark light" />
     <title>tmux-ide</title>
     <link rel="stylesheet" href="/src/styles.css" />

--- a/apps/desktop-renderer/vite.config.ts
+++ b/apps/desktop-renderer/vite.config.ts
@@ -3,24 +3,29 @@ import solid from "vite-plugin-solid";
 
 export default defineConfig({
   base: "./",
-  plugins: [
-    solid(),
-    {
-      name: "desktop-preview-hmr-policy",
-      apply: "serve",
-      transformIndexHtml(html) {
-        return html.replace("connect-src 'self'", "connect-src 'self' ws://127.0.0.1:5173");
-      },
-    },
-  ],
+  plugins: [solid()],
   build: {
     target: "es2022",
-    sourcemap: true,
+    sourcemap: false,
     emptyOutDir: true,
   },
   server: {
     host: "127.0.0.1",
     port: 5173,
     strictPort: true,
+    headers: {
+      "Content-Security-Policy": [
+        "default-src 'self'",
+        "script-src 'self'",
+        "style-src 'self'",
+        "img-src 'self' data:",
+        "font-src 'self'",
+        "connect-src 'self' ws://127.0.0.1:5173",
+        "object-src 'none'",
+        "base-uri 'none'",
+        "frame-ancestors 'none'",
+        "form-action 'none'",
+      ].join("; "),
+    },
   },
 });

--- a/apps/electron-shell/scripts/build.mjs
+++ b/apps/electron-shell/scripts/build.mjs
@@ -39,28 +39,16 @@ await Promise.all([
 await cp(rendererDist, join(dist, "renderer"), { recursive: true });
 
 const rendererHtml = await readFile(join(dist, "renderer", "index.html"), "utf8");
-for (const directive of [
-  "default-src 'self'",
-  "script-src 'self'",
-  "object-src 'none'",
-  "base-uri 'none'",
-  "frame-ancestors 'none'",
-]) {
-  if (!rendererHtml.includes(directive)) {
-    throw new Error(`desktop renderer CSP is missing: ${directive}`);
-  }
-}
-if (/unsafe-(?:inline|eval)/u.test(rendererHtml)) {
-  throw new Error("desktop renderer CSP must not permit unsafe-inline or unsafe-eval");
-}
-if (/connect-src[^;]*(?:127\.0\.0\.1|localhost|\[::1\]|https?:|wss?:)/u.test(rendererHtml)) {
-  throw new Error("packaged desktop renderer CSP must not permit daemon or network origins");
-}
-if (/connect-src[^;]*\*/u.test(rendererHtml)) {
-  throw new Error("packaged desktop renderer CSP must not permit a wildcard connection source");
+if (/Content-Security-Policy/iu.test(rendererHtml)) {
+  throw new Error(
+    "packaged renderer must receive its exact CSP from the trusted protocol response",
+  );
 }
 
 const rendererAssets = await readdir(join(dist, "renderer", "assets"));
+if (rendererAssets.some((name) => name.endsWith(".map"))) {
+  throw new Error("packaged renderer must not ship source maps");
+}
 for (const asset of rendererAssets.filter((name) => name.endsWith(".js"))) {
   const source = await readFile(join(dist, "renderer", "assets", asset), "utf8");
   for (const forbidden of [

--- a/apps/electron-shell/src/daemon-connection-coordinator.test.ts
+++ b/apps/electron-shell/src/daemon-connection-coordinator.test.ts
@@ -131,18 +131,14 @@ function brokerHarness(
 }
 
 describe("main-process daemon connection coordinator", () => {
-  it("keeps the broker and subscriptions intact when revalidation verifies the same identity", async () => {
-    const sameA = {
-      ...A,
-      descriptor: { ...A.descriptor, apiBaseUrl: "http://localhost:6060" },
-    } satisfies DesktopDaemonHostState;
+  it("keeps the broker and subscriptions intact when revalidation verifies the same authority", async () => {
     const first = brokerHarness(A, {
       earlyEvent: { type: "connection.changed", state: "live", error: null },
     });
     const createBroker = vi.fn(() => first.authority);
     const coordinator = new DaemonConnectionCoordinator({
       initialDaemon: A,
-      preflight: preflight(async () => sameA),
+      preflight: preflight(async () => A),
       createBroker,
     });
     const events: DesktopDaemonEvent[] = [];
@@ -166,6 +162,38 @@ describe("main-process daemon connection coordinator", () => {
     ]);
   });
 
+  it("replaces the broker and publishes policy state when the verified endpoint changes", async () => {
+    const movedA = {
+      ...A,
+      descriptor: { ...A.descriptor, apiBaseUrl: "http://localhost:6060" },
+    } satisfies Extract<DesktopDaemonHostState, { status: "connected" }>;
+    const first = brokerHarness(A);
+    const second = brokerHarness(movedA);
+    const createBroker = vi
+      .fn<(daemon: typeof A) => DaemonResourceAuthority>()
+      .mockReturnValueOnce(first.authority)
+      .mockReturnValueOnce(second.authority);
+    const hostStates: DesktopDaemonHostState[] = [];
+    const coordinator = new DaemonConnectionCoordinator({
+      initialDaemon: A,
+      preflight: preflight(async () => movedA),
+      createBroker,
+      onHostStateChanged: (state) => hostStates.push(state),
+    });
+
+    const result = await coordinator.refreshConnection();
+
+    expect(result).toMatchObject({
+      outcome: "generation-replaced",
+      previousIdentity: { instanceId: A.descriptor.instanceId },
+      daemon: { status: "connected", identity: { instanceId: A.descriptor.instanceId } },
+    });
+    expect(createBroker).toHaveBeenCalledTimes(2);
+    expect(first.dispose).toHaveBeenCalledOnce();
+    expect(second.dispose).not.toHaveBeenCalled();
+    expect(hostStates).toEqual([A, movedA]);
+  });
+
   it("atomically replaces A with B, emits one generation event, and rejects late A activity", async () => {
     const first = brokerHarness(A);
     const second = brokerHarness(B);
@@ -173,10 +201,12 @@ describe("main-process daemon connection coordinator", () => {
       .fn<(daemon: typeof A | typeof B) => DaemonResourceAuthority>()
       .mockReturnValueOnce(first.authority)
       .mockReturnValueOnce(second.authority);
+    const hostStates: DesktopDaemonHostState[] = [];
     const coordinator = new DaemonConnectionCoordinator({
       initialDaemon: A,
       preflight: preflight(async () => B),
       createBroker,
+      onHostStateChanged: (state) => hostStates.push(state),
     });
     const events: DesktopDaemonEvent[] = [];
     await coordinator.subscribe(["product"], (event) => events.push(event));
@@ -202,6 +232,7 @@ describe("main-process daemon connection coordinator", () => {
     expect(first.unsubscribe).toHaveBeenCalledOnce();
     expect(first.dispose).toHaveBeenCalledOnce();
     expect((await coordinator.listWorkspaces()).status).toBe("ok");
+    expect(hostStates).toEqual([A, B]);
   });
 
   it("retires connected authority on failed preflight without leaking its malformed payload", async () => {

--- a/apps/electron-shell/src/daemon-connection-coordinator.ts
+++ b/apps/electron-shell/src/daemon-connection-coordinator.ts
@@ -54,6 +54,8 @@ export interface DaemonConnectionCoordinatorDependencies {
   readonly preflight: DaemonPreflight;
   readonly preflightTimeoutMs?: number;
   readonly createBroker?: (daemon: ConnectedDaemonState) => DaemonResourceAuthority;
+  /** Main-process-only observer; renderer-safe state remains behind state(). */
+  readonly onHostStateChanged?: (daemon: DesktopDaemonHostState) => void;
 }
 
 interface RefreshFlight {
@@ -124,6 +126,7 @@ export class DaemonConnectionCoordinator implements DaemonConnectionAuthority {
   readonly #preflight: DaemonPreflight;
   readonly #preflightTimeoutMs: number | undefined;
   readonly #createBroker: (daemon: ConnectedDaemonState) => DaemonResourceAuthority;
+  readonly #onHostStateChanged: ((daemon: DesktopDaemonHostState) => void) | undefined;
   readonly #subscriptions = new Map<number, CoordinatorSubscription>();
 
   #daemon: DesktopDaemonHostState;
@@ -139,6 +142,7 @@ export class DaemonConnectionCoordinator implements DaemonConnectionAuthority {
     this.#preflight = dependencies.preflight;
     this.#preflightTimeoutMs = dependencies.preflightTimeoutMs;
     this.#createBroker = dependencies.createBroker ?? defaultBrokerFactory;
+    this.#onHostStateChanged = dependencies.onHostStateChanged;
     if (this.#daemon.status === "connected") {
       try {
         this.#broker = this.#createBroker(this.#daemon);
@@ -146,6 +150,7 @@ export class DaemonConnectionCoordinator implements DaemonConnectionAuthority {
         this.#daemon = BROKER_FAILED_STATE;
       }
     }
+    this.#publishHostState();
   }
 
   state(): DesktopDaemonCapabilityState {
@@ -394,7 +399,12 @@ export class DaemonConnectionCoordinator implements DaemonConnectionAuthority {
 
     if (candidate.status === "connected") {
       const nextIdentity = identityOf(candidate);
-      if (previousIdentity && sameIdentity(previousIdentity, nextIdentity)) {
+      if (
+        previousDaemon.status === "connected" &&
+        previousIdentity &&
+        sameIdentity(previousIdentity, nextIdentity) &&
+        previousDaemon.descriptor.apiBaseUrl === candidate.descriptor.apiBaseUrl
+      ) {
         return this.#parseResult({ outcome: "unchanged", daemon: this.state() });
       }
 
@@ -416,6 +426,7 @@ export class DaemonConnectionCoordinator implements DaemonConnectionAuthority {
       const previousBroker = this.#broker;
       this.#daemon = candidate;
       this.#broker = nextBroker;
+      this.#publishHostState();
       const daemon = this.state();
       this.#retireSubscriptions({
         type: "daemon-generation.changed",
@@ -436,6 +447,7 @@ export class DaemonConnectionCoordinator implements DaemonConnectionAuthority {
 
     if (sameDisconnectedState(previousDaemon, candidate)) {
       this.#daemon = candidate;
+      this.#publishHostState();
       return this.#parseResult({ outcome: "unchanged", daemon: this.state() });
     }
     return this.#transitionToDisconnected(candidate, previousIdentity);
@@ -451,6 +463,7 @@ export class DaemonConnectionCoordinator implements DaemonConnectionAuthority {
     const previousBroker = this.#broker;
     this.#daemon = candidate;
     this.#broker = null;
+    this.#publishHostState();
     const daemon = this.state();
     if (previousIdentity) {
       this.#retireSubscriptions({
@@ -489,6 +502,14 @@ export class DaemonConnectionCoordinator implements DaemonConnectionAuthority {
       } catch {
         // Logical retirement happened before transport teardown.
       }
+    }
+  }
+
+  #publishHostState(): void {
+    try {
+      this.#onHostStateChanged?.(this.#daemon);
+    } catch {
+      // Presentation policy observation cannot change daemon authority state.
     }
   }
 

--- a/apps/electron-shell/src/daemon-resource-broker.test.ts
+++ b/apps/electron-shell/src/daemon-resource-broker.test.ts
@@ -1,6 +1,7 @@
 import {
   APPLICATION_SHELL_RESOURCE_VERSION,
   COHESION_FIXTURE_V1,
+  DESKTOP_PACKAGED_RENDERER_ORIGIN,
   TERMINAL_ATTACHMENT_ISSUE_PATH,
   type DesktopDaemonEvent,
   type DesktopDaemonHostState,
@@ -136,60 +137,64 @@ describe("Electron main daemon resource broker", () => {
     }
   });
 
-  it("issues a bounded terminal attachment against only the exact owner-authorized endpoint", async () => {
-    const requests: Array<{ url: string; init?: RequestInit }> = [];
-    const now = 1_784_662_800_000;
-    const requestId = "10000000-0000-4000-8000-000000000001";
-    const descriptor = {
-      protocolVersion: 1 as const,
-      webSocketUrl: "ws://127.0.0.1:6060/v1/terminal/attachments/redeem",
-      subprotocol: "tmux-ide-terminal.v1" as const,
-      redemptionTicket: `ta1_${"A".repeat(43)}`,
-      daemonInstanceId: IDENTITY.instanceId,
-      requestId,
-      expiresAt: now + 30_000,
-      effectiveViewerMode: "interactive" as const,
-    };
-    const broker = new DaemonResourceBroker({
-      daemon: CONNECTED,
-      ownerToken: "owner-only-token",
-      now: () => now,
-      fetch: async (input, init) => {
-        requests.push({ url: input.toString(), init });
-        return json({ status: "issued", descriptor });
-      },
-    });
-    const mutation = {
-      requestId,
-      expectedDaemonInstanceId: IDENTITY.instanceId,
-      attachment: {
+  it.each(["http://127.0.0.1:5173", DESKTOP_PACKAGED_RENDERER_ORIGIN])(
+    "issues a bounded terminal attachment for renderer origin %s against only the exact owner-authorized endpoint",
+    async (rendererOrigin) => {
+      const requests: Array<{ url: string; init?: RequestInit }> = [];
+      const now = 1_784_662_800_000;
+      const requestId = "10000000-0000-4000-8000-000000000001";
+      const descriptor = {
         protocolVersion: 1 as const,
-        target: { workspaceName: "product", semanticPaneId: "pane.worker" },
-        viewerMode: "interactive" as const,
-        viewport: { cols: 120, rows: 40 },
-      },
-    };
+        webSocketUrl: "ws://127.0.0.1:6060/v1/terminal/attachments/redeem",
+        subprotocol: "tmux-ide-terminal.v1" as const,
+        redemptionTicket: `ta1_${"A".repeat(43)}`,
+        daemonInstanceId: IDENTITY.instanceId,
+        requestId,
+        expiresAt: now + 30_000,
+        effectiveViewerMode: "interactive" as const,
+      };
+      const broker = new DaemonResourceBroker({
+        daemon: CONNECTED,
+        ownerToken: "owner-only-token",
+        now: () => now,
+        fetch: async (input, init) => {
+          requests.push({ url: input.toString(), init });
+          return json({ status: "issued", descriptor });
+        },
+      });
+      const mutation = {
+        requestId,
+        expectedDaemonInstanceId: IDENTITY.instanceId,
+        attachment: {
+          protocolVersion: 1 as const,
+          target: { workspaceName: "product", semanticPaneId: "pane.worker" },
+          viewerMode: "interactive" as const,
+          viewport: { cols: 120, rows: 40 },
+        },
+      };
 
-    await expect(
-      broker.issueTerminalAttachment(mutation, "http://127.0.0.1:5173"),
-    ).resolves.toEqual({ status: "issued", descriptor });
-    expect(requests).toHaveLength(1);
-    const sent = requests[0]!;
-    expect(sent.url).toBe(`${CONNECTED.descriptor.apiBaseUrl}${TERMINAL_ATTACHMENT_ISSUE_PATH}`);
-    expect(sent.init).toMatchObject({
-      method: "POST",
-      credentials: "omit",
-      redirect: "error",
-      cache: "no-store",
-    });
-    const headers = new Headers(sent.init?.headers);
-    expect(headers.get("authorization")).toBe("Bearer owner-only-token");
-    expect(headers.get("origin")).toBe("http://127.0.0.1:5173");
-    expect(headers.get("x-tmux-ide-request-id")).toBe(requestId);
-    expect(headers.get("x-tmux-ide-expected-daemon-instance-id")).toBe(IDENTITY.instanceId);
-    expect(JSON.parse(String(sent.init?.body))).toEqual(mutation);
-    expect(JSON.stringify(sent)).not.toContain(descriptor.redemptionTicket);
-  });
+      await expect(broker.issueTerminalAttachment(mutation, rendererOrigin)).resolves.toEqual({
+        status: "issued",
+        descriptor,
+      });
+      expect(requests).toHaveLength(1);
+      const sent = requests[0]!;
+      expect(sent.url).toBe(`${CONNECTED.descriptor.apiBaseUrl}${TERMINAL_ATTACHMENT_ISSUE_PATH}`);
+      expect(sent.init).toMatchObject({
+        method: "POST",
+        credentials: "omit",
+        redirect: "error",
+        cache: "no-store",
+      });
+      const headers = new Headers(sent.init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer owner-only-token");
+      expect(headers.get("origin")).toBe(rendererOrigin);
+      expect(headers.get("x-tmux-ide-request-id")).toBe(requestId);
+      expect(headers.get("x-tmux-ide-expected-daemon-instance-id")).toBe(IDENTITY.instanceId);
+      expect(JSON.parse(String(sent.init?.body))).toEqual(mutation);
+      expect(JSON.stringify(sent)).not.toContain(descriptor.redemptionTicket);
+    },
+  );
 
   it("does not accept a remote capability in place of the canonical owner secret", async () => {
     const fetch = vi.fn();

--- a/apps/electron-shell/src/daemon-resource-broker.ts
+++ b/apps/electron-shell/src/daemon-resource-broker.ts
@@ -686,7 +686,14 @@ export class DaemonResourceBroker {
   }
 
   #canonicalRendererOrigin(value: string): string {
-    if (typeof value !== "string" || value.length > 2_048 || /[\0\r\n\t ]/u.test(value)) {
+    if (
+      typeof value !== "string" ||
+      value.length < 4 ||
+      value.length > 2_048 ||
+      value === "null" ||
+      value === "*" ||
+      /[\0\r\n\t ]/u.test(value)
+    ) {
       throw new BrokerFailure(daemonCapabilityError("invalid-request"));
     }
     let origin: URL;
@@ -696,17 +703,22 @@ export class DaemonResourceBroker {
       throw new BrokerFailure(daemonCapabilityError("invalid-request"));
     }
     if (
-      (origin.protocol !== "http:" && origin.protocol !== "https:") ||
-      origin.origin !== value ||
+      !/^[a-z][a-z0-9+.-]*:$/u.test(origin.protocol) ||
+      origin.protocol === "file:" ||
       origin.username.length > 0 ||
       origin.password.length > 0 ||
-      origin.pathname !== "/" ||
+      (origin.pathname !== "" && origin.pathname !== "/") ||
       origin.search.length > 0 ||
-      origin.hash.length > 0
+      origin.hash.length > 0 ||
+      !origin.hostname
     ) {
       throw new BrokerFailure(daemonCapabilityError("invalid-request"));
     }
-    return origin.origin;
+    const canonical = `${origin.protocol}//${origin.host}`;
+    if (canonical !== value) {
+      throw new BrokerFailure(daemonCapabilityError("invalid-request"));
+    }
+    return canonical;
   }
 
   async #mutationJson(

--- a/apps/electron-shell/src/host-ipc.test.ts
+++ b/apps/electron-shell/src/host-ipc.test.ts
@@ -5,6 +5,10 @@ import type {
   TerminalAttachmentIssueResult,
   WorkspacePaneCreateMutationRequest,
 } from "@tmux-ide/contracts";
+import {
+  DESKTOP_PACKAGED_RENDERER_ENTRY_URL,
+  DESKTOP_PACKAGED_RENDERER_ORIGIN,
+} from "@tmux-ide/contracts";
 
 import type { DaemonConnectionAuthority } from "./daemon-connection-coordinator.ts";
 import { registerHostIpc, rendererLocationIsTrusted } from "./host-ipc.ts";
@@ -426,137 +430,166 @@ describe("host IPC trust boundary", () => {
     registration.dispose();
   });
 
-  it("authors terminal authority in main and discards a ticket completed after retirement", async () => {
-    const handlers = new Map<string, (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown>();
-    const ipcMain = {
-      handle: (
-        channel: string,
-        handler: (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown,
-      ) => handlers.set(channel, handler),
-      removeHandler: (channel: string) => handlers.delete(channel),
-    } as unknown as IpcMain;
-    const mainFrame = { url: "http://127.0.0.1:5173/src/main.tsx" };
-    const webContents = { id: 17, mainFrame, send: vi.fn() };
-    const window = {
-      isDestroyed: () => false,
-      isMaximized: () => false,
-      isFullScreen: () => false,
-      isFocused: () => true,
-      webContents,
-    } as unknown as BrowserWindow;
-    const identity = {
-      protocolVersion: 1,
-      productVersion: "2.8.0",
-      instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
-      startedAt: "2026-07-21T00:00:00.000Z",
-    };
-    const descriptorFor = (request: TerminalAttachmentIssueMutationRequest, ticket: string) => ({
-      protocolVersion: 1 as const,
-      webSocketUrl: "ws://127.0.0.1:6060/v1/terminal/attachments/redeem",
-      subprotocol: "tmux-ide-terminal.v1" as const,
-      redemptionTicket: ticket,
-      daemonInstanceId: identity.instanceId,
-      requestId: request.requestId,
-      expiresAt: Date.now() + 30_000,
-      effectiveViewerMode: "interactive" as const,
-    });
-    const issueTerminalAttachment = vi.fn(
-      async (
-        request: TerminalAttachmentIssueMutationRequest,
-        origin: string,
-      ): Promise<TerminalAttachmentIssueResult> => {
-        expect(origin).toBe("http://127.0.0.1:5173");
-        return {
-          status: "issued" as const,
-          descriptor: descriptorFor(request, `ta1_${"A".repeat(43)}`),
-        };
-      },
-    );
-    const daemonResources = {
-      state: () => ({ status: "connected" as const, identity }),
-      createWorkspacePane: vi.fn(),
-      issueTerminalAttachment,
-      refreshConnection: vi.fn(),
-      listWorkspaces: vi.fn(),
-      fetchApplicationShell: vi.fn(),
-      subscribe: vi.fn(),
-      releaseRenderer: vi.fn(),
-      dispose: vi.fn(),
-    } as unknown as DaemonConnectionAuthority;
-    const registration = registerHostIpc({
-      ipcMain,
-      getWindow: () => window,
-      appVersion: "test",
-      platform: "darwin",
-      daemonResources,
-      requestQuit: vi.fn(),
-      selectProjectDirectory: async () => null,
-      getTheme: () => ({ mode: "dark", highContrast: false, reducedMotion: false }),
+  it.each([
+    {
+      label: "development renderer",
+      frameUrl: "http://127.0.0.1:5173/src/main.tsx",
+      expectedOrigin: "http://127.0.0.1:5173",
       trustedRendererLocation: {
-        kind: "development-origin",
+        kind: "development-origin" as const,
         origin: "http://127.0.0.1:5173",
       },
-    });
-    const event = { sender: webContents, senderFrame: mainFrame } as unknown as IpcMainInvokeEvent;
-    handlers.get(HOST_IPC.bootstrap)?.(event);
-    const attachment = {
-      protocolVersion: 1,
-      target: { workspaceName: "product", semanticPaneId: "pane.worker" },
-      viewerMode: "interactive",
-      viewport: { cols: 120, rows: 40 },
-    };
+    },
+    {
+      label: "packaged renderer",
+      frameUrl: DESKTOP_PACKAGED_RENDERER_ENTRY_URL,
+      expectedOrigin: DESKTOP_PACKAGED_RENDERER_ORIGIN,
+      trustedRendererLocation: {
+        kind: "packaged-origin" as const,
+        origin: DESKTOP_PACKAGED_RENDERER_ORIGIN,
+        entryUrl: DESKTOP_PACKAGED_RENDERER_ENTRY_URL,
+      },
+    },
+  ])(
+    "authors terminal authority for the $label and discards a ticket completed after retirement",
+    async ({ frameUrl, expectedOrigin, trustedRendererLocation }) => {
+      const handlers = new Map<
+        string,
+        (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown
+      >();
+      const ipcMain = {
+        handle: (
+          channel: string,
+          handler: (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown,
+        ) => handlers.set(channel, handler),
+        removeHandler: (channel: string) => handlers.delete(channel),
+      } as unknown as IpcMain;
+      const mainFrame = { url: frameUrl };
+      const webContents = { id: 17, mainFrame, send: vi.fn() };
+      const window = {
+        isDestroyed: () => false,
+        isMaximized: () => false,
+        isFullScreen: () => false,
+        isFocused: () => true,
+        webContents,
+      } as unknown as BrowserWindow;
+      const identity = {
+        protocolVersion: 1,
+        productVersion: "2.8.0",
+        instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+        startedAt: "2026-07-21T00:00:00.000Z",
+      };
+      const descriptorFor = (request: TerminalAttachmentIssueMutationRequest, ticket: string) => ({
+        protocolVersion: 1 as const,
+        webSocketUrl: "ws://127.0.0.1:6060/v1/terminal/attachments/redeem",
+        subprotocol: "tmux-ide-terminal.v1" as const,
+        redemptionTicket: ticket,
+        daemonInstanceId: identity.instanceId,
+        requestId: request.requestId,
+        expiresAt: Date.now() + 30_000,
+        effectiveViewerMode: "interactive" as const,
+      });
+      const issueTerminalAttachment = vi.fn(
+        async (
+          request: TerminalAttachmentIssueMutationRequest,
+          origin: string,
+        ): Promise<TerminalAttachmentIssueResult> => {
+          expect(origin).toBe(expectedOrigin);
+          return {
+            status: "issued" as const,
+            descriptor: descriptorFor(request, `ta1_${"A".repeat(43)}`),
+          };
+        },
+      );
+      const daemonResources = {
+        state: () => ({ status: "connected" as const, identity }),
+        createWorkspacePane: vi.fn(),
+        issueTerminalAttachment,
+        refreshConnection: vi.fn(),
+        listWorkspaces: vi.fn(),
+        fetchApplicationShell: vi.fn(),
+        subscribe: vi.fn(),
+        releaseRenderer: vi.fn(),
+        dispose: vi.fn(),
+      } as unknown as DaemonConnectionAuthority;
+      const registration = registerHostIpc({
+        ipcMain,
+        getWindow: () => window,
+        appVersion: "test",
+        platform: "darwin",
+        daemonResources,
+        requestQuit: vi.fn(),
+        selectProjectDirectory: async () => null,
+        getTheme: () => ({ mode: "dark", highContrast: false, reducedMotion: false }),
+        trustedRendererLocation,
+      });
+      const event = {
+        sender: webContents,
+        senderFrame: mainFrame,
+      } as unknown as IpcMainInvokeEvent;
+      handlers.get(HOST_IPC.bootstrap)?.(event);
+      const attachment = {
+        protocolVersion: 1,
+        target: { workspaceName: "product", semanticPaneId: "pane.worker" },
+        viewerMode: "interactive",
+        viewport: { cols: 120, rows: 40 },
+      };
 
-    const issued = await handlers.get(HOST_IPC.daemonIssueTerminalAttachment)?.(event, attachment);
-    expect(issued).toMatchObject({
-      status: "issued",
-      descriptor: { daemonInstanceId: identity.instanceId },
-    });
-    const authored = issueTerminalAttachment.mock.calls[0]?.[0];
-    expect(authored).toMatchObject({
-      expectedDaemonInstanceId: identity.instanceId,
-      attachment,
-    });
-    expect(authored?.requestId).toMatch(/^[0-9a-f-]{36}$/u);
-    expect(JSON.stringify(authored)).not.toMatch(/ownerToken|authorization|rendererOrigin/iu);
-
-    expect(
-      await handlers.get(HOST_IPC.daemonIssueTerminalAttachment)?.(event, {
-        ...attachment,
-        ownerToken: "renderer-secret",
-      }),
-    ).toMatchObject({ status: "error", error: { code: "invalid-request" } });
-    expect(issueTerminalAttachment).toHaveBeenCalledOnce();
-    await expect(
-      handlers.get(HOST_IPC.daemonIssueTerminalAttachment)?.(
-        {
-          sender: webContents,
-          senderFrame: { url: mainFrame.url },
-        } as unknown as IpcMainInvokeEvent,
+      const issued = await handlers.get(HOST_IPC.daemonIssueTerminalAttachment)?.(
+        event,
         attachment,
-      ),
-    ).rejects.toThrow("untrusted renderer");
+      );
+      expect(issued).toMatchObject({
+        status: "issued",
+        descriptor: { daemonInstanceId: identity.instanceId },
+      });
+      const authored = issueTerminalAttachment.mock.calls[0]?.[0];
+      expect(authored).toMatchObject({
+        expectedDaemonInstanceId: identity.instanceId,
+        attachment,
+      });
+      expect(authored?.requestId).toMatch(/^[0-9a-f-]{36}$/u);
+      expect(JSON.stringify(authored)).not.toMatch(/ownerToken|authorization|rendererOrigin/iu);
 
-    let finishIssue: ((result: TerminalAttachmentIssueResult) => void) | undefined;
-    issueTerminalAttachment.mockImplementationOnce(
-      async () =>
-        new Promise<TerminalAttachmentIssueResult>((resolve) => {
-          finishIssue = resolve;
+      expect(
+        await handlers.get(HOST_IPC.daemonIssueTerminalAttachment)?.(event, {
+          ...attachment,
+          ownerToken: "renderer-secret",
         }),
-    );
-    const pending = handlers.get(HOST_IPC.daemonIssueTerminalAttachment)?.(event, attachment);
-    await vi.waitFor(() => expect(issueTerminalAttachment).toHaveBeenCalledTimes(2));
-    const lateRequest = issueTerminalAttachment.mock.calls[1]?.[0];
-    registration.releaseRenderer();
-    finishIssue?.({
-      status: "issued",
-      descriptor: descriptorFor(lateRequest!, `ta1_${"B".repeat(43)}`),
-    });
-    const retired = await pending;
-    expect(retired).toMatchObject({ status: "error", error: { code: "disposed" } });
-    expect(JSON.stringify(retired)).not.toContain(`ta1_${"B".repeat(43)}`);
-    expect(daemonResources.releaseRenderer).toHaveBeenCalledOnce();
-    registration.dispose();
-  });
+      ).toMatchObject({ status: "error", error: { code: "invalid-request" } });
+      expect(issueTerminalAttachment).toHaveBeenCalledOnce();
+      await expect(
+        handlers.get(HOST_IPC.daemonIssueTerminalAttachment)?.(
+          {
+            sender: webContents,
+            senderFrame: { url: mainFrame.url },
+          } as unknown as IpcMainInvokeEvent,
+          attachment,
+        ),
+      ).rejects.toThrow("untrusted renderer");
+
+      let finishIssue: ((result: TerminalAttachmentIssueResult) => void) | undefined;
+      issueTerminalAttachment.mockImplementationOnce(
+        async () =>
+          new Promise<TerminalAttachmentIssueResult>((resolve) => {
+            finishIssue = resolve;
+          }),
+      );
+      const pending = handlers.get(HOST_IPC.daemonIssueTerminalAttachment)?.(event, attachment);
+      await vi.waitFor(() => expect(issueTerminalAttachment).toHaveBeenCalledTimes(2));
+      const lateRequest = issueTerminalAttachment.mock.calls[1]?.[0];
+      registration.releaseRenderer();
+      finishIssue?.({
+        status: "issued",
+        descriptor: descriptorFor(lateRequest!, `ta1_${"B".repeat(43)}`),
+      });
+      const retired = await pending;
+      expect(retired).toMatchObject({ status: "error", error: { code: "disposed" } });
+      expect(JSON.stringify(retired)).not.toContain(`ta1_${"B".repeat(43)}`);
+      expect(daemonResources.releaseRenderer).toHaveBeenCalledOnce();
+      registration.dispose();
+    },
+  );
 
   it("accepts a configured development origin but not a lookalike or foreign origin", () => {
     const trusted = { kind: "development-origin", origin: "http://127.0.0.1:5173" } as const;
@@ -564,5 +597,19 @@ describe("host IPC trust boundary", () => {
     expect(rendererLocationIsTrusted("http://127.0.0.1:5173.evil.invalid/", trusted)).toBe(false);
     expect(rendererLocationIsTrusted("http://127.0.0.1:5174/", trusted)).toBe(false);
     expect(rendererLocationIsTrusted("not a URL", trusted)).toBe(false);
+  });
+
+  it("accepts only the exact packaged application entry URL", () => {
+    const trusted = {
+      kind: "packaged-origin",
+      origin: DESKTOP_PACKAGED_RENDERER_ORIGIN,
+      entryUrl: DESKTOP_PACKAGED_RENDERER_ENTRY_URL,
+    } as const;
+    expect(rendererLocationIsTrusted(DESKTOP_PACKAGED_RENDERER_ENTRY_URL, trusted)).toBe(true);
+    expect(rendererLocationIsTrusted("tmux-ide://app/", trusted)).toBe(false);
+    expect(rendererLocationIsTrusted("tmux-ide://app.evil.invalid/index.html", trusted)).toBe(
+      false,
+    );
+    expect(rendererLocationIsTrusted("file:///trusted/renderer/index.html", trusted)).toBe(false);
   });
 });

--- a/apps/electron-shell/src/host-ipc.ts
+++ b/apps/electron-shell/src/host-ipc.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from "electron";
 import {
+  DESKTOP_PACKAGED_RENDERER_ENTRY_URL,
+  DESKTOP_PACKAGED_RENDERER_ORIGIN,
   DESKTOP_HOST_API_VERSION,
   DesktopDaemonEventSubscriptionRequestSchemaZ,
   DesktopDaemonEventWireEnvelopeSchemaZ,
@@ -42,6 +44,11 @@ export interface HostIpcDependencies {
 
 export type TrustedRendererLocation =
   | { kind: "packaged-url"; url: string }
+  | {
+      kind: "packaged-origin";
+      origin: typeof DESKTOP_PACKAGED_RENDERER_ORIGIN;
+      entryUrl: typeof DESKTOP_PACKAGED_RENDERER_ENTRY_URL;
+    }
   | { kind: "development-origin"; origin: string };
 
 export function rendererLocationIsTrusted(
@@ -51,6 +58,18 @@ export function rendererLocationIsTrusted(
   try {
     const location = new URL(frameUrl);
     if (trusted.kind === "packaged-url") return location.toString() === trusted.url;
+    if (trusted.kind === "packaged-origin") {
+      return (
+        location.protocol === "tmux-ide:" &&
+        location.hostname === "app" &&
+        location.port.length === 0 &&
+        location.username.length === 0 &&
+        location.password.length === 0 &&
+        location.search.length === 0 &&
+        location.hash.length === 0 &&
+        location.toString() === trusted.entryUrl
+      );
+    }
     return location.origin === trusted.origin;
   } catch {
     return false;
@@ -359,25 +378,23 @@ export function registerHostIpc(deps: HostIpcDependencies): RegisteredHostIpc {
         error: terminalAttachmentIssueError("invalid-request"),
       });
     }
-    if (deps.trustedRendererLocation.kind !== "development-origin") {
-      return TerminalAttachmentIssueResultSchemaZ.parse({
-        status: "error",
-        error: terminalAttachmentIssueError("renderer-origin-unavailable"),
-      });
-    }
     const rendererFrameUrl = authority.mainFrame?.url;
-    if (!rendererFrameUrl) {
+    if (
+      !rendererFrameUrl ||
+      !rendererLocationIsTrusted(rendererFrameUrl, deps.trustedRendererLocation)
+    ) {
       return TerminalAttachmentIssueResultSchemaZ.parse({
         status: "error",
         error: terminalAttachmentIssueError("renderer-origin-unavailable"),
       });
     }
-    const rendererOrigin = new URL(rendererFrameUrl).origin;
-    if (
-      rendererOrigin === "null" ||
-      rendererOrigin !== deps.trustedRendererLocation.origin ||
-      !["http:", "https:"].includes(new URL(rendererOrigin).protocol)
-    ) {
+    const rendererOrigin =
+      deps.trustedRendererLocation.kind === "development-origin"
+        ? deps.trustedRendererLocation.origin
+        : deps.trustedRendererLocation.kind === "packaged-origin"
+          ? deps.trustedRendererLocation.origin
+          : null;
+    if (!rendererOrigin) {
       return TerminalAttachmentIssueResultSchemaZ.parse({
         status: "error",
         error: terminalAttachmentIssueError("renderer-origin-unavailable"),

--- a/apps/electron-shell/src/import-boundaries.test.ts
+++ b/apps/electron-shell/src/import-boundaries.test.ts
@@ -89,19 +89,18 @@ describe("desktop process boundaries", () => {
 
   it("ships a strict browser renderer policy", async () => {
     const html = await readFile(join(packageRoot, "..", "desktop-renderer", "index.html"), "utf8");
-    expect(html).toContain("default-src 'self'");
-    expect(html).toContain("object-src 'none'");
-    expect(html).toContain("frame-ancestors 'none'");
-    expect(html).toContain("connect-src 'self'");
-    expect(html).not.toMatch(/connect-src[^;]*(?:127\.0\.0\.1|localhost|\[::1\]|https?:|wss?:)/u);
-    expect(html).not.toMatch(/connect-src[^;]*\*/u);
-    expect(html).not.toMatch(/unsafe-(?:inline|eval)/u);
+    expect(html).not.toMatch(/Content-Security-Policy/iu);
 
     const vite = await readFile(
       join(packageRoot, "..", "desktop-renderer", "vite.config.ts"),
       "utf8",
     );
-    expect(vite).toContain('apply: "serve"');
+    expect(vite).toContain('"Content-Security-Policy"');
+    expect(vite).toContain("default-src 'self'");
+    expect(vite).toContain("object-src 'none'");
+    expect(vite).toContain("frame-ancestors 'none'");
     expect(vite).toContain("ws://127.0.0.1:5173");
+    expect(vite).toContain("sourcemap: false");
+    expect(vite).not.toMatch(/unsafe-(?:inline|eval)/u);
   });
 });

--- a/apps/electron-shell/src/main.ts
+++ b/apps/electron-shell/src/main.ts
@@ -1,8 +1,22 @@
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
 
-import { app, BrowserWindow, dialog, ipcMain, nativeTheme, screen, session } from "electron";
-import type { DesktopPlatform, DesktopThemeState } from "@tmux-ide/contracts";
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  nativeTheme,
+  net,
+  protocol,
+  screen,
+  session,
+} from "electron";
+import {
+  DESKTOP_PACKAGED_RENDERER_ENTRY_URL,
+  DESKTOP_PACKAGED_RENDERER_ORIGIN,
+  type DesktopPlatform,
+  type DesktopThemeState,
+} from "@tmux-ide/contracts";
 
 import {
   canonicalDaemonPreflight,
@@ -18,6 +32,13 @@ import {
   type TrustedRendererLocation,
 } from "./host-ipc.ts";
 import { ShutdownBarrier } from "./shutdown-barrier.ts";
+import {
+  developmentRendererContentSecurityPolicy,
+  installPackagedRendererProtocol,
+  installDevelopmentRendererCsp,
+  packagedRendererContentSecurityPolicy,
+  registerPackagedRendererScheme,
+} from "./packaged-renderer-protocol.ts";
 import { loadHiddenWindow } from "./window-loader.ts";
 import { denyRendererEscapes, secureWebPreferences } from "./window-security.ts";
 import {
@@ -32,6 +53,8 @@ export interface DesktopAppDependencies {
   daemonPreflight?: DaemonPreflight;
   loadTimeoutMs?: number;
 }
+
+registerPackagedRendererScheme(protocol);
 
 const smokeTest = process.argv.includes("--smoke-test");
 
@@ -79,6 +102,7 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
   let hostIpc: RegisteredHostIpc | null = null;
   let quittingAfterBarrier = false;
   let persistTimer: ReturnType<typeof setTimeout> | null = null;
+  let rendererPolicyReloadTimer: ReturnType<typeof setTimeout> | null = null;
   let lastBoundsWrite = Promise.resolve();
   let rendererDidBootstrap: (() => void) | null = null;
   let latestNormalBounds: DesktopWindowBounds | null = null;
@@ -97,15 +121,45 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
   );
   const daemonPreflight = deps.daemonPreflight ?? canonicalDaemonPreflight;
   const daemon = await runDaemonPreflight(daemonPreflight);
+  let daemonHttpOrigin = daemon.status === "connected" ? daemon.descriptor.apiBaseUrl : null;
+  const developmentUrl = trustedDevelopmentUrl();
+  const developmentOrigin = developmentUrl ? new URL(developmentUrl).origin : null;
+  const disposePackagedRendererProtocol = installPackagedRendererProtocol({
+    protocol,
+    fileFetcher: { fetch: (url) => net.fetch(url) },
+    rendererRoot: join(__dirname, "renderer"),
+    contentSecurityPolicy: () => packagedRendererContentSecurityPolicy(daemonHttpOrigin),
+  });
+  const disposeDevelopmentRendererCsp = developmentOrigin
+    ? installDevelopmentRendererCsp({
+        webRequest: desktopSession.webRequest,
+        rendererOrigin: developmentOrigin,
+        contentSecurityPolicy: () =>
+          developmentRendererContentSecurityPolicy(daemonHttpOrigin, developmentOrigin),
+      })
+    : () => undefined;
   const daemonResources = new DaemonConnectionCoordinator({
     initialDaemon: daemon,
     preflight: daemonPreflight,
+    onHostStateChanged: (state) => {
+      const nextOrigin = state.status === "connected" ? state.descriptor.apiBaseUrl : null;
+      if (nextOrigin === daemonHttpOrigin) return;
+      daemonHttpOrigin = nextOrigin;
+      if (!currentWindow || currentWindow.isDestroyed()) return;
+      if (rendererPolicyReloadTimer) clearTimeout(rendererPolicyReloadTimer);
+      rendererPolicyReloadTimer = setTimeout(() => {
+        rendererPolicyReloadTimer = null;
+        if (currentWindow && !currentWindow.isDestroyed()) currentWindow.reload();
+      }, 0);
+    },
   });
-  const developmentUrl = trustedDevelopmentUrl();
-  const packagedRendererPath = join(__dirname, "renderer", "index.html");
   const trustedRendererLocation: TrustedRendererLocation = developmentUrl
     ? { kind: "development-origin", origin: new URL(developmentUrl).origin }
-    : { kind: "packaged-url", url: pathToFileURL(packagedRendererPath).toString() };
+    : {
+        kind: "packaged-origin",
+        origin: DESKTOP_PACKAGED_RENDERER_ORIGIN,
+        entryUrl: DESKTOP_PACKAGED_RENDERER_ENTRY_URL,
+      };
 
   const persistBounds = async (): Promise<void> => {
     latestNormalBounds = captureDesktopWindowNormalBounds(currentWindow, latestNormalBounds);
@@ -171,7 +225,7 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
         rendererReady,
         load: async () => {
           if (developmentUrl) await window.loadURL(developmentUrl);
-          else await window.loadFile(packagedRendererPath);
+          else await window.loadURL(DESKTOP_PACKAGED_RENDERER_ENTRY_URL);
         },
       });
     } finally {
@@ -228,8 +282,11 @@ export async function runDesktopApp(deps: DesktopAppDependencies = {}): Promise<
         persistBounds,
         () => {
           if (persistTimer) clearTimeout(persistTimer);
+          if (rendererPolicyReloadTimer) clearTimeout(rendererPolicyReloadTimer);
           hostIpc?.dispose();
           daemonResources.dispose();
+          disposeDevelopmentRendererCsp();
+          disposePackagedRendererProtocol();
           nativeTheme.removeListener("updated", onThemeUpdated);
         },
       ])

--- a/apps/electron-shell/src/packaged-renderer-protocol.test.ts
+++ b/apps/electron-shell/src/packaged-renderer-protocol.test.ts
@@ -1,0 +1,187 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DESKTOP_PACKAGED_RENDERER_ENTRY_URL,
+  DESKTOP_PACKAGED_RENDERER_ORIGIN,
+  developmentRendererContentSecurityPolicy,
+  installDevelopmentRendererCsp,
+  installPackagedRendererProtocol,
+  packagedRendererContentSecurityPolicy,
+  registerPackagedRendererScheme,
+} from "./packaged-renderer-protocol.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "tmux-ide-renderer-"));
+  roots.push(root);
+  await mkdir(join(root, "assets"));
+  await writeFile(join(root, "index.html"), "<!doctype html><title>tmux-ide</title>");
+  await writeFile(join(root, "assets", "app-ABC123.js"), "export {};\n");
+
+  let handler: ((request: Request) => Response | Promise<Response>) | null = null;
+  const protocol = {
+    handle: vi.fn((_scheme: string, next: typeof handler) => {
+      handler = next;
+    }),
+    unhandle: vi.fn(),
+  };
+  const fileFetcher = {
+    fetch: vi.fn(
+      async () =>
+        new Response("export {};\n", {
+          headers: { "Content-Type": "text/javascript" },
+        }),
+    ),
+  };
+  const dispose = installPackagedRendererProtocol({
+    protocol,
+    fileFetcher,
+    rendererRoot: root,
+    contentSecurityPolicy: () => packagedRendererContentSecurityPolicy("http://127.0.0.1:6060"),
+  });
+  const installedHandler = handler as ((request: Request) => Response | Promise<Response>) | null;
+  if (!installedHandler) throw new Error("handler was not installed");
+  return { handler: installedHandler, protocol, fileFetcher, dispose };
+}
+
+describe("packaged renderer protocol", () => {
+  it("registers one standard secure scheme without CSP bypass or service workers", () => {
+    const registerSchemesAsPrivileged = vi.fn();
+    registerPackagedRendererScheme({ registerSchemesAsPrivileged });
+    expect(registerSchemesAsPrivileged).toHaveBeenCalledWith([
+      {
+        scheme: "tmux-ide",
+        privileges: expect.objectContaining({
+          standard: true,
+          secure: true,
+          supportFetchAPI: true,
+          bypassCSP: false,
+          allowServiceWorkers: false,
+          corsEnabled: false,
+        }),
+      },
+    ]);
+  });
+
+  it("serves only the entry point and flat, built asset names", async () => {
+    const { handler, fileFetcher } = await fixture();
+    const entry = await handler(new Request(DESKTOP_PACKAGED_RENDERER_ENTRY_URL));
+    expect(entry.status).toBe(200);
+    expect(await entry.text()).toContain("tmux-ide");
+    expect(entry.headers.get("content-security-policy")).toContain(
+      "connect-src 'self' ws://127.0.0.1:6060",
+    );
+    expect(entry.headers.get("x-content-type-options")).toBe("nosniff");
+
+    const asset = await handler(
+      new Request(`${DESKTOP_PACKAGED_RENDERER_ORIGIN}/assets/app-ABC123.js`),
+    );
+    expect(asset.status).toBe(200);
+    expect(fileFetcher.fetch).toHaveBeenCalledOnce();
+
+    for (const url of [
+      "tmux-ide://other/index.html",
+      `${DESKTOP_PACKAGED_RENDERER_ORIGIN}/secret.txt`,
+      `${DESKTOP_PACKAGED_RENDERER_ORIGIN}/assets/nested/app.js`,
+      `${DESKTOP_PACKAGED_RENDERER_ORIGIN}/assets/%2e%2e/secret.js`,
+      `${DESKTOP_PACKAGED_RENDERER_ORIGIN}/assets/app.js?cache=1`,
+      `${DESKTOP_PACKAGED_RENDERER_ORIGIN}/assets/no-extension`,
+      `${DESKTOP_PACKAGED_RENDERER_ORIGIN}/assets/app.js.map`,
+    ]) {
+      expect((await handler(new Request(url))).status, url).toBe(404);
+    }
+    expect(
+      (await handler(new Request(DESKTOP_PACKAGED_RENDERER_ENTRY_URL, { method: "POST" }))).status,
+    ).toBe(405);
+  });
+
+  it("unregisters the exact scheme and contains file failures", async () => {
+    const { handler, protocol, fileFetcher, dispose } = await fixture();
+    fileFetcher.fetch.mockRejectedValueOnce(new Error("private path"));
+    expect(
+      (await handler(new Request(`${DESKTOP_PACKAGED_RENDERER_ORIGIN}/assets/app-ABC123.js`)))
+        .status,
+    ).toBe(404);
+    dispose();
+    expect(protocol.unhandle).toHaveBeenCalledWith("tmux-ide");
+  });
+
+  it("emits an exact current loopback daemon connect source and rejects malformed origins", () => {
+    expect(packagedRendererContentSecurityPolicy("http://localhost:6123")).toContain(
+      "connect-src 'self' ws://localhost:6123",
+    );
+    expect(packagedRendererContentSecurityPolicy("http://[::1]:6123")).toContain(
+      "connect-src 'self' ws://[::1]:6123",
+    );
+    for (const value of [
+      "https://127.0.0.1:6060",
+      "http://127.0.0.1",
+      "http://127.0.0.1:6060/path",
+      "http://evil.invalid:6060",
+      "not-an-origin",
+    ]) {
+      expect(packagedRendererContentSecurityPolicy(value)).toContain("connect-src 'self';");
+      expect(packagedRendererContentSecurityPolicy(value)).not.toContain("ws://");
+    }
+  });
+
+  it("narrows development responses to Vite HMR and the current daemon", () => {
+    let listener:
+      | ((
+          details: {
+            url: string;
+            resourceType: string;
+            responseHeaders?: Record<string, string | string[]>;
+          },
+          callback: (response: { responseHeaders?: Record<string, string | string[]> }) => void,
+        ) => void)
+      | null = null;
+    const onHeadersReceived = vi.fn((_filter, next) => {
+      listener = next;
+    });
+    const dispose = installDevelopmentRendererCsp({
+      webRequest: { onHeadersReceived },
+      rendererOrigin: "http://127.0.0.1:5173",
+      contentSecurityPolicy: () =>
+        developmentRendererContentSecurityPolicy("http://127.0.0.1:6060", "http://127.0.0.1:5173"),
+    });
+    const installed = listener as
+      | ((
+          details: {
+            url: string;
+            resourceType: string;
+            responseHeaders?: Record<string, string | string[]>;
+          },
+          callback: (response: { responseHeaders?: Record<string, string | string[]> }) => void,
+        ) => void)
+      | null;
+    if (!installed) throw new Error("CSP listener was not installed");
+    let response: { responseHeaders?: Record<string, string | string[]> } | undefined;
+    installed(
+      {
+        url: "http://127.0.0.1:5173/",
+        resourceType: "mainFrame",
+        responseHeaders: { Server: ["vite"], "content-security-policy": ["stale"] },
+      },
+      (value: { responseHeaders?: Record<string, string | string[]> }) => {
+        response = value;
+      },
+    );
+    const policy = response?.responseHeaders?.["Content-Security-Policy"]?.[0];
+    expect(policy).toContain("connect-src 'self' ws://127.0.0.1:5173 ws://127.0.0.1:6060");
+    expect(JSON.stringify(response?.responseHeaders)).not.toContain("stale");
+    expect(response?.responseHeaders?.Server).toEqual(["vite"]);
+
+    dispose();
+    expect(onHeadersReceived).toHaveBeenLastCalledWith({ urls: ["http://127.0.0.1:5173/*"] }, null);
+  });
+});

--- a/apps/electron-shell/src/packaged-renderer-protocol.ts
+++ b/apps/electron-shell/src/packaged-renderer-protocol.ts
@@ -1,0 +1,262 @@
+import { readFile } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  DESKTOP_PACKAGED_RENDERER_ENTRY_URL,
+  DESKTOP_PACKAGED_RENDERER_HOST,
+  DESKTOP_PACKAGED_RENDERER_ORIGIN,
+  DESKTOP_PACKAGED_RENDERER_SCHEME,
+} from "@tmux-ide/contracts";
+
+interface SchemeRegistrar {
+  registerSchemesAsPrivileged(
+    schemes: {
+      scheme: string;
+      privileges: Record<string, boolean>;
+    }[],
+  ): void;
+}
+
+interface ProtocolHandlerRegistry {
+  handle(scheme: string, handler: (request: Request) => Response | Promise<Response>): void;
+  unhandle(scheme: string): void;
+}
+
+interface FileFetcher {
+  fetch(url: string): Promise<Response>;
+}
+
+interface RendererWebRequest {
+  onHeadersReceived(
+    filter: { urls: string[] },
+    listener:
+      | ((
+          details: {
+            readonly url: string;
+            readonly resourceType: string;
+            readonly responseHeaders?: Record<string, string | string[]>;
+          },
+          callback: (response: {
+            readonly responseHeaders?: Record<string, string | string[]>;
+          }) => void,
+        ) => void)
+      | null,
+  ): void;
+}
+
+export interface PackagedRendererProtocolOptions {
+  readonly protocol: ProtocolHandlerRegistry;
+  readonly fileFetcher: FileFetcher;
+  readonly rendererRoot: string;
+  readonly contentSecurityPolicy: () => string;
+}
+
+export interface DevelopmentRendererCspOptions {
+  readonly webRequest: RendererWebRequest;
+  readonly rendererOrigin: string;
+  readonly contentSecurityPolicy: () => string;
+}
+
+const ASSET_PATH = /^\/assets\/[A-Za-z0-9][A-Za-z0-9._-]{0,239}$/u;
+const PACKAGED_ASSET_EXTENSIONS = new Set([
+  ".avif",
+  ".css",
+  ".ico",
+  ".js",
+  ".png",
+  ".svg",
+  ".webp",
+  ".woff",
+  ".woff2",
+]);
+
+/** Must run exactly once, synchronously, before Electron's ready event. */
+export function registerPackagedRendererScheme(protocol: SchemeRegistrar): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: DESKTOP_PACKAGED_RENDERER_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        codeCache: true,
+        bypassCSP: false,
+        allowServiceWorkers: false,
+        corsEnabled: false,
+        stream: false,
+      },
+    },
+  ]);
+}
+
+function requestedRendererPath(rawUrl: string): "/index.html" | `/assets/${string}` | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (
+    url.protocol !== `${DESKTOP_PACKAGED_RENDERER_SCHEME}:` ||
+    url.hostname !== DESKTOP_PACKAGED_RENDERER_HOST ||
+    url.port ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.pathname.includes("%") ||
+    url.pathname.includes("\\")
+  ) {
+    return null;
+  }
+  if (url.pathname === "/" || url.pathname === "/index.html") return "/index.html";
+  return ASSET_PATH.test(url.pathname) ? (url.pathname as `/assets/${string}`) : null;
+}
+
+function rendererHeaders(contentSecurityPolicy: string): Headers {
+  return new Headers({
+    "Cache-Control": "no-store",
+    "Content-Security-Policy": contentSecurityPolicy,
+    "Content-Type": "text/html; charset=UTF-8",
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "X-Content-Type-Options": "nosniff",
+  });
+}
+
+/**
+ * Serves only the built renderer entry point and flat Vite assets. There is no
+ * arbitrary file-protocol bridge and no path authored by the renderer reaches
+ * the filesystem unchecked.
+ */
+export function installPackagedRendererProtocol(
+  options: PackagedRendererProtocolOptions,
+): () => void {
+  const rendererRoot = options.rendererRoot;
+  options.protocol.handle(DESKTOP_PACKAGED_RENDERER_SCHEME, async (request) => {
+    if (request.method !== "GET") return new Response("Method not allowed", { status: 405 });
+    const pathname = requestedRendererPath(request.url);
+    if (!pathname) return new Response("Not found", { status: 404 });
+    if (pathname === "/index.html") {
+      try {
+        const html = await readFile(join(rendererRoot, "index.html"), "utf8");
+        return new Response(html, {
+          status: 200,
+          headers: rendererHeaders(options.contentSecurityPolicy()),
+        });
+      } catch {
+        return new Response("Not found", { status: 404 });
+      }
+    }
+    const assetName = basename(pathname);
+    if (
+      assetName !== pathname.slice("/assets/".length) ||
+      !PACKAGED_ASSET_EXTENSIONS.has(extname(assetName).toLowerCase())
+    ) {
+      return new Response("Not found", { status: 404 });
+    }
+    try {
+      return await options.fileFetcher.fetch(
+        pathToFileURL(join(rendererRoot, "assets", assetName)).toString(),
+      );
+    } catch {
+      return new Response("Not found", { status: 404 });
+    }
+  });
+  return () => options.protocol.unhandle(DESKTOP_PACKAGED_RENDERER_SCHEME);
+}
+
+function canonicalLoopbackWebSocketOrigin(httpOrigin: string): string | null {
+  try {
+    const url = new URL(httpOrigin);
+    if (
+      url.protocol !== "http:" ||
+      !["127.0.0.1", "localhost", "[::1]"].includes(url.hostname) ||
+      !url.port ||
+      url.username ||
+      url.password ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash ||
+      url.origin !== httpOrigin
+    ) {
+      return null;
+    }
+    url.protocol = "ws:";
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+/** Packaged documents receive one response-header policy for the verified daemon. */
+export function packagedRendererContentSecurityPolicy(daemonHttpOrigin: string | null): string {
+  const daemonWebSocketOrigin = daemonHttpOrigin
+    ? canonicalLoopbackWebSocketOrigin(daemonHttpOrigin)
+    : null;
+  const connectSources = ["'self'", ...(daemonWebSocketOrigin ? [daemonWebSocketOrigin] : [])];
+  return [
+    "default-src 'self'",
+    "script-src 'self'",
+    "style-src 'self'",
+    "img-src 'self' data:",
+    "font-src 'self'",
+    `connect-src ${connectSources.join(" ")}`,
+    "object-src 'none'",
+    "base-uri 'none'",
+    "frame-ancestors 'none'",
+    "form-action 'none'",
+  ].join("; ");
+}
+
+export function developmentRendererContentSecurityPolicy(
+  daemonHttpOrigin: string | null,
+  developmentHttpOrigin: string,
+): string {
+  const developmentWebSocketOrigin = canonicalLoopbackWebSocketOrigin(developmentHttpOrigin);
+  const daemonWebSocketOrigin = daemonHttpOrigin
+    ? canonicalLoopbackWebSocketOrigin(daemonHttpOrigin)
+    : null;
+  const connectSources = [
+    "'self'",
+    ...(developmentWebSocketOrigin ? [developmentWebSocketOrigin] : []),
+    ...(daemonWebSocketOrigin && daemonWebSocketOrigin !== developmentWebSocketOrigin
+      ? [daemonWebSocketOrigin]
+      : []),
+  ];
+  return packagedRendererContentSecurityPolicy(null).replace(
+    "connect-src 'self'",
+    `connect-src ${connectSources.join(" ")}`,
+  );
+}
+
+/** Replaces Vite's preview header with Vite/HMR plus one verified daemon. */
+export function installDevelopmentRendererCsp(options: DevelopmentRendererCspOptions): () => void {
+  const canonicalOrigin = new URL(options.rendererOrigin).origin;
+  if (
+    canonicalOrigin !== options.rendererOrigin ||
+    !canonicalLoopbackWebSocketOrigin(canonicalOrigin)
+  ) {
+    throw new TypeError("Development renderer origin must be canonical loopback HTTP.");
+  }
+  options.webRequest.onHeadersReceived({ urls: [`${canonicalOrigin}/*`] }, (details, callback) => {
+    if (details.resourceType !== "mainFrame" || new URL(details.url).origin !== canonicalOrigin) {
+      callback({ responseHeaders: details.responseHeaders });
+      return;
+    }
+    const responseHeaders = Object.fromEntries(
+      Object.entries(details.responseHeaders ?? {}).filter(
+        ([name]) => name.toLowerCase() !== "content-security-policy",
+      ),
+    );
+    callback({
+      responseHeaders: {
+        ...responseHeaders,
+        "Content-Security-Policy": [options.contentSecurityPolicy()],
+      },
+    });
+  });
+  return () => options.webRequest.onHeadersReceived({ urls: [`${canonicalOrigin}/*`] }, null);
+}
+
+export { DESKTOP_PACKAGED_RENDERER_ENTRY_URL, DESKTOP_PACKAGED_RENDERER_ORIGIN };

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3843,13 +3843,17 @@ var init_application_shell_resource = __esm({
 
 // packages/contracts/src/desktop-host.ts
 import { z as z21 } from "zod";
-var DESKTOP_HOST_API_VERSION, DesktopRuntimeKindSchemaZ, DesktopPlatformSchemaZ, DesktopThemeModeSchemaZ, DesktopThemeStateSchemaZ, DesktopWindowStateSchemaZ, DesktopDaemonLoopbackUrlSchemaZ, DesktopDaemonHostDescriptorSchemaZ, DesktopDaemonHostIssueCodeSchemaZ, DesktopDaemonHostIssueSchemaFields, DesktopDaemonCapabilityIssueSchemaFields, DesktopDaemonHostStateSchemaZ, DesktopDaemonCapabilityStateSchemaZ, DesktopWorkspaceNameSchemaZ, DesktopDaemonCapabilityErrorCodeSchemaZ, DesktopDaemonCapabilityErrorSchemaZ, DesktopDaemonWorkspaceSummarySchemaZ, DesktopDaemonListWorkspacesResultSchemaZ, DesktopDaemonFetchApplicationShellRequestSchemaZ, DesktopApplicationShellTargetSchemaZ, DesktopDaemonFetchApplicationShellResultSchemaZ, DesktopDaemonEventSubscriptionRequestSchemaZ, DesktopDaemonSubscriptionIdSchemaZ, DesktopDaemonEventSchemaZ, DesktopDaemonDisconnectedCapabilityStateSchemaZ, DesktopDaemonConnectedCapabilityStateSchemaZ, DesktopDaemonRefreshConnectionResultSchemaZ, DesktopDaemonSubscribeWireResultSchemaZ, DesktopDaemonEventWireEnvelopeSchemaZ, DesktopHostBootstrapSchemaZ, DesktopMenuResultSchemaZ, DesktopDirectorySelectionSchemaZ;
+var DESKTOP_HOST_API_VERSION, DESKTOP_PACKAGED_RENDERER_SCHEME, DESKTOP_PACKAGED_RENDERER_HOST, DESKTOP_PACKAGED_RENDERER_ORIGIN, DESKTOP_PACKAGED_RENDERER_ENTRY_URL, DesktopRuntimeKindSchemaZ, DesktopPlatformSchemaZ, DesktopThemeModeSchemaZ, DesktopThemeStateSchemaZ, DesktopWindowStateSchemaZ, DesktopDaemonLoopbackUrlSchemaZ, DesktopDaemonHostDescriptorSchemaZ, DesktopDaemonHostIssueCodeSchemaZ, DesktopDaemonHostIssueSchemaFields, DesktopDaemonCapabilityIssueSchemaFields, DesktopDaemonHostStateSchemaZ, DesktopDaemonCapabilityStateSchemaZ, DesktopWorkspaceNameSchemaZ, DesktopDaemonCapabilityErrorCodeSchemaZ, DesktopDaemonCapabilityErrorSchemaZ, DesktopDaemonWorkspaceSummarySchemaZ, DesktopDaemonListWorkspacesResultSchemaZ, DesktopDaemonFetchApplicationShellRequestSchemaZ, DesktopApplicationShellTargetSchemaZ, DesktopDaemonFetchApplicationShellResultSchemaZ, DesktopDaemonEventSubscriptionRequestSchemaZ, DesktopDaemonSubscriptionIdSchemaZ, DesktopDaemonEventSchemaZ, DesktopDaemonDisconnectedCapabilityStateSchemaZ, DesktopDaemonConnectedCapabilityStateSchemaZ, DesktopDaemonRefreshConnectionResultSchemaZ, DesktopDaemonSubscribeWireResultSchemaZ, DesktopDaemonEventWireEnvelopeSchemaZ, DesktopHostBootstrapSchemaZ, DesktopMenuResultSchemaZ, DesktopDirectorySelectionSchemaZ;
 var init_desktop_host = __esm({
   "packages/contracts/src/desktop-host.ts"() {
     "use strict";
     init_application_shell_resource();
     init_daemon_wire();
     DESKTOP_HOST_API_VERSION = 5;
+    DESKTOP_PACKAGED_RENDERER_SCHEME = "tmux-ide";
+    DESKTOP_PACKAGED_RENDERER_HOST = "app";
+    DESKTOP_PACKAGED_RENDERER_ORIGIN = `${DESKTOP_PACKAGED_RENDERER_SCHEME}://${DESKTOP_PACKAGED_RENDERER_HOST}`;
+    DESKTOP_PACKAGED_RENDERER_ENTRY_URL = `${DESKTOP_PACKAGED_RENDERER_ORIGIN}/index.html`;
     DesktopRuntimeKindSchemaZ = z21.enum(["browser", "electron"]);
     DesktopPlatformSchemaZ = z21.enum(["darwin", "linux", "win32", "unknown"]);
     DesktopThemeModeSchemaZ = z21.enum(["light", "dark"]);

--- a/packages/contracts/src/desktop-host.ts
+++ b/packages/contracts/src/desktop-host.ts
@@ -13,6 +13,14 @@ import type {
 /** Versioned, deliberately narrow bridge exposed by a desktop host preload. */
 export const DESKTOP_HOST_API_VERSION = 5 as const;
 
+/** Stable tuple origin for the packaged, sandboxed Electron renderer. */
+export const DESKTOP_PACKAGED_RENDERER_SCHEME = "tmux-ide" as const;
+export const DESKTOP_PACKAGED_RENDERER_HOST = "app" as const;
+export const DESKTOP_PACKAGED_RENDERER_ORIGIN =
+  `${DESKTOP_PACKAGED_RENDERER_SCHEME}://${DESKTOP_PACKAGED_RENDERER_HOST}` as const;
+export const DESKTOP_PACKAGED_RENDERER_ENTRY_URL =
+  `${DESKTOP_PACKAGED_RENDERER_ORIGIN}/index.html` as const;
+
 export const DesktopRuntimeKindSchemaZ = z.enum(["browser", "electron"]);
 export const DesktopPlatformSchemaZ = z.enum(["darwin", "linux", "win32", "unknown"]);
 export const DesktopThemeModeSchemaZ = z.enum(["light", "dark"]);


### PR DESCRIPTION
## Summary
- serve the packaged Solid renderer from a privileged, standard tmux-ide app origin
- enforce a jailed asset handler, strict response-header CSP, and navigation/window-open policy
- keep dev/Vite and packaged daemon WebSocket origins exact while reconciling daemon endpoint drift

## Verification
- pnpm check
- Electron: 101 tests
- desktop renderer: 160 tests
- contracts: 154 tests
- packaged signed-app smoke
- independent review: 0 blockers / 0 majors / 0 minors