### PR TITLE
Unify TUI multiplexer actions with GUI

### DIFF
--- a/apps/desktop-renderer/docs/multiplexer-verbs/AUDIT.md
+++ b/apps/desktop-renderer/docs/multiplexer-verbs/AUDIT.md
@@ -1,5 +1,66 @@
 # m48 multiplexer-verb completeness audit
 
+> Historical note: the original audit below was the baseline that produced the
+> multiplexer-verb work. It is intentionally preserved as evidence, but its
+> reachability counts are no longer current. The current-main status is recorded
+> here first.
+
+## Current main — 2026-08-07
+
+The browser GUI now has an authoritative, versioned table of 15 multiplexer
+verbs in `packages/contracts/src/multiplexer-verbs.ts`. The browser uses that
+table for labels, descriptions, availability, menus, mutation dispatch, and
+feedback. The TUI command palette now consumes the same entries for the eight
+shared verbs it exposes instead of maintaining parallel copy and enablement
+rules.
+
+| Verb                 | Browser GUI                                                           | TUI                                    | Shared-contract status                                   |
+| -------------------- | --------------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------- |
+| `session.new`        | Open-directory flow; native picker is unavailable in browser-dev host | “Open folder…” flow                    | Separate entry points; shared execution is still pending |
+| `session.kill`       | Session menu, daemon-authorized, confirmed                            | Not exposed                            | Browser only                                             |
+| `session.rename`     | Inline session rename                                                 | Not exposed                            | Browser only                                             |
+| `session.detach`     | Client-local detach                                                   | Quit/detach key path                   | Same intent, not yet one command descriptor              |
+| `window.new`         | Pane chrome and menu                                                  | Palette: “New terminal or agent”       | Shared identity, copy, and availability                  |
+| `window.kill`        | Pane menu, confirmed                                                  | Palette: “Close window”, confirmed     | Shared identity, copy, and availability                  |
+| `window.rename`      | Pane menu and inline rename                                           | Palette query action                   | Shared identity, copy, and availability                  |
+| `window.zoom.toggle` | Pane menu and double-click                                            | Palette: “Zoom pane”                   | Shared identity, copy, and availability                  |
+| `pane.split.right`   | Pane menu                                                             | Palette: “Split right”                 | Shared identity, copy, and availability                  |
+| `pane.split.down`    | Pane menu                                                             | Palette: “Split down”                  | Shared identity, copy, and availability                  |
+| `pane.kill`          | Two-step armed close                                                  | Confirmation dialog                    | Shared identity, copy, and availability                  |
+| `pane.select`        | Click/focus and menu state                                            | Direct terminal focus                  | Native on both surfaces; not one descriptor              |
+| `pane.swap`          | Drag between pane chromes                                             | Palette: “Swap panes”                  | Shared identity, copy, and availability                  |
+| `pane.resize`        | Drag a tmux split border                                              | Mouse border drag                      | Shared intent; gesture paths remain surface-specific     |
+| `stack.activate`     | App-layout stack selection                                            | Not applicable to the native tmux grid | Deliberately browser-only                                |
+
+### Live acceptance evidence
+
+- Browser GUI and TUI were connected to the same real `new-name` session.
+- Browser pane chrome exposed the correct enabled and disabled verbs for the
+  selected pane. “Split right” created a seventh real tmux pane; the two-step
+  close action returned the workspace to six panes.
+- The updated TUI palette displayed “Split right” and “Split down” from the
+  shared contract. Executing “Split right” created pane `%230` in the selected
+  pane's current working directory; the acceptance pane was then removed and the
+  workspace returned to six panes.
+- Focused TUI tests cover shared verb mapping, contract-derived descriptions and
+  categories, last-pane/last-window availability, and dispatch gating.
+
+### Next architecture card
+
+The remaining important gap is execution authority. Browser verbs travel through
+the daemon's typed, owner-authorized mutation path; the TUI still translates its
+shared palette actions into raw tmux commands locally. Add a typed
+`MultiplexerVerbInvocation` client in the TUI and route the common eight verbs
+through the daemon dispatcher. Keep a narrowly-scoped local fallback only for
+standalone/offline use. This gives browser, TUI, and future native clients one
+authorization policy, one revision model, one event stream, and one source of
+truth for multi-client conflict handling.
+
+Multi-client geometry belongs in the same card. Attaching the TUI while the web
+client was open caused tmux to renegotiate the window to the smaller terminal
+size. Client viewport geometry must remain local view state; only an explicit,
+leased layout mutation should resize authoritative tmux panes.
+
 Reconnaissance for the GUI-first milestone. The scope call makes terminals the
 product, so the question this answers is narrow and literal: **which tmux verbs
 can a person perform with the mouse today, and does the app tell the truth about

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -4124,6 +4124,14 @@ try {
           hasPath: Boolean(editorPath()),
           readOnlyReason: editorReadOnly(),
         },
+        multiplexerFacts: {
+          workspaceConnected: mode() === "mirror" && mirror !== null,
+          sessionWindowCount: windowTabs().length,
+          windowPaneCount: panes().length,
+          windowZoomed: panes().some((pane) => pane.zoomed),
+          targetIsActivePane: true,
+          targetIsDockedStackMember: false,
+        },
         fallbackGroup: paletteQuery().trim() ? "Results" : "Commands",
       });
     });
@@ -4327,7 +4335,7 @@ try {
       applicationRootController.setDockMode(nextMode, source);
     const executeFocusCommand = (target: SemanticFocusTarget, source: CommandSource) =>
       applicationRootController.moveFocus(target, source);
-    const runPaletteAction = (a: PaletteAction) => {
+    const runPaletteAction = async (a: PaletteAction) => {
       // Usage history (M24.4): every dispatched action bumps its stable key —
       // count + lastUsed feed the "recent" group and the ranking tie-break.
       setPaletteUsage((u) =>
@@ -4435,7 +4443,15 @@ try {
         case "kill-window": {
           const idx = windowTabs().find((w) => w.active)?.index;
           if (idx !== undefined) {
-            void mirror?.command(`kill-window -t ${curTarget()}:${idx}`).catch(() => {});
+            const ok = await DialogConfirm.show({
+              title: "Close this window?",
+              body: "Closes every pane and process in the active tmux window.",
+              yesLabel: "Close window",
+              noLabel: "Keep window",
+              defaultNo: true,
+            });
+            if (!ok) break;
+            await mirror?.command(`kill-window -t ${curTarget()}:${idx}`).catch(() => {});
             setStatusNote("killed window");
           }
           break;
@@ -4449,6 +4465,42 @@ try {
           const pid = mirror?.focusedPane();
           if (pid) void mirror?.command(`swap-pane -D -t ${pid}`).catch(() => {});
           setStatusNote("swapped pane");
+          break;
+        }
+        case "split-pane-right": {
+          const pid = mirror?.focusedPane();
+          if (pid) {
+            void mirror
+              ?.command(`split-window -h -t ${pid} -c "#{pane_current_path}"`)
+              .catch(() => {});
+            setStatusNote("split pane right");
+          }
+          break;
+        }
+        case "split-pane-down": {
+          const pid = mirror?.focusedPane();
+          if (pid) {
+            void mirror
+              ?.command(`split-window -v -t ${pid} -c "#{pane_current_path}"`)
+              .catch(() => {});
+            setStatusNote("split pane down");
+          }
+          break;
+        }
+        case "kill-pane": {
+          const pid = mirror?.focusedPane();
+          if (pid) {
+            const ok = await DialogConfirm.show({
+              title: "Close this pane?",
+              body: "Closes the active tmux pane and the process running inside it.",
+              yesLabel: "Close pane",
+              noLabel: "Keep pane",
+              defaultNo: true,
+            });
+            if (!ok) break;
+            await mirror?.command(`kill-pane -t ${pid}`).catch(() => {});
+            setStatusNote("closed pane");
+          }
           break;
         }
         case "break-pane": {

--- a/packages/daemon/src/tui/mirror/palette-surface-adapter.test.ts
+++ b/packages/daemon/src/tui/mirror/palette-surface-adapter.test.ts
@@ -135,6 +135,42 @@ describe("live command palette adapter", () => {
     expect(executed).toEqual([quit]);
   });
 
+  it("uses the shared tmux availability rules for TUI pane and window verbs", () => {
+    const closePane: PaletteAction = { kind: "kill-pane", label: "Close pane" };
+    const splitRight: PaletteAction = { kind: "split-pane-right", label: "Split right" };
+    const closeWindow: PaletteAction = { kind: "kill-window", label: "Close window" };
+    const entries = adaptPaletteRowsToCommands(
+      [actionRow(closePane), actionRow(splitRight), actionRow(closeWindow)],
+      {
+        multiplexerFacts: {
+          workspaceConnected: true,
+          sessionWindowCount: 1,
+          windowPaneCount: 1,
+          windowZoomed: false,
+          targetIsActivePane: true,
+          targetIsDockedStackMember: false,
+        },
+      },
+    );
+
+    expect(entries[0]!.descriptor).toMatchObject({
+      category: "Pane",
+      icon: "close",
+      disabledReason: "this is the session's last pane",
+    });
+    expect(entries[1]!.descriptor).toMatchObject({
+      category: "Pane",
+      icon: "split-right",
+      disabledReason: null,
+    });
+    expect(entries[2]!.descriptor).toMatchObject({
+      category: "Window",
+      disabledReason: "this is the session's last window",
+    });
+    expect(paletteActionForCommand(entries, entries[0]!.id)).toBeNull();
+    expect(paletteActionForCommand(entries, entries[1]!.id)).toBe(splitRight);
+  });
+
   it.each([
     [
       "missing buffer",

--- a/packages/daemon/src/tui/mirror/palette-surface-adapter.ts
+++ b/packages/daemon/src/tui/mirror/palette-surface-adapter.ts
@@ -1,6 +1,12 @@
-import { CANONICAL_SURFACE_REGISTRY, type ProductSurfaceId } from "@tmux-ide/contracts";
+import {
+  CANONICAL_SURFACE_REGISTRY,
+  multiplexerVerb,
+  multiplexerVerbAvailability,
+  type MultiplexerVerbFacts,
+  type ProductSurfaceId,
+} from "@tmux-ide/contracts";
 import type { Tab } from "./app-state.ts";
-import type { PaletteAction, PaletteRow } from "./palette.ts";
+import { paletteMultiplexerVerbId, type PaletteAction, type PaletteRow } from "./palette.ts";
 import type {
   CommandPaletteDescriptor,
   CommandPaletteProjection,
@@ -14,6 +20,8 @@ export interface PaletteSurfaceAdapterContext {
   currentSession?: string | null;
   syncOn?: boolean;
   saveState?: PaletteSaveState;
+  /** Shared tmux facts used by both the browser menus and this TUI palette. */
+  multiplexerFacts?: MultiplexerVerbFacts;
   /** Return a reason to disable an otherwise offered action. */
   disabledReason?: (action: PaletteAction) => string | null | undefined;
   fallbackGroup?: string;
@@ -145,6 +153,12 @@ function iconForAction(action: PaletteAction): WorkspaceIconId {
     case "swap-pane":
     case "rotate-window":
       return "move";
+    case "split-pane-right":
+      return "split-right";
+    case "split-pane-down":
+      return "split-down";
+    case "kill-pane":
+      return "close";
     case "break-pane":
       return "split-right";
     case "select-layout":
@@ -158,6 +172,11 @@ function iconForAction(action: PaletteAction): WorkspaceIconId {
 }
 
 function categoryForAction(action: PaletteAction): string {
+  const verbId = paletteMultiplexerVerbId(action);
+  if (verbId) {
+    const scope = multiplexerVerb(verbId).scope;
+    return scope === "session" ? "Session" : scope === "window" ? "Window" : "Pane";
+  }
   switch (action.kind) {
     case "surface":
     case "tab":
@@ -187,6 +206,9 @@ function categoryForAction(action: PaletteAction): string {
     case "kill-window":
     case "zoom-pane":
     case "swap-pane":
+    case "split-pane-right":
+    case "split-pane-down":
+    case "kill-pane":
     case "break-pane":
     case "rotate-window":
     case "sync-toggle":
@@ -202,6 +224,8 @@ function categoryForAction(action: PaletteAction): string {
 }
 
 function detailForAction(action: PaletteAction): string {
+  const verbId = paletteMultiplexerVerbId(action);
+  if (verbId) return multiplexerVerb(verbId).description;
   switch (action.kind) {
     case "surface":
     case "tab":
@@ -244,6 +268,12 @@ function detailForAction(action: PaletteAction): string {
       return "Toggle focus on the active terminal pane";
     case "swap-pane":
       return "Swap the active pane with the next pane";
+    case "split-pane-right":
+      return "Split the active pane and place a new shell on its right";
+    case "split-pane-down":
+      return "Split the active pane and place a new shell below it";
+    case "kill-pane":
+      return "Close the active tmux pane";
     case "break-pane":
       return "Move the active pane into its own window";
     case "rotate-window":
@@ -288,6 +318,14 @@ function disabledReason(
 ): string | null {
   const explicit = context.disabledReason?.(action)?.trim();
   if (explicit) return explicit;
+  const verbId = paletteMultiplexerVerbId(action);
+  if (verbId && context.multiplexerFacts) {
+    const availability = multiplexerVerbAvailability(
+      multiplexerVerb(verbId),
+      context.multiplexerFacts,
+    );
+    if (!availability.available) return availability.reason;
+  }
   if (action.kind === "save" && context.saveState) {
     if (!context.saveState.hasBuffer || !context.saveState.hasPath) return "No file is open";
     if (context.saveState.readOnlyReason) return "File is read-only";

--- a/packages/daemon/src/tui/mirror/palette.test.ts
+++ b/packages/daemon/src/tui/mirror/palette.test.ts
@@ -11,6 +11,7 @@ import {
   PALETTE_RECENT_LIMIT,
   goToFileActions,
   GO_FILE_CAP,
+  paletteMultiplexerVerbId,
   type PaletteAction,
   type PaletteRow,
 } from "./palette.ts";
@@ -219,7 +220,15 @@ describe("filterPaletteActions", () => {
     expect(off).not.toContain("sync-toggle");
     const on = staticPaletteActions(["a"], { terminal: true });
     expect(on.map((x) => x.kind)).toEqual(
-      expect.arrayContaining(["swap-pane", "break-pane", "rotate-window", "sync-toggle"]),
+      expect.arrayContaining([
+        "swap-pane",
+        "split-pane-right",
+        "split-pane-down",
+        "kill-pane",
+        "break-pane",
+        "rotate-window",
+        "sync-toggle",
+      ]),
     );
     // One select-layout action per preset, carrying the layout name.
     const layouts = on.filter((x) => x.kind === "select-layout");
@@ -229,6 +238,23 @@ describe("filterPaletteActions", () => {
       "main-horizontal",
       "main-vertical",
       "tiled",
+    ]);
+  });
+
+  it("maps every shared TUI tmux action to the renderer-neutral verb table", () => {
+    const actions = staticPaletteActions(["a"], { terminal: true });
+    expect(
+      actions
+        .map((action) => paletteMultiplexerVerbId(action))
+        .filter((verbId): verbId is NonNullable<typeof verbId> => verbId !== null),
+    ).toEqual([
+      "window.new",
+      "window.kill",
+      "window.zoom.toggle",
+      "pane.swap",
+      "pane.split.right",
+      "pane.split.down",
+      "pane.kill",
     ]);
   });
 
@@ -467,7 +493,14 @@ describe("paletteRows (M24.4 — grouped empty query)", () => {
     const suggested = ls.slice(sug + 1, cmd);
     expect(suggested[0]).toBe("New agent: claude (again)");
     expect(suggested).toEqual(
-      expect.arrayContaining(["New window", "Zoom pane", "Swap pane with next"]),
+      expect.arrayContaining([
+        "New terminal or agent",
+        "Zoom pane",
+        "Swap panes",
+        "Split right",
+        "Split down",
+        "Close pane",
+      ]),
     );
   });
 

--- a/packages/daemon/src/tui/mirror/palette.ts
+++ b/packages/daemon/src/tui/mirror/palette.ts
@@ -12,7 +12,12 @@
  * to the top when the query looks like a path.
  */
 import { fuzzyFilter } from "../team/fuzzy.ts";
-import { CANONICAL_SURFACE_REGISTRY, type ProductSurfaceId } from "@tmux-ide/contracts";
+import {
+  CANONICAL_SURFACE_REGISTRY,
+  multiplexerVerb,
+  type MultiplexerVerbId,
+  type ProductSurfaceId,
+} from "@tmux-ide/contracts";
 import type { PaletteUsageEntry, Tab } from "./app-state.ts";
 import type { AgentRowInput } from "./agent-rows.ts";
 import type { HostedPanelView } from "./panel-host.ts";
@@ -52,6 +57,9 @@ export type PaletteAction =
   | { kind: "kill-window"; label: string }
   | { kind: "zoom-pane"; label: string }
   | { kind: "swap-pane"; label: string }
+  | { kind: "split-pane-right"; label: string }
+  | { kind: "split-pane-down"; label: string }
+  | { kind: "kill-pane"; label: string }
   | { kind: "break-pane"; label: string }
   | { kind: "rotate-window"; label: string }
   | { kind: "select-layout"; layout: string; label: string }
@@ -60,6 +68,44 @@ export type PaletteAction =
   | { kind: "resize-window"; label: string }
   | { kind: "settings"; id: SettingsCommandId; label: string }
   | { kind: "quit"; label: string };
+
+/**
+ * Join the OpenTUI palette to the renderer-neutral multiplexer contract.
+ *
+ * The TUI still owns presentation and execution, but it no longer invents the
+ * identity, copy, or availability rules for verbs that the browser also
+ * exposes. TUI-only power-user actions (rotate, layouts, break-pane, sync)
+ * deliberately return null until they become product-wide verbs.
+ */
+export function paletteMultiplexerVerbId(action: PaletteAction): MultiplexerVerbId | null {
+  switch (action.kind) {
+    case "new-window":
+      return "window.new";
+    case "rename-window":
+      return "window.rename";
+    case "kill-window":
+      return "window.kill";
+    case "zoom-pane":
+      return "window.zoom.toggle";
+    case "swap-pane":
+      return "pane.swap";
+    case "split-pane-right":
+      return "pane.split.right";
+    case "split-pane-down":
+      return "pane.split.down";
+    case "kill-pane":
+      return "pane.kill";
+    default:
+      return null;
+  }
+}
+
+function sharedVerbAction<Kind extends PaletteAction["kind"]>(
+  kind: Kind,
+  verbId: MultiplexerVerbId,
+): Extract<PaletteAction, { kind: Kind }> {
+  return { kind, label: multiplexerVerb(verbId).label } as Extract<PaletteAction, { kind: Kind }>;
+}
 
 /** The five tmux `select-layout` presets, offered one palette action each so the
  *  fuzzy filter finds "tiled" / "main-vertical" directly. Shared with the pane
@@ -209,10 +255,13 @@ export function staticPaletteActions(
     // belongs to the pane — agents' slash commands); this is the always-there
     // entry.
     actions.push({ kind: "search-scrollback", label: "Search scrollback" });
-    actions.push({ kind: "new-window", label: "New window" });
-    actions.push({ kind: "kill-window", label: "Kill window" });
-    actions.push({ kind: "zoom-pane", label: "Zoom pane" });
-    actions.push({ kind: "swap-pane", label: "Swap pane with next" });
+    actions.push(sharedVerbAction("new-window", "window.new"));
+    actions.push(sharedVerbAction("kill-window", "window.kill"));
+    actions.push(sharedVerbAction("zoom-pane", "window.zoom.toggle"));
+    actions.push(sharedVerbAction("swap-pane", "pane.swap"));
+    actions.push(sharedVerbAction("split-pane-right", "pane.split.right"));
+    actions.push(sharedVerbAction("split-pane-down", "pane.split.down"));
+    actions.push(sharedVerbAction("kill-pane", "pane.kill"));
     actions.push({ kind: "break-pane", label: "Break pane to window" });
     actions.push({ kind: "rotate-window", label: "Rotate panes" });
     actions.push({ kind: "sync-toggle", label: "Synchronize panes (toggle)" });
@@ -465,6 +514,9 @@ const TERMINAL_SUGGESTED_KINDS: ReadonlyArray<PaletteAction["kind"]> = [
   "kill-window",
   "zoom-pane",
   "swap-pane",
+  "split-pane-right",
+  "split-pane-down",
+  "kill-pane",
   "break-pane",
   "rotate-window",
 ];


### PR DESCRIPTION
## Summary
- derive TUI palette labels, descriptions, categories, and availability from the shared multiplexer verb contract
- add Split right, Split down, and safely confirmed Close pane/window actions to the TUI
- document current browser/TUI parity and the remaining daemon-authority and multi-client geometry cards

## Verification
- pnpm check
- live browser split + two-step close against the real new-name session
- live TUI Split right against the same session; acceptance pane removed afterward