### PR TITLE
Complete semantic mutation route cutover

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11918,17 +11918,6 @@ var init_process_tree = __esm({
   }
 });
 
-// packages/daemon/src/lib/tmux-interaction-options.ts
-var INTERNAL_SEND_OPERATION_OPTION, INTERNAL_READ_OPERATION_OPTION, INTERNAL_READ_OPERATION_MARKER;
-var init_tmux_interaction_options = __esm({
-  "packages/daemon/src/lib/tmux-interaction-options.ts"() {
-    "use strict";
-    INTERNAL_SEND_OPERATION_OPTION = "@tmux_ide_send_operation";
-    INTERNAL_READ_OPERATION_OPTION = "@tmux_ide_read_operation";
-    INTERNAL_READ_OPERATION_MARKER = "tmux-ide-internal-read-v1";
-  }
-});
-
 // packages/daemon/src/tui/detect/snapshot.ts
 function stripAnsi(input) {
   return input.replace(ANSI, "");
@@ -11943,31 +11932,11 @@ function parseSnapshot(raw, opts = {}) {
 function readPaneSnapshot(target, opts = {}) {
   const lines = opts.lines ?? DEFAULT_LINES;
   try {
-    const raw = runTmux(
-      [
-        "set-option",
-        "-p",
-        "-t",
-        target,
-        INTERNAL_READ_OPERATION_OPTION,
-        INTERNAL_READ_OPERATION_MARKER,
-        ";",
-        "capture-pane",
-        "-t",
-        target,
-        "-p",
-        "-J",
-        "-S",
-        `-${lines}`
-      ],
-      { encoding: "utf-8" }
-    );
+    const raw = runTmux(["capture-pane", "-t", target, "-p", "-J", "-S", `-${lines}`], {
+      encoding: "utf-8"
+    });
     return parseSnapshot(raw, { lines });
   } catch {
-    try {
-      runTmux(["set-option", "-pu", "-t", target, INTERNAL_READ_OPERATION_OPTION]);
-    } catch {
-    }
     return { bottomNonEmpty: [], text: "", raw: "" };
   }
 }
@@ -11976,7 +11945,6 @@ var init_snapshot = __esm({
   "packages/daemon/src/tui/detect/snapshot.ts"() {
     "use strict";
     init_src2();
-    init_tmux_interaction_options();
     ANSI = /[\u001b\u009b][[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g;
     DEFAULT_LINES = 20;
   }
@@ -26519,6 +26487,40 @@ var init_app_window_mutation2 = __esm({
   }
 });
 
+// packages/daemon/src/lib/tmux-interaction-options.ts
+import { randomUUID as randomUUID4 } from "node:crypto";
+function registerInternalReadOperation(runtimePaneId) {
+  const now = Date.now();
+  for (const [marker2, registration] of internalReads) {
+    if (registration.expiresAt <= now) internalReads.delete(marker2);
+  }
+  while (internalReads.size >= INTERNAL_READ_CAPACITY) {
+    internalReads.delete(internalReads.keys().next().value);
+  }
+  const marker = `${INTERNAL_READ_PREFIX}${randomUUID4()}`;
+  internalReads.set(marker, { paneId: runtimePaneId, expiresAt: now + INTERNAL_READ_TTL_MS });
+  return marker;
+}
+function consumeInternalReadOperation(marker, runtimePaneId, operationKind) {
+  if (marker === null || !marker.startsWith(INTERNAL_READ_PREFIX)) return false;
+  const registration = internalReads.get(marker);
+  if (!registration) return false;
+  internalReads.delete(marker);
+  return operationKind === "workspace.pane.read" && registration.paneId === runtimePaneId && registration.expiresAt > Date.now();
+}
+var INTERNAL_SEND_OPERATION_OPTION, INTERNAL_READ_OPERATION_OPTION, INTERNAL_READ_PREFIX, INTERNAL_READ_TTL_MS, INTERNAL_READ_CAPACITY, internalReads;
+var init_tmux_interaction_options = __esm({
+  "packages/daemon/src/lib/tmux-interaction-options.ts"() {
+    "use strict";
+    INTERNAL_SEND_OPERATION_OPTION = "@tmux_ide_send_operation";
+    INTERNAL_READ_OPERATION_OPTION = "@tmux_ide_read_operation";
+    INTERNAL_READ_PREFIX = "tmux-ide-internal-read-v2:";
+    INTERNAL_READ_TTL_MS = 1e4;
+    INTERNAL_READ_CAPACITY = 512;
+    internalReads = /* @__PURE__ */ new Map();
+  }
+});
+
 // packages/daemon/src/lib/tmux-external-interaction-observer.ts
 import { execFile as execFile3 } from "node:child_process";
 import { z as z60 } from "zod";
@@ -26705,7 +26707,7 @@ var init_tmux_external_interaction_observer = __esm({
         try {
           this.#io.runTmux(["set-buffer", "-b", this.#bufferName, "-n", drainName]);
         } catch {
-          return;
+          return false;
         }
         let raw;
         try {
@@ -26713,7 +26715,11 @@ var init_tmux_external_interaction_observer = __esm({
         } finally {
           this.#deleteBuffer(drainName);
         }
-        for (const record of parseTmuxInputHookRecords(raw)) this.#project(record);
+        let consumed = false;
+        for (const record of parseTmuxInputHookRecords(raw)) {
+          consumed = this.#project(record) || consumed;
+        }
+        return consumed;
       }
       async #run() {
         while (this.#active && !this.#abort.signal.aborted) {
@@ -26729,8 +26735,12 @@ var init_tmux_external_interaction_observer = __esm({
         }
       }
       #project(record) {
-        if (record.operationKind === "workspace.pane.read" && record.operationMarker === INTERNAL_READ_OPERATION_MARKER) {
-          return;
+        if (consumeInternalReadOperation(
+          record.operationMarker,
+          record.runtimePaneId,
+          record.operationKind
+        )) {
+          return true;
         }
         const ownPrefix = `${this.#daemonInstanceId}:`;
         const authoredOperationId = record.operationMarker?.startsWith(ownPrefix) ? record.operationMarker.slice(ownPrefix.length) : null;
@@ -26745,16 +26755,16 @@ var init_tmux_external_interaction_observer = __esm({
             `#{session_name}	#{${"@tmux_ide_pane_id"}}`
           ]);
         } catch {
-          return;
+          return false;
         }
         const separator = identity.indexOf("	");
-        if (separator < 1) return;
+        if (separator < 1) return false;
         const sessionName = identity.slice(0, separator);
         const semanticPaneId3 = identity.slice(separator + 1);
-        if (!WorkspacePaneCreationReferenceSchemaZ.safeParse(semanticPaneId3).success) return;
+        if (!WorkspacePaneCreationReferenceSchemaZ.safeParse(semanticPaneId3).success) return false;
         const workspace = this.#registry.list().find((entry) => entry.sessionName === sessionName);
-        if (!workspace) return;
-        this.#onObserved({
+        if (!workspace) return false;
+        return this.#onObserved({
           workspaceName: workspace.name,
           semanticPaneId: semanticPaneId3,
           operationKind: record.operationKind,
@@ -27449,22 +27459,84 @@ var init_workspace_multiplexer_verbs = __esm({
         const before = this.#panes(sessionName);
         const pane = resolvePaneRow(before, intent.semanticPaneId);
         const sourcePane = intent.sourceSemanticPaneId ? resolvePaneRow(before, intent.sourceSemanticPaneId) : null;
-        const input = intent.submit ? `${intent.text}\r` : intent.text;
-        this.#io.runTmux([
-          "set-option",
-          "-p",
-          "-t",
-          pane.paneId,
-          INTERNAL_SEND_OPERATION_OPTION,
-          internalInteractionOperationMarker(this.#daemonInstanceId, envelope.operationId),
-          ";",
-          "send-keys",
-          "-t",
-          pane.paneId,
-          "-l",
-          "--",
-          input
-        ]);
+        const marker = internalInteractionOperationMarker(this.#daemonInstanceId, envelope.operationId);
+        if (intent.submit) {
+          const buffer = `tmux-ide-send-${envelope.operationId}`;
+          try {
+            this.#io.runTmux([
+              "set-buffer",
+              "-b",
+              buffer,
+              "--",
+              intent.text,
+              ";",
+              "paste-buffer",
+              "-d",
+              "-b",
+              buffer,
+              "-t",
+              pane.paneId,
+              ";",
+              "set-option",
+              "-p",
+              "-t",
+              pane.paneId,
+              INTERNAL_SEND_OPERATION_OPTION,
+              marker,
+              ";",
+              "send-keys",
+              "-t",
+              pane.paneId,
+              "Enter"
+            ]);
+          } catch (error) {
+            try {
+              this.#io.runTmux(["delete-buffer", "-b", buffer]);
+            } catch {
+            }
+            try {
+              this.#io.runTmux([
+                "set-option",
+                "-pu",
+                "-t",
+                pane.paneId,
+                INTERNAL_SEND_OPERATION_OPTION
+              ]);
+            } catch {
+            }
+            throw error;
+          }
+        } else {
+          try {
+            this.#io.runTmux([
+              "set-option",
+              "-p",
+              "-t",
+              pane.paneId,
+              INTERNAL_SEND_OPERATION_OPTION,
+              marker,
+              ";",
+              "send-keys",
+              "-t",
+              pane.paneId,
+              "-l",
+              "--",
+              intent.text
+            ]);
+          } catch (error) {
+            try {
+              this.#io.runTmux([
+                "set-option",
+                "-pu",
+                "-t",
+                pane.paneId,
+                INTERNAL_SEND_OPERATION_OPTION
+              ]);
+            } catch {
+            }
+            throw error;
+          }
+        }
         const observed = resolvePaneRow(this.#panes(sessionName), intent.semanticPaneId);
         if (observed.paneId !== pane.paneId) {
           throw new WorkspaceMultiplexerError("mutation_unverified", {
@@ -28841,8 +28913,9 @@ var init_session_channel = __esm({
         const epoch = sub.feed.beginReseed();
         this.input.flush();
         const history = this.opts.historyLines ?? DEFAULT_HISTORY_LINES;
+        const internalReadMarker = registerInternalReadOperation(runtime);
         this.io.commandListInline(
-          `set-option -p -t ${runtime} ${INTERNAL_READ_OPERATION_OPTION} ${INTERNAL_READ_OPERATION_MARKER} ; capture-pane -p -e -J -S -${history} -t ${runtime}`,
+          `set-option -p -t ${runtime} ${INTERNAL_READ_OPERATION_OPTION} ${internalReadMarker} ; capture-pane -p -e -J -S -${history} -t ${runtime}`,
           2,
           1,
           (reply) => {
@@ -29712,17 +29785,21 @@ var init_semantic_mutation_executor = __esm({
       constructor(options) {
         this.#options = options;
       }
-      submit(rawOperationId, rawIntent, authenticatedSourceSemanticPaneId = null, authorizeBeforeEffect, authenticatedOrigin) {
+      submit(rawOperationId, rawIntent, authority) {
         if (this.#disposed) {
           return Promise.reject(
             new SessionRuntimeIntentError("rejected", "Session semantic mutation executor is disposed")
           );
         }
         const operationId = z61.uuid().parse(rawOperationId);
-        const intent = SessionRuntimeSemanticIntentSchemaZ.parse(rawIntent);
+        let intent = SessionRuntimeSemanticIntentSchemaZ.parse(rawIntent);
+        if (intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read") {
+          intent = { ...intent, origin: authority.origin };
+        }
+        const authenticatedSourceSemanticPaneId = authority.authenticatedSourceSemanticPaneId ?? null;
         const session = this.#options.resolveSession(intent.workspaceName);
         const ledger = this.#ledger(session ?? MISSING_SESSION_LEDGER);
-        const origin = authenticatedOrigin ?? ("origin" in intent ? intent.origin : "sdk");
+        const origin = authority.origin;
         const fingerprint2 = JSON.stringify([intent, authenticatedSourceSemanticPaneId, origin]);
         const existing = ledger.get(operationId);
         if (existing) {
@@ -29762,7 +29839,7 @@ var init_semantic_mutation_executor = __esm({
             operationId,
             intent,
             authenticatedSourceSemanticPaneId,
-            authorizeBeforeEffect,
+            authority.authorizeBeforeEffect,
             origin
           ),
           () => this.#run(
@@ -29770,7 +29847,7 @@ var init_semantic_mutation_executor = __esm({
             operationId,
             intent,
             authenticatedSourceSemanticPaneId,
-            authorizeBeforeEffect,
+            authority.authorizeBeforeEffect,
             origin
           )
         );
@@ -29988,7 +30065,7 @@ var init_semantic_mutation_executor = __esm({
 });
 
 // packages/daemon/src/terminal/session-runtime/registry.ts
-import { randomUUID as randomUUID4 } from "node:crypto";
+import { randomUUID as randomUUID5 } from "node:crypto";
 import { z as z62 } from "zod";
 function authoredOriginForSurface(surface) {
   if (surface === "opentui") return "tui";
@@ -30026,7 +30103,7 @@ var init_registry2 = __esm({
         this.#mirror = new MirrorService(options.mirror);
         this.#semanticMutations = options.semanticMutations ? new SessionSemanticMutationExecutor(options.semanticMutations) : null;
         this.#resolveSession = options.semanticMutations?.resolveSession ?? null;
-        this.#createControllerToken = options.createControllerToken ?? randomUUID4;
+        this.#createControllerToken = options.createControllerToken ?? randomUUID5;
         this.#stopExitObserver = this.#mirror.onSessionExit((session) => {
           this.#sessions.get(session)?.noteControlExit();
         });
@@ -30083,9 +30160,11 @@ var init_registry2 = __esm({
         return this.#semanticMutations.submit(
           operationId,
           { ...intent, sourceSemanticPaneId: semanticPaneId3 },
-          semanticPaneId3,
-          authorizeBeforeEffect,
-          "cli"
+          {
+            origin: "cli",
+            authenticatedSourceSemanticPaneId: semanticPaneId3,
+            authorizeBeforeEffect
+          }
         );
       }
       submitAuthenticatedIntent(handle, operationId, intent) {
@@ -30177,13 +30256,11 @@ var init_registry2 = __esm({
         if (!this.#semanticMutations) {
           return Promise.reject(new Error("Session semantic mutations are unavailable"));
         }
-        return this.#semanticMutations.submit(
-          operationId,
-          intent,
+        return this.#semanticMutations.submit(operationId, intent, {
+          origin: authenticatedOrigin ?? "sdk",
           authenticatedSourceSemanticPaneId,
-          authorizeBeforeEffect,
-          authenticatedOrigin
-        );
+          authorizeBeforeEffect
+        });
       }
       observeTmuxInteraction(observation2) {
         return this.#semanticMutations?.observe(observation2) ?? false;
@@ -31015,7 +31092,7 @@ var init_grouped_tmux = __esm({
 });
 
 // packages/daemon/src/terminal/attachments/lease-manager.ts
-import { createHash as createHash11, randomBytes as randomBytes3, randomUUID as randomUUID5, timingSafeEqual as timingSafeEqual2 } from "node:crypto";
+import { createHash as createHash11, randomBytes as randomBytes3, randomUUID as randomUUID6, timingSafeEqual as timingSafeEqual2 } from "node:crypto";
 import { z as z66 } from "zod";
 function positiveDuration(value, fallback, label2) {
   const resolved2 = value ?? fallback;
@@ -31088,7 +31165,7 @@ var init_lease_manager = __esm({
         this.#viewExecutor = options.viewExecutor;
         this.#now = options.now ?? Date.now;
         this.#randomBytes = options.randomBytes ?? randomBytes3;
-        this.#createId = options.createId ?? randomUUID5;
+        this.#createId = options.createId ?? randomUUID6;
         this.#ticketTtlMs = positiveDuration(options.ticketTtlMs, 15e3, "ticketTtlMs");
         this.#leaseTtlMs = positiveDuration(options.leaseTtlMs, 6e4, "leaseTtlMs");
         this.#maxLeaseTtlMs = positiveDuration(
@@ -33461,7 +33538,7 @@ var init_tmux_view_executor = __esm({
 // packages/daemon/src/terminal/attachments/pty-tmux-attachment-launcher.ts
 import { accessSync as accessSync4, constants as constants5, realpathSync as realpathSync9, statSync as statSync10 } from "node:fs";
 import { delimiter as delimiter3, isAbsolute as isAbsolute8, join as join29 } from "node:path";
-import { randomUUID as randomUUID6 } from "node:crypto";
+import { randomUUID as randomUUID7 } from "node:crypto";
 import { execFileSync as execFileSync12 } from "node:child_process";
 function defaultSchedule2(callback, delayMs) {
   const timer = setTimeout(callback, delayMs);
@@ -33651,7 +33728,7 @@ var init_pty_tmux_attachment_launcher = __esm({
         if (existing) this.#dispose(existing);
         this.#reservedAttachments.add(request.identity.attachmentId);
         const lifecycleEpoch = this.#lifecycleEpoch;
-        const attemptId = randomUUID6();
+        const attemptId = randomUUID7();
         let resolveOutcome;
         const outcome = new Promise((resolve31) => {
           resolveOutcome = resolve31;
@@ -34729,7 +34806,7 @@ function createTmuxAgentStatusProbe(deps2) {
       "-t",
       runtimePaneId,
       INTERNAL_READ_OPERATION_OPTION,
-      INTERNAL_READ_OPERATION_MARKER,
+      registerInternalReadOperation(runtimePaneId),
       ";",
       "capture-pane",
       "-p",
@@ -34982,7 +35059,7 @@ var init_terminal_attachment_upgrade = __esm({
 });
 
 // packages/daemon/src/terminal/pane-stream/lease-manager.ts
-import { createHash as createHash12, randomBytes as randomBytes4, randomUUID as randomUUID7, timingSafeEqual as timingSafeEqual3 } from "node:crypto";
+import { createHash as createHash12, randomBytes as randomBytes4, randomUUID as randomUUID8, timingSafeEqual as timingSafeEqual3 } from "node:crypto";
 import { z as z70 } from "zod";
 function positiveDuration2(value, fallback, label2) {
   const resolved2 = value ?? fallback;
@@ -35035,7 +35112,7 @@ var init_lease_manager2 = __esm({
         this.#instanceId = BindingIdSchemaZ3.parse(options.daemonInstanceId);
         this.#now = options.now ?? Date.now;
         this.#randomBytes = options.randomBytes ?? randomBytes4;
-        this.#createId = options.createId ?? randomUUID7;
+        this.#createId = options.createId ?? randomUUID8;
         this.#ticketTtlMs = positiveDuration2(options.ticketTtlMs, 15e3, "ticketTtlMs");
         this.#redemptionProcessingTtlMs = positiveDuration2(
           options.redemptionProcessingTtlMs,
@@ -36462,7 +36539,6 @@ function createSessionRuntimeMultiplexerBackend(options) {
       throw error;
     }
   };
-  const withTrustedOrigin = (intent, origin) => intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read" ? { ...intent, origin } : intent;
   const acquireOwner = (session) => {
     let owner = owners.get(session);
     if (!owner) {
@@ -36487,7 +36563,7 @@ function createSessionRuntimeMultiplexerBackend(options) {
     await owner.consumer.close();
   };
   return {
-    mutate: async (request, authenticatedHostClientId, sourcePaneCredential) => {
+    mutate: async (request, authenticatedHostClientId, sourcePaneCredential, ownerAuthorized = false) => {
       const session = options.resolveSession(request.intent.workspaceName);
       if (!session) {
         throw new Error(`Workspace ${request.intent.workspaceName} has no live tmux session`);
@@ -36506,7 +36582,7 @@ function createSessionRuntimeMultiplexerBackend(options) {
           () => options.registry.submitAuthenticatedIntent(
             authenticatedContext,
             request.operationId,
-            withTrustedOrigin(request.intent, "gui")
+            request.intent
           )
         );
         if (!result) throw new Error("Session mutation completed without a mutation result");
@@ -36523,7 +36599,7 @@ function createSessionRuntimeMultiplexerBackend(options) {
           () => options.registry.submitPaneCredentialIntent(
             session,
             request.operationId,
-            withTrustedOrigin(request.intent, "cli"),
+            request.intent,
             credentialSource,
             () => {
               const current = options.resolvePaneSourceCredential?.(
@@ -36540,6 +36616,9 @@ function createSessionRuntimeMultiplexerBackend(options) {
         if (!result) throw new Error("Session mutation completed without a mutation result");
         return result;
       }
+      if (!ownerAuthorized) {
+        throw new Error("Semantic mutation requires a live host, pane, or owner principal");
+      }
       const owner = acquireOwner(session);
       try {
         const lease = owner.consumer.acquireController();
@@ -36547,7 +36626,7 @@ function createSessionRuntimeMultiplexerBackend(options) {
           () => owner.consumer.submitIntent(
             lease,
             request.operationId,
-            withTrustedOrigin(request.intent, "sdk")
+            request.intent
           )
         );
         if (!result) throw new Error("Session mutation completed without a mutation result");
@@ -36673,7 +36752,7 @@ var init_active_projects = __esm({
 });
 
 // packages/daemon/src/lib/environment-identity.ts
-import { randomUUID as randomUUID8 } from "node:crypto";
+import { randomUUID as randomUUID9 } from "node:crypto";
 import { linkSync as linkSync3, mkdirSync as mkdirSync21, readFileSync as readFileSync23, rmSync as rmSync3, writeFileSync as writeFileSync19 } from "node:fs";
 import { dirname as dirname26, join as join30 } from "node:path";
 function environmentIdentityPath() {
@@ -36690,7 +36769,7 @@ function readPersistedEnvironmentId(path2) {
   }
 }
 function persistEnvironmentId(path2, environmentId) {
-  const temporary = `${path2}.${process.pid}.${randomUUID8()}.tmp`;
+  const temporary = `${path2}.${process.pid}.${randomUUID9()}.tmp`;
   try {
     mkdirSync21(dirname26(path2), { recursive: true });
     writeFileSync19(
@@ -36716,7 +36795,7 @@ function readOrMintEnvironmentId() {
     rmSync3(path2, { force: true });
   } catch {
   }
-  const minted = randomUUID8();
+  const minted = randomUUID9();
   persistEnvironmentId(path2, minted);
   return readPersistedEnvironmentId(path2) ?? minted;
 }
@@ -36730,7 +36809,7 @@ var init_environment_identity = __esm({
 });
 
 // packages/daemon/src/send.ts
-import { randomUUID as randomUUID9 } from "node:crypto";
+import { randomUUID as randomUUID10 } from "node:crypto";
 import { execFileSync as execFileSync13 } from "node:child_process";
 import { resolve as resolve23, join as join31 } from "node:path";
 import { existsSync as existsSync29, mkdirSync as mkdirSync22, writeFileSync as writeFileSync20 } from "node:fs";
@@ -36739,7 +36818,7 @@ function writeDispatchFile(dir, paneId, message) {
   const dispatchDir = join31(dir, ".tasks", "dispatch");
   if (!existsSync29(dispatchDir)) mkdirSync22(dispatchDir, { recursive: true });
   const paneSlug = paneId.replace("%", "");
-  const filename = `send-${paneSlug}-${Date.now()}-${randomUUID9().slice(0, 8)}.md`;
+  const filename = `send-${paneSlug}-${Date.now()}-${randomUUID10().slice(0, 8)}.md`;
   const filePath = join31(dispatchDir, filename);
   writeFileSync20(filePath, message);
   return { filePath, triggerCmd: `Read and execute: .tasks/dispatch/${filename}` };
@@ -36877,7 +36956,7 @@ async function deliverMessageThroughDaemon(opts) {
   const prepared = prepareMessage(opts.message, busyStatus);
   const dispatch = opts.noEnter ? null : writeDispatchFile(opts.dir, pane.id, prepared);
   const actualText = dispatch?.triggerCmd ?? prepared;
-  const operationId = randomUUID9();
+  const operationId = randomUUID10();
   const sourceSemanticPaneId = cliSourceSemanticPaneId(opts.session);
   const sourcePaneCredential = cliPaneSourceCredential();
   const outcome = await tryDispatchAction(
@@ -37012,6 +37091,32 @@ var init_log = __esm({
       warn: (component, msg, data) => writeStructuredLog("warn", component, msg, data),
       error: (component, msg, data) => writeStructuredLog("error", component, msg, data)
     };
+  }
+});
+
+// packages/daemon/src/command-center/actions/semantic-multiplexer-actions.ts
+function isSemanticMultiplexerActionName(actionName) {
+  return semanticMultiplexerActionNames.has(actionName);
+}
+var SEMANTIC_MULTIPLEXER_ACTION_NAMES, semanticMultiplexerActionNames;
+var init_semantic_multiplexer_actions = __esm({
+  "packages/daemon/src/command-center/actions/semantic-multiplexer-actions.ts"() {
+    "use strict";
+    SEMANTIC_MULTIPLEXER_ACTION_NAMES = [
+      "workspace.window.split",
+      "workspace.window.kill",
+      "workspace.pane.kill",
+      "workspace.session.kill",
+      "workspace.rename",
+      "workspace.pane.zoom.toggle",
+      "workspace.pane.select",
+      "workspace.pane.send",
+      "workspace.pane.swap",
+      "workspace.pane.resize"
+    ];
+    semanticMultiplexerActionNames = new Set(
+      SEMANTIC_MULTIPLEXER_ACTION_NAMES
+    );
   }
 });
 
@@ -38018,7 +38123,12 @@ async function runVerb(verb, input, context, deps2) {
       expectedDaemonInstanceId: context.daemonInstanceId,
       intent: { ...input, verb }
     };
-    return context.hostClientId || context.sourcePaneCredential ? await authority.mutate(request, context.hostClientId, context.sourcePaneCredential) : await authority.mutate(request);
+    return await authority.mutate(
+      request,
+      context.hostClientId,
+      context.sourcePaneCredential,
+      context.ownerAuthorized
+    );
   } catch (error) {
     if (!(error instanceof WorkspaceMultiplexerError)) throw error;
     throw new ActionError({
@@ -38423,6 +38533,13 @@ var init_command_definitions = __esm({
 });
 
 // packages/daemon/src/command-center/actions/dispatcher.ts
+function markActionOwnerAuthorized(context) {
+  ownerAuthorizedContexts.add(context);
+}
+function shouldBroadcastGenericActionComplete(actionName, result, unchangedAppWindowMutation) {
+  if (unchangedAppWindowMutation) return false;
+  return !(isSemanticMultiplexerActionName(actionName) && WorkspaceMultiplexerMutationResultSchemaZ.safeParse(result).success);
+}
 function resourceChangesForAction(actionName, result) {
   if (actionName === "workspace.app-window.mutate") {
     const mutation = AppWindowMutationResultSchemaZ.safeParse(result);
@@ -38602,6 +38719,7 @@ function createActionDispatcher(deps2 = {}) {
       daemonInstanceId: deps2.daemonInstanceId,
       hostClientId: c.req.header("X-Tmux-Ide-Host-Client-Id"),
       sourcePaneCredential: c.req.header(PANE_SOURCE_CREDENTIAL_HEADER),
+      ownerAuthorized: ownerAuthorizedContexts.has(c),
       workspacePaneCreationBackend: deps2.workspacePaneCreationBackend,
       workspaceOpenBackend: deps2.workspaceOpenBackend,
       workspacePromotionBackend: deps2.workspacePromotionBackend,
@@ -38622,7 +38740,11 @@ function createActionDispatcher(deps2 = {}) {
       return c.json(outputZodErrorEnvelope(outputParsed.error), 200);
     }
     const unchangedAppWindowMutation = actionName === "workspace.app-window.mutate" && typeof outputParsed.data === "object" && outputParsed.data !== null && "outcome" in outputParsed.data && outputParsed.data.outcome === "unchanged";
-    if (!unchangedAppWindowMutation) {
+    if (shouldBroadcastGenericActionComplete(
+      actionName,
+      outputParsed.data,
+      unchangedAppWindowMutation
+    )) {
       try {
         broadcast(actionName, outputParsed.data);
       } catch (err) {
@@ -38653,6 +38775,7 @@ function createActionDispatcher(deps2 = {}) {
     return c.json({ ok: true, result: outputParsed.data }, 200);
   };
 }
+var ownerAuthorizedContexts;
 var init_dispatcher = __esm({
   "packages/daemon/src/command-center/actions/dispatcher.ts"() {
     "use strict";
@@ -38663,6 +38786,8 @@ var init_dispatcher = __esm({
     init_ws_events();
     init_src();
     init_command_definitions();
+    init_semantic_multiplexer_actions();
+    ownerAuthorizedContexts = /* @__PURE__ */ new WeakSet();
   }
 });
 
@@ -42034,7 +42159,7 @@ __export(widget_asset_store_exports, {
   publishWidgetAsset: () => publishWidgetAsset,
   readWidgetAsset: () => readWidgetAsset
 });
-import { createHash as createHash15, randomUUID as randomUUID11 } from "node:crypto";
+import { createHash as createHash15, randomUUID as randomUUID12 } from "node:crypto";
 import {
   chmodSync as chmodSync5,
   existsSync as existsSync33,
@@ -42135,11 +42260,11 @@ function publishWidgetAsset(bytes, options) {
     createdAt: (/* @__PURE__ */ new Date()).toISOString()
   };
   if (!existsSync33(paths.data)) {
-    const temporary = join35(root, `.${assetId}.${randomUUID11()}.bin`);
+    const temporary = join35(root, `.${assetId}.${randomUUID12()}.bin`);
     writeFileSync22(temporary, bytes, { mode: 384, flag: "wx" });
     renameSync13(temporary, paths.data);
   }
-  const metadataTemporary = join35(root, `.${assetId}.${randomUUID11()}.json`);
+  const metadataTemporary = join35(root, `.${assetId}.${randomUUID12()}.json`);
   writeFileSync22(metadataTemporary, `${JSON.stringify(metadata)}
 `, { mode: 384, flag: "wx" });
   renameSync13(metadataTemporary, paths.metadata);
@@ -42208,7 +42333,7 @@ import { z as z74 } from "zod";
 import { realpathSync as realpathSync14 } from "node:fs";
 import { homedir as homedir21 } from "node:os";
 import { isAbsolute as isAbsolute13, resolve as pathResolve } from "node:path";
-import { randomUUID as randomUUID12 } from "node:crypto";
+import { randomUUID as randomUUID13 } from "node:crypto";
 import { WebSocketServer as WebSocketServer3 } from "ws";
 function bearerToken(authHeader) {
   if (!authHeader?.startsWith("Bearer ")) return null;
@@ -42248,8 +42373,12 @@ function requireHostCapability(ownerToken) {
     const actionName = c.req.param("name");
     const requirement = actionName ? GATED_ACTIONS[actionName] : void 0;
     if (!requirement) return next();
-    const denied = gate(c);
-    if (denied) return denied;
+    const semanticPrincipal = isSemanticMultiplexerActionName(actionName ?? "") && (c.req.header("X-Tmux-Ide-Host-Client-Id") !== void 0 || c.req.header(PANE_SOURCE_CREDENTIAL_HEADER) !== void 0);
+    if (!semanticPrincipal) {
+      const denied = gate(c);
+      if (denied) return denied;
+      markActionOwnerAuthorized(c);
+    }
     if (requirement === "owner-and-operation-id" && !z74.uuid().safeParse(c.req.header("X-Tmux-Ide-Operation-Id")).success) {
       return c.json({ error: "A stable host operation id is required" }, 400);
     }
@@ -42339,7 +42468,7 @@ function createApp(options = {}) {
   const authService = options.authService ?? new AuthService();
   const daemonIdentity = options.daemonIdentity ?? {
     productVersion: "0.0.0",
-    instanceId: randomUUID12(),
+    instanceId: randomUUID13(),
     startedAt: (/* @__PURE__ */ new Date()).toISOString()
   };
   const daemonInstanceIdentity = DaemonInstanceIdentitySchemaZ.parse({
@@ -42770,7 +42899,7 @@ function createApp(options = {}) {
         });
         scripted = true;
       }
-      if (!id) id = randomUUID12();
+      if (!id) id = randomUUID13();
       try {
         const upsertInput = {
           id,
@@ -43214,7 +43343,7 @@ function createApp(options = {}) {
     if (!existsSync34(parsed.data.dir)) {
       return c.json({ error: `Directory "${parsed.data.dir}" does not exist` }, 400);
     }
-    const jobId = randomUUID12();
+    const jobId = randomUUID13();
     const command2 = process.env.TMUX_IDE_INIT_COMMAND ?? "tmux-ide";
     void (async () => {
       try {
@@ -43393,6 +43522,7 @@ var init_server = __esm({
     init_config_context();
     init_ide_config2();
     init_log();
+    init_semantic_multiplexer_actions();
     init_workspace_registry();
     init_src();
     init_schemas();
@@ -43404,6 +43534,7 @@ var init_server = __esm({
     init_middleware();
     init_ws_events();
     init_dispatcher();
+    init_pane_source_credentials();
     init_project_registry();
     init_project_init_runner();
     init_registry();
@@ -43454,6 +43585,7 @@ var init_server = __esm({
       "workspace.rename": "owner-and-operation-id",
       "workspace.pane.zoom.toggle": "owner-and-operation-id",
       "workspace.pane.select": "owner-and-operation-id",
+      "workspace.pane.send": "owner-and-operation-id",
       "workspace.pane.swap": "owner-and-operation-id",
       "workspace.pane.resize": "owner-and-operation-id",
       "project.launch": "owner",
@@ -43488,7 +43620,7 @@ var init_types = __esm({
 
 // packages/daemon/src/lib/daemon-embed.ts
 import { execFileSync as execFileSync14 } from "node:child_process";
-import { randomBytes as randomBytes7, randomUUID as randomUUID13 } from "node:crypto";
+import { randomBytes as randomBytes7, randomUUID as randomUUID14 } from "node:crypto";
 import { createServer } from "node:http";
 import { createRequire as createRequire2 } from "node:module";
 import { performance } from "node:perf_hooks";
@@ -44124,7 +44256,7 @@ async function startEmbeddedDaemon(opts) {
     validatePort(port);
     const dir = process.cwd();
     const productVersion = resolveDaemonProductVersion(opts.productVersion);
-    const instanceId = randomUUID13();
+    const instanceId = randomUUID14();
     const startedAt = (/* @__PURE__ */ new Date()).toISOString();
     const environmentId = readOrMintEnvironmentId();
     const workspaceRegistry = getDefaultWorkspaceRegistry();
@@ -44197,12 +44329,12 @@ async function startEmbeddedDaemon(opts) {
             semanticPaneId: semanticPaneId3,
             operationKind
           }) ?? false;
-          if (consumed) return;
+          if (consumed) return true;
         }
         try {
           broadcastInteractionReceipt(
             {
-              operationId: randomUUID13(),
+              operationId: randomUUID14(),
               origin: "external",
               workspaceName,
               target: { kind: "pane", semanticPaneId: semanticPaneId3 },
@@ -44216,6 +44348,7 @@ async function startEmbeddedDaemon(opts) {
         } catch (error) {
           if (!opts.silent) console.error("[daemon] External interaction receipt failed:", error);
         }
+        return false;
       }
     });
     let terminalAttachmentRuntime = null;
@@ -44629,7 +44762,7 @@ var init_daemon_embed = __esm({
 
 // packages/daemon/src/lib/cli-action-bridge.ts
 import { createRequire as createRequire3 } from "node:module";
-import { randomUUID as randomUUID14 } from "node:crypto";
+import { randomUUID as randomUUID15 } from "node:crypto";
 import { z as z75 } from "zod";
 function timeoutSignal2(ms) {
   const controller = new AbortController();
@@ -44711,7 +44844,7 @@ async function tryDispatchAction(name, input, options = {}) {
   if (!daemon) return null;
   const contract = ActionContractsZ[name];
   const parsedInput = contract.input.parse(input);
-  const operationId = RETRY_SAFE_OWNER_ACTIONS.has(name) ? options.operationId ?? randomUUID14() : null;
+  const operationId = RETRY_SAFE_OWNER_ACTIONS.has(name) ? options.operationId ?? randomUUID15() : null;
   if (operationId && !daemon.ownerToken) {
     await stopTransientDaemon(daemon);
     return null;

--- a/packages/daemon/src/command-center/actions/dispatcher.test.ts
+++ b/packages/daemon/src/command-center/actions/dispatcher.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
+import { WorkspaceMultiplexerMutationResultSchemaZ } from "@tmux-ide/contracts";
 import { ActionContractsZ } from "./contract.ts";
-import { createActionDispatcher } from "./dispatcher.ts";
+import { createActionDispatcher, shouldBroadcastGenericActionComplete } from "./dispatcher.ts";
 import { setDaemonShutdownBackend } from "./handlers/daemon-shutdown.ts";
 import type { WorkspacePaneCreationBackend } from "./handlers/workspace-pane-create.ts";
 import type { WorkspaceOpenBackend } from "./handlers/workspace-open.ts";
@@ -31,6 +32,23 @@ afterEach(() => {
 });
 
 describe("command-backed action dispatcher compatibility", () => {
+  it("broadcasts a non-semantic action even when test data has a multiplexer result shape", () => {
+    const multiplexerResult = {
+      verb: "workspace.pane.select",
+      outcome: "applied",
+      operationId: "10000000-0000-4000-8000-000000000001",
+      daemonInstanceId: "20000000-0000-4000-8000-000000000002",
+      workspaceName: "workspace.alpha",
+      semanticPaneId: "pane.target",
+    };
+    expect(WorkspaceMultiplexerMutationResultSchemaZ.safeParse(multiplexerResult).success).toBe(
+      true,
+    );
+    expect(shouldBroadcastGenericActionComplete("daemon.shutdown", multiplexerResult, false)).toBe(
+      true,
+    );
+  });
+
   it("forwards trusted host and pane credentials out-of-band to the runtime backend", async () => {
     const mutate = vi.fn(async (input) => ({
       verb: "workspace.pane.send" as const,
@@ -76,6 +94,7 @@ describe("command-backed action dispatcher compatibility", () => {
       expect.objectContaining({ intent: expect.objectContaining({ text: "hello" }) }),
       "trusted-host",
       "trusted-pane-credential",
+      false,
     );
   });
 
@@ -94,10 +113,11 @@ describe("command-backed action dispatcher compatibility", () => {
       submitted: true,
     }));
     const app = new Hono();
+    const broadcast = vi.fn();
     app.post(
       "/api/v2/action/:name",
       createActionDispatcher({
-        broadcast: vi.fn(),
+        broadcast,
         broadcastResourceChanged: vi.fn(),
         daemonInstanceId: "20000000-0000-4000-8000-000000000002",
         workspaceMultiplexerBackend: { mutate },
@@ -122,7 +142,11 @@ describe("command-backed action dispatcher compatibility", () => {
     expect(response.status).toBe(200);
     expect(mutate).toHaveBeenCalledWith(
       expect.objectContaining({ intent: expect.objectContaining({ text: "private prompt" }) }),
+      undefined,
+      undefined,
+      false,
     );
+    expect(broadcast).not.toHaveBeenCalled();
   });
   it("keeps unknown action transport behavior unchanged", async () => {
     const { app } = actionApp();

--- a/packages/daemon/src/command-center/actions/dispatcher.ts
+++ b/packages/daemon/src/command-center/actions/dispatcher.ts
@@ -46,6 +46,7 @@ import type { WorkspaceMultiplexerBackend } from "./handlers/workspace-multiplex
 import type { WorkspaceOpenBackend } from "./handlers/workspace-open.ts";
 import type { WorkspacePromotionBackend } from "./handlers/workspace-promote.ts";
 import type { AppWindowMutationBackend } from "./handlers/app-window-mutate.ts";
+import { isSemanticMultiplexerActionName } from "./semantic-multiplexer-actions.ts";
 
 export interface DispatcherDeps {
   /** Override the WS broadcaster (tests / non-default daemons). */
@@ -68,9 +69,28 @@ export interface DispatcherDeps {
   workspaceMultiplexerBackend?: WorkspaceMultiplexerBackend;
 }
 
+const ownerAuthorizedContexts = new WeakSet<object>();
+
+/** Stamp set only by the owner-auth middleware after bearer verification. */
+export function markActionOwnerAuthorized(context: object): void {
+  ownerAuthorizedContexts.add(context);
+}
+
 interface DispatchOk {
   ok: true;
   result: unknown;
+}
+
+export function shouldBroadcastGenericActionComplete(
+  actionName: ActionName,
+  result: unknown,
+  unchangedAppWindowMutation: boolean,
+): boolean {
+  if (unchangedAppWindowMutation) return false;
+  return !(
+    isSemanticMultiplexerActionName(actionName) &&
+    WorkspaceMultiplexerMutationResultSchemaZ.safeParse(result).success
+  );
 }
 
 function resourceChangesForAction(
@@ -285,6 +305,7 @@ export function createActionDispatcher(deps: DispatcherDeps = {}) {
       daemonInstanceId: deps.daemonInstanceId,
       hostClientId: c.req.header("X-Tmux-Ide-Host-Client-Id"),
       sourcePaneCredential: c.req.header(PANE_SOURCE_CREDENTIAL_HEADER),
+      ownerAuthorized: ownerAuthorizedContexts.has(c),
       workspacePaneCreationBackend: deps.workspacePaneCreationBackend,
       workspaceOpenBackend: deps.workspaceOpenBackend,
       workspacePromotionBackend: deps.workspacePromotionBackend,
@@ -314,7 +335,13 @@ export function createActionDispatcher(deps: DispatcherDeps = {}) {
       outputParsed.data !== null &&
       "outcome" in outputParsed.data &&
       outputParsed.data.outcome === "unchanged";
-    if (!unchangedAppWindowMutation) {
+    if (
+      shouldBroadcastGenericActionComplete(
+        actionName,
+        outputParsed.data,
+        unchangedAppWindowMutation,
+      )
+    ) {
       // Fire-and-forget: subscribers learn about durable state changes via WS.
       try {
         broadcast(actionName, outputParsed.data);

--- a/packages/daemon/src/command-center/actions/handlers/workspace-multiplexer.ts
+++ b/packages/daemon/src/command-center/actions/handlers/workspace-multiplexer.ts
@@ -23,6 +23,7 @@ export interface WorkspaceMultiplexerBackend {
     input: WorkspaceMultiplexerMutationRequest,
     authenticatedHostClientId?: string,
     sourcePaneCredential?: string,
+    ownerAuthorized?: boolean,
   ): Promise<WorkspaceMultiplexerMutationResult>;
 }
 
@@ -51,9 +52,12 @@ async function runVerb(
       expectedDaemonInstanceId: context.daemonInstanceId,
       intent: { ...input, verb } as WorkspaceMultiplexerIntent,
     };
-    return context.hostClientId || context.sourcePaneCredential
-      ? await authority.mutate(request, context.hostClientId, context.sourcePaneCredential)
-      : await authority.mutate(request);
+    return await authority.mutate(
+      request,
+      context.hostClientId,
+      context.sourcePaneCredential,
+      context.ownerAuthorized,
+    );
   } catch (error) {
     if (!(error instanceof WorkspaceMultiplexerError)) throw error;
     throw new ActionError({

--- a/packages/daemon/src/command-center/actions/registry.ts
+++ b/packages/daemon/src/command-center/actions/registry.ts
@@ -81,12 +81,15 @@ export interface ActionExecutionContext {
       input: WorkspaceMultiplexerMutationRequest,
       authenticatedHostClientId?: string,
       sourcePaneCredential?: string,
+      ownerAuthorized?: boolean,
     ): Promise<WorkspaceMultiplexerMutationResult>;
   };
   /** Owner-authenticated host principal injected outside request JSON. */
   readonly hostClientId?: string;
   /** Generation-scoped local tmux pane proof, carried only in a header. */
   readonly sourcePaneCredential?: string;
+  /** Verified owner bearer fact injected by middleware, never request JSON. */
+  readonly ownerAuthorized?: boolean;
 }
 
 export type ActionHandler<N extends ActionName> = (

--- a/packages/daemon/src/command-center/actions/semantic-multiplexer-actions.ts
+++ b/packages/daemon/src/command-center/actions/semantic-multiplexer-actions.ts
@@ -1,0 +1,26 @@
+import type { ActionName } from "./contract.ts";
+
+export const SEMANTIC_MULTIPLEXER_ACTION_NAMES = [
+  "workspace.window.split",
+  "workspace.window.kill",
+  "workspace.pane.kill",
+  "workspace.session.kill",
+  "workspace.rename",
+  "workspace.pane.zoom.toggle",
+  "workspace.pane.select",
+  "workspace.pane.send",
+  "workspace.pane.swap",
+  "workspace.pane.resize",
+] as const satisfies readonly ActionName[];
+
+export type SemanticMultiplexerActionName = (typeof SEMANTIC_MULTIPLEXER_ACTION_NAMES)[number];
+
+const semanticMultiplexerActionNames: ReadonlySet<string> = new Set(
+  SEMANTIC_MULTIPLEXER_ACTION_NAMES,
+);
+
+export function isSemanticMultiplexerActionName(
+  actionName: string,
+): actionName is SemanticMultiplexerActionName {
+  return semanticMultiplexerActionNames.has(actionName);
+}

--- a/packages/daemon/src/command-center/server.ts
+++ b/packages/daemon/src/command-center/server.ts
@@ -29,6 +29,7 @@ import { IdeConfigSchema } from "../schemas/ide-config.ts";
 import { getLogBuffer, subscribeLogs, type LogEntry } from "../lib/log.ts";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
+import { isSemanticMultiplexerActionName } from "./actions/semantic-multiplexer-actions.ts";
 import {
   getDefaultWorkspaceRegistry,
   WorkspaceAlreadyExistsError,
@@ -80,7 +81,8 @@ import { AuthService } from "../lib/auth/auth-service.ts";
 import { authMiddleware } from "../lib/auth/middleware.ts";
 import type { AuthConfig } from "../lib/auth/types.ts";
 import { handleWsEventsConnection, broadcastInitOutput, broadcastInitError } from "./ws-events.ts";
-import { createActionDispatcher } from "./actions/dispatcher.ts";
+import { createActionDispatcher, markActionOwnerAuthorized } from "./actions/dispatcher.ts";
+import { PANE_SOURCE_CREDENTIAL_HEADER } from "../lib/pane-source-credentials.ts";
 import {
   listProjects,
   getProject,
@@ -287,6 +289,7 @@ const GATED_ACTIONS: Readonly<Record<string, "owner" | "owner-and-operation-id">
   "workspace.rename": "owner-and-operation-id",
   "workspace.pane.zoom.toggle": "owner-and-operation-id",
   "workspace.pane.select": "owner-and-operation-id",
+  "workspace.pane.send": "owner-and-operation-id",
   "workspace.pane.swap": "owner-and-operation-id",
   "workspace.pane.resize": "owner-and-operation-id",
   "project.launch": "owner",
@@ -306,8 +309,15 @@ function requireHostCapability(ownerToken: string | null): MiddlewareHandler {
     const actionName = c.req.param("name");
     const requirement = actionName ? GATED_ACTIONS[actionName] : undefined;
     if (!requirement) return next();
-    const denied = gate(c);
-    if (denied) return denied;
+    const semanticPrincipal =
+      isSemanticMultiplexerActionName(actionName ?? "") &&
+      (c.req.header("X-Tmux-Ide-Host-Client-Id") !== undefined ||
+        c.req.header(PANE_SOURCE_CREDENTIAL_HEADER) !== undefined);
+    if (!semanticPrincipal) {
+      const denied = gate(c);
+      if (denied) return denied;
+      markActionOwnerAuthorized(c);
+    }
     if (
       requirement === "owner-and-operation-id" &&
       !z.uuid().safeParse(c.req.header("X-Tmux-Ide-Operation-Id")).success

--- a/packages/daemon/src/command-center/workspace-pane-swap-auth.test.ts
+++ b/packages/daemon/src/command-center/workspace-pane-swap-auth.test.ts
@@ -78,10 +78,39 @@ describe("workspace pane swap host capability", () => {
       ok: true,
       result: { verb: "workspace.pane.swap", outcome: "applied", ...INPUT },
     });
-    expect(mutate).toHaveBeenCalledWith({
-      operationId: OPERATION_ID,
-      expectedDaemonInstanceId: expect.any(String),
-      intent: { verb: "workspace.pane.swap", ...INPUT },
+    expect(mutate).toHaveBeenCalledWith(
+      {
+        operationId: OPERATION_ID,
+        expectedDaemonInstanceId: expect.any(String),
+        intent: { verb: "workspace.pane.swap", ...INPUT },
+      },
+      undefined,
+      undefined,
+      true,
+    );
+  });
+
+  it("does not treat loopback as owner authority for pane sends", async () => {
+    const mutate = vi.fn();
+    const app = createApp({
+      remoteAccess: { ownerToken: HOST_TOKEN },
+      workspaceMultiplexerBackend: { mutate },
     });
+    const response = await app.request("http://127.0.0.1/api/v2/action/workspace.pane.send", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Tmux-Ide-Operation-Id": OPERATION_ID,
+      },
+      body: JSON.stringify({
+        workspaceName: "workspace.alpha",
+        semanticPaneId: "pane.target",
+        text: "hello",
+        submit: true,
+        origin: "sdk",
+      }),
+    });
+    expect(response.status).toBe(401);
+    expect(mutate).not.toHaveBeenCalled();
   });
 });

--- a/packages/daemon/src/lib/daemon-embed.ts
+++ b/packages/daemon/src/lib/daemon-embed.ts
@@ -1071,7 +1071,7 @@ export async function startEmbeddedDaemon(
               semanticPaneId,
               operationKind,
             }) ?? false;
-          if (consumed) return;
+          if (consumed) return true;
         }
         try {
           broadcastInteractionReceipt(
@@ -1093,6 +1093,7 @@ export async function startEmbeddedDaemon(
         } catch (error) {
           if (!opts.silent) console.error("[daemon] External interaction receipt failed:", error);
         }
+        return false;
       },
     });
     let terminalAttachmentRuntime: NativeTerminalAttachmentRuntime | null = null;

--- a/packages/daemon/src/lib/tmux-external-interaction-observer.test.ts
+++ b/packages/daemon/src/lib/tmux-external-interaction-observer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { WorkspaceRegistry } from "./workspace-registry.ts";
 import {
@@ -7,7 +7,7 @@ import {
   parseTmuxInputHookRecords,
   type ExternalTmuxInteractionObserverIo,
 } from "./tmux-external-interaction-observer.ts";
-import { INTERNAL_READ_OPERATION_MARKER } from "./tmux-interaction-options.ts";
+import { registerInternalReadOperation } from "./tmux-interaction-options.ts";
 
 const DAEMON = "21f2625e-d1a5-4ad2-9068-b1426bcc6651";
 const OPERATION = "8be47b5a-43da-4632-9930-e1aba61c8da6";
@@ -15,6 +15,7 @@ const FIELD = "|tmux-ide-input-field-v1|";
 const EVENT = "|tmux-ide-input-event-v1|";
 const SEND = "workspace.pane.send";
 const READ = "workspace.pane.read";
+const FORGED_INTERNAL_READ = "tmux-ide-internal-read-v2:11111111-1111-4111-8111-111111111111";
 
 function registry(): WorkspaceRegistry {
   return {
@@ -28,7 +29,10 @@ function registry(): WorkspaceRegistry {
   } as unknown as WorkspaceRegistry;
 }
 
-function harness(raw: string): {
+function harness(
+  raw: string,
+  consumeOperationId: string | null = null,
+): {
   observer: TmuxExternalInteractionObserver;
   calls: readonly (readonly string[])[];
   observed: readonly {
@@ -76,7 +80,10 @@ function harness(raw: string): {
       },
       registry: registry(),
       io,
-      onObserved: (interaction) => observed.push(interaction),
+      onObserved: (interaction) => {
+        observed.push(interaction);
+        return interaction.operationId === consumeOperationId && consumeOperationId !== null;
+      },
     }),
     calls,
     observed,
@@ -116,7 +123,7 @@ function statefulHookHarness(): {
       },
       registry: registry(),
       io,
-      onObserved: () => {},
+      onObserved: () => false,
     }),
     calls,
     removeHooks: () => hooks.clear(),
@@ -167,12 +174,13 @@ describe("tmux external interaction observer", () => {
     expect(calls.filter((args) => args[0] === "set-hook" && args[1] === "-ag")).toHaveLength(4);
   });
 
-  it("projects external observations and correlates sends marked by this daemon generation", () => {
+  it("projects external observations and propagates whether the live executor consumed one", () => {
     const own = internalInteractionOperationMarker(DAEMON, OPERATION);
     const { observer, observed } = harness(
       `%9${FIELD}${FIELD}${SEND}${EVENT}%9${FIELD}${own}${FIELD}${SEND}${EVENT}%9${FIELD}another-daemon:${OPERATION}${FIELD}${READ}${EVENT}`,
+      OPERATION,
     );
-    observer.drain();
+    expect(observer.drain()).toBe(true);
 
     expect(observed).toEqual([
       {
@@ -196,11 +204,11 @@ describe("tmux external interaction observer", () => {
     ]);
   });
 
-  it("suppresses product-owned mirror reads while preserving raw external reads", () => {
+  it("does not trust a forgeable internal-looking read marker", () => {
     const { observer, observed } = harness(
-      `%9${FIELD}${INTERNAL_READ_OPERATION_MARKER}${FIELD}${READ}${EVENT}%9${FIELD}${FIELD}${READ}${EVENT}`,
+      `%9${FIELD}${FORGED_INTERNAL_READ}${FIELD}${READ}${EVENT}%9${FIELD}${FIELD}${READ}${EVENT}`,
     );
-    observer.drain();
+    expect(observer.drain()).toBe(false);
     expect(observed).toEqual([
       {
         workspaceName: "workspace.project",
@@ -208,6 +216,49 @@ describe("tmux external interaction observer", () => {
         operationKind: READ,
         operationId: null,
       },
+      {
+        workspaceName: "workspace.project",
+        semanticPaneId: "pane.editor",
+        operationKind: READ,
+        operationId: null,
+      },
     ]);
+  });
+
+  it("consumes a registered internal read exactly once for its exact pane", () => {
+    const marker = registerInternalReadOperation("%9");
+    const first = harness(`%9${FIELD}${marker}${FIELD}${READ}${EVENT}`);
+    expect(first.observer.drain()).toBe(true);
+    expect(first.observed).toEqual([]);
+
+    const replay = harness(`%9${FIELD}${marker}${FIELD}${READ}${EVENT}`);
+    expect(replay.observer.drain()).toBe(false);
+    expect(replay.observed).toHaveLength(1);
+  });
+
+  it("externalizes a registered marker used for the wrong pane or operation kind", () => {
+    const wrongPane = registerInternalReadOperation("%8");
+    const pane = harness(`%9${FIELD}${wrongPane}${FIELD}${READ}${EVENT}`);
+    expect(pane.observer.drain()).toBe(false);
+    expect(pane.observed).toHaveLength(1);
+
+    const wrongKind = registerInternalReadOperation("%9");
+    const kind = harness(`%9${FIELD}${wrongKind}${FIELD}${SEND}${EVENT}`);
+    expect(kind.observer.drain()).toBe(false);
+    expect(kind.observed).toHaveLength(1);
+  });
+
+  it("externalizes a stale internal-read registration", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-11T10:00:00.000Z"));
+      const marker = registerInternalReadOperation("%9");
+      vi.setSystemTime(new Date("2026-08-11T10:00:11.000Z"));
+      const stale = harness(`%9${FIELD}${marker}${FIELD}${READ}${EVENT}`);
+      expect(stale.observer.drain()).toBe(false);
+      expect(stale.observed).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/daemon/src/lib/tmux-external-interaction-observer.ts
+++ b/packages/daemon/src/lib/tmux-external-interaction-observer.ts
@@ -7,7 +7,7 @@ import type { WorkspacePaneTmuxAuthority } from "./workspace-pane-creation.ts";
 import { createPinnedWorkspaceTmuxRunner } from "./workspace-pane-creation.ts";
 import { getDefaultWorkspaceRegistry, type WorkspaceRegistry } from "./workspace-registry.ts";
 import {
-  INTERNAL_READ_OPERATION_MARKER,
+  consumeInternalReadOperation,
   INTERNAL_READ_OPERATION_OPTION,
   INTERNAL_SEND_OPERATION_OPTION,
 } from "./tmux-interaction-options.ts";
@@ -141,7 +141,7 @@ export class TmuxExternalInteractionObserver {
   readonly #daemonInstanceId: string;
   readonly #registry: WorkspaceRegistry;
   readonly #io: ExternalTmuxInteractionObserverIo;
-  readonly #onObserved: (interaction: ExternalTmuxInteraction) => void;
+  readonly #onObserved: (interaction: ExternalTmuxInteraction) => boolean;
   readonly #bufferName: string;
   readonly #signalChannel: string;
   readonly #tmuxCommandPrefix: readonly string[];
@@ -157,7 +157,12 @@ export class TmuxExternalInteractionObserver {
     tmuxAuthority: WorkspacePaneTmuxAuthority;
     registry?: WorkspaceRegistry;
     io?: Partial<ExternalTmuxInteractionObserverIo>;
-    onObserved: (interaction: ExternalTmuxInteraction) => void;
+    /**
+     * Returns true only when a live, product-authored operation consumed the
+     * observation. Internal-looking metadata is not authority: a false return
+     * must fall through to the caller's honest external-observation path.
+     */
+    onObserved: (interaction: ExternalTmuxInteraction) => boolean;
   }) {
     this.#daemonInstanceId = options.daemonInstanceId;
     this.#registry = options.registry ?? getDefaultWorkspaceRegistry();
@@ -257,12 +262,12 @@ export class TmuxExternalInteractionObserver {
   }
 
   /** Atomically detach and drain the current event buffer. */
-  drain(): void {
+  drain(): boolean {
     const drainName = `${this.#bufferName}-drain-${++this.#drainSequence}`;
     try {
       this.#io.runTmux(["set-buffer", "-b", this.#bufferName, "-n", drainName]);
     } catch {
-      return;
+      return false;
     }
     let raw: string;
     try {
@@ -270,7 +275,11 @@ export class TmuxExternalInteractionObserver {
     } finally {
       this.#deleteBuffer(drainName);
     }
-    for (const record of parseTmuxInputHookRecords(raw)) this.#project(record);
+    let consumed = false;
+    for (const record of parseTmuxInputHookRecords(raw)) {
+      consumed = this.#project(record) || consumed;
+    }
+    return consumed;
   }
 
   async #run(): Promise<void> {
@@ -289,12 +298,15 @@ export class TmuxExternalInteractionObserver {
     }
   }
 
-  #project(record: TmuxInputHookRecord): void {
+  #project(record: TmuxInputHookRecord): boolean {
     if (
-      record.operationKind === "workspace.pane.read" &&
-      record.operationMarker === INTERNAL_READ_OPERATION_MARKER
+      consumeInternalReadOperation(
+        record.operationMarker,
+        record.runtimePaneId,
+        record.operationKind,
+      )
     ) {
-      return;
+      return true;
     }
     const ownPrefix = `${this.#daemonInstanceId}:`;
     const authoredOperationId = record.operationMarker?.startsWith(ownPrefix)
@@ -311,16 +323,16 @@ export class TmuxExternalInteractionObserver {
         `#{session_name}\t#{${"@tmux_ide_pane_id"}}`,
       ]);
     } catch {
-      return;
+      return false;
     }
     const separator = identity.indexOf("\t");
-    if (separator < 1) return;
+    if (separator < 1) return false;
     const sessionName = identity.slice(0, separator);
     const semanticPaneId = identity.slice(separator + 1);
-    if (!WorkspacePaneCreationReferenceSchemaZ.safeParse(semanticPaneId).success) return;
+    if (!WorkspacePaneCreationReferenceSchemaZ.safeParse(semanticPaneId).success) return false;
     const workspace = this.#registry.list().find((entry) => entry.sessionName === sessionName);
-    if (!workspace) return;
-    this.#onObserved({
+    if (!workspace) return false;
+    return this.#onObserved({
       workspaceName: workspace.name,
       semanticPaneId,
       operationKind: record.operationKind,

--- a/packages/daemon/src/lib/tmux-interaction-options.ts
+++ b/packages/daemon/src/lib/tmux-interaction-options.ts
@@ -2,5 +2,43 @@
 export const INTERNAL_SEND_OPERATION_OPTION = "@tmux_ide_send_operation";
 export const INTERNAL_READ_OPERATION_OPTION = "@tmux_ide_read_operation";
 
-/** Presence marker for product-owned capture-pane work (mirror seeds/status probes). */
-export const INTERNAL_READ_OPERATION_MARKER = "tmux-ide-internal-read-v1";
+import { randomUUID } from "node:crypto";
+
+const INTERNAL_READ_PREFIX = "tmux-ide-internal-read-v2:";
+const INTERNAL_READ_TTL_MS = 10_000;
+const INTERNAL_READ_CAPACITY = 512;
+const internalReads = new Map<string, { readonly paneId: string; readonly expiresAt: number }>();
+
+/**
+ * Register one bounded, one-use product capture. A marker-shaped tmux option
+ * alone is never trusted: the observer must redeem this in-memory fact for the
+ * exact pane and read operation before it suppresses any external activity.
+ */
+export function registerInternalReadOperation(runtimePaneId: string): string {
+  const now = Date.now();
+  for (const [marker, registration] of internalReads) {
+    if (registration.expiresAt <= now) internalReads.delete(marker);
+  }
+  while (internalReads.size >= INTERNAL_READ_CAPACITY) {
+    internalReads.delete(internalReads.keys().next().value!);
+  }
+  const marker = `${INTERNAL_READ_PREFIX}${randomUUID()}`;
+  internalReads.set(marker, { paneId: runtimePaneId, expiresAt: now + INTERNAL_READ_TTL_MS });
+  return marker;
+}
+
+export function consumeInternalReadOperation(
+  marker: string | null,
+  runtimePaneId: string,
+  operationKind: "workspace.pane.send" | "workspace.pane.read",
+): boolean {
+  if (marker === null || !marker.startsWith(INTERNAL_READ_PREFIX)) return false;
+  const registration = internalReads.get(marker);
+  if (!registration) return false;
+  internalReads.delete(marker);
+  return (
+    operationKind === "workspace.pane.read" &&
+    registration.paneId === runtimePaneId &&
+    registration.expiresAt > Date.now()
+  );
+}

--- a/packages/daemon/src/lib/workspace-multiplexer-verbs.test.ts
+++ b/packages/daemon/src/lib/workspace-multiplexer-verbs.test.ts
@@ -212,6 +212,36 @@ class FakeTmux {
         }
         return "";
       }
+      case "set-buffer": {
+        if (
+          args[1] !== "-b" ||
+          args[3] !== "--" ||
+          args[5] !== ";" ||
+          args[6] !== "paste-buffer" ||
+          args[7] !== "-d" ||
+          args[8] !== "-b" ||
+          args[9] !== args[2] ||
+          args[10] !== "-t" ||
+          args[12] !== ";" ||
+          args[13] !== "set-option" ||
+          args[14] !== "-p" ||
+          args[15] !== "-t" ||
+          args[16] !== args[11] ||
+          args[19] !== ";" ||
+          args[20] !== "send-keys" ||
+          args[21] !== "-t" ||
+          args[22] !== args[11] ||
+          args[23] !== "Enter" ||
+          args.length !== 24
+        ) {
+          throw new Error(`unsupported submitted send: ${args.join(" ")}`);
+        }
+        const pane = this.#pane(args[11]!);
+        pane.options.set(args[17]!, args[18]!);
+        // Model the synchronous pinned after-hook after the sole Enter key.
+        pane.options.delete(args[17]!);
+        return "";
+      }
       case "split-window": {
         const source = this.#pane(args[7]!);
         const pane = this.addPane(source.windowId);
@@ -554,6 +584,19 @@ describe("the multiplexer authority", () => {
       );
 
       expect(tmux.calls).toContainEqual([
+        "set-buffer",
+        "-b",
+        `tmux-ide-send-${operationId}`,
+        "--",
+        text,
+        ";",
+        "paste-buffer",
+        "-d",
+        "-b",
+        `tmux-ide-send-${operationId}`,
+        "-t",
+        "%0",
+        ";",
         "set-option",
         "-p",
         "-t",
@@ -564,9 +607,7 @@ describe("the multiplexer authority", () => {
         "send-keys",
         "-t",
         "%0",
-        "-l",
-        "--",
-        `${text}\r`,
+        "Enter",
       ]);
       expect(result).toMatchObject({
         verb: "workspace.pane.send",

--- a/packages/daemon/src/lib/workspace-multiplexer-verbs.ts
+++ b/packages/daemon/src/lib/workspace-multiplexer-verbs.ts
@@ -857,28 +857,93 @@ export class WorkspaceMultiplexerAuthority {
     const sourcePane = intent.sourceSemanticPaneId
       ? resolvePaneRow(before, intent.sourceSemanticPaneId)
       : null;
-    // A submitted message is one literal PTY write (text + carriage return),
-    // hence one after-send-keys hook. The marker, effect, and cleanup are one
-    // tmux command list so unrelated send-keys cannot interleave inside the
-    // daemon-authored attribution window. The synchronous pinned after-hook
-    // records and unsets the marker before tmux advances this command queue;
-    // unsetting here would run before the after-hook can observe it.
-    const input = intent.submit ? `${intent.text}\r` : intent.text;
-    this.#io.runTmux([
-      "set-option",
-      "-p",
-      "-t",
-      pane.paneId,
-      INTERNAL_SEND_OPERATION_OPTION,
-      internalInteractionOperationMarker(this.#daemonInstanceId, envelope.operationId),
-      ";",
-      "send-keys",
-      "-t",
-      pane.paneId,
-      "-l",
-      "--",
-      input,
-    ]);
+    // `send-keys -l` treats a trailing carriage return as literal input rather
+    // than the Enter key. For submitted text, paste the caller bytes from a
+    // private one-shot tmux buffer, then mark and send exactly one Enter key.
+    // This preserves literal-data safety and gives the after-send hook exactly
+    // one authoritative completion edge. Non-submitted input remains one
+    // marked literal send.
+    const marker = internalInteractionOperationMarker(this.#daemonInstanceId, envelope.operationId);
+    if (intent.submit) {
+      const buffer = `tmux-ide-send-${envelope.operationId}`;
+      try {
+        this.#io.runTmux([
+          "set-buffer",
+          "-b",
+          buffer,
+          "--",
+          intent.text,
+          ";",
+          "paste-buffer",
+          "-d",
+          "-b",
+          buffer,
+          "-t",
+          pane.paneId,
+          ";",
+          "set-option",
+          "-p",
+          "-t",
+          pane.paneId,
+          INTERNAL_SEND_OPERATION_OPTION,
+          marker,
+          ";",
+          "send-keys",
+          "-t",
+          pane.paneId,
+          "Enter",
+        ]);
+      } catch (error) {
+        try {
+          this.#io.runTmux(["delete-buffer", "-b", buffer]);
+        } catch {
+          // The one-shot paste already removed it, or the server disappeared.
+        }
+        try {
+          this.#io.runTmux([
+            "set-option",
+            "-pu",
+            "-t",
+            pane.paneId,
+            INTERNAL_SEND_OPERATION_OPTION,
+          ]);
+        } catch {
+          // The pane may have disappeared with the failed send.
+        }
+        throw error;
+      }
+    } else {
+      try {
+        this.#io.runTmux([
+          "set-option",
+          "-p",
+          "-t",
+          pane.paneId,
+          INTERNAL_SEND_OPERATION_OPTION,
+          marker,
+          ";",
+          "send-keys",
+          "-t",
+          pane.paneId,
+          "-l",
+          "--",
+          intent.text,
+        ]);
+      } catch (error) {
+        try {
+          this.#io.runTmux([
+            "set-option",
+            "-pu",
+            "-t",
+            pane.paneId,
+            INTERNAL_SEND_OPERATION_OPTION,
+          ]);
+        } catch {
+          // The pane may have disappeared with the failed send.
+        }
+        throw error;
+      }
+    }
 
     const observed = resolvePaneRow(this.#panes(sessionName), intent.semanticPaneId);
     if (observed.paneId !== pane.paneId) {

--- a/packages/daemon/src/terminal/attachments/agent-status-probe.ts
+++ b/packages/daemon/src/terminal/attachments/agent-status-probe.ts
@@ -35,8 +35,8 @@ import {
 } from "../../tui/detect/process-tree.ts";
 import { parseSnapshot } from "../../tui/detect/snapshot.ts";
 import {
-  INTERNAL_READ_OPERATION_MARKER,
   INTERNAL_READ_OPERATION_OPTION,
+  registerInternalReadOperation,
 } from "../../lib/tmux-interaction-options.ts";
 
 /** The per-pane facts the pure projector consumes (see `ApplicationShellPanePresentationFacts`). */
@@ -190,7 +190,7 @@ export function createTmuxAgentStatusProbe(deps: TmuxAgentStatusProbeDeps): Agen
         "-t",
         runtimePaneId,
         INTERNAL_READ_OPERATION_OPTION,
-        INTERNAL_READ_OPERATION_MARKER,
+        registerInternalReadOperation(runtimePaneId),
         ";",
         "capture-pane",
         "-p",

--- a/packages/daemon/src/terminal/mirror/session-channel.ts
+++ b/packages/daemon/src/terminal/mirror/session-channel.ts
@@ -64,8 +64,8 @@ import type {
 import { FlowLedger } from "./flow-ledger.ts";
 import { PaneFeed } from "./pane-feed.ts";
 import {
-  INTERNAL_READ_OPERATION_MARKER,
   INTERNAL_READ_OPERATION_OPTION,
+  registerInternalReadOperation,
 } from "../../lib/tmux-interaction-options.ts";
 
 /** Notifications whose payload cannot be applied directly — fall back to the
@@ -339,9 +339,10 @@ export class SessionChannel {
     // Keystroke ordering: pending coalesced input leaves before the probes.
     this.input.flush();
     const history = this.opts.historyLines ?? DEFAULT_HISTORY_LINES;
+    const internalReadMarker = registerInternalReadOperation(runtime);
     // Both probes ride one write burst; the FIFO reply order is the seam.
     this.io.commandListInline(
-      `set-option -p -t ${runtime} ${INTERNAL_READ_OPERATION_OPTION} ${INTERNAL_READ_OPERATION_MARKER} ; capture-pane -p -e -J -S -${history} -t ${runtime}`,
+      `set-option -p -t ${runtime} ${INTERNAL_READ_OPERATION_OPTION} ${internalReadMarker} ; capture-pane -p -e -J -S -${history} -t ${runtime}`,
       2,
       1,
       (reply) => {

--- a/packages/daemon/src/terminal/session-runtime/multiplexer-backend.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/multiplexer-backend.test.ts
@@ -188,7 +188,10 @@ describe("createSessionRuntimeMultiplexerBackend", () => {
       axis: "cols",
       cells: 80,
     });
-    await Promise.all([h.backend.mutate(mutation), h.backend.mutate(mutation)]);
+    await Promise.all([
+      h.backend.mutate(mutation, undefined, undefined, true),
+      h.backend.mutate(mutation, undefined, undefined, true),
+    ]);
     expect(h.connect).toHaveBeenCalledOnce();
     expect(h.submitIntent).toHaveBeenCalledTimes(2);
     expect(h.submitIntent.mock.calls.map((call) => call[1])).toEqual([
@@ -231,6 +234,9 @@ describe("createSessionRuntimeMultiplexerBackend", () => {
         axis: "cols",
         cells: 80,
       }),
+      undefined,
+      undefined,
+      true,
     );
     expect(registry.activeControllerLeaseCount()).toBe(0);
     const gui = registry.connect("alpha-session", "terminal-attachment", "host:gui");
@@ -270,6 +276,9 @@ describe("createSessionRuntimeMultiplexerBackend", () => {
           axis: "cols",
           cells: 80,
         }),
+        undefined,
+        undefined,
+        true,
       ),
     ).rejects.toBe(refusal);
     await typed.registry.dispose();
@@ -284,6 +293,9 @@ describe("createSessionRuntimeMultiplexerBackend", () => {
           axis: "cols",
           cells: 80,
         }),
+        undefined,
+        undefined,
+        true,
       ),
     ).rejects.toBeInstanceOf(SessionRuntimeIntentError);
     await generic.registry.dispose();
@@ -293,7 +305,7 @@ describe("createSessionRuntimeMultiplexerBackend", () => {
     const h = rig();
     const verbs = intents();
     for (const [index, intent] of verbs.entries()) {
-      await h.backend.mutate(request(intent, OPERATION_IDS[index]!));
+      await h.backend.mutate(request(intent, OPERATION_IDS[index]!), undefined, undefined, true);
     }
 
     expect(h.connect).toHaveBeenCalledTimes(verbs.length);
@@ -309,7 +321,7 @@ describe("createSessionRuntimeMultiplexerBackend", () => {
     );
     expect(
       h.submitIntent.mock.calls.find((call) => call[2].verb === "workspace.pane.send")?.[2],
-    ).toMatchObject({ origin: "sdk" });
+    ).toMatchObject({ origin: "gui" });
   });
 
   it("uses an exact live authenticated host grant and never manufactures an owner", async () => {
@@ -334,7 +346,7 @@ describe("createSessionRuntimeMultiplexerBackend", () => {
 
     await h.backend.mutate(request(intent), "host-a");
     expect(h.submitAuthenticatedIntent).toHaveBeenCalledOnce();
-    expect(h.submitAuthenticatedIntent.mock.calls[0]![2]).toMatchObject({ origin: "gui" });
+    expect(h.submitAuthenticatedIntent.mock.calls[0]![2]).toEqual(intent);
     expect(h.submitIntent).not.toHaveBeenCalled();
     expect(h.connect).toHaveBeenCalledTimes(1);
     await binding.close();
@@ -377,6 +389,23 @@ describe("createSessionRuntimeMultiplexerBackend", () => {
     );
     expect(h.connect).not.toHaveBeenCalled();
     expect(h.submitPaneCredentialIntent).not.toHaveBeenCalled();
+  });
+
+  it("rejects a direct semantic mutation with no authenticated principal", async () => {
+    const h = rig();
+    await expect(
+      h.backend.mutate(
+        request({
+          verb: "workspace.pane.resize",
+          workspaceName: "alpha",
+          semanticPaneId: "pane.alpha",
+          axis: "cols",
+          cells: 80,
+        }),
+      ),
+    ).rejects.toThrow("requires a live host, pane, or owner principal");
+    expect(h.connect).not.toHaveBeenCalled();
+    expect(h.submitIntent).not.toHaveBeenCalled();
   });
 
   it("re-resolves a pane credential at the final effect boundary", async () => {

--- a/packages/daemon/src/terminal/session-runtime/multiplexer-backend.ts
+++ b/packages/daemon/src/terminal/session-runtime/multiplexer-backend.ts
@@ -63,14 +63,6 @@ export function createSessionRuntimeMultiplexerBackend(
     }
   };
 
-  const withTrustedOrigin = (
-    intent: SessionRuntimeSemanticIntent,
-    origin: "gui" | "cli" | "sdk",
-  ): SessionRuntimeSemanticIntent =>
-    intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read"
-      ? { ...intent, origin }
-      : intent;
-
   const acquireOwner = (session: string): OwnerUse => {
     let owner = owners.get(session);
     if (!owner) {
@@ -101,6 +93,7 @@ export function createSessionRuntimeMultiplexerBackend(
       request: WorkspaceMultiplexerMutationRequest,
       authenticatedHostClientId?: string,
       sourcePaneCredential?: string,
+      ownerAuthorized = false,
     ): Promise<WorkspaceMultiplexerMutationResult> => {
       const session = options.resolveSession(request.intent.workspaceName);
       if (!session) {
@@ -123,7 +116,7 @@ export function createSessionRuntimeMultiplexerBackend(
           options.registry.submitAuthenticatedIntent(
             authenticatedContext,
             request.operationId,
-            withTrustedOrigin(request.intent as SessionRuntimeSemanticIntent, "gui"),
+            request.intent as SessionRuntimeSemanticIntent,
           ),
         );
         if (!result) throw new Error("Session mutation completed without a mutation result");
@@ -140,7 +133,7 @@ export function createSessionRuntimeMultiplexerBackend(
           options.registry.submitPaneCredentialIntent(
             session,
             request.operationId,
-            withTrustedOrigin(request.intent as SessionRuntimeSemanticIntent, "cli"),
+            request.intent as SessionRuntimeSemanticIntent,
             credentialSource,
             () => {
               const current = options.resolvePaneSourceCredential?.(
@@ -157,6 +150,9 @@ export function createSessionRuntimeMultiplexerBackend(
         if (!result) throw new Error("Session mutation completed without a mutation result");
         return result;
       }
+      if (!ownerAuthorized) {
+        throw new Error("Semantic mutation requires a live host, pane, or owner principal");
+      }
       const owner = acquireOwner(session);
       try {
         const lease = owner.consumer.acquireController();
@@ -164,7 +160,7 @@ export function createSessionRuntimeMultiplexerBackend(
           owner.consumer.submitIntent(
             lease,
             request.operationId,
-            withTrustedOrigin(request.intent as SessionRuntimeSemanticIntent, "sdk"),
+            request.intent as SessionRuntimeSemanticIntent,
           ),
         );
         if (!result) throw new Error("Session mutation completed without a mutation result");

--- a/packages/daemon/src/terminal/session-runtime/registry.ts
+++ b/packages/daemon/src/terminal/session-runtime/registry.ts
@@ -219,9 +219,11 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
     return this.#semanticMutations.submit(
       operationId,
       { ...intent, sourceSemanticPaneId: semanticPaneId },
-      semanticPaneId,
-      authorizeBeforeEffect,
-      "cli",
+      {
+        origin: "cli",
+        authenticatedSourceSemanticPaneId: semanticPaneId,
+        authorizeBeforeEffect,
+      },
     );
   }
 
@@ -337,13 +339,11 @@ export class SessionRuntimeRegistry implements PaneStreamMirror {
     if (!this.#semanticMutations) {
       return Promise.reject(new Error("Session semantic mutations are unavailable"));
     }
-    return this.#semanticMutations.submit(
-      operationId,
-      intent,
+    return this.#semanticMutations.submit(operationId, intent, {
+      origin: authenticatedOrigin ?? "sdk",
       authenticatedSourceSemanticPaneId,
       authorizeBeforeEffect,
-      authenticatedOrigin,
-    );
+    });
   }
 
   observeTmuxInteraction(observation: SessionRuntimeTmuxObservation): boolean {

--- a/packages/daemon/src/terminal/session-runtime/semantic-mutation-architecture.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/semantic-mutation-architecture.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const source = (relative: string) =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
+
+describe("semantic mutation production architecture", () => {
+  it("constructs one executor and one tmux authority only in their lifecycle owners", () => {
+    const registry = source("./registry.ts");
+    const daemon = source("../../lib/daemon-embed.ts");
+    expect(registry.match(/new SessionSemanticMutationExecutor\(/gu)).toHaveLength(1);
+    expect(daemon.match(/new WorkspaceMultiplexerAuthority\(/gu)).toHaveLength(1);
+    expect(daemon.match(/workspaceMultiplexer\.(?:mutate|readPane)\(/gu)).toHaveLength(2);
+  });
+
+  it("keeps every transport on mandatory trusted metadata with no adapter origin rewrite", () => {
+    const executor = source("./semantic-mutation-executor.ts");
+    const backend = source("./multiplexer-backend.ts");
+    expect(executor).toContain("authority: SessionRuntimeSubmissionAuthority");
+    expect(executor).toContain("origin: authority.origin");
+    expect(backend).not.toContain("withTrustedOrigin");
+    expect(backend).toContain("Semantic mutation requires a live host, pane, or owner principal");
+  });
+
+  it("gates pane send and suppresses the legacy generic completion channel", () => {
+    const server = source("../../command-center/server.ts");
+    const dispatcher = source("../../command-center/actions/dispatcher.ts");
+    const semanticActions = source("../../command-center/actions/semantic-multiplexer-actions.ts");
+    expect(server).toContain('"workspace.pane.send": "owner-and-operation-id"');
+    expect(server).toContain("isSemanticMultiplexerActionName(actionName");
+    expect(dispatcher).toContain("isSemanticMultiplexerActionName(actionName)");
+    expect(dispatcher).toContain("WorkspaceMultiplexerMutationResultSchemaZ.safeParse(result)");
+    expect(semanticActions).toContain('"workspace.pane.send"');
+    expect(dispatcher).toContain("ownerAuthorized: ownerAuthorizedContexts.has(c)");
+  });
+
+  it("contains no fixed internal-read suppression marker", () => {
+    expect(source("../../lib/tmux-interaction-options.ts")).not.toContain(
+      "tmux-ide-internal-read-v1",
+    );
+    expect(source("../../lib/tmux-external-interaction-observer.ts")).toContain(
+      "consumeInternalReadOperation",
+    );
+  });
+});

--- a/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.test.ts
@@ -117,6 +117,21 @@ function rig(
   return { executor, receipts };
 }
 
+function submit(
+  executor: SessionSemanticMutationExecutor,
+  operationId: string,
+  intent: SessionRuntimeSemanticIntent,
+  authenticatedSourceSemanticPaneId: string | null = null,
+  authorizeBeforeEffect?: () => void,
+  origin: "gui" | "tui" | "cli" | "sdk" = "sdk",
+) {
+  return executor.submit(operationId, intent, {
+    origin,
+    authenticatedSourceSemanticPaneId,
+    authorizeBeforeEffect,
+  });
+}
+
 describe("SessionSemanticMutationExecutor", () => {
   it("publishes result-derived accepted and observed receipts for all eleven intents", async () => {
     const intents: SessionRuntimeSemanticIntent[] = [
@@ -181,7 +196,7 @@ describe("SessionSemanticMutationExecutor", () => {
     executor = built.executor;
 
     for (const [index, intent] of intents.entries()) {
-      await executor.submit(operationId(index + 100), intent);
+      await submit(executor, operationId(index + 100), intent);
     }
 
     expect(built.receipts).toHaveLength(intents.length * 2);
@@ -214,7 +229,7 @@ describe("SessionSemanticMutationExecutor", () => {
       },
     });
     let authorized = true;
-    const first = executor.submit(OP_A, send());
+    const first = submit(executor, OP_A, send());
     const resizeIntent = {
       verb: "workspace.pane.resize",
       workspaceName: "alpha",
@@ -222,7 +237,7 @@ describe("SessionSemanticMutationExecutor", () => {
       axis: "cols",
       cells: 80,
     } as const;
-    const queued = executor.submit(OP_B, resizeIntent, null, () => {
+    const queued = submit(executor, OP_B, resizeIntent, null, () => {
       if (!authorized) throw new Error("controller became stale");
     });
     await vi.waitFor(() => expect(started).toEqual([OP_A]));
@@ -252,8 +267,8 @@ describe("SessionSemanticMutationExecutor", () => {
       },
     });
     let authorized = true;
-    const first = executor.submit(OP_A, send());
-    const queued = executor.submit(OP_B, send("alpha", "pane.beta"), "pane.source", () => {
+    const first = submit(executor, OP_A, send());
+    const queued = submit(executor, OP_B, send("alpha", "pane.beta"), "pane.source", () => {
       if (!authorized) throw new Error("principal became stale");
     });
     await vi.waitFor(() => expect(started).toEqual([OP_A]));
@@ -288,8 +303,8 @@ describe("SessionSemanticMutationExecutor", () => {
         return resultFor(operationId, intent);
       },
     });
-    const first = executor.submit(OP_A, send(), "pane.source", firstGuard);
-    const replay = executor.submit(OP_A, send(), "pane.source", replayGuard);
+    const first = submit(executor, OP_A, send(), "pane.source", firstGuard);
+    const replay = submit(executor, OP_A, send(), "pane.source", replayGuard);
     expect(replay).toBe(first);
     await vi.waitFor(() => expect(started).toEqual([OP_A]));
     executor.observe({
@@ -312,8 +327,8 @@ describe("SessionSemanticMutationExecutor", () => {
         return resultFor(operationId, intent);
       },
     });
-    const first = executor.submit(OP_A, send());
-    const second = executor.submit(OP_B, send("alpha", "pane.beta"));
+    const first = submit(executor, OP_A, send());
+    const second = submit(executor, OP_B, send("alpha", "pane.beta"));
 
     await vi.waitFor(() => expect(started).toEqual([OP_A]));
     executor.observe({
@@ -349,21 +364,21 @@ describe("SessionSemanticMutationExecutor", () => {
         return resultFor(id, intent);
       },
     });
-    const sent = executor.submit(operationId(20), send());
-    const resized = executor.submit(operationId(21), {
+    const sent = submit(executor, operationId(20), send());
+    const resized = submit(executor, operationId(21), {
       verb: "workspace.pane.resize",
       workspaceName: "alpha",
       semanticPaneId: "pane.alpha",
       axis: "cols",
       cells: 80,
     });
-    const read = executor.submit(operationId(22), {
+    const read = submit(executor, operationId(22), {
       verb: "workspace.pane.read",
       workspaceName: "alpha",
       semanticPaneId: "pane.alpha",
       origin: "sdk",
     });
-    const split = executor.submit(operationId(23), {
+    const split = submit(executor, operationId(23), {
       verb: "workspace.window.split",
       workspaceName: "alpha",
       semanticPaneId: "pane.alpha",
@@ -413,8 +428,8 @@ describe("SessionSemanticMutationExecutor", () => {
       axis: "cols",
       cells: 80,
     } as const;
-    const first = await executor.submit(OP_A, intent);
-    const retry = await executor.submit(OP_A, intent);
+    const first = await submit(executor, OP_A, intent);
+    const retry = await submit(executor, OP_A, intent);
     expect(execute).toHaveBeenCalledOnce();
     expect(first).toMatchObject({ outcome: "applied", cells: 72 });
     expect(retry).toMatchObject({ outcome: "replayed", cells: 72 });
@@ -430,8 +445,8 @@ describe("SessionSemanticMutationExecutor", () => {
         return resultFor(operationId, intent);
       },
     });
-    const alpha = executor.submit(OP_A, send("alpha", "pane.alpha"));
-    const beta = executor.submit(OP_B, send("beta", "pane.beta"));
+    const alpha = submit(executor, OP_A, send("alpha", "pane.alpha"));
+    const beta = submit(executor, OP_B, send("beta", "pane.beta"));
     await vi.waitFor(() => expect(new Set(started)).toEqual(new Set([OP_A, OP_B])));
 
     executor.observe({
@@ -464,14 +479,14 @@ describe("SessionSemanticMutationExecutor", () => {
     const { executor } = rig({ execute });
     const alphaPending = Array.from(
       { length: SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY },
-      (_, index) => executor.submit(operationId(index + 1), send("alpha", "pane.alpha")),
+      (_, index) => submit(executor, operationId(index + 1), send("alpha", "pane.alpha")),
     );
     await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
     await expect(
-      executor.submit(operationId(10_000), send("alpha", "pane.alpha")),
+      submit(executor, operationId(10_000), send("alpha", "pane.alpha")),
     ).rejects.toMatchObject({ outcome: "rejected" });
     await expect(
-      executor.submit(operationId(10_001), {
+      submit(executor, operationId(10_001), {
         verb: "workspace.pane.resize",
         workspaceName: "beta",
         semanticPaneId: "pane.beta",
@@ -493,8 +508,8 @@ describe("SessionSemanticMutationExecutor", () => {
         return resultFor(id, intent);
       },
     });
-    const alpha = executor.submit(OP_A, send("alpha", "pane.alpha"));
-    const beta = executor.submit(OP_A, send("beta", "pane.beta"));
+    const alpha = submit(executor, OP_A, send("alpha", "pane.alpha"));
+    const beta = submit(executor, OP_A, send("beta", "pane.beta"));
     await vi.waitFor(() => expect(new Set(started)).toEqual(new Set(["alpha", "beta"])));
     executor.observe({
       operationId: OP_A,
@@ -527,7 +542,8 @@ describe("SessionSemanticMutationExecutor", () => {
         return resultFor(id, intent);
       },
     });
-    const completed = executor.submit(
+    const completed = submit(
+      executor,
       OP_A,
       {
         verb: "workspace.pane.resize",
@@ -560,8 +576,8 @@ describe("SessionSemanticMutationExecutor", () => {
       axis: "cols",
       cells: 80,
     } as const;
-    await executor.submit(OP_A, intent, null, undefined, "gui");
-    await expect(executor.submit(OP_A, intent, null, undefined, "tui")).rejects.toMatchObject({
+    await submit(executor, OP_A, intent, null, undefined, "gui");
+    await expect(submit(executor, OP_A, intent, null, undefined, "tui")).rejects.toMatchObject({
       outcome: "rejected",
     });
     expect(execute).toHaveBeenCalledOnce();
@@ -577,7 +593,7 @@ describe("SessionSemanticMutationExecutor", () => {
     const disconnect = executor.onReceipt(disconnected);
     disconnect();
 
-    const submitted = executor.submit(OP_A, send());
+    const submitted = submit(executor, OP_A, send());
     await vi.waitFor(() => expect(slow).toHaveBeenCalledTimes(1));
     executor.observe({
       operationId: OP_A,
@@ -595,8 +611,8 @@ describe("SessionSemanticMutationExecutor", () => {
       resultFor(operationId, intent),
     );
     const { executor, receipts } = rig({ execute });
-    const first = executor.submit(OP_A, send());
-    const retry = executor.submit(OP_A, send());
+    const first = submit(executor, OP_A, send());
+    const retry = submit(executor, OP_A, send());
     await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
     executor.observe({
       operationId: OP_A,
@@ -605,7 +621,7 @@ describe("SessionSemanticMutationExecutor", () => {
       operationKind: "workspace.pane.send",
     });
     await Promise.all([first, retry]);
-    await executor.submit(OP_A, send());
+    await submit(executor, OP_A, send());
     expect(execute).toHaveBeenCalledTimes(1);
     expect(receipts.map((receipt) => receipt.phase)).toEqual(["accepted", "observed"]);
     await executor.dispose();
@@ -616,11 +632,11 @@ describe("SessionSemanticMutationExecutor", () => {
       resultFor(operationId, intent),
     );
     const { executor, receipts } = rig({ execute });
-    const first = executor.submit(OP_A, send());
+    const first = submit(executor, OP_A, send());
     await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
 
     await expect(
-      executor.submit(OP_A, { ...send(), semanticPaneId: "pane.other" }),
+      submit(executor, OP_A, { ...send(), semanticPaneId: "pane.other" }),
     ).rejects.toMatchObject({ outcome: "rejected" });
     expect(execute).toHaveBeenCalledTimes(1);
     expect(receipts.map((receipt) => receipt.phase)).toEqual(["accepted"]);
@@ -653,7 +669,7 @@ describe("SessionSemanticMutationExecutor", () => {
     executor = built.executor;
 
     for (let index = 1; index <= SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY + 1; index += 1) {
-      await executor.submit(operationId(index), send());
+      await submit(executor, operationId(index), send());
     }
 
     expect(execute).toHaveBeenCalledTimes(SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY + 1);
@@ -667,13 +683,13 @@ describe("SessionSemanticMutationExecutor", () => {
     );
     const { executor, receipts } = rig({ execute });
     const pending = Array.from({ length: SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY }, (_, index) =>
-      executor.submit(operationId(index + 1), send()),
+      submit(executor, operationId(index + 1), send()),
     );
-    const firstRetry = executor.submit(operationId(1), send());
+    const firstRetry = submit(executor, operationId(1), send());
     expect(firstRetry).toBe(pending[0]);
 
     await expect(
-      executor.submit(operationId(SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY + 1), send()),
+      submit(executor, operationId(SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY + 1), send()),
     ).rejects.toMatchObject({ outcome: "rejected" });
     expect(receipts).toHaveLength(SESSION_RUNTIME_OPERATION_LEDGER_CAPACITY);
 
@@ -688,14 +704,14 @@ describe("SessionSemanticMutationExecutor", () => {
         throw new Error("no pane");
       },
     });
-    await expect(rejected.executor.submit(OP_A, send())).rejects.toMatchObject({
+    await expect(submit(rejected.executor, OP_A, send())).rejects.toMatchObject({
       outcome: "rejected",
     });
     expect(rejected.receipts.map((receipt) => receipt.phase)).toEqual(["accepted", "rejected"]);
     await rejected.executor.dispose();
 
     const timedOut = rig({ timeout: 5 });
-    await expect(timedOut.executor.submit(OP_B, send())).rejects.toMatchObject({
+    await expect(submit(timedOut.executor, OP_B, send())).rejects.toMatchObject({
       outcome: "timed-out",
     });
     expect(timedOut.receipts.map((receipt) => receipt.phase)).toEqual(["accepted", "timed-out"]);
@@ -705,7 +721,7 @@ describe("SessionSemanticMutationExecutor", () => {
   it("rejects a structural success that cannot produce verb-matched proof", async () => {
     const broken = rig({ execute: () => undefined });
     await expect(
-      broken.executor.submit(OP_A, {
+      submit(broken.executor, OP_A, {
         verb: "workspace.pane.resize",
         workspaceName: "alpha",
         semanticPaneId: "pane.alpha",
@@ -725,7 +741,7 @@ describe("SessionSemanticMutationExecutor", () => {
       timeout: 1,
     });
     await expect(
-      refused.executor.submit(OP_A, {
+      submit(refused.executor, OP_A, {
         verb: "workspace.pane.resize",
         workspaceName: "alpha",
         semanticPaneId: "pane.alpha",
@@ -750,8 +766,8 @@ describe("SessionSemanticMutationExecutor", () => {
       axis: "cols",
       cells: 80,
     } as const;
-    const first = await executor.submit(OP_A, intent).catch((error: unknown) => error);
-    const retry = await executor.submit(OP_A, intent).catch((error: unknown) => error);
+    const first = await submit(executor, OP_A, intent).catch((error: unknown) => error);
+    const retry = await submit(executor, OP_A, intent).catch((error: unknown) => error);
     expect(retry).toBe(first);
     expect(execute).toHaveBeenCalledOnce();
     expect(receipts.map(({ phase }) => phase)).toEqual(["accepted", "rejected"]);
@@ -766,8 +782,8 @@ describe("SessionSemanticMutationExecutor", () => {
         return resultFor(operationId, intent);
       },
     });
-    const first = executor.submit(OP_A, send());
-    const second = executor.submit(OP_B, send("alpha", "pane.beta"));
+    const first = submit(executor, OP_A, send());
+    const second = submit(executor, OP_B, send("alpha", "pane.beta"));
     await vi.waitFor(() => expect(started).toEqual([OP_A]));
 
     const disposed = executor.dispose();

--- a/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.ts
+++ b/packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.ts
@@ -23,6 +23,13 @@ export interface SessionRuntimeTmuxObservation {
   readonly operationKind: "workspace.pane.send" | "workspace.pane.read";
 }
 
+export interface SessionRuntimeSubmissionAuthority {
+  /** Trusted submitting surface, established outside caller-authored intent JSON. */
+  readonly origin: AuthoredInteractionOrigin;
+  readonly authenticatedSourceSemanticPaneId?: string | null;
+  readonly authorizeBeforeEffect?: () => void;
+}
+
 export type SessionRuntimeReceiptInput = Omit<InteractionReceipt, "type" | "sequence">;
 
 export interface SessionSemanticMutationExecutorOptions {
@@ -94,9 +101,7 @@ export class SessionSemanticMutationExecutor {
   submit(
     rawOperationId: string,
     rawIntent: SessionRuntimeSemanticIntent,
-    authenticatedSourceSemanticPaneId: string | null = null,
-    authorizeBeforeEffect?: () => void,
-    authenticatedOrigin?: AuthoredInteractionOrigin,
+    authority: SessionRuntimeSubmissionAuthority,
   ): Promise<SessionRuntimeIntentResult> {
     if (this.#disposed) {
       return Promise.reject(
@@ -104,12 +109,18 @@ export class SessionSemanticMutationExecutor {
       );
     }
     const operationId = z.uuid().parse(rawOperationId);
-    const intent = SessionRuntimeSemanticIntentSchemaZ.parse(rawIntent);
+    let intent = SessionRuntimeSemanticIntentSchemaZ.parse(rawIntent);
+    // Caller JSON never decides attribution. Normalize authored send/read
+    // intent before fingerprinting and before the sole synchronous effect.
+    if (intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read") {
+      intent = { ...intent, origin: authority.origin };
+    }
+    const authenticatedSourceSemanticPaneId = authority.authenticatedSourceSemanticPaneId ?? null;
     const session = this.#options.resolveSession(intent.workspaceName);
     // All unresolved workspace names share one bounded refusal bucket. Never
     // retain an attacker-controlled workspace-name alias as a ledger key.
     const ledger = this.#ledger(session ?? MISSING_SESSION_LEDGER);
-    const origin = authenticatedOrigin ?? ("origin" in intent ? intent.origin : "sdk");
+    const origin = authority.origin;
     const fingerprint = JSON.stringify([intent, authenticatedSourceSemanticPaneId, origin]);
     const existing = ledger.get(operationId);
     if (existing) {
@@ -153,7 +164,7 @@ export class SessionSemanticMutationExecutor {
           operationId,
           intent,
           authenticatedSourceSemanticPaneId,
-          authorizeBeforeEffect,
+          authority.authorizeBeforeEffect,
           origin,
         ),
       () =>
@@ -162,7 +173,7 @@ export class SessionSemanticMutationExecutor {
           operationId,
           intent,
           authenticatedSourceSemanticPaneId,
-          authorizeBeforeEffect,
+          authority.authorizeBeforeEffect,
           origin,
         ),
     );

--- a/packages/daemon/src/terminal/session-runtime/semantic-mutation-route-cutover.live.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/semantic-mutation-route-cutover.live.test.ts
@@ -1,0 +1,285 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import type { InteractionReceipt, SessionRuntimeSemanticIntent } from "@tmux-ide/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TmuxExternalInteractionObserver } from "../../lib/tmux-external-interaction-observer.ts";
+import { WorkspaceMultiplexerAuthority } from "../../lib/workspace-multiplexer-verbs.ts";
+import { WorkspaceRegistry } from "../../lib/workspace-registry.ts";
+import { SessionRuntimeRegistry } from "./registry.ts";
+
+const tmuxPath = spawnSync("sh", ["-c", "command -v tmux"], { encoding: "utf8" }).stdout.trim();
+const hasTmux = tmuxPath.length > 0;
+
+describe.skipIf(!hasTmux).sequential("semantic mutation production cutover, live tmux", () => {
+  const sockets: string[] = [];
+
+  afterEach(() => {
+    for (const socket of sockets.splice(0)) {
+      spawnSync(tmuxPath, ["-L", socket, "kill-server"], { stdio: "ignore" });
+    }
+  });
+
+  it("executes a mixed FIFO once and publishes one accepted plus one verified terminal receipt", async () => {
+    const socket = `zz-m56-cutover-${process.pid}-${randomUUID().slice(0, 8)}`;
+    const session = `m56-cutover-${randomUUID().slice(0, 8)}`;
+    const generation = randomUUID();
+    const workspaceName = "cutover.workspace";
+    const effectFile = join(tmpdir(), `tmux-ide-m56-effect-${randomUUID()}`);
+    const readyFile = join(tmpdir(), `tmux-ide-m56-ready-${randomUUID()}`);
+    sockets.push(socket);
+    writeFileSync(effectFile, "");
+    writeFileSync(readyFile, "");
+    const run = (args: readonly string[]): string => {
+      const result = spawnSync(tmuxPath, ["-L", socket, ...args], { encoding: "utf8" });
+      if (result.status !== 0) throw new Error(result.stderr || `tmux ${args[0]} failed`);
+      return result.stdout;
+    };
+
+    const firstPane = run([
+      "new-session",
+      "-d",
+      "-x",
+      "120",
+      "-y",
+      "40",
+      "-P",
+      "-F",
+      "#{pane_id}",
+      "-s",
+      session,
+      "-n",
+      "main",
+      `printf r > '${readyFile}'; exec /bin/sh`,
+    ]).trim();
+    const secondPane = run([
+      "split-window",
+      "-h",
+      "-P",
+      "-F",
+      "#{pane_id}",
+      "-t",
+      firstPane,
+    ]).trim();
+    const auxPane = run([
+      "new-window",
+      "-d",
+      "-P",
+      "-F",
+      "#{pane_id}",
+      "-t",
+      `=${session}`,
+      "-n",
+      "aux",
+    ]).trim();
+    run(["set-option", "-p", "-t", firstPane, "@tmux_ide_pane_id", "pane.editor"]);
+    run(["set-option", "-p", "-t", secondPane, "@tmux_ide_pane_id", "pane.tests"]);
+    run(["set-option", "-p", "-t", auxPane, "@tmux_ide_pane_id", "pane.aux"]);
+    run(["set-option", "-w", "-t", firstPane, "@tmux_ide_window_id", "window.main"]);
+    await vi.waitFor(() => expect(readFileSync(readyFile, "utf8")).toBe("r"), {
+      timeout: 15_000,
+    });
+
+    const workspaceRegistry = new WorkspaceRegistry({
+      dir: tmpdir(),
+      listSessions: () => [session],
+    });
+    workspaceRegistry.add({ name: workspaceName, sessionName: session, projectDir: tmpdir() });
+    const socketPath = run(["display-message", "-p", "#{socket_path}"]).trim();
+    const tmuxAuthority = {
+      executablePath: tmuxPath,
+      socketSelector: { kind: "path" as const, path: socketPath },
+    };
+    const authority = new WorkspaceMultiplexerAuthority({
+      daemonInstanceId: generation,
+      registry: workspaceRegistry,
+      tmuxAuthority,
+    });
+    const receipts: InteractionReceipt[] = [];
+    const executionOrder: string[] = [];
+    let sequence = 0;
+    let registry!: SessionRuntimeRegistry;
+    registry = new SessionRuntimeRegistry({
+      generation,
+      semanticMutations: {
+        resolveSession: (workspace) =>
+          workspace === workspaceName
+            ? (workspaceRegistry.get(workspace)?.sessionName ?? null)
+            : null,
+        execute: (operationId, intent) => {
+          executionOrder.push(intent.verb);
+          if (intent.verb === "workspace.pane.read") {
+            authority.readPane(operationId, intent);
+            return;
+          }
+          return authority.mutate({
+            operationId,
+            expectedDaemonInstanceId: generation,
+            intent,
+          });
+        },
+        publishReceipt: (receipt) => {
+          const published = {
+            type: "interaction.receipt",
+            sequence: ++sequence,
+            ...receipt,
+          } as InteractionReceipt;
+          receipts.push(published);
+          return published;
+        },
+        observationTimeoutMs: 5_000,
+      },
+    });
+    const observer = new TmuxExternalInteractionObserver({
+      daemonInstanceId: generation,
+      tmuxAuthority,
+      registry: workspaceRegistry,
+      onObserved: (observation) =>
+        observation.operationId === null
+          ? false
+          : registry.observeTmuxInteraction({
+              operationId: observation.operationId,
+              workspaceName: observation.workspaceName,
+              semanticPaneId: observation.semanticPaneId,
+              operationKind: observation.operationKind,
+            }),
+    });
+    observer.start();
+
+    const consumer = registry.connect(session, "command-center", `live:${randomUUID()}`);
+    const lease = consumer.acquireController();
+    const ids = Array.from({ length: 8 }, () => randomUUID());
+    const intents: readonly SessionRuntimeSemanticIntent[] = [
+      {
+        verb: "workspace.rename",
+        workspaceName,
+        scope: "window",
+        target: { by: "pane", semanticPaneId: "pane.editor" },
+        name: "cutover-proof",
+      },
+      {
+        verb: "workspace.pane.send",
+        workspaceName,
+        semanticPaneId: "pane.editor",
+        text: `printf x >> '${effectFile}'`,
+        submit: true,
+        origin: "sdk",
+      },
+      {
+        verb: "workspace.pane.resize",
+        workspaceName,
+        semanticPaneId: "pane.editor",
+        axis: "cols",
+        cells: 48,
+      },
+      {
+        verb: "workspace.pane.read",
+        workspaceName,
+        semanticPaneId: "pane.editor",
+        origin: "sdk",
+      },
+      {
+        verb: "workspace.pane.swap",
+        workspaceName,
+        sourceSemanticPaneId: "pane.editor",
+        targetSemanticPaneId: "pane.tests",
+      },
+      {
+        verb: "workspace.pane.select",
+        workspaceName,
+        semanticPaneId: "pane.tests",
+      },
+      {
+        verb: "workspace.pane.zoom.toggle",
+        workspaceName,
+        semanticPaneId: "pane.editor",
+        desired: "zoomed",
+      },
+      {
+        verb: "workspace.window.split",
+        workspaceName,
+        semanticPaneId: "pane.editor",
+        direction: "down",
+        displayTitle: "Cutover child",
+      },
+    ];
+
+    try {
+      const firstResults = await Promise.all(
+        intents.map((intent, index) => consumer.submitIntent(lease, ids[index]!, intent)),
+      );
+      expect(executionOrder).toEqual(intents.map(({ verb }) => verb));
+      expect(receipts).toHaveLength(intents.length * 2);
+      for (const [index, intent] of intents.entries()) {
+        const operationReceipts = receipts.filter(({ operationId }) => operationId === ids[index]);
+        expect(operationReceipts.map(({ phase }) => phase)).toEqual(["accepted", "observed"]);
+        expect(operationReceipts[1]).toMatchObject({
+          operationKind: intent.verb,
+          phase: "observed",
+          proof: { operationKind: intent.verb },
+        });
+      }
+
+      expect(run(["display-message", "-p", "-t", firstPane, "#{window_name}"]).trim()).toBe(
+        "cutover-proof",
+      );
+      await vi.waitFor(() => expect(readFileSync(effectFile, "utf8")).toBe("x"));
+
+      const receiptCount = receipts.length;
+      const replayed = await Promise.all(
+        intents.map((intent, index) => consumer.submitIntent(lease, ids[index]!, intent)),
+      );
+      expect(receipts).toHaveLength(receiptCount);
+      expect(executionOrder).toHaveLength(intents.length);
+      expect(replayed[0]).toMatchObject({ outcome: "replayed" });
+      expect(replayed[1]).toMatchObject({ outcome: "replayed" });
+      expect(replayed[2]).toMatchObject({ outcome: "replayed" });
+      expect(replayed[3]).toBeUndefined();
+      expect(replayed[4]).toMatchObject({ outcome: "replayed" });
+      expect(readFileSync(effectFile, "utf8")).toBe("x");
+
+      const createdPane = (firstResults[7] as { semanticPaneId: string }).semanticPaneId;
+      const finalIds = [randomUUID(), randomUUID(), randomUUID()];
+      const finalIntents: readonly SessionRuntimeSemanticIntent[] = [
+        { verb: "workspace.pane.kill", workspaceName, semanticPaneId: createdPane },
+        {
+          verb: "workspace.window.kill",
+          workspaceName,
+          target: { by: "pane", semanticPaneId: "pane.aux" },
+        },
+        { verb: "workspace.session.kill", workspaceName },
+      ];
+      for (const [index, intent] of finalIntents.entries()) {
+        await consumer.submitIntent(lease, finalIds[index]!, intent);
+      }
+      expect(executionOrder).toEqual([...intents, ...finalIntents].map(({ verb }) => verb));
+      for (const [index, intent] of finalIntents.entries()) {
+        const operationReceipts = receipts.filter(
+          ({ operationId }) => operationId === finalIds[index],
+        );
+        expect(operationReceipts.map(({ phase }) => phase)).toEqual(["accepted", "observed"]);
+        expect(operationReceipts[1]?.proof).toMatchObject({ operationKind: intent.verb });
+      }
+      expect(spawnSync(tmuxPath, ["-L", socket, "has-session", "-t", session]).status).not.toBe(0);
+      const finalReceiptCount = receipts.length;
+      for (const [index, intent] of finalIntents.entries()) {
+        expect(await consumer.submitIntent(lease, finalIds[index]!, intent)).toMatchObject({
+          outcome: "replayed",
+        });
+      }
+      expect(receipts).toHaveLength(finalReceiptCount);
+      expect(executionOrder).toHaveLength(11);
+    } finally {
+      await consumer.close();
+      await observer.dispose();
+      await registry.dispose();
+      await authority.dispose();
+      rmSync(effectFile, { force: true });
+      rmSync(readyFile, { force: true });
+    }
+  }, 30_000);
+});

--- a/packages/daemon/src/tui/detect/snapshot.ts
+++ b/packages/daemon/src/tui/detect/snapshot.ts
@@ -7,10 +7,6 @@
  * unit-tested; `readPaneSnapshot` is the thin tmux I/O wrapper.
  */
 import { runTmux } from "@tmux-ide/tmux-bridge";
-import {
-  INTERNAL_READ_OPERATION_MARKER,
-  INTERNAL_READ_OPERATION_OPTION,
-} from "../../lib/tmux-interaction-options.ts";
 
 export interface PaneSnapshot {
   /** Last N non-empty lines, ANSI-stripped, trailing whitespace trimmed. */
@@ -66,34 +62,14 @@ export function parseSnapshot(raw: string, opts: { lines?: number } = {}): PaneS
 export function readPaneSnapshot(target: string, opts: { lines?: number } = {}): PaneSnapshot {
   const lines = opts.lines ?? DEFAULT_LINES;
   try {
-    const raw = runTmux(
-      [
-        "set-option",
-        "-p",
-        "-t",
-        target,
-        INTERNAL_READ_OPERATION_OPTION,
-        INTERNAL_READ_OPERATION_MARKER,
-        ";",
-        "capture-pane",
-        "-t",
-        target,
-        "-p",
-        "-J",
-        "-S",
-        `-${lines}`,
-      ],
-      { encoding: "utf-8" },
-    ) as string;
-    // One tmux command-list owns both operations, so another GUI/TUI reader
-    // cannot consume this pane-scoped marker between mark and capture.
+    // OpenTUI is a separate process from the daemon observer. Do not mint an
+    // in-memory "internal" registration it cannot redeem; this read remains
+    // honestly observable as external until the TUI transport cutover.
+    const raw = runTmux(["capture-pane", "-t", target, "-p", "-J", "-S", `-${lines}`], {
+      encoding: "utf-8",
+    }) as string;
     return parseSnapshot(raw, { lines });
   } catch {
-    try {
-      runTmux(["set-option", "-pu", "-t", target, INTERNAL_READ_OPERATION_OPTION]);
-    } catch {
-      // The pane may have closed between marker installation and cleanup.
-    }
     return { bottomNonEmpty: [], text: "", raw: "" };
   }
 }

--- a/packages/daemon/src/tui/mirror/session-mirror.ts
+++ b/packages/daemon/src/tui/mirror/session-mirror.ts
@@ -40,10 +40,6 @@ import { initialWindowSizeCommands, windowSizeClaimNeedsCorrection } from "./win
 import type { WidgetMarker } from "@tmux-ide/contracts";
 import { tapInputOutput, tapRepin, tapResize } from "./perf-tap.ts";
 import {
-  INTERNAL_READ_OPERATION_MARKER,
-  INTERNAL_READ_OPERATION_OPTION,
-} from "../../lib/tmux-interaction-options.ts";
-import {
   parseLayout,
   parseLayoutChange,
   parseWindowPaneChanged,
@@ -848,15 +844,10 @@ export class SessionMirror {
       const mirror = this.mirrors.get(pane.id);
       if (!mirror) continue;
       const seedReply = this.client
-        .commandList(
-          `set-option -p -t ${pane.id} ${INTERNAL_READ_OPERATION_OPTION} ${INTERNAL_READ_OPERATION_MARKER} ; capture-pane -p -e -J -S -2000 -t ${pane.id}`,
-          2,
-          1,
-        )
+        // This OpenTUI process cannot redeem the daemon's in-memory internal
+        // read registrations. Keep the capture unmarked and honestly external.
+        .command(`capture-pane -p -e -J -S -2000 -t ${pane.id}`)
         .catch(() => {
-          // A successful capture consumes the marker in after-capture-pane.
-          // The command-list makes mark + capture indivisible to other clients.
-          this.client.send(`set-option -pu -t ${pane.id} ${INTERNAL_READ_OPERATION_OPTION}`);
           return [] as string[];
         });
       // The pane's REAL cursor (D2): the seed replay leaves xterm's cursor

--- a/scripts/pack-check-run.mjs
+++ b/scripts/pack-check-run.mjs
@@ -102,6 +102,8 @@ try {
     "SessionRuntimeSourcePaneBinding",
     "executeAuthorized",
     "The daemon has reached its bounded multiplexer operation capacity.",
+    "tmux-ide-internal-read-v1",
+    "withTrustedOrigin",
   ]) {
     if (installedBundle.includes(removed)) {
       throw new Error(`Installed CLI still contains removed authority architecture: ${removed}`);
@@ -112,6 +114,9 @@ try {
     "X-Tmux-Ide-Pane-Source-Credential",
     "X-Tmux-Ide-Host-Client-Id",
     "submitPaneCredentialIntent",
+    "SessionSemanticMutationExecutor",
+    "registerInternalReadOperation",
+    "Semantic mutation requires a live host, pane, or owner principal",
   ]) {
     if (!installedBundle.includes(required)) {
       throw new Error(


### PR DESCRIPTION
## Summary
- route every semantic tmux mutation through the single SessionRuntime FIFO with explicit authority
- close anonymous loopback access, normalize trusted provenance, and remove duplicate semantic completions
- replace forgeable read markers with bounded one-use daemon registrations
- add deterministic live acceptance for all 11 mutation verbs and packed-bundle architecture guards

## Verification
- independent review: approved after three rounds
- daemon: 242 files / 3192 tests
- renderer: 73 files / 851 tests
- Electron: 31 files / 334 tests
- Bun daemon parity, typechecks, lint, format, diff, build and pack/install gates passed
- desktop smoke: first repository run hit the known disposable-tmux restart race; immediate isolated rerun passed all rungs including replay repair

Completes the final route-cutover slice of Sfora card #185.