### PR TITLE
Route TUI multiplexer actions through daemon

### DIFF
--- a/apps/desktop-renderer/docs/multiplexer-verbs/AUDIT.md
+++ b/apps/desktop-renderer/docs/multiplexer-verbs/AUDIT.md
@@ -12,23 +12,27 @@ verbs in `packages/contracts/src/multiplexer-verbs.ts`. The browser uses that
 table for labels, descriptions, availability, menus, mutation dispatch, and
 feedback. The TUI command palette now consumes the same entries for the eight
 shared verbs it exposes instead of maintaining parallel copy and enablement
-rules.
+rules. Palette and context-menu mutations now resolve the daemon's
+generation-stamped session-to-workspace catalog and durable pane identities,
+then use the same owner-gated action dispatcher as the browser. Raw control-mode
+tmux remains only as a standalone fallback when no canonical daemon is alive;
+live-daemon refusals fail closed and appear in the TUI status line.
 
 | Verb                 | Browser GUI                                                           | TUI                                    | Shared-contract status                                   |
 | -------------------- | --------------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------- |
 | `session.new`        | Open-directory flow; native picker is unavailable in browser-dev host | “Open folder…” flow                    | Separate entry points; shared execution is still pending |
-| `session.kill`       | Session menu, daemon-authorized, confirmed                            | Not exposed                            | Browser only                                             |
-| `session.rename`     | Inline session rename                                                 | Not exposed                            | Browser only                                             |
+| `session.kill`       | Session menu, daemon-authorized, confirmed                            | Session context menu                   | Shared daemon execution and feedback                     |
+| `session.rename`     | Inline session rename                                                 | Session context menu                   | Shared daemon execution and feedback                     |
 | `session.detach`     | Client-local detach                                                   | Quit/detach key path                   | Same intent, not yet one command descriptor              |
-| `window.new`         | Pane chrome and menu                                                  | Palette: “New terminal or agent”       | Shared identity, copy, and availability                  |
-| `window.kill`        | Pane menu, confirmed                                                  | Palette: “Close window”, confirmed     | Shared identity, copy, and availability                  |
-| `window.rename`      | Pane menu and inline rename                                           | Palette query action                   | Shared identity, copy, and availability                  |
-| `window.zoom.toggle` | Pane menu and double-click                                            | Palette: “Zoom pane”                   | Shared identity, copy, and availability                  |
-| `pane.split.right`   | Pane menu                                                             | Palette: “Split right”                 | Shared identity, copy, and availability                  |
-| `pane.split.down`    | Pane menu                                                             | Palette: “Split down”                  | Shared identity, copy, and availability                  |
-| `pane.kill`          | Two-step armed close                                                  | Confirmation dialog                    | Shared identity, copy, and availability                  |
+| `window.new`         | Pane chrome and menu                                                  | Palette and window context menu        | Shared daemon execution and feedback                     |
+| `window.kill`        | Pane menu, confirmed                                                  | Palette/context menu, confirmed        | Shared daemon execution and feedback                     |
+| `window.rename`      | Pane menu and inline rename                                           | Palette query and context menu         | Shared daemon execution and feedback                     |
+| `window.zoom.toggle` | Pane menu and double-click                                            | Palette and pane context menu          | Shared daemon execution and feedback                     |
+| `pane.split.right`   | Pane menu                                                             | Palette and pane context menu          | Shared daemon execution and feedback                     |
+| `pane.split.down`    | Pane menu                                                             | Palette and pane context menu          | Shared daemon execution and feedback                     |
+| `pane.kill`          | Two-step armed close                                                  | Confirmation/context-menu arming       | Shared daemon execution and feedback                     |
 | `pane.select`        | Click/focus and menu state                                            | Direct terminal focus                  | Native on both surfaces; not one descriptor              |
-| `pane.swap`          | Drag between pane chromes                                             | Palette: “Swap panes”                  | Shared identity, copy, and availability                  |
+| `pane.swap`          | Drag between pane chromes                                             | Palette and pane context menu          | Shared daemon execution and feedback                     |
 | `pane.resize`        | Drag a tmux split border                                              | Mouse border drag                      | Shared intent; gesture paths remain surface-specific     |
 | `stack.activate`     | App-layout stack selection                                            | Not applicable to the native tmux grid | Deliberately browser-only                                |
 
@@ -42,24 +46,32 @@ rules.
   shared contract. Executing “Split right” created pane `%230` in the selected
   pane's current working directory; the acceptance pane was then removed and the
   workspace returned to six panes.
+- The daemon-first TUI adapter was then exercised against a restarted canonical
+  daemon. Two split invocations created durable `pane.<operation-id>` stamps;
+  typed pane-kill invocations removed both acceptance panes and returned
+  `new-name` to six panes.
+- A disposable one-window workspace exercised the destructive refusal path.
+  `workspace.window.kill` returned `last_window_refused`, the tmux session
+  remained alive, and the local fallback spy was never called. The disposable
+  registry entry and session were removed afterwards.
 - Focused TUI tests cover shared verb mapping, contract-derived descriptions and
-  categories, last-pane/last-window availability, and dispatch gating.
+  categories, catalog/generation correlation, stable owner-operation retries,
+  offline-only fallback, semantic swaps, last-pane/last-window availability,
+  and dispatch gating.
 
 ### Next architecture card
 
-The remaining important gap is execution authority. Browser verbs travel through
-the daemon's typed, owner-authorized mutation path; the TUI still translates its
-shared palette actions into raw tmux commands locally. Add a typed
-`MultiplexerVerbInvocation` client in the TUI and route the common eight verbs
-through the daemon dispatcher. Keep a narrowly-scoped local fallback only for
-standalone/offline use. This gives browser, TUI, and future native clients one
-authorization policy, one revision model, one event stream, and one source of
-truth for multi-client conflict handling.
-
-Multi-client geometry belongs in the same card. Attaching the TUI while the web
+Multi-client geometry is now the important remaining durability gap. Attaching the TUI while the web
 client was open caused tmux to renegotiate the window to the smaller terminal
 size. Client viewport geometry must remain local view state; only an explicit,
 leased layout mutation should resize authoritative tmux panes.
+
+The TUI currently discovers durable descriptors for the active window only.
+That is sufficient for its pane canvas and palette, but an inactive window's
+context-menu rename/close cannot safely produce a semantic target. The UI now
+asks the user to open that window first. A session-wide semantic window catalog
+would remove that limitation without reintroducing runtime `@window` ids at the
+client boundary.
 
 Reconnaissance for the GUI-first milestone. The scope call makes terminals the
 product, so the question this answers is narrow and literal: **which tmux verbs

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -32594,15 +32594,6 @@ var init_control_channel = __esm({
       get inputErrorCount() {
         return this.core.inputErrorCount;
       }
-      /** TESTS ONLY — stop draining tmux's stdout to simulate a stalled renderer
-       *  (the flood/%pause live scenario). */
-      stallReaderForTest() {
-        this.proc?.stdout?.pause();
-      }
-      /** TESTS ONLY — resume the stalled reader. */
-      resumeReaderForTest() {
-        this.proc?.stdout?.resume();
-      }
       /**
        * Detach-before-kill hygiene: resume a stalled reader (the server must be
        * able to flush), ask tmux to detach us, and drain until the process exits;
@@ -41915,7 +41906,7 @@ function expectedDaemonVersion() {
     return "0.0.0";
   }
 }
-async function resolveCanonicalDaemon() {
+async function resolveCanonicalDaemon(options) {
   const existing = deps.readCanonicalDaemonInfo();
   if (existing) {
     if (await deps.isCanonicalDaemonAlive(existing)) {
@@ -41928,7 +41919,7 @@ async function resolveCanonicalDaemon() {
       };
     }
   }
-  if (process.env.TMUX_IDE_CLI_NO_AUTOSTART) {
+  if (!options.autostart || process.env.TMUX_IDE_CLI_NO_AUTOSTART) {
     return null;
   }
   const dir = deps.cwd();
@@ -41964,7 +41955,7 @@ async function tryDispatchAction(name, input, options = {}) {
   const dir = options.cwd ?? deps.cwd();
   const previousDeps = deps;
   deps = { ...deps, cwd: () => dir };
-  const daemon = await resolveCanonicalDaemon();
+  const daemon = await resolveCanonicalDaemon({ autostart: options.autostart ?? true });
   deps = previousDeps;
   if (!daemon) return null;
   const contract = ActionContractsZ[name];
@@ -42027,7 +42018,16 @@ var init_cli_action_bridge = __esm({
     });
     RETRY_SAFE_OWNER_ACTIONS = /* @__PURE__ */ new Set([
       "workspace.pane.create",
-      "workspace.open"
+      "workspace.open",
+      "workspace.window.split",
+      "workspace.window.kill",
+      "workspace.pane.kill",
+      "workspace.session.kill",
+      "workspace.rename",
+      "workspace.pane.zoom.toggle",
+      "workspace.pane.select",
+      "workspace.pane.swap",
+      "workspace.pane.resize"
     ]);
     deps = {
       fetch,

--- a/packages/daemon/src/lib/cli-action-bridge.test.ts
+++ b/packages/daemon/src/lib/cli-action-bridge.test.ts
@@ -9,6 +9,87 @@ const OPERATION = "10000000-0000-4000-8000-000000000001";
 const INSTANCE = "20000000-0000-4000-8000-000000000002";
 
 describe("CLI owner action bridge", () => {
+  it("does not autostart a daemon when an interactive caller requests canonical-only dispatch", async () => {
+    const startEmbeddedDaemon = vi.fn();
+    const restore = __setCliActionBridgeDepsForTests({
+      readCanonicalDaemonInfo: () => null,
+      startEmbeddedDaemon,
+    });
+    try {
+      await expect(
+        tryDispatchAction(
+          "workspace.window.split",
+          {
+            workspaceName: "workspace.alpha",
+            semanticPaneId: "pane.source",
+            direction: "right",
+          },
+          { operationId: OPERATION, autostart: false },
+        ),
+      ).resolves.toBeNull();
+    } finally {
+      restore();
+    }
+    expect(startEmbeddedDaemon).not.toHaveBeenCalled();
+  });
+
+  it("gives multiplexer verbs one stable owner operation id across retry", async () => {
+    const canonical: CanonicalDaemonInfo = {
+      pid: process.pid,
+      port: 6060,
+      protocolVersion: DAEMON_WIRE_PROTOCOL_VERSION,
+      productVersion: "2.8.0",
+      instanceId: INSTANCE,
+      startedAt: "2026-07-22T00:00:00.000Z",
+      bindHostname: "127.0.0.1",
+      authToken: "owner-only-token",
+    };
+    const requests: RequestInit[] = [];
+    const fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(init ?? {});
+      if (requests.length === 1) throw new Error("connection closed after commit");
+      return Response.json({
+        ok: true,
+        result: {
+          operationId: OPERATION,
+          daemonInstanceId: INSTANCE,
+          outcome: "replayed",
+          workspaceName: "workspace.alpha",
+          verb: "workspace.window.split",
+          direction: "right",
+          semanticPaneId: "pane.created",
+          displayTitle: "Terminal",
+        },
+      });
+    });
+    const restore = __setCliActionBridgeDepsForTests({
+      fetch: fetch as typeof globalThis.fetch,
+      readCanonicalDaemonInfo: () => canonical,
+      isCanonicalDaemonAlive: async () => true,
+    });
+    try {
+      await expect(
+        tryDispatchAction(
+          "workspace.window.split",
+          {
+            workspaceName: "workspace.alpha",
+            semanticPaneId: "pane.source",
+            direction: "right",
+          },
+          { operationId: OPERATION, autostart: false },
+        ),
+      ).resolves.toMatchObject({ outcome: "replayed", operationId: OPERATION });
+    } finally {
+      restore();
+    }
+    expect(requests).toHaveLength(2);
+    for (const request of requests) {
+      const headers = new Headers(request.headers);
+      expect(headers.get("authorization")).toBe("Bearer owner-only-token");
+      expect(headers.get("x-tmux-ide-operation-id")).toBe(OPERATION);
+    }
+  });
+
   it("uses the owner-only token and one stable operation id across retry", async () => {
     const canonical: CanonicalDaemonInfo = {
       pid: process.pid,

--- a/packages/daemon/src/lib/cli-action-bridge.ts
+++ b/packages/daemon/src/lib/cli-action-bridge.ts
@@ -40,6 +40,15 @@ const FailureEnvelopeZ = z.object({
 const RETRY_SAFE_OWNER_ACTIONS: ReadonlySet<ActionName> = new Set([
   "workspace.pane.create",
   "workspace.open",
+  "workspace.window.split",
+  "workspace.window.kill",
+  "workspace.pane.kill",
+  "workspace.session.kill",
+  "workspace.rename",
+  "workspace.pane.zoom.toggle",
+  "workspace.pane.select",
+  "workspace.pane.swap",
+  "workspace.pane.resize",
 ]);
 
 interface CliActionBridgeDeps {
@@ -114,7 +123,7 @@ function expectedDaemonVersion(): string {
   }
 }
 
-async function resolveCanonicalDaemon(): Promise<{
+async function resolveCanonicalDaemon(options: { autostart: boolean }): Promise<{
   baseUrl: string;
   ownerToken: string | null;
   transientHandle: EmbeddedDaemonHandle | null;
@@ -140,7 +149,7 @@ async function resolveCanonicalDaemon(): Promise<{
   // exercise the local-mutation fallback path; without this guard a
   // single `tmux-ide config enable-team` in a fixture dir would start a
   // full embedded daemon and never tear it down in time.
-  if (process.env.TMUX_IDE_CLI_NO_AUTOSTART) {
+  if (!options.autostart || process.env.TMUX_IDE_CLI_NO_AUTOSTART) {
     return null;
   }
 
@@ -181,12 +190,12 @@ async function stopTransientDaemon(daemon: {
 export async function tryDispatchAction<Name extends ActionName>(
   name: Name,
   input: ActionInput<Name>,
-  options: { cwd?: string; operationId?: string } = {},
+  options: { cwd?: string; operationId?: string; autostart?: boolean } = {},
 ): Promise<ActionResult<Name> | null> {
   const dir = options.cwd ?? deps.cwd();
   const previousDeps = deps;
   deps = { ...deps, cwd: () => dir };
-  const daemon = await resolveCanonicalDaemon();
+  const daemon = await resolveCanonicalDaemon({ autostart: options.autostart ?? true });
   deps = previousDeps;
   if (!daemon) return null;
 

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -319,6 +319,10 @@ import {
   type TmuxBuffer,
 } from "./palette.ts";
 import {
+  executeTuiMultiplexerAction,
+  type TuiMultiplexerAction,
+} from "./multiplexer-action-executor.ts";
+import {
   adaptPaletteRowsToCommands,
   appendPalettePaste,
   dispatchPaletteCommand,
@@ -4335,6 +4339,29 @@ try {
       applicationRootController.setDockMode(nextMode, source);
     const executeFocusCommand = (target: SemanticFocusTarget, source: CommandSource) =>
       applicationRootController.moveFocus(target, source);
+    const executeSharedMultiplexerAction = async (
+      action: TuiMultiplexerAction,
+      target: { sessionName?: string; runtimePaneId?: string | null } = {},
+    ) => {
+      const activeMirror = mirror;
+      if (!activeMirror) {
+        setStatusNote("no active tmux workspace");
+        return;
+      }
+      const result = await executeTuiMultiplexerAction(
+        action,
+        {
+          sessionName: target.sessionName ?? curTarget(),
+          focusedRuntimePaneId:
+            target.runtimePaneId === undefined
+              ? activeMirror.focusedPane() || null
+              : target.runtimePaneId,
+          paneDescriptors: activeMirror.paneDescriptors(),
+        },
+        (command) => activeMirror.command(command),
+      );
+      setStatusNote(result.message);
+    };
     const runPaletteAction = async (a: PaletteAction) => {
       // Usage history (M24.4): every dispatched action bumps its stable key —
       // count + lastUsed feed the "recent" group and the ranking tie-break.
@@ -4427,80 +4454,45 @@ try {
           else enterDiff(workspaceDir());
           break;
         case "new-window":
-          void mirror?.command(`new-window -t ${curTarget()}:`).catch(() => {});
-          setStatusNote("new window");
+          await executeSharedMultiplexerAction(a);
           break;
-        case "rename-window": {
-          const idx = windowTabs().find((w) => w.active)?.index;
-          if (idx !== undefined) {
-            void mirror
-              ?.command(`rename-window -t ${curTarget()}:${idx} ${tmuxQuote(a.name)}`)
-              .catch(() => {});
-            setStatusNote(`renamed window → ${a.name}`);
-          }
+        case "rename-window":
+          await executeSharedMultiplexerAction(a);
           break;
-        }
         case "kill-window": {
-          const idx = windowTabs().find((w) => w.active)?.index;
-          if (idx !== undefined) {
-            const ok = await DialogConfirm.show({
-              title: "Close this window?",
-              body: "Closes every pane and process in the active tmux window.",
-              yesLabel: "Close window",
-              noLabel: "Keep window",
-              defaultNo: true,
-            });
-            if (!ok) break;
-            await mirror?.command(`kill-window -t ${curTarget()}:${idx}`).catch(() => {});
-            setStatusNote("killed window");
-          }
+          const ok = await DialogConfirm.show({
+            title: "Close this window?",
+            body: "Closes every pane and process in the active tmux window.",
+            yesLabel: "Close window",
+            noLabel: "Keep window",
+            defaultNo: true,
+          });
+          if (!ok) break;
+          await executeSharedMultiplexerAction(a);
           break;
         }
-        case "zoom-pane": {
-          const pid = mirror?.focusedPane();
-          if (pid) void mirror?.command(`resize-pane -Z -t ${pid}`).catch(() => {});
+        case "zoom-pane":
+          await executeSharedMultiplexerAction(a);
           break;
-        }
-        case "swap-pane": {
-          const pid = mirror?.focusedPane();
-          if (pid) void mirror?.command(`swap-pane -D -t ${pid}`).catch(() => {});
-          setStatusNote("swapped pane");
+        case "swap-pane":
+          await executeSharedMultiplexerAction(a);
           break;
-        }
-        case "split-pane-right": {
-          const pid = mirror?.focusedPane();
-          if (pid) {
-            void mirror
-              ?.command(`split-window -h -t ${pid} -c "#{pane_current_path}"`)
-              .catch(() => {});
-            setStatusNote("split pane right");
-          }
+        case "split-pane-right":
+          await executeSharedMultiplexerAction(a);
           break;
-        }
-        case "split-pane-down": {
-          const pid = mirror?.focusedPane();
-          if (pid) {
-            void mirror
-              ?.command(`split-window -v -t ${pid} -c "#{pane_current_path}"`)
-              .catch(() => {});
-            setStatusNote("split pane down");
-          }
+        case "split-pane-down":
+          await executeSharedMultiplexerAction(a);
           break;
-        }
         case "kill-pane": {
-          const pid = mirror?.focusedPane();
-          if (pid) {
-            const ok = await DialogConfirm.show({
-              title: "Close this pane?",
-              body: "Closes the active tmux pane and the process running inside it.",
-              yesLabel: "Close pane",
-              noLabel: "Keep pane",
-              defaultNo: true,
-            });
-            if (!ok) break;
-            await mirror?.command(`kill-pane -t ${pid}`).catch(() => {});
-            setStatusNote("closed pane");
-          }
+          const ok = await DialogConfirm.show({
+            title: "Close this pane?",
+            body: "Closes the active tmux pane and the process running inside it.",
+            yesLabel: "Close pane",
+            noLabel: "Keep pane",
+            defaultNo: true,
+          });
+          if (!ok) break;
+          await executeSharedMultiplexerAction(a);
           break;
         }
         case "break-pane": {
@@ -5802,18 +5794,18 @@ try {
           return;
         }
         if (id === "kill") {
-          execFile("tmux", ["kill-session", "-t", name], () =>
-            setTimeout(() => fleetRefresh?.(), 200),
-          );
-          setStatusNote(`killed ${name}`);
           closeMenu();
+          void executeSharedMultiplexerAction(
+            { kind: "kill-session" },
+            { sessionName: name, runtimePaneId: null },
+          ).then(() => setTimeout(() => fleetRefresh?.(), 200));
           return;
         }
         if (id === "rename" && val) {
-          execFile("tmux", ["rename-session", "-t", name, val], () =>
-            setTimeout(() => fleetRefresh?.(), 200),
-          );
-          setStatusNote(`renamed ${name} → ${val}`);
+          void executeSharedMultiplexerAction(
+            { kind: "rename-session", name: val },
+            { sessionName: name, runtimePaneId: null },
+          ).then(() => setTimeout(() => fleetRefresh?.(), 200));
         }
         closeMenu();
         return;
@@ -5863,17 +5855,21 @@ try {
         return;
       }
       if (m.region === "window") {
-        const sess = curTarget();
         const idx = m.windowIndex;
         if (id === "new") {
-          void mirror?.command(`new-window -t ${sess}:`).catch(() => {});
-          setStatusNote("new window");
+          void executeSharedMultiplexerAction({ kind: "new-window" });
         } else if (id === "rename" && val && idx !== undefined) {
-          void mirror?.command(`rename-window -t ${sess}:${idx} ${tmuxQuote(val)}`).catch(() => {});
-          setStatusNote(`renamed window → ${val}`);
+          if (windowTabs().find((window) => window.index === idx)?.active) {
+            void executeSharedMultiplexerAction({ kind: "rename-window", name: val });
+          } else {
+            setStatusNote("open that window before renaming it");
+          }
         } else if (id === "kill" && idx !== undefined) {
-          void mirror?.command(`kill-window -t ${sess}:${idx}`).catch(() => {});
-          setStatusNote("killed window");
+          if (windowTabs().find((window) => window.index === idx)?.active) {
+            void executeSharedMultiplexerAction({ kind: "kill-window" });
+          } else {
+            setStatusNote("open that window before closing it");
+          }
         }
         closeMenu();
         return;
@@ -5922,25 +5918,32 @@ try {
           closeMenu();
           return;
         }
-        const cmd =
+        const sharedAction: TuiMultiplexerAction | null =
           id === "split-h"
-            ? `split-window -h -t ${pid}`
+            ? { kind: "split-pane-right" }
             : id === "split-v"
-              ? `split-window -v -t ${pid}`
+              ? { kind: "split-pane-down" }
               : id === "zoom"
-                ? `resize-pane -Z -t ${pid}`
+                ? { kind: "zoom-pane" }
                 : id === "swap-next"
-                  ? `swap-pane -D -t ${pid}`
-                  : id === "break"
-                    ? // Pin the destination to THIS session — break-pane's default
-                      // `-t` resolves to the globally-active client's session, which
-                      // could fling the pane into an unrelated session.
-                      `break-pane -s ${pid} -t ${curTarget()}:`
-                    : id === "rotate"
-                      ? `rotate-window -t ${pid}`
-                      : id === "kill"
-                        ? `kill-pane -t ${pid}`
-                        : "";
+                  ? { kind: "swap-pane" }
+                  : id === "kill"
+                    ? { kind: "kill-pane" }
+                    : null;
+        if (sharedAction) {
+          closeMenu();
+          void executeSharedMultiplexerAction(sharedAction, { runtimePaneId: pid });
+          return;
+        }
+        const cmd =
+          id === "break"
+            ? // Pin the destination to THIS session — break-pane's default
+              // `-t` resolves to the globally-active client's session, which
+              // could fling the pane into an unrelated session.
+              `break-pane -s ${pid} -t ${curTarget()}:`
+            : id === "rotate"
+              ? `rotate-window -t ${pid}`
+              : "";
         if (cmd) void mirror?.command(cmd).catch(() => {});
         closeMenu();
         return;

--- a/packages/daemon/src/tui/mirror/multiplexer-action-executor.test.ts
+++ b/packages/daemon/src/tui/mirror/multiplexer-action-executor.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DAEMON_WIRE_PROTOCOL_VERSION, type CanonicalDaemonInfo } from "@tmux-ide/contracts";
+
+import { CliActionInvocationError } from "../../lib/cli-action-bridge.ts";
+import type { SessionPaneDescriptor } from "../../terminal/protocol/session-descriptor-discovery.ts";
+import { executeTuiMultiplexerAction } from "./multiplexer-action-executor.ts";
+
+const INSTANCE = "20000000-0000-4000-8000-000000000002";
+const OPERATION = "10000000-0000-4000-8000-000000000001";
+
+const canonical: CanonicalDaemonInfo = {
+  pid: process.pid,
+  port: 6060,
+  protocolVersion: DAEMON_WIRE_PROTOCOL_VERSION,
+  productVersion: "2.8.0",
+  instanceId: INSTANCE,
+  startedAt: "2026-08-07T00:00:00.000Z",
+  bindHostname: "127.0.0.1",
+  authToken: "owner-token",
+};
+
+const descriptors: readonly SessionPaneDescriptor[] = [
+  {
+    runtimePaneId: "%1",
+    semanticPaneId: "pane.source",
+    role: null,
+    type: null,
+    currentCommand: "zsh",
+    cwd: "/workspace",
+    title: "Editor",
+    windowIndex: 0,
+    windowName: "main",
+    windowId: "@1",
+  },
+  {
+    runtimePaneId: "%2",
+    semanticPaneId: "pane.target",
+    role: null,
+    type: null,
+    currentCommand: "zsh",
+    cwd: "/workspace",
+    title: "Shell",
+    windowIndex: 0,
+    windowName: "main",
+    windowId: "@1",
+  },
+];
+
+function context() {
+  return {
+    sessionName: "renamed-session",
+    focusedRuntimePaneId: "%1",
+    paneDescriptors: descriptors,
+  } as const;
+}
+
+function catalog(instanceId = INSTANCE): Response {
+  return Response.json({
+    version: 1,
+    daemon: {
+      protocolVersion: DAEMON_WIRE_PROTOCOL_VERSION,
+      productVersion: "2.8.0",
+      instanceId,
+      startedAt: canonical.startedAt,
+    },
+    workspaces: [
+      {
+        workspaceName: "project-stable-identity",
+        sessionName: "renamed-session",
+      },
+    ],
+  });
+}
+
+describe("TUI multiplexer action executor", () => {
+  it("uses raw control-mode tmux only when no canonical daemon exists", async () => {
+    const runLocal = vi.fn(async () => undefined);
+    const dispatchAction = vi.fn();
+
+    await expect(
+      executeTuiMultiplexerAction({ kind: "split-pane-right" }, context(), runLocal, {
+        readCanonicalDaemonInfo: () => null,
+        dispatchAction: dispatchAction as never,
+      }),
+    ).resolves.toEqual({ status: "local", message: "split pane right" });
+
+    expect(runLocal).toHaveBeenCalledWith('split-window -h -t %1 -c "#{pane_current_path}"');
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
+  it("resolves a renamed session through the generation-stamped catalog before dispatch", async () => {
+    const dispatchAction = vi.fn(async () => ({ outcome: "applied" }));
+    const runLocal = vi.fn(async () => undefined);
+
+    await expect(
+      executeTuiMultiplexerAction({ kind: "split-pane-down" }, context(), runLocal, {
+        readCanonicalDaemonInfo: () => canonical,
+        isCanonicalDaemonAlive: async () => true,
+        fetch: vi.fn(async () => catalog()) as typeof fetch,
+        dispatchAction: dispatchAction as never,
+        operationId: () => OPERATION,
+      }),
+    ).resolves.toEqual({ status: "daemon", message: "split pane down" });
+
+    expect(dispatchAction).toHaveBeenCalledWith(
+      "workspace.window.split",
+      {
+        workspaceName: "project-stable-identity",
+        semanticPaneId: "pane.source",
+        direction: "down",
+      },
+      { operationId: OPERATION, autostart: false },
+    );
+    expect(runLocal).not.toHaveBeenCalled();
+  });
+
+  it("swaps durable semantic pane identities instead of runtime pane ids", async () => {
+    const dispatchAction = vi.fn(async () => ({ outcome: "applied" }));
+
+    await executeTuiMultiplexerAction({ kind: "swap-pane" }, context(), vi.fn(), {
+      readCanonicalDaemonInfo: () => canonical,
+      isCanonicalDaemonAlive: async () => true,
+      fetch: vi.fn(async () => catalog()) as typeof fetch,
+      dispatchAction: dispatchAction as never,
+      operationId: () => OPERATION,
+    });
+
+    expect(dispatchAction).toHaveBeenCalledWith(
+      "workspace.pane.swap",
+      {
+        workspaceName: "project-stable-identity",
+        sourceSemanticPaneId: "pane.source",
+        targetSemanticPaneId: "pane.target",
+      },
+      { operationId: OPERATION, autostart: false },
+    );
+  });
+
+  it("routes session-menu rename through the stable workspace identity", async () => {
+    const dispatchAction = vi.fn(async () => ({ outcome: "applied" }));
+
+    await expect(
+      executeTuiMultiplexerAction(
+        { kind: "rename-session", name: "fresh-name" },
+        { ...context(), focusedRuntimePaneId: null, paneDescriptors: [] },
+        vi.fn(),
+        {
+          readCanonicalDaemonInfo: () => canonical,
+          isCanonicalDaemonAlive: async () => true,
+          fetch: vi.fn(async () => catalog()) as typeof fetch,
+          dispatchAction: dispatchAction as never,
+          operationId: () => OPERATION,
+        },
+      ),
+    ).resolves.toEqual({ status: "daemon", message: "renamed session → fresh-name" });
+
+    expect(dispatchAction).toHaveBeenCalledWith(
+      "workspace.rename",
+      {
+        workspaceName: "project-stable-identity",
+        scope: "session",
+        name: "fresh-name",
+      },
+      { operationId: OPERATION, autostart: false },
+    );
+  });
+
+  it("surfaces a typed daemon refusal without bypassing it locally", async () => {
+    const runLocal = vi.fn(async () => undefined);
+    const dispatchAction = vi.fn(async () => {
+      throw new CliActionInvocationError({
+        code: "bad_request",
+        message: "This is the session's last window. Close the session instead.",
+      });
+    });
+
+    await expect(
+      executeTuiMultiplexerAction({ kind: "kill-window" }, context(), runLocal, {
+        readCanonicalDaemonInfo: () => canonical,
+        isCanonicalDaemonAlive: async () => true,
+        fetch: vi.fn(async () => catalog()) as typeof fetch,
+        dispatchAction: dispatchAction as never,
+      }),
+    ).resolves.toEqual({
+      status: "error",
+      message: "This is the session's last window. Close the session instead.",
+    });
+    expect(runLocal).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when semantic identity or daemon generation is unavailable", async () => {
+    const runLocal = vi.fn(async () => undefined);
+    const noIdentity = {
+      ...context(),
+      paneDescriptors: descriptors.map((descriptor) => ({
+        ...descriptor,
+        semanticPaneId: null,
+      })),
+    };
+
+    const missingIdentity = await executeTuiMultiplexerAction(
+      { kind: "kill-pane" },
+      noIdentity,
+      runLocal,
+      {
+        readCanonicalDaemonInfo: () => canonical,
+        isCanonicalDaemonAlive: async () => true,
+        fetch: vi.fn(async () => catalog()) as typeof fetch,
+        dispatchAction: vi.fn() as never,
+      },
+    );
+    expect(missingIdentity).toEqual({
+      status: "error",
+      message:
+        "tmux action unavailable: the active pane does not have a durable semantic identity yet",
+    });
+
+    const generationChanged = await executeTuiMultiplexerAction(
+      { kind: "new-window" },
+      context(),
+      runLocal,
+      {
+        readCanonicalDaemonInfo: () => canonical,
+        isCanonicalDaemonAlive: async () => true,
+        fetch: vi.fn(async () => catalog("30000000-0000-4000-8000-000000000003")) as typeof fetch,
+        dispatchAction: vi.fn() as never,
+      },
+    );
+    expect(generationChanged).toEqual({
+      status: "error",
+      message: "tmux action unavailable: daemon generation changed while resolving the workspace",
+    });
+    expect(runLocal).not.toHaveBeenCalled();
+  });
+});

--- a/packages/daemon/src/tui/mirror/multiplexer-action-executor.ts
+++ b/packages/daemon/src/tui/mirror/multiplexer-action-executor.ts
@@ -1,0 +1,317 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  WorkspaceCatalogResourceV1SchemaZ,
+  type CanonicalDaemonInfo,
+  type WorkspaceCatalogResourceV1,
+} from "@tmux-ide/contracts";
+
+import { CliActionInvocationError, tryDispatchAction } from "../../lib/cli-action-bridge.ts";
+import {
+  canonicalDaemonUrl,
+  isCanonicalDaemonAlive,
+  readCanonicalDaemonInfo,
+} from "../../lib/canonical-daemon.ts";
+import type { SessionPaneDescriptor } from "../../terminal/protocol/session-descriptor-discovery.ts";
+
+export type TuiMultiplexerAction =
+  | { kind: "rename-session"; name: string }
+  | { kind: "kill-session" }
+  | { kind: "new-window" }
+  | { kind: "rename-window"; name: string }
+  | { kind: "kill-window" }
+  | { kind: "zoom-pane" }
+  | { kind: "swap-pane" }
+  | { kind: "split-pane-right" }
+  | { kind: "split-pane-down" }
+  | { kind: "kill-pane" };
+
+export interface TuiMultiplexerContext {
+  readonly sessionName: string;
+  readonly focusedRuntimePaneId: string | null;
+  readonly paneDescriptors: readonly SessionPaneDescriptor[];
+}
+
+export type TuiMultiplexerExecutionResult =
+  | { readonly status: "daemon"; readonly message: string }
+  | { readonly status: "local"; readonly message: string }
+  | { readonly status: "error"; readonly message: string };
+
+interface TuiMultiplexerExecutorDeps {
+  readonly readCanonicalDaemonInfo: () => CanonicalDaemonInfo | null;
+  readonly isCanonicalDaemonAlive: (info: CanonicalDaemonInfo) => Promise<boolean>;
+  readonly fetch: typeof fetch;
+  readonly dispatchAction: typeof tryDispatchAction;
+  readonly operationId: () => string;
+}
+
+const DEFAULT_DEPS: TuiMultiplexerExecutorDeps = {
+  readCanonicalDaemonInfo,
+  isCanonicalDaemonAlive,
+  fetch,
+  dispatchAction: tryDispatchAction,
+  operationId: randomUUID,
+};
+
+function tmuxQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function localCommand(action: TuiMultiplexerAction, context: TuiMultiplexerContext): string | null {
+  const pane = context.focusedRuntimePaneId;
+  switch (action.kind) {
+    case "rename-session":
+      return `rename-session -t ${context.sessionName} ${tmuxQuote(action.name)}`;
+    case "kill-session":
+      return `kill-session -t ${context.sessionName}`;
+    case "new-window":
+      return `new-window -t ${context.sessionName}:`;
+    case "rename-window":
+      return pane ? `rename-window -t ${pane} ${tmuxQuote(action.name)}` : null;
+    case "kill-window":
+      return pane ? `kill-window -t ${pane}` : null;
+    case "zoom-pane":
+      return pane ? `resize-pane -Z -t ${pane}` : null;
+    case "swap-pane":
+      return pane ? `swap-pane -D -t ${pane}` : null;
+    case "split-pane-right":
+      return pane ? `split-window -h -t ${pane} -c "#{pane_current_path}"` : null;
+    case "split-pane-down":
+      return pane ? `split-window -v -t ${pane} -c "#{pane_current_path}"` : null;
+    case "kill-pane":
+      return pane ? `kill-pane -t ${pane}` : null;
+  }
+}
+
+function successMessage(action: TuiMultiplexerAction, result?: unknown): string {
+  switch (action.kind) {
+    case "rename-session":
+      return `renamed session → ${action.name}`;
+    case "kill-session":
+      return "closed session";
+    case "new-window":
+      return "new window";
+    case "rename-window":
+      return `renamed window → ${action.name}`;
+    case "kill-window":
+      return "closed window";
+    case "zoom-pane": {
+      const zoomed =
+        typeof result === "object" && result !== null && "zoomed" in result
+          ? Boolean(result.zoomed)
+          : null;
+      return zoomed === null ? "toggled pane zoom" : zoomed ? "zoomed pane" : "unzoomed pane";
+    }
+    case "swap-pane":
+      return "swapped pane";
+    case "split-pane-right":
+      return "split pane right";
+    case "split-pane-down":
+      return "split pane down";
+    case "kill-pane":
+      return "closed pane";
+  }
+}
+
+function focusedDescriptor(context: TuiMultiplexerContext): SessionPaneDescriptor | null {
+  if (!context.focusedRuntimePaneId) return null;
+  return (
+    context.paneDescriptors.find(
+      (descriptor) => descriptor.runtimePaneId === context.focusedRuntimePaneId,
+    ) ?? null
+  );
+}
+
+function semanticPane(
+  context: TuiMultiplexerContext,
+): { descriptor: SessionPaneDescriptor; semanticPaneId: string } | null {
+  const descriptor = focusedDescriptor(context);
+  return descriptor?.semanticPaneId
+    ? { descriptor, semanticPaneId: descriptor.semanticPaneId }
+    : null;
+}
+
+function swapTarget(context: TuiMultiplexerContext, source: SessionPaneDescriptor): string | null {
+  const peers = context.paneDescriptors.filter(
+    (descriptor) => descriptor.windowId === source.windowId && descriptor.semanticPaneId !== null,
+  );
+  if (peers.length < 2) return null;
+  const sourceIndex = peers.findIndex(
+    (descriptor) => descriptor.runtimePaneId === source.runtimePaneId,
+  );
+  if (sourceIndex < 0) return null;
+  return peers[(sourceIndex + 1) % peers.length]?.semanticPaneId ?? null;
+}
+
+async function fetchCatalog(
+  info: CanonicalDaemonInfo,
+  deps: TuiMultiplexerExecutorDeps,
+): Promise<WorkspaceCatalogResourceV1> {
+  const baseUrl = canonicalDaemonUrl("http", info.bindHostname, info.port);
+  const response = await deps.fetch(`${baseUrl}/api/resources/workspace-catalog`, {
+    signal: AbortSignal.timeout(1_000),
+  });
+  if (!response.ok) throw new Error(`workspace catalog returned HTTP ${response.status}`);
+  const catalog = WorkspaceCatalogResourceV1SchemaZ.parse(await response.json());
+  if (catalog.daemon.instanceId !== info.instanceId) {
+    throw new Error("daemon generation changed while resolving the workspace");
+  }
+  return catalog;
+}
+
+async function dispatch(
+  action: TuiMultiplexerAction,
+  context: TuiMultiplexerContext,
+  workspaceName: string,
+  operationId: string,
+  deps: TuiMultiplexerExecutorDeps,
+): Promise<unknown> {
+  const pane = semanticPane(context);
+  if (
+    action.kind !== "new-window" &&
+    action.kind !== "rename-session" &&
+    action.kind !== "kill-session" &&
+    !pane
+  ) {
+    throw new Error("the active pane does not have a durable semantic identity yet");
+  }
+  const options = { operationId, autostart: false } as const;
+  switch (action.kind) {
+    case "rename-session":
+      return deps.dispatchAction(
+        "workspace.rename",
+        { workspaceName, scope: "session", name: action.name },
+        options,
+      );
+    case "kill-session":
+      return deps.dispatchAction("workspace.session.kill", { workspaceName }, options);
+    case "new-window":
+      return deps.dispatchAction(
+        "workspace.pane.create",
+        { kind: "terminal", workspaceName },
+        options,
+      );
+    case "rename-window":
+      return deps.dispatchAction(
+        "workspace.rename",
+        {
+          workspaceName,
+          scope: "window",
+          target: { by: "pane", semanticPaneId: pane!.semanticPaneId },
+          name: action.name,
+        },
+        options,
+      );
+    case "kill-window":
+      return deps.dispatchAction(
+        "workspace.window.kill",
+        {
+          workspaceName,
+          target: { by: "pane", semanticPaneId: pane!.semanticPaneId },
+        },
+        options,
+      );
+    case "zoom-pane":
+      return deps.dispatchAction(
+        "workspace.pane.zoom.toggle",
+        { workspaceName, semanticPaneId: pane!.semanticPaneId, desired: "toggle" },
+        options,
+      );
+    case "swap-pane": {
+      const targetSemanticPaneId = swapTarget(context, pane!.descriptor);
+      if (!targetSemanticPaneId) throw new Error("this window has no other semantic pane to swap");
+      return deps.dispatchAction(
+        "workspace.pane.swap",
+        {
+          workspaceName,
+          sourceSemanticPaneId: pane!.semanticPaneId,
+          targetSemanticPaneId,
+        },
+        options,
+      );
+    }
+    case "split-pane-right":
+    case "split-pane-down":
+      return deps.dispatchAction(
+        "workspace.window.split",
+        {
+          workspaceName,
+          semanticPaneId: pane!.semanticPaneId,
+          direction: action.kind === "split-pane-right" ? "right" : "down",
+        },
+        options,
+      );
+    case "kill-pane":
+      return deps.dispatchAction(
+        "workspace.pane.kill",
+        { workspaceName, semanticPaneId: pane!.semanticPaneId },
+        options,
+      );
+  }
+}
+
+/**
+ * Execute one TUI multiplexer verb through the canonical daemon when present.
+ *
+ * Raw control-mode tmux is a deliberately narrow standalone fallback. Once a
+ * live daemon exists, catalog, semantic-identity, authorization, and mutation
+ * failures fail closed so the TUI cannot bypass the same authority the web GUI
+ * is required to use.
+ */
+export async function executeTuiMultiplexerAction(
+  action: TuiMultiplexerAction,
+  context: TuiMultiplexerContext,
+  runLocal: (command: string) => Promise<unknown>,
+  overrides: Partial<TuiMultiplexerExecutorDeps> = {},
+): Promise<TuiMultiplexerExecutionResult> {
+  const deps = { ...DEFAULT_DEPS, ...overrides };
+  const command = localCommand(action, context);
+  const canonical = deps.readCanonicalDaemonInfo();
+  if (!canonical || !(await deps.isCanonicalDaemonAlive(canonical))) {
+    if (!command) return { status: "error", message: "no active tmux pane" };
+    try {
+      await runLocal(command);
+      return { status: "local", message: successMessage(action) };
+    } catch (error) {
+      return {
+        status: "error",
+        message: `tmux action failed: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  if (!canonical.authToken) {
+    return { status: "error", message: "the live daemon has no local owner credential" };
+  }
+
+  try {
+    const catalog = await fetchCatalog(canonical, deps);
+    const workspace = catalog.workspaces.find((entry) => entry.sessionName === context.sessionName);
+    if (!workspace) {
+      return {
+        status: "error",
+        message: `the live daemon does not own session ${context.sessionName}`,
+      };
+    }
+    const result = await dispatch(
+      action,
+      context,
+      workspace.workspaceName,
+      deps.operationId(),
+      deps,
+    );
+    if (result === null) {
+      return {
+        status: "error",
+        message: "the daemon did not confirm the tmux action; nothing was retried locally",
+      };
+    }
+    return { status: "daemon", message: successMessage(action, result) };
+  } catch (error) {
+    const message =
+      error instanceof CliActionInvocationError
+        ? error.message
+        : `tmux action unavailable: ${error instanceof Error ? error.message : String(error)}`;
+    return { status: "error", message };
+  }
+}


### PR DESCRIPTION
## Summary
- resolve TUI session and pane targets through the canonical daemon catalog and semantic pane descriptors
- dispatch palette and context-menu multiplexer mutations through the owner-gated typed action bridge
- retain raw tmux only as an offline fallback and fail closed on live-daemon refusals or ambiguity
- extend stable operation-id retries to all multiplexer actions and document live acceptance

## Verification
- `pnpm check`
- targeted executor/bridge tests (11 passing)
- live canonical-daemon split + cleanup returned `new-name` to six panes
- live disposable last-window refusal preserved the session and never called local fallback
- daemon health and browser dev host both HTTP 200 after suite restart