### PR TITLE
refactor: centralize daemon session runtime ownership

### DIFF
--- a/packages/daemon/src/architecture/session-runtime-boundary.test.ts
+++ b/packages/daemon/src/architecture/session-runtime-boundary.test.ts
@@ -17,6 +17,11 @@ const M56_4_DELETION_TARGET = [
   "packages/daemon/src/tui/mirror/session-mirror.ts",
 ] as const;
 
+const MIRROR_SERVICE_CONSTRUCTION = /\bnew\s+MirrorService\s*\(/u;
+const SESSION_RUNTIME_CONTROL_OWNER = [
+  "packages/daemon/src/terminal/session-runtime/registry.ts",
+] as const;
+
 const CONTROL_OWNERSHIP_IMPORT =
   /(?:from\s+|import\s*\(\s*)["'][^"']*(?:session-mirror|control-client|terminal\/mirror\/(?:mirror-service|control-channel|session-channel)|terminal\/pane-stream\/runtime)\.ts["']/u;
 const M56_4_DEPENDENCY_DELETION_TARGET = [
@@ -66,7 +71,21 @@ async function matches(pattern: RegExp): Promise<string[]> {
   return findings.sort();
 }
 
+async function matchesUnder(root: string, pattern: RegExp): Promise<string[]> {
+  const findings: string[] = [];
+  for (const file of await sourceFiles(join(REPO, root))) {
+    if (pattern.test(await readFile(file, "utf8"))) findings.push(relative(REPO, file));
+  }
+  return findings.sort();
+}
+
 describe("one SessionRuntime import DAG", () => {
+  it("allows exactly one production MirrorService construction owner", async () => {
+    expect(await matchesUnder("packages/daemon/src", MIRROR_SERVICE_CONSTRUCTION)).toEqual(
+      [...SESSION_RUNTIME_CONTROL_OWNER].sort(),
+    );
+  });
+
   it("freezes the two actual direct control owners for deletion in m56.4", async () => {
     expect(await matches(DIRECT_CONTROL_CONSTRUCTION)).toEqual([...M56_4_DELETION_TARGET].sort());
   });

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -277,6 +277,11 @@ export {
   type PaneStreamRuntimeOptions,
 } from "./terminal/pane-stream/runtime.ts";
 export {
+  SessionRuntimeRegistry,
+  type SessionRuntimeConsumer,
+  type SessionRuntimeRegistryOptions,
+} from "./terminal/session-runtime/registry.ts";
+export {
   TerminalInputAuthority,
   TerminalInputAuthorityConflictError,
   type TerminalInputAuthoritySnapshot,

--- a/packages/daemon/src/lib/daemon-embed.ts
+++ b/packages/daemon/src/lib/daemon-embed.ts
@@ -57,6 +57,7 @@ import {
   createPaneStreamRuntime,
   type PaneStreamRuntime,
 } from "../terminal/pane-stream/runtime.ts";
+import { SessionRuntimeRegistry } from "../terminal/session-runtime/registry.ts";
 import { setActivationBackend, type ProjectActivationOptions } from "./active-projects.ts";
 import { readOrMintEnvironmentId } from "./environment-identity.ts";
 import {
@@ -996,6 +997,7 @@ export async function startEmbeddedDaemon(
       },
     });
     let terminalAttachmentRuntime: NativeTerminalAttachmentRuntime | null = null;
+    let sessionRuntimeRegistry: SessionRuntimeRegistry | null = null;
     let paneStreamRuntime: PaneStreamRuntime | null = null;
     let startedServer: Awaited<ReturnType<typeof startHttpServer>>;
     try {
@@ -1015,11 +1017,21 @@ export async function startEmbeddedDaemon(
       // Orphan reconciliation is a hard startup barrier: neither the HTTP
       // mutation nor direct WebSocket redemption is exposed before it passes.
       await terminalAttachmentRuntime.whenReady();
+      const selector = tmuxAuthority.socketSelector;
+      sessionRuntimeRegistry = new SessionRuntimeRegistry({
+        generation: instanceId,
+        mirror: {
+          executable: tmuxAuthority.executablePath,
+          ...(selector.kind === "path" ? { socketPath: selector.path } : {}),
+          ...(selector.kind === "name" && selector.name !== "default"
+            ? { socketName: selector.name }
+            : {}),
+        },
+      });
       paneStreamRuntime = createPaneStreamRuntime({
         daemonInstanceId: instanceId,
         webSocketUrl: paneStreamWebSocketUrl(bindHostname, port),
-        tmuxExecutablePath: tmuxAuthority.executablePath,
-        tmuxSocketSelector: tmuxAuthority.socketSelector,
+        sessionRuntimeRegistry,
         inputAuthority: terminalAttachmentRuntime.inputAuthority,
         semanticPaneCatalog: terminalAttachmentRuntime.semanticPaneCatalog,
       });
@@ -1053,6 +1065,10 @@ export async function startEmbeddedDaemon(
         workspaceMultiplexer.dispose(),
         externalInteractionObserver.dispose(),
       ]);
+      // The pane-stream coordinator may still hold runtime consumers while it
+      // drains. Preserve the normal shutdown order on startup rollback too:
+      // transports first, then the one session/control authority.
+      await Promise.allSettled([sessionRuntimeRegistry?.dispose() ?? Promise.resolve()]);
       throw error;
     }
     const {
@@ -1065,11 +1081,16 @@ export async function startEmbeddedDaemon(
     } = startedServer;
     externalInteractionObserver.start();
     const retirePaneStreamTransport = async (): Promise<readonly unknown[]> => {
-      const results = await Promise.allSettled([
+      const transportResults = await Promise.allSettled([
         Promise.resolve().then(() => paneStreamRuntime!.dispose()),
         Promise.resolve().then(() => paneStreamBoundary.close()),
       ]);
-      return results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+      const runtimeResults = await Promise.allSettled([
+        Promise.resolve().then(() => sessionRuntimeRegistry!.dispose()),
+      ]);
+      return [...transportResults, ...runtimeResults].flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
     };
     const abortStartedServer = async (): Promise<void> => {
       const terminalFailures = [

--- a/packages/daemon/src/terminal/mirror/mirror-service.test.ts
+++ b/packages/daemon/src/terminal/mirror/mirror-service.test.ts
@@ -41,6 +41,46 @@ async function subscribed(service: MirrorService, session: string, pane: string)
 }
 
 describe("MirrorService refcounting", () => {
+  it("never returns a channel that exited between start settlement and acquire continuation", async () => {
+    const sims: SimulatedChannel[] = [];
+    let creation = 0;
+    const service = new MirrorService({
+      createIo: (_session, handlers) => {
+        creation += 1;
+        const sim = new SimulatedChannel(handlers, (cmd) => {
+          const auto = fixtureAutoReply(fixtureState())(cmd);
+          if (auto) return auto;
+          if (cmd.startsWith("capture-pane")) return ["seed"];
+          if (cmd.startsWith("display-message")) return ["0 0 100 50"];
+          return [];
+        });
+        sims.push(sim);
+        const exitDuringStart = creation === 1;
+        return {
+          start: async () => {
+            await sim.start();
+            if (exitDuringStart) handlers.onExit("exited during start handoff");
+          },
+          request: (command) => sim.request(command),
+          commandInline: (command, onReply) => sim.commandInline(command, onReply),
+          commandListInline: (command, replyCount, resultIndex, onReply) =>
+            sim.commandListInline(command, replyCount, resultIndex, onReply),
+          send: (command) => sim.send(command),
+          dispose: () => sim.dispose(),
+        };
+      },
+      generatePaneId: () => "pane.mirror.gen1",
+    });
+
+    const retention = await service.retainSession(FIXTURE.session);
+
+    expect(sims).toHaveLength(2);
+    expect(sims[0]!.disposed).toBe(true);
+    expect(sims[1]!.disposed).toBe(false);
+    expect(service.activeChannelCount()).toBe(1);
+    await retention.close();
+  });
+
   it("rejects a second control-mode owner for the same server session", async () => {
     const first = rig();
     const second = rig();

--- a/packages/daemon/src/terminal/mirror/mirror-service.ts
+++ b/packages/daemon/src/terminal/mirror/mirror-service.ts
@@ -62,11 +62,17 @@ export interface MirrorSubscription {
   close(): Promise<void>;
 }
 
+export interface MirrorSessionRetention {
+  readonly session: string;
+  close(): Promise<void>;
+}
+
 interface ChannelEntry {
   channel: SessionChannel;
   started: Promise<void>;
   refs: number;
   releaseAuthority: () => void;
+  retired: boolean;
 }
 
 export class MirrorService {
@@ -74,6 +80,7 @@ export class MirrorService {
   private readonly channels = new Map<string, ChannelEntry>();
   private readonly pendingDisposals = new Set<Promise<void>>();
   private readonly drainingChannels = new Map<string, Promise<void>>();
+  private readonly sessionExitListeners = new Set<(session: string) => void>();
   private readonly owner = Symbol("MirrorService control-mode owner");
   private disposed = false;
 
@@ -123,6 +130,31 @@ export class MirrorService {
     };
   }
 
+  /**
+   * Keep one session channel alive independently of renderer subscriptions.
+   * The daemon SessionRuntime registry owns this retention; clients never do.
+   */
+  async retainSession(session: string): Promise<MirrorSessionRetention> {
+    const entry = await this.acquire(session);
+    let closed = false;
+    return {
+      session,
+      close: async () => {
+        if (closed) return;
+        closed = true;
+        this.release(session, entry);
+        await Promise.allSettled([...this.pendingDisposals]);
+      },
+    };
+  }
+
+  /** SessionRuntime's reconnect seam; runtime addresses never cross it. */
+  onSessionExit(listener: (session: string) => void): () => void {
+    if (this.disposed) throw new Error("MirrorService is disposed");
+    this.sessionExitListeners.add(listener);
+    return () => this.sessionExitListeners.delete(listener);
+  }
+
   /** Fall-behind telemetry for an ACTIVE session channel; null when no
    *  channel is running for the session. */
   ageTelemetry(session: string): { maxAgeMs: number; byPane: Record<string, number> } | null {
@@ -140,10 +172,12 @@ export class MirrorService {
 
   async dispose(): Promise<void> {
     this.disposed = true;
+    this.sessionExitListeners.clear();
     const entries = [...this.channels.values()];
     this.channels.clear();
     await Promise.allSettled(
       entries.map(async (entry) => {
+        entry.retired = true;
         try {
           await entry.channel.dispose();
         } finally {
@@ -191,9 +225,10 @@ export class MirrorService {
             // The channel died underneath its subscribers (tmux exit/detach):
             // drop the entry so the next acquire starts fresh; open handles
             // already received their `closed` events.
-            if (this.channels.get(session)?.channel === channel) {
-              this.channels.delete(session);
-              releaseAuthority();
+            const active = this.channels.get(session);
+            if (active?.channel === channel) {
+              this.retire(session, active);
+              for (const listener of this.sessionExitListeners) listener(session);
             }
           },
         };
@@ -202,7 +237,13 @@ export class MirrorService {
         releaseAuthority();
         throw cause;
       }
-      entry = { channel, started: channel.start(), refs: 0, releaseAuthority };
+      entry = {
+        channel,
+        started: channel.start(),
+        refs: 0,
+        releaseAuthority,
+        retired: false,
+      };
       this.channels.set(session, entry);
     }
     entry.refs += 1;
@@ -212,12 +253,26 @@ export class MirrorService {
       this.release(session, entry);
       throw cause;
     }
+    // A control client can exit after its start promise settles but before this
+    // continuation runs. Never hand that retired entry to a caller as ready:
+    // release its provisional ref, wait for the drain, and acquire the single
+    // successor through the same ownership path.
+    if (entry.retired) {
+      this.release(session, entry);
+      return await this.acquire(session);
+    }
     return entry;
   }
 
   private release(session: string, entry: ChannelEntry): void {
     entry.refs -= 1;
     if (entry.refs > 0) return;
+    this.retire(session, entry);
+  }
+
+  private retire(session: string, entry: ChannelEntry): void {
+    if (entry.retired) return;
+    entry.retired = true;
     if (this.channels.get(session) === entry) this.channels.delete(session);
     const disposal = entry.channel
       .dispose()

--- a/packages/daemon/src/terminal/pane-stream/runtime.ts
+++ b/packages/daemon/src/terminal/pane-stream/runtime.ts
@@ -1,7 +1,6 @@
-import { MirrorService } from "../mirror/mirror-service.ts";
-import type { DaemonTmuxSocketSelector } from "../attachments/pty-tmux-attachment-launcher.ts";
 import type { SemanticPaneCatalog } from "../attachments/semantic-pane-catalog.ts";
 import type { TerminalInputAuthority } from "../input-authority.ts";
+import type { SessionRuntimeRegistry } from "../session-runtime/registry.ts";
 import { PaneStreamLeaseManager } from "./lease-manager.ts";
 import {
   PaneStreamAdmissionCoordinator,
@@ -11,9 +10,8 @@ import {
 export interface PaneStreamRuntimeOptions {
   readonly daemonInstanceId: string;
   readonly webSocketUrl: string;
-  /** The daemon's pinned tmux authority; omit both for the default server. */
-  readonly tmuxExecutablePath?: string;
-  readonly tmuxSocketSelector?: DaemonTmuxSocketSelector;
+  /** Canonical daemon-generation session/control owner. */
+  readonly sessionRuntimeRegistry: SessionRuntimeRegistry;
   /** Shared production authority and trusted semantic resolver. */
   readonly inputAuthority?: TerminalInputAuthority;
   readonly semanticPaneCatalog?: SemanticPaneCatalog;
@@ -24,25 +22,15 @@ export interface PaneStreamRuntimeOptions {
 }
 
 /**
- * One daemon-generation owner for the pane-stream surface: the shared
- * MirrorService (one control client per session, refcounted), the lease
- * authority, and the WebSocket admission coordinator. The coordinator is the
- * issue backend the broker mutation route consumes.
+ * One daemon-generation owner for the pane-stream transport: lease authority
+ * and WebSocket admission. Session/control lifecycle belongs exclusively to
+ * the injected SessionRuntimeRegistry.
  */
 export class PaneStreamRuntime {
   readonly coordinator: PaneStreamAdmissionCoordinator;
-  readonly mirror: MirrorService;
   #disposePromise: Promise<void> | null = null;
 
   constructor(options: PaneStreamRuntimeOptions) {
-    const selector = options.tmuxSocketSelector;
-    this.mirror = new MirrorService({
-      executable: options.tmuxExecutablePath,
-      ...(selector?.kind === "path" ? { socketPath: selector.path } : {}),
-      ...(selector?.kind === "name" && selector.name !== "default"
-        ? { socketName: selector.name }
-        : {}),
-    });
     const leaseManager = new PaneStreamLeaseManager({
       daemonInstanceId: options.daemonInstanceId,
       ...(options.inputAuthority && options.semanticPaneCatalog
@@ -57,7 +45,7 @@ export class PaneStreamRuntime {
       daemonInstanceId: options.daemonInstanceId,
       webSocketUrl: options.webSocketUrl,
       leaseManager,
-      mirror: this.mirror,
+      mirror: options.sessionRuntimeRegistry,
     });
   }
 
@@ -65,7 +53,6 @@ export class PaneStreamRuntime {
     if (!this.#disposePromise) {
       this.#disposePromise = (async () => {
         await this.coordinator.shutdown();
-        await this.mirror.dispose();
       })();
     }
     return this.#disposePromise;

--- a/packages/daemon/src/terminal/session-runtime/registry.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/registry.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MirrorServiceOptions } from "../mirror/mirror-service.ts";
+import { ControlModeOwnershipRegistry } from "../mirror/control-mode-ownership.ts";
+import {
+  FIXTURE,
+  SimulatedChannel,
+  fixtureAutoReply,
+  fixtureState,
+} from "../mirror/__tests__/simulated-channel.ts";
+import { SessionRuntimeRegistry } from "./registry.ts";
+
+const GENERATION_A = "11111111-1111-4111-8111-111111111111";
+const GENERATION_B = "22222222-2222-4222-8222-222222222222";
+
+function rig(generation = GENERATION_A): {
+  registry: SessionRuntimeRegistry;
+  sims: SimulatedChannel[];
+  mirror: MirrorServiceOptions;
+} {
+  const sims: SimulatedChannel[] = [];
+  const mirror: MirrorServiceOptions = {
+    createIo: (_session, handlers) => {
+      const sim = new SimulatedChannel(handlers, (command) => {
+        const reply = fixtureAutoReply(fixtureState())(command);
+        if (reply) return reply;
+        if (command.includes("capture-pane")) return ["seed"];
+        if (command.startsWith("display-message")) return ["0 0 100 50"];
+        return [];
+      });
+      sims.push(sim);
+      return sim;
+    },
+    generatePaneId: () => "pane.mirror.generated",
+    controlModeOwnershipRegistry: new ControlModeOwnershipRegistry(),
+  };
+  return { registry: new SessionRuntimeRegistry({ generation, mirror }), sims, mirror };
+}
+
+function finishSeed(sim: SimulatedChannel): void {
+  sim.reply(["seed"]);
+  sim.reply(["0 0 100 50"]);
+}
+
+describe("SessionRuntimeRegistry", () => {
+  it("shares one long-lived control authority across three independent consumer handles", async () => {
+    const { registry, sims } = rig();
+    const tui = registry.connect(FIXTURE.session, "opentui");
+    const webOne = registry.connect(FIXTURE.session, "web:one");
+    const webTwo = registry.connect(FIXTURE.session, "web:two");
+
+    const subscriptions = await Promise.all([
+      tui.subscribe("pane.alpha", () => {}),
+      webOne.subscribe("pane.alpha", () => {}),
+      webTwo.subscribe("pane.beta", () => {}),
+    ]);
+
+    expect(sims).toHaveLength(1);
+    expect(registry.sessionCount()).toBe(1);
+    expect(registry.activeControlChannelCount()).toBe(1);
+    expect([tui.generation, webOne.generation, webTwo.generation]).toEqual([
+      GENERATION_A,
+      GENERATION_A,
+      GENERATION_A,
+    ]);
+
+    await Promise.all(subscriptions.map((subscription) => subscription.close()));
+    await Promise.all([tui.close(), webOne.close(), webTwo.close()]);
+
+    // Consumer churn does not churn the session's daemon-owned control lane.
+    expect(registry.activeControlChannelCount()).toBe(1);
+    expect(sims[0]!.disposed).toBe(false);
+
+    await registry.dispose();
+    expect(registry.activeControlChannelCount()).toBe(0);
+    expect(sims[0]!.disposed).toBe(true);
+  });
+
+  it("isolates a frozen or disconnected consumer from live ingestion", async () => {
+    const { registry, sims } = rig();
+    const slow = registry.connect(FIXTURE.session, "web:slow");
+    const live = registry.connect(FIXTURE.session, "web:live");
+    const slowEvents: string[] = [];
+    const liveEvents: string[] = [];
+    const slowSubscription = await slow.subscribe("pane.alpha", (event) => {
+      slowEvents.push(event.type);
+    });
+    finishSeed(sims[0]!);
+    await live.subscribe("pane.alpha", (event) => liveEvents.push(event.type));
+    finishSeed(sims[0]!);
+
+    slowEvents.length = 0;
+    liveEvents.length = 0;
+    slowSubscription.freeze();
+    sims[0]!.output("%1", "first");
+    expect(slowEvents).toEqual(["flow"]);
+    expect(liveEvents).toEqual(["delta"]);
+
+    await slow.close();
+    sims[0]!.output("%1", "second");
+    expect(liveEvents).toEqual(["delta", "delta"]);
+    expect(registry.activeControlChannelCount()).toBe(1);
+
+    await live.close();
+    await registry.dispose();
+  });
+
+  it("rebuilds one channel on demand after exit under the same generation owner", async () => {
+    const { registry, sims } = rig();
+    const tui = registry.connect(FIXTURE.session, "opentui");
+    const closed: string[] = [];
+    await tui.subscribe("pane.alpha", (event) => {
+      if (event.type === "closed") closed.push(event.type);
+    });
+
+    sims[0]!.feedLines("%exit detached");
+    expect(closed).toEqual(["closed"]);
+    expect(registry.activeControlChannelCount()).toBe(0);
+
+    const webOne = registry.connect(FIXTURE.session, "web:replacement:one");
+    const webTwo = registry.connect(FIXTURE.session, "web:replacement:two");
+    await Promise.all([
+      webOne.subscribe("pane.alpha", () => {}),
+      webTwo.subscribe("pane.beta", () => {}),
+    ]);
+    expect(sims).toHaveLength(2);
+    expect(registry.activeControlChannelCount()).toBe(1);
+    expect(webOne.generation).toBe(GENERATION_A);
+    expect(webTwo.generation).toBe(GENERATION_A);
+    await vi.waitFor(() => expect(sims[0]!.disposed).toBe(true));
+
+    await Promise.all([tui.close(), webOne.close(), webTwo.close()]);
+    await registry.dispose();
+  });
+
+  it("rebuilds deterministically for a new daemon generation without tmux process ownership", async () => {
+    const first = rig(GENERATION_A);
+    const firstClient = first.registry.connect(FIXTURE.session, "web:first-generation");
+    await firstClient.subscribe("pane.alpha", () => {});
+    await first.registry.dispose();
+
+    const second = new SessionRuntimeRegistry({ generation: GENERATION_B, mirror: first.mirror });
+    const secondClient = second.connect(FIXTURE.session, "web:second-generation");
+    await secondClient.subscribe("pane.alpha", () => {});
+
+    expect(first.sims).toHaveLength(2);
+    expect(first.sims[0]!.disposed).toBe(true);
+    expect(secondClient.generation).toBe(GENERATION_B);
+    expect(second.activeControlChannelCount()).toBe(1);
+
+    await second.dispose();
+    expect(first.sims[1]!.disposed).toBe(true);
+  });
+});

--- a/packages/daemon/src/terminal/session-runtime/registry.ts
+++ b/packages/daemon/src/terminal/session-runtime/registry.ts
@@ -1,0 +1,245 @@
+import {
+  SessionRuntimeGenerationSchemaZ,
+  type SessionRuntimeGeneration,
+} from "@tmux-ide/contracts";
+import type {
+  MirrorLayoutEvent,
+  MirrorPaneEvent,
+  MirrorSessionDescription,
+} from "../mirror/events.ts";
+import {
+  MirrorService,
+  type MirrorServiceOptions,
+  type MirrorSubscribeRequest,
+  type MirrorSubscription,
+} from "../mirror/mirror-service.ts";
+import type { PaneStreamMirror } from "../pane-stream/pane-stream-websocket.ts";
+
+export interface SessionRuntimeRegistryOptions {
+  readonly generation: string;
+  readonly mirror?: MirrorServiceOptions;
+}
+
+export interface SessionRuntimeConsumer {
+  readonly generation: SessionRuntimeGeneration;
+  readonly session: string;
+  readonly surface: string;
+  describe(): Promise<MirrorSessionDescription>;
+  subscribe(
+    semanticPaneId: string,
+    onEvent: (event: MirrorPaneEvent) => void,
+    onLayout?: (event: MirrorLayoutEvent) => void,
+  ): Promise<MirrorSubscription>;
+  close(): Promise<void>;
+}
+
+/**
+ * One daemon-generation lifecycle owner for every discovered tmux session.
+ *
+ * A session runtime retains the canonical MirrorService channel independently
+ * of its GUI/TUI/SDK consumers. Consumer departure therefore cannot churn the
+ * tmux control client. A channel exit invalidates only that retention; the next
+ * operation rebuilds it through the same registry and generation without
+ * starting, stopping, or otherwise owning the tmux server process.
+ */
+export class SessionRuntimeRegistry implements PaneStreamMirror {
+  readonly generation: SessionRuntimeGeneration;
+  readonly #mirror: MirrorService;
+  readonly #sessions = new Map<string, SessionRuntime>();
+  readonly #stopExitObserver: () => void;
+  #disposed = false;
+  #disposePromise: Promise<void> | null = null;
+
+  constructor(options: SessionRuntimeRegistryOptions) {
+    this.generation = SessionRuntimeGenerationSchemaZ.parse(options.generation);
+    this.#mirror = new MirrorService(options.mirror);
+    this.#stopExitObserver = this.#mirror.onSessionExit((session) => {
+      this.#sessions.get(session)?.noteControlExit();
+    });
+  }
+
+  connect(session: string, surface: string): SessionRuntimeConsumer {
+    return this.#runtime(session).connect(surface);
+  }
+
+  async describeSession(session: string): Promise<MirrorSessionDescription> {
+    return await this.#runtime(session).describe();
+  }
+
+  async subscribe(request: MirrorSubscribeRequest): Promise<MirrorSubscription> {
+    const runtime = this.#runtime(request.session);
+    await runtime.whenReady();
+    return await this.#mirror.subscribe(request);
+  }
+
+  sessionCount(): number {
+    return this.#sessions.size;
+  }
+
+  activeControlChannelCount(): number {
+    return this.#mirror.activeChannelCount();
+  }
+
+  dispose(): Promise<void> {
+    if (!this.#disposePromise) {
+      this.#disposed = true;
+      this.#stopExitObserver();
+      this.#disposePromise = (async () => {
+        await Promise.allSettled([...this.#sessions.values()].map((runtime) => runtime.dispose()));
+        this.#sessions.clear();
+        await this.#mirror.dispose();
+      })();
+    }
+    return this.#disposePromise;
+  }
+
+  #runtime(session: string): SessionRuntime {
+    if (this.#disposed) throw new Error("SessionRuntimeRegistry is disposed");
+    const existing = this.#sessions.get(session);
+    if (existing) return existing;
+    const runtime = new SessionRuntime(this.generation, session, this.#mirror);
+    this.#sessions.set(session, runtime);
+    return runtime;
+  }
+}
+
+class SessionRuntime {
+  readonly #mirror: MirrorService;
+  readonly #consumers = new Set<SessionRuntimeConsumerImpl>();
+  #retention: Awaited<ReturnType<MirrorService["retainSession"]>> | null = null;
+  #startPromise: Promise<void> | null = null;
+  #restartBarrier: Promise<void> = Promise.resolve();
+  #disposed = false;
+
+  constructor(
+    readonly generation: SessionRuntimeGeneration,
+    readonly session: string,
+    mirror: MirrorService,
+  ) {
+    this.#mirror = mirror;
+  }
+
+  connect(surface: string): SessionRuntimeConsumer {
+    if (this.#disposed) throw new Error(`SessionRuntime ${this.session} is disposed`);
+    const consumer = new SessionRuntimeConsumerImpl(this, surface);
+    this.#consumers.add(consumer);
+    return consumer;
+  }
+
+  async whenReady(): Promise<void> {
+    if (this.#disposed) throw new Error(`SessionRuntime ${this.session} is disposed`);
+    if (!this.#startPromise) {
+      this.#startPromise = (async () => {
+        await this.#restartBarrier;
+        if (this.#disposed) throw new Error(`SessionRuntime ${this.session} is disposed`);
+        this.#retention = await this.#mirror.retainSession(this.session);
+      })().catch((error) => {
+        this.#startPromise = null;
+        throw error;
+      });
+    }
+    await this.#startPromise;
+  }
+
+  async describe(): Promise<MirrorSessionDescription> {
+    await this.whenReady();
+    return await this.#mirror.describeSession(this.session);
+  }
+
+  async subscribe(
+    semanticPaneId: string,
+    onEvent: (event: MirrorPaneEvent) => void,
+    onLayout?: (event: MirrorLayoutEvent) => void,
+  ): Promise<MirrorSubscription> {
+    await this.whenReady();
+    return await this.#mirror.subscribe({
+      session: this.session,
+      semanticPaneId,
+      onEvent,
+      onLayout,
+    });
+  }
+
+  release(consumer: SessionRuntimeConsumerImpl): void {
+    this.#consumers.delete(consumer);
+  }
+
+  noteControlExit(): void {
+    const retention = this.#retention;
+    this.#retention = null;
+    this.#startPromise = null;
+    if (retention) {
+      this.#restartBarrier = this.#restartBarrier.then(() => retention.close());
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    const consumers = [...this.#consumers];
+    await Promise.allSettled(consumers.map((consumer) => consumer.close()));
+    await this.#restartBarrier;
+    await this.#retention?.close();
+    this.#retention = null;
+  }
+}
+
+class SessionRuntimeConsumerImpl implements SessionRuntimeConsumer {
+  readonly #runtime: SessionRuntime;
+  readonly generation: SessionRuntimeGeneration;
+  readonly session: string;
+  readonly #subscriptions = new Set<MirrorSubscription>();
+  #closed = false;
+
+  constructor(
+    runtime: SessionRuntime,
+    readonly surface: string,
+  ) {
+    this.#runtime = runtime;
+    this.generation = runtime.generation;
+    this.session = runtime.session;
+  }
+
+  async describe(): Promise<MirrorSessionDescription> {
+    this.#assertOpen();
+    return await this.#runtime.describe();
+  }
+
+  async subscribe(
+    semanticPaneId: string,
+    onEvent: (event: MirrorPaneEvent) => void,
+    onLayout?: (event: MirrorLayoutEvent) => void,
+  ): Promise<MirrorSubscription> {
+    this.#assertOpen();
+    const upstream = await this.#runtime.subscribe(semanticPaneId, onEvent, onLayout);
+    if (this.#closed) {
+      await upstream.close();
+      throw new Error(`SessionRuntime consumer ${this.surface} is closed`);
+    }
+    let closed = false;
+    const subscription: MirrorSubscription = {
+      ...upstream,
+      close: async () => {
+        if (closed) return;
+        closed = true;
+        this.#subscriptions.delete(subscription);
+        await upstream.close();
+      },
+    };
+    this.#subscriptions.add(subscription);
+    return subscription;
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    const subscriptions = [...this.#subscriptions];
+    this.#subscriptions.clear();
+    await Promise.allSettled(subscriptions.map((subscription) => subscription.close()));
+    this.#runtime.release(this);
+  }
+
+  #assertOpen(): void {
+    if (this.#closed) throw new Error(`SessionRuntime consumer ${this.surface} is closed`);
+  }
+}


### PR DESCRIPTION
## Summary
- add one daemon-generation `SessionRuntimeRegistry` that owns stable per-session control lifecycle
- route pane-stream through the registry and delete its direct `MirrorService` construction/disposal bypass
- retain session authority across consumer churn and rebuild exactly one successor after control exit
- enforce transport-before-authority teardown in normal shutdown and startup rollback
- add an architecture gate allowing exactly one production `MirrorService` construction

## Review hardening
- prevent `acquire()` from returning a channel retired during startup handoff
- prove concurrent reconnect demand still creates one successor channel
- bind consumer generations to the shared contract type
- keep the tests honest: this proves independent consumer handles; the real OpenTUI cutover remains m56.4

## Verification
- daemon: 236 test files / 3,121 tests
- all daemon typecheck variants
- daemon lint
- Prettier and `git diff --check`

Part m56.1a of Sfora card #185. Ordered mutations/receipts, controller handoff, authenticated attribution, and the OpenTUI cutover remain separate reviewed slices.