### PR TITLE
refactor: serialize semantic session mutations

### DIFF
--- a/packages/contracts/src/__tests__/session-runtime.test.ts
+++ b/packages/contracts/src/__tests__/session-runtime.test.ts
@@ -15,6 +15,14 @@ describe("session runtime architecture contract", () => {
     expect(SessionRuntimeSemanticIntentSchemaZ.safeParse({ ...intent, paneId: "%7" }).success).toBe(
       false,
     );
+    expect(
+      SessionRuntimeSemanticIntentSchemaZ.safeParse({
+        verb: "workspace.window.split",
+        workspaceName: "project",
+        semanticPaneId: "pane.editor",
+        direction: "right",
+      }).success,
+    ).toBe(true);
   });
 
   it.each(["accepted", "observed", "rejected", "timed-out"] as const)(

--- a/packages/contracts/src/session-runtime.ts
+++ b/packages/contracts/src/session-runtime.ts
@@ -58,6 +58,7 @@ export const SessionRuntimePaneReadIntentSchemaZ = z
     origin: AuthoredInteractionOriginSchemaZ,
   })
   .strict();
+export type SessionRuntimePaneReadIntent = z.infer<typeof SessionRuntimePaneReadIntentSchemaZ>;
 
 /** The only intents a client may submit: semantic identity, never tmux addresses. */
 export const SessionRuntimeSemanticIntentSchemaZ = z.union([

--- a/packages/daemon/src/command-center/actions/dispatcher.test.ts
+++ b/packages/daemon/src/command-center/actions/dispatcher.test.ts
@@ -31,8 +31,7 @@ afterEach(() => {
 });
 
 describe("command-backed action dispatcher compatibility", () => {
-  it("emits accepted and applied send receipts without exposing literal input", async () => {
-    const receipts = vi.fn();
+  it("delegates pane send and its receipt lifecycle to the runtime backend", async () => {
     const mutate = vi.fn(async (input) => ({
       verb: "workspace.pane.send" as const,
       outcome: "applied" as const,
@@ -52,7 +51,6 @@ describe("command-backed action dispatcher compatibility", () => {
       createActionDispatcher({
         broadcast: vi.fn(),
         broadcastResourceChanged: vi.fn(),
-        broadcastInteractionReceipt: receipts,
         daemonInstanceId: "20000000-0000-4000-8000-000000000002",
         workspaceMultiplexerBackend: { mutate },
       }),
@@ -74,12 +72,6 @@ describe("command-backed action dispatcher compatibility", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(receipts.mock.calls.map(([receipt]) => receipt.phase)).toEqual(["accepted", "applied"]);
-    expect(receipts.mock.calls.map(([receipt]) => receipt.sourceSemanticPaneId)).toEqual([
-      null,
-      "pane.orchestrator",
-    ]);
-    expect(JSON.stringify(receipts.mock.calls)).not.toContain("private prompt");
     expect(mutate).toHaveBeenCalledWith(
       expect.objectContaining({ intent: expect.objectContaining({ text: "private prompt" }) }),
     );

--- a/packages/daemon/src/command-center/actions/dispatcher.ts
+++ b/packages/daemon/src/command-center/actions/dispatcher.ts
@@ -28,11 +28,9 @@ import { ActionError, wrapInternalError } from "./errors.ts";
 import { getLooseActionEntry } from "./registry.ts";
 import {
   broadcastActionComplete,
-  broadcastInteractionReceipt,
   broadcastResourceChanged,
   broadcastWorkspacePromotionCompleted,
   type ResourceChangedBroadcast,
-  type InteractionReceiptBroadcast,
 } from "../ws-events.ts";
 import {
   AppWindowMutationResultSchemaZ,
@@ -40,8 +38,6 @@ import {
   WorkspaceOpenMutationResultSchemaZ,
   WorkspacePaneCreateMutationResultSchemaZ,
   WorkspacePromoteMutationResultSchemaZ,
-  WorkspacePaneSendArgumentsSchemaZ,
-  WorkspacePaneSendResultSchemaZ,
 } from "@tmux-ide/contracts";
 import { daemonActionCommandRegistry } from "./command-definitions.ts";
 import type { WorkspacePaneCreationBackend } from "./handlers/workspace-pane-create.ts";
@@ -57,11 +53,6 @@ export interface DispatcherDeps {
   broadcastPromotionCompleted?: (workspaceName: string, outcome: "promoted" | "replayed") => void;
   /** Override the scoped replayable invalidation broadcaster (tests). */
   broadcastResourceChanged?: (change: ResourceChangedBroadcast, daemonInstanceId: string) => void;
-  /** Override the replayable interaction receipt broadcaster (tests). */
-  broadcastInteractionReceipt?: (
-    receipt: InteractionReceiptBroadcast,
-    daemonInstanceId: string,
-  ) => void;
   /** Trusted daemon generation; never accepted from an HTTP request body. */
   daemonInstanceId?: string;
   /** Instance-owned privileged mutation authority; never module-global. */
@@ -213,7 +204,6 @@ export function createActionDispatcher(deps: DispatcherDeps = {}) {
   const broadcastPromotionCompleted =
     deps.broadcastPromotionCompleted ?? broadcastWorkspacePromotionCompleted;
   const broadcastResource = deps.broadcastResourceChanged ?? broadcastResourceChanged;
-  const broadcastInteraction = deps.broadcastInteractionReceipt ?? broadcastInteractionReceipt;
 
   return async function dispatcher(c: Context): Promise<Response> {
     const name = c.req.param("name");
@@ -298,53 +288,12 @@ export function createActionDispatcher(deps: DispatcherDeps = {}) {
       appWindowMutationBackend: deps.appWindowMutationBackend,
       workspaceMultiplexerBackend: deps.workspaceMultiplexerBackend,
     };
-    const paneSend =
-      actionName === "workspace.pane.send"
-        ? WorkspacePaneSendArgumentsSchemaZ.safeParse(commandResolution.command.input)
-        : null;
-    const paneSendReceipt = (phase: "accepted" | "applied" | "failed", result?: unknown): void => {
-      if (!paneSend?.success || !operationId || !deps.daemonInstanceId) return;
-      const parsedResult = WorkspacePaneSendResultSchemaZ.safeParse(result);
-      const text = paneSend.data.text;
-      try {
-        broadcastInteraction(
-          {
-            operationId,
-            origin: paneSend.data.origin,
-            workspaceName: paneSend.data.workspaceName,
-            // A request-body source is only a claim. Publish it after the
-            // multiplexer authority returned the live-tmux-verified identity.
-            sourceSemanticPaneId:
-              phase === "applied" && parsedResult.success
-                ? parsedResult.data.sourceSemanticPaneId
-                : null,
-            semanticPaneId: paneSend.data.semanticPaneId,
-            phase,
-            summary: {
-              characterCount: parsedResult.success
-                ? parsedResult.data.characterCount
-                : Array.from(text).length,
-              byteCount: parsedResult.success
-                ? parsedResult.data.byteCount
-                : Buffer.byteLength(text, "utf8"),
-              submitted: paneSend.data.submit,
-            },
-          },
-          deps.daemonInstanceId,
-        );
-      } catch (error) {
-        console.error("[actions] interaction receipt broadcast failed:", error);
-      }
-    };
-    paneSendReceipt("accepted");
-
     let result: unknown;
     try {
       result = entry.handlerWithContext
         ? await entry.handlerWithContext(commandResolution.command.input, context)
         : await entry.handler(commandResolution.command.input);
     } catch (err) {
-      paneSendReceipt("failed");
       const wrapped = wrapInternalError(err);
       return c.json(errorEnvelope(wrapped) satisfies ActionErrorEnvelope, 200);
     }
@@ -353,11 +302,8 @@ export function createActionDispatcher(deps: DispatcherDeps = {}) {
       result,
     );
     if (!outputParsed.success) {
-      paneSendReceipt("failed");
       return c.json(outputZodErrorEnvelope(outputParsed.error) satisfies ActionErrorEnvelope, 200);
     }
-
-    paneSendReceipt("applied", outputParsed.data);
 
     const unchangedAppWindowMutation =
       actionName === "workspace.app-window.mutate" &&

--- a/packages/daemon/src/lib/daemon-embed.ts
+++ b/packages/daemon/src/lib/daemon-embed.ts
@@ -29,6 +29,7 @@ import {
 } from "../command-center/ws-events.ts";
 import { setRemoteAccessRestartBackend } from "../command-center/actions/handlers/app-set-remote-access.ts";
 import { setDaemonShutdownBackend } from "../command-center/actions/handlers/daemon-shutdown.ts";
+import type { WorkspaceMultiplexerBackend } from "../command-center/actions/handlers/workspace-multiplexer.ts";
 import { readAppSettings } from "./app-settings.ts";
 import { getDefaultWorkspaceRegistry, type WorkspaceRegistry } from "./workspace-registry.ts";
 import {
@@ -699,7 +700,7 @@ async function startHttpServer({
   workspaceOpenBackend: WorkspaceOpenAuthority;
   workspacePromotionBackend: WorkspacePromotionAuthority;
   appWindowMutationBackend: AppWindowMutationAuthority;
-  workspaceMultiplexerBackend: WorkspaceMultiplexerAuthority;
+  workspaceMultiplexerBackend: WorkspaceMultiplexerBackend;
   workspaceRegistry: WorkspaceRegistry;
   terminalAttachmentRuntime: NativeTerminalAttachmentRuntime;
   paneStreamRuntime: PaneStreamRuntime;
@@ -973,11 +974,21 @@ export async function startEmbeddedDaemon(
       registry: workspaceRegistry,
       tmuxAuthority,
     });
+    let sessionRuntimeRegistry: SessionRuntimeRegistry | null = null;
     const externalInteractionObserver = new TmuxExternalInteractionObserver({
       daemonInstanceId: instanceId,
       registry: workspaceRegistry,
       tmuxAuthority,
-      onObserved: ({ workspaceName, semanticPaneId, operationKind }) => {
+      onObserved: ({ workspaceName, semanticPaneId, operationKind, operationId }) => {
+        if (operationId) {
+          sessionRuntimeRegistry?.observeTmuxInteraction({
+            operationId,
+            workspaceName,
+            semanticPaneId,
+            operationKind,
+          });
+          return;
+        }
         try {
           broadcastInteractionReceipt(
             {
@@ -997,7 +1008,6 @@ export async function startEmbeddedDaemon(
       },
     });
     let terminalAttachmentRuntime: NativeTerminalAttachmentRuntime | null = null;
-    let sessionRuntimeRegistry: SessionRuntimeRegistry | null = null;
     let paneStreamRuntime: PaneStreamRuntime | null = null;
     let startedServer: Awaited<ReturnType<typeof startHttpServer>>;
     try {
@@ -1020,6 +1030,22 @@ export async function startEmbeddedDaemon(
       const selector = tmuxAuthority.socketSelector;
       sessionRuntimeRegistry = new SessionRuntimeRegistry({
         generation: instanceId,
+        semanticMutations: {
+          resolveSession: (workspaceName) =>
+            workspaceRegistry.get(workspaceName)?.sessionName ?? null,
+          execute: async (operationId, intent) => {
+            if (intent.verb === "workspace.pane.read") {
+              await workspaceMultiplexer.readPane(operationId, intent);
+              return;
+            }
+            return await workspaceMultiplexer.mutate({
+              operationId,
+              expectedDaemonInstanceId: instanceId,
+              intent,
+            });
+          },
+          publishReceipt: (receipt) => broadcastInteractionReceipt(receipt, instanceId),
+        },
         mirror: {
           executable: tmuxAuthority.executablePath,
           ...(selector.kind === "path" ? { socketPath: selector.path } : {}),
@@ -1035,6 +1061,19 @@ export async function startEmbeddedDaemon(
         inputAuthority: terminalAttachmentRuntime.inputAuthority,
         semanticPaneCatalog: terminalAttachmentRuntime.semanticPaneCatalog,
       });
+      const orderedMultiplexerBackend: WorkspaceMultiplexerBackend = {
+        mutate: async (request) => {
+          if (request.intent.verb !== "workspace.pane.send") {
+            return await workspaceMultiplexer.mutate(request);
+          }
+          const result = await sessionRuntimeRegistry!.submitIntent(
+            request.operationId,
+            request.intent,
+          );
+          if (!result) throw new Error("Pane send completed without a mutation result");
+          return result;
+        },
+      };
       startedServer = await startHttpServer({
         sessionName,
         requestedPort: port,
@@ -1049,7 +1088,7 @@ export async function startEmbeddedDaemon(
         workspaceOpenBackend: workspaceOpen,
         workspacePromotionBackend: workspacePromotion,
         appWindowMutationBackend: appWindowMutation,
-        workspaceMultiplexerBackend: workspaceMultiplexer,
+        workspaceMultiplexerBackend: orderedMultiplexerBackend,
         workspaceRegistry,
         terminalAttachmentRuntime,
         paneStreamRuntime,

--- a/packages/daemon/src/lib/tmux-external-interaction-observer.test.ts
+++ b/packages/daemon/src/lib/tmux-external-interaction-observer.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { WorkspaceRegistry } from "./workspace-registry.ts";
 import {
   TmuxExternalInteractionObserver,
-  internalSendOperationMarker,
+  internalInteractionOperationMarker,
   parseTmuxInputHookRecords,
   type ExternalTmuxInteractionObserverIo,
 } from "./tmux-external-interaction-observer.ts";
@@ -35,6 +35,7 @@ function harness(raw: string): {
     workspaceName: string;
     semanticPaneId: string;
     operationKind: typeof SEND | typeof READ;
+    operationId: string | null;
   }[];
 } {
   const calls: (readonly string[])[] = [];
@@ -42,6 +43,7 @@ function harness(raw: string): {
     workspaceName: string;
     semanticPaneId: string;
     operationKind: typeof SEND | typeof READ;
+    operationId: string | null;
   }[] = [];
   let buffer = raw;
   const io: ExternalTmuxInteractionObserverIo = {
@@ -165,8 +167,8 @@ describe("tmux external interaction observer", () => {
     expect(calls.filter((args) => args[0] === "set-hook" && args[1] === "-ag")).toHaveLength(4);
   });
 
-  it("projects external sends but suppresses sends marked by this daemon generation", () => {
-    const own = internalSendOperationMarker(DAEMON, OPERATION);
+  it("projects external observations and correlates sends marked by this daemon generation", () => {
+    const own = internalInteractionOperationMarker(DAEMON, OPERATION);
     const { observer, observed } = harness(
       `%9${FIELD}${FIELD}${SEND}${EVENT}%9${FIELD}${own}${FIELD}${SEND}${EVENT}%9${FIELD}another-daemon:${OPERATION}${FIELD}${READ}${EVENT}`,
     );
@@ -177,11 +179,19 @@ describe("tmux external interaction observer", () => {
         workspaceName: "workspace.project",
         semanticPaneId: "pane.editor",
         operationKind: SEND,
+        operationId: null,
+      },
+      {
+        workspaceName: "workspace.project",
+        semanticPaneId: "pane.editor",
+        operationKind: SEND,
+        operationId: OPERATION,
       },
       {
         workspaceName: "workspace.project",
         semanticPaneId: "pane.editor",
         operationKind: READ,
+        operationId: null,
       },
     ]);
   });
@@ -196,6 +206,7 @@ describe("tmux external interaction observer", () => {
         workspaceName: "workspace.project",
         semanticPaneId: "pane.editor",
         operationKind: READ,
+        operationId: null,
       },
     ]);
   });

--- a/packages/daemon/src/lib/tmux-external-interaction-observer.ts
+++ b/packages/daemon/src/lib/tmux-external-interaction-observer.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 
 import { WorkspacePaneCreationReferenceSchemaZ } from "@tmux-ide/contracts";
+import { z } from "zod";
 
 import type { WorkspacePaneTmuxAuthority } from "./workspace-pane-creation.ts";
 import { createPinnedWorkspaceTmuxRunner } from "./workspace-pane-creation.ts";
@@ -30,6 +31,8 @@ export interface ExternalTmuxInteraction {
   readonly workspaceName: string;
   readonly semanticPaneId: string;
   readonly operationKind: "workspace.pane.send" | "workspace.pane.read";
+  /** Present only for this daemon generation's product-authored operation. */
+  readonly operationId: string | null;
 }
 
 export interface ExternalTmuxInteractionObserverIo {
@@ -80,7 +83,10 @@ function abortableDelay(milliseconds: number, signal: AbortSignal): Promise<void
   });
 }
 
-export function internalSendOperationMarker(daemonInstanceId: string, operationId: string): string {
+export function internalInteractionOperationMarker(
+  daemonInstanceId: string,
+  operationId: string,
+): string {
   return `${daemonInstanceId}:${operationId}`;
 }
 
@@ -290,7 +296,11 @@ export class TmuxExternalInteractionObserver {
     ) {
       return;
     }
-    if (record.operationMarker?.startsWith(`${this.#daemonInstanceId}:`)) return;
+    const ownPrefix = `${this.#daemonInstanceId}:`;
+    const authoredOperationId = record.operationMarker?.startsWith(ownPrefix)
+      ? record.operationMarker.slice(ownPrefix.length)
+      : null;
+    const operationId = z.uuid().safeParse(authoredOperationId);
     let identity: string;
     try {
       identity = this.#io.runTmux([
@@ -314,6 +324,7 @@ export class TmuxExternalInteractionObserver {
       workspaceName: workspace.name,
       semanticPaneId,
       operationKind: record.operationKind,
+      operationId: operationId.success ? operationId.data : null,
     });
   }
 

--- a/packages/daemon/src/lib/workspace-multiplexer-verbs.test.ts
+++ b/packages/daemon/src/lib/workspace-multiplexer-verbs.test.ts
@@ -600,6 +600,36 @@ describe("the multiplexer authority", () => {
     });
   });
 
+  describe("session runtime read", () => {
+    it("marks and captures one semantic pane in one tmux command-list", async () => {
+      const operationId = randomUUID();
+      await authority.readPane(operationId, {
+        verb: "workspace.pane.read",
+        workspaceName: "work",
+        semanticPaneId: "pane.one",
+        origin: "sdk",
+      });
+
+      expect(tmux.calls).toContainEqual([
+        "set-option",
+        "-p",
+        "-t",
+        "%0",
+        "@tmux_ide_read_operation",
+        `${DAEMON_ID}:${operationId}`,
+        ";",
+        "capture-pane",
+        "-p",
+        "-e",
+        "-J",
+        "-S",
+        "-2000",
+        "-t",
+        "%0",
+      ]);
+    });
+  });
+
   describe("kill", () => {
     it("kills a window and reports what is left", async () => {
       const result = await authority.mutate(

--- a/packages/daemon/src/lib/workspace-multiplexer-verbs.ts
+++ b/packages/daemon/src/lib/workspace-multiplexer-verbs.ts
@@ -4,7 +4,7 @@
  *
  * This is the tmux authority the m48 audit found missing. It follows the
  * `workspace.pane.create` discipline deliberately and in full — one serialized
- * queue, operation-id idempotency with a request fingerprint, a pinned tmux
+ * queue per tmux session, operation-id idempotency with a request fingerprint, a pinned tmux
  * executable and socket resolved once per daemon generation, semantic-id
  * resolution that never trusts a renderer-supplied tmux target, and a read-back
  * verification after every mutation. Where creation proves a pane exists, these
@@ -26,6 +26,7 @@ import {
   type WorkspaceMultiplexerMutationRequest,
   type WorkspaceMultiplexerMutationResult,
   type WorkspaceMultiplexerWindowTarget,
+  type SessionRuntimePaneReadIntent,
   type Workspace,
 } from "@tmux-ide/contracts";
 import { TmuxError } from "@tmux-ide/tmux-bridge";
@@ -37,8 +38,11 @@ import {
   type WorkspacePaneTmuxAuthority,
 } from "./workspace-pane-creation.ts";
 import { getDefaultWorkspaceRegistry, type WorkspaceRegistry } from "./workspace-registry.ts";
-import { internalSendOperationMarker } from "./tmux-external-interaction-observer.ts";
-import { INTERNAL_SEND_OPERATION_OPTION } from "./tmux-interaction-options.ts";
+import { internalInteractionOperationMarker } from "./tmux-external-interaction-observer.ts";
+import {
+  INTERNAL_READ_OPERATION_OPTION,
+  INTERNAL_SEND_OPERATION_OPTION,
+} from "./tmux-interaction-options.ts";
 
 const MAX_OPERATIONS = 128;
 
@@ -281,7 +285,7 @@ export class WorkspaceMultiplexerAuthority {
   readonly #registry: WorkspaceRegistry;
   readonly #io: WorkspaceMultiplexerIo;
   readonly #operations = new Map<string, OperationRecord>();
-  #tail: Promise<void> = Promise.resolve();
+  readonly #tails = new Map<string, Promise<void>>();
   #disposed = false;
 
   constructor(options: {
@@ -303,22 +307,88 @@ export class WorkspaceMultiplexerAuthority {
     };
   }
 
-  /** Serialized: two verbs must never interleave their read-decide-mutate. */
+  /** Serialized per tmux session: read-decide-mutate never interleaves locally. */
   mutate(raw: WorkspaceMultiplexerMutationRequest): Promise<WorkspaceMultiplexerMutationResult> {
-    const run = this.#tail.then(
-      () => this.#mutate(raw),
-      () => this.#mutate(raw),
-    );
-    this.#tail = run.then(
-      () => undefined,
-      () => undefined,
-    );
-    return run;
+    return Promise.resolve().then(() => {
+      const request = WorkspaceMultiplexerMutationRequestSchemaZ.parse(raw);
+      const session = this.#registry.get(request.intent.workspaceName)?.sessionName;
+      const queue = session ?? `missing:${request.intent.workspaceName}`;
+      const previous = this.#tails.get(queue) ?? Promise.resolve();
+      const run = previous.then(
+        () => this.#mutate(request),
+        () => this.#mutate(request),
+      );
+      const tail = run.then(
+        () => undefined,
+        () => undefined,
+      );
+      this.#tails.set(queue, tail);
+      void tail.finally(() => {
+        if (this.#tails.get(queue) === tail) this.#tails.delete(queue);
+      });
+      return run;
+    });
+  }
+
+  /**
+   * Capture a semantically addressed pane for an authored read. The tmux
+   * after-capture hook is the completion authority; this method only performs
+   * the command-list and verifies that its semantic target survived it.
+   * SessionRuntimeRegistry serializes this lane with authored sends.
+   */
+  async readPane(operationId: string, intent: SessionRuntimePaneReadIntent): Promise<void> {
+    if (this.#disposed) {
+      throw new WorkspaceMultiplexerError("workspace_unavailable", {
+        reason: "authority_disposed",
+      });
+    }
+    const workspace = this.#registry.get(intent.workspaceName);
+    if (!workspace) {
+      throw new WorkspaceMultiplexerError("workspace_not_found", {
+        operationId,
+        workspaceName: intent.workspaceName,
+      });
+    }
+    const pane = resolvePaneRow(this.#panes(workspace.sessionName), intent.semanticPaneId);
+    try {
+      this.#io.runTmux([
+        "set-option",
+        "-p",
+        "-t",
+        pane.paneId,
+        INTERNAL_READ_OPERATION_OPTION,
+        internalInteractionOperationMarker(this.#daemonInstanceId, operationId),
+        ";",
+        "capture-pane",
+        "-p",
+        "-e",
+        "-J",
+        "-S",
+        "-2000",
+        "-t",
+        pane.paneId,
+      ]);
+    } catch (error) {
+      try {
+        this.#io.runTmux(["set-option", "-pu", "-t", pane.paneId, INTERNAL_READ_OPERATION_OPTION]);
+      } catch {
+        // The pane may have disappeared with the failed capture.
+      }
+      throw error;
+    }
+    const observed = resolvePaneRow(this.#panes(workspace.sessionName), intent.semanticPaneId);
+    if (observed.paneId !== pane.paneId) {
+      throw new WorkspaceMultiplexerError("mutation_unverified", {
+        operationId,
+        reason: "pane_identity_changed_during_read",
+      });
+    }
   }
 
   dispose(): Promise<void> {
     this.#disposed = true;
-    return this.#tail.then(() => {
+    return Promise.allSettled(this.#tails.values()).then(() => {
+      this.#tails.clear();
       this.#operations.clear();
     });
   }
@@ -867,7 +937,7 @@ export class WorkspaceMultiplexerAuthority {
       "-t",
       pane.paneId,
       INTERNAL_SEND_OPERATION_OPTION,
-      internalSendOperationMarker(this.#daemonInstanceId, envelope.operationId),
+      internalInteractionOperationMarker(this.#daemonInstanceId, envelope.operationId),
     ]);
     try {
       this.#io.runTmux(["send-keys", "-t", pane.paneId, "-l", "--", intent.text]);

--- a/packages/daemon/src/terminal/session-runtime/registry.ts
+++ b/packages/daemon/src/terminal/session-runtime/registry.ts
@@ -1,6 +1,8 @@
 import {
   SessionRuntimeGenerationSchemaZ,
+  type InteractionReceipt,
   type SessionRuntimeGeneration,
+  type SessionRuntimeSemanticIntent,
 } from "@tmux-ide/contracts";
 import type {
   MirrorLayoutEvent,
@@ -14,10 +16,17 @@ import {
   type MirrorSubscription,
 } from "../mirror/mirror-service.ts";
 import type { PaneStreamMirror } from "../pane-stream/pane-stream-websocket.ts";
+import {
+  SessionSemanticMutationExecutor,
+  type SessionRuntimeIntentResult,
+  type SessionRuntimeTmuxObservation,
+  type SessionSemanticMutationExecutorOptions,
+} from "./semantic-mutation-executor.ts";
 
 export interface SessionRuntimeRegistryOptions {
   readonly generation: string;
   readonly mirror?: MirrorServiceOptions;
+  readonly semanticMutations?: SessionSemanticMutationExecutorOptions;
 }
 
 export interface SessionRuntimeConsumer {
@@ -45,6 +54,7 @@ export interface SessionRuntimeConsumer {
 export class SessionRuntimeRegistry implements PaneStreamMirror {
   readonly generation: SessionRuntimeGeneration;
   readonly #mirror: MirrorService;
+  readonly #semanticMutations: SessionSemanticMutationExecutor | null;
   readonly #sessions = new Map<string, SessionRuntime>();
   readonly #stopExitObserver: () => void;
   #disposed = false;
@@ -53,6 +63,9 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
   constructor(options: SessionRuntimeRegistryOptions) {
     this.generation = SessionRuntimeGenerationSchemaZ.parse(options.generation);
     this.#mirror = new MirrorService(options.mirror);
+    this.#semanticMutations = options.semanticMutations
+      ? new SessionSemanticMutationExecutor(options.semanticMutations)
+      : null;
     this.#stopExitObserver = this.#mirror.onSessionExit((session) => {
       this.#sessions.get(session)?.noteControlExit();
     });
@@ -72,6 +85,25 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
     return await this.#mirror.subscribe(request);
   }
 
+  submitIntent(
+    operationId: string,
+    intent: SessionRuntimeSemanticIntent,
+  ): Promise<SessionRuntimeIntentResult> {
+    if (this.#disposed) return Promise.reject(new Error("SessionRuntimeRegistry is disposed"));
+    if (!this.#semanticMutations) {
+      return Promise.reject(new Error("Session semantic mutations are unavailable"));
+    }
+    return this.#semanticMutations.submit(operationId, intent);
+  }
+
+  observeTmuxInteraction(observation: SessionRuntimeTmuxObservation): void {
+    this.#semanticMutations?.observe(observation);
+  }
+
+  onReceipt(listener: (receipt: InteractionReceipt) => void): () => void {
+    return this.#semanticMutations?.onReceipt(listener) ?? (() => undefined);
+  }
+
   sessionCount(): number {
     return this.#sessions.size;
   }
@@ -85,6 +117,7 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
       this.#disposed = true;
       this.#stopExitObserver();
       this.#disposePromise = (async () => {
+        await this.#semanticMutations?.dispose();
         await Promise.allSettled([...this.#sessions.values()].map((runtime) => runtime.dispose()));
         this.#sessions.clear();
         await this.#mirror.dispose();

--- a/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.test.ts
@@ -1,0 +1,279 @@
+import type { InteractionReceipt, SessionRuntimeSemanticIntent } from "@tmux-ide/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  SessionRuntimeIntentError,
+  SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY,
+  SessionSemanticMutationExecutor,
+  type ExecutableSessionRuntimeIntent,
+  type SessionRuntimeReceiptInput,
+} from "./semantic-mutation-executor.ts";
+
+const OP_A = "11111111-1111-4111-8111-111111111111";
+const OP_B = "22222222-2222-4222-8222-222222222222";
+
+function operationId(index: number): string {
+  return `${index.toString(16).padStart(8, "0")}-0000-4000-8000-${index
+    .toString(16)
+    .padStart(12, "0")}`;
+}
+
+function send(workspaceName = "alpha", semanticPaneId = "pane.alpha") {
+  return {
+    verb: "workspace.pane.send",
+    workspaceName,
+    semanticPaneId,
+    text: "hello",
+    submit: true,
+    origin: "sdk",
+  } satisfies SessionRuntimeSemanticIntent;
+}
+
+function rig(
+  options: {
+    execute?: (operationId: string, intent: ExecutableSessionRuntimeIntent) => Promise<void>;
+    timeout?: number;
+  } = {},
+) {
+  let sequence = 0;
+  const receipts: InteractionReceipt[] = [];
+  const publishReceipt = (input: SessionRuntimeReceiptInput): InteractionReceipt => {
+    const receipt = { type: "interaction.receipt", sequence: ++sequence, ...input } as const;
+    receipts.push(receipt);
+    return receipt;
+  };
+  const executor = new SessionSemanticMutationExecutor({
+    resolveSession: (workspace) => (workspace === "beta" ? "session-beta" : "session-alpha"),
+    execute: options.execute ?? (async () => undefined),
+    publishReceipt,
+    observationTimeoutMs: options.timeout ?? 100,
+    now: () => new Date("2026-08-11T10:00:00.000Z"),
+  });
+  return { executor, receipts };
+}
+
+describe("SessionSemanticMutationExecutor", () => {
+  it("keeps one strict FIFO through tmux observation for each session", async () => {
+    const started: string[] = [];
+    const { executor, receipts } = rig({
+      execute: async (operationId) => {
+        started.push(operationId);
+      },
+    });
+    const first = executor.submit(OP_A, send());
+    const second = executor.submit(OP_B, send("alpha", "pane.beta"));
+
+    await vi.waitFor(() => expect(started).toEqual([OP_A]));
+    executor.observe({
+      operationId: OP_A,
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      operationKind: "workspace.pane.send",
+    });
+    await first;
+    await vi.waitFor(() => expect(started).toEqual([OP_A, OP_B]));
+    executor.observe({
+      operationId: OP_B,
+      workspaceName: "alpha",
+      semanticPaneId: "pane.beta",
+      operationKind: "workspace.pane.send",
+    });
+    await second;
+
+    expect(receipts.map(({ operationId, phase }) => [operationId, phase])).toEqual([
+      [OP_A, "accepted"],
+      [OP_B, "accepted"],
+      [OP_A, "observed"],
+      [OP_B, "observed"],
+    ]);
+    await executor.dispose();
+  });
+
+  it("allows different tmux sessions to progress independently", async () => {
+    const started: string[] = [];
+    const { executor } = rig({
+      execute: async (operationId) => {
+        started.push(operationId);
+      },
+    });
+    const alpha = executor.submit(OP_A, send("alpha", "pane.alpha"));
+    const beta = executor.submit(OP_B, send("beta", "pane.beta"));
+    await vi.waitFor(() => expect(new Set(started)).toEqual(new Set([OP_A, OP_B])));
+
+    executor.observe({
+      operationId: OP_B,
+      workspaceName: "beta",
+      semanticPaneId: "pane.beta",
+      operationKind: "workspace.pane.send",
+    });
+    await beta;
+    let alphaSettled = false;
+    void alpha.finally(() => {
+      alphaSettled = true;
+    });
+    await Promise.resolve();
+    expect(alphaSettled).toBe(false);
+    executor.observe({
+      operationId: OP_A,
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      operationKind: "workspace.pane.send",
+    });
+    await alpha;
+    await executor.dispose();
+  });
+
+  it("does not await slow or disconnected receipt consumers", async () => {
+    const { executor } = rig();
+    const never = new Promise<void>(() => undefined);
+    const slow = vi.fn(async () => await never);
+    const disconnected = vi.fn();
+    executor.onReceipt(slow);
+    const disconnect = executor.onReceipt(disconnected);
+    disconnect();
+
+    const submitted = executor.submit(OP_A, send());
+    await vi.waitFor(() => expect(slow).toHaveBeenCalledTimes(1));
+    executor.observe({
+      operationId: OP_A,
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      operationKind: "workspace.pane.send",
+    });
+    await submitted;
+    expect(disconnected).not.toHaveBeenCalled();
+    await executor.dispose();
+  });
+
+  it("reuses one receipt lifecycle and dispatch for a same-fingerprint retry", async () => {
+    const execute = vi.fn(async () => undefined);
+    const { executor, receipts } = rig({ execute });
+    const first = executor.submit(OP_A, send());
+    const retry = executor.submit(OP_A, send());
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+    executor.observe({
+      operationId: OP_A,
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      operationKind: "workspace.pane.send",
+    });
+    await Promise.all([first, retry]);
+    await executor.submit(OP_A, send());
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(receipts.map((receipt) => receipt.phase)).toEqual(["accepted", "observed"]);
+    await executor.dispose();
+  });
+
+  it("rejects conflicting operation ids and unsupported verbs at the request boundary", async () => {
+    const execute = vi.fn(async () => undefined);
+    const { executor, receipts } = rig({ execute });
+    const first = executor.submit(OP_A, send());
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+
+    await expect(
+      executor.submit(OP_A, { ...send(), semanticPaneId: "pane.other" }),
+    ).rejects.toMatchObject({ outcome: "rejected" });
+    await expect(
+      executor.submit(OP_B, {
+        verb: "workspace.window.split",
+        workspaceName: "alpha",
+        semanticPaneId: "pane.alpha",
+        direction: "right",
+      }),
+    ).rejects.toMatchObject({ outcome: "rejected" });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(receipts.map((receipt) => receipt.phase)).toEqual(["accepted"]);
+
+    executor.observe({
+      operationId: OP_A,
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      operationKind: "workspace.pane.send",
+    });
+    await first;
+    expect(receipts.map((receipt) => receipt.phase)).toEqual(["accepted", "observed"]);
+    await executor.dispose();
+  });
+
+  it("accepts operation 257 by retiring the oldest settled replay record", async () => {
+    let executor!: SessionSemanticMutationExecutor;
+    const execute = vi.fn(async (id: string, intent: ExecutableSessionRuntimeIntent) => {
+      queueMicrotask(() => {
+        executor.observe({
+          operationId: id,
+          workspaceName: intent.workspaceName,
+          semanticPaneId: intent.semanticPaneId,
+          operationKind: intent.verb,
+        });
+      });
+    });
+    const built = rig({ execute });
+    executor = built.executor;
+
+    for (let index = 1; index <= SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY + 1; index += 1) {
+      await executor.submit(operationId(index), send());
+    }
+
+    expect(execute).toHaveBeenCalledTimes(SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY + 1);
+    expect(built.receipts).toHaveLength((SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY + 1) * 2);
+    await executor.dispose();
+  });
+
+  it("never evicts pending records and backpressures only when every slot is active", async () => {
+    const execute = vi.fn(async () => undefined);
+    const { executor, receipts } = rig({ execute });
+    const pending = Array.from({ length: SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY }, (_, index) =>
+      executor.submit(operationId(index + 1), send()),
+    );
+    const firstRetry = executor.submit(operationId(1), send());
+    expect(firstRetry).toBe(pending[0]);
+
+    await expect(
+      executor.submit(operationId(SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY + 1), send()),
+    ).rejects.toMatchObject({ outcome: "rejected" });
+    expect(receipts).toHaveLength(SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY);
+
+    const outcomes = Promise.allSettled(pending);
+    await executor.dispose();
+    expect((await outcomes).every((outcome) => outcome.status === "rejected")).toBe(true);
+  });
+
+  it("publishes rejected when authority refuses and timed-out without tmux truth", async () => {
+    const rejected = rig({ execute: async () => Promise.reject(new Error("no pane")) });
+    await expect(rejected.executor.submit(OP_A, send())).rejects.toMatchObject({
+      outcome: "rejected",
+    });
+    expect(rejected.receipts.map((receipt) => receipt.phase)).toEqual(["accepted", "rejected"]);
+    await rejected.executor.dispose();
+
+    const timedOut = rig({ timeout: 5 });
+    await expect(timedOut.executor.submit(OP_B, send())).rejects.toMatchObject({
+      outcome: "timed-out",
+    });
+    expect(timedOut.receipts.map((receipt) => receipt.phase)).toEqual(["accepted", "timed-out"]);
+    await timedOut.executor.dispose();
+  });
+
+  it("settles in-flight and queued work deterministically on shutdown", async () => {
+    const started: string[] = [];
+    const { executor, receipts } = rig({
+      execute: async (operationId) => {
+        started.push(operationId);
+      },
+    });
+    const first = executor.submit(OP_A, send());
+    const second = executor.submit(OP_B, send("alpha", "pane.beta"));
+    await vi.waitFor(() => expect(started).toEqual([OP_A]));
+
+    const disposed = executor.dispose();
+    await expect(first).rejects.toBeInstanceOf(SessionRuntimeIntentError);
+    await expect(second).rejects.toBeInstanceOf(SessionRuntimeIntentError);
+    await disposed;
+    expect(receipts.map(({ operationId, phase }) => [operationId, phase])).toEqual([
+      [OP_A, "accepted"],
+      [OP_B, "accepted"],
+      [OP_A, "rejected"],
+      [OP_B, "rejected"],
+    ]);
+  });
+});

--- a/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.ts
+++ b/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.ts
@@ -1,0 +1,347 @@
+import {
+  InteractionReceiptSchemaZ,
+  SessionRuntimeSemanticIntentSchemaZ,
+  type InteractionReceipt,
+  type SessionRuntimeSemanticIntent,
+  type WorkspaceMultiplexerMutationResult,
+} from "@tmux-ide/contracts";
+import { z } from "zod";
+
+export type SessionRuntimeIntentResult = WorkspaceMultiplexerMutationResult | void;
+export type ExecutableSessionRuntimeIntent = Extract<
+  SessionRuntimeSemanticIntent,
+  { verb: "workspace.pane.send" | "workspace.pane.read" }
+>;
+
+export interface SessionRuntimeTmuxObservation {
+  readonly operationId: string;
+  readonly workspaceName: string;
+  readonly semanticPaneId: string;
+  readonly operationKind: "workspace.pane.send" | "workspace.pane.read";
+}
+
+export type SessionRuntimeReceiptInput = Omit<InteractionReceipt, "type" | "sequence">;
+
+export interface SessionSemanticMutationExecutorOptions {
+  readonly resolveSession: (workspaceName: string) => string | null;
+  readonly execute: (
+    operationId: string,
+    intent: ExecutableSessionRuntimeIntent,
+  ) => Promise<SessionRuntimeIntentResult>;
+  /** Publishes through the daemon's existing replayable interaction journal. */
+  readonly publishReceipt: (receipt: SessionRuntimeReceiptInput) => InteractionReceipt;
+  readonly observationTimeoutMs?: number;
+  readonly now?: () => Date;
+}
+
+export class SessionRuntimeIntentError extends Error {
+  constructor(
+    readonly outcome: "rejected" | "timed-out",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "SessionRuntimeIntentError";
+  }
+}
+
+interface PendingObservation {
+  readonly expected: SessionRuntimeTmuxObservation;
+  resolve(): void;
+  reject(error: Error): void;
+}
+
+interface OperationRecord {
+  readonly fingerprint: string;
+  readonly promise: Promise<SessionRuntimeIntentResult>;
+  status: "active" | "settled";
+}
+
+/** Allows hook repair and a loaded tmux server to settle without false failure. */
+export const SESSION_RUNTIME_OBSERVATION_TIMEOUT_MS = 10_000;
+/** Bounded replay/conflict horizon; active work is never evicted. */
+export const SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY = 256;
+
+function isExecutableIntent(
+  intent: SessionRuntimeSemanticIntent,
+): intent is ExecutableSessionRuntimeIntent {
+  return intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read";
+}
+
+/**
+ * The single semantic mutation lane for a daemon generation.
+ *
+ * FIFO is scoped to the resolved tmux session: work for one session cannot
+ * overtake itself, while a stalled observation in another session does not
+ * hold it hostage. Receipt publication is synchronous into the existing
+ * journal; consumer callbacks are always detached from execution.
+ */
+export class SessionSemanticMutationExecutor {
+  readonly #options: SessionSemanticMutationExecutorOptions;
+  readonly #tails = new Map<string, Promise<void>>();
+  readonly #pending = new Map<string, PendingObservation>();
+  readonly #operations = new Map<string, OperationRecord>();
+  readonly #listeners = new Set<(receipt: InteractionReceipt) => void>();
+  #disposed = false;
+
+  constructor(options: SessionSemanticMutationExecutorOptions) {
+    this.#options = options;
+  }
+
+  submit(
+    rawOperationId: string,
+    rawIntent: SessionRuntimeSemanticIntent,
+  ): Promise<SessionRuntimeIntentResult> {
+    if (this.#disposed) {
+      return Promise.reject(
+        new SessionRuntimeIntentError("rejected", "Session semantic mutation executor is disposed"),
+      );
+    }
+    const operationId = z.uuid().parse(rawOperationId);
+    const intent = SessionRuntimeSemanticIntentSchemaZ.parse(rawIntent);
+    const fingerprint = JSON.stringify(intent);
+    const existing = this.#operations.get(operationId);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) {
+        return Promise.reject(
+          new SessionRuntimeIntentError(
+            "rejected",
+            "Operation id was already used for a different semantic interaction",
+          ),
+        );
+      }
+      return existing.promise;
+    }
+    if (!isExecutableIntent(intent)) {
+      return Promise.reject(
+        new SessionRuntimeIntentError(
+          "rejected",
+          `Semantic verb ${intent.verb} is not routed through the session executor yet`,
+        ),
+      );
+    }
+    if (!this.#makeOperationRoom()) {
+      return Promise.reject(
+        new SessionRuntimeIntentError(
+          "rejected",
+          "All session semantic mutation ledger slots are active",
+        ),
+      );
+    }
+
+    const session = this.#options.resolveSession(intent.workspaceName);
+    this.#publish(operationId, intent, "accepted");
+    if (session === null) {
+      const error = new SessionRuntimeIntentError(
+        "rejected",
+        `Workspace ${intent.workspaceName} has no live tmux session`,
+      );
+      this.#publish(operationId, intent, "rejected");
+      const rejected = Promise.reject<SessionRuntimeIntentResult>(error);
+      this.#remember(operationId, fingerprint, rejected);
+      return rejected;
+    }
+
+    const previous = this.#tails.get(session) ?? Promise.resolve();
+    const result = previous.then(
+      () => this.#run(operationId, intent),
+      () => this.#run(operationId, intent),
+    );
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.#tails.set(session, tail);
+    this.#remember(operationId, fingerprint, result);
+    void tail.finally(() => {
+      if (this.#tails.get(session) === tail) this.#tails.delete(session);
+    });
+    return result;
+  }
+
+  observe(observation: SessionRuntimeTmuxObservation): void {
+    const pending = this.#pending.get(observation.operationId);
+    if (!pending) return;
+    const expected = pending.expected;
+    if (
+      expected.workspaceName !== observation.workspaceName ||
+      expected.semanticPaneId !== observation.semanticPaneId ||
+      expected.operationKind !== observation.operationKind
+    ) {
+      return;
+    }
+    pending.resolve();
+  }
+
+  onReceipt(listener: (receipt: InteractionReceipt) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    const error = new SessionRuntimeIntentError(
+      "rejected",
+      "Session semantic mutation executor shut down",
+    );
+    for (const pending of this.#pending.values()) pending.reject(error);
+    await Promise.allSettled(this.#tails.values());
+    this.#pending.clear();
+    this.#tails.clear();
+    this.#listeners.clear();
+    this.#operations.clear();
+  }
+
+  #remember(
+    operationId: string,
+    fingerprint: string,
+    promise: Promise<SessionRuntimeIntentResult>,
+  ) {
+    const record: OperationRecord = { fingerprint, promise, status: "active" };
+    this.#operations.set(operationId, record);
+    void promise.then(
+      () => {
+        record.status = "settled";
+      },
+      () => {
+        record.status = "settled";
+      },
+    );
+  }
+
+  /**
+   * Keep exact replay/conflict protection inside the bounded settled ledger
+   * horizon. A new unique operation may retire the oldest settled record, but
+   * pending work is never evicted or duplicated. This matches the daemon's
+   * bounded replay journal rather than imposing a lifetime mutation ceiling.
+   */
+  #makeOperationRoom(): boolean {
+    if (this.#operations.size < SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY) return true;
+    for (const [operationId, record] of this.#operations) {
+      if (record.status !== "settled") continue;
+      this.#operations.delete(operationId);
+      return true;
+    }
+    return false;
+  }
+
+  async #run(
+    operationId: string,
+    intent: ExecutableSessionRuntimeIntent,
+  ): Promise<SessionRuntimeIntentResult> {
+    if (this.#disposed) {
+      const error = new SessionRuntimeIntentError(
+        "rejected",
+        "Session semantic mutation executor shut down before execution",
+      );
+      this.#publish(operationId, intent, "rejected");
+      throw error;
+    }
+
+    let settleObservation!: () => void;
+    let rejectObservation!: (error: Error) => void;
+    const observed = new Promise<void>((resolve, reject) => {
+      settleObservation = resolve;
+      rejectObservation = reject;
+    });
+    this.#pending.set(operationId, {
+      expected: {
+        operationId,
+        workspaceName: intent.workspaceName,
+        semanticPaneId: intent.semanticPaneId,
+        operationKind: intent.verb,
+      },
+      resolve: settleObservation,
+      reject: rejectObservation,
+    });
+
+    let result: SessionRuntimeIntentResult;
+    try {
+      result = await this.#options.execute(operationId, intent);
+    } catch (cause) {
+      this.#pending.delete(operationId);
+      const error = new SessionRuntimeIntentError(
+        "rejected",
+        "tmux rejected the semantic interaction",
+        { cause },
+      );
+      this.#publish(operationId, intent, "rejected");
+      throw error;
+    }
+
+    const timeoutMs = this.#options.observationTimeoutMs ?? SESSION_RUNTIME_OBSERVATION_TIMEOUT_MS;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        observed,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () =>
+              reject(
+                new SessionRuntimeIntentError(
+                  "timed-out",
+                  "tmux did not expose the interaction through its observation hook in time",
+                ),
+              ),
+            timeoutMs,
+          );
+          timeout.unref?.();
+        }),
+      ]);
+    } catch (cause) {
+      const error =
+        cause instanceof SessionRuntimeIntentError
+          ? cause
+          : new SessionRuntimeIntentError("rejected", "Interaction observation was cancelled", {
+              cause,
+            });
+      this.#publish(operationId, intent, error.outcome);
+      throw error;
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      this.#pending.delete(operationId);
+    }
+
+    this.#publish(operationId, intent, "observed");
+    return result;
+  }
+
+  #publish(
+    operationId: string,
+    intent: ExecutableSessionRuntimeIntent,
+    phase: "accepted" | "observed" | "rejected" | "timed-out",
+  ): void {
+    const summary =
+      intent.verb === "workspace.pane.read"
+        ? ({ observedOnly: true } as const)
+        : {
+            characterCount: Array.from(intent.text).length,
+            byteCount: Buffer.byteLength(intent.text, "utf8"),
+            submitted: intent.submit,
+          };
+    const receipt = InteractionReceiptSchemaZ.parse(
+      this.#options.publishReceipt({
+        operationId,
+        origin: intent.origin,
+        workspaceName: intent.workspaceName,
+        sourceSemanticPaneId: null,
+        semanticPaneId: intent.semanticPaneId,
+        operationKind: intent.verb,
+        phase,
+        summary,
+        at: (this.#options.now ?? (() => new Date()))().toISOString(),
+        resourceRevision: null,
+      }),
+    );
+    for (const listener of this.#listeners) {
+      queueMicrotask(() => {
+        try {
+          listener(receipt);
+        } catch {
+          // A renderer callback is never mutation backpressure.
+        }
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Outcome

- Routes authored pane send/read through one per-session FIFO mutation executor.
- Correlates accepted intents with observed tmux hooks and terminal receipts.
- Deduplicates operation retries inside a bounded idempotency horizon without evicting active work.
- Removes the duplicate dispatcher-owned send receipt lifecycle.
- Keeps different tmux sessions independent and slow clients off the execution path.

## Verification

- Full pnpm check passed.
- 237 daemon files / 3,131 tests.
- 71 renderer files / 838 tests.
- 31 Electron files / 334 tests.
- 106 OpenTUI renderer tests / 66 snapshots.
- Docs build, package install, native dependency check, and live desktop smoke passed.

Part of Sfora card #185 (m56.1b).