### PR TITLE
refactor: unify semantic mutation execution

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26900,7 +26900,7 @@ function canonicalProjectDir2(path2) {
   if (!statSync9(canonical).isDirectory()) throw new Error("project root is not a directory");
   return canonical;
 }
-var MAX_OPERATIONS4, CREATION_OPTION2, SEMANTIC_PANE_OPTION4, SEMANTIC_WINDOW_OPTION3, DISPLAY_TITLE_OPTION, ERROR_MESSAGES5, WorkspaceMultiplexerError, PANE_FIELDS, RUNTIME_PANE2, RUNTIME_WINDOW, DEFAULT_IO4, WorkspaceMultiplexerAuthority;
+var CREATION_OPTION2, SEMANTIC_PANE_OPTION4, SEMANTIC_WINDOW_OPTION3, DISPLAY_TITLE_OPTION, ERROR_MESSAGES5, WorkspaceMultiplexerError, PANE_FIELDS, RUNTIME_PANE2, RUNTIME_WINDOW, DEFAULT_IO4, WorkspaceMultiplexerAuthority;
 var init_workspace_multiplexer_verbs = __esm({
   "packages/daemon/src/lib/workspace-multiplexer-verbs.ts"() {
     "use strict";
@@ -26910,7 +26910,6 @@ var init_workspace_multiplexer_verbs = __esm({
     init_workspace_registry();
     init_tmux_external_interaction_observer();
     init_tmux_interaction_options();
-    MAX_OPERATIONS4 = 128;
     CREATION_OPTION2 = "@tmux_ide_creation_id";
     SEMANTIC_PANE_OPTION4 = "@tmux_ide_pane_id";
     SEMANTIC_WINDOW_OPTION3 = "@tmux_ide_window_id";
@@ -26922,8 +26921,6 @@ var init_workspace_multiplexer_verbs = __esm({
       pane_not_found: "No pane in this workspace carries the requested semantic identity.",
       window_not_found: "No window in this workspace carries the requested identity.",
       ambiguous_target: "The requested identity names more than one live tmux object.",
-      operation_conflict: "The operation id was already used for a different intent.",
-      operation_capacity: "The daemon has reached its bounded multiplexer operation capacity.",
       last_window_refused: "This is the session's last window. Close the session instead if that is what you mean.",
       last_pane_refused: "This is the session's last pane. Close the session instead if that is what you mean.",
       mutation_failed: "tmux refused the requested change.",
@@ -26963,8 +26960,6 @@ var init_workspace_multiplexer_verbs = __esm({
       #daemonInstanceId;
       #registry;
       #io;
-      #operations = /* @__PURE__ */ new Map();
-      #tails = /* @__PURE__ */ new Map();
       #disposed = false;
       constructor(options) {
         this.#daemonInstanceId = options.daemonInstanceId;
@@ -26977,27 +26972,13 @@ var init_workspace_multiplexer_verbs = __esm({
           )
         };
       }
-      /** Serialized per tmux session: read-decide-mutate never interleaves locally. */
-      mutate(raw, authorizeBeforeEffect) {
-        return Promise.resolve().then(() => {
-          const request = WorkspaceMultiplexerMutationRequestSchemaZ.parse(raw);
-          const session = this.#registry.get(request.intent.workspaceName)?.sessionName;
-          const queue = session ?? `missing:${request.intent.workspaceName}`;
-          const previous = this.#tails.get(queue) ?? Promise.resolve();
-          const run = previous.then(
-            () => this.#mutate(request, authorizeBeforeEffect),
-            () => this.#mutate(request, authorizeBeforeEffect)
-          );
-          const tail = run.then(
-            () => void 0,
-            () => void 0
-          );
-          this.#tails.set(queue, tail);
-          void tail.finally(() => {
-            if (this.#tails.get(queue) === tail) this.#tails.delete(queue);
-          });
-          return run;
-        });
+      /**
+       * Execute immediately in the caller's already-serialized semantic lane.
+       * The returned promise is only an API envelope: no second queue or replay
+       * ledger is allowed below SessionSemanticMutationExecutor.
+       */
+      mutate(raw) {
+        return this.#mutate(raw);
       }
       /**
        * Capture a semantically addressed pane for an authored read. The tmux
@@ -27005,7 +26986,7 @@ var init_workspace_multiplexer_verbs = __esm({
        * the command-list and verifies that its semantic target survived it.
        * SessionRuntimeRegistry serializes this lane with authored sends.
        */
-      async readPane(operationId, intent) {
+      readPane(operationId, intent) {
         if (this.#disposed) {
           throw new WorkspaceMultiplexerError("workspace_unavailable", {
             reason: "authority_disposed"
@@ -27054,12 +27035,9 @@ var init_workspace_multiplexer_verbs = __esm({
       }
       dispose() {
         this.#disposed = true;
-        return Promise.allSettled(this.#tails.values()).then(() => {
-          this.#tails.clear();
-          this.#operations.clear();
-        });
+        return Promise.resolve();
       }
-      async #mutate(raw, authorizeBeforeEffect) {
+      #mutate(raw) {
         if (this.#disposed) {
           throw new WorkspaceMultiplexerError("workspace_unavailable", {
             reason: "authority_disposed"
@@ -27071,47 +27049,15 @@ var init_workspace_multiplexer_verbs = __esm({
             operationId: request.operationId
           });
         }
-        const requestFingerprint3 = JSON.stringify(request);
-        const existing = this.#operations.get(request.operationId);
-        if (existing) {
-          if (existing.fingerprint !== requestFingerprint3) {
-            throw new WorkspaceMultiplexerError("operation_conflict", {
-              operationId: request.operationId
-            });
-          }
-          if (existing.status === "error") throw existing.error;
-          return WorkspaceMultiplexerMutationResultSchemaZ.parse({
-            ...existing.result,
-            outcome: "replayed"
-          });
-        }
-        if (this.#operations.size >= MAX_OPERATIONS4) {
-          const oldest = this.#operations.keys().next().value;
-          if (oldest !== void 0) this.#operations.delete(oldest);
-        }
         const workspace = this.#registry.get(request.intent.workspaceName);
         if (!workspace) {
-          const error = new WorkspaceMultiplexerError("workspace_not_found", {
+          throw new WorkspaceMultiplexerError("workspace_not_found", {
             operationId: request.operationId,
             workspaceName: request.intent.workspaceName
           });
-          this.#operations.set(request.operationId, {
-            fingerprint: requestFingerprint3,
-            status: "error",
-            error
-          });
-          throw error;
         }
         try {
-          authorizeBeforeEffect?.();
-          const result = await this.#perform(request, workspace);
-          const parsed = WorkspaceMultiplexerMutationResultSchemaZ.parse(result);
-          this.#operations.set(request.operationId, {
-            fingerprint: requestFingerprint3,
-            status: "success",
-            result: parsed
-          });
-          return parsed;
+          return WorkspaceMultiplexerMutationResultSchemaZ.parse(this.#perform(request, workspace));
         } catch (error) {
           const mapped = error instanceof WorkspaceMultiplexerError ? error : new WorkspaceMultiplexerError(
             "mutation_failed",
@@ -27121,11 +27067,6 @@ var init_workspace_multiplexer_verbs = __esm({
             },
             error
           );
-          this.#operations.set(request.operationId, {
-            fingerprint: requestFingerprint3,
-            status: "error",
-            error: mapped
-          });
           throw mapped;
         }
       }
@@ -27142,7 +27083,7 @@ var init_workspace_multiplexer_verbs = __esm({
         }
         return parseMultiplexerPaneRows(output);
       }
-      async #perform(request, workspace) {
+      #perform(request, workspace) {
         const intent = request.intent;
         const sessionName = workspace.sessionName;
         const envelope = {
@@ -29596,16 +29537,161 @@ var init_mirror_service = __esm({
   }
 });
 
-// packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.ts
-import { z as z61 } from "zod";
-function isExecutableIntent(intent) {
+// packages/daemon/src/terminal/session-runtime/interaction-receipt-facts.ts
+function sessionRuntimeInteractionFacts(intent) {
+  switch (intent.verb) {
+    case "workspace.window.split":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb, direction: intent.direction }
+      };
+    case "workspace.window.kill":
+      return {
+        target: { kind: "window", target: intent.target },
+        summary: { operationKind: intent.verb }
+      };
+    case "workspace.pane.kill":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb }
+      };
+    case "workspace.session.kill":
+      return { target: { kind: "session" }, summary: { operationKind: intent.verb } };
+    case "workspace.rename":
+      return intent.scope === "session" ? {
+        target: { kind: "session" },
+        summary: { operationKind: intent.verb, scope: intent.scope }
+      } : {
+        target: { kind: "window", target: intent.target },
+        summary: { operationKind: intent.verb, scope: intent.scope }
+      };
+    case "workspace.pane.zoom.toggle":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb, desired: intent.desired }
+      };
+    case "workspace.pane.select":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb }
+      };
+    case "workspace.pane.send":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: {
+          operationKind: intent.verb,
+          characterCount: Array.from(intent.text).length,
+          byteCount: Buffer.byteLength(intent.text, "utf8"),
+          submitted: intent.submit
+        }
+      };
+    case "workspace.pane.swap":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.sourceSemanticPaneId },
+        summary: {
+          operationKind: intent.verb,
+          targetSemanticPaneId: intent.targetSemanticPaneId
+        }
+      };
+    case "workspace.pane.resize":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb, axis: intent.axis, cells: intent.cells }
+      };
+    case "workspace.pane.read":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb, observedOnly: true }
+      };
+  }
+}
+function sessionRuntimeObservedProof(intent, rawResult) {
+  if (intent.verb === "workspace.pane.read") {
+    if (rawResult !== void 0) throw new TypeError("Pane read returned an unexpected result");
+    return { operationKind: intent.verb, observed: true, semanticPaneId: intent.semanticPaneId };
+  }
+  const result = WorkspaceMultiplexerMutationResultSchemaZ.parse(rawResult);
+  if (result.verb !== intent.verb)
+    throw new TypeError("Mutation result verb does not match intent");
+  switch (result.verb) {
+    case "workspace.window.split":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        direction: result.direction,
+        semanticPaneId: result.semanticPaneId
+      };
+    case "workspace.window.kill":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        remainingWindowCount: result.remainingWindowCount
+      };
+    case "workspace.pane.kill":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        semanticPaneId: intent.semanticPaneId,
+        windowClosed: result.windowClosed,
+        remainingWindowCount: result.remainingWindowCount
+      };
+    case "workspace.session.kill":
+      return { operationKind: result.verb, outcome: result.outcome };
+    case "workspace.rename":
+      return { operationKind: result.verb, outcome: result.outcome, scope: result.scope };
+    case "workspace.pane.zoom.toggle":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        semanticPaneId: result.semanticPaneId,
+        zoomed: result.zoomed
+      };
+    case "workspace.pane.select":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        semanticPaneId: result.semanticPaneId
+      };
+    case "workspace.pane.send":
+      return { operationKind: result.verb, observed: true, semanticPaneId: result.semanticPaneId };
+    case "workspace.pane.swap":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        sourceSemanticPaneId: result.sourceSemanticPaneId,
+        targetSemanticPaneId: result.targetSemanticPaneId
+      };
+    case "workspace.pane.resize":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        semanticPaneId: result.semanticPaneId,
+        axis: result.axis,
+        cells: result.cells
+      };
+  }
+}
+function sessionRuntimeIntentNeedsTmuxObservation(intent) {
   return intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read";
 }
-var SessionRuntimeIntentError, SESSION_RUNTIME_OBSERVATION_TIMEOUT_MS, SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY, SessionSemanticMutationExecutor;
+var init_interaction_receipt_facts = __esm({
+  "packages/daemon/src/terminal/session-runtime/interaction-receipt-facts.ts"() {
+    "use strict";
+    init_src();
+  }
+});
+
+// packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.ts
+import { z as z61 } from "zod";
+function replayedResult(result) {
+  return result === void 0 ? void 0 : { ...result, outcome: "replayed" };
+}
+var SessionRuntimeIntentError, SESSION_RUNTIME_OBSERVATION_TIMEOUT_MS, SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY, MISSING_SESSION_LEDGER, SessionSemanticMutationExecutor;
 var init_semantic_mutation_executor = __esm({
   "packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.ts"() {
     "use strict";
     init_src();
+    init_interaction_receipt_facts();
     SessionRuntimeIntentError = class extends Error {
       constructor(outcome, message, options) {
         super(message, options);
@@ -29615,6 +29701,7 @@ var init_semantic_mutation_executor = __esm({
     };
     SESSION_RUNTIME_OBSERVATION_TIMEOUT_MS = 1e4;
     SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY = 256;
+    MISSING_SESSION_LEDGER = /* @__PURE__ */ Symbol("missing-session-ledger");
     SessionSemanticMutationExecutor = class {
       #options;
       #tails = /* @__PURE__ */ new Map();
@@ -29625,7 +29712,7 @@ var init_semantic_mutation_executor = __esm({
       constructor(options) {
         this.#options = options;
       }
-      submit(rawOperationId, rawIntent, authenticatedSourceSemanticPaneId = null, authorizeBeforeEffect) {
+      submit(rawOperationId, rawIntent, authenticatedSourceSemanticPaneId = null, authorizeBeforeEffect, authenticatedOrigin) {
         if (this.#disposed) {
           return Promise.reject(
             new SessionRuntimeIntentError("rejected", "Session semantic mutation executor is disposed")
@@ -29633,8 +29720,11 @@ var init_semantic_mutation_executor = __esm({
         }
         const operationId = z61.uuid().parse(rawOperationId);
         const intent = SessionRuntimeSemanticIntentSchemaZ.parse(rawIntent);
-        const fingerprint2 = JSON.stringify([intent, authenticatedSourceSemanticPaneId]);
-        const existing = this.#operations.get(operationId);
+        const session = this.#options.resolveSession(intent.workspaceName);
+        const ledger = this.#ledger(session ?? MISSING_SESSION_LEDGER);
+        const origin = authenticatedOrigin ?? ("origin" in intent ? intent.origin : "sdk");
+        const fingerprint2 = JSON.stringify([intent, authenticatedSourceSemanticPaneId, origin]);
+        const existing = ledger.get(operationId);
         if (existing) {
           if (existing.fingerprint !== fingerprint2) {
             return Promise.reject(
@@ -29644,17 +29734,9 @@ var init_semantic_mutation_executor = __esm({
               )
             );
           }
-          return existing.promise;
+          return existing.status === "active" ? existing.promise : existing.promise.then(replayedResult);
         }
-        if (!isExecutableIntent(intent)) {
-          return Promise.reject(
-            new SessionRuntimeIntentError(
-              "rejected",
-              `Semantic verb ${intent.verb} is not routed through the session executor yet`
-            )
-          );
-        }
-        if (!this.#makeOperationRoom()) {
+        if (!this.#makeOperationRoom(ledger)) {
           return Promise.reject(
             new SessionRuntimeIntentError(
               "rejected",
@@ -29662,36 +29744,51 @@ var init_semantic_mutation_executor = __esm({
             )
           );
         }
-        const session = this.#options.resolveSession(intent.workspaceName);
-        this.#publish(operationId, intent, "accepted");
+        this.#publish(operationId, intent, "accepted", null, void 0, origin);
         if (session === null) {
           const error = new SessionRuntimeIntentError(
             "rejected",
             `Workspace ${intent.workspaceName} has no live tmux session`
           );
-          this.#publish(operationId, intent, "rejected");
+          this.#publish(operationId, intent, "rejected", null, void 0, origin);
           const rejected = Promise.reject(error);
-          this.#remember(operationId, fingerprint2, rejected);
+          this.#remember(ledger, operationId, fingerprint2, rejected);
           return rejected;
         }
         const previous = this.#tails.get(session) ?? Promise.resolve();
         const result = previous.then(
-          () => this.#run(operationId, intent, authenticatedSourceSemanticPaneId, authorizeBeforeEffect),
-          () => this.#run(operationId, intent, authenticatedSourceSemanticPaneId, authorizeBeforeEffect)
+          () => this.#run(
+            session,
+            operationId,
+            intent,
+            authenticatedSourceSemanticPaneId,
+            authorizeBeforeEffect,
+            origin
+          ),
+          () => this.#run(
+            session,
+            operationId,
+            intent,
+            authenticatedSourceSemanticPaneId,
+            authorizeBeforeEffect,
+            origin
+          )
         );
         const tail = result.then(
           () => void 0,
           () => void 0
         );
         this.#tails.set(session, tail);
-        this.#remember(operationId, fingerprint2, result);
+        this.#remember(ledger, operationId, fingerprint2, result);
         void tail.finally(() => {
           if (this.#tails.get(session) === tail) this.#tails.delete(session);
         });
         return result;
       }
       observe(observation2) {
-        const pending = this.#pending.get(observation2.operationId);
+        const session = this.#options.resolveSession(observation2.workspaceName);
+        if (session === null) return false;
+        const pending = this.#pending.get(session)?.get(observation2.operationId);
         if (!pending) return false;
         const expected = pending.expected;
         if (expected.workspaceName !== observation2.workspaceName || expected.semanticPaneId !== observation2.semanticPaneId || expected.operationKind !== observation2.operationKind) {
@@ -29711,16 +29808,25 @@ var init_semantic_mutation_executor = __esm({
           "rejected",
           "Session semantic mutation executor shut down"
         );
-        for (const pending of this.#pending.values()) pending.reject(error);
+        for (const sessionPending of this.#pending.values()) {
+          for (const pending of sessionPending.values()) pending.reject(error);
+        }
         await Promise.allSettled(this.#tails.values());
         this.#pending.clear();
         this.#tails.clear();
         this.#listeners.clear();
         this.#operations.clear();
       }
-      #remember(operationId, fingerprint2, promise) {
+      #ledger(key) {
+        const existing = this.#operations.get(key);
+        if (existing) return existing;
+        const ledger = /* @__PURE__ */ new Map();
+        this.#operations.set(key, ledger);
+        return ledger;
+      }
+      #remember(ledger, operationId, fingerprint2, promise) {
         const record = { fingerprint: fingerprint2, promise, status: "active" };
-        this.#operations.set(operationId, record);
+        ledger.set(operationId, record);
         void promise.then(
           () => {
             record.status = "settled";
@@ -29736,103 +29842,134 @@ var init_semantic_mutation_executor = __esm({
        * pending work is never evicted or duplicated. This matches the daemon's
        * bounded replay journal rather than imposing a lifetime mutation ceiling.
        */
-      #makeOperationRoom() {
-        if (this.#operations.size < SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY) return true;
-        for (const [operationId, record] of this.#operations) {
+      #makeOperationRoom(ledger) {
+        if (ledger.size < SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY) return true;
+        for (const [operationId, record] of ledger) {
           if (record.status !== "settled") continue;
-          this.#operations.delete(operationId);
+          ledger.delete(operationId);
           return true;
         }
         return false;
       }
-      async #run(operationId, intent, authenticatedSourceSemanticPaneId, authorizeBeforeEffect) {
+      async #run(session, operationId, intent, authenticatedSourceSemanticPaneId, authorizeBeforeEffect, origin = "sdk") {
         if (this.#disposed) {
           const error = new SessionRuntimeIntentError(
             "rejected",
             "Session semantic mutation executor shut down before execution"
           );
-          this.#publish(operationId, intent, "rejected");
+          this.#publish(operationId, intent, "rejected", null, void 0, origin);
           throw error;
         }
-        let settleObservation;
-        let rejectObservation;
-        const observed = new Promise((resolve31, reject) => {
-          settleObservation = resolve31;
-          rejectObservation = reject;
-        });
-        this.#pending.set(operationId, {
-          expected: {
-            operationId,
-            workspaceName: intent.workspaceName,
-            semanticPaneId: intent.semanticPaneId,
-            operationKind: intent.verb
-          },
-          resolve: settleObservation,
-          reject: rejectObservation
-        });
+        const needsTmuxObservation = sessionRuntimeIntentNeedsTmuxObservation(intent);
+        let observed = null;
+        if (needsTmuxObservation) {
+          let settleObservation;
+          let rejectObservation;
+          observed = new Promise((resolve31, reject) => {
+            settleObservation = resolve31;
+            rejectObservation = reject;
+          });
+          let sessionPending = this.#pending.get(session);
+          if (!sessionPending) {
+            sessionPending = /* @__PURE__ */ new Map();
+            this.#pending.set(session, sessionPending);
+          }
+          sessionPending.set(operationId, {
+            expected: {
+              operationId,
+              workspaceName: intent.workspaceName,
+              semanticPaneId: intent.semanticPaneId,
+              operationKind: intent.verb
+            },
+            resolve: settleObservation,
+            reject: rejectObservation
+          });
+        }
         let result;
         try {
           authorizeBeforeEffect?.();
-          result = await this.#options.execute(operationId, intent);
+          result = this.#options.execute(operationId, intent);
         } catch (cause) {
-          this.#pending.delete(operationId);
+          if (needsTmuxObservation) this.#deletePending(session, operationId);
           const error = new SessionRuntimeIntentError(
             "rejected",
             "tmux rejected the semantic interaction",
             { cause }
           );
-          this.#publish(operationId, intent, "rejected");
+          this.#publish(operationId, intent, "rejected", null, void 0, origin);
           throw error;
         }
-        const timeoutMs = this.#options.observationTimeoutMs ?? SESSION_RUNTIME_OBSERVATION_TIMEOUT_MS;
-        let timeout;
         try {
-          await Promise.race([
-            observed,
-            new Promise((_, reject) => {
-              timeout = setTimeout(
-                () => reject(
-                  new SessionRuntimeIntentError(
-                    "timed-out",
-                    "tmux did not expose the interaction through its observation hook in time"
-                  )
-                ),
-                timeoutMs
-              );
-              timeout.unref?.();
-            })
-          ]);
+          sessionRuntimeObservedProof(intent, result);
         } catch (cause) {
-          const error = cause instanceof SessionRuntimeIntentError ? cause : new SessionRuntimeIntentError("rejected", "Interaction observation was cancelled", {
-            cause
-          });
-          this.#publish(operationId, intent, error.outcome);
+          if (needsTmuxObservation) this.#deletePending(session, operationId);
+          const error = new SessionRuntimeIntentError(
+            "rejected",
+            "tmux returned invalid semantic mutation proof",
+            { cause }
+          );
+          this.#publish(operationId, intent, "rejected", null, void 0, origin);
           throw error;
-        } finally {
-          if (timeout) clearTimeout(timeout);
-          this.#pending.delete(operationId);
         }
-        this.#publish(operationId, intent, "observed", authenticatedSourceSemanticPaneId);
+        if (needsTmuxObservation) {
+          const timeoutMs = this.#options.observationTimeoutMs ?? SESSION_RUNTIME_OBSERVATION_TIMEOUT_MS;
+          let timeout;
+          try {
+            await Promise.race([
+              observed,
+              new Promise((_, reject) => {
+                timeout = setTimeout(
+                  () => reject(
+                    new SessionRuntimeIntentError(
+                      "timed-out",
+                      "tmux did not expose the interaction through its observation hook in time"
+                    )
+                  ),
+                  timeoutMs
+                );
+                timeout.unref?.();
+              })
+            ]);
+          } catch (cause) {
+            const error = cause instanceof SessionRuntimeIntentError ? cause : new SessionRuntimeIntentError("rejected", "Interaction observation was cancelled", {
+              cause
+            });
+            this.#publish(operationId, intent, error.outcome, null, void 0, origin);
+            throw error;
+          } finally {
+            if (timeout) clearTimeout(timeout);
+            this.#deletePending(session, operationId);
+          }
+        }
+        this.#publish(
+          operationId,
+          intent,
+          "observed",
+          authenticatedSourceSemanticPaneId,
+          result,
+          origin
+        );
         return result;
       }
-      #publish(operationId, intent, phase, authenticatedSourceSemanticPaneId = null) {
-        const summary = intent.verb === "workspace.pane.read" ? { operationKind: intent.verb, observedOnly: true } : {
-          operationKind: intent.verb,
-          characterCount: Array.from(intent.text).length,
-          byteCount: Buffer.byteLength(intent.text, "utf8"),
-          submitted: intent.submit
-        };
+      #deletePending(session, operationId) {
+        const pending = this.#pending.get(session);
+        pending?.delete(operationId);
+        if (pending?.size === 0) this.#pending.delete(session);
+      }
+      #publish(operationId, intent, phase, authenticatedSourceSemanticPaneId = null, result, authenticatedOrigin) {
+        const facts = sessionRuntimeInteractionFacts(intent);
+        const origin = authenticatedOrigin ?? ("origin" in intent ? intent.origin : "sdk");
         const receipt = InteractionReceiptSchemaZ.parse(
           this.#options.publishReceipt({
             operationId,
-            origin: intent.origin,
+            origin,
             workspaceName: intent.workspaceName,
             sourceSemanticPaneId: phase === "observed" ? authenticatedSourceSemanticPaneId : null,
-            target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+            target: facts.target,
             operationKind: intent.verb,
             phase,
-            summary,
-            proof: phase === "observed" ? { operationKind: intent.verb, observed: true, semanticPaneId: intent.semanticPaneId } : null,
+            summary: facts.summary,
+            proof: phase === "observed" ? sessionRuntimeObservedProof(intent, result) : null,
             at: (this.#options.now ?? (() => /* @__PURE__ */ new Date()))().toISOString(),
             resourceRevision: null
           })
@@ -29853,6 +29990,12 @@ var init_semantic_mutation_executor = __esm({
 // packages/daemon/src/terminal/session-runtime/registry.ts
 import { randomUUID as randomUUID4 } from "node:crypto";
 import { z as z62 } from "zod";
+function authoredOriginForSurface(surface) {
+  if (surface === "opentui") return "tui";
+  if (surface === "command-center") return "sdk";
+  if (surface === "cli") return "cli";
+  return "gui";
+}
 var SessionRuntimeControllerLeaseError, SessionRuntimeRegistry, SessionRuntime, SessionRuntimeConsumerImpl;
 var init_registry2 = __esm({
   "packages/daemon/src/terminal/session-runtime/registry.ts"() {
@@ -29871,7 +30014,6 @@ var init_registry2 = __esm({
       generation;
       #mirror;
       #semanticMutations;
-      #executeAuthorized;
       #resolveSession;
       #createControllerToken;
       #sessions = /* @__PURE__ */ new Map();
@@ -29883,7 +30025,6 @@ var init_registry2 = __esm({
         this.generation = SessionRuntimeGenerationSchemaZ.parse(options.generation);
         this.#mirror = new MirrorService(options.mirror);
         this.#semanticMutations = options.semanticMutations ? new SessionSemanticMutationExecutor(options.semanticMutations) : null;
-        this.#executeAuthorized = options.executeAuthorized ?? null;
         this.#resolveSession = options.semanticMutations?.resolveSession ?? null;
         this.#createControllerToken = options.createControllerToken ?? randomUUID4;
         this.#stopExitObserver = this.#mirror.onSessionExit((session) => {
@@ -29943,7 +30084,8 @@ var init_registry2 = __esm({
           operationId,
           { ...intent, sourceSemanticPaneId: semanticPaneId3 },
           semanticPaneId3,
-          authorizeBeforeEffect
+          authorizeBeforeEffect,
+          "cli"
         );
       }
       submitAuthenticatedIntent(handle, operationId, intent) {
@@ -29982,7 +30124,8 @@ var init_registry2 = __esm({
           operationId,
           normalizedIntent,
           authenticatedSourceSemanticPaneId,
-          () => this.#assertExecutionHandle(handle, state.sourceSemanticPaneId ?? void 0)
+          () => this.#assertExecutionHandle(handle, state.sourceSemanticPaneId ?? void 0),
+          authoredOriginForSurface(state.consumer.surface)
         );
       }
       #assertExecutionHandle(handle, semanticPaneId3) {
@@ -30011,7 +30154,7 @@ var init_registry2 = __esm({
         await runtime.whenReady();
         return await this.#mirror.subscribe(request);
       }
-      #submitAuthorizedIntent(runtime, lease, operationId, rawIntent, authenticatedSourceSemanticPaneId = null, authorizeBeforeEffect) {
+      #submitAuthorizedIntent(runtime, lease, operationId, rawIntent, authenticatedSourceSemanticPaneId = null, authorizeBeforeEffect, authenticatedOrigin) {
         if (this.#disposed) return Promise.reject(new Error("SessionRuntimeRegistry is disposed"));
         runtime.assertController(lease);
         let intent = SessionRuntimeSemanticIntentSchemaZ.parse(rawIntent);
@@ -30031,12 +30174,6 @@ var init_registry2 = __esm({
             intent = sourceLess;
           }
         }
-        if (intent.verb !== "workspace.pane.send" && intent.verb !== "workspace.pane.read") {
-          if (!this.#executeAuthorized) {
-            return Promise.reject(new Error("Authorized session mutations are unavailable"));
-          }
-          return this.#executeAuthorized(operationId, intent, authorizeBeforeEffect);
-        }
         if (!this.#semanticMutations) {
           return Promise.reject(new Error("Session semantic mutations are unavailable"));
         }
@@ -30044,7 +30181,8 @@ var init_registry2 = __esm({
           operationId,
           intent,
           authenticatedSourceSemanticPaneId,
-          authorizeBeforeEffect
+          authorizeBeforeEffect,
+          authenticatedOrigin
         );
       }
       observeTmuxInteraction(observation2) {
@@ -30088,7 +30226,7 @@ var init_registry2 = __esm({
           session,
           this.#mirror,
           this.#createControllerToken,
-          (owner, lease, operationId, intent) => this.#submitAuthorizedIntent(owner, lease, operationId, intent)
+          (owner, lease, operationId, intent, origin) => this.#submitAuthorizedIntent(owner, lease, operationId, intent, null, void 0, origin)
         );
         this.#sessions.set(session, runtime);
         return runtime;
@@ -30206,7 +30344,15 @@ var init_registry2 = __esm({
       submitIntent(callerClientId, lease, operationId, intent) {
         try {
           this.assertController(lease, callerClientId);
-          return this.#submitAuthorized(this, lease, operationId, intent);
+          const surface = this.#consumersByClientId.get(callerClientId)?.surface;
+          if (surface === void 0) throw new Error("Session runtime consumer disappeared");
+          return this.#submitAuthorized(
+            this,
+            lease,
+            operationId,
+            intent,
+            authoredOriginForSurface(surface)
+          );
         } catch (error) {
           return Promise.reject(error);
         }
@@ -36306,6 +36452,16 @@ function createSessionRuntimeMultiplexerBackend(options) {
   const owners = /* @__PURE__ */ new Map();
   const transportBinder = new SessionRuntimeTransportBinder(options.registry);
   let ownerEpoch = 0;
+  const submit = async (work) => {
+    try {
+      return await work();
+    } catch (error) {
+      if (error instanceof SessionRuntimeIntentError && error.cause instanceof WorkspaceMultiplexerError) {
+        throw error.cause;
+      }
+      throw error;
+    }
+  };
   const withTrustedOrigin = (intent, origin) => intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read" ? { ...intent, origin } : intent;
   const acquireOwner = (session) => {
     let owner = owners.get(session);
@@ -36346,10 +36502,12 @@ function createSessionRuntimeMultiplexerBackend(options) {
         if (!authenticatedContext) {
           throw new Error("Authenticated host has no live controller grant for this mutation");
         }
-        const result = await options.registry.submitAuthenticatedIntent(
-          authenticatedContext,
-          request.operationId,
-          withTrustedOrigin(request.intent, "gui")
+        const result = await submit(
+          () => options.registry.submitAuthenticatedIntent(
+            authenticatedContext,
+            request.operationId,
+            withTrustedOrigin(request.intent, "gui")
+          )
         );
         if (!result) throw new Error("Session mutation completed without a mutation result");
         return result;
@@ -36361,21 +36519,23 @@ function createSessionRuntimeMultiplexerBackend(options) {
       );
       if (sourcePaneCredential) {
         if (!credentialSource) throw new Error("Pane source credential is invalid or stale");
-        const result = await options.registry.submitPaneCredentialIntent(
-          session,
-          request.operationId,
-          withTrustedOrigin(request.intent, "cli"),
-          credentialSource,
-          () => {
-            const current = options.resolvePaneSourceCredential?.(
-              sourcePaneCredential,
-              session,
-              claimedSource
-            );
-            if (current !== credentialSource) {
-              throw new Error("Pane source credential became invalid before execution");
+        const result = await submit(
+          () => options.registry.submitPaneCredentialIntent(
+            session,
+            request.operationId,
+            withTrustedOrigin(request.intent, "cli"),
+            credentialSource,
+            () => {
+              const current = options.resolvePaneSourceCredential?.(
+                sourcePaneCredential,
+                session,
+                claimedSource
+              );
+              if (current !== credentialSource) {
+                throw new Error("Pane source credential became invalid before execution");
+              }
             }
-          }
+          )
         );
         if (!result) throw new Error("Session mutation completed without a mutation result");
         return result;
@@ -36383,10 +36543,12 @@ function createSessionRuntimeMultiplexerBackend(options) {
       const owner = acquireOwner(session);
       try {
         const lease = owner.consumer.acquireController();
-        const result = await owner.consumer.submitIntent(
-          lease,
-          request.operationId,
-          withTrustedOrigin(request.intent, "sdk")
+        const result = await submit(
+          () => owner.consumer.submitIntent(
+            lease,
+            request.operationId,
+            withTrustedOrigin(request.intent, "sdk")
+          )
         );
         if (!result) throw new Error("Session mutation completed without a mutation result");
         return result;
@@ -36399,6 +36561,8 @@ function createSessionRuntimeMultiplexerBackend(options) {
 var init_multiplexer_backend = __esm({
   "packages/daemon/src/terminal/session-runtime/multiplexer-backend.ts"() {
     "use strict";
+    init_workspace_multiplexer_verbs();
+    init_semantic_mutation_executor();
     init_transport_binding();
   }
 });
@@ -44059,19 +44223,16 @@ async function startEmbeddedDaemon(opts) {
     let startedServer;
     try {
       const selector = tmuxAuthority.socketSelector;
-      const executeRuntimeIntent = async (operationId, intent, authorizeBeforeEffect) => {
+      const executeRuntimeIntent = (operationId, intent) => {
         if (intent.verb === "workspace.pane.read") {
-          await workspaceMultiplexer.readPane(operationId, intent);
+          workspaceMultiplexer.readPane(operationId, intent);
           return;
         }
-        return await workspaceMultiplexer.mutate(
-          {
-            operationId,
-            expectedDaemonInstanceId: instanceId,
-            intent
-          },
-          authorizeBeforeEffect
-        );
+        return workspaceMultiplexer.mutate({
+          operationId,
+          expectedDaemonInstanceId: instanceId,
+          intent
+        });
       };
       sessionRuntimeRegistry = new SessionRuntimeRegistry({
         generation: instanceId,
@@ -44080,7 +44241,6 @@ async function startEmbeddedDaemon(opts) {
           execute: executeRuntimeIntent,
           publishReceipt: (receipt) => broadcastInteractionReceipt(receipt, instanceId)
         },
-        executeAuthorized: executeRuntimeIntent,
         mirror: {
           executable: tmuxAuthority.executablePath,
           ...selector.kind === "path" ? { socketPath: selector.path } : {},

--- a/packages/daemon/src/lib/__tests__/workspace-multiplexer-verbs-live.test.ts
+++ b/packages/daemon/src/lib/__tests__/workspace-multiplexer-verbs-live.test.ts
@@ -97,7 +97,7 @@ describe.skipIf(!hasTmux)("multiplexer verbs against live tmux", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  const mutate = (intent: Record<string, unknown>, operationId = randomUUID()) =>
+  const mutate = async (intent: Record<string, unknown>, operationId = randomUUID()) =>
     authority.mutate({
       operationId,
       expectedDaemonInstanceId: DAEMON_ID,

--- a/packages/daemon/src/lib/daemon-embed.ts
+++ b/packages/daemon/src/lib/daemon-embed.ts
@@ -1100,23 +1100,16 @@ export async function startEmbeddedDaemon(
     let startedServer: Awaited<ReturnType<typeof startHttpServer>>;
     try {
       const selector = tmuxAuthority.socketSelector;
-      const executeRuntimeIntent = async (
-        operationId: string,
-        intent: SessionRuntimeSemanticIntent,
-        authorizeBeforeEffect?: () => void,
-      ) => {
+      const executeRuntimeIntent = (operationId: string, intent: SessionRuntimeSemanticIntent) => {
         if (intent.verb === "workspace.pane.read") {
-          await workspaceMultiplexer.readPane(operationId, intent);
+          workspaceMultiplexer.readPane(operationId, intent);
           return;
         }
-        return await workspaceMultiplexer.mutate(
-          {
-            operationId,
-            expectedDaemonInstanceId: instanceId,
-            intent,
-          },
-          authorizeBeforeEffect,
-        );
+        return workspaceMultiplexer.mutate({
+          operationId,
+          expectedDaemonInstanceId: instanceId,
+          intent,
+        });
       };
       sessionRuntimeRegistry = new SessionRuntimeRegistry({
         generation: instanceId,
@@ -1126,7 +1119,6 @@ export async function startEmbeddedDaemon(
           execute: executeRuntimeIntent,
           publishReceipt: (receipt) => broadcastInteractionReceipt(receipt, instanceId),
         },
-        executeAuthorized: executeRuntimeIntent,
         mirror: {
           executable: tmuxAuthority.executablePath,
           ...(selector.kind === "path" ? { socketPath: selector.path } : {}),

--- a/packages/daemon/src/lib/pane-source-credentials.live.test.ts
+++ b/packages/daemon/src/lib/pane-source-credentials.live.test.ts
@@ -111,7 +111,7 @@ describe.skipIf(!hasTmux).sequential("pane source credentials, live tmux", () =>
       generation: randomUUID(),
       semanticMutations: {
         resolveSession: (workspaceName) => (workspaceName === "alpha" ? session : null),
-        execute: async (operationId, intent) => {
+        execute: (operationId, intent) => {
           if (intent.verb !== "workspace.pane.send") throw new Error("unexpected read");
           run(["send-keys", "-t", targetPane, "-l", "--", intent.text]);
           if (intent.submit) run(["send-keys", "-t", targetPane, "Enter"]);
@@ -123,7 +123,19 @@ describe.skipIf(!hasTmux).sequential("pane source credentials, live tmux", () =>
               operationKind: "workspace.pane.send",
             }),
           );
-          return { outcome: "applied" } as never;
+          return {
+            operationId,
+            daemonInstanceId: registry.generation,
+            workspaceName: intent.workspaceName,
+            verb: intent.verb,
+            outcome: "applied",
+            sourceSemanticPaneId: intent.sourceSemanticPaneId ?? null,
+            semanticPaneId: intent.semanticPaneId,
+            origin: intent.origin,
+            characterCount: Array.from(intent.text).length,
+            byteCount: Buffer.byteLength(intent.text, "utf8"),
+            submitted: intent.submit,
+          };
         },
         publishReceipt: (receipt) => {
           const published = {

--- a/packages/daemon/src/lib/workspace-multiplexer-verbs.test.ts
+++ b/packages/daemon/src/lib/workspace-multiplexer-verbs.test.ts
@@ -297,14 +297,16 @@ class FakeTmux {
 
 const DAEMON_ID = "11111111-1111-4111-8111-111111111111";
 
-async function expectRefusal(
-  promise: Promise<unknown>,
+function expectRefusal(
+  run: () => unknown,
   code: WorkspaceMultiplexerErrorCode,
-): Promise<WorkspaceMultiplexerError> {
-  const error = await promise.then(
-    () => null,
-    (caught: unknown) => caught,
-  );
+): WorkspaceMultiplexerError {
+  let error: unknown = null;
+  try {
+    run();
+  } catch (caught) {
+    error = caught;
+  }
   expect(error).toBeInstanceOf(WorkspaceMultiplexerError);
   expect((error as WorkspaceMultiplexerError).code).toBe(code);
   return error as WorkspaceMultiplexerError;
@@ -433,42 +435,21 @@ describe("the multiplexer authority", () => {
 
   it("refuses a request from a different daemon generation", async () => {
     await expectRefusal(
-      authority.mutate({
-        operationId: randomUUID(),
-        expectedDaemonInstanceId: randomUUID(),
-        intent: { verb: "workspace.session.kill", workspaceName: "work" },
-      }),
+      () =>
+        authority.mutate({
+          operationId: randomUUID(),
+          expectedDaemonInstanceId: randomUUID(),
+          intent: { verb: "workspace.session.kill", workspaceName: "work" },
+        }),
       "daemon_instance_mismatch",
     );
   });
 
   it("refuses an unregistered workspace", async () => {
     await expectRefusal(
-      authority.mutate(request({ verb: "workspace.session.kill", workspaceName: "ghost" })),
+      () => authority.mutate(request({ verb: "workspace.session.kill", workspaceName: "ghost" })),
       "workspace_not_found",
     );
-  });
-
-  it("rechecks queued structural authority after the multiplexer queue and before tmux effect", async () => {
-    let controllerLive = true;
-    const first = authority.mutate(
-      request({ verb: "workspace.pane.select", semanticPaneId: "pane.one" }),
-      () => queueMicrotask(() => (controllerLive = false)),
-    );
-    const stale = authority.mutate(
-      request({
-        verb: "workspace.pane.resize",
-        semanticPaneId: "pane.one",
-        axis: "cols",
-        cells: 80,
-      }),
-      () => {
-        if (!controllerLive) throw new Error("controller handed off while queued");
-      },
-    );
-    await first;
-    await expect(stale).rejects.toMatchObject({ code: "mutation_failed" });
-    expect(tmux.calls.filter((args) => args[0] === "resize-pane")).toHaveLength(0);
   });
 
   describe("split", () => {
@@ -522,13 +503,14 @@ describe("the multiplexer authority", () => {
         error: new Error("option refused"),
       };
       await expectRefusal(
-        authority.mutate(
-          request({
-            verb: "workspace.window.split",
-            semanticPaneId: "pane.one",
-            direction: "right",
-          }),
-        ),
+        () =>
+          authority.mutate(
+            request({
+              verb: "workspace.window.split",
+              semanticPaneId: "pane.one",
+              direction: "right",
+            }),
+          ),
         "mutation_failed",
       );
       // The half-built pane must not survive the failure.
@@ -550,25 +532,6 @@ describe("the multiplexer authority", () => {
         (first as { semanticPaneId: string }).semanticPaneId,
       );
       expect(tmux.panes.length).toBe(paneCount);
-    });
-
-    it("refuses to reuse an operation id for a different intent", async () => {
-      const operationId = randomUUID();
-      await authority.mutate(
-        request(
-          { verb: "workspace.window.split", semanticPaneId: "pane.one", direction: "right" },
-          operationId,
-        ),
-      );
-      await expectRefusal(
-        authority.mutate(
-          request(
-            { verb: "workspace.window.split", semanticPaneId: "pane.one", direction: "down" },
-            operationId,
-          ),
-        ),
-        "operation_conflict",
-      );
     });
   });
 
@@ -621,41 +584,20 @@ describe("the multiplexer authority", () => {
     it("refuses an unverified source identity before sending any input", async () => {
       const sendsBefore = tmux.calls.filter((args) => args.includes("send-keys")).length;
       await expectRefusal(
-        authority.mutate(
-          request({
-            verb: "workspace.pane.send",
-            sourceSemanticPaneId: "pane.not-in-workspace",
-            semanticPaneId: "pane.one",
-            text: "never delivered",
-            submit: true,
-            origin: "sdk",
-          }),
-        ),
+        () =>
+          authority.mutate(
+            request({
+              verb: "workspace.pane.send",
+              sourceSemanticPaneId: "pane.not-in-workspace",
+              semanticPaneId: "pane.one",
+              text: "never delivered",
+              submit: true,
+              origin: "sdk",
+            }),
+          ),
         "pane_not_found",
       );
       expect(tmux.calls.filter((args) => args.includes("send-keys"))).toHaveLength(sendsBefore);
-    });
-
-    it("replays one operation id without delivering terminal input twice", async () => {
-      const operationId = randomUUID();
-      const mutation = request(
-        {
-          verb: "workspace.pane.send",
-          semanticPaneId: "pane.one",
-          text: "only once",
-          submit: false,
-          origin: "cli",
-        },
-        operationId,
-      );
-      const first = await authority.mutate(mutation);
-      const sendsAfterFirst = tmux.calls.filter((args) => args.includes("send-keys")).length;
-      const second = await authority.mutate(mutation);
-
-      expect(first.outcome).toBe("applied");
-      expect(second).toEqual({ ...first, outcome: "replayed" });
-      expect(tmux.calls.filter((args) => args.includes("send-keys"))).toHaveLength(sendsAfterFirst);
-      expect(tmux.calls.filter((args) => args.includes("send-keys"))).toHaveLength(1);
     });
   });
 
@@ -709,12 +651,13 @@ describe("the multiplexer authority", () => {
         }),
       );
       const error = await expectRefusal(
-        authority.mutate(
-          request({
-            verb: "workspace.window.kill",
-            target: { by: "window", semanticWindowId: "win.editor" },
-          }),
-        ),
+        () =>
+          authority.mutate(
+            request({
+              verb: "workspace.window.kill",
+              target: { by: "window", semanticWindowId: "win.editor" },
+            }),
+          ),
         "last_window_refused",
       );
       expect(error.message).toMatch(/Close the session instead/u);
@@ -745,7 +688,8 @@ describe("the multiplexer authority", () => {
         }),
       );
       await expectRefusal(
-        authority.mutate(request({ verb: "workspace.pane.kill", semanticPaneId: "pane.one" })),
+        () =>
+          authority.mutate(request({ verb: "workspace.pane.kill", semanticPaneId: "pane.one" })),
         "last_pane_refused",
       );
       expect(tmux.sessionName).toBe("work");
@@ -910,14 +854,15 @@ describe("the multiplexer authority", () => {
 
     it("refuses a one-pane window, which has no border to move", async () => {
       await expectRefusal(
-        authority.mutate(
-          request({
-            verb: "workspace.pane.resize",
-            semanticPaneId: "pane.one",
-            axis: "cols",
-            cells: 40,
-          }),
-        ),
+        () =>
+          authority.mutate(
+            request({
+              verb: "workspace.pane.resize",
+              semanticPaneId: "pane.one",
+              axis: "cols",
+              cells: 40,
+            }),
+          ),
         "single_pane_window",
       );
       expect(tmux.calls.some((args) => args[0] === "resize-pane")).toBe(false);
@@ -927,28 +872,30 @@ describe("the multiplexer authority", () => {
       split();
       tmux.windows[0]!.zoomed = true;
       await expectRefusal(
-        authority.mutate(
-          request({
-            verb: "workspace.pane.resize",
-            semanticPaneId: "pane.one",
-            axis: "cols",
-            cells: 40,
-          }),
-        ),
+        () =>
+          authority.mutate(
+            request({
+              verb: "workspace.pane.resize",
+              semanticPaneId: "pane.one",
+              axis: "cols",
+              cells: 40,
+            }),
+          ),
         "zoomed_window_refused",
       );
     });
 
     it("refuses a pane that no longer carries the requested stamp", async () => {
       await expectRefusal(
-        authority.mutate(
-          request({
-            verb: "workspace.pane.resize",
-            semanticPaneId: "pane.gone",
-            axis: "cols",
-            cells: 40,
-          }),
-        ),
+        () =>
+          authority.mutate(
+            request({
+              verb: "workspace.pane.resize",
+              semanticPaneId: "pane.gone",
+              axis: "cols",
+              cells: 40,
+            }),
+          ),
         "pane_not_found",
       );
     });
@@ -1009,13 +956,14 @@ describe("the multiplexer authority", () => {
 
     it("refuses panes in different windows before invoking tmux", async () => {
       await expectRefusal(
-        authority.mutate(
-          request({
-            verb: "workspace.pane.swap",
-            sourceSemanticPaneId: "pane.one",
-            targetSemanticPaneId: "pane.two",
-          }),
-        ),
+        () =>
+          authority.mutate(
+            request({
+              verb: "workspace.pane.swap",
+              sourceSemanticPaneId: "pane.one",
+              targetSemanticPaneId: "pane.two",
+            }),
+          ),
         "different_window_refused",
       );
       expect(tmux.calls.some((args) => args[0] === "swap-pane")).toBe(false);
@@ -1024,13 +972,14 @@ describe("the multiplexer authority", () => {
     it("refuses a missing target semantic identity", async () => {
       split();
       await expectRefusal(
-        authority.mutate(
-          request({
-            verb: "workspace.pane.swap",
-            sourceSemanticPaneId: "pane.one",
-            targetSemanticPaneId: "pane.missing",
-          }),
-        ),
+        () =>
+          authority.mutate(
+            request({
+              verb: "workspace.pane.swap",
+              sourceSemanticPaneId: "pane.one",
+              targetSemanticPaneId: "pane.missing",
+            }),
+          ),
         "pane_not_found",
       );
     });
@@ -1039,13 +988,14 @@ describe("the multiplexer authority", () => {
       split();
       tmux.ignoreSwap = true;
       await expectRefusal(
-        authority.mutate(
-          request({
-            verb: "workspace.pane.swap",
-            sourceSemanticPaneId: "pane.one",
-            targetSemanticPaneId: "pane.split",
-          }),
-        ),
+        () =>
+          authority.mutate(
+            request({
+              verb: "workspace.pane.swap",
+              sourceSemanticPaneId: "pane.one",
+              targetSemanticPaneId: "pane.split",
+            }),
+          ),
         "mutation_unverified",
       );
     });
@@ -1105,25 +1055,17 @@ describe("the multiplexer authority", () => {
     it("refuses a pane that no longer carries the requested stamp", async () => {
       tmux.panes[0]!.options.delete("@tmux_ide_pane_id");
       await expectRefusal(
-        authority.mutate(request({ verb: "workspace.pane.select", semanticPaneId: "pane.one" })),
+        () =>
+          authority.mutate(request({ verb: "workspace.pane.select", semanticPaneId: "pane.one" })),
         "pane_not_found",
       );
     });
   });
 
-  it("replays a remembered refusal instead of re-running it", async () => {
-    const operationId = randomUUID();
-    const intent = { verb: "workspace.pane.select", semanticPaneId: "pane.absent" };
-    await expectRefusal(authority.mutate(request(intent, operationId)), "pane_not_found");
-    const callCount = tmux.calls.length;
-    await expectRefusal(authority.mutate(request(intent, operationId)), "pane_not_found");
-    expect(tmux.calls.length).toBe(callCount);
-  });
-
   it("stops admitting verbs once disposed", async () => {
     await authority.dispose();
     await expectRefusal(
-      authority.mutate(request({ verb: "workspace.session.kill" })),
+      () => authority.mutate(request({ verb: "workspace.session.kill" })),
       "workspace_unavailable",
     );
   });

--- a/packages/daemon/src/lib/workspace-multiplexer-verbs.ts
+++ b/packages/daemon/src/lib/workspace-multiplexer-verbs.ts
@@ -3,8 +3,7 @@
  * and resize.
  *
  * This is the tmux authority the m48 audit found missing. It follows the
- * `workspace.pane.create` discipline deliberately and in full — one serialized
- * queue per tmux session, operation-id idempotency with a request fingerprint, a pinned tmux
+ * `workspace.pane.create` discipline deliberately and in full — a pinned tmux
  * executable and socket resolved once per daemon generation, semantic-id
  * resolution that never trusts a renderer-supplied tmux target, and a read-back
  * verification after every mutation. Where creation proves a pane exists, these
@@ -44,8 +43,6 @@ import {
   INTERNAL_SEND_OPERATION_OPTION,
 } from "./tmux-interaction-options.ts";
 
-const MAX_OPERATIONS = 128;
-
 const CREATION_OPTION = "@tmux_ide_creation_id";
 const SEMANTIC_PANE_OPTION = "@tmux_ide_pane_id";
 const SEMANTIC_WINDOW_OPTION = "@tmux_ide_window_id";
@@ -58,8 +55,6 @@ export type WorkspaceMultiplexerErrorCode =
   | "pane_not_found"
   | "window_not_found"
   | "ambiguous_target"
-  | "operation_conflict"
-  | "operation_capacity"
   /** Refused: killing it would take the whole session with it. */
   | "last_window_refused"
   /** Refused: killing it would take the whole session with it. */
@@ -80,8 +75,6 @@ const ERROR_MESSAGES: Readonly<Record<WorkspaceMultiplexerErrorCode, string>> = 
   pane_not_found: "No pane in this workspace carries the requested semantic identity.",
   window_not_found: "No window in this workspace carries the requested identity.",
   ambiguous_target: "The requested identity names more than one live tmux object.",
-  operation_conflict: "The operation id was already used for a different intent.",
-  operation_capacity: "The daemon has reached its bounded multiplexer operation capacity.",
   last_window_refused:
     "This is the session's last window. Close the session instead if that is what you mean.",
   last_pane_refused:
@@ -254,13 +247,6 @@ function tmuxFormatLiteral(value: string): string {
   return value.replaceAll("#", "##");
 }
 
-interface OperationRecord {
-  readonly fingerprint: string;
-  readonly status: "success" | "error";
-  readonly result?: WorkspaceMultiplexerMutationResult;
-  readonly error?: WorkspaceMultiplexerError;
-}
-
 export interface WorkspaceMultiplexerIo {
   readonly runTmux: (args: readonly string[]) => string;
   readonly canonicalProjectDir: (path: string) => string;
@@ -284,8 +270,6 @@ export class WorkspaceMultiplexerAuthority {
   readonly #daemonInstanceId: string;
   readonly #registry: WorkspaceRegistry;
   readonly #io: WorkspaceMultiplexerIo;
-  readonly #operations = new Map<string, OperationRecord>();
-  readonly #tails = new Map<string, Promise<void>>();
   #disposed = false;
 
   constructor(options: {
@@ -307,30 +291,13 @@ export class WorkspaceMultiplexerAuthority {
     };
   }
 
-  /** Serialized per tmux session: read-decide-mutate never interleaves locally. */
-  mutate(
-    raw: WorkspaceMultiplexerMutationRequest,
-    authorizeBeforeEffect?: () => void,
-  ): Promise<WorkspaceMultiplexerMutationResult> {
-    return Promise.resolve().then(() => {
-      const request = WorkspaceMultiplexerMutationRequestSchemaZ.parse(raw);
-      const session = this.#registry.get(request.intent.workspaceName)?.sessionName;
-      const queue = session ?? `missing:${request.intent.workspaceName}`;
-      const previous = this.#tails.get(queue) ?? Promise.resolve();
-      const run = previous.then(
-        () => this.#mutate(request, authorizeBeforeEffect),
-        () => this.#mutate(request, authorizeBeforeEffect),
-      );
-      const tail = run.then(
-        () => undefined,
-        () => undefined,
-      );
-      this.#tails.set(queue, tail);
-      void tail.finally(() => {
-        if (this.#tails.get(queue) === tail) this.#tails.delete(queue);
-      });
-      return run;
-    });
+  /**
+   * Execute immediately in the caller's already-serialized semantic lane.
+   * The returned promise is only an API envelope: no second queue or replay
+   * ledger is allowed below SessionSemanticMutationExecutor.
+   */
+  mutate(raw: WorkspaceMultiplexerMutationRequest): WorkspaceMultiplexerMutationResult {
+    return this.#mutate(raw);
   }
 
   /**
@@ -339,7 +306,7 @@ export class WorkspaceMultiplexerAuthority {
    * the command-list and verifies that its semantic target survived it.
    * SessionRuntimeRegistry serializes this lane with authored sends.
    */
-  async readPane(operationId: string, intent: SessionRuntimePaneReadIntent): Promise<void> {
+  readPane(operationId: string, intent: SessionRuntimePaneReadIntent): void {
     if (this.#disposed) {
       throw new WorkspaceMultiplexerError("workspace_unavailable", {
         reason: "authority_disposed",
@@ -390,16 +357,10 @@ export class WorkspaceMultiplexerAuthority {
 
   dispose(): Promise<void> {
     this.#disposed = true;
-    return Promise.allSettled(this.#tails.values()).then(() => {
-      this.#tails.clear();
-      this.#operations.clear();
-    });
+    return Promise.resolve();
   }
 
-  async #mutate(
-    raw: WorkspaceMultiplexerMutationRequest,
-    authorizeBeforeEffect?: () => void,
-  ): Promise<WorkspaceMultiplexerMutationResult> {
+  #mutate(raw: WorkspaceMultiplexerMutationRequest): WorkspaceMultiplexerMutationResult {
     if (this.#disposed) {
       throw new WorkspaceMultiplexerError("workspace_unavailable", {
         reason: "authority_disposed",
@@ -411,53 +372,16 @@ export class WorkspaceMultiplexerAuthority {
         operationId: request.operationId,
       });
     }
-    const requestFingerprint = JSON.stringify(request);
-    const existing = this.#operations.get(request.operationId);
-    if (existing) {
-      if (existing.fingerprint !== requestFingerprint) {
-        throw new WorkspaceMultiplexerError("operation_conflict", {
-          operationId: request.operationId,
-        });
-      }
-      if (existing.status === "error") throw existing.error!;
-      return WorkspaceMultiplexerMutationResultSchemaZ.parse({
-        ...existing.result!,
-        outcome: "replayed",
-      });
-    }
-    if (this.#operations.size >= MAX_OPERATIONS) {
-      // Bounded FIFO. An evicted id loses only its replay guarantee; the world
-      // it already changed is unaffected.
-      const oldest = this.#operations.keys().next().value as string | undefined;
-      if (oldest !== undefined) this.#operations.delete(oldest);
-    }
-
     const workspace = this.#registry.get(request.intent.workspaceName);
     if (!workspace) {
-      const error = new WorkspaceMultiplexerError("workspace_not_found", {
+      throw new WorkspaceMultiplexerError("workspace_not_found", {
         operationId: request.operationId,
         workspaceName: request.intent.workspaceName,
       });
-      this.#operations.set(request.operationId, {
-        fingerprint: requestFingerprint,
-        status: "error",
-        error,
-      });
-      throw error;
     }
 
     try {
-      // This authority has its own per-session queue. Recheck only after that
-      // wait, immediately before the synchronous read/decide/tmux effect lane.
-      authorizeBeforeEffect?.();
-      const result = await this.#perform(request, workspace);
-      const parsed = WorkspaceMultiplexerMutationResultSchemaZ.parse(result);
-      this.#operations.set(request.operationId, {
-        fingerprint: requestFingerprint,
-        status: "success",
-        result: parsed,
-      });
-      return parsed;
+      return WorkspaceMultiplexerMutationResultSchemaZ.parse(this.#perform(request, workspace));
     } catch (error) {
       const mapped =
         error instanceof WorkspaceMultiplexerError
@@ -470,11 +394,6 @@ export class WorkspaceMultiplexerAuthority {
               },
               error,
             );
-      this.#operations.set(request.operationId, {
-        fingerprint: requestFingerprint,
-        status: "error",
-        error: mapped,
-      });
       throw mapped;
     }
   }
@@ -493,10 +412,10 @@ export class WorkspaceMultiplexerAuthority {
     return parseMultiplexerPaneRows(output);
   }
 
-  async #perform(
+  #perform(
     request: WorkspaceMultiplexerMutationRequest,
     workspace: Workspace,
-  ): Promise<WorkspaceMultiplexerMutationResult> {
+  ): WorkspaceMultiplexerMutationResult {
     const intent = request.intent;
     const sessionName = workspace.sessionName;
     const envelope = {

--- a/packages/daemon/src/terminal/session-runtime/interaction-receipt-facts.ts
+++ b/packages/daemon/src/terminal/session-runtime/interaction-receipt-facts.ts
@@ -1,0 +1,168 @@
+import {
+  WorkspaceMultiplexerMutationResultSchemaZ,
+  type InteractionProof,
+  type InteractionSafeSummary,
+  type InteractionTarget,
+  type SessionRuntimeSemanticIntent,
+  type WorkspaceMultiplexerMutationResult,
+} from "@tmux-ide/contracts";
+
+export interface SessionRuntimeInteractionFacts {
+  readonly target: InteractionTarget;
+  readonly summary: InteractionSafeSummary;
+}
+
+/** Privacy-safe request facts. Literal input and authored names never leave the mutation request. */
+export function sessionRuntimeInteractionFacts(
+  intent: SessionRuntimeSemanticIntent,
+): SessionRuntimeInteractionFacts {
+  switch (intent.verb) {
+    case "workspace.window.split":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb, direction: intent.direction },
+      };
+    case "workspace.window.kill":
+      return {
+        target: { kind: "window", target: intent.target },
+        summary: { operationKind: intent.verb },
+      };
+    case "workspace.pane.kill":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb },
+      };
+    case "workspace.session.kill":
+      return { target: { kind: "session" }, summary: { operationKind: intent.verb } };
+    case "workspace.rename":
+      return intent.scope === "session"
+        ? {
+            target: { kind: "session" },
+            summary: { operationKind: intent.verb, scope: intent.scope },
+          }
+        : {
+            target: { kind: "window", target: intent.target },
+            summary: { operationKind: intent.verb, scope: intent.scope },
+          };
+    case "workspace.pane.zoom.toggle":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb, desired: intent.desired },
+      };
+    case "workspace.pane.select":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb },
+      };
+    case "workspace.pane.send":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: {
+          operationKind: intent.verb,
+          characterCount: Array.from(intent.text).length,
+          byteCount: Buffer.byteLength(intent.text, "utf8"),
+          submitted: intent.submit,
+        },
+      };
+    case "workspace.pane.swap":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.sourceSemanticPaneId },
+        summary: {
+          operationKind: intent.verb,
+          targetSemanticPaneId: intent.targetSemanticPaneId,
+        },
+      };
+    case "workspace.pane.resize":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb, axis: intent.axis, cells: intent.cells },
+      };
+    case "workspace.pane.read":
+      return {
+        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        summary: { operationKind: intent.verb, observedOnly: true },
+      };
+  }
+}
+
+/** Convert verified lower-authority results into the receipt contract's bounded proof vocabulary. */
+export function sessionRuntimeObservedProof(
+  intent: SessionRuntimeSemanticIntent,
+  rawResult: WorkspaceMultiplexerMutationResult | void,
+): InteractionProof {
+  if (intent.verb === "workspace.pane.read") {
+    if (rawResult !== undefined) throw new TypeError("Pane read returned an unexpected result");
+    return { operationKind: intent.verb, observed: true, semanticPaneId: intent.semanticPaneId };
+  }
+  const result = WorkspaceMultiplexerMutationResultSchemaZ.parse(rawResult);
+  if (result.verb !== intent.verb)
+    throw new TypeError("Mutation result verb does not match intent");
+  switch (result.verb) {
+    case "workspace.window.split":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        direction: result.direction,
+        semanticPaneId: result.semanticPaneId,
+      };
+    case "workspace.window.kill":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        remainingWindowCount: result.remainingWindowCount,
+      };
+    case "workspace.pane.kill":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        semanticPaneId: (
+          intent as Extract<SessionRuntimeSemanticIntent, { verb: "workspace.pane.kill" }>
+        ).semanticPaneId,
+        windowClosed: result.windowClosed,
+        remainingWindowCount: result.remainingWindowCount,
+      };
+    case "workspace.session.kill":
+      return { operationKind: result.verb, outcome: result.outcome };
+    case "workspace.rename":
+      return { operationKind: result.verb, outcome: result.outcome, scope: result.scope };
+    case "workspace.pane.zoom.toggle":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        semanticPaneId: result.semanticPaneId,
+        zoomed: result.zoomed,
+      };
+    case "workspace.pane.select":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        semanticPaneId: result.semanticPaneId,
+      };
+    case "workspace.pane.send":
+      return { operationKind: result.verb, observed: true, semanticPaneId: result.semanticPaneId };
+    case "workspace.pane.swap":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        sourceSemanticPaneId: result.sourceSemanticPaneId,
+        targetSemanticPaneId: result.targetSemanticPaneId,
+      };
+    case "workspace.pane.resize":
+      return {
+        operationKind: result.verb,
+        outcome: result.outcome,
+        semanticPaneId: result.semanticPaneId,
+        axis: result.axis,
+        cells: result.cells,
+      };
+  }
+}
+
+export function sessionRuntimeIntentNeedsTmuxObservation(
+  intent: SessionRuntimeSemanticIntent,
+): intent is Extract<
+  SessionRuntimeSemanticIntent,
+  { verb: "workspace.pane.send" | "workspace.pane.read" }
+> {
+  return intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read";
+}

--- a/packages/daemon/src/terminal/session-runtime/multiplexer-backend.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/multiplexer-backend.test.ts
@@ -10,6 +10,8 @@ import type {
 } from "./registry.ts";
 import { SessionRuntimeRegistry } from "./registry.ts";
 import { createSessionRuntimeMultiplexerBackend } from "./multiplexer-backend.ts";
+import { WorkspaceMultiplexerError } from "../../lib/workspace-multiplexer-verbs.ts";
+import { SessionRuntimeIntentError } from "./semantic-mutation-executor.ts";
 import { SessionRuntimeTransportBinder } from "./transport-binding.ts";
 
 const GENERATION = "11111111-1111-4111-8111-111111111111";
@@ -201,10 +203,21 @@ describe("createSessionRuntimeMultiplexerBackend", () => {
       generation: GENERATION,
       semanticMutations: {
         resolveSession: () => "alpha-session",
-        execute: async () => ({ outcome: "applied" }) as never,
+        execute: (operationId, intent) => {
+          if (intent.verb !== "workspace.pane.resize") throw new Error("unexpected intent");
+          return {
+            operationId,
+            daemonInstanceId: GENERATION,
+            workspaceName: intent.workspaceName,
+            verb: intent.verb,
+            outcome: "applied",
+            semanticPaneId: intent.semanticPaneId,
+            axis: intent.axis,
+            cells: intent.cells,
+          };
+        },
         publishReceipt: (receipt) => ({ type: "interaction.receipt", sequence: 1, ...receipt }),
       },
-      executeAuthorized: async () => ({ outcome: "applied" }) as never,
     });
     const backend = createSessionRuntimeMultiplexerBackend({
       registry,
@@ -224,6 +237,56 @@ describe("createSessionRuntimeMultiplexerBackend", () => {
     expect(gui.acquireController()).toMatchObject({ clientId: "host:gui" });
     await gui.close();
     await registry.dispose();
+  });
+
+  it("preserves typed multiplexer refusals but retains the runtime envelope for generic failures", async () => {
+    const refusal = new WorkspaceMultiplexerError("single_pane_window");
+    const build = (failure: Error) => {
+      const registry = new SessionRuntimeRegistry({
+        generation: GENERATION,
+        semanticMutations: {
+          resolveSession: () => "alpha-session",
+          execute: () => {
+            throw failure;
+          },
+          publishReceipt: (receipt) => ({ type: "interaction.receipt", sequence: 1, ...receipt }),
+        },
+      });
+      return {
+        registry,
+        backend: createSessionRuntimeMultiplexerBackend({
+          registry,
+          resolveSession: () => "alpha-session",
+        }),
+      };
+    };
+    const typed = build(refusal);
+    await expect(
+      typed.backend.mutate(
+        request({
+          verb: "workspace.pane.resize",
+          workspaceName: "alpha",
+          semanticPaneId: "pane.alpha",
+          axis: "cols",
+          cells: 80,
+        }),
+      ),
+    ).rejects.toBe(refusal);
+    await typed.registry.dispose();
+
+    const generic = build(new Error("generic effect failure"));
+    await expect(
+      generic.backend.mutate(
+        request({
+          verb: "workspace.pane.resize",
+          workspaceName: "alpha",
+          semanticPaneId: "pane.alpha",
+          axis: "cols",
+          cells: 80,
+        }),
+      ),
+    ).rejects.toBeInstanceOf(SessionRuntimeIntentError);
+    await generic.registry.dispose();
   });
 
   it("keeps anonymous owner access explicit and releases authority after each settled action", async () => {

--- a/packages/daemon/src/terminal/session-runtime/multiplexer-backend.ts
+++ b/packages/daemon/src/terminal/session-runtime/multiplexer-backend.ts
@@ -4,7 +4,9 @@ import type {
   WorkspaceMultiplexerMutationResult,
 } from "@tmux-ide/contracts";
 import type { WorkspaceMultiplexerBackend } from "../../command-center/actions/handlers/workspace-multiplexer.ts";
+import { WorkspaceMultiplexerError } from "../../lib/workspace-multiplexer-verbs.ts";
 import type { SessionRuntimeConsumer, SessionRuntimeRegistry } from "./registry.ts";
+import { SessionRuntimeIntentError } from "./semantic-mutation-executor.ts";
 import { SessionRuntimeTransportBinder } from "./transport-binding.ts";
 
 export interface SessionRuntimeMultiplexerBackendOptions {
@@ -44,6 +46,22 @@ export function createSessionRuntimeMultiplexerBackend(
   const owners = new Map<string, OwnerUse>();
   const transportBinder = new SessionRuntimeTransportBinder(options.registry);
   let ownerEpoch = 0;
+
+  const submit = async <T>(work: () => Promise<T>): Promise<T> => {
+    try {
+      return await work();
+    } catch (error) {
+      // The executor owns lifecycle receipts, but command-center handlers still
+      // need the multiplexer authority's typed refusal for stable HTTP mapping.
+      if (
+        error instanceof SessionRuntimeIntentError &&
+        error.cause instanceof WorkspaceMultiplexerError
+      ) {
+        throw error.cause;
+      }
+      throw error;
+    }
+  };
 
   const withTrustedOrigin = (
     intent: SessionRuntimeSemanticIntent,
@@ -101,10 +119,12 @@ export function createSessionRuntimeMultiplexerBackend(
         if (!authenticatedContext) {
           throw new Error("Authenticated host has no live controller grant for this mutation");
         }
-        const result = await options.registry.submitAuthenticatedIntent(
-          authenticatedContext,
-          request.operationId,
-          withTrustedOrigin(request.intent as SessionRuntimeSemanticIntent, "gui"),
+        const result = await submit(() =>
+          options.registry.submitAuthenticatedIntent(
+            authenticatedContext,
+            request.operationId,
+            withTrustedOrigin(request.intent as SessionRuntimeSemanticIntent, "gui"),
+          ),
         );
         if (!result) throw new Error("Session mutation completed without a mutation result");
         return result;
@@ -116,21 +136,23 @@ export function createSessionRuntimeMultiplexerBackend(
       );
       if (sourcePaneCredential) {
         if (!credentialSource) throw new Error("Pane source credential is invalid or stale");
-        const result = await options.registry.submitPaneCredentialIntent(
-          session,
-          request.operationId,
-          withTrustedOrigin(request.intent as SessionRuntimeSemanticIntent, "cli"),
-          credentialSource,
-          () => {
-            const current = options.resolvePaneSourceCredential?.(
-              sourcePaneCredential,
-              session,
-              claimedSource,
-            );
-            if (current !== credentialSource) {
-              throw new Error("Pane source credential became invalid before execution");
-            }
-          },
+        const result = await submit(() =>
+          options.registry.submitPaneCredentialIntent(
+            session,
+            request.operationId,
+            withTrustedOrigin(request.intent as SessionRuntimeSemanticIntent, "cli"),
+            credentialSource,
+            () => {
+              const current = options.resolvePaneSourceCredential?.(
+                sourcePaneCredential,
+                session,
+                claimedSource,
+              );
+              if (current !== credentialSource) {
+                throw new Error("Pane source credential became invalid before execution");
+              }
+            },
+          ),
         );
         if (!result) throw new Error("Session mutation completed without a mutation result");
         return result;
@@ -138,10 +160,12 @@ export function createSessionRuntimeMultiplexerBackend(
       const owner = acquireOwner(session);
       try {
         const lease = owner.consumer.acquireController();
-        const result = await owner.consumer.submitIntent(
-          lease,
-          request.operationId,
-          withTrustedOrigin(request.intent as SessionRuntimeSemanticIntent, "sdk"),
+        const result = await submit(() =>
+          owner.consumer.submitIntent(
+            lease,
+            request.operationId,
+            withTrustedOrigin(request.intent as SessionRuntimeSemanticIntent, "sdk"),
+          ),
         );
         if (!result) throw new Error("Session mutation completed without a mutation result");
         return result;

--- a/packages/daemon/src/terminal/session-runtime/registry.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { SessionRuntimeSemanticIntent } from "@tmux-ide/contracts";
 import type { MirrorServiceOptions } from "../mirror/mirror-service.ts";
 import { ControlModeOwnershipRegistry } from "../mirror/control-mode-ownership.ts";
 import {
@@ -39,26 +40,58 @@ function send(workspaceName = "alpha") {
   };
 }
 
+function resultFor(operationId: string, intent: SessionRuntimeSemanticIntent) {
+  const base = {
+    operationId,
+    daemonInstanceId: GENERATION_A,
+    workspaceName: intent.workspaceName,
+    outcome: "applied" as const,
+  };
+  if (intent.verb === "workspace.pane.send") {
+    return {
+      ...base,
+      verb: intent.verb,
+      sourceSemanticPaneId: intent.sourceSemanticPaneId ?? null,
+      semanticPaneId: intent.semanticPaneId,
+      origin: intent.origin,
+      characterCount: 5,
+      byteCount: 5,
+      submitted: intent.submit,
+    };
+  }
+  if (intent.verb === "workspace.pane.resize") {
+    return {
+      ...base,
+      verb: intent.verb,
+      semanticPaneId: intent.semanticPaneId,
+      axis: intent.axis,
+      cells: intent.cells,
+    };
+  }
+  throw new Error(`unhandled test intent ${intent.verb}`);
+}
+
 function controllerRig(generation = GENERATION_A) {
   const base = rig(generation);
   const executed: string[] = [];
   const tokens = [TOKEN_A, TOKEN_B, TOKEN_C];
   let tokenIndex = 0;
+  let sequence = 0;
   const registry = new SessionRuntimeRegistry({
     generation,
     mirror: base.mirror,
     createControllerToken: () => tokens[tokenIndex++]!,
     semanticMutations: {
       resolveSession: (workspaceName) => `${workspaceName}-session`,
-      execute: async (_operationId, intent) => {
+      execute: (operationId, intent) => {
         executed.push(intent.verb);
+        return resultFor(operationId, intent);
       },
-      publishReceipt: () => {
-        throw new Error("receipt publication is not expected in controller authorization tests");
-      },
-    },
-    executeAuthorized: async (_operationId, intent) => {
-      executed.push(intent.verb);
+      publishReceipt: (receipt) => ({
+        type: "interaction.receipt",
+        sequence: (sequence += 1),
+        ...receipt,
+      }),
     },
   });
   return { registry, executed, sims: base.sims };
@@ -104,8 +137,9 @@ describe("SessionRuntimeRegistry", () => {
       mirror: base.mirror,
       semanticMutations: {
         resolveSession: () => "alpha-session",
-        execute: async (_operationId, intent) => {
+        execute: (operationId, intent) => {
           if (intent.verb === "workspace.pane.send") executed.push(intent);
+          return resultFor(operationId, intent);
         },
         publishReceipt: (receipt) => {
           receipts.push(receipt);
@@ -149,7 +183,10 @@ describe("SessionRuntimeRegistry", () => {
       createControllerToken: () => TOKEN_A,
       semanticMutations: {
         resolveSession: () => "alpha-session",
-        execute: async (operationId) => void executed.push(operationId),
+        execute: (operationId, intent) => {
+          executed.push(operationId);
+          return resultFor(operationId, intent);
+        },
         publishReceipt: (receipt) => {
           receipts.push(receipt);
           return { type: "interaction.receipt", sequence: (sequence += 1), ...receipt };
@@ -204,7 +241,10 @@ describe("SessionRuntimeRegistry", () => {
       mirror: base.mirror,
       semanticMutations: {
         resolveSession: () => "alpha-session",
-        execute: async (operationId) => void executed.push(operationId),
+        execute: (operationId, intent) => {
+          executed.push(operationId);
+          return resultFor(operationId, intent);
+        },
         publishReceipt: (receipt) => ({
           type: "interaction.receipt",
           sequence: (sequence += 1),
@@ -255,8 +295,9 @@ describe("SessionRuntimeRegistry", () => {
       createControllerToken: () => TOKEN_A,
       semanticMutations: {
         resolveSession: () => "alpha-session",
-        execute: async (_operationId, intent) => {
+        execute: (operationId, intent) => {
           if (intent.verb === "workspace.pane.send") executed.push(intent);
+          return resultFor(operationId, intent);
         },
         publishReceipt: (receipt) => {
           receipts.push(receipt);
@@ -289,6 +330,35 @@ describe("SessionRuntimeRegistry", () => {
     await registry.dispose();
   });
 
+  it("publishes authenticated GUI origin for a structural intent with no caller origin field", async () => {
+    const base = rig();
+    const receipts: Array<{ phase: string; origin: string; operationKind: string }> = [];
+    let sequence = 0;
+    const registry = new SessionRuntimeRegistry({
+      generation: GENERATION_A,
+      mirror: base.mirror,
+      createControllerToken: () => TOKEN_A,
+      semanticMutations: {
+        resolveSession: () => "alpha-session",
+        execute: (operationId, intent) => resultFor(operationId, intent),
+        publishReceipt: (receipt) => {
+          receipts.push(receipt);
+          return { type: "interaction.receipt", sequence: (sequence += 1), ...receipt };
+        },
+      },
+    });
+    const gui = registry.connect("alpha-session", "terminal-attachment", "client:gui");
+    const lease = gui.acquireController();
+    const handle = registry.createExecutionHandle(gui, lease, []);
+    await registry.submitAuthenticatedIntent(handle, OP_A, resize());
+    expect(receipts).toMatchObject([
+      { phase: "accepted", origin: "gui", operationKind: "workspace.pane.resize" },
+      { phase: "observed", origin: "gui", operationKind: "workspace.pane.resize" },
+    ]);
+    await gui.close();
+    await registry.dispose();
+  });
+
   it("strips naked source claims and rejects cross-client or stale source capabilities", async () => {
     const base = rig();
     const executed: Array<{ sourceSemanticPaneId?: string }> = [];
@@ -299,8 +369,9 @@ describe("SessionRuntimeRegistry", () => {
       createControllerToken: () => TOKEN_A,
       semanticMutations: {
         resolveSession: () => "alpha-session",
-        execute: async (_operationId, intent) => {
+        execute: (operationId, intent) => {
           if (intent.verb === "workspace.pane.send") executed.push(intent);
+          return resultFor(operationId, intent);
         },
         publishReceipt: (receipt) => ({
           type: "interaction.receipt",

--- a/packages/daemon/src/terminal/session-runtime/registry.ts
+++ b/packages/daemon/src/terminal/session-runtime/registry.ts
@@ -3,6 +3,7 @@ import {
   SessionRuntimeControllerLeaseSchemaZ,
   SessionRuntimeGenerationSchemaZ,
   SessionRuntimeSemanticIntentSchemaZ,
+  type AuthoredInteractionOrigin,
   type InteractionReceipt,
   type SessionRuntimeControllerLease,
   type SessionRuntimeControllerRole,
@@ -35,12 +36,6 @@ export interface SessionRuntimeRegistryOptions {
   readonly generation: string;
   readonly mirror?: MirrorServiceOptions;
   readonly semanticMutations?: SessionSemanticMutationExecutorOptions;
-  /** Executes controller-authorized verbs that do not yet need tmux observation. */
-  readonly executeAuthorized?: (
-    operationId: string,
-    intent: SessionRuntimeSemanticIntent,
-    authorizeBeforeEffect?: () => void,
-  ) => Promise<SessionRuntimeIntentResult>;
   /** Deterministic seam for lease tests. Production uses cryptographic UUIDs. */
   readonly createControllerToken?: () => string;
 }
@@ -50,6 +45,13 @@ export type {
   SessionRuntimeControllerRole,
   SessionRuntimeControllerSnapshot,
 } from "@tmux-ide/contracts";
+
+function authoredOriginForSurface(surface: string): AuthoredInteractionOrigin {
+  if (surface === "opentui") return "tui";
+  if (surface === "command-center") return "sdk";
+  if (surface === "cli") return "cli";
+  return "gui";
+}
 
 export type SessionRuntimeControllerLeaseErrorCode =
   | "controller-conflict"
@@ -126,13 +128,6 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
   readonly generation: SessionRuntimeGeneration;
   readonly #mirror: MirrorService;
   readonly #semanticMutations: SessionSemanticMutationExecutor | null;
-  readonly #executeAuthorized:
-    | ((
-        operationId: string,
-        intent: SessionRuntimeSemanticIntent,
-        authorizeBeforeEffect?: () => void,
-      ) => Promise<SessionRuntimeIntentResult>)
-    | null;
   readonly #resolveSession: ((workspaceName: string) => string | null) | null;
   readonly #createControllerToken: () => string;
   readonly #sessions = new Map<string, SessionRuntime>();
@@ -147,7 +142,6 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
     this.#semanticMutations = options.semanticMutations
       ? new SessionSemanticMutationExecutor(options.semanticMutations)
       : null;
-    this.#executeAuthorized = options.executeAuthorized ?? null;
     this.#resolveSession = options.semanticMutations?.resolveSession ?? null;
     this.#createControllerToken = options.createControllerToken ?? randomUUID;
     this.#stopExitObserver = this.#mirror.onSessionExit((session) => {
@@ -227,6 +221,7 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
       { ...intent, sourceSemanticPaneId: semanticPaneId },
       semanticPaneId,
       authorizeBeforeEffect,
+      "cli",
     );
   }
 
@@ -274,6 +269,7 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
       normalizedIntent,
       authenticatedSourceSemanticPaneId,
       () => this.#assertExecutionHandle(handle, state.sourceSemanticPaneId ?? undefined),
+      authoredOriginForSurface(state.consumer.surface),
     );
   }
 
@@ -316,6 +312,7 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
     rawIntent: SessionRuntimeSemanticIntent,
     authenticatedSourceSemanticPaneId: string | null = null,
     authorizeBeforeEffect?: () => void,
+    authenticatedOrigin?: AuthoredInteractionOrigin,
   ): Promise<SessionRuntimeIntentResult> {
     if (this.#disposed) return Promise.reject(new Error("SessionRuntimeRegistry is disposed"));
     runtime.assertController(lease);
@@ -337,12 +334,6 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
         intent = sourceLess;
       }
     }
-    if (intent.verb !== "workspace.pane.send" && intent.verb !== "workspace.pane.read") {
-      if (!this.#executeAuthorized) {
-        return Promise.reject(new Error("Authorized session mutations are unavailable"));
-      }
-      return this.#executeAuthorized(operationId, intent, authorizeBeforeEffect);
-    }
     if (!this.#semanticMutations) {
       return Promise.reject(new Error("Session semantic mutations are unavailable"));
     }
@@ -351,6 +342,7 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
       intent,
       authenticatedSourceSemanticPaneId,
       authorizeBeforeEffect,
+      authenticatedOrigin,
     );
   }
 
@@ -401,8 +393,8 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
       session,
       this.#mirror,
       this.#createControllerToken,
-      (owner, lease, operationId, intent): Promise<SessionRuntimeIntentResult> =>
-        this.#submitAuthorizedIntent(owner, lease, operationId, intent),
+      (owner, lease, operationId, intent, origin): Promise<SessionRuntimeIntentResult> =>
+        this.#submitAuthorizedIntent(owner, lease, operationId, intent, null, undefined, origin),
     );
     this.#sessions.set(session, runtime);
     return runtime;
@@ -419,6 +411,7 @@ class SessionRuntime {
     lease: SessionRuntimeControllerLease,
     operationId: string,
     intent: SessionRuntimeSemanticIntent,
+    origin: AuthoredInteractionOrigin,
   ) => Promise<SessionRuntimeIntentResult>;
   #retention: Awaited<ReturnType<MirrorService["retainSession"]>> | null = null;
   #startPromise: Promise<void> | null = null;
@@ -440,6 +433,7 @@ class SessionRuntime {
       lease: SessionRuntimeControllerLease,
       operationId: string,
       intent: SessionRuntimeSemanticIntent,
+      origin: AuthoredInteractionOrigin,
     ) => Promise<SessionRuntimeIntentResult>,
   ) {
     this.#mirror = mirror;
@@ -562,7 +556,15 @@ class SessionRuntime {
   ): Promise<SessionRuntimeIntentResult> {
     try {
       this.assertController(lease, callerClientId);
-      return this.#submitAuthorized(this, lease, operationId, intent);
+      const surface = this.#consumersByClientId.get(callerClientId)?.surface;
+      if (surface === undefined) throw new Error("Session runtime consumer disappeared");
+      return this.#submitAuthorized(
+        this,
+        lease,
+        operationId,
+        intent,
+        authoredOriginForSurface(surface),
+      );
     } catch (error) {
       return Promise.reject(error);
     }

--- a/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.test.ts
@@ -6,6 +6,7 @@ import {
   SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY,
   SessionSemanticMutationExecutor,
   type ExecutableSessionRuntimeIntent,
+  type SessionRuntimeIntentResult,
   type SessionRuntimeReceiptInput,
 } from "./semantic-mutation-executor.ts";
 
@@ -29,9 +30,73 @@ function send(workspaceName = "alpha", semanticPaneId = "pane.alpha") {
   } satisfies SessionRuntimeSemanticIntent;
 }
 
+function resultFor(
+  operationId: string,
+  intent: ExecutableSessionRuntimeIntent,
+): SessionRuntimeIntentResult {
+  if (intent.verb === "workspace.pane.read") return;
+  const base = {
+    operationId,
+    daemonInstanceId: OP_A,
+    workspaceName: intent.workspaceName,
+    outcome: "applied" as const,
+  };
+  switch (intent.verb) {
+    case "workspace.window.split":
+      return {
+        ...base,
+        verb: intent.verb,
+        direction: intent.direction,
+        semanticPaneId: "pane.created",
+        displayTitle: intent.displayTitle ?? "Terminal",
+      };
+    case "workspace.window.kill":
+      return { ...base, verb: intent.verb, remainingWindowCount: 1 };
+    case "workspace.pane.kill":
+      return { ...base, verb: intent.verb, windowClosed: false, remainingWindowCount: 1 };
+    case "workspace.session.kill":
+      return { ...base, verb: intent.verb };
+    case "workspace.rename":
+      return { ...base, verb: intent.verb, scope: intent.scope, name: intent.name };
+    case "workspace.pane.zoom.toggle":
+      return { ...base, verb: intent.verb, semanticPaneId: intent.semanticPaneId, zoomed: true };
+    case "workspace.pane.select":
+      return { ...base, verb: intent.verb, semanticPaneId: intent.semanticPaneId };
+    case "workspace.pane.send":
+      return {
+        ...base,
+        verb: intent.verb,
+        sourceSemanticPaneId: intent.sourceSemanticPaneId ?? null,
+        semanticPaneId: intent.semanticPaneId,
+        origin: intent.origin,
+        characterCount: 5,
+        byteCount: 5,
+        submitted: intent.submit,
+      };
+    case "workspace.pane.swap":
+      return {
+        ...base,
+        verb: intent.verb,
+        sourceSemanticPaneId: intent.sourceSemanticPaneId,
+        targetSemanticPaneId: intent.targetSemanticPaneId,
+      };
+    case "workspace.pane.resize":
+      return {
+        ...base,
+        verb: intent.verb,
+        semanticPaneId: intent.semanticPaneId,
+        axis: intent.axis,
+        cells: 72,
+      };
+  }
+}
+
 function rig(
   options: {
-    execute?: (operationId: string, intent: ExecutableSessionRuntimeIntent) => Promise<void>;
+    execute?: (
+      operationId: string,
+      intent: ExecutableSessionRuntimeIntent,
+    ) => SessionRuntimeIntentResult;
     timeout?: number;
   } = {},
 ) {
@@ -44,7 +109,7 @@ function rig(
   };
   const executor = new SessionSemanticMutationExecutor({
     resolveSession: (workspace) => (workspace === "beta" ? "session-beta" : "session-alpha"),
-    execute: options.execute ?? (async () => undefined),
+    execute: options.execute ?? resultFor,
     publishReceipt,
     observationTimeoutMs: options.timeout ?? 100,
     now: () => new Date("2026-08-11T10:00:00.000Z"),
@@ -53,11 +118,137 @@ function rig(
 }
 
 describe("SessionSemanticMutationExecutor", () => {
+  it("publishes result-derived accepted and observed receipts for all eleven intents", async () => {
+    const intents: SessionRuntimeSemanticIntent[] = [
+      {
+        verb: "workspace.window.split",
+        workspaceName: "alpha",
+        semanticPaneId: "pane.alpha",
+        direction: "right",
+      },
+      {
+        verb: "workspace.window.kill",
+        workspaceName: "alpha",
+        target: { by: "pane", semanticPaneId: "pane.alpha" },
+      },
+      { verb: "workspace.pane.kill", workspaceName: "alpha", semanticPaneId: "pane.alpha" },
+      { verb: "workspace.session.kill", workspaceName: "alpha" },
+      { verb: "workspace.rename", workspaceName: "alpha", scope: "session", name: "renamed" },
+      {
+        verb: "workspace.pane.zoom.toggle",
+        workspaceName: "alpha",
+        semanticPaneId: "pane.alpha",
+        desired: "toggle",
+      },
+      { verb: "workspace.pane.select", workspaceName: "alpha", semanticPaneId: "pane.alpha" },
+      send(),
+      {
+        verb: "workspace.pane.swap",
+        workspaceName: "alpha",
+        sourceSemanticPaneId: "pane.alpha",
+        targetSemanticPaneId: "pane.beta",
+      },
+      {
+        verb: "workspace.pane.resize",
+        workspaceName: "alpha",
+        semanticPaneId: "pane.alpha",
+        axis: "cols",
+        cells: 80,
+      },
+      {
+        verb: "workspace.pane.read",
+        workspaceName: "alpha",
+        semanticPaneId: "pane.alpha",
+        origin: "sdk",
+      },
+    ];
+    let executor!: SessionSemanticMutationExecutor;
+    const built = rig({
+      execute: (id, intent) => {
+        if (intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read") {
+          queueMicrotask(() =>
+            executor.observe({
+              operationId: id,
+              workspaceName: intent.workspaceName,
+              semanticPaneId: intent.semanticPaneId,
+              operationKind: intent.verb,
+            }),
+          );
+        }
+        return resultFor(id, intent);
+      },
+    });
+    executor = built.executor;
+
+    for (const [index, intent] of intents.entries()) {
+      await executor.submit(operationId(index + 100), intent);
+    }
+
+    expect(built.receipts).toHaveLength(intents.length * 2);
+    for (const [index, intent] of intents.entries()) {
+      const [accepted, observed] = built.receipts.slice(index * 2, index * 2 + 2);
+      expect(accepted).toMatchObject({
+        operationKind: intent.verb,
+        phase: "accepted",
+        proof: null,
+      });
+      expect(observed).toMatchObject({ operationKind: intent.verb, phase: "observed" });
+      expect(observed!.proof).toMatchObject({ operationKind: intent.verb });
+      expect(observed!.target.kind).toMatch(/^(session|window|pane)$/u);
+    }
+    expect(
+      built.receipts.find(
+        (receipt) =>
+          receipt.operationKind === "workspace.pane.resize" && receipt.phase === "observed",
+      )?.proof,
+    ).toMatchObject({ cells: 72 });
+    await executor.dispose();
+  });
+
+  it("revalidates a queued structural mutation before the sole synchronous effect lane", async () => {
+    const started: string[] = [];
+    const { executor, receipts } = rig({
+      execute: (id, intent) => {
+        started.push(id);
+        return resultFor(id, intent);
+      },
+    });
+    let authorized = true;
+    const first = executor.submit(OP_A, send());
+    const resizeIntent = {
+      verb: "workspace.pane.resize",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      axis: "cols",
+      cells: 80,
+    } as const;
+    const queued = executor.submit(OP_B, resizeIntent, null, () => {
+      if (!authorized) throw new Error("controller became stale");
+    });
+    await vi.waitFor(() => expect(started).toEqual([OP_A]));
+    authorized = false;
+    executor.observe({
+      operationId: OP_A,
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      operationKind: "workspace.pane.send",
+    });
+    await first;
+    await expect(queued).rejects.toMatchObject({ outcome: "rejected" });
+    expect(started).toEqual([OP_A]);
+    expect(receipts.at(-1)).toMatchObject({
+      operationKind: "workspace.pane.resize",
+      phase: "rejected",
+    });
+    await executor.dispose();
+  });
+
   it("revalidates queued authority immediately before effect and rejects stale work", async () => {
     const started: string[] = [];
     const { executor, receipts } = rig({
-      execute: async (operationId) => {
+      execute: (operationId, intent) => {
         started.push(operationId);
+        return resultFor(operationId, intent);
       },
     });
     let authorized = true;
@@ -91,7 +282,12 @@ describe("SessionSemanticMutationExecutor", () => {
       throw new Error("must not replace original submission guard");
     });
     const started: string[] = [];
-    const { executor } = rig({ execute: async (operationId) => void started.push(operationId) });
+    const { executor } = rig({
+      execute: (operationId, intent) => {
+        started.push(operationId);
+        return resultFor(operationId, intent);
+      },
+    });
     const first = executor.submit(OP_A, send(), "pane.source", firstGuard);
     const replay = executor.submit(OP_A, send(), "pane.source", replayGuard);
     expect(replay).toBe(first);
@@ -111,8 +307,9 @@ describe("SessionSemanticMutationExecutor", () => {
   it("keeps one strict FIFO through tmux observation for each session", async () => {
     const started: string[] = [];
     const { executor, receipts } = rig({
-      execute: async (operationId) => {
+      execute: (operationId, intent) => {
         started.push(operationId);
+        return resultFor(operationId, intent);
       },
     });
     const first = executor.submit(OP_A, send());
@@ -144,11 +341,93 @@ describe("SessionSemanticMutationExecutor", () => {
     await executor.dispose();
   });
 
+  it("keeps send, structural mutation, read, and split in one mixed FIFO", async () => {
+    const started: string[] = [];
+    const { executor } = rig({
+      execute: (id, intent) => {
+        started.push(intent.verb);
+        return resultFor(id, intent);
+      },
+    });
+    const sent = executor.submit(operationId(20), send());
+    const resized = executor.submit(operationId(21), {
+      verb: "workspace.pane.resize",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      axis: "cols",
+      cells: 80,
+    });
+    const read = executor.submit(operationId(22), {
+      verb: "workspace.pane.read",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      origin: "sdk",
+    });
+    const split = executor.submit(operationId(23), {
+      verb: "workspace.window.split",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      direction: "down",
+    });
+    await vi.waitFor(() => expect(started).toEqual(["workspace.pane.send"]));
+    executor.observe({
+      operationId: operationId(20),
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      operationKind: "workspace.pane.send",
+    });
+    await sent;
+    await resized;
+    await vi.waitFor(() =>
+      expect(started).toEqual([
+        "workspace.pane.send",
+        "workspace.pane.resize",
+        "workspace.pane.read",
+      ]),
+    );
+    executor.observe({
+      operationId: operationId(22),
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      operationKind: "workspace.pane.read",
+    });
+    await Promise.all([read, split]);
+    expect(started).toEqual([
+      "workspace.pane.send",
+      "workspace.pane.resize",
+      "workspace.pane.read",
+      "workspace.window.split",
+    ]);
+    await executor.dispose();
+  });
+
+  it("replays a settled structural result from the sole ledger without another effect", async () => {
+    const execute = vi.fn((id: string, intent: ExecutableSessionRuntimeIntent) =>
+      resultFor(id, intent),
+    );
+    const { executor, receipts } = rig({ execute });
+    const intent = {
+      verb: "workspace.pane.resize",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      axis: "cols",
+      cells: 80,
+    } as const;
+    const first = await executor.submit(OP_A, intent);
+    const retry = await executor.submit(OP_A, intent);
+    expect(execute).toHaveBeenCalledOnce();
+    expect(first).toMatchObject({ outcome: "applied", cells: 72 });
+    expect(retry).toMatchObject({ outcome: "replayed", cells: 72 });
+    expect(receipts.map(({ phase }) => phase)).toEqual(["accepted", "observed"]);
+    await executor.dispose();
+  });
+
   it("allows different tmux sessions to progress independently", async () => {
     const started: string[] = [];
     const { executor } = rig({
-      execute: async (operationId) => {
+      execute: (operationId, intent) => {
         started.push(operationId);
+        return resultFor(operationId, intent);
       },
     });
     const alpha = executor.submit(OP_A, send("alpha", "pane.alpha"));
@@ -178,6 +457,117 @@ describe("SessionSemanticMutationExecutor", () => {
     await executor.dispose();
   });
 
+  it("keeps a saturated alpha ledger from rejecting a healthy beta mutation", async () => {
+    const execute = vi.fn((id: string, intent: ExecutableSessionRuntimeIntent) =>
+      resultFor(id, intent),
+    );
+    const { executor } = rig({ execute });
+    const alphaPending = Array.from(
+      { length: SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY },
+      (_, index) => executor.submit(operationId(index + 1), send("alpha", "pane.alpha")),
+    );
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+    await expect(
+      executor.submit(operationId(10_000), send("alpha", "pane.alpha")),
+    ).rejects.toMatchObject({ outcome: "rejected" });
+    await expect(
+      executor.submit(operationId(10_001), {
+        verb: "workspace.pane.resize",
+        workspaceName: "beta",
+        semanticPaneId: "pane.beta",
+        axis: "cols",
+        cells: 80,
+      }),
+    ).resolves.toMatchObject({ workspaceName: "beta", outcome: "applied" });
+    expect(execute).toHaveBeenCalledTimes(2);
+    const outcomes = Promise.allSettled(alphaPending);
+    await executor.dispose();
+    expect((await outcomes).every(({ status }) => status === "rejected")).toBe(true);
+  });
+
+  it("scopes the same operation id and pending observation independently per session", async () => {
+    const started: string[] = [];
+    const { executor } = rig({
+      execute: (id, intent) => {
+        started.push(intent.workspaceName);
+        return resultFor(id, intent);
+      },
+    });
+    const alpha = executor.submit(OP_A, send("alpha", "pane.alpha"));
+    const beta = executor.submit(OP_A, send("beta", "pane.beta"));
+    await vi.waitFor(() => expect(new Set(started)).toEqual(new Set(["alpha", "beta"])));
+    executor.observe({
+      operationId: OP_A,
+      workspaceName: "beta",
+      semanticPaneId: "pane.beta",
+      operationKind: "workspace.pane.send",
+    });
+    await beta;
+    let alphaSettled = false;
+    void alpha.finally(() => {
+      alphaSettled = true;
+    });
+    await Promise.resolve();
+    expect(alphaSettled).toBe(false);
+    executor.observe({
+      operationId: OP_A,
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      operationKind: "workspace.pane.send",
+    });
+    await alpha;
+    await executor.dispose();
+  });
+
+  it("keeps authorization synchronously adjacent to the lower tmux effect", async () => {
+    const order: string[] = [];
+    const { executor } = rig({
+      execute: (id, intent) => {
+        order.push("effect");
+        return resultFor(id, intent);
+      },
+    });
+    const completed = executor.submit(
+      OP_A,
+      {
+        verb: "workspace.pane.resize",
+        workspaceName: "alpha",
+        semanticPaneId: "pane.alpha",
+        axis: "cols",
+        cells: 80,
+      },
+      null,
+      () => {
+        order.push("authorize");
+        queueMicrotask(() => order.push("microtask"));
+      },
+    );
+    await completed;
+    expect(order.slice(0, 2)).toEqual(["authorize", "effect"]);
+    expect(order).toEqual(["authorize", "effect", "microtask"]);
+    await executor.dispose();
+  });
+
+  it("includes trusted out-of-band origin in the replay fingerprint", async () => {
+    const execute = vi.fn((id: string, intent: ExecutableSessionRuntimeIntent) =>
+      resultFor(id, intent),
+    );
+    const { executor } = rig({ execute });
+    const intent = {
+      verb: "workspace.pane.resize",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      axis: "cols",
+      cells: 80,
+    } as const;
+    await executor.submit(OP_A, intent, null, undefined, "gui");
+    await expect(executor.submit(OP_A, intent, null, undefined, "tui")).rejects.toMatchObject({
+      outcome: "rejected",
+    });
+    expect(execute).toHaveBeenCalledOnce();
+    await executor.dispose();
+  });
+
   it("does not await slow or disconnected receipt consumers", async () => {
     const { executor } = rig();
     const never = new Promise<void>(() => undefined);
@@ -201,7 +591,9 @@ describe("SessionSemanticMutationExecutor", () => {
   });
 
   it("reuses one receipt lifecycle and dispatch for a same-fingerprint retry", async () => {
-    const execute = vi.fn(async () => undefined);
+    const execute = vi.fn((operationId: string, intent: ExecutableSessionRuntimeIntent) =>
+      resultFor(operationId, intent),
+    );
     const { executor, receipts } = rig({ execute });
     const first = executor.submit(OP_A, send());
     const retry = executor.submit(OP_A, send());
@@ -219,22 +611,16 @@ describe("SessionSemanticMutationExecutor", () => {
     await executor.dispose();
   });
 
-  it("rejects conflicting operation ids and unsupported verbs at the request boundary", async () => {
-    const execute = vi.fn(async () => undefined);
+  it("rejects conflicting operation ids without replacing the active execution", async () => {
+    const execute = vi.fn((operationId: string, intent: ExecutableSessionRuntimeIntent) =>
+      resultFor(operationId, intent),
+    );
     const { executor, receipts } = rig({ execute });
     const first = executor.submit(OP_A, send());
     await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
 
     await expect(
       executor.submit(OP_A, { ...send(), semanticPaneId: "pane.other" }),
-    ).rejects.toMatchObject({ outcome: "rejected" });
-    await expect(
-      executor.submit(OP_B, {
-        verb: "workspace.window.split",
-        workspaceName: "alpha",
-        semanticPaneId: "pane.alpha",
-        direction: "right",
-      }),
     ).rejects.toMatchObject({ outcome: "rejected" });
     expect(execute).toHaveBeenCalledTimes(1);
     expect(receipts.map((receipt) => receipt.phase)).toEqual(["accepted"]);
@@ -252,7 +638,7 @@ describe("SessionSemanticMutationExecutor", () => {
 
   it("accepts operation 257 by retiring the oldest settled replay record", async () => {
     let executor!: SessionSemanticMutationExecutor;
-    const execute = vi.fn(async (id: string, intent: ExecutableSessionRuntimeIntent) => {
+    const execute = vi.fn((id: string, intent: ExecutableSessionRuntimeIntent) => {
       queueMicrotask(() => {
         executor.observe({
           operationId: id,
@@ -261,6 +647,7 @@ describe("SessionSemanticMutationExecutor", () => {
           operationKind: intent.verb,
         });
       });
+      return resultFor(id, intent);
     });
     const built = rig({ execute });
     executor = built.executor;
@@ -275,7 +662,9 @@ describe("SessionSemanticMutationExecutor", () => {
   });
 
   it("never evicts pending records and backpressures only when every slot is active", async () => {
-    const execute = vi.fn(async () => undefined);
+    const execute = vi.fn((operationId: string, intent: ExecutableSessionRuntimeIntent) =>
+      resultFor(operationId, intent),
+    );
     const { executor, receipts } = rig({ execute });
     const pending = Array.from({ length: SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY }, (_, index) =>
       executor.submit(operationId(index + 1), send()),
@@ -294,7 +683,11 @@ describe("SessionSemanticMutationExecutor", () => {
   });
 
   it("publishes rejected when authority refuses and timed-out without tmux truth", async () => {
-    const rejected = rig({ execute: async () => Promise.reject(new Error("no pane")) });
+    const rejected = rig({
+      execute: () => {
+        throw new Error("no pane");
+      },
+    });
     await expect(rejected.executor.submit(OP_A, send())).rejects.toMatchObject({
       outcome: "rejected",
     });
@@ -309,11 +702,68 @@ describe("SessionSemanticMutationExecutor", () => {
     await timedOut.executor.dispose();
   });
 
+  it("rejects a structural success that cannot produce verb-matched proof", async () => {
+    const broken = rig({ execute: () => undefined });
+    await expect(
+      broken.executor.submit(OP_A, {
+        verb: "workspace.pane.resize",
+        workspaceName: "alpha",
+        semanticPaneId: "pane.alpha",
+        axis: "cols",
+        cells: 80,
+      }),
+    ).rejects.toMatchObject({ outcome: "rejected" });
+    expect(broken.receipts.map(({ phase }) => phase)).toEqual(["accepted", "rejected"]);
+    await broken.executor.dispose();
+  });
+
+  it("rejects a structural authority refusal without entering the observation timeout lane", async () => {
+    const refused = rig({
+      execute: () => {
+        throw new Error("resize refused");
+      },
+      timeout: 1,
+    });
+    await expect(
+      refused.executor.submit(OP_A, {
+        verb: "workspace.pane.resize",
+        workspaceName: "alpha",
+        semanticPaneId: "pane.alpha",
+        axis: "cols",
+        cells: 80,
+      }),
+    ).rejects.toMatchObject({ outcome: "rejected" });
+    expect(refused.receipts.map(({ phase }) => phase)).toEqual(["accepted", "rejected"]);
+    await refused.executor.dispose();
+  });
+
+  it("replays one remembered structural refusal without another effect or lifecycle", async () => {
+    const failure = new Error("resize refused");
+    const execute = vi.fn(() => {
+      throw failure;
+    });
+    const { executor, receipts } = rig({ execute });
+    const intent = {
+      verb: "workspace.pane.resize",
+      workspaceName: "alpha",
+      semanticPaneId: "pane.alpha",
+      axis: "cols",
+      cells: 80,
+    } as const;
+    const first = await executor.submit(OP_A, intent).catch((error: unknown) => error);
+    const retry = await executor.submit(OP_A, intent).catch((error: unknown) => error);
+    expect(retry).toBe(first);
+    expect(execute).toHaveBeenCalledOnce();
+    expect(receipts.map(({ phase }) => phase)).toEqual(["accepted", "rejected"]);
+    await executor.dispose();
+  });
+
   it("settles in-flight and queued work deterministically on shutdown", async () => {
     const started: string[] = [];
     const { executor, receipts } = rig({
-      execute: async (operationId) => {
+      execute: (operationId, intent) => {
         started.push(operationId);
+        return resultFor(operationId, intent);
       },
     });
     const first = executor.submit(OP_A, send());

--- a/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.ts
+++ b/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.ts
@@ -1,17 +1,20 @@
 import {
   InteractionReceiptSchemaZ,
   SessionRuntimeSemanticIntentSchemaZ,
+  type AuthoredInteractionOrigin,
   type InteractionReceipt,
   type SessionRuntimeSemanticIntent,
   type WorkspaceMultiplexerMutationResult,
 } from "@tmux-ide/contracts";
 import { z } from "zod";
+import {
+  sessionRuntimeInteractionFacts,
+  sessionRuntimeIntentNeedsTmuxObservation,
+  sessionRuntimeObservedProof,
+} from "./interaction-receipt-facts.ts";
 
 export type SessionRuntimeIntentResult = WorkspaceMultiplexerMutationResult | void;
-export type ExecutableSessionRuntimeIntent = Extract<
-  SessionRuntimeSemanticIntent,
-  { verb: "workspace.pane.send" | "workspace.pane.read" }
->;
+export type ExecutableSessionRuntimeIntent = SessionRuntimeSemanticIntent;
 
 export interface SessionRuntimeTmuxObservation {
   readonly operationId: string;
@@ -27,7 +30,7 @@ export interface SessionSemanticMutationExecutorOptions {
   readonly execute: (
     operationId: string,
     intent: ExecutableSessionRuntimeIntent,
-  ) => Promise<SessionRuntimeIntentResult>;
+  ) => SessionRuntimeIntentResult;
   /** Publishes through the daemon's existing replayable interaction journal. */
   readonly publishReceipt: (receipt: SessionRuntimeReceiptInput) => InteractionReceipt;
   readonly observationTimeoutMs?: number;
@@ -61,11 +64,11 @@ interface OperationRecord {
 export const SESSION_RUNTIME_OBSERVATION_TIMEOUT_MS = 10_000;
 /** Bounded replay/conflict horizon; active work is never evicted. */
 export const SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY = 256;
+const MISSING_SESSION_LEDGER = Symbol("missing-session-ledger");
+type SessionLedgerKey = string | typeof MISSING_SESSION_LEDGER;
 
-function isExecutableIntent(
-  intent: SessionRuntimeSemanticIntent,
-): intent is ExecutableSessionRuntimeIntent {
-  return intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read";
+function replayedResult(result: SessionRuntimeIntentResult): SessionRuntimeIntentResult {
+  return result === undefined ? undefined : { ...result, outcome: "replayed" };
 }
 
 /**
@@ -79,8 +82,8 @@ function isExecutableIntent(
 export class SessionSemanticMutationExecutor {
   readonly #options: SessionSemanticMutationExecutorOptions;
   readonly #tails = new Map<string, Promise<void>>();
-  readonly #pending = new Map<string, PendingObservation>();
-  readonly #operations = new Map<string, OperationRecord>();
+  readonly #pending = new Map<string, Map<string, PendingObservation>>();
+  readonly #operations = new Map<SessionLedgerKey, Map<string, OperationRecord>>();
   readonly #listeners = new Set<(receipt: InteractionReceipt) => void>();
   #disposed = false;
 
@@ -93,6 +96,7 @@ export class SessionSemanticMutationExecutor {
     rawIntent: SessionRuntimeSemanticIntent,
     authenticatedSourceSemanticPaneId: string | null = null,
     authorizeBeforeEffect?: () => void,
+    authenticatedOrigin?: AuthoredInteractionOrigin,
   ): Promise<SessionRuntimeIntentResult> {
     if (this.#disposed) {
       return Promise.reject(
@@ -101,8 +105,13 @@ export class SessionSemanticMutationExecutor {
     }
     const operationId = z.uuid().parse(rawOperationId);
     const intent = SessionRuntimeSemanticIntentSchemaZ.parse(rawIntent);
-    const fingerprint = JSON.stringify([intent, authenticatedSourceSemanticPaneId]);
-    const existing = this.#operations.get(operationId);
+    const session = this.#options.resolveSession(intent.workspaceName);
+    // All unresolved workspace names share one bounded refusal bucket. Never
+    // retain an attacker-controlled workspace-name alias as a ledger key.
+    const ledger = this.#ledger(session ?? MISSING_SESSION_LEDGER);
+    const origin = authenticatedOrigin ?? ("origin" in intent ? intent.origin : "sdk");
+    const fingerprint = JSON.stringify([intent, authenticatedSourceSemanticPaneId, origin]);
+    const existing = ledger.get(operationId);
     if (existing) {
       if (existing.fingerprint !== fingerprint) {
         return Promise.reject(
@@ -112,17 +121,11 @@ export class SessionSemanticMutationExecutor {
           ),
         );
       }
-      return existing.promise;
+      return existing.status === "active"
+        ? existing.promise
+        : existing.promise.then(replayedResult);
     }
-    if (!isExecutableIntent(intent)) {
-      return Promise.reject(
-        new SessionRuntimeIntentError(
-          "rejected",
-          `Semantic verb ${intent.verb} is not routed through the session executor yet`,
-        ),
-      );
-    }
-    if (!this.#makeOperationRoom()) {
+    if (!this.#makeOperationRoom(ledger)) {
       return Promise.reject(
         new SessionRuntimeIntentError(
           "rejected",
@@ -130,33 +133,45 @@ export class SessionSemanticMutationExecutor {
         ),
       );
     }
-
-    const session = this.#options.resolveSession(intent.workspaceName);
-    this.#publish(operationId, intent, "accepted");
+    this.#publish(operationId, intent, "accepted", null, undefined, origin);
     if (session === null) {
       const error = new SessionRuntimeIntentError(
         "rejected",
         `Workspace ${intent.workspaceName} has no live tmux session`,
       );
-      this.#publish(operationId, intent, "rejected");
+      this.#publish(operationId, intent, "rejected", null, undefined, origin);
       const rejected = Promise.reject<SessionRuntimeIntentResult>(error);
-      this.#remember(operationId, fingerprint, rejected);
+      this.#remember(ledger, operationId, fingerprint, rejected);
       return rejected;
     }
 
     const previous = this.#tails.get(session) ?? Promise.resolve();
     const result = previous.then(
       () =>
-        this.#run(operationId, intent, authenticatedSourceSemanticPaneId, authorizeBeforeEffect),
+        this.#run(
+          session,
+          operationId,
+          intent,
+          authenticatedSourceSemanticPaneId,
+          authorizeBeforeEffect,
+          origin,
+        ),
       () =>
-        this.#run(operationId, intent, authenticatedSourceSemanticPaneId, authorizeBeforeEffect),
+        this.#run(
+          session,
+          operationId,
+          intent,
+          authenticatedSourceSemanticPaneId,
+          authorizeBeforeEffect,
+          origin,
+        ),
     );
     const tail = result.then(
       () => undefined,
       () => undefined,
     );
     this.#tails.set(session, tail);
-    this.#remember(operationId, fingerprint, result);
+    this.#remember(ledger, operationId, fingerprint, result);
     void tail.finally(() => {
       if (this.#tails.get(session) === tail) this.#tails.delete(session);
     });
@@ -164,7 +179,9 @@ export class SessionSemanticMutationExecutor {
   }
 
   observe(observation: SessionRuntimeTmuxObservation): boolean {
-    const pending = this.#pending.get(observation.operationId);
+    const session = this.#options.resolveSession(observation.workspaceName);
+    if (session === null) return false;
+    const pending = this.#pending.get(session)?.get(observation.operationId);
     if (!pending) return false;
     const expected = pending.expected;
     if (
@@ -190,7 +207,9 @@ export class SessionSemanticMutationExecutor {
       "rejected",
       "Session semantic mutation executor shut down",
     );
-    for (const pending of this.#pending.values()) pending.reject(error);
+    for (const sessionPending of this.#pending.values()) {
+      for (const pending of sessionPending.values()) pending.reject(error);
+    }
     await Promise.allSettled(this.#tails.values());
     this.#pending.clear();
     this.#tails.clear();
@@ -198,13 +217,22 @@ export class SessionSemanticMutationExecutor {
     this.#operations.clear();
   }
 
+  #ledger(key: SessionLedgerKey): Map<string, OperationRecord> {
+    const existing = this.#operations.get(key);
+    if (existing) return existing;
+    const ledger = new Map<string, OperationRecord>();
+    this.#operations.set(key, ledger);
+    return ledger;
+  }
+
   #remember(
+    ledger: Map<string, OperationRecord>,
     operationId: string,
     fingerprint: string,
     promise: Promise<SessionRuntimeIntentResult>,
   ) {
     const record: OperationRecord = { fingerprint, promise, status: "active" };
-    this.#operations.set(operationId, record);
+    ledger.set(operationId, record);
     void promise.then(
       () => {
         record.status = "settled";
@@ -221,100 +249,142 @@ export class SessionSemanticMutationExecutor {
    * pending work is never evicted or duplicated. This matches the daemon's
    * bounded replay journal rather than imposing a lifetime mutation ceiling.
    */
-  #makeOperationRoom(): boolean {
-    if (this.#operations.size < SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY) return true;
-    for (const [operationId, record] of this.#operations) {
+  #makeOperationRoom(ledger: Map<string, OperationRecord>): boolean {
+    if (ledger.size < SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY) return true;
+    for (const [operationId, record] of ledger) {
       if (record.status !== "settled") continue;
-      this.#operations.delete(operationId);
+      ledger.delete(operationId);
       return true;
     }
     return false;
   }
 
   async #run(
+    session: string,
     operationId: string,
     intent: ExecutableSessionRuntimeIntent,
     authenticatedSourceSemanticPaneId: string | null,
     authorizeBeforeEffect?: () => void,
+    origin: AuthoredInteractionOrigin = "sdk",
   ): Promise<SessionRuntimeIntentResult> {
     if (this.#disposed) {
       const error = new SessionRuntimeIntentError(
         "rejected",
         "Session semantic mutation executor shut down before execution",
       );
-      this.#publish(operationId, intent, "rejected");
+      this.#publish(operationId, intent, "rejected", null, undefined, origin);
       throw error;
     }
 
-    let settleObservation!: () => void;
-    let rejectObservation!: (error: Error) => void;
-    const observed = new Promise<void>((resolve, reject) => {
-      settleObservation = resolve;
-      rejectObservation = reject;
-    });
-    this.#pending.set(operationId, {
-      expected: {
-        operationId,
-        workspaceName: intent.workspaceName,
-        semanticPaneId: intent.semanticPaneId,
-        operationKind: intent.verb,
-      },
-      resolve: settleObservation,
-      reject: rejectObservation,
-    });
+    const needsTmuxObservation = sessionRuntimeIntentNeedsTmuxObservation(intent);
+    let observed: Promise<void> | null = null;
+    if (needsTmuxObservation) {
+      let settleObservation!: () => void;
+      let rejectObservation!: (error: Error) => void;
+      observed = new Promise<void>((resolve, reject) => {
+        settleObservation = resolve;
+        rejectObservation = reject;
+      });
+      let sessionPending = this.#pending.get(session);
+      if (!sessionPending) {
+        sessionPending = new Map();
+        this.#pending.set(session, sessionPending);
+      }
+      sessionPending.set(operationId, {
+        expected: {
+          operationId,
+          workspaceName: intent.workspaceName,
+          semanticPaneId: intent.semanticPaneId,
+          operationKind: intent.verb,
+        },
+        resolve: settleObservation,
+        reject: rejectObservation,
+      });
+    }
 
     let result: SessionRuntimeIntentResult;
     try {
       // Admission can wait behind prior work. Revalidate the opaque principal
       // at the last synchronous boundary before tmux receives any effect.
       authorizeBeforeEffect?.();
-      result = await this.#options.execute(operationId, intent);
+      result = this.#options.execute(operationId, intent);
     } catch (cause) {
-      this.#pending.delete(operationId);
+      if (needsTmuxObservation) this.#deletePending(session, operationId);
       const error = new SessionRuntimeIntentError(
         "rejected",
         "tmux rejected the semantic interaction",
         { cause },
       );
-      this.#publish(operationId, intent, "rejected");
+      this.#publish(operationId, intent, "rejected", null, undefined, origin);
       throw error;
     }
 
-    const timeoutMs = this.#options.observationTimeoutMs ?? SESSION_RUNTIME_OBSERVATION_TIMEOUT_MS;
-    let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
-      await Promise.race([
-        observed,
-        new Promise<never>((_, reject) => {
-          timeout = setTimeout(
-            () =>
-              reject(
-                new SessionRuntimeIntentError(
-                  "timed-out",
-                  "tmux did not expose the interaction through its observation hook in time",
-                ),
-              ),
-            timeoutMs,
-          );
-          timeout.unref?.();
-        }),
-      ]);
+      // A successful command is not completion proof. Validate the bounded,
+      // verb-matched result before waiting for a hook or publishing observed.
+      sessionRuntimeObservedProof(intent, result);
     } catch (cause) {
-      const error =
-        cause instanceof SessionRuntimeIntentError
-          ? cause
-          : new SessionRuntimeIntentError("rejected", "Interaction observation was cancelled", {
-              cause,
-            });
-      this.#publish(operationId, intent, error.outcome);
+      if (needsTmuxObservation) this.#deletePending(session, operationId);
+      const error = new SessionRuntimeIntentError(
+        "rejected",
+        "tmux returned invalid semantic mutation proof",
+        { cause },
+      );
+      this.#publish(operationId, intent, "rejected", null, undefined, origin);
       throw error;
-    } finally {
-      if (timeout) clearTimeout(timeout);
-      this.#pending.delete(operationId);
     }
 
-    this.#publish(operationId, intent, "observed", authenticatedSourceSemanticPaneId);
+    if (needsTmuxObservation) {
+      const timeoutMs =
+        this.#options.observationTimeoutMs ?? SESSION_RUNTIME_OBSERVATION_TIMEOUT_MS;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          observed!,
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(
+              () =>
+                reject(
+                  new SessionRuntimeIntentError(
+                    "timed-out",
+                    "tmux did not expose the interaction through its observation hook in time",
+                  ),
+                ),
+              timeoutMs,
+            );
+            timeout.unref?.();
+          }),
+        ]);
+      } catch (cause) {
+        const error =
+          cause instanceof SessionRuntimeIntentError
+            ? cause
+            : new SessionRuntimeIntentError("rejected", "Interaction observation was cancelled", {
+                cause,
+              });
+        this.#publish(operationId, intent, error.outcome, null, undefined, origin);
+        throw error;
+      } finally {
+        if (timeout) clearTimeout(timeout);
+        this.#deletePending(session, operationId);
+      }
+    }
+
+    this.#publish(
+      operationId,
+      intent,
+      "observed",
+      authenticatedSourceSemanticPaneId,
+      result,
+      origin,
+    );
     return result;
+  }
+
+  #deletePending(session: string, operationId: string): void {
+    const pending = this.#pending.get(session);
+    pending?.delete(operationId);
+    if (pending?.size === 0) this.#pending.delete(session);
   }
 
   #publish(
@@ -322,30 +392,22 @@ export class SessionSemanticMutationExecutor {
     intent: ExecutableSessionRuntimeIntent,
     phase: "accepted" | "observed" | "rejected" | "timed-out",
     authenticatedSourceSemanticPaneId: string | null = null,
+    result?: SessionRuntimeIntentResult,
+    authenticatedOrigin?: AuthoredInteractionOrigin,
   ): void {
-    const summary =
-      intent.verb === "workspace.pane.read"
-        ? ({ operationKind: intent.verb, observedOnly: true } as const)
-        : {
-            operationKind: intent.verb,
-            characterCount: Array.from(intent.text).length,
-            byteCount: Buffer.byteLength(intent.text, "utf8"),
-            submitted: intent.submit,
-          };
+    const facts = sessionRuntimeInteractionFacts(intent);
+    const origin = authenticatedOrigin ?? ("origin" in intent ? intent.origin : "sdk");
     const receipt = InteractionReceiptSchemaZ.parse(
       this.#options.publishReceipt({
         operationId,
-        origin: intent.origin,
+        origin,
         workspaceName: intent.workspaceName,
         sourceSemanticPaneId: phase === "observed" ? authenticatedSourceSemanticPaneId : null,
-        target: { kind: "pane", semanticPaneId: intent.semanticPaneId },
+        target: facts.target,
         operationKind: intent.verb,
         phase,
-        summary,
-        proof:
-          phase === "observed"
-            ? { operationKind: intent.verb, observed: true, semanticPaneId: intent.semanticPaneId }
-            : null,
+        summary: facts.summary,
+        proof: phase === "observed" ? sessionRuntimeObservedProof(intent, result) : null,
         at: (this.#options.now ?? (() => new Date()))().toISOString(),
         resourceRevision: null,
       }),

--- a/packages/daemon/src/terminal/session-runtime/transport-binding.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/transport-binding.test.ts
@@ -26,6 +26,22 @@ function sendIntent() {
   };
 }
 
+function sendResult(operationId: string, intent: ReturnType<typeof sendIntent>) {
+  return {
+    operationId,
+    daemonInstanceId: GENERATION,
+    workspaceName: intent.workspaceName,
+    verb: intent.verb,
+    outcome: "applied" as const,
+    sourceSemanticPaneId: null,
+    semanticPaneId: intent.semanticPaneId,
+    origin: intent.origin,
+    characterCount: 9,
+    byteCount: 9,
+    submitted: intent.submit,
+  };
+}
+
 describe("SessionRuntimeTransportBinder", () => {
   it("never promotes a passive cross-transport pane into an authorship grant", async () => {
     const registry = new SessionRuntimeRegistry({
@@ -163,7 +179,11 @@ describe("SessionRuntimeTransportBinder", () => {
         .mockReturnValueOnce("cccccccc-cccc-4ccc-8ccc-cccccccccccc"),
       semanticMutations: {
         resolveSession: (workspaceName) => `${workspaceName}-session`,
-        execute: async (operationId) => void executed.push(operationId),
+        execute: (operationId, intent) => {
+          if (intent.verb !== "workspace.pane.send") throw new Error("unexpected intent");
+          executed.push(operationId);
+          return sendResult(operationId, intent);
+        },
         publishReceipt: (receipt) => ({ type: "interaction.receipt", sequence: 1, ...receipt }),
       },
     });
@@ -231,7 +251,11 @@ describe("SessionRuntimeTransportBinder", () => {
       createControllerToken: () => "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       semanticMutations: {
         resolveSession: (workspaceName) => `${workspaceName}-session`,
-        execute: async (operationId) => void executed.push(operationId),
+        execute: (operationId, intent) => {
+          if (intent.verb !== "workspace.pane.send") throw new Error("unexpected intent");
+          executed.push(operationId);
+          return sendResult(operationId, intent);
+        },
         publishReceipt: (receipt) => ({ type: "interaction.receipt", sequence: 1, ...receipt }),
       },
     });

--- a/scripts/pack-check-run.mjs
+++ b/scripts/pack-check-run.mjs
@@ -100,6 +100,8 @@ try {
     "terminal/input-authority",
     "SessionRuntimeClientCapability",
     "SessionRuntimeSourcePaneBinding",
+    "executeAuthorized",
+    "The daemon has reached its bounded multiplexer operation capacity.",
   ]) {
     if (installedBundle.includes(removed)) {
       throw new Error(`Installed CLI still contains removed authority architecture: ${removed}`);


### PR DESCRIPTION
## Summary
- route all 11 semantic tmux verbs through one per-session FIFO/idempotency executor
- remove the duplicate multiplexer authority queue, ledger, and authorization path
- publish result-proven receipts with trusted out-of-band GUI/TUI/CLI/SDK origin
- make authorization synchronously adjacent to the lower tmux effect
- isolate replay capacity and pending observations across sessions

## Validation
- independent reviewer: APPROVE
- 116 focused tests including live tmux
- full `pnpm check` passed
- daemon: 3,181 tests
- desktop renderer: 851 tests
- Electron: 334 tests
- OpenTUI renderer: 106 tests
- packed-install architecture smoke and desktop replay-repair smoke passed

Part of Sfora card #185 (m56.1e-b).
