### PR TITLE
feat(desktop): compose live terminal canvas

### DIFF
--- a/apps/desktop-renderer/src/App.tsx
+++ b/apps/desktop-renderer/src/App.tsx
@@ -22,6 +22,7 @@ import {
   DesktopLiveApplication,
   type DesktopDaemonRecoveryPhase,
 } from "./runtime/live-app-composition.tsx";
+import { createHostNativeTerminalTransport } from "./runtime/host-terminal-transport.ts";
 import type { NativeTerminalTransport } from "./terminal/native-terminal-transport.ts";
 import type {
   PaneFrameActionIntent,
@@ -67,6 +68,10 @@ export function App(props: AppProps = {}) {
   let bootstrapRequest = 0;
   let daemonRefreshFlight: Promise<void> | null = null;
   let disposed = false;
+  let productionTerminalAuthority: {
+    readonly key: string;
+    readonly transport: NativeTerminalTransport;
+  } | null = null;
 
   const loadBootstrap = (): void => {
     if (!host || disposed) return;
@@ -142,6 +147,21 @@ export function App(props: AppProps = {}) {
   const terminalThemeKey = createMemo(() => {
     const current = effectiveTheme();
     return `${current?.mode ?? "system"}:${current?.highContrast ?? false}`;
+  });
+  const productionTerminalTransport = createMemo<NativeTerminalTransport | null>(() => {
+    const daemon = bootstrap()?.daemon;
+    if (!host || browserPreview || daemon?.status !== "connected") return null;
+    const identity = daemon.identity;
+    const key = [
+      identity.protocolVersion,
+      identity.productVersion,
+      identity.instanceId,
+      identity.startedAt,
+    ].join("\u0000");
+    if (productionTerminalAuthority?.key === key) return productionTerminalAuthority.transport;
+    const transport = createHostNativeTerminalTransport(host, identity);
+    productionTerminalAuthority = { key, transport };
+    return transport;
   });
 
   return (
@@ -255,7 +275,11 @@ export function App(props: AppProps = {}) {
                           platform={ready().platform}
                           windowState={effectiveWindow()}
                           daemonRecovery={daemonRecovery()}
-                          terminalTransport={props.terminalTransport}
+                          terminalTransport={
+                            props.terminalTransport === undefined
+                              ? productionTerminalTransport()
+                              : props.terminalTransport
+                          }
                           reducedMotion={experience().accessibility.reducedMotion}
                           terminalThemeKey={terminalThemeKey()}
                           onRetryDaemonConnection={refreshDaemonConnection}

--- a/apps/desktop-renderer/src/experience/application-shell.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.tsx
@@ -15,6 +15,7 @@ import {
   type PaneAppearance,
   type ProductSurfaceId,
   type SemanticFocusTarget,
+  type WorkspacePaneCreateInvocation,
   resolvePaneAppearance,
 } from "@tmux-ide/contracts";
 import {
@@ -45,6 +46,8 @@ import type {
   WorkbenchDockHostTabId,
 } from "../../../../packages/daemon/src/ui/workbench-dock/presenter.tsx";
 import { CommandPalette } from "./command-palette.tsx";
+import { CreatePaneFlow } from "./create-pane-flow.tsx";
+import type { CreatePaneFlowCatalogs } from "./create-pane-flow-presenter.ts";
 import { DomIcon } from "./dom-icon.tsx";
 import { TerminalSurface } from "../terminal/terminal-surface.tsx";
 import type { NativeTerminalTransport } from "../terminal/native-terminal-transport.ts";
@@ -79,6 +82,11 @@ export interface DomApplicationShellProps {
   readonly onCommand?: (invocation: ApplicationShellCommandInvocation) => void;
   readonly paneFrames?: readonly PaneFrameModel[];
   readonly terminalPanes?: readonly ApplicationShellTerminalPaneFrame[];
+  readonly createPaneFlow?: {
+    readonly catalogs: CreatePaneFlowCatalogs;
+    readonly initialWorkspaceName: string;
+    readonly onCommand: (invocation: WorkspacePaneCreateInvocation) => void | Promise<void>;
+  };
   readonly onPaneAction?: (
     intent: PaneFrameActionIntent,
     source: PaneFrameActivationSource,
@@ -189,6 +197,7 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
   );
   const [state, setState] = createSignal(createDomShellReplayState(input()));
   const [viewport, setViewport] = createSignal(initialViewport());
+  const [createPaneOpen, setCreatePaneOpen] = createSignal(false);
   let previousInput = input();
   let previousDataMode = dataMode();
   let returnFocusElement: HTMLElement | null = null;
@@ -513,6 +522,17 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
           }
         />
         <div class="titlebar__drag titlebar__spacer" />
+        <Show when={props.createPaneFlow}>
+          {(flow) => (
+            <CreatePaneFlow
+              open={createPaneOpen()}
+              catalogs={flow().catalogs}
+              initialWorkspaceName={flow().initialWorkspaceName}
+              onOpenChange={setCreatePaneOpen}
+              onCommand={flow().onCommand}
+            />
+          )}
+        </Show>
         <button
           class="palette-trigger"
           type="button"

--- a/apps/desktop-renderer/src/production-terminal-composition.test.tsx
+++ b/apps/desktop-renderer/src/production-terminal-composition.test.tsx
@@ -1,0 +1,384 @@
+/* @vitest-environment happy-dom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "solid-js/web";
+import {
+  APPLICATION_SHELL_RESOURCE_V2_VERSION,
+  ApplicationShellProjectionInputV2SchemaZ,
+  DESKTOP_HOST_API_VERSION,
+  type ApplicationShellProjectionInputV2,
+  type DaemonInstanceIdentity,
+  type DesktopDaemonEvent,
+  type HostCapabilities,
+} from "@tmux-ide/contracts";
+
+const terminalHarness = vi.hoisted(() => {
+  const generations: Array<{
+    daemon: DaemonInstanceIdentity;
+    connect: ReturnType<typeof vi.fn>;
+    attachment: { dispose: ReturnType<typeof vi.fn> };
+  }> = [];
+  const create = vi.fn((_host: unknown, daemon: DaemonInstanceIdentity) => {
+    const attachment = {
+      write: vi.fn(async () => ({ status: "ok" as const })),
+      resize: vi.fn(async () => ({ status: "ok" as const })),
+      dispose: vi.fn(),
+    };
+    const connect = vi.fn(async () => ({ status: "connected" as const, attachment }));
+    generations.push({ daemon, connect, attachment });
+    return { connect };
+  });
+  return { create, generations };
+});
+
+const xtermHarness = vi.hoisted(() => ({
+  create: vi.fn(() => ({
+    open: vi.fn(),
+    write: vi.fn(async () => undefined),
+    focus: vi.fn(),
+    fit: vi.fn(() => ({ cols: 80, rows: 24 })),
+    refreshTheme: vi.fn(),
+    setReducedMotion: vi.fn(),
+    onInput: vi.fn(() => ({ dispose: vi.fn() })),
+    dispose: vi.fn(),
+  })),
+}));
+
+vi.mock("./runtime/host-terminal-transport.ts", () => ({
+  createHostNativeTerminalTransport: terminalHarness.create,
+}));
+
+vi.mock("./terminal/xterm-renderer.ts", () => ({
+  createXtermRenderer: xtermHarness.create,
+}));
+
+import { App } from "./App.tsx";
+import { createDefaultDomShellInput } from "./experience/dom-shell.ts";
+
+const DAEMON_A: DaemonInstanceIdentity = {
+  protocolVersion: 1,
+  productVersion: "test-a",
+  instanceId: "00000000-0000-4000-8000-000000000001",
+  startedAt: "2026-07-22T00:00:00.000Z",
+};
+
+const DAEMON_B: DaemonInstanceIdentity = {
+  protocolVersion: 1,
+  productVersion: "test-b",
+  instanceId: "00000000-0000-4000-8000-000000000002",
+  startedAt: "2026-07-22T00:01:00.000Z",
+};
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: (value) => resolvePromise?.(value) };
+}
+
+function shellInput(extraTerminalId?: string): ApplicationShellProjectionInputV2 {
+  const base = createDefaultDomShellInput();
+  const agentResources = base.workspace.sidebar.agents.flatMap((agent) =>
+    agent.paneId
+      ? [
+          {
+            id: agent.paneId,
+            title: agent.name,
+            kind: "agent" as const,
+            active: false,
+            attachability: {
+              status: "unavailable" as const,
+              reason: "invalid-runtime-proof" as const,
+            },
+          },
+        ]
+      : [],
+  );
+  return ApplicationShellProjectionInputV2SchemaZ.parse({
+    ...base,
+    project: { ...base.project, name: "alpha", rootLabel: "alpha workspace" },
+    workspace: { ...base.workspace, name: "alpha" },
+    terminalInventory: {
+      activeResourceId: "pane.shell",
+      resources: [
+        ...agentResources,
+        {
+          id: "pane.shell",
+          title: "Project shell",
+          kind: "terminal",
+          active: true,
+          attachability: { status: "available", semanticPaneId: "pane.shell" },
+        },
+        {
+          id: "pane.logs",
+          title: "Logs shell",
+          kind: "terminal",
+          active: false,
+          attachability: { status: "available", semanticPaneId: "pane.logs" },
+        },
+        {
+          id: "pane.unavailable",
+          title: "Unavailable shell",
+          kind: "terminal",
+          active: false,
+          attachability: { status: "unavailable", reason: "invalid-runtime-proof" },
+        },
+        ...(extraTerminalId
+          ? [
+              {
+                id: extraTerminalId,
+                title: "Release shell",
+                kind: "terminal" as const,
+                active: false,
+                attachability: {
+                  status: "available" as const,
+                  semanticPaneId: extraTerminalId,
+                },
+              },
+            ]
+          : []),
+      ],
+    },
+  });
+}
+
+function createHostHarness() {
+  let daemon = DAEMON_A;
+  let resource = shellInput();
+  const subscriptions: Array<(event: DesktopDaemonEvent) => void> = [];
+  const host: HostCapabilities = {
+    apiVersion: DESKTOP_HOST_API_VERSION,
+    bootstrap: vi.fn(async () => ({
+      apiVersion: DESKTOP_HOST_API_VERSION,
+      runtime: "electron" as const,
+      platform: "linux" as const,
+      appVersion: "test",
+      theme: { mode: "dark" as const, highContrast: false, reducedMotion: false },
+      window: { maximized: false, fullscreen: false, focused: true },
+      daemon: { status: "connected" as const, identity: daemon },
+    })),
+    lifecycle: { requestQuit: async () => undefined },
+    window: {
+      getState: async () => ({ maximized: false, fullscreen: false, focused: true }),
+      minimize: async () => ({ maximized: false, fullscreen: false, focused: true }),
+      toggleMaximized: async () => ({ maximized: true, fullscreen: false, focused: true }),
+      close: async () => undefined,
+      onStateChanged: () => () => undefined,
+    },
+    menu: { showApplicationMenu: async () => ({ status: "unavailable" }) },
+    dialog: { selectProjectDirectory: async () => null },
+    theme: {
+      getState: async () => ({ mode: "dark", highContrast: false, reducedMotion: false }),
+      onChanged: () => () => undefined,
+    },
+    daemon: {
+      createWorkspacePane: vi.fn(async () => ({
+        status: "ok" as const,
+        result: {
+          operationId: "00000000-0000-4000-8000-000000000010",
+          daemonInstanceId: daemon.instanceId,
+          outcome: "created" as const,
+          resource: {
+            resourceVersion: 1 as const,
+            workspaceName: "alpha",
+            semanticPaneId: "pane.new",
+            displayTitle: "Release shell",
+            kind: "terminal" as const,
+            harnessProfileId: null,
+            role: null,
+            missionId: null,
+          },
+        },
+      })),
+      issueTerminalAttachment: vi.fn(async () => ({
+        status: "error" as const,
+        error: { code: "preview-only" as const, reason: "test transport", retryable: false },
+      })),
+      refreshConnection: vi.fn(async () => ({
+        outcome: "generation-replaced" as const,
+        previousIdentity: DAEMON_A,
+        daemon: { status: "connected" as const, identity: daemon },
+      })),
+      listWorkspaces: vi.fn(async () => ({
+        status: "ok" as const,
+        daemon,
+        workspaces: [{ workspaceName: "alpha" }],
+      })),
+      fetchApplicationShell: vi.fn(async () => ({
+        status: "ok" as const,
+        envelope: {
+          version: APPLICATION_SHELL_RESOURCE_V2_VERSION,
+          daemon,
+          resource,
+        },
+      })),
+      subscribe: vi.fn(async (_request, listener) => {
+        subscriptions.push(listener);
+        return { status: "subscribed" as const, unsubscribe: () => undefined };
+      }),
+    },
+  };
+  return {
+    host,
+    setDaemon(next: DaemonInstanceIdentity) {
+      daemon = next;
+    },
+    setResource(next: ApplicationShellProjectionInputV2) {
+      resource = next;
+    },
+    emit(event: DesktopDaemonEvent) {
+      for (const listener of subscriptions) listener(event);
+    },
+  };
+}
+
+class ResizeObserverHarness {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+function click(element: Element | null): void {
+  if (!(element instanceof HTMLElement)) throw new Error("Expected a clickable element.");
+  element.click();
+}
+
+beforeEach(() => {
+  terminalHarness.generations.length = 0;
+  vi.clearAllMocks();
+  vi.stubGlobal("ResizeObserver", ResizeObserverHarness);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    queueMicrotask(() => callback(1));
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.spyOn(window, "matchMedia").mockImplementation(
+    (query) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(() => true),
+      }) satisfies MediaQueryList,
+  );
+});
+
+afterEach(() => {
+  delete window.tmuxIdeHost;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  document.body.replaceChildren();
+});
+
+describe("production terminal composition", () => {
+  it("uses every available semantic inventory entry and never attaches unavailable panes", async () => {
+    const harness = createHostHarness();
+    window.tmuxIdeHost = harness.host;
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(() => <App />, root);
+
+    await vi.waitFor(() => expect(terminalHarness.generations).toHaveLength(1));
+    await vi.waitFor(() => expect(terminalHarness.generations[0]!.connect).toHaveBeenCalled());
+    const requests = terminalHarness.generations[0]!.connect.mock.calls.map(([request]) => request);
+    expect(requests.map((request) => request.target)).toContainEqual(
+      expect.objectContaining({ workspaceName: "alpha", semanticPaneId: "pane.shell" }),
+    );
+    expect(JSON.stringify(requests)).not.toMatch(/tmuxPaneId|sessionName|%\d+/u);
+    expect(root.querySelectorAll(".web-pane-frame").length).toBeGreaterThanOrEqual(3);
+    expect(root.querySelectorAll(".terminal-surface__viewport").length).toBeGreaterThanOrEqual(2);
+    expect(root.textContent).toContain("Logs shell");
+    expect(root.textContent).toContain("Unavailable shell");
+    expect(requests).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ target: { semanticPaneId: "pane.unavailable" } }),
+      ]),
+    );
+    dispose();
+  });
+
+  it("creates a terminal through the host and waits for an authoritative refresh before closing", async () => {
+    const harness = createHostHarness();
+    window.tmuxIdeHost = harness.host;
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(() => <App />, root);
+    await vi.waitFor(() => expect(root.querySelector("#create-pane-flow-trigger")).not.toBeNull());
+
+    const refreshed =
+      deferred<Awaited<ReturnType<HostCapabilities["daemon"]["fetchApplicationShell"]>>>();
+    vi.mocked(harness.host.daemon.fetchApplicationShell).mockReturnValueOnce(refreshed.promise);
+    click(root.querySelector("#create-pane-flow-trigger"));
+    click(
+      [...root.querySelectorAll(".create-pane-flow__kind-card")].find((item) =>
+        item.textContent?.includes("Terminal"),
+      ) ?? null,
+    );
+    const title = root.querySelector<HTMLInputElement>("#create-pane-flow-display-title")!;
+    title.value = "Release shell";
+    title.dispatchEvent(new Event("input", { bubbles: true }));
+    root
+      .querySelector<HTMLFormElement>(".create-pane-flow__form")!
+      .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await vi.waitFor(() => expect(harness.host.daemon.createWorkspacePane).toHaveBeenCalledOnce());
+    expect(root.querySelector(".create-pane-flow__overlay")?.getAttribute("aria-hidden")).toBe(
+      "false",
+    );
+    expect(harness.host.daemon.createWorkspacePane).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: { kind: "terminal", workspaceName: "alpha", displayTitle: "Release shell" },
+      }),
+    );
+
+    harness.setResource(shellInput("pane.new"));
+    refreshed.resolve({
+      status: "ok",
+      envelope: {
+        version: APPLICATION_SHELL_RESOURCE_V2_VERSION,
+        daemon: DAEMON_A,
+        resource: shellInput("pane.new"),
+      },
+    });
+    await vi.waitFor(() => expect(root.textContent).toContain("Release shell"));
+    await vi.waitFor(() =>
+      expect(root.querySelector(".create-pane-flow__overlay")?.getAttribute("aria-hidden")).toBe(
+        "true",
+      ),
+    );
+    expect(harness.host.daemon.fetchApplicationShell).toHaveBeenCalledTimes(2);
+    dispose();
+  });
+
+  it("retires terminal attachments and replaces transport authority on generation change", async () => {
+    const harness = createHostHarness();
+    window.tmuxIdeHost = harness.host;
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(() => <App />, root);
+    await vi.waitFor(() => expect(terminalHarness.generations).toHaveLength(1));
+    await vi.waitFor(() => expect(terminalHarness.generations[0]!.connect).toHaveBeenCalled());
+
+    harness.setDaemon(DAEMON_B);
+    harness.emit({
+      type: "daemon-generation.changed",
+      previousIdentity: DAEMON_A,
+      daemon: { status: "connected", identity: DAEMON_B },
+    });
+    await vi.waitFor(() => expect(terminalHarness.generations).toHaveLength(2));
+    expect(terminalHarness.generations.map(({ daemon }) => daemon.instanceId)).toEqual([
+      DAEMON_A.instanceId,
+      DAEMON_B.instanceId,
+    ]);
+    await vi.waitFor(() =>
+      expect(terminalHarness.generations[0]!.attachment.dispose).toHaveBeenCalled(),
+    );
+    dispose();
+  });
+});

--- a/apps/desktop-renderer/src/runtime/host-terminal-transport.test.ts
+++ b/apps/desktop-renderer/src/runtime/host-terminal-transport.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DaemonInstanceIdentity, HostCapabilities } from "@tmux-ide/contracts";
+import type { NativeTerminalWebSocketTransportDependencies } from "../terminal/native-terminal-websocket-transport.ts";
+
+const nativeFactory = vi.hoisted(() =>
+  vi.fn((_dependencies: NativeTerminalWebSocketTransportDependencies) => ({ connect: vi.fn() })),
+);
+
+vi.mock("../terminal/native-terminal-websocket-transport.ts", () => ({
+  createNativeTerminalWebSocketTransport: nativeFactory,
+}));
+
+import { createHostNativeTerminalTransport } from "./host-terminal-transport.ts";
+
+const DAEMON: DaemonInstanceIdentity = {
+  protocolVersion: 1,
+  productVersion: "2.8.0",
+  instanceId: "9bcf33b0-c837-4a94-b5e8-c0977f54464f",
+  startedAt: "2026-07-22T00:00:00.000Z",
+};
+
+const REQUEST = {
+  protocolVersion: 1 as const,
+  target: { workspaceName: "alpha", semanticPaneId: "pane.shell" },
+  viewerMode: "interactive" as const,
+  viewport: { cols: 80, rows: 24 },
+};
+
+function hostWithDescriptor(daemonInstanceId = DAEMON.instanceId) {
+  const issueTerminalAttachment = vi.fn(async () => ({
+    status: "issued" as const,
+    descriptor: {
+      protocolVersion: 1 as const,
+      webSocketUrl: "ws://127.0.0.1:6070/v1/terminal/attachments/redeem",
+      subprotocol: "tmux-ide-terminal.v1" as const,
+      redemptionTicket: `ta1_${"a".repeat(43)}`,
+      daemonInstanceId,
+      requestId: "2a215cf2-547e-42a2-91c7-454df8e56121",
+      expiresAt: Date.now() + 15_000,
+      effectiveViewerMode: "interactive" as const,
+    },
+  }));
+  return {
+    host: { daemon: { issueTerminalAttachment } } as unknown as Pick<HostCapabilities, "daemon">,
+    issueTerminalAttachment,
+  };
+}
+
+describe("HostCapabilities-backed native terminal transport", () => {
+  it("delegates semantic issuance to the reviewed host and unwraps the descriptor", async () => {
+    const { host, issueTerminalAttachment } = hostWithDescriptor();
+    createHostNativeTerminalTransport(host, DAEMON);
+    const dependencies = nativeFactory.mock.calls.at(-1)?.[0];
+    if (!dependencies) throw new Error("Expected native transport dependencies.");
+
+    await expect(dependencies.issueAttachment(REQUEST)).resolves.toMatchObject({
+      daemonInstanceId: DAEMON.instanceId,
+      requestId: "2a215cf2-547e-42a2-91c7-454df8e56121",
+    });
+    expect(issueTerminalAttachment).toHaveBeenCalledWith(REQUEST);
+    expect(JSON.stringify(issueTerminalAttachment.mock.calls)).not.toMatch(
+      /tmuxPaneId|sessionName|authorization/iu,
+    );
+  });
+
+  it("rejects host errors and descriptors from another daemon generation", async () => {
+    const mismatch = hostWithDescriptor("66ab67ed-18fe-431b-913b-70972b78c96f");
+    createHostNativeTerminalTransport(mismatch.host, DAEMON);
+    const mismatchDependencies = nativeFactory.mock.calls.at(-1)?.[0];
+    if (!mismatchDependencies) throw new Error("Expected mismatch transport dependencies.");
+    await expect(mismatchDependencies.issueAttachment(REQUEST)).rejects.toThrow(
+      "another daemon generation",
+    );
+
+    const host = {
+      daemon: {
+        issueTerminalAttachment: vi.fn(async () => ({
+          status: "error" as const,
+          error: {
+            code: "daemon-unavailable" as const,
+            reason: "The daemon is unavailable.",
+            retryable: true,
+          },
+        })),
+      },
+    } as unknown as Pick<HostCapabilities, "daemon">;
+    createHostNativeTerminalTransport(host, DAEMON);
+    const errorDependencies = nativeFactory.mock.calls.at(-1)?.[0];
+    if (!errorDependencies) throw new Error("Expected error transport dependencies.");
+    await expect(errorDependencies.issueAttachment(REQUEST)).rejects.toThrow(
+      "daemon is unavailable",
+    );
+  });
+});

--- a/apps/desktop-renderer/src/runtime/host-terminal-transport.ts
+++ b/apps/desktop-renderer/src/runtime/host-terminal-transport.ts
@@ -1,0 +1,31 @@
+import {
+  TerminalAttachmentIssueResultSchemaZ,
+  type DaemonInstanceIdentity,
+  type HostCapabilities,
+} from "@tmux-ide/contracts";
+
+import { createNativeTerminalWebSocketTransport } from "../terminal/native-terminal-websocket-transport.ts";
+import type { NativeTerminalTransport } from "../terminal/native-terminal-transport.ts";
+
+/**
+ * Production terminal authority adapter. The renderer authors only a semantic
+ * attachment request; the reviewed host capability owns daemon credentials,
+ * the attachment ticket, and the exact daemon-generation check.
+ */
+export function createHostNativeTerminalTransport(
+  host: Pick<HostCapabilities, "daemon">,
+  daemon: DaemonInstanceIdentity,
+): NativeTerminalTransport {
+  return createNativeTerminalWebSocketTransport({
+    issueAttachment: async (request) => {
+      const result = TerminalAttachmentIssueResultSchemaZ.parse(
+        await host.daemon.issueTerminalAttachment(request),
+      );
+      if (result.status === "error") throw new Error(result.error.reason);
+      if (result.descriptor.daemonInstanceId !== daemon.instanceId) {
+        throw new Error("The terminal attachment belongs to another daemon generation.");
+      }
+      return result.descriptor;
+    },
+  });
+}

--- a/apps/desktop-renderer/src/runtime/live-app-composition.tsx
+++ b/apps/desktop-renderer/src/runtime/live-app-composition.tsx
@@ -1,4 +1,5 @@
 import {
+  WorkspacePaneCreateHostResultSchemaZ,
   projectApplicationShellV1,
   type ApplicationShellCommandInvocation,
   type ApplicationShellProjectionInputV1,
@@ -7,8 +8,9 @@ import {
   type DesktopPlatform,
   type DesktopWindowState,
   type HostCapabilities,
+  type WorkspacePaneCreateInvocation,
 } from "@tmux-ide/contracts";
-import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
 import {
   paneFrameTerminalsFromApplicationShellInventory,
@@ -20,6 +22,7 @@ import type {
   PaneFrameGripIntent,
 } from "../../../../packages/daemon/src/ui/pane-frame/presenter.tsx";
 import { DomApplicationShell } from "../experience/application-shell.tsx";
+import type { CreatePaneFlowCatalogs } from "../experience/create-pane-flow-presenter.ts";
 import { DomIcon } from "../experience/dom-icon.tsx";
 import type { DesktopApplicationShellResourceState } from "./connection-state.ts";
 import { createSolidDesktopApplicationShellResourceStore } from "./desktop-resource-store.ts";
@@ -391,6 +394,114 @@ function LiveWorkspace(props: LiveWorkspaceProps) {
   });
   createEffect(() => store.setTarget(props.target));
 
+  const createPaneCatalogs = createMemo<CreatePaneFlowCatalogs>(() => {
+    const snapshot = props.catalogState.snapshot;
+    return {
+      workspaces: snapshot
+        ? {
+            status: "ready",
+            items: snapshot.workspaces.map(({ workspaceName }) => ({
+              name: workspaceName,
+              label: workspaceName,
+              available: workspaceName === props.target.workspaceName,
+            })),
+          }
+        : props.catalogState.status === "loading"
+          ? { status: "loading" }
+          : { status: "unavailable" },
+      // These catalogs do not yet exist as reviewed host resources. Keep the
+      // agent affordance visible but honestly unavailable until that card lands.
+      harnessProfiles: { status: "unavailable" },
+      missions: { status: "unavailable" },
+    };
+  });
+
+  let pendingRefresh: {
+    readonly semanticPaneId: string;
+    readonly daemonInstanceId: string;
+    readonly workspaceName: string;
+    readonly initialState: DesktopApplicationShellResourceState;
+    readonly resolve: () => void;
+    readonly reject: () => void;
+    readonly timer: ReturnType<typeof setTimeout>;
+  } | null = null;
+  let disposed = false;
+
+  const settlePendingRefresh = (outcome: "resolve" | "reject"): void => {
+    const pending = pendingRefresh;
+    if (!pending) return;
+    pendingRefresh = null;
+    clearTimeout(pending.timer);
+    pending[outcome]();
+  };
+
+  createEffect(() => {
+    const state = store.state();
+    const pending = pendingRefresh;
+    if (!pending || state === pending.initialState) return;
+    if (
+      props.target.daemon.instanceId !== pending.daemonInstanceId ||
+      props.target.workspaceName !== pending.workspaceName
+    ) {
+      settlePendingRefresh("reject");
+      return;
+    }
+    const data = resourceData(state);
+    if (data?.terminalInventory?.resources.some(({ id }) => id === pending.semanticPaneId)) {
+      settlePendingRefresh("resolve");
+      return;
+    }
+    if (state.status === "error" || state.status === "degraded") {
+      settlePendingRefresh("reject");
+    }
+  });
+
+  onCleanup(() => {
+    disposed = true;
+    settlePendingRefresh("reject");
+  });
+
+  const createWorkspacePane = async (invocation: WorkspacePaneCreateInvocation): Promise<void> => {
+    if (
+      disposed ||
+      pendingRefresh ||
+      invocation.args.workspaceName !== props.target.workspaceName
+    ) {
+      throw new Error("The selected workspace is not available for terminal creation.");
+    }
+    const result = WorkspacePaneCreateHostResultSchemaZ.parse(
+      await props.host.daemon.createWorkspacePane(invocation),
+    );
+    if (disposed) throw new Error("The active workspace changed during terminal creation.");
+    if (result.status === "error") {
+      if (result.error.code === "daemon-identity-mismatch") props.onDaemonIdentityMismatch?.();
+      throw new Error(result.error.reason);
+    }
+    if (
+      result.result.daemonInstanceId !== props.target.daemon.instanceId ||
+      result.result.resource.workspaceName !== props.target.workspaceName ||
+      result.result.resource.kind !== invocation.args.kind
+    ) {
+      props.onDaemonIdentityMismatch?.();
+      throw new Error("The created terminal does not belong to the active workspace generation.");
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      pendingRefresh = {
+        semanticPaneId: result.result.resource.semanticPaneId,
+        daemonInstanceId: props.target.daemon.instanceId,
+        workspaceName: props.target.workspaceName,
+        initialState: store.state(),
+        resolve,
+        reject: () => reject(new Error("The authoritative terminal inventory did not refresh.")),
+        timer: setTimeout(() => settlePendingRefresh("reject"), 8_000),
+      };
+      // Force a read in addition to the daemon event invalidation; the dialog
+      // closes only after that authoritative inventory contains the new pane.
+      store.refresh();
+    });
+  };
+
   const input = createMemo(() => resourceData(store.state()));
   const projection = createMemo<LiveWorkspaceProjection | null>(() => {
     const snapshot = input();
@@ -511,6 +622,11 @@ function LiveWorkspace(props: LiveWorkspaceProps) {
             terminalThemeKey={props.terminalThemeKey}
             onCommand={props.onCommand}
             terminalPanes={ready().terminalPanes}
+            createPaneFlow={{
+              catalogs: createPaneCatalogs(),
+              initialWorkspaceName: props.target.workspaceName,
+              onCommand: createWorkspacePane,
+            }}
             onPaneAction={props.onPaneAction}
             onPaneGrip={props.onPaneGrip}
           />


### PR DESCRIPTION
## Summary
- construct the native terminal WebSocket transport from real Electron host capabilities in production
- key transport ownership to the exact daemon generation and retire old attachments on replacement
- render every trusted V2 terminal inventory resource, including plain shell panes, on the terminal canvas
- mount Create Pane with the real workspace catalog and route terminal creation through the typed host action
- wait for authoritative inventory visibility before closing; keep agent catalogs honestly unavailable

## Verification
- full pnpm check
- desktop renderer: 171 tests
- focused composition/lifecycle: 57 tests
- Electron host/IPC lifecycle: 10 tests
- production Electron build
- independent review: 0 blockers / 0 majors / 0 minors