### PR TITLE
Fix explicit TUI workspace context

### DIFF
--- a/packages/daemon/src/tui/mirror/app-state.test.ts
+++ b/packages/daemon/src/tui/mirror/app-state.test.ts
@@ -17,6 +17,7 @@ import {
   rememberSpawn,
   serializeAppState,
   spawnMemoryKey,
+  startupContextSession,
   type AppState,
 } from "./app-state.ts";
 import type { LastSpawn } from "./agent-lifecycle.ts";
@@ -30,6 +31,17 @@ describe("isTab", () => {
     expect(isTab("mirror")).toBe(false);
     expect(isTab(2)).toBe(false);
     expect(isTab(null)).toBe(false);
+  });
+});
+
+describe("startupContextSession", () => {
+  it("makes an explicit target authoritative over persisted context", () => {
+    expect(startupContextSession("fixture", false, "previous")).toBe("fixture");
+  });
+
+  it("restores persisted context for a bare Home launch", () => {
+    expect(startupContextSession("", true, "previous")).toBe("previous");
+    expect(startupContextSession("", true, null)).toBe("");
   });
 });
 

--- a/packages/daemon/src/tui/mirror/app-state.ts
+++ b/packages/daemon/src/tui/mirror/app-state.ts
@@ -114,6 +114,19 @@ export const DEFAULT_APP_STATE: AppState = {
   filesShowIgnored: false,
 };
 
+/**
+ * Resolve the workspace context shown at startup. A concrete CLI target is an
+ * explicit navigation request and must override the previously persisted
+ * context; a bare Home launch restores the last workspace for quick return.
+ */
+export function startupContextSession(
+  target: string,
+  bareHome: boolean,
+  persistedContext: string | null,
+): string {
+  return bareHome ? (persistedContext ?? "") : target;
+}
+
 /** PURE — the "again" memory key for a spawn context: the concrete dir when
  *  known, else the session name (namespaced so a dirless session can't collide
  *  with a path), else null — nothing stable to remember under. */

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -275,6 +275,7 @@ import {
   isTab,
   rememberSpawn,
   spawnMemoryKey,
+  startupContextSession,
   type AppState,
   type PaletteUsageEntry,
   type Tab,
@@ -978,7 +979,7 @@ try {
     // onMount (after the FFI buffer + fleet arrive).
     const persisted: AppState = loadAppState();
     const [contextSession, setContextSession] = createSignal<string>(
-      persisted.contextSession ?? "",
+      startupContextSession(target, bareHome, persisted.contextSession),
     );
     const [contextDir, setContextDir] = createSignal<string>("");
     const [projectsData, setProjectsData] = createSignal<FleetProject[]>([]);
@@ -1240,7 +1241,7 @@ try {
     );
 
     const [curTarget, setCurTarget] = createSignal(
-      bareHome ? (persisted.contextSession ?? "") : target,
+      startupContextSession(target, bareHome, persisted.contextSession),
     );
     // Size truth (M22.8): the actual tmux window size when a co-attached terminal
     // has shrunk it below our pinned canvas (else null). Set in the tick from the


### PR DESCRIPTION
## Summary
- make an explicit TUI target override persisted workspace context
- keep bare Home launches restoring the previous context
- cover startup context precedence with pure unit tests

## Validation
- pnpm exec vitest run packages/daemon/src/tui/mirror/app-state.test.ts
- pnpm --filter @tmux-ide/daemon typecheck
- pnpm exec prettier --check packages/daemon/src/tui/mirror/app-state.ts packages/daemon/src/tui/mirror/app-state.test.ts packages/daemon/src/tui/mirror/app.tsx
- live disposable tmux framebuffer replay