### PR TITLE
refactor: centralize session controller leases

### DIFF
--- a/packages/contracts/src/__tests__/session-runtime.test.ts
+++ b/packages/contracts/src/__tests__/session-runtime.test.ts
@@ -1,9 +1,38 @@
 import { describe, expect, it } from "vitest";
 
-import { SessionRuntimeSemanticIntentSchemaZ } from "../session-runtime.ts";
+import {
+  SessionRuntimeControllerLeaseSchemaZ,
+  SessionRuntimeControllerSnapshotSchemaZ,
+  SessionRuntimeSemanticIntentSchemaZ,
+} from "../session-runtime.ts";
 import { InteractionReceiptSchemaZ } from "../interaction-receipts.ts";
 
 describe("session runtime architecture contract", () => {
+  it("pins controller capabilities to one client, session, revision, and daemon generation", () => {
+    const lease = {
+      generation: "11111111-1111-4111-8111-111111111111",
+      session: "alpha",
+      clientId: "web:stable-client",
+      token: "22222222-2222-4222-8222-222222222222",
+      revision: 1,
+    };
+    expect(SessionRuntimeControllerLeaseSchemaZ.parse(lease)).toEqual(lease);
+    expect(SessionRuntimeControllerLeaseSchemaZ.safeParse({ ...lease, revision: 0 }).success).toBe(
+      false,
+    );
+    expect(
+      SessionRuntimeControllerLeaseSchemaZ.safeParse({ ...lease, clientId: "%7\n" }).success,
+    ).toBe(false);
+    expect(
+      SessionRuntimeControllerSnapshotSchemaZ.parse({
+        generation: lease.generation,
+        session: lease.session,
+        controllerClientId: null,
+        revision: 0,
+      }),
+    ).toMatchObject({ controllerClientId: null, revision: 0 });
+  });
+
   it("accepts semantic intents and refuses raw tmux addresses", () => {
     const intent = {
       verb: "workspace.pane.read",

--- a/packages/contracts/src/session-runtime.ts
+++ b/packages/contracts/src/session-runtime.ts
@@ -21,6 +21,47 @@ export const SESSION_RUNTIME_CONTRACT_VERSION = 1 as const;
 export const SessionRuntimeGenerationSchemaZ = DaemonInstanceIdentitySchemaZ.shape.instanceId;
 export type SessionRuntimeGeneration = z.infer<typeof SessionRuntimeGenerationSchemaZ>;
 
+/** Stable authenticated product-client identity; never a renderer-local pane address. */
+export const SessionRuntimeClientIdSchemaZ = z
+  .string()
+  .min(1)
+  .max(4096)
+  .refine((value) => !/[\0\r\n]/u.test(value));
+export type SessionRuntimeClientId = z.infer<typeof SessionRuntimeClientIdSchemaZ>;
+
+export const SessionRuntimeControllerRoleSchemaZ = z.enum(["controller", "viewer"]);
+export type SessionRuntimeControllerRole = z.infer<typeof SessionRuntimeControllerRoleSchemaZ>;
+
+const SessionRuntimeSessionNameSchemaZ = z
+  .string()
+  .min(1)
+  .max(256)
+  .refine((value) => !/[\0\r\n]/u.test(value));
+
+/** One generation- and revision-pinned capability for both input and geometry. */
+export const SessionRuntimeControllerLeaseSchemaZ = z
+  .object({
+    generation: SessionRuntimeGenerationSchemaZ,
+    session: SessionRuntimeSessionNameSchemaZ,
+    clientId: SessionRuntimeClientIdSchemaZ,
+    token: z.uuid(),
+    revision: z.number().int().positive(),
+  })
+  .strict();
+export type SessionRuntimeControllerLease = z.infer<typeof SessionRuntimeControllerLeaseSchemaZ>;
+
+export const SessionRuntimeControllerSnapshotSchemaZ = z
+  .object({
+    generation: SessionRuntimeGenerationSchemaZ,
+    session: SessionRuntimeSessionNameSchemaZ,
+    controllerClientId: SessionRuntimeClientIdSchemaZ.nullable(),
+    revision: z.number().int().nonnegative(),
+  })
+  .strict();
+export type SessionRuntimeControllerSnapshot = z.infer<
+  typeof SessionRuntimeControllerSnapshotSchemaZ
+>;
+
 export const TerminalReplicaRevisionSchemaZ = z.number().int().nonnegative();
 export type TerminalReplicaRevision = z.infer<typeof TerminalReplicaRevisionSchemaZ>;
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -278,9 +278,18 @@ export {
 } from "./terminal/pane-stream/runtime.ts";
 export {
   SessionRuntimeRegistry,
+  SessionRuntimeControllerLeaseError,
   type SessionRuntimeConsumer,
+  type SessionRuntimeControllerLease,
+  type SessionRuntimeControllerLeaseErrorCode,
+  type SessionRuntimeControllerRole,
+  type SessionRuntimeControllerSnapshot,
   type SessionRuntimeRegistryOptions,
 } from "./terminal/session-runtime/registry.ts";
+export {
+  createSessionRuntimeMultiplexerBackend,
+  type SessionRuntimeMultiplexerBackendOptions,
+} from "./terminal/session-runtime/multiplexer-backend.ts";
 export {
   TerminalInputAuthority,
   TerminalInputAuthorityConflictError,

--- a/packages/daemon/src/lib/daemon-embed.ts
+++ b/packages/daemon/src/lib/daemon-embed.ts
@@ -19,6 +19,7 @@ import {
   TERMINAL_ATTACHMENT_REDEEM_PATH,
   TerminalAttachmentLoopbackWebSocketUrlSchemaZ,
   type DaemonInstanceIdentity,
+  type SessionRuntimeSemanticIntent,
 } from "@tmux-ide/contracts";
 import { computeAgentStates, computePortPanes } from "./session-monitor.ts";
 import { DaemonShutdownError, DaemonStartupError } from "./errors.ts";
@@ -59,6 +60,7 @@ import {
   type PaneStreamRuntime,
 } from "../terminal/pane-stream/runtime.ts";
 import { SessionRuntimeRegistry } from "../terminal/session-runtime/registry.ts";
+import { createSessionRuntimeMultiplexerBackend } from "../terminal/session-runtime/multiplexer-backend.ts";
 import { setActivationBackend, type ProjectActivationOptions } from "./active-projects.ts";
 import { readOrMintEnvironmentId } from "./environment-identity.ts";
 import {
@@ -1028,24 +1030,29 @@ export async function startEmbeddedDaemon(
       // mutation nor direct WebSocket redemption is exposed before it passes.
       await terminalAttachmentRuntime.whenReady();
       const selector = tmuxAuthority.socketSelector;
+      const executeRuntimeIntent = async (
+        operationId: string,
+        intent: SessionRuntimeSemanticIntent,
+      ) => {
+        if (intent.verb === "workspace.pane.read") {
+          await workspaceMultiplexer.readPane(operationId, intent);
+          return;
+        }
+        return await workspaceMultiplexer.mutate({
+          operationId,
+          expectedDaemonInstanceId: instanceId,
+          intent,
+        });
+      };
       sessionRuntimeRegistry = new SessionRuntimeRegistry({
         generation: instanceId,
         semanticMutations: {
           resolveSession: (workspaceName) =>
             workspaceRegistry.get(workspaceName)?.sessionName ?? null,
-          execute: async (operationId, intent) => {
-            if (intent.verb === "workspace.pane.read") {
-              await workspaceMultiplexer.readPane(operationId, intent);
-              return;
-            }
-            return await workspaceMultiplexer.mutate({
-              operationId,
-              expectedDaemonInstanceId: instanceId,
-              intent,
-            });
-          },
+          execute: executeRuntimeIntent,
           publishReceipt: (receipt) => broadcastInteractionReceipt(receipt, instanceId),
         },
+        executeAuthorized: executeRuntimeIntent,
         mirror: {
           executable: tmuxAuthority.executablePath,
           ...(selector.kind === "path" ? { socketPath: selector.path } : {}),
@@ -1061,19 +1068,11 @@ export async function startEmbeddedDaemon(
         inputAuthority: terminalAttachmentRuntime.inputAuthority,
         semanticPaneCatalog: terminalAttachmentRuntime.semanticPaneCatalog,
       });
-      const orderedMultiplexerBackend: WorkspaceMultiplexerBackend = {
-        mutate: async (request) => {
-          if (request.intent.verb !== "workspace.pane.send") {
-            return await workspaceMultiplexer.mutate(request);
-          }
-          const result = await sessionRuntimeRegistry!.submitIntent(
-            request.operationId,
-            request.intent,
-          );
-          if (!result) throw new Error("Pane send completed without a mutation result");
-          return result;
-        },
-      };
+      const orderedMultiplexerBackend = createSessionRuntimeMultiplexerBackend({
+        registry: sessionRuntimeRegistry,
+        resolveSession: (workspaceName) =>
+          workspaceRegistry.get(workspaceName)?.sessionName ?? null,
+      });
       startedServer = await startHttpServer({
         sessionName,
         requestedPort: port,

--- a/packages/daemon/src/terminal/input-authority.ts
+++ b/packages/daemon/src/terminal/input-authority.ts
@@ -52,10 +52,17 @@ function validatedWindows(runtimeWindowIds: readonly string[]): readonly string[
 }
 
 /**
- * Daemon-generation-scoped authority for terminal input. Both the grouped PTY
+ * Transport-level safety guard for terminal input. Both the grouped PTY
  * attachment and pane-stream transports claim through this one object, so two
  * semantic panes in the same live tmux window can never acquire independent
  * interactive grants. Passive/read-only viewers never enter this authority.
+ *
+ * SessionRuntime is the product-level controller authority. This window guard
+ * is subordinate to it: it protects the existing attachment protocols while
+ * those protocols still lack a stable authenticated client identity, and must
+ * never authorize a semantic/geometry mutation on its own. The m56.1d identity
+ * cutover deletes this parallel owner map once both transports bind their
+ * connection to a SessionRuntime controller lease.
  *
  * The object is intentionally in-memory. Constructing the next daemon
  * generation creates a fresh authority, invalidating every prior grant along

--- a/packages/daemon/src/terminal/session-runtime/multiplexer-backend.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/multiplexer-backend.test.ts
@@ -1,0 +1,112 @@
+import type {
+  SessionRuntimeSemanticIntent,
+  WorkspaceMultiplexerMutationRequest,
+  WorkspaceMultiplexerMutationResult,
+} from "@tmux-ide/contracts";
+import { describe, expect, it, vi } from "vitest";
+import type { SessionRuntimeConsumer, SessionRuntimeControllerLease } from "./registry.ts";
+import { createSessionRuntimeMultiplexerBackend } from "./multiplexer-backend.ts";
+
+const GENERATION = "11111111-1111-4111-8111-111111111111";
+const OPERATION_IDS = [
+  "00000000-0000-4000-8000-000000000001",
+  "00000000-0000-4000-8000-000000000002",
+  "00000000-0000-4000-8000-000000000003",
+  "00000000-0000-4000-8000-000000000004",
+  "00000000-0000-4000-8000-000000000005",
+  "00000000-0000-4000-8000-000000000006",
+  "00000000-0000-4000-8000-000000000007",
+  "00000000-0000-4000-8000-000000000008",
+  "00000000-0000-4000-8000-000000000009",
+  "00000000-0000-4000-8000-000000000010",
+] as const;
+
+function intents(): readonly SessionRuntimeSemanticIntent[] {
+  return [
+    {
+      verb: "workspace.window.split",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      direction: "right",
+    },
+    {
+      verb: "workspace.window.kill",
+      workspaceName: "alpha",
+      target: { by: "pane", semanticPaneId: "pane.alpha" },
+    },
+    { verb: "workspace.pane.kill", workspaceName: "alpha", semanticPaneId: "pane.alpha" },
+    { verb: "workspace.session.kill", workspaceName: "alpha" },
+    { verb: "workspace.rename", workspaceName: "alpha", scope: "session", name: "renamed" },
+    {
+      verb: "workspace.pane.zoom.toggle",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      desired: "toggle",
+    },
+    { verb: "workspace.pane.select", workspaceName: "alpha", semanticPaneId: "pane.alpha" },
+    {
+      verb: "workspace.pane.send",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      text: "hello",
+      submit: true,
+      origin: "gui",
+    },
+    {
+      verb: "workspace.pane.swap",
+      workspaceName: "alpha",
+      sourceSemanticPaneId: "pane.alpha",
+      targetSemanticPaneId: "pane.beta",
+    },
+    {
+      verb: "workspace.pane.resize",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      axis: "cols",
+      cells: 80,
+    },
+  ];
+}
+
+describe("createSessionRuntimeMultiplexerBackend", () => {
+  it("routes every command-center multiplexer verb through one runtime controller consumer", async () => {
+    const lease: SessionRuntimeControllerLease = {
+      generation: GENERATION,
+      session: "alpha-session",
+      clientId: `command-center:${GENERATION}:alpha-session`,
+      token: "22222222-2222-4222-8222-222222222222",
+      revision: 1,
+    };
+    const submitted: SessionRuntimeSemanticIntent[] = [];
+    const consumer = {
+      acquireController: vi.fn(() => lease),
+      submitIntent: vi.fn(async (_lease, _operationId, intent) => {
+        submitted.push(intent);
+        return { outcome: "applied" } as WorkspaceMultiplexerMutationResult;
+      }),
+    } as unknown as SessionRuntimeConsumer;
+    const connect = vi.fn(() => consumer);
+    const backend = createSessionRuntimeMultiplexerBackend({
+      registry: { generation: GENERATION, connect },
+      resolveSession: (workspaceName) => (workspaceName === "alpha" ? "alpha-session" : null),
+    });
+
+    const verbs = intents();
+    for (const [index, intent] of verbs.entries()) {
+      await backend.mutate({
+        operationId: OPERATION_IDS[index]!,
+        expectedDaemonInstanceId: GENERATION,
+        intent,
+      } as WorkspaceMultiplexerMutationRequest);
+    }
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledWith(
+      "alpha-session",
+      "command-center",
+      `command-center:${GENERATION}:alpha-session`,
+    );
+    expect(consumer.acquireController).toHaveBeenCalledTimes(verbs.length);
+    expect(submitted.map((intent) => intent.verb)).toEqual(verbs.map((intent) => intent.verb));
+  });
+});

--- a/packages/daemon/src/terminal/session-runtime/multiplexer-backend.ts
+++ b/packages/daemon/src/terminal/session-runtime/multiplexer-backend.ts
@@ -1,0 +1,54 @@
+import type {
+  SessionRuntimeSemanticIntent,
+  WorkspaceMultiplexerMutationRequest,
+  WorkspaceMultiplexerMutationResult,
+} from "@tmux-ide/contracts";
+import type { WorkspaceMultiplexerBackend } from "../../command-center/actions/handlers/workspace-multiplexer.ts";
+import type { SessionRuntimeConsumer, SessionRuntimeRegistry } from "./registry.ts";
+
+export interface SessionRuntimeMultiplexerBackendOptions {
+  readonly registry: Pick<SessionRuntimeRegistry, "connect" | "generation">;
+  readonly resolveSession: (workspaceName: string) => string | null;
+}
+
+/**
+ * The command center's single route into tmux mutation authority.
+ *
+ * Every verb, including geometry, crosses the same session controller consumer.
+ * The command center is currently one authenticated daemon-local client. The
+ * m56.1d wire-identity cutover replaces this identity with the authenticated
+ * originating client and then removes the subordinate window input guard.
+ */
+export function createSessionRuntimeMultiplexerBackend(
+  options: SessionRuntimeMultiplexerBackendOptions,
+): WorkspaceMultiplexerBackend {
+  const consumers = new Map<string, SessionRuntimeConsumer>();
+
+  return {
+    mutate: async (
+      request: WorkspaceMultiplexerMutationRequest,
+    ): Promise<WorkspaceMultiplexerMutationResult> => {
+      const session = options.resolveSession(request.intent.workspaceName);
+      if (!session) {
+        throw new Error(`Workspace ${request.intent.workspaceName} has no live tmux session`);
+      }
+      let consumer = consumers.get(session);
+      if (!consumer) {
+        consumer = options.registry.connect(
+          session,
+          "command-center",
+          `command-center:${options.registry.generation}:${session}`,
+        );
+        consumers.set(session, consumer);
+      }
+      const lease = consumer.acquireController();
+      const result = await consumer.submitIntent(
+        lease,
+        request.operationId,
+        request.intent as SessionRuntimeSemanticIntent,
+      );
+      if (!result) throw new Error("Session mutation completed without a mutation result");
+      return result;
+    },
+  };
+}

--- a/packages/daemon/src/terminal/session-runtime/registry.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/registry.test.ts
@@ -11,6 +11,57 @@ import { SessionRuntimeRegistry } from "./registry.ts";
 
 const GENERATION_A = "11111111-1111-4111-8111-111111111111";
 const GENERATION_B = "22222222-2222-4222-8222-222222222222";
+const TOKEN_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TOKEN_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const TOKEN_C = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const OP_A = "00000000-0000-4000-8000-000000000001";
+const OP_B = "00000000-0000-4000-8000-000000000002";
+
+function resize(workspaceName = "alpha") {
+  return {
+    verb: "workspace.pane.resize" as const,
+    workspaceName,
+    semanticPaneId: "pane.alpha",
+    axis: "cols" as const,
+    cells: 80,
+  };
+}
+
+function send(workspaceName = "alpha") {
+  return {
+    verb: "workspace.pane.send" as const,
+    workspaceName,
+    semanticPaneId: "pane.alpha",
+    text: "hello",
+    submit: true,
+    origin: "gui" as const,
+  };
+}
+
+function controllerRig(generation = GENERATION_A) {
+  const base = rig(generation);
+  const executed: string[] = [];
+  const tokens = [TOKEN_A, TOKEN_B, TOKEN_C];
+  let tokenIndex = 0;
+  const registry = new SessionRuntimeRegistry({
+    generation,
+    mirror: base.mirror,
+    createControllerToken: () => tokens[tokenIndex++]!,
+    semanticMutations: {
+      resolveSession: (workspaceName) => `${workspaceName}-session`,
+      execute: async (_operationId, intent) => {
+        executed.push(intent.verb);
+      },
+      publishReceipt: () => {
+        throw new Error("receipt publication is not expected in controller authorization tests");
+      },
+    },
+    executeAuthorized: async (_operationId, intent) => {
+      executed.push(intent.verb);
+    },
+  });
+  return { registry, executed, sims: base.sims };
+}
 
 function rig(generation = GENERATION_A): {
   registry: SessionRuntimeRegistry;
@@ -44,9 +95,9 @@ function finishSeed(sim: SimulatedChannel): void {
 describe("SessionRuntimeRegistry", () => {
   it("shares one long-lived control authority across three independent consumer handles", async () => {
     const { registry, sims } = rig();
-    const tui = registry.connect(FIXTURE.session, "opentui");
-    const webOne = registry.connect(FIXTURE.session, "web:one");
-    const webTwo = registry.connect(FIXTURE.session, "web:two");
+    const tui = registry.connect(FIXTURE.session, "opentui", "client:tui");
+    const webOne = registry.connect(FIXTURE.session, "web:one", "client:web:one");
+    const webTwo = registry.connect(FIXTURE.session, "web:two", "client:web:two");
 
     const subscriptions = await Promise.all([
       tui.subscribe("pane.alpha", () => {}),
@@ -77,8 +128,8 @@ describe("SessionRuntimeRegistry", () => {
 
   it("isolates a frozen or disconnected consumer from live ingestion", async () => {
     const { registry, sims } = rig();
-    const slow = registry.connect(FIXTURE.session, "web:slow");
-    const live = registry.connect(FIXTURE.session, "web:live");
+    const slow = registry.connect(FIXTURE.session, "web:slow", "client:web:slow");
+    const live = registry.connect(FIXTURE.session, "web:live", "client:web:live");
     const slowEvents: string[] = [];
     const liveEvents: string[] = [];
     const slowSubscription = await slow.subscribe("pane.alpha", (event) => {
@@ -106,7 +157,7 @@ describe("SessionRuntimeRegistry", () => {
 
   it("rebuilds one channel on demand after exit under the same generation owner", async () => {
     const { registry, sims } = rig();
-    const tui = registry.connect(FIXTURE.session, "opentui");
+    const tui = registry.connect(FIXTURE.session, "opentui", "client:tui");
     const closed: string[] = [];
     await tui.subscribe("pane.alpha", (event) => {
       if (event.type === "closed") closed.push(event.type);
@@ -116,8 +167,16 @@ describe("SessionRuntimeRegistry", () => {
     expect(closed).toEqual(["closed"]);
     expect(registry.activeControlChannelCount()).toBe(0);
 
-    const webOne = registry.connect(FIXTURE.session, "web:replacement:one");
-    const webTwo = registry.connect(FIXTURE.session, "web:replacement:two");
+    const webOne = registry.connect(
+      FIXTURE.session,
+      "web:replacement:one",
+      "client:web:replacement:one",
+    );
+    const webTwo = registry.connect(
+      FIXTURE.session,
+      "web:replacement:two",
+      "client:web:replacement:two",
+    );
     await Promise.all([
       webOne.subscribe("pane.alpha", () => {}),
       webTwo.subscribe("pane.beta", () => {}),
@@ -134,12 +193,20 @@ describe("SessionRuntimeRegistry", () => {
 
   it("rebuilds deterministically for a new daemon generation without tmux process ownership", async () => {
     const first = rig(GENERATION_A);
-    const firstClient = first.registry.connect(FIXTURE.session, "web:first-generation");
+    const firstClient = first.registry.connect(
+      FIXTURE.session,
+      "web:first-generation",
+      "client:web:first-generation",
+    );
     await firstClient.subscribe("pane.alpha", () => {});
     await first.registry.dispose();
 
     const second = new SessionRuntimeRegistry({ generation: GENERATION_B, mirror: first.mirror });
-    const secondClient = second.connect(FIXTURE.session, "web:second-generation");
+    const secondClient = second.connect(
+      FIXTURE.session,
+      "web:second-generation",
+      "client:web:second-generation",
+    );
     await secondClient.subscribe("pane.alpha", () => {});
 
     expect(first.sims).toHaveLength(2);
@@ -149,5 +216,157 @@ describe("SessionRuntimeRegistry", () => {
 
     await second.dispose();
     expect(first.sims[1]!.disposed).toBe(true);
+  });
+
+  it("grants exactly one controller while every other connected client is a viewer", async () => {
+    const { registry } = controllerRig();
+    const tui = registry.connect("alpha-session", "opentui", "client:tui");
+    const webOne = registry.connect("alpha-session", "web", "client:web:one");
+    const webTwo = registry.connect("alpha-session", "web", "client:web:two");
+
+    const lease = tui.acquireController();
+    expect(tui.acquireController()).toEqual(lease);
+    expect([tui.controllerRole(), webOne.controllerRole(), webTwo.controllerRole()]).toEqual([
+      "controller",
+      "viewer",
+      "viewer",
+    ]);
+    expect(registry.activeControllerLeaseCount()).toBe(1);
+    expect(() => webOne.acquireController()).toThrowError(
+      expect.objectContaining({ code: "controller-conflict" }),
+    );
+    await registry.dispose();
+  });
+
+  it("rejects viewer input and geometry before either tmux executor can run", async () => {
+    const { registry, executed } = controllerRig();
+    const controller = registry.connect("alpha-session", "web", "client:controller");
+    const viewer = registry.connect("alpha-session", "web", "client:viewer");
+    const lease = controller.acquireController();
+
+    await expect(viewer.submitIntent(lease, OP_A, send())).rejects.toMatchObject({
+      code: "stale-controller-lease",
+    });
+    await expect(viewer.submitIntent(lease, OP_B, resize())).rejects.toMatchObject({
+      code: "stale-controller-lease",
+    });
+    expect(executed).toEqual([]);
+    await registry.dispose();
+  });
+
+  it("hands controller authority over without creating another control connection", async () => {
+    const { registry, sims } = controllerRig();
+    const first = registry.connect("alpha-session", "opentui", "client:first");
+    const second = registry.connect("alpha-session", "web", "client:second");
+    await Promise.all([
+      first.subscribe("pane.alpha", () => {}),
+      second.subscribe("pane.beta", () => {}),
+    ]);
+    const firstLease = first.acquireController();
+    const secondLease = first.handoffController(firstLease, second.clientId);
+    expect(first.handoffController(firstLease, second.clientId)).toEqual(secondLease);
+
+    expect(first.controllerRole()).toBe("viewer");
+    expect(second.controllerRole()).toBe("controller");
+    expect(secondLease.revision).toBeGreaterThan(firstLease.revision);
+    expect(sims).toHaveLength(1);
+    expect(registry.activeControlChannelCount()).toBe(1);
+    await expect(first.submitIntent(firstLease, OP_A, resize())).rejects.toMatchObject({
+      code: "stale-controller-lease",
+    });
+    await second.submitIntent(secondLease, OP_B, resize());
+    second.releaseController(secondLease);
+    expect(() => second.releaseController(secondLease)).not.toThrow();
+    await registry.dispose();
+  });
+
+  it("refuses an old handoff replay after controller authority advances again", async () => {
+    const { registry } = controllerRig();
+    const first = registry.connect("alpha-session", "opentui", "client:first");
+    const second = registry.connect("alpha-session", "web", "client:second");
+    const firstLease = first.acquireController();
+    const secondLease = first.handoffController(firstLease, second.clientId);
+    const current = second.handoffController(secondLease, first.clientId);
+
+    expect(first.controllerRole()).toBe("controller");
+    expect(current.revision).toBeGreaterThan(secondLease.revision);
+    expect(() => first.handoffController(firstLease, second.clientId)).toThrowError(
+      expect.objectContaining({ code: "stale-controller-lease" }),
+    );
+    await registry.dispose();
+  });
+
+  it("refuses an old handoff replay after its target disconnects", async () => {
+    const { registry } = controllerRig();
+    const first = registry.connect("alpha-session", "opentui", "client:first");
+    const second = registry.connect("alpha-session", "web", "client:second");
+    const firstLease = first.acquireController();
+    first.handoffController(firstLease, second.clientId);
+    await second.close();
+
+    expect(registry.activeControllerLeaseCount()).toBe(0);
+    expect(() => first.handoffController(firstLease, second.clientId)).toThrowError(
+      expect.objectContaining({ code: "stale-controller-lease" }),
+    );
+    await registry.dispose();
+  });
+
+  it("advances authority on disconnect and refuses stale tokens after reconnect", async () => {
+    const { registry } = controllerRig();
+    const first = registry.connect("alpha-session", "web", "client:stable");
+    const stale = first.acquireController();
+    await first.close();
+    expect(registry.activeControllerLeaseCount()).toBe(0);
+
+    const reconnected = registry.connect("alpha-session", "web", "client:stable");
+    const current = reconnected.acquireController();
+    expect(current.revision).toBeGreaterThan(stale.revision);
+    expect(current.token).not.toBe(stale.token);
+    await expect(reconnected.submitIntent(stale, OP_A, resize())).rejects.toMatchObject({
+      code: "stale-controller-lease",
+    });
+    await registry.dispose();
+  });
+
+  it("keeps controller leases independent between sessions", async () => {
+    const { registry } = controllerRig();
+    const alpha = registry.connect("alpha-session", "web", "client:shared");
+    const beta = registry.connect("beta-session", "web", "client:shared");
+    const alphaLease = alpha.acquireController();
+    const betaLease = beta.acquireController();
+
+    expect(registry.activeControllerLeaseCount()).toBe(2);
+    expect(alphaLease.session).toBe("alpha-session");
+    expect(betaLease.session).toBe("beta-session");
+    await expect(alpha.submitIntent(alphaLease, OP_A, resize("beta"))).rejects.toMatchObject({
+      code: "intent-session-mismatch",
+    });
+    await registry.dispose();
+  });
+
+  it("decides controller authority synchronously while a viewer stream is frozen", async () => {
+    const { registry, sims } = controllerRig();
+    const slow = registry.connect("alpha-session", "web", "client:slow");
+    const controller = registry.connect("alpha-session", "opentui", "client:controller");
+    const subscription = await slow.subscribe("pane.alpha", () => {});
+    finishSeed(sims[0]!);
+    subscription.freeze();
+
+    const lease = controller.acquireController();
+    expect(lease.clientId).toBe("client:controller");
+    expect(controller.controllerRole()).toBe("controller");
+    await registry.dispose();
+  });
+
+  it("clears leases on registry disposal without acquiring tmux process ownership", async () => {
+    const { registry, sims } = controllerRig();
+    const controller = registry.connect("alpha-session", "web", "client:controller");
+    controller.acquireController();
+    expect(registry.activeControllerLeaseCount()).toBe(1);
+    expect(sims).toHaveLength(0);
+
+    await registry.dispose();
+    expect(registry.activeControllerLeaseCount()).toBe(0);
+    expect(sims).toHaveLength(0);
   });
 });

--- a/packages/daemon/src/terminal/session-runtime/registry.ts
+++ b/packages/daemon/src/terminal/session-runtime/registry.ts
@@ -1,9 +1,17 @@
 import {
+  SessionRuntimeClientIdSchemaZ,
+  SessionRuntimeControllerLeaseSchemaZ,
   SessionRuntimeGenerationSchemaZ,
+  SessionRuntimeSemanticIntentSchemaZ,
   type InteractionReceipt,
+  type SessionRuntimeControllerLease,
+  type SessionRuntimeControllerRole,
+  type SessionRuntimeControllerSnapshot,
   type SessionRuntimeGeneration,
   type SessionRuntimeSemanticIntent,
 } from "@tmux-ide/contracts";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
 import type {
   MirrorLayoutEvent,
   MirrorPaneEvent,
@@ -27,12 +35,55 @@ export interface SessionRuntimeRegistryOptions {
   readonly generation: string;
   readonly mirror?: MirrorServiceOptions;
   readonly semanticMutations?: SessionSemanticMutationExecutorOptions;
+  /** Executes controller-authorized verbs that do not yet need tmux observation. */
+  readonly executeAuthorized?: (
+    operationId: string,
+    intent: SessionRuntimeSemanticIntent,
+  ) => Promise<SessionRuntimeIntentResult>;
+  /** Deterministic seam for lease tests. Production uses cryptographic UUIDs. */
+  readonly createControllerToken?: () => string;
+}
+
+export type {
+  SessionRuntimeControllerLease,
+  SessionRuntimeControllerRole,
+  SessionRuntimeControllerSnapshot,
+} from "@tmux-ide/contracts";
+
+export type SessionRuntimeControllerLeaseErrorCode =
+  | "controller-conflict"
+  | "controller-target-unavailable"
+  | "stale-controller-lease"
+  | "intent-session-mismatch";
+
+export class SessionRuntimeControllerLeaseError extends Error {
+  constructor(
+    readonly code: SessionRuntimeControllerLeaseErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SessionRuntimeControllerLeaseError";
+  }
 }
 
 export interface SessionRuntimeConsumer {
   readonly generation: SessionRuntimeGeneration;
   readonly session: string;
   readonly surface: string;
+  readonly clientId: string;
+  controllerRole(): SessionRuntimeControllerRole;
+  controllerSnapshot(): SessionRuntimeControllerSnapshot;
+  acquireController(): SessionRuntimeControllerLease;
+  handoffController(
+    lease: SessionRuntimeControllerLease,
+    targetClientId: string,
+  ): SessionRuntimeControllerLease;
+  releaseController(lease: SessionRuntimeControllerLease): void;
+  submitIntent(
+    lease: SessionRuntimeControllerLease,
+    operationId: string,
+    intent: SessionRuntimeSemanticIntent,
+  ): Promise<SessionRuntimeIntentResult>;
   describe(): Promise<MirrorSessionDescription>;
   subscribe(
     semanticPaneId: string,
@@ -55,6 +106,14 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
   readonly generation: SessionRuntimeGeneration;
   readonly #mirror: MirrorService;
   readonly #semanticMutations: SessionSemanticMutationExecutor | null;
+  readonly #executeAuthorized:
+    | ((
+        operationId: string,
+        intent: SessionRuntimeSemanticIntent,
+      ) => Promise<SessionRuntimeIntentResult>)
+    | null;
+  readonly #resolveSession: ((workspaceName: string) => string | null) | null;
+  readonly #createControllerToken: () => string;
   readonly #sessions = new Map<string, SessionRuntime>();
   readonly #stopExitObserver: () => void;
   #disposed = false;
@@ -66,13 +125,16 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
     this.#semanticMutations = options.semanticMutations
       ? new SessionSemanticMutationExecutor(options.semanticMutations)
       : null;
+    this.#executeAuthorized = options.executeAuthorized ?? null;
+    this.#resolveSession = options.semanticMutations?.resolveSession ?? null;
+    this.#createControllerToken = options.createControllerToken ?? randomUUID;
     this.#stopExitObserver = this.#mirror.onSessionExit((session) => {
       this.#sessions.get(session)?.noteControlExit();
     });
   }
 
-  connect(session: string, surface: string): SessionRuntimeConsumer {
-    return this.#runtime(session).connect(surface);
+  connect(session: string, surface: string, clientId: string): SessionRuntimeConsumer {
+    return this.#runtime(session).connect(surface, SessionRuntimeClientIdSchemaZ.parse(clientId));
   }
 
   async describeSession(session: string): Promise<MirrorSessionDescription> {
@@ -85,11 +147,30 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
     return await this.#mirror.subscribe(request);
   }
 
-  submitIntent(
+  #submitAuthorizedIntent(
+    runtime: SessionRuntime,
+    lease: SessionRuntimeControllerLease,
     operationId: string,
-    intent: SessionRuntimeSemanticIntent,
+    rawIntent: SessionRuntimeSemanticIntent,
   ): Promise<SessionRuntimeIntentResult> {
     if (this.#disposed) return Promise.reject(new Error("SessionRuntimeRegistry is disposed"));
+    runtime.assertController(lease);
+    const intent = SessionRuntimeSemanticIntentSchemaZ.parse(rawIntent);
+    const resolvedSession = this.#resolveSession?.(intent.workspaceName) ?? null;
+    if (resolvedSession !== runtime.session) {
+      return Promise.reject(
+        new SessionRuntimeControllerLeaseError(
+          "intent-session-mismatch",
+          "The semantic intent does not belong to the controller lease session.",
+        ),
+      );
+    }
+    if (intent.verb !== "workspace.pane.send" && intent.verb !== "workspace.pane.read") {
+      if (!this.#executeAuthorized) {
+        return Promise.reject(new Error("Authorized session mutations are unavailable"));
+      }
+      return this.#executeAuthorized(operationId, intent);
+    }
     if (!this.#semanticMutations) {
       return Promise.reject(new Error("Session semantic mutations are unavailable"));
     }
@@ -112,6 +193,14 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
     return this.#mirror.activeChannelCount();
   }
 
+  activeControllerLeaseCount(): number {
+    let count = 0;
+    for (const runtime of this.#sessions.values()) {
+      if (runtime.hasController()) count += 1;
+    }
+    return count;
+  }
+
   dispose(): Promise<void> {
     if (!this.#disposePromise) {
       this.#disposed = true;
@@ -130,7 +219,14 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
     if (this.#disposed) throw new Error("SessionRuntimeRegistry is disposed");
     const existing = this.#sessions.get(session);
     if (existing) return existing;
-    const runtime = new SessionRuntime(this.generation, session, this.#mirror);
+    const runtime: SessionRuntime = new SessionRuntime(
+      this.generation,
+      session,
+      this.#mirror,
+      this.#createControllerToken,
+      (owner, lease, operationId, intent): Promise<SessionRuntimeIntentResult> =>
+        this.#submitAuthorizedIntent(owner, lease, operationId, intent),
+    );
     this.#sessions.set(session, runtime);
     return runtime;
   }
@@ -139,24 +235,156 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
 class SessionRuntime {
   readonly #mirror: MirrorService;
   readonly #consumers = new Set<SessionRuntimeConsumerImpl>();
+  readonly #consumersByClientId = new Map<string, SessionRuntimeConsumerImpl>();
+  readonly #createControllerToken: () => string;
+  readonly #submitAuthorized: (
+    runtime: SessionRuntime,
+    lease: SessionRuntimeControllerLease,
+    operationId: string,
+    intent: SessionRuntimeSemanticIntent,
+  ) => Promise<SessionRuntimeIntentResult>;
   #retention: Awaited<ReturnType<MirrorService["retainSession"]>> | null = null;
   #startPromise: Promise<void> | null = null;
   #restartBarrier: Promise<void> = Promise.resolve();
+  #controllerClientId: string | null = null;
+  #controllerToken: string | null = null;
+  #controllerRevision = 0;
+  readonly #completedHandoffs = new Map<string, SessionRuntimeControllerLease>();
+  readonly #releasedLeases = new Set<string>();
   #disposed = false;
 
   constructor(
     readonly generation: SessionRuntimeGeneration,
     readonly session: string,
     mirror: MirrorService,
+    createControllerToken: () => string,
+    submitAuthorized: (
+      runtime: SessionRuntime,
+      lease: SessionRuntimeControllerLease,
+      operationId: string,
+      intent: SessionRuntimeSemanticIntent,
+    ) => Promise<SessionRuntimeIntentResult>,
   ) {
     this.#mirror = mirror;
+    this.#createControllerToken = createControllerToken;
+    this.#submitAuthorized = submitAuthorized;
   }
 
-  connect(surface: string): SessionRuntimeConsumer {
+  connect(surface: string, clientId: string): SessionRuntimeConsumer {
     if (this.#disposed) throw new Error(`SessionRuntime ${this.session} is disposed`);
-    const consumer = new SessionRuntimeConsumerImpl(this, surface);
+    if (this.#consumersByClientId.has(clientId)) {
+      throw new TypeError(`SessionRuntime client ${clientId} is already connected`);
+    }
+    const consumer = new SessionRuntimeConsumerImpl(this, surface, clientId);
     this.#consumers.add(consumer);
+    this.#consumersByClientId.set(clientId, consumer);
     return consumer;
+  }
+
+  controllerRole(clientId: string): SessionRuntimeControllerRole {
+    return this.#controllerClientId === clientId ? "controller" : "viewer";
+  }
+
+  controllerSnapshot(): SessionRuntimeControllerSnapshot {
+    return {
+      generation: this.generation,
+      session: this.session,
+      controllerClientId: this.#controllerClientId,
+      revision: this.#controllerRevision,
+    };
+  }
+
+  hasController(): boolean {
+    return this.#controllerClientId !== null;
+  }
+
+  acquireController(clientId: string): SessionRuntimeControllerLease {
+    this.#assertConnected(clientId);
+    if (this.#controllerClientId === clientId) return this.#currentLease();
+    if (this.#controllerClientId !== null) {
+      throw new SessionRuntimeControllerLeaseError(
+        "controller-conflict",
+        `Session ${this.session} already has a controller.`,
+      );
+    }
+    return this.#assignController(clientId);
+  }
+
+  handoffController(
+    callerClientId: string,
+    lease: SessionRuntimeControllerLease,
+    targetClientId: string,
+  ): SessionRuntimeControllerLease {
+    const candidate = this.#validatedLease(lease);
+    const parsedTarget = SessionRuntimeClientIdSchemaZ.parse(targetClientId);
+    const replayKey = this.#handoffKey(candidate, parsedTarget);
+    const replay = this.#completedHandoffs.get(replayKey);
+    if (replay && candidate.clientId === callerClientId) {
+      if (this.#consumersByClientId.has(parsedTarget) && this.#isCurrentControllerLease(replay)) {
+        return replay;
+      }
+      throw new SessionRuntimeControllerLeaseError(
+        "stale-controller-lease",
+        "The replayed handoff no longer names the current connected controller.",
+      );
+    }
+    this.assertController(candidate, callerClientId);
+    if (!this.#consumersByClientId.has(parsedTarget)) {
+      throw new SessionRuntimeControllerLeaseError(
+        "controller-target-unavailable",
+        "The handoff target is not connected to this session runtime.",
+      );
+    }
+    if (parsedTarget === this.#controllerClientId) return this.#currentLease();
+    const handedOff = this.#assignController(parsedTarget);
+    this.#completedHandoffs.set(replayKey, handedOff);
+    if (this.#completedHandoffs.size > 32) {
+      this.#completedHandoffs.delete(this.#completedHandoffs.keys().next().value!);
+    }
+    return handedOff;
+  }
+
+  releaseController(callerClientId: string, lease: SessionRuntimeControllerLease): void {
+    const candidate = this.#validatedLease(lease);
+    const releaseKey = this.#leaseKey(candidate);
+    if (this.#releasedLeases.has(releaseKey) && candidate.clientId === callerClientId) return;
+    this.assertController(candidate, callerClientId);
+    this.#releasedLeases.add(releaseKey);
+    if (this.#releasedLeases.size > 32) {
+      this.#releasedLeases.delete(this.#releasedLeases.values().next().value!);
+    }
+    this.#clearController();
+  }
+
+  assertController(lease: SessionRuntimeControllerLease, callerClientId?: string): void {
+    const parsedLease = this.#validatedLease(lease);
+    if (
+      parsedLease.generation !== this.generation ||
+      parsedLease.session !== this.session ||
+      (callerClientId !== undefined && parsedLease.clientId !== callerClientId) ||
+      parsedLease.clientId !== this.#controllerClientId ||
+      parsedLease.token !== this.#controllerToken ||
+      parsedLease.revision !== this.#controllerRevision
+    ) {
+      throw new SessionRuntimeControllerLeaseError(
+        "stale-controller-lease",
+        "The controller lease is stale or belongs to another session generation.",
+      );
+    }
+  }
+
+  submitIntent(
+    callerClientId: string,
+    lease: SessionRuntimeControllerLease,
+    operationId: string,
+    intent: SessionRuntimeSemanticIntent,
+  ): Promise<SessionRuntimeIntentResult> {
+    try {
+      this.assertController(lease, callerClientId);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    return this.#submitAuthorized(this, lease, operationId, intent);
   }
 
   async whenReady(): Promise<void> {
@@ -195,6 +423,10 @@ class SessionRuntime {
 
   release(consumer: SessionRuntimeConsumerImpl): void {
     this.#consumers.delete(consumer);
+    if (this.#consumersByClientId.get(consumer.clientId) === consumer) {
+      this.#consumersByClientId.delete(consumer.clientId);
+    }
+    if (this.#controllerClientId === consumer.clientId) this.#clearController();
   }
 
   noteControlExit(): void {
@@ -211,9 +443,80 @@ class SessionRuntime {
     this.#disposed = true;
     const consumers = [...this.#consumers];
     await Promise.allSettled(consumers.map((consumer) => consumer.close()));
+    this.#clearController();
+    this.#completedHandoffs.clear();
+    this.#releasedLeases.clear();
     await this.#restartBarrier;
     await this.#retention?.close();
     this.#retention = null;
+  }
+
+  #assertConnected(clientId: string): void {
+    if (!this.#consumersByClientId.has(clientId)) {
+      throw new SessionRuntimeControllerLeaseError(
+        "controller-target-unavailable",
+        "The controller client is not connected to this session runtime.",
+      );
+    }
+  }
+
+  #assignController(clientId: string): SessionRuntimeControllerLease {
+    this.#controllerRevision += 1;
+    this.#controllerClientId = clientId;
+    this.#controllerToken = z.uuid().parse(this.#createControllerToken());
+    return this.#currentLease();
+  }
+
+  #clearController(): void {
+    if (this.#controllerClientId === null && this.#controllerToken === null) return;
+    this.#controllerRevision += 1;
+    this.#controllerClientId = null;
+    this.#controllerToken = null;
+  }
+
+  #currentLease(): SessionRuntimeControllerLease {
+    if (this.#controllerClientId === null || this.#controllerToken === null) {
+      throw new SessionRuntimeControllerLeaseError(
+        "stale-controller-lease",
+        "The session has no active controller.",
+      );
+    }
+    return {
+      generation: this.generation,
+      session: this.session,
+      clientId: this.#controllerClientId,
+      token: this.#controllerToken,
+      revision: this.#controllerRevision,
+    };
+  }
+
+  #handoffKey(lease: SessionRuntimeControllerLease, targetClientId: string): string {
+    return `${this.#leaseKey(lease)}\0${targetClientId}`;
+  }
+
+  #leaseKey(lease: SessionRuntimeControllerLease): string {
+    return `${lease.generation}\0${lease.session}\0${lease.clientId}\0${lease.token}\0${lease.revision}`;
+  }
+
+  #isCurrentControllerLease(lease: SessionRuntimeControllerLease): boolean {
+    return (
+      lease.generation === this.generation &&
+      lease.session === this.session &&
+      lease.clientId === this.#controllerClientId &&
+      lease.token === this.#controllerToken &&
+      lease.revision === this.#controllerRevision
+    );
+  }
+
+  #validatedLease(lease: SessionRuntimeControllerLease): SessionRuntimeControllerLease {
+    const parsed = SessionRuntimeControllerLeaseSchemaZ.safeParse(lease);
+    if (!parsed.success) {
+      throw new SessionRuntimeControllerLeaseError(
+        "stale-controller-lease",
+        "The controller lease is malformed or belongs to another session generation.",
+      );
+    }
+    return parsed.data;
   }
 }
 
@@ -221,16 +524,56 @@ class SessionRuntimeConsumerImpl implements SessionRuntimeConsumer {
   readonly #runtime: SessionRuntime;
   readonly generation: SessionRuntimeGeneration;
   readonly session: string;
+  readonly clientId: string;
   readonly #subscriptions = new Set<MirrorSubscription>();
   #closed = false;
 
   constructor(
     runtime: SessionRuntime,
     readonly surface: string,
+    clientId: string,
   ) {
     this.#runtime = runtime;
     this.generation = runtime.generation;
     this.session = runtime.session;
+    this.clientId = clientId;
+  }
+
+  controllerRole(): SessionRuntimeControllerRole {
+    this.#assertOpen();
+    return this.#runtime.controllerRole(this.clientId);
+  }
+
+  controllerSnapshot(): SessionRuntimeControllerSnapshot {
+    this.#assertOpen();
+    return this.#runtime.controllerSnapshot();
+  }
+
+  acquireController(): SessionRuntimeControllerLease {
+    this.#assertOpen();
+    return this.#runtime.acquireController(this.clientId);
+  }
+
+  handoffController(
+    lease: SessionRuntimeControllerLease,
+    targetClientId: string,
+  ): SessionRuntimeControllerLease {
+    this.#assertOpen();
+    return this.#runtime.handoffController(this.clientId, lease, targetClientId);
+  }
+
+  releaseController(lease: SessionRuntimeControllerLease): void {
+    this.#assertOpen();
+    this.#runtime.releaseController(this.clientId, lease);
+  }
+
+  submitIntent(
+    lease: SessionRuntimeControllerLease,
+    operationId: string,
+    intent: SessionRuntimeSemanticIntent,
+  ): Promise<SessionRuntimeIntentResult> {
+    this.#assertOpen();
+    return this.#runtime.submitIntent(this.clientId, lease, operationId, intent);
   }
 
   async describe(): Promise<MirrorSessionDescription> {


### PR DESCRIPTION
## Outcome

- Makes each SessionRuntime the sole product-level owner of one per-session controller lease.
- Pins controller capabilities to daemon generation, session, stable client identity, token, and monotonic revision.
- Supports deterministic idempotent acquire, handoff, release, disconnect, and reconnect behavior.
- Rejects viewer input and geometry before tmux execution.
- Routes every command-center multiplexer verb through one runtime controller consumer and removes the direct non-send bypass.
- Keeps the existing window-level TerminalInputAuthority only as a named subordinate transport safety guard until m56.1d binds authenticated client identity on attachment and pane-stream wires.

## Verification

- Contracts: 416 tests.
- Core: 38 tests.
- Daemon: clean independent full run, 238 files / 3,141 tests.
- Focused controller/routing/transport tests passed.
- Contracts/core/daemon typechecks, repository lint, formatting, and diff checks passed.
- The combined release command encountered the pre-existing workspace-open-live readiness timeout; immediate isolated rerun passed. No assertion was weakened and no retry was added.

Part of Sfora card #185 (m56.1c).