### PR TITLE
fix: restore single terminal rendering authority

### DIFF
--- a/apps/desktop-renderer/e2e/alpha-loop.e2e.ts
+++ b/apps/desktop-renderer/e2e/alpha-loop.e2e.ts
@@ -413,167 +413,30 @@ test("a live fleet opens, types, composes panes, survives its session being kill
   ).toBeGreaterThan(10_000);
   await page.screenshot({ path: testInfo.outputPath("3-terminal-typed.png") });
 
-  // --- User path: tmux's panes are composed into its own layout -----------
-  // There is no separate mirror deck in the GUI-first path. The pane streams
-  // are the visible bodies of the non-overlapping tmux tiles, while one hidden
-  // whole-window attachment remains the geometry and keyboard owner.
+  // --- A one-pane window has exactly one visible terminal -----------------
+  // Pane streams are a compositor primitive for split windows. Starting one
+  // for an ordinary one-pane window used to mount a second xterm directly over
+  // the live interactive terminal: the mirror owned pointer hit-testing while
+  // the covered terminal owned input. With nothing to compose, the interactive
+  // attachment is both the only renderer and the only visible pixel owner.
   const tiledArea = page.locator(".tiled-pane-area");
   await expect(
     tiledArea,
-    "the tiled workspace never promoted its live pane streams into the visible compositor",
-  ).toHaveAttribute("data-pane-compositor", "true", { timeout: 30_000 });
-
-  const composedTiles = page.locator('.pane-tile[data-composed="true"]');
+    "a single-pane workspace mounted the pane-stream compositor over its interactive terminal",
+  ).toHaveAttribute("data-pane-compositor", "false");
   await expect(
-    composedTiles.first(),
-    "no composed pane appeared for a workspace that has attachable panes",
-  ).toBeVisible({ timeout: 30_000 });
-  const composedCount = await composedTiles.count();
-  expect(
-    composedCount,
-    "the compositor painted no tiles for a workspace that has attachable panes",
-  ).toBeGreaterThan(0);
-  const firstTile = composedTiles.first();
-  const firstComposedPane = await firstTile.getAttribute("data-pane");
-  const firstCompositorNode = firstTile.locator(".mirror-pane-node");
-  await expect(firstCompositorNode, "the first composed pane body is not visible").toBeVisible();
-  const compositorRect = await firstCompositorNode.boundingBox();
-  expect(compositorRect, "the first composed pane body has no measurable box").not.toBeNull();
-  expect(
-    compositorRect!.width >= 120 && compositorRect!.height >= 100,
-    `the first composed pane body is only ${Math.round(compositorRect!.width)}x${Math.round(compositorRect!.height)}px`,
-  ).toBe(true);
-  // Bug this catches: the pane body is laid out below the fold or under the
-  // dock, so its frame technically exists and the user sees a strip or nothing.
-  const windowSize = page.viewportSize()!;
-  expect(
-    compositorRect!.y + compositorRect!.height,
-    `the first composed pane ends at y=${Math.round(compositorRect!.y + compositorRect!.height)} ` +
-      `in a ${windowSize.height}px window — its body is below the visible area`,
-  ).toBeLessThanOrEqual(windowSize.height);
-  const dockTop = await page
-    .locator(".workbench-dock, [data-workbench-dock]")
-    .first()
-    .boundingBox()
-    .then((box) => box?.y ?? windowSize.height)
-    .catch(() => windowSize.height);
-  expect(
-    compositorRect!.y + compositorRect!.height,
-    "the first composed pane body runs under the dock",
-  ).toBeLessThanOrEqual(dockTop);
-
-  // Bug this catches: the tile frame appears but its stream never seeds, so the
-  // user gets labelled chrome around an empty rectangle.
-  await expect
-    .poll(() => firstCompositorNode.getAttribute("data-state"), {
-      message:
-        "the composed pane never reached a live state — the frame is on screen with no pane " +
-        "content behind it",
-      timeout: 30_000,
-    })
-    .toBe("live");
-  // Bug this catches: the compositor renders a terminal grid that never
-  // receives the pane's bytes — a live-looking tile showing a blank screen.
-  await expect
-    .poll(() => firstCompositorNode.locator(".xterm-rows").first().innerText(), {
-      message:
-        "the composed pane painted no content — it reports a live stream but its terminal grid " +
-        "is empty",
-      timeout: 30_000,
-    })
-    .toMatch(/\S/u);
-
-  /*
-   * The GRID is inside the card, not merely the card inside the window.
-   *
-   * Bug this catches (m50.2): the letterbox fit scaled the emulator about its
-   * own centre, which is the centre of the card only while the grid still fits
-   * it. Once the app owned tmux's window geometry the element laid out at grid
-   * size — far larger than the card — and the render was parked around a point
-   * outside it: measured 180px below the card and off the bottom of the window,
-   * where xterm stops painting. The card stayed on screen and reported a live
-   * stream the whole time, which is why every existing placement assertion
-   * passed; only the pixels the user reads were somewhere else.
-   */
-  const gridPlacement = await firstCompositorNode.evaluate((element) => {
-    const screen = element.querySelector(".xterm-screen");
-    if (!screen) return null;
-    const card = element.parentElement?.getBoundingClientRect() ?? element.getBoundingClientRect();
-    const grid = screen.getBoundingClientRect();
-    return {
-      card: { top: card.top, bottom: card.bottom, left: card.left, right: card.right },
-      grid: { top: grid.top, bottom: grid.bottom, left: grid.left, right: grid.right },
-      viewport: { width: window.innerWidth, height: window.innerHeight },
-    };
+    page.locator('.pane-tile[data-composed="true"]'),
+    "a single pane received a duplicate composed terminal body",
+  ).toHaveCount(0);
+  await expect(
+    page.locator(".mirror-deck"),
+    "the disabled one-pane compositor leaked its legacy mirror deck into the workspace",
+  ).toHaveCount(0);
+  await proveVisible(terminal.locator(".xterm-screen"), "the one authoritative terminal screen", {
+    minWidth: 120,
+    minHeight: 100,
   });
-  expect(gridPlacement, "the composed pane has no rendered grid at all").not.toBeNull();
-  const placement = gridPlacement!;
-  const slack = 1; // sub-pixel: a fractional scale cannot round to an escape.
-  expect(
-    placement.grid.top >= placement.card.top - slack &&
-      placement.grid.bottom <= placement.card.bottom + slack &&
-      placement.grid.left >= placement.card.left - slack &&
-      placement.grid.right <= placement.card.right + slack,
-    `the composed pane's grid is rendered at ${JSON.stringify(placement.grid)} but its card is at ` +
-      `${JSON.stringify(placement.card)} — the render escaped the card that frames it`,
-  ).toBe(true);
-  expect(
-    placement.grid.bottom <= placement.viewport.height && placement.grid.top >= 0,
-    `the composed pane's grid runs from ${Math.round(placement.grid.top)} to ` +
-      `${Math.round(placement.grid.bottom)} in a ${placement.viewport.height}px window — the ` +
-      "emulator stops painting outside the viewport, so the pane would freeze mid-stream",
-  ).toBe(true);
-
-  // Bug this catches — the defect this step was rewritten for: the compositor
-  // rebuilt every pane body's DOM on each stream update, so each tick threw away the
-  // xterm instance and re-initialized it. Identity is asserted on the element
-  // itself, across ticks driven by real typing into the mirrored pane.
-  const compositorHandle = (await firstCompositorNode.elementHandle())!;
-  for (let tick = 0; tick < 3; tick += 1) {
-    const echo = `MIRROR-TICK-${tick}`;
-    /*
-     * Click near the top of the terminal BODY, below the one-row pane header.
-     * The header deliberately receives pointer input for drag, zoom, and menu
-     * actions; the transparent remainder forwards input to the whole-window
-     * attachment beneath the compositor.
-     */
-    await terminal.locator(".xterm-screen").click({ position: { x: 24, y: 48 } });
-    await page.keyboard.type(`echo ${echo}`);
-    await page.keyboard.press("Enter");
-    await expect
-      .poll(() => firstCompositorNode.locator(".xterm-rows").first().innerText(), {
-        message: `the composed pane never streamed the output of tick ${tick}`,
-        timeout: 20_000,
-      })
-      .toContain(echo);
-    const current = (await firstCompositorNode.elementHandle())!;
-    expect(
-      await page.evaluate(([before, after]) => before === after, [
-        compositorHandle,
-        current,
-      ] as const),
-      "the composed pane was replaced by a stream update — its xterm re-initializes every tick, " +
-        "which is the re-mount defect",
-    ).toBe(true);
-    expect(
-      await firstCompositorNode.getAttribute("data-pane"),
-      "the composed pane list reordered under a stream update",
-    ).toBe(firstComposedPane);
-  }
-  // And the pane is STILL fully on screen after those ticks: placement must
-  // survive re-measurement, not merely be right on the first paint.
-  await expect(
-    firstCompositorNode,
-    "the first composed pane disappeared after several stream updates",
-  ).toBeVisible();
-  const finalCompositorRect = await firstCompositorNode.boundingBox();
-  expect(
-    finalCompositorRect !== null &&
-      finalCompositorRect.width >= 120 &&
-      finalCompositorRect.height >= 100,
-    "the first composed pane collapsed after several stream updates",
-  ).toBe(true);
-  await page.screenshot({ path: testInfo.outputPath("4-pane-compositor-live.png") });
+  await page.screenshot({ path: testInfo.outputPath("4-single-terminal-authority.png") });
 
   // --- The session dies under the app ------------------------------------
   // Setup-level, and deliberately so: no in-app affordance can make a tmux

--- a/apps/desktop-renderer/e2e/pane-manipulation.e2e.ts
+++ b/apps/desktop-renderer/e2e/pane-manipulation.e2e.ts
@@ -26,7 +26,9 @@ import {
 test.use({ scratchSessions: 1, promoteSessions: 1 });
 
 const INITIAL_MARKER = "MANIPULATION-SEED-41C7";
-const LIVE_MARKER = "MANIPULATION-STILL-LIVE-8A2D";
+// Keep the proof on one physical row even after a vertical split; the visible
+// pane stream is narrower than the hidden whole-window controller by design.
+const LIVE_MARKER = "STILL-LIVE-8A2D";
 
 interface DomLayout {
   readonly semanticPaneId: string;
@@ -393,10 +395,18 @@ test("resize previews locally; header drag cancels or swaps without remounting t
     await expectSameTerminal(page, originalTerminal!, terminal, "after confirmed pane swap");
     await expectLiveCompositor(terminal, area, "after confirmed pane swap");
 
-    // The identity assertion above proves no remount; this proves that same
-    // attachment still accepts input and repaints output after all mutations.
-    const beforeTyping = await paintFingerprint(terminal);
-    await terminal.locator(".xterm-screen").click({ position: { x: 28, y: 24 } });
+    // The identity assertion above proves the geometry/input attachment did
+    // not remount. In a split window the visible per-pane compositor owns
+    // pixels and hit testing, so exercise the pane body a user actually clicks
+    // rather than reaching through it to the intentionally hidden controller.
+    const visiblePane = page.locator('.pane-tile[data-composed="true"] .mirror-pane-node').first();
+    await proveVisible(visiblePane, "the active composed pane after manipulation", {
+      minWidth: 80,
+      minHeight: 40,
+      timeoutMs: 30_000,
+    });
+    const beforeTyping = await paintFingerprint(visiblePane);
+    await visiblePane.click({ position: { x: 28, y: 24 } });
     await page.keyboard.type(`echo ${LIVE_MARKER}`);
     await page.keyboard.press("Enter");
     await expect
@@ -406,11 +416,15 @@ test("resize previews locally; header drag cancels or swaps without remounting t
       })
       .toContain(LIVE_MARKER);
     await proveVisible(
-      terminal.locator(".xterm-rows > div").filter({ hasText: LIVE_MARKER }).first(),
+      visiblePane.locator(".xterm-rows > div").filter({ hasText: LIVE_MARKER }).first(),
       `the post-manipulation terminal row showing "${LIVE_MARKER}"`,
       { minWidth: 80, minHeight: 4, timeoutMs: 30_000 },
     );
-    provePaintChanged(beforeTyping, await paintFingerprint(terminal), "the manipulated terminal");
+    provePaintChanged(
+      beforeTyping,
+      await paintFingerprint(visiblePane),
+      "the visible manipulated terminal",
+    );
     await expectSameTerminal(page, originalTerminal!, terminal, "after post-swap terminal input");
 
     // --- Header double-click: tmux zoom, then exact restoration ------------

--- a/apps/desktop-renderer/scripts/dev-csp-smoke.mjs
+++ b/apps/desktop-renderer/scripts/dev-csp-smoke.mjs
@@ -1127,10 +1127,10 @@ try {
           evidence.styleElements !== 0 ||
           evidence.violations.some(({ directive }) => directive.startsWith("style-src")) ||
           evidence.consoleViolations.length > 0 ||
-          evidence.paletteEvidence.groups !== 2 ||
-          evidence.paletteEvidence.options !== 6 ||
-          evidence.paletteEvidence.icons !== 6 ||
-          evidence.paletteEvidence.shortcuts !== 6 ||
+          evidence.paletteEvidence.groups !== 4 ||
+          evidence.paletteEvidence.options !== 16 ||
+          evidence.paletteEvidence.icons !== 16 ||
+          evidence.paletteEvidence.shortcuts !== 16 ||
           !evidence.paletteEvidence.width ||
           evidence.paletteEvidence.width > 680 ||
           !evidence.paletteEvidence.height ||
@@ -1140,7 +1140,7 @@ try {
           evidence.paletteEvidence.keyboardOverlayDuration !== "0s" ||
           evidence.paletteEvidence.keyboardPaletteDuration !== "0s" ||
           !evidence.paletteEvidence.keyboardFocusReturned ||
-          !evidence.paletteEvidence.emptyText?.includes("No commands found") ||
+          !evidence.paletteEvidence.emptyText?.includes("No results found") ||
           evidence.paletteEvidence.pointerOpen.source !== "mouse" ||
           evidence.paletteEvidence.pointerOpen.overlayDuration !== "0.15s, 0s" ||
           evidence.paletteEvidence.pointerOpen.paletteDuration !== "0.15s, 0.15s" ||

--- a/apps/desktop-renderer/src/experience/application-shell.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.tsx
@@ -624,7 +624,18 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
   const semanticPaneIdFor = (resourceId: string): string | null => {
     const inventory = shell().terminalInventory;
     if (!inventory) return null;
-    const resource = inventory.resources.find(({ id }) => id === resourceId);
+    /*
+     * Canvas frames address panes by resource id; authoritative tiled-layout
+     * frames already carry the semantic pane id. Context-menu targets can come
+     * from either surface, so accepting only the former made a confirmed tiled
+     * pane verb disappear whenever those two identities differed (most visibly
+     * on a freshly split pane whose inventory projection had just advanced).
+     */
+    const resource = inventory.resources.find(
+      ({ id, attachability }) =>
+        id === resourceId ||
+        (attachability.status === "available" && attachability.semanticPaneId === resourceId),
+    );
     return resource?.attachability.status === "available"
       ? resource.attachability.semanticPaneId
       : null;
@@ -784,9 +795,30 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
    * painting over the whole-window xterm. The hidden whole-window attachment
    * remains the input/geometry client; these streams are the visible pixels.
    */
-  const tiledPaneCompositorEnabled = createMemo(
-    () => !experimentalSurfaces && dataMode() === "runtime" && mirrorTransport() !== null,
-  );
+  const tiledPaneCompositorEnabled = createMemo(() => {
+    if (experimentalSurfaces || dataMode() !== "runtime" || mirrorTransport() === null) {
+      return false;
+    }
+
+    /*
+     * A pane stream is a compositor primitive, not a second rendering path for
+     * an ordinary one-pane window. Mounting it for every runtime workspace put
+     * a read-only xterm directly over the interactive xterm even when there was
+     * nothing to compose. Besides wasting a stream and emulator, the foreign
+     * screen owned hit testing while the live terminal beneath owned input.
+     *
+     * Start the compositor only when tmux actually has a multi-pane window.
+     * Inventory is available before the first layout stream, so this decision
+     * does not depend on a late frame and remains true while that frame settles.
+     */
+    const paneCounts = new Map<string, number>();
+    for (const resource of shell().terminalInventory?.resources ?? []) {
+      if (resource.attachability.status !== "available") continue;
+      const window = resource.windowResourceId ?? resource.id;
+      paneCounts.set(window, (paneCounts.get(window) ?? 0) + 1);
+    }
+    return [...paneCounts.values()].some((count) => count > 1);
+  });
   let activeMirrorKey = "";
   createEffect(() => {
     const transport = mirrorTransport();

--- a/apps/desktop-renderer/src/experience/workspace-tiled-surface.test.tsx
+++ b/apps/desktop-renderer/src/experience/workspace-tiled-surface.test.tsx
@@ -253,9 +253,8 @@ describe("the layout-faithful workspace view", () => {
     expect(headers.every((header) => !header.style.height.includes("calc"))).toBe(true);
   });
 
-  it("selects and copies text from the visible composed pane", () => {
+  it("keeps a single-pane window on its one interactive terminal renderer", () => {
     const recording = createRecordingMirrorRendererFactory();
-    const onFocusPane = vi.fn();
     const mirror: AppWindowCanvasMirrorProps = {
       enabled: true,
       onToggle: vi.fn(),
@@ -272,7 +271,42 @@ describe("the layout-faithful workspace view", () => {
       onRetry: vi.fn(),
       rendererFactory: recording.factory,
     };
-    const { root } = renderSurface([layout()], { mirror, onFocusPane });
+    const { root } = renderSurface([layout()], { mirror });
+
+    expect(root.querySelector(".tiled-pane-area")?.getAttribute("data-pane-compositor")).toBe(
+      "false",
+    );
+    expect(root.querySelectorAll('.pane-tile[data-composed="true"]')).toHaveLength(0);
+    expect(root.querySelectorAll(".pane-tile__body > .mirror-pane-node")).toHaveLength(0);
+  });
+
+  it("selects and copies text from the visible composed pane", () => {
+    const recording = createRecordingMirrorRendererFactory();
+    const onFocusPane = vi.fn();
+    const mirror: AppWindowCanvasMirrorProps = {
+      enabled: true,
+      onToggle: vi.fn(),
+      nodes: [
+        {
+          pane: "pane.a",
+          title: "Editor",
+          frame: null,
+          state: { kind: "live", flowPaused: false },
+          registerSink: () => () => undefined,
+        },
+        {
+          pane: "pane.b",
+          title: "Tests",
+          frame: null,
+          state: { kind: "live", flowPaused: false },
+          registerSink: () => () => undefined,
+        },
+      ],
+      connection: { kind: "connected" },
+      onRetry: vi.fn(),
+      rendererFactory: recording.factory,
+    };
+    const { root } = renderSurface([SPLIT], { mirror, onFocusPane });
     const body = root.querySelector<HTMLElement>(
       '.pane-tile[data-composed="true"] > .pane-tile__body',
     )!;

--- a/apps/desktop-renderer/src/experience/workspace-tiled-surface.tsx
+++ b/apps/desktop-renderer/src/experience/workspace-tiled-surface.tsx
@@ -398,12 +398,20 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
   });
   const compositorNodes = createMemo(() => {
     const mirror = props.mirror;
-    return new Map(mirror?.enabled ? mirror.nodes.map((node) => [node.pane, node] as const) : []);
+    return new Map(
+      mirror?.enabled && tiles().length > 1
+        ? mirror.nodes.map((node) => [node.pane, node] as const)
+        : [],
+    );
   });
   const paneCompositorEnabled = createMemo(() => {
     const visible = tiles();
     const nodes = compositorNodes();
-    return visible.length > 0 && visible.every((tile) => nodes.has(tile.pane));
+    // One pane already has one authoritative interactive renderer. Pane
+    // streams exist here only to compose a multi-pane tmux window; using one
+    // for a single pane creates two overlapping xterms with split pixel/input
+    // ownership and lets the mirror intercept the live terminal's hit tests.
+    return visible.length > 1 && visible.every((tile) => nodes.has(tile.pane));
   });
   const borders = createMemo(() => {
     const frame = currentFrame();
@@ -1712,59 +1720,6 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
           </span>
         </div>
       </div>
-      <Show when={paneCompositorEnabled() ? undefined : props.mirror}>
-        {(mirror) => (
-          <div class="mirror-deck" data-enabled={mirror().enabled}>
-            <div class="mirror-deck__controls">
-              <button
-                type="button"
-                class="mirror-deck__toggle"
-                aria-pressed={mirror().enabled}
-                data-mirror-toggle="true"
-                onClick={() => mirror().onToggle(!mirror().enabled)}
-              >
-                Mirror
-              </button>
-            </div>
-            <Show when={mirror().enabled}>
-              {/*
-               * `Index`, never `For`.
-               *
-               * The node list is rebuilt on every stream tick, so `For` — which
-               * keys by reference — would throw away each node's DOM and
-               * re-initialize its xterm several times a second. That is the
-               * re-mount defect the mirror was fixed for once already; the
-               * element identity is what the suite asserts across ticks.
-               */}
-              <div class="mirror-deck__nodes">
-                <Index each={mirror().nodes}>
-                  {(node) => (
-                    <div
-                      class="mirror-deck__node"
-                      data-mirror-node-id={`mirror:${node().pane}`}
-                      data-pane={node().pane}
-                      data-state={node().state.kind}
-                    >
-                      <span class="mirror-deck__title">{node().title}</span>
-                      <MirrorPaneNode
-                        pane={node().pane}
-                        title={node().title}
-                        state={node().state}
-                        connection={mirror().connection}
-                        faultLabel={mirror().faultLabel}
-                        registerSink={node().registerSink}
-                        onRetry={mirror().onRetry}
-                        reducedMotion={props.reducedMotion}
-                        themeKey={props.terminalThemeKey}
-                      />
-                    </div>
-                  )}
-                </Index>
-              </div>
-            </Show>
-          </div>
-        )}
-      </Show>
       <AttachmentReporter area={() => areaElement} onChange={props.onAttachmentChanged} />
     </div>
   );

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -6837,64 +6837,6 @@ kbd {
   }
 }
 
-.mirror-deck {
-  flex: 0 0 auto;
-  padding: 0 var(--tmi-space-2) var(--tmi-space-2);
-}
-
-.mirror-deck__controls {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.mirror-deck__toggle {
-  padding: var(--tmi-space-1) var(--tmi-space-3);
-  border: 1px solid var(--tmux-ide-border-default);
-  border-radius: var(--tmi-radius-control);
-  color: var(--tmux-ide-text-muted);
-  background: transparent;
-  font: inherit;
-  cursor: pointer;
-}
-
-.mirror-deck__toggle[aria-pressed="true"] {
-  color: var(--tmux-ide-text-bright);
-  background: var(--desktop-active);
-}
-
-.mirror-deck__nodes {
-  display: flex;
-  gap: var(--tmi-space-2);
-  margin-top: var(--tmi-space-2);
-  overflow-x: auto;
-}
-
-.mirror-deck__node {
-  position: relative;
-  display: flex;
-  flex: 0 0 auto;
-  flex-direction: column;
-  width: 320px;
-  height: 200px;
-  border: 1px solid var(--tmux-ide-border-default);
-  border-radius: var(--tmi-radius-control);
-  overflow: hidden;
-}
-
-.mirror-deck__title {
-  flex: 0 0 auto;
-  padding: 0 var(--tmi-space-2);
-  color: var(--tmux-ide-text-muted);
-  font-size: 0.75rem;
-  line-height: 1.8;
-}
-
-.mirror-deck__node .mirror-pane-node {
-  position: relative;
-  flex: 1 1 auto;
-  min-height: 0;
-}
-
 /* ==========================================================================
  * m51 — Kowalski design-engineering pass
  *
@@ -6977,8 +6919,7 @@ kbd {
 .create-pane-flow__trigger,
 .canvas-controls button,
 .fleet-sidebar__open-action,
-.mirror-pane-node__state button,
-.mirror-deck__toggle {
+.mirror-pane-node__state button {
   border-color: color-mix(in oklab, var(--desktop-separator) 82%, transparent);
   background: color-mix(in oklab, var(--desktop-raised) 88%, transparent);
   box-shadow: var(--desktop-control-highlight), var(--desktop-control-shadow);


### PR DESCRIPTION
## Summary
- make pane-stream composition a multi-pane-only rendering path
- keep single-pane windows on one interactive xterm and remove the legacy mirror deck
- update live journeys and strict-CSP expectations to the current UI contract

## Verification
- 71 renderer test files / 838 tests
- renderer typecheck and lint
- strict-CSP development smoke
- complete serial Playwright suite: 8/8 live journeys
- Prettier and git diff checks

This repairs the already-failing protected-main baseline before the session-runtime contract PR is rebased.