### PR TITLE
m56.0: define the one-session-runtime boundary

### DIFF
--- a/docs/product/one-session-runtime.md
+++ b/docs/product/one-session-runtime.md
@@ -1,0 +1,63 @@
+# ADR: one session runtime, many thin clients
+
+Status: accepted for m56 migration (2026-08-11)
+
+## Decision
+
+Exactly one daemon `SessionRuntime` owns observation and mutation for a tmux
+server/session pair. GUI, OpenTUI, CLI, SDK, and test drivers speak semantic
+contracts. They never create a tmux control client, resolve `%N`/`@N`/`$N`, or
+run tmux commands.
+
+```mermaid
+flowchart LR
+  tmux["ordinary tmux server"] --> runtime["daemon SessionRuntime"]
+  runtime --> replica["terminal replica + revisions"]
+  runtime --> truth["workspace and interaction truth"]
+  clients["GUI · OpenTUI · CLI · SDK"] -->|"semantic intents"| runtime
+  replica -->|"seed / patch"| clients
+  truth -->|"receipts / resource patches"| clients
+  clients --> local["client-local view state"]
+```
+
+The daemon owns shared truth: semantic identity joins, terminal generations and
+revisions, layout, mutations and their ordered receipts, leases, and recovery.
+A client owns presentation truth: focus, selection, scroll/search state, open
+dialogs, dock/tab presentation, and its render baseline. Local state may be
+persisted per view but is never published as shared tmux state.
+
+## Contracts
+
+- Terminal replicas begin with a generation-bound seed. Every patch names its
+  exact base revision; a gap requires a new seed.
+- Mutations are semantic intents and receive an accepted, observed, rejected,
+  or timed-out receipt on the existing interaction spine. Runtime tmux
+  addresses never cross the contract; there is no second receipt vocabulary.
+- `.tmux-ide/workspace.yml` remains optional. Discovery of ordinary live tmux
+  sessions is daemon truth and requires no project configuration.
+
+## Forbidden dependencies
+
+Client layers must not import `@tmux-ide/tmux-bridge`, control-mode parsers or
+clients, `MirrorService`, `SessionChannel`, or daemon tmux adapters. The
+architecture test freezes the two actual OpenTUI direct-control constructions
+to an exact m56.4 deletion target. A separate assertion freezes direct
+`tmux-bridge` command/polling imports for deletion in m56.6; helper debt is not
+mislabelled as control ownership. Both migrations retain the current OpenTUI
+framebuffer and input lifecycle.
+
+## Migration
+
+1. m56.1 composes the existing daemon authorities behind one runtime lifecycle.
+2. m56.2 adds bounded seed/patch payloads and gap recovery to this type seam.
+3. A test harness may compare daemon replica fixtures against legacy TUI mirror
+   fixtures during cutover. This is not a production flag or client API.
+4. m56.4 switches OpenTUI to the daemon adapter and deletes its direct control
+   lane. Web then consumes the same runtime truth.
+
+## Non-goals
+
+This ADR does not replace the retained OpenTUI renderer, add another TUI
+runtime, introduce a canvas SDK, require a workspace file, or prescribe a Rust
+rewrite. Infinite-canvas experiments and closed-source canvas dependencies are
+outside the architecture.

--- a/packages/contracts/src/__tests__/session-runtime.test.ts
+++ b/packages/contracts/src/__tests__/session-runtime.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { SessionRuntimeSemanticIntentSchemaZ } from "../session-runtime.ts";
+import { InteractionReceiptSchemaZ } from "../interaction-receipts.ts";
+
+describe("session runtime architecture contract", () => {
+  it("accepts semantic intents and refuses raw tmux addresses", () => {
+    const intent = {
+      verb: "workspace.pane.read",
+      workspaceName: "project",
+      semanticPaneId: "pane.editor",
+      origin: "tui",
+    };
+    expect(SessionRuntimeSemanticIntentSchemaZ.parse(intent)).toEqual(intent);
+    expect(SessionRuntimeSemanticIntentSchemaZ.safeParse({ ...intent, paneId: "%7" }).success).toBe(
+      false,
+    );
+  });
+
+  it.each(["accepted", "observed", "rejected", "timed-out"] as const)(
+    "models the %s receipt phase",
+    (phase) => {
+      expect(
+        InteractionReceiptSchemaZ.parse({
+          type: "interaction.receipt",
+          operationId: "2a50f1d4-6f57-4f02-8b10-b94bf24967ec",
+          sequence: 1,
+          phase,
+          origin: "tui",
+          workspaceName: "project",
+          semanticPaneId: "pane.editor",
+          sourceSemanticPaneId: null,
+          operationKind: "workspace.pane.read",
+          summary: { observedOnly: true },
+          at: "2026-08-11T10:00:00.000Z",
+          resourceRevision: null,
+        }).phase,
+      ).toBe(phase);
+    },
+  );
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -39,6 +39,7 @@ export * from "./daemon-resource-request.ts";
 export * from "./desktop-missions.ts";
 export * from "./experience-identifiers.ts";
 export * from "./semantic-identity.ts";
+export * from "./session-runtime.ts";
 export * from "./experience-shell.ts";
 export * from "./application-shell.ts";
 export * from "./application-shell-resource.ts";

--- a/packages/contracts/src/interaction-receipts.ts
+++ b/packages/contracts/src/interaction-receipts.ts
@@ -16,7 +16,14 @@ export const InteractionOperationKindSchemaZ = z.enum([
 ]);
 export type InteractionOperationKind = z.infer<typeof InteractionOperationKindSchemaZ>;
 
-export const InteractionPhaseSchemaZ = z.enum(["accepted", "applied", "observed", "failed"]);
+export const InteractionPhaseSchemaZ = z.enum([
+  "accepted",
+  "applied",
+  "observed",
+  "rejected",
+  "timed-out",
+  "failed",
+]);
 export type InteractionPhase = z.infer<typeof InteractionPhaseSchemaZ>;
 
 /**

--- a/packages/contracts/src/session-runtime.ts
+++ b/packages/contracts/src/session-runtime.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+import { DaemonInstanceIdentitySchemaZ } from "./daemon-wire.ts";
+import {
+  AuthoredInteractionOriginSchemaZ,
+  type InteractionReceipt,
+} from "./interaction-receipts.ts";
+import {
+  TerminalAttachmentSemanticPaneIdSchemaZ,
+  type TerminalAttachmentSemanticPaneId,
+} from "./semantic-identity.ts";
+import {
+  WorkspaceMultiplexerIntentSchemaZ,
+  type WorkspaceMultiplexerMutationResult,
+} from "./workspace-multiplexer.ts";
+import { WorkspaceIdSchemaZ, type WorkspaceId } from "./workspace-state.ts";
+
+/** Architecture-level contract version. Payload encodings land in m56.2. */
+export const SESSION_RUNTIME_CONTRACT_VERSION = 1 as const;
+
+export const SessionRuntimeGenerationSchemaZ = DaemonInstanceIdentitySchemaZ.shape.instanceId;
+export type SessionRuntimeGeneration = z.infer<typeof SessionRuntimeGenerationSchemaZ>;
+
+export const TerminalReplicaRevisionSchemaZ = z.number().int().nonnegative();
+export type TerminalReplicaRevision = z.infer<typeof TerminalReplicaRevisionSchemaZ>;
+
+export interface TerminalReplicaAddress {
+  readonly workspaceName: WorkspaceId;
+  readonly semanticPaneId: TerminalAttachmentSemanticPaneId;
+}
+
+/** A complete generation-bound renderer seed. Snapshot remains host-neutral. */
+export interface TerminalReplicaSeed<Snapshot = unknown> extends TerminalReplicaAddress {
+  readonly type: "terminal.seed";
+  readonly generation: SessionRuntimeGeneration;
+  readonly revision: TerminalReplicaRevision;
+  readonly snapshot: Snapshot;
+}
+
+/** A patch is valid only against exactly `baseRevision` in the same generation. */
+export interface TerminalReplicaPatch<Patch = unknown> extends TerminalReplicaAddress {
+  readonly type: "terminal.patch";
+  readonly generation: SessionRuntimeGeneration;
+  readonly baseRevision: TerminalReplicaRevision;
+  readonly revision: TerminalReplicaRevision;
+  readonly patch: Patch;
+}
+
+export type TerminalReplicaUpdate<Snapshot = unknown, Patch = unknown> =
+  | TerminalReplicaSeed<Snapshot>
+  | TerminalReplicaPatch<Patch>;
+
+export const SessionRuntimePaneReadIntentSchemaZ = z
+  .object({
+    verb: z.literal("workspace.pane.read"),
+    workspaceName: WorkspaceIdSchemaZ,
+    semanticPaneId: TerminalAttachmentSemanticPaneIdSchemaZ,
+    origin: AuthoredInteractionOriginSchemaZ,
+  })
+  .strict();
+
+/** The only intents a client may submit: semantic identity, never tmux addresses. */
+export const SessionRuntimeSemanticIntentSchemaZ = z.union([
+  WorkspaceMultiplexerIntentSchemaZ,
+  SessionRuntimePaneReadIntentSchemaZ,
+]);
+export type SessionRuntimeSemanticIntent = z.infer<typeof SessionRuntimeSemanticIntentSchemaZ>;
+
+export interface SessionRuntimeTerminalSubscription<Snapshot = unknown, Patch = unknown> {
+  readonly generation: SessionRuntimeGeneration;
+  close(): Promise<void>;
+  freeze(): void;
+  thaw(): void;
+  onUpdate(listener: (update: TerminalReplicaUpdate<Snapshot, Patch>) => void): () => void;
+}
+
+/** Client-facing port. Implementations live only in daemon runtime modules. */
+export interface SessionRuntimeClientPort<Snapshot = unknown, Patch = unknown> {
+  readonly generation: SessionRuntimeGeneration;
+  subscribeTerminal(
+    target: TerminalReplicaAddress,
+  ): Promise<SessionRuntimeTerminalSubscription<Snapshot, Patch>>;
+  submitIntent(
+    operationId: string,
+    intent: SessionRuntimeSemanticIntent,
+  ): Promise<WorkspaceMultiplexerMutationResult | void>;
+  /** Reuses the one privacy-safe interaction spine; no parallel receipt bus. */
+  onReceipt(listener: (receipt: InteractionReceipt) => void): () => void;
+}

--- a/packages/contracts/src/workspace-state.ts
+++ b/packages/contracts/src/workspace-state.ts
@@ -25,6 +25,7 @@ const SafeStringSchemaZ = (max: number) =>
     .max(max)
     .refine((value) => !value.includes("\0"), "text must not contain NUL bytes");
 export const WorkspaceIdSchemaZ = PortableWorkspaceIdSchemaZ;
+export type WorkspaceId = z.infer<typeof WorkspaceIdSchemaZ>;
 const NullableTextSchemaZ = (max: number) => SafeStringSchemaZ(max).nullable();
 const AbsolutePathSchemaZ = SafeStringSchemaZ(4096).refine(
   (value) => /^(?:[/\\]{1,2}|[A-Za-z]:[/\\])/u.test(value),

--- a/packages/core/src/interaction-receipts.ts
+++ b/packages/core/src/interaction-receipts.ts
@@ -73,7 +73,7 @@ export function paneInteractionPresence(
   const kind = interaction.operationKind === "workspace.pane.read" ? "read" : "send";
   const endpoint = interaction.direction === "outgoing" ? "source" : "target";
   const role: PaneInteractionPresenceRole = `${kind}-${endpoint}`;
-  const failed = interaction.phase === "failed";
+  const failed = ["failed", "rejected", "timed-out"].includes(interaction.phase);
   let badge: string;
   if (failed) badge = "FAILED";
   else if (kind === "read") badge = endpoint === "source" ? "READING" : "READ";
@@ -120,6 +120,8 @@ export function interactionReceiptLabel(receipt: InteractionReceipt): string {
   const action = interactionSummaryLabel(receipt.operationKind, receipt.summary);
   if (receipt.phase === "accepted") return `${receipt.origin} accepted · ${action}`;
   if (receipt.phase === "failed") return `${receipt.origin} failed · ${action}`;
+  if (receipt.phase === "rejected") return `${receipt.origin} rejected · ${action}`;
+  if (receipt.phase === "timed-out") return `${receipt.origin} timed out · ${action}`;
   if (receipt.phase === "observed") return `${receipt.origin} observed · ${action}`;
   return `${receipt.origin} applied · ${action}`;
 }

--- a/packages/daemon/src/architecture/session-runtime-boundary.test.ts
+++ b/packages/daemon/src/architecture/session-runtime-boundary.test.ts
@@ -1,0 +1,83 @@
+import { readdir, readFile } from "node:fs/promises";
+import { extname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const REPO = fileURLToPath(new URL("../../../../", import.meta.url));
+const CLIENT_ROOTS = [
+  "apps/desktop-renderer/src",
+  "packages/daemon-client/src",
+  "packages/sdk/src",
+  "packages/daemon/src/tui",
+] as const;
+
+const DIRECT_CONTROL_CONSTRUCTION = /\bnew\s+(?:SessionMirror|ControlModeClient)\s*\(/u;
+const M56_4_DELETION_TARGET = [
+  "packages/daemon/src/tui/mirror/app.tsx",
+  "packages/daemon/src/tui/mirror/session-mirror.ts",
+] as const;
+
+const CONTROL_OWNERSHIP_IMPORT =
+  /(?:from\s+|import\s*\(\s*)["'][^"']*(?:session-mirror|control-client|terminal\/mirror\/(?:mirror-service|control-channel|session-channel)|terminal\/pane-stream\/runtime)\.ts["']/u;
+const M56_4_DEPENDENCY_DELETION_TARGET = [
+  "packages/daemon/src/tui/mirror/app.tsx",
+  "packages/daemon/src/tui/mirror/pane-frame-state.ts",
+  "packages/daemon/src/tui/mirror/pane-surface.tsx",
+  "packages/daemon/src/tui/mirror/session-mirror.ts",
+] as const;
+
+const DIRECT_TMUX_BRIDGE_IMPORT = /["']@tmux-ide\/tmux-bridge["']/u;
+const M56_6_DELETION_TARGET = [
+  "packages/daemon/src/tui/chrome/notify.ts",
+  "packages/daemon/src/tui/chrome/sidebar.ts",
+  "packages/daemon/src/tui/chrome/snapshot.ts",
+  "packages/daemon/src/tui/chrome/statusline.ts",
+  "packages/daemon/src/tui/chrome/updater.ts",
+  "packages/daemon/src/tui/detect/snapshot.ts",
+  "packages/daemon/src/tui/team/index.tsx",
+  "packages/daemon/src/tui/team/projects.ts",
+  "packages/daemon/src/tui/team/wait.ts",
+] as const;
+
+async function sourceFiles(path: string): Promise<string[]> {
+  const entries = await readdir(path, { withFileTypes: true });
+  const result: string[] = [];
+  for (const entry of entries) {
+    const child = join(path, entry.name);
+    if (entry.isDirectory()) result.push(...(await sourceFiles(child)));
+    else if (
+      [".ts", ".tsx"].includes(extname(entry.name)) &&
+      !entry.name.includes(".test.") &&
+      !child.includes("/__snapshots__/")
+    ) {
+      result.push(child);
+    }
+  }
+  return result;
+}
+
+async function matches(pattern: RegExp): Promise<string[]> {
+  const findings: string[] = [];
+  for (const root of CLIENT_ROOTS) {
+    for (const file of await sourceFiles(join(REPO, root))) {
+      if (pattern.test(await readFile(file, "utf8"))) findings.push(relative(REPO, file));
+    }
+  }
+  return findings.sort();
+}
+
+describe("one SessionRuntime import DAG", () => {
+  it("freezes the two actual direct control owners for deletion in m56.4", async () => {
+    expect(await matches(DIRECT_CONTROL_CONSTRUCTION)).toEqual([...M56_4_DELETION_TARGET].sort());
+  });
+
+  it("freezes every client dependency on control ownership for deletion in m56.4", async () => {
+    expect(await matches(CONTROL_OWNERSHIP_IMPORT)).toEqual(
+      [...M56_4_DEPENDENCY_DELETION_TARGET].sort(),
+    );
+  });
+
+  it("separately freezes direct tmux command and polling debt for deletion in m56.6", async () => {
+    expect(await matches(DIRECT_TMUX_BRIDGE_IMPORT)).toEqual([...M56_6_DELETION_TARGET].sort());
+  });
+});

--- a/packages/daemon/src/terminal/mirror/control-mode-ownership.test.ts
+++ b/packages/daemon/src/terminal/mirror/control-mode-ownership.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { ControlModeOwnershipRegistry, controlModeAuthorityKey } from "./control-mode-ownership.ts";
+
+describe("ControlModeOwnershipRegistry", () => {
+  it("allows exactly one owner for a server session until release", () => {
+    const registry = new ControlModeOwnershipRegistry();
+    const authority = controlModeAuthorityKey("workspace", { socketName: "test" });
+    const release = registry.claim(authority, Symbol("first"));
+
+    expect(() => registry.claim(authority, Symbol("second"))).toThrow(
+      /control-mode authority already exists/,
+    );
+
+    release();
+    const releaseSuccessor = registry.claim(authority, Symbol("successor"));
+    expect(() => releaseSuccessor()).not.toThrow();
+  });
+
+  it("isolates distinct sessions and socket selectors", () => {
+    const registry = new ControlModeOwnershipRegistry();
+    const releases = [
+      registry.claim(controlModeAuthorityKey("one", { socketName: "test" }), Symbol("one")),
+      registry.claim(controlModeAuthorityKey("two", { socketName: "test" }), Symbol("two")),
+      registry.claim(
+        controlModeAuthorityKey("one", { socketPath: "/tmp/tmux-test" }),
+        Symbol("path"),
+      ),
+    ];
+
+    for (const release of releases) release();
+  });
+});

--- a/packages/daemon/src/terminal/mirror/control-mode-ownership.ts
+++ b/packages/daemon/src/terminal/mirror/control-mode-ownership.ts
@@ -1,0 +1,34 @@
+/**
+ * Process-local invariant for the daemon generation: one control-mode owner
+ * per tmux server/session. Cross-process exclusion remains the canonical
+ * daemon lock's responsibility.
+ */
+export class ControlModeOwnershipRegistry {
+  readonly #owners = new Map<string, symbol>();
+
+  claim(authorityKey: string, owner: symbol): () => void {
+    const existing = this.#owners.get(authorityKey);
+    if (existing) {
+      throw new Error(`control-mode authority already exists for ${authorityKey}`);
+    }
+    this.#owners.set(authorityKey, owner);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      if (this.#owners.get(authorityKey) === owner) this.#owners.delete(authorityKey);
+    };
+  }
+}
+
+export const processControlModeOwnershipRegistry = new ControlModeOwnershipRegistry();
+
+export function controlModeAuthorityKey(
+  session: string,
+  selector: { readonly socketName?: string; readonly socketPath?: string },
+): string {
+  const server = selector.socketPath
+    ? `path:${selector.socketPath}`
+    : `name:${selector.socketName ?? "default"}`;
+  return `${server}/session:${session}`;
+}

--- a/packages/daemon/src/terminal/mirror/mirror-service.test.ts
+++ b/packages/daemon/src/terminal/mirror/mirror-service.test.ts
@@ -8,9 +8,12 @@ import {
   fixtureState,
   FIXTURE,
 } from "./__tests__/simulated-channel.ts";
-import { MirrorService } from "./mirror-service.ts";
+import { MirrorService, type MirrorServiceOptions } from "./mirror-service.ts";
 
-function rig(): { service: MirrorService; sims: Map<string, SimulatedChannel[]> } {
+function rig(options: MirrorServiceOptions = {}): {
+  service: MirrorService;
+  sims: Map<string, SimulatedChannel[]>;
+} {
   const sims = new Map<string, SimulatedChannel[]>();
   const service = new MirrorService({
     createIo: (session, handlers) => {
@@ -28,6 +31,7 @@ function rig(): { service: MirrorService; sims: Map<string, SimulatedChannel[]> 
       return sim;
     },
     generatePaneId: () => "pane.mirror.gen1",
+    ...options,
   });
   return { service, sims };
 }
@@ -37,6 +41,18 @@ async function subscribed(service: MirrorService, session: string, pane: string)
 }
 
 describe("MirrorService refcounting", () => {
+  it("rejects a second control-mode owner for the same server session", async () => {
+    const first = rig();
+    const second = rig();
+    const subscription = await subscribed(first.service, FIXTURE.session, "pane.alpha");
+    await expect(subscribed(second.service, FIXTURE.session, "pane.alpha")).rejects.toThrow(
+      /control-mode authority already exists/,
+    );
+    await subscription.close();
+    const successor = await subscribed(second.service, FIXTURE.session, "pane.alpha");
+    await successor.close();
+  });
+
   it("shares one channel per session across subscriptions and disposes with the last one", async () => {
     const { service, sims } = rig();
     const first = await subscribed(service, FIXTURE.session, "pane.alpha");

--- a/packages/daemon/src/terminal/mirror/mirror-service.ts
+++ b/packages/daemon/src/terminal/mirror/mirror-service.ts
@@ -16,7 +16,12 @@ import {
   type MirrorChannelIo,
 } from "./control-channel.ts";
 import type { MirrorLayoutEvent, MirrorPaneEvent, MirrorSessionDescription } from "./events.ts";
-import { SessionChannel } from "./session-channel.ts";
+import { SessionChannel, type SessionChannelOptions } from "./session-channel.ts";
+import {
+  controlModeAuthorityKey,
+  processControlModeOwnershipRegistry,
+  type ControlModeOwnershipRegistry,
+} from "./control-mode-ownership.ts";
 
 export interface MirrorServiceOptions {
   /** `tmux -L <name>` for every channel — isolated servers in tests. */
@@ -33,6 +38,8 @@ export interface MirrorServiceOptions {
   createIo?: (session: string, handlers: MirrorChannelHandlers) => MirrorChannelIo;
   generatePaneId?: () => string;
   generateWindowId?: () => string;
+  /** Test seam; production uses the daemon-generation process registry. */
+  controlModeOwnershipRegistry?: ControlModeOwnershipRegistry;
 }
 
 export interface MirrorSubscribeRequest {
@@ -59,12 +66,15 @@ interface ChannelEntry {
   channel: SessionChannel;
   started: Promise<void>;
   refs: number;
+  releaseAuthority: () => void;
 }
 
 export class MirrorService {
   private readonly opts: MirrorServiceOptions;
   private readonly channels = new Map<string, ChannelEntry>();
   private readonly pendingDisposals = new Set<Promise<void>>();
+  private readonly drainingChannels = new Map<string, Promise<void>>();
+  private readonly owner = Symbol("MirrorService control-mode owner");
   private disposed = false;
 
   constructor(opts: MirrorServiceOptions = {}) {
@@ -132,38 +142,67 @@ export class MirrorService {
     this.disposed = true;
     const entries = [...this.channels.values()];
     this.channels.clear();
-    await Promise.allSettled(entries.map((entry) => entry.channel.dispose()));
+    await Promise.allSettled(
+      entries.map(async (entry) => {
+        try {
+          await entry.channel.dispose();
+        } finally {
+          entry.releaseAuthority();
+        }
+      }),
+    );
     await Promise.allSettled([...this.pendingDisposals]);
   }
 
   private async acquire(session: string): Promise<ChannelEntry> {
     if (this.disposed) throw new Error("MirrorService is disposed");
+    await this.drainingChannels.get(session);
+    if (this.disposed) throw new Error("MirrorService is disposed");
     let entry = this.channels.get(session);
     if (!entry) {
-      const channel = new SessionChannel({
-        session,
-        createIo: (handlers) =>
-          this.opts.createIo?.(session, handlers) ??
-          new MirrorControlChannel({
-            session,
-            handlers,
-            socketName: this.opts.socketName,
-            socketPath: this.opts.socketPath,
-            executable: this.opts.executable,
-            configFile: this.opts.configFile,
-            pauseAfterSeconds: this.opts.pauseAfterSeconds,
-          }),
-        historyLines: this.opts.historyLines,
-        generatePaneId: this.opts.generatePaneId,
-        generateWindowId: this.opts.generateWindowId,
-        onExit: () => {
-          // The channel died underneath its subscribers (tmux exit/detach):
-          // drop the entry so the next acquire starts fresh; open handles
-          // already received their `closed` events.
-          if (this.channels.get(session)?.channel === channel) this.channels.delete(session);
-        },
-      });
-      entry = { channel, started: channel.start(), refs: 0 };
+      const releaseAuthority = (
+        this.opts.controlModeOwnershipRegistry ?? processControlModeOwnershipRegistry
+      ).claim(
+        controlModeAuthorityKey(session, {
+          socketName: this.opts.socketName,
+          socketPath: this.opts.socketPath,
+        }),
+        this.owner,
+      );
+      let channel: SessionChannel;
+      try {
+        const channelOptions: SessionChannelOptions = {
+          session,
+          createIo: (handlers) =>
+            this.opts.createIo?.(session, handlers) ??
+            new MirrorControlChannel({
+              session,
+              handlers,
+              socketName: this.opts.socketName,
+              socketPath: this.opts.socketPath,
+              executable: this.opts.executable,
+              configFile: this.opts.configFile,
+              pauseAfterSeconds: this.opts.pauseAfterSeconds,
+            }),
+          historyLines: this.opts.historyLines,
+          generatePaneId: this.opts.generatePaneId,
+          generateWindowId: this.opts.generateWindowId,
+          onExit: () => {
+            // The channel died underneath its subscribers (tmux exit/detach):
+            // drop the entry so the next acquire starts fresh; open handles
+            // already received their `closed` events.
+            if (this.channels.get(session)?.channel === channel) {
+              this.channels.delete(session);
+              releaseAuthority();
+            }
+          },
+        };
+        channel = new SessionChannel(channelOptions);
+      } catch (cause) {
+        releaseAuthority();
+        throw cause;
+      }
+      entry = { channel, started: channel.start(), refs: 0, releaseAuthority };
       this.channels.set(session, entry);
     }
     entry.refs += 1;
@@ -180,8 +219,15 @@ export class MirrorService {
     entry.refs -= 1;
     if (entry.refs > 0) return;
     if (this.channels.get(session) === entry) this.channels.delete(session);
-    const disposal = entry.channel.dispose().catch(() => {});
+    const disposal = entry.channel
+      .dispose()
+      .catch(() => {})
+      .finally(() => entry.releaseAuthority());
+    this.drainingChannels.set(session, disposal);
     this.pendingDisposals.add(disposal);
-    void disposal.finally(() => this.pendingDisposals.delete(disposal));
+    void disposal.finally(() => {
+      this.pendingDisposals.delete(disposal);
+      if (this.drainingChannels.get(session) === disposal) this.drainingChannels.delete(session);
+    });
   }
 }


### PR DESCRIPTION
Implements Sfora card #184.

- defines the shared SessionRuntime contract and revisioned terminal seed/patch seam
- reuses the canonical interaction receipt spine
- enforces exact m56.4 and m56.6 legacy deletion targets
- adds process-local single control-mode ownership per tmux server/session
- documents daemon truth versus client-local view state and the no-canvas boundary

Verified with contracts, core, and daemon suites; affected typechecks; lint; formatting; and diff checks.