### PR TITLE
Add the canonical terminal replica core

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1462,8 +1462,8 @@ function refineScene(scene, ctx) {
       path: ["windows"]
     });
   }
-  for (const [key, window] of windowEntries) {
-    if (key !== window.id) {
+  for (const [key, window2] of windowEntries) {
+    if (key !== window2.id) {
       ctx.addIssue({
         code: z10.ZodIssueCode.custom,
         message: "window record key must match window id",
@@ -1510,17 +1510,17 @@ function refineScene(scene, ctx) {
       path: ["floatingOrder"]
     });
   }
-  for (const [windowId, window] of windowEntries) {
+  for (const [windowId, window2] of windowEntries) {
     const dockedAt = dockMembership.get(windowId);
     const isFloating = floatingSet.has(windowId);
-    if (window.placement.mode === "docked") {
+    if (window2.placement.mode === "docked") {
       if (!dockedAt || isFloating) {
         ctx.addIssue({
           code: z10.ZodIssueCode.custom,
           message: "docked window must occur only in the dock tree",
           path: ["windows", windowId, "placement"]
         });
-      } else if (window.placement.docked?.stackId !== dockedAt.stackId || window.placement.docked.index !== dockedAt.index) {
+      } else if (window2.placement.docked?.stackId !== dockedAt.stackId || window2.placement.docked.index !== dockedAt.index) {
         ctx.addIssue({
           code: z10.ZodIssueCode.custom,
           message: "dock placement memory must match current stack membership",
@@ -7893,9 +7893,98 @@ var init_daemon_resource_request = __esm({
   }
 });
 
-// packages/contracts/src/session-runtime.ts
+// packages/contracts/src/terminal-replica.ts
 import { z as z48 } from "zod";
-var SessionRuntimeGenerationSchemaZ, SessionRuntimeClientIdSchemaZ, SessionRuntimeSessionNameSchemaZ, SessionRuntimeControllerRoleSchemaZ, SessionRuntimeControllerLeaseSchemaZ, SessionRuntimeControllerSnapshotSchemaZ, TerminalReplicaRevisionSchemaZ, SessionRuntimePaneReadIntentSchemaZ, SessionRuntimeSemanticIntentSchemaZ;
+var TerminalReplicaColorSchemaZ, TerminalReplicaCellAttributesSchemaZ, TerminalReplicaCellSchemaZ, TerminalReplicaRowSchemaZ, TerminalReplicaCursorSchemaZ, TerminalReplicaModesSchemaZ, TerminalReplicaPlacementSchemaZ, TerminalReplicaSnapshotSchemaZ, TerminalReplicaPatchPayloadSchemaZ, TerminalReplicaTombstonePayloadSchemaZ, TERMINAL_REPLICA_ATTRIBUTE;
+var init_terminal_replica = __esm({
+  "packages/contracts/src/terminal-replica.ts"() {
+    "use strict";
+    TerminalReplicaColorSchemaZ = z48.discriminatedUnion("kind", [
+      z48.object({ kind: z48.literal("default") }).strict(),
+      z48.object({ kind: z48.literal("indexed"), index: z48.number().int().min(0).max(255) }).strict(),
+      z48.object({ kind: z48.literal("rgb"), value: z48.number().int().min(0).max(16777215) }).strict()
+    ]);
+    TerminalReplicaCellAttributesSchemaZ = z48.number().int().min(0).max(255);
+    TerminalReplicaCellSchemaZ = z48.object({
+      grapheme: z48.string(),
+      width: z48.union([z48.literal(0), z48.literal(1), z48.literal(2)]),
+      foreground: TerminalReplicaColorSchemaZ,
+      background: TerminalReplicaColorSchemaZ,
+      attributes: TerminalReplicaCellAttributesSchemaZ
+    }).strict();
+    TerminalReplicaRowSchemaZ = z48.object({ cells: z48.array(TerminalReplicaCellSchemaZ), wrapped: z48.boolean() }).strict();
+    TerminalReplicaCursorSchemaZ = z48.object({
+      x: z48.number().int().nonnegative(),
+      y: z48.number().int().nonnegative(),
+      hidden: z48.boolean(),
+      style: z48.enum(["block", "underline", "bar"]),
+      blink: z48.boolean()
+    }).strict();
+    TerminalReplicaModesSchemaZ = z48.object({
+      alternateScreen: z48.boolean(),
+      applicationCursor: z48.boolean(),
+      applicationKeypad: z48.boolean(),
+      bracketedPaste: z48.boolean(),
+      insert: z48.boolean(),
+      origin: z48.boolean(),
+      wraparound: z48.boolean(),
+      mouseTracking: z48.boolean(),
+      synchronizedOutput: z48.boolean()
+    }).strict();
+    TerminalReplicaPlacementSchemaZ = z48.object({
+      id: z48.string().min(1),
+      kind: z48.string().min(1),
+      row: z48.number().int().nonnegative(),
+      column: z48.number().int().nonnegative(),
+      columns: z48.number().int().positive(),
+      rows: z48.number().int().positive(),
+      contentDigest: z48.string().min(1)
+    }).strict();
+    TerminalReplicaSnapshotSchemaZ = z48.object({
+      cols: z48.number().int().positive(),
+      rows: z48.number().int().positive(),
+      grid: z48.array(TerminalReplicaRowSchemaZ),
+      history: z48.array(TerminalReplicaRowSchemaZ),
+      cursor: TerminalReplicaCursorSchemaZ,
+      modes: TerminalReplicaModesSchemaZ,
+      placements: z48.array(TerminalReplicaPlacementSchemaZ),
+      bootstrap: z48.object({
+        kind: z48.enum(["painted-capture", "authoritative-stream"]),
+        hiddenState: z48.enum(["unknown", "observed-from-start"])
+      }).strict()
+    }).strict();
+    TerminalReplicaPatchPayloadSchemaZ = z48.object({
+      dimensions: z48.object({ cols: z48.number().int().positive(), rows: z48.number().int().positive() }).strict().optional(),
+      rows: z48.array(
+        z48.object({ index: z48.number().int().nonnegative(), row: TerminalReplicaRowSchemaZ }).strict()
+      ),
+      history: z48.array(TerminalReplicaRowSchemaZ).optional(),
+      historyDelta: z48.object({
+        trim: z48.number().int().nonnegative(),
+        append: z48.array(TerminalReplicaRowSchemaZ)
+      }).strict().optional(),
+      cursor: TerminalReplicaCursorSchemaZ.optional(),
+      modes: TerminalReplicaModesSchemaZ.optional(),
+      placements: z48.array(TerminalReplicaPlacementSchemaZ).optional(),
+      bootstrap: TerminalReplicaSnapshotSchemaZ.shape.bootstrap.optional()
+    }).strict();
+    TerminalReplicaTombstonePayloadSchemaZ = z48.object({ reason: z48.enum(["pane-closed", "session-restarted", "runtime-disposed"]) }).strict();
+    TERMINAL_REPLICA_ATTRIBUTE = Object.freeze({
+      bold: 1,
+      dim: 2,
+      italic: 4,
+      underline: 8,
+      blink: 16,
+      inverse: 32,
+      hidden: 64,
+      strikethrough: 128
+    });
+  }
+});
+
+// packages/contracts/src/session-runtime.ts
+import { z as z49 } from "zod";
+var SessionRuntimeGenerationSchemaZ, SessionRuntimeClientIdSchemaZ, SessionRuntimeSessionNameSchemaZ, SessionRuntimeControllerRoleSchemaZ, SessionRuntimeControllerLeaseSchemaZ, SessionRuntimeControllerSnapshotSchemaZ, TerminalReplicaRevisionSchemaZ, TerminalReplicaFrameMetadataSchemaZ, CanonicalTerminalReplicaSeedSchemaZ, CanonicalTerminalReplicaPatchSchemaZ, CanonicalTerminalReplicaTombstoneSchemaZ, CanonicalTerminalReplicaUpdateSchemaZ, SessionRuntimePaneReadIntentSchemaZ, SessionRuntimeSemanticIntentSchemaZ;
 var init_session_runtime = __esm({
   "packages/contracts/src/session-runtime.ts"() {
     "use strict";
@@ -7904,31 +7993,64 @@ var init_session_runtime = __esm({
     init_semantic_identity();
     init_workspace_multiplexer();
     init_workspace_state();
+    init_terminal_replica();
     SessionRuntimeGenerationSchemaZ = DaemonInstanceIdentitySchemaZ.shape.instanceId;
-    SessionRuntimeClientIdSchemaZ = z48.string().min(1).max(4096).refine((value) => !/[\0\r\n]/u.test(value));
-    SessionRuntimeSessionNameSchemaZ = z48.string().min(1).max(256).refine((value) => !/[\0\r\n]/u.test(value));
-    SessionRuntimeControllerRoleSchemaZ = z48.enum(["controller", "viewer"]);
-    SessionRuntimeControllerLeaseSchemaZ = z48.object({
+    SessionRuntimeClientIdSchemaZ = z49.string().min(1).max(4096).refine((value) => !/[\0\r\n]/u.test(value));
+    SessionRuntimeSessionNameSchemaZ = z49.string().min(1).max(256).refine((value) => !/[\0\r\n]/u.test(value));
+    SessionRuntimeControllerRoleSchemaZ = z49.enum(["controller", "viewer"]);
+    SessionRuntimeControllerLeaseSchemaZ = z49.object({
       generation: SessionRuntimeGenerationSchemaZ,
       session: SessionRuntimeSessionNameSchemaZ,
       clientId: SessionRuntimeClientIdSchemaZ,
-      token: z48.uuid(),
-      revision: z48.number().int().positive()
+      token: z49.uuid(),
+      revision: z49.number().int().positive()
     }).strict();
-    SessionRuntimeControllerSnapshotSchemaZ = z48.object({
+    SessionRuntimeControllerSnapshotSchemaZ = z49.object({
       generation: SessionRuntimeGenerationSchemaZ,
       session: SessionRuntimeSessionNameSchemaZ,
       controllerClientId: SessionRuntimeClientIdSchemaZ.nullable(),
-      revision: z48.number().int().nonnegative()
+      revision: z49.number().int().nonnegative()
     }).strict();
-    TerminalReplicaRevisionSchemaZ = z48.number().int().nonnegative();
-    SessionRuntimePaneReadIntentSchemaZ = z48.object({
-      verb: z48.literal("workspace.pane.read"),
+    TerminalReplicaRevisionSchemaZ = z49.number().int().nonnegative();
+    TerminalReplicaFrameMetadataSchemaZ = z49.object({
+      workspaceName: WorkspaceIdSchemaZ,
+      semanticPaneId: TerminalAttachmentSemanticPaneIdSchemaZ,
+      generation: SessionRuntimeGenerationSchemaZ,
+      incarnation: z49.string().min(1).max(256),
+      cols: z49.number().int().positive(),
+      rows: z49.number().int().positive(),
+      stateHash: z49.string().regex(/^[0-9a-f]{16}$/u),
+      hashAlgorithm: z49.literal("fnv1a64-v1")
+    }).strict();
+    CanonicalTerminalReplicaSeedSchemaZ = TerminalReplicaFrameMetadataSchemaZ.extend({
+      type: z49.literal("terminal.seed"),
+      revision: TerminalReplicaRevisionSchemaZ,
+      snapshot: TerminalReplicaSnapshotSchemaZ
+    }).strict();
+    CanonicalTerminalReplicaPatchSchemaZ = TerminalReplicaFrameMetadataSchemaZ.extend({
+      type: z49.literal("terminal.patch"),
+      baseRevision: TerminalReplicaRevisionSchemaZ,
+      revision: TerminalReplicaRevisionSchemaZ,
+      patch: TerminalReplicaPatchPayloadSchemaZ
+    }).strict();
+    CanonicalTerminalReplicaTombstoneSchemaZ = TerminalReplicaFrameMetadataSchemaZ.extend({
+      type: z49.literal("terminal.tombstone"),
+      baseRevision: TerminalReplicaRevisionSchemaZ,
+      revision: TerminalReplicaRevisionSchemaZ,
+      tombstone: TerminalReplicaTombstonePayloadSchemaZ
+    }).strict();
+    CanonicalTerminalReplicaUpdateSchemaZ = z49.discriminatedUnion("type", [
+      CanonicalTerminalReplicaSeedSchemaZ,
+      CanonicalTerminalReplicaPatchSchemaZ,
+      CanonicalTerminalReplicaTombstoneSchemaZ
+    ]);
+    SessionRuntimePaneReadIntentSchemaZ = z49.object({
+      verb: z49.literal("workspace.pane.read"),
       workspaceName: WorkspaceIdSchemaZ,
       semanticPaneId: TerminalAttachmentSemanticPaneIdSchemaZ,
       origin: AuthoredInteractionOriginSchemaZ
     }).strict();
-    SessionRuntimeSemanticIntentSchemaZ = z48.union([
+    SessionRuntimeSemanticIntentSchemaZ = z49.union([
       WorkspaceMultiplexerIntentSchemaZ,
       SessionRuntimePaneReadIntentSchemaZ
     ]);
@@ -7936,21 +8058,21 @@ var init_session_runtime = __esm({
 });
 
 // packages/contracts/src/workspace-catalog-resource.ts
-import { z as z49 } from "zod";
+import { z as z50 } from "zod";
 var WORKSPACE_CATALOG_RESOURCE_VERSION, WorkspaceCatalogEntryV1SchemaZ, WorkspaceCatalogResourceV1SchemaZ;
 var init_workspace_catalog_resource = __esm({
   "packages/contracts/src/workspace-catalog-resource.ts"() {
     "use strict";
     init_daemon_wire();
     WORKSPACE_CATALOG_RESOURCE_VERSION = 1;
-    WorkspaceCatalogEntryV1SchemaZ = z49.object({
-      workspaceName: z49.string().min(1),
-      sessionName: z49.string().min(1)
+    WorkspaceCatalogEntryV1SchemaZ = z50.object({
+      workspaceName: z50.string().min(1),
+      sessionName: z50.string().min(1)
     }).strict();
-    WorkspaceCatalogResourceV1SchemaZ = z49.object({
-      version: z49.literal(WORKSPACE_CATALOG_RESOURCE_VERSION),
+    WorkspaceCatalogResourceV1SchemaZ = z50.object({
+      version: z50.literal(WORKSPACE_CATALOG_RESOURCE_VERSION),
       daemon: DaemonInstanceIdentitySchemaZ,
-      workspaces: z49.array(WorkspaceCatalogEntryV1SchemaZ)
+      workspaces: z50.array(WorkspaceCatalogEntryV1SchemaZ)
     }).strict();
   }
 });
@@ -8091,7 +8213,7 @@ var init_fleet_agent_graph = __esm({
 });
 
 // packages/contracts/src/daemon-resources.ts
-import { z as z50 } from "zod";
+import { z as z51 } from "zod";
 var DaemonSessionOverviewSchemaZ, DaemonPaneInfoSchemaZ, DaemonSessionsResponseSchemaZ, DaemonProjectResponseSchemaZ, DaemonPanesResponseSchemaZ, DaemonWorkspaceSchemaZ, DaemonWorkspacesResponseSchemaZ, DaemonWorkspaceResponseSchemaZ, DaemonRegisteredProjectSchemaZ, DaemonProjectsResponseSchemaZ, DaemonRegisteredProjectResponseSchemaZ, DaemonProjectTemplateSchemaZ, DaemonProjectTemplatesResponseSchemaZ;
 var init_daemon_resources = __esm({
   "packages/contracts/src/daemon-resources.ts"() {
@@ -8100,55 +8222,55 @@ var init_daemon_resources = __esm({
     init_workspace();
     DaemonSessionOverviewSchemaZ = SessionOverviewSchemaZ.strict();
     DaemonPaneInfoSchemaZ = PaneInfoSchemaZ.strict();
-    DaemonSessionsResponseSchemaZ = z50.object({
-      sessions: z50.array(DaemonSessionOverviewSchemaZ)
+    DaemonSessionsResponseSchemaZ = z51.object({
+      sessions: z51.array(DaemonSessionOverviewSchemaZ)
     }).strict();
-    DaemonProjectResponseSchemaZ = z50.object({
-      session: z50.string(),
-      dir: z50.string(),
-      panes: z50.array(DaemonPaneInfoSchemaZ)
+    DaemonProjectResponseSchemaZ = z51.object({
+      session: z51.string(),
+      dir: z51.string(),
+      panes: z51.array(DaemonPaneInfoSchemaZ)
     }).strict();
-    DaemonPanesResponseSchemaZ = z50.object({
-      panes: z50.array(DaemonPaneInfoSchemaZ)
+    DaemonPanesResponseSchemaZ = z51.object({
+      panes: z51.array(DaemonPaneInfoSchemaZ)
     }).strict();
     DaemonWorkspaceSchemaZ = WorkspaceSchemaZ.strict();
-    DaemonWorkspacesResponseSchemaZ = z50.object({
-      workspaces: z50.array(DaemonWorkspaceSchemaZ)
+    DaemonWorkspacesResponseSchemaZ = z51.object({
+      workspaces: z51.array(DaemonWorkspaceSchemaZ)
     }).strict();
-    DaemonWorkspaceResponseSchemaZ = z50.object({
+    DaemonWorkspaceResponseSchemaZ = z51.object({
       workspace: DaemonWorkspaceSchemaZ
     }).strict();
-    DaemonRegisteredProjectSchemaZ = z50.object({
-      name: z50.string(),
-      dir: z50.string(),
-      hasIdeYml: z50.boolean(),
-      hasWorkspaceConfig: z50.boolean().optional(),
-      configKind: z50.enum(["workspace", "legacy", "none"]).optional(),
-      configPath: z50.string().nullable().optional(),
-      ideConfigPath: z50.string().nullable().optional(),
-      gitOrigin: z50.string().nullable(),
-      gitBranch: z50.string().nullable(),
-      registeredAt: z50.string()
+    DaemonRegisteredProjectSchemaZ = z51.object({
+      name: z51.string(),
+      dir: z51.string(),
+      hasIdeYml: z51.boolean(),
+      hasWorkspaceConfig: z51.boolean().optional(),
+      configKind: z51.enum(["workspace", "legacy", "none"]).optional(),
+      configPath: z51.string().nullable().optional(),
+      ideConfigPath: z51.string().nullable().optional(),
+      gitOrigin: z51.string().nullable(),
+      gitBranch: z51.string().nullable(),
+      registeredAt: z51.string()
     }).strict();
-    DaemonProjectsResponseSchemaZ = z50.object({
-      projects: z50.array(DaemonRegisteredProjectSchemaZ)
+    DaemonProjectsResponseSchemaZ = z51.object({
+      projects: z51.array(DaemonRegisteredProjectSchemaZ)
     }).strict();
-    DaemonRegisteredProjectResponseSchemaZ = z50.object({
+    DaemonRegisteredProjectResponseSchemaZ = z51.object({
       project: DaemonRegisteredProjectSchemaZ
     }).strict();
-    DaemonProjectTemplateSchemaZ = z50.object({
-      id: z50.string(),
-      label: z50.string(),
-      description: z50.string()
+    DaemonProjectTemplateSchemaZ = z51.object({
+      id: z51.string(),
+      label: z51.string(),
+      description: z51.string()
     }).strict();
-    DaemonProjectTemplatesResponseSchemaZ = z50.object({
-      templates: z50.array(DaemonProjectTemplateSchemaZ)
+    DaemonProjectTemplatesResponseSchemaZ = z51.object({
+      templates: z51.array(DaemonProjectTemplateSchemaZ)
     }).strict();
   }
 });
 
 // packages/contracts/src/daemon-events.ts
-import { z as z51 } from "zod";
+import { z as z52 } from "zod";
 var SessionNamesSchemaZ, DaemonEventSubscribeFrameSchemaZ, DaemonEventUnsubscribeFrameSchemaZ, DaemonEventPingFrameSchemaZ, DaemonEventClientFrameSchemaZ, DaemonSessionSnapshotSchemaZ, DaemonEventHelloFrameSchemaZ, DaemonEventSnapshotFrameSchemaZ, DaemonEventSessionsChangedFrameSchemaZ, DaemonEventProjectsChangedFrameSchemaZ, DaemonEventInitOutputFrameSchemaZ, DaemonEventInitErrorFrameSchemaZ, DaemonEventPongFrameSchemaZ, DaemonEventActionCompleteFrameSchemaZ, DaemonEventConfigChangedFrameSchemaZ, DaemonEventTerminalsChangedFrameSchemaZ, DaemonEventResourceKindSchemaZ, DaemonEventResourceChangedFrameSchemaZ, DaemonEventSnapshotRequiredFrameSchemaZ, DaemonEventAgentStatusChangedFrameSchemaZ, DaemonEventFleetChangedFrameSchemaZ, DaemonEventAgentTurnCompletedFrameSchemaZ, DaemonEventWorkspacePromotionCompletedFrameSchemaZ, DaemonEventWorkspaceAddedFrameSchemaZ, DaemonEventWorkspaceRemovedFrameSchemaZ, DaemonEventProtocolErrorCodeSchemaZ, DaemonEventProtocolErrorFrameSchemaZ, DaemonEventServerFrameSchemaZ;
 var init_daemon_events = __esm({
   "packages/contracts/src/daemon-events.ts"() {
@@ -8157,9 +8279,9 @@ var init_daemon_events = __esm({
     init_daemon_wire();
     init_desktop_host();
     init_interaction_receipts();
-    SessionNamesSchemaZ = z51.array(z51.string());
-    DaemonEventSubscribeFrameSchemaZ = z51.object({
-      type: z51.literal("subscribe"),
+    SessionNamesSchemaZ = z52.array(z52.string());
+    DaemonEventSubscribeFrameSchemaZ = z52.object({
+      type: z52.literal("subscribe"),
       sessions: SessionNamesSchemaZ,
       /**
        * Last resource-event sequence the client applied for this daemon
@@ -8167,116 +8289,116 @@ var init_daemon_events = __esm({
        * later retained event or answers `snapshot-required` when the bounded
        * journal no longer covers the requested cursor.
        */
-      afterSequence: z51.number().int().nonnegative().optional()
+      afterSequence: z52.number().int().nonnegative().optional()
     }).strict();
-    DaemonEventUnsubscribeFrameSchemaZ = z51.object({
-      type: z51.literal("unsubscribe"),
+    DaemonEventUnsubscribeFrameSchemaZ = z52.object({
+      type: z52.literal("unsubscribe"),
       sessions: SessionNamesSchemaZ
     }).strict();
-    DaemonEventPingFrameSchemaZ = z51.object({ type: z51.literal("ping") }).strict();
-    DaemonEventClientFrameSchemaZ = z51.discriminatedUnion("type", [
+    DaemonEventPingFrameSchemaZ = z52.object({ type: z52.literal("ping") }).strict();
+    DaemonEventClientFrameSchemaZ = z52.discriminatedUnion("type", [
       DaemonEventSubscribeFrameSchemaZ,
       DaemonEventUnsubscribeFrameSchemaZ,
       DaemonEventPingFrameSchemaZ
     ]);
-    DaemonSessionSnapshotSchemaZ = z51.object({
+    DaemonSessionSnapshotSchemaZ = z52.object({
       project: DaemonProjectResponseSchemaZ
     }).strict();
-    DaemonEventHelloFrameSchemaZ = z51.object({
-      type: z51.literal("hello"),
+    DaemonEventHelloFrameSchemaZ = z52.object({
+      type: z52.literal("hello"),
       daemon: DaemonInstanceIdentitySchemaZ,
-      sessions: z51.array(DaemonSessionOverviewSchemaZ),
+      sessions: z52.array(DaemonSessionOverviewSchemaZ),
       /** Current head of the generation-scoped resource-event journal. */
-      eventSequence: z51.number().int().nonnegative().optional()
+      eventSequence: z52.number().int().nonnegative().optional()
     }).strict();
-    DaemonEventSnapshotFrameSchemaZ = z51.object({
-      type: z51.literal("snapshot"),
-      sessionName: z51.string(),
+    DaemonEventSnapshotFrameSchemaZ = z52.object({
+      type: z52.literal("snapshot"),
+      sessionName: z52.string(),
       data: DaemonSessionSnapshotSchemaZ
     }).strict();
-    DaemonEventSessionsChangedFrameSchemaZ = z51.object({ type: z51.literal("sessions.changed") }).strict();
-    DaemonEventProjectsChangedFrameSchemaZ = z51.object({ type: z51.literal("projects.changed") }).strict();
-    DaemonEventInitOutputFrameSchemaZ = z51.object({
-      type: z51.literal("init.output"),
-      jobId: z51.string(),
-      chunk: z51.string(),
-      done: z51.boolean().optional()
+    DaemonEventSessionsChangedFrameSchemaZ = z52.object({ type: z52.literal("sessions.changed") }).strict();
+    DaemonEventProjectsChangedFrameSchemaZ = z52.object({ type: z52.literal("projects.changed") }).strict();
+    DaemonEventInitOutputFrameSchemaZ = z52.object({
+      type: z52.literal("init.output"),
+      jobId: z52.string(),
+      chunk: z52.string(),
+      done: z52.boolean().optional()
     }).strict();
-    DaemonEventInitErrorFrameSchemaZ = z51.object({
-      type: z51.literal("init.error"),
-      jobId: z51.string(),
-      message: z51.string()
+    DaemonEventInitErrorFrameSchemaZ = z52.object({
+      type: z52.literal("init.error"),
+      jobId: z52.string(),
+      message: z52.string()
     }).strict();
-    DaemonEventPongFrameSchemaZ = z51.object({ type: z51.literal("pong") }).strict();
-    DaemonEventActionCompleteFrameSchemaZ = z51.object({
-      type: z51.literal("action.complete"),
-      name: z51.string(),
-      result: z51.unknown()
+    DaemonEventPongFrameSchemaZ = z52.object({ type: z52.literal("pong") }).strict();
+    DaemonEventActionCompleteFrameSchemaZ = z52.object({
+      type: z52.literal("action.complete"),
+      name: z52.string(),
+      result: z52.unknown()
     }).strict();
-    DaemonEventConfigChangedFrameSchemaZ = z51.object({
-      type: z51.literal("config.changed"),
-      sessionName: z51.string()
+    DaemonEventConfigChangedFrameSchemaZ = z52.object({
+      type: z52.literal("config.changed"),
+      sessionName: z52.string()
     }).strict();
-    DaemonEventTerminalsChangedFrameSchemaZ = z51.object({
-      type: z51.literal("terminals.changed"),
-      sessionName: z51.string()
+    DaemonEventTerminalsChangedFrameSchemaZ = z52.object({
+      type: z52.literal("terminals.changed"),
+      sessionName: z52.string()
     }).strict();
-    DaemonEventResourceKindSchemaZ = z51.enum([
+    DaemonEventResourceKindSchemaZ = z52.enum([
       "workspace-catalog",
       "fleet-catalog",
       "application-shell",
       "workspace-files",
       "workspace-changes"
     ]);
-    DaemonEventResourceChangedFrameSchemaZ = z51.object({
-      type: z51.literal("resource.changed"),
-      sequence: z51.number().int().positive(),
+    DaemonEventResourceChangedFrameSchemaZ = z52.object({
+      type: z52.literal("resource.changed"),
+      sequence: z52.number().int().positive(),
       workspaceName: DesktopWorkspaceNameSchemaZ.nullable(),
       resource: DaemonEventResourceKindSchemaZ,
-      revision: z51.number().int().nonnegative(),
-      causeOperationId: z51.uuid().nullable()
+      revision: z52.number().int().nonnegative(),
+      causeOperationId: z52.uuid().nullable()
     }).strict();
-    DaemonEventSnapshotRequiredFrameSchemaZ = z51.object({
-      type: z51.literal("snapshot-required"),
-      afterSequence: z51.number().int().nonnegative(),
-      oldestAvailableSequence: z51.number().int().positive().nullable(),
-      currentSequence: z51.number().int().nonnegative(),
-      reason: z51.enum(["cursor-ahead", "journal-gap"])
+    DaemonEventSnapshotRequiredFrameSchemaZ = z52.object({
+      type: z52.literal("snapshot-required"),
+      afterSequence: z52.number().int().nonnegative(),
+      oldestAvailableSequence: z52.number().int().positive().nullable(),
+      currentSequence: z52.number().int().nonnegative(),
+      reason: z52.enum(["cursor-ahead", "journal-gap"])
     }).strict();
-    DaemonEventAgentStatusChangedFrameSchemaZ = z51.object({
-      type: z51.literal("agent-status.changed"),
-      sessionName: z51.string()
+    DaemonEventAgentStatusChangedFrameSchemaZ = z52.object({
+      type: z52.literal("agent-status.changed"),
+      sessionName: z52.string()
     }).strict();
-    DaemonEventFleetChangedFrameSchemaZ = z51.object({ type: z51.literal("fleet.changed") }).strict();
-    DaemonEventAgentTurnCompletedFrameSchemaZ = z51.object({
-      type: z51.literal("agent.turn-completed"),
-      sessionName: z51.string(),
-      agentId: z51.string().regex(/^agent\.[0-9a-f]{20}$/u).nullable(),
-      fromStatus: z51.literal("working"),
-      toStatus: z51.enum(["done", "idle"]),
-      at: z51.iso.datetime({ offset: true })
+    DaemonEventFleetChangedFrameSchemaZ = z52.object({ type: z52.literal("fleet.changed") }).strict();
+    DaemonEventAgentTurnCompletedFrameSchemaZ = z52.object({
+      type: z52.literal("agent.turn-completed"),
+      sessionName: z52.string(),
+      agentId: z52.string().regex(/^agent\.[0-9a-f]{20}$/u).nullable(),
+      fromStatus: z52.literal("working"),
+      toStatus: z52.enum(["done", "idle"]),
+      at: z52.iso.datetime({ offset: true })
     }).strict();
-    DaemonEventWorkspacePromotionCompletedFrameSchemaZ = z51.object({
-      type: z51.literal("workspace.promotion-completed"),
+    DaemonEventWorkspacePromotionCompletedFrameSchemaZ = z52.object({
+      type: z52.literal("workspace.promotion-completed"),
       workspaceName: DesktopWorkspaceNameSchemaZ,
-      outcome: z51.enum(["promoted", "replayed"]),
-      at: z51.iso.datetime({ offset: true })
+      outcome: z52.enum(["promoted", "replayed"]),
+      at: z52.iso.datetime({ offset: true })
     }).strict();
-    DaemonEventWorkspaceAddedFrameSchemaZ = z51.object({
-      type: z51.literal("workspace.added"),
+    DaemonEventWorkspaceAddedFrameSchemaZ = z52.object({
+      type: z52.literal("workspace.added"),
       workspace: DaemonWorkspaceSchemaZ
     }).strict();
-    DaemonEventWorkspaceRemovedFrameSchemaZ = z51.object({
-      type: z51.literal("workspace.removed"),
-      name: z51.string()
+    DaemonEventWorkspaceRemovedFrameSchemaZ = z52.object({
+      type: z52.literal("workspace.removed"),
+      name: z52.string()
     }).strict();
-    DaemonEventProtocolErrorCodeSchemaZ = z51.enum(["invalid-json", "invalid-frame"]);
-    DaemonEventProtocolErrorFrameSchemaZ = z51.object({
-      type: z51.literal("protocol.error"),
+    DaemonEventProtocolErrorCodeSchemaZ = z52.enum(["invalid-json", "invalid-frame"]);
+    DaemonEventProtocolErrorFrameSchemaZ = z52.object({
+      type: z52.literal("protocol.error"),
       code: DaemonEventProtocolErrorCodeSchemaZ,
-      message: z51.string()
+      message: z52.string()
     }).strict();
-    DaemonEventServerFrameSchemaZ = z51.discriminatedUnion("type", [
+    DaemonEventServerFrameSchemaZ = z52.discriminatedUnion("type", [
       DaemonEventHelloFrameSchemaZ,
       DaemonEventSnapshotFrameSchemaZ,
       DaemonEventSessionsChangedFrameSchemaZ,
@@ -8302,27 +8424,27 @@ var init_daemon_events = __esm({
 });
 
 // packages/contracts/src/desktop-update.ts
-import { z as z52 } from "zod";
+import { z as z53 } from "zod";
 var DesktopUpdatePhaseSchemaZ, DesktopUpdateStatusSchemaZ;
 var init_desktop_update = __esm({
   "packages/contracts/src/desktop-update.ts"() {
     "use strict";
-    DesktopUpdatePhaseSchemaZ = z52.enum([
+    DesktopUpdatePhaseSchemaZ = z53.enum([
       "idle",
       "checking",
       "downloading",
       "ready",
       "applying"
     ]);
-    DesktopUpdateStatusSchemaZ = z52.object({
+    DesktopUpdateStatusSchemaZ = z53.object({
       phase: DesktopUpdatePhaseSchemaZ,
       /** The running version — always known. */
-      currentVersion: z52.string().min(1),
+      currentVersion: z53.string().min(1),
       /**
        * The newer version being downloaded or staged, or null when there is
        * nothing pending. Present from `downloading` through `applying`.
        */
-      availableVersion: z52.string().min(1).nullable()
+      availableVersion: z53.string().min(1).nullable()
     }).strict();
   }
 });
@@ -8349,6 +8471,17 @@ function encodeBase64Url(text) {
   const bytes = new TextEncoder().encode(text);
   return btoa(bytesToBinaryString(bytes)).replace(/\+/gu, "-").replace(/\//gu, "_").replace(/=+$/u, "");
 }
+function decodeBase64Url(value) {
+  const padded = value.replace(/-/gu, "+").replace(/_/gu, "/");
+  try {
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
 function encodeWidgetMarkerLine(id, args) {
   if (!WIDGET_ID_PATTERN.test(id)) {
     throw new Error(`"${id}" is not a valid widget id.`);
@@ -8363,7 +8496,54 @@ function widgetMarkerAnnouncement(id, args) {
   return `${WIDGET_MARKER_CONCEAL_PREFIX}${encodeWidgetMarkerLine(id, args)}${WIDGET_MARKER_CONCEAL_SUFFIX}
 `;
 }
-var WIDGET_MARKER_SENTINEL, WIDGET_MARKER_CONCEAL_PREFIX, WIDGET_MARKER_CONCEAL_SUFFIX, WIDGET_MARKER_MAX_PAYLOAD_CHARACTERS, WIDGET_ID_PATTERN, EMPTY_PAYLOAD, WidgetMarkerTooLargeError;
+function decodeWidgetMarkerLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith(WIDGET_MARKER_SENTINEL)) return null;
+  const fields = trimmed.split(" ").filter((field) => field.length > 0);
+  if (fields.length !== 4) return null;
+  const [sentinel, id, payload, digest4] = fields;
+  if (sentinel !== WIDGET_MARKER_SENTINEL) return null;
+  if (!WIDGET_ID_PATTERN.test(id)) return null;
+  if (!DIGEST_PATTERN.test(digest4)) return null;
+  if (payload.length > WIDGET_MARKER_MAX_PAYLOAD_CHARACTERS) return null;
+  if (payload !== EMPTY_PAYLOAD && !BASE64URL_PATTERN.test(payload)) return null;
+  if (widgetMarkerDigest(id, payload) !== digest4) return null;
+  if (payload === EMPTY_PAYLOAD) return { id, args: null };
+  const json2 = decodeBase64Url(payload);
+  if (json2 === null) return null;
+  try {
+    return { id, args: JSON.parse(json2) };
+  } catch {
+    return null;
+  }
+}
+function widgetLogicalLines(rows) {
+  const lines = [];
+  for (const row of rows) {
+    let end = row.cells.length;
+    while (end > 0 && isBlankCell(row.cells[end - 1])) end -= 1;
+    let text = "";
+    for (let index = 0; index < end; index += 1) text += row.cells[index] ?? "";
+    if (row.wrapped && lines.length > 0) {
+      lines[lines.length - 1] += text;
+    } else {
+      lines.push(text);
+    }
+  }
+  return lines;
+}
+function isBlankCell(cell) {
+  return cell === void 0 || cell === "" || cell === " ";
+}
+function detectWidgetMarker(rows) {
+  const lines = widgetLogicalLines(rows);
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const decoded = decodeWidgetMarkerLine(lines[index]);
+    if (decoded) return { id: decoded.id, args: decoded.args, lineIndex: index };
+  }
+  return null;
+}
+var WIDGET_MARKER_SENTINEL, WIDGET_MARKER_CONCEAL_PREFIX, WIDGET_MARKER_CONCEAL_SUFFIX, WIDGET_MARKER_MAX_PAYLOAD_CHARACTERS, WIDGET_ID_PATTERN, BASE64URL_PATTERN, DIGEST_PATTERN, EMPTY_PAYLOAD, WidgetMarkerTooLargeError;
 var init_pane_widget_marker = __esm({
   "packages/contracts/src/pane-widget-marker.ts"() {
     "use strict";
@@ -8372,6 +8552,8 @@ var init_pane_widget_marker = __esm({
     WIDGET_MARKER_CONCEAL_SUFFIX = "\x1B[0m";
     WIDGET_MARKER_MAX_PAYLOAD_CHARACTERS = 96 * 1024;
     WIDGET_ID_PATTERN = /^[a-z][a-z0-9-]{0,31}$/u;
+    BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/u;
+    DIGEST_PATTERN = /^[0-9a-f]{8}$/u;
     EMPTY_PAYLOAD = "-";
     WidgetMarkerTooLargeError = class extends Error {
       payloadCharacters;
@@ -8387,48 +8569,48 @@ var init_pane_widget_marker = __esm({
 });
 
 // packages/contracts/src/rich-card-widget.ts
-import { z as z53 } from "zod";
+import { z as z54 } from "zod";
 var RichCardToneSchemaZ, RichCardItemSchemaZ, RichCardWidgetArgsSchemaZ;
 var init_rich_card_widget = __esm({
   "packages/contracts/src/rich-card-widget.ts"() {
     "use strict";
-    RichCardToneSchemaZ = z53.enum(["neutral", "info", "success", "warning", "danger"]);
-    RichCardItemSchemaZ = z53.discriminatedUnion("type", [
-      z53.object({ type: z53.literal("text"), text: z53.string().max(8e3) }).strict(),
-      z53.object({
-        type: z53.literal("badge"),
-        text: z53.string().min(1).max(120),
+    RichCardToneSchemaZ = z54.enum(["neutral", "info", "success", "warning", "danger"]);
+    RichCardItemSchemaZ = z54.discriminatedUnion("type", [
+      z54.object({ type: z54.literal("text"), text: z54.string().max(8e3) }).strict(),
+      z54.object({
+        type: z54.literal("badge"),
+        text: z54.string().min(1).max(120),
         tone: RichCardToneSchemaZ.default("neutral")
       }).strict(),
-      z53.object({
-        type: z53.literal("progress"),
-        label: z53.string().max(160).optional(),
-        value: z53.number().min(0).max(100)
+      z54.object({
+        type: z54.literal("progress"),
+        label: z54.string().max(160).optional(),
+        value: z54.number().min(0).max(100)
       }).strict(),
-      z53.object({
-        type: z53.literal("code"),
-        code: z53.string().max(32e3),
-        language: z53.string().max(40).optional()
+      z54.object({
+        type: z54.literal("code"),
+        code: z54.string().max(32e3),
+        language: z54.string().max(40).optional()
       }).strict(),
-      z53.object({
-        type: z53.literal("button"),
-        label: z53.string().min(1).max(120),
+      z54.object({
+        type: z54.literal("button"),
+        label: z54.string().min(1).max(120),
         /** Bytes written to the owning pane after an explicit user click. */
-        input: z53.string().min(1).max(2e3),
-        submit: z53.boolean().default(true),
+        input: z54.string().min(1).max(2e3),
+        submit: z54.boolean().default(true),
         tone: RichCardToneSchemaZ.default("neutral")
       }).strict()
     ]);
-    RichCardWidgetArgsSchemaZ = z53.object({
-      title: z53.string().min(1).max(200),
-      subtitle: z53.string().max(500).optional(),
-      items: z53.array(RichCardItemSchemaZ).max(128)
+    RichCardWidgetArgsSchemaZ = z54.object({
+      title: z54.string().min(1).max(200),
+      subtitle: z54.string().max(500).optional(),
+      items: z54.array(RichCardItemSchemaZ).max(128)
     }).strict();
   }
 });
 
 // packages/contracts/src/pane-widget-descriptor.ts
-import { z as z54 } from "zod";
+import { z as z55 } from "zod";
 var PANE_MARKDOWN_WIDGET_ID, PANE_IMAGE_WIDGET_ID, PANE_CARD_WIDGET_ID, InlinePaneMarkdownWidgetArgsSchemaZ, AssetPaneMarkdownWidgetArgsSchemaZ, PaneMarkdownWidgetArgsSchemaZ, PANE_IMAGE_WIDGET_MEDIA_TYPES, InlinePaneImageWidgetArgsSchemaZ, AssetPaneImageWidgetArgsSchemaZ, PaneImageWidgetArgsSchemaZ, PaneWidgetDescriptorSchemaZ;
 var init_pane_widget_descriptor = __esm({
   "packages/contracts/src/pane-widget-descriptor.ts"() {
@@ -8438,15 +8620,15 @@ var init_pane_widget_descriptor = __esm({
     PANE_MARKDOWN_WIDGET_ID = "markdown";
     PANE_IMAGE_WIDGET_ID = "image";
     PANE_CARD_WIDGET_ID = "card";
-    InlinePaneMarkdownWidgetArgsSchemaZ = z54.strictObject({
-      text: z54.string().max(512 * 1024),
-      title: z54.string().max(200).optional()
+    InlinePaneMarkdownWidgetArgsSchemaZ = z55.strictObject({
+      text: z55.string().max(512 * 1024),
+      title: z55.string().max(200).optional()
     });
-    AssetPaneMarkdownWidgetArgsSchemaZ = z54.strictObject({
+    AssetPaneMarkdownWidgetArgsSchemaZ = z55.strictObject({
       assetId: WidgetAssetIdSchemaZ,
-      title: z54.string().max(200).optional()
+      title: z55.string().max(200).optional()
     });
-    PaneMarkdownWidgetArgsSchemaZ = z54.union([
+    PaneMarkdownWidgetArgsSchemaZ = z55.union([
       InlinePaneMarkdownWidgetArgsSchemaZ,
       AssetPaneMarkdownWidgetArgsSchemaZ
     ]);
@@ -8457,25 +8639,25 @@ var init_pane_widget_descriptor = __esm({
       "image/webp",
       "image/avif"
     ];
-    InlinePaneImageWidgetArgsSchemaZ = z54.strictObject({
-      media: z54.enum(PANE_IMAGE_WIDGET_MEDIA_TYPES),
-      data: z54.string().min(1).max(512 * 1024).regex(/^[A-Za-z0-9+/]+={0,2}$/u, "The image payload is not base64."),
-      name: z54.string().max(200).optional(),
-      alt: z54.string().max(500).optional()
+    InlinePaneImageWidgetArgsSchemaZ = z55.strictObject({
+      media: z55.enum(PANE_IMAGE_WIDGET_MEDIA_TYPES),
+      data: z55.string().min(1).max(512 * 1024).regex(/^[A-Za-z0-9+/]+={0,2}$/u, "The image payload is not base64."),
+      name: z55.string().max(200).optional(),
+      alt: z55.string().max(500).optional()
     });
-    AssetPaneImageWidgetArgsSchemaZ = z54.strictObject({
+    AssetPaneImageWidgetArgsSchemaZ = z55.strictObject({
       assetId: WidgetAssetIdSchemaZ,
-      name: z54.string().max(200).optional(),
-      alt: z54.string().max(500).optional()
+      name: z55.string().max(200).optional(),
+      alt: z55.string().max(500).optional()
     });
-    PaneImageWidgetArgsSchemaZ = z54.union([
+    PaneImageWidgetArgsSchemaZ = z55.union([
       InlinePaneImageWidgetArgsSchemaZ,
       AssetPaneImageWidgetArgsSchemaZ
     ]);
-    PaneWidgetDescriptorSchemaZ = z54.discriminatedUnion("id", [
-      z54.object({ id: z54.literal(PANE_MARKDOWN_WIDGET_ID), args: PaneMarkdownWidgetArgsSchemaZ }).strict(),
-      z54.object({ id: z54.literal(PANE_IMAGE_WIDGET_ID), args: PaneImageWidgetArgsSchemaZ }).strict(),
-      z54.object({ id: z54.literal(PANE_CARD_WIDGET_ID), args: RichCardWidgetArgsSchemaZ }).strict()
+    PaneWidgetDescriptorSchemaZ = z55.discriminatedUnion("id", [
+      z55.object({ id: z55.literal(PANE_MARKDOWN_WIDGET_ID), args: PaneMarkdownWidgetArgsSchemaZ }).strict(),
+      z55.object({ id: z55.literal(PANE_IMAGE_WIDGET_ID), args: PaneImageWidgetArgsSchemaZ }).strict(),
+      z55.object({ id: z55.literal(PANE_CARD_WIDGET_ID), args: RichCardWidgetArgsSchemaZ }).strict()
     ]);
   }
 });
@@ -8511,6 +8693,7 @@ var init_src = __esm({
     init_experience_identifiers();
     init_semantic_identity();
     init_session_runtime();
+    init_terminal_replica();
     init_experience_shell();
     init_application_shell();
     init_application_shell_resource();
@@ -13989,20 +14172,20 @@ var init_session_id = __esm({
 });
 
 // packages/daemon/src/schemas/registry.ts
-import { z as z55 } from "zod";
+import { z as z56 } from "zod";
 var RegisteredProjectSchemaZ, RegisterProjectRequestSchemaZ, InitProjectRequestSchemaZ;
 var init_registry = __esm({
   "packages/daemon/src/schemas/registry.ts"() {
     "use strict";
     init_src();
     RegisteredProjectSchemaZ = DaemonRegisteredProjectSchemaZ;
-    RegisterProjectRequestSchemaZ = z55.object({
-      dir: z55.string().min(1),
-      name: z55.string().min(1).optional()
+    RegisterProjectRequestSchemaZ = z56.object({
+      dir: z56.string().min(1),
+      name: z56.string().min(1).optional()
     });
-    InitProjectRequestSchemaZ = z55.object({
-      dir: z55.string().min(1),
-      template: z55.string().min(1).optional()
+    InitProjectRequestSchemaZ = z56.object({
+      dir: z56.string().min(1),
+      template: z56.string().min(1).optional()
     });
   }
 });
@@ -14064,7 +14247,7 @@ import { EventEmitter } from "node:events";
 import { existsSync as existsSync16, mkdirSync as mkdirSync11, readFileSync as readFileSync12, renameSync as renameSync5, writeFileSync as writeFileSync10 } from "node:fs";
 import { homedir as homedir12 } from "node:os";
 import { dirname as dirname16, isAbsolute as isAbsolute3, join as join16, resolve as resolve11 } from "node:path";
-import { z as z56 } from "zod";
+import { z as z57 } from "zod";
 function applyAction(state, action) {
   switch (action.type) {
     case "register":
@@ -14203,9 +14386,9 @@ var init_project_registry = __esm({
     init_registry();
     init_project_probe();
     REGISTRY_DIR_ENV = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ = z56.object({
-      version: z56.literal(1),
-      projects: z56.array(RegisteredProjectSchemaZ)
+    RegistryFileSchemaZ = z57.object({
+      version: z57.literal(1),
+      projects: z57.array(RegisteredProjectSchemaZ)
     });
     ProjectRegistryError = class extends Error {
       code;
@@ -14977,7 +15160,7 @@ var init_notify_state = __esm({
 import { existsSync as existsSync20, mkdirSync as mkdirSync14, readFileSync as readFileSync15, renameSync as renameSync7, writeFileSync as writeFileSync12 } from "node:fs";
 import { homedir as homedir14 } from "node:os";
 import { dirname as dirname18, join as join20 } from "node:path";
-import { z as z57 } from "zod";
+import { z as z58 } from "zod";
 function isBareShell(cmd) {
   return /^-?(zsh|bash|sh|fish|dash|ksh|tcsh|csh|nu)$/.test(cmd.trim());
 }
@@ -15149,32 +15332,32 @@ var init_snapshot2 = __esm({
     init_src2();
     init_process_tree();
     init_sessions2();
-    PaneSnapshotSchemaZ = z57.object({
-      index: z57.number(),
-      cwd: z57.string(),
-      command: z57.string().nullable(),
-      agent: z57.string().nullable(),
-      agentSessionId: z57.string().nullable(),
-      agentState: z57.string().nullable(),
-      title: z57.string()
+    PaneSnapshotSchemaZ = z58.object({
+      index: z58.number(),
+      cwd: z58.string(),
+      command: z58.string().nullable(),
+      agent: z58.string().nullable(),
+      agentSessionId: z58.string().nullable(),
+      agentState: z58.string().nullable(),
+      title: z58.string()
     });
-    WindowSnapshotSchemaZ = z57.object({
-      index: z57.number(),
-      name: z57.string(),
-      active: z57.boolean(),
-      layout: z57.string(),
-      panes: z57.array(PaneSnapshotSchemaZ)
+    WindowSnapshotSchemaZ = z58.object({
+      index: z58.number(),
+      name: z58.string(),
+      active: z58.boolean(),
+      layout: z58.string(),
+      panes: z58.array(PaneSnapshotSchemaZ)
     });
-    SessionSnapshotSchemaZ = z57.object({
-      name: z57.string(),
-      cwd: z57.string(),
-      adopted: z57.boolean(),
-      windows: z57.array(WindowSnapshotSchemaZ)
+    SessionSnapshotSchemaZ = z58.object({
+      name: z58.string(),
+      cwd: z58.string(),
+      adopted: z58.boolean(),
+      windows: z58.array(WindowSnapshotSchemaZ)
     });
-    FleetSnapshotSchemaZ = z57.object({
-      version: z57.literal(1),
-      savedAt: z57.string(),
-      sessions: z57.array(SessionSnapshotSchemaZ)
+    FleetSnapshotSchemaZ = z58.object({
+      version: z58.literal(1),
+      savedAt: z58.string(),
+      sessions: z58.array(SessionSnapshotSchemaZ)
     });
     SNAPSHOT_PANE_FORMAT = [
       "#{session_name}",
@@ -18283,7 +18466,7 @@ import { EventEmitter as EventEmitter3 } from "node:events";
 import { existsSync as existsSync26, mkdirSync as mkdirSync18, readFileSync as readFileSync20, renameSync as renameSync9, writeFileSync as writeFileSync16 } from "node:fs";
 import { homedir as homedir17 } from "node:os";
 import { dirname as dirname24, join as join25 } from "node:path";
-import { z as z58 } from "zod";
+import { z as z59 } from "zod";
 function getDefaultWorkspaceRegistry() {
   if (!_default) _default = new WorkspaceRegistry();
   return _default;
@@ -18306,9 +18489,9 @@ var init_workspace_registry = __esm({
     "use strict";
     init_src();
     REGISTRY_DIR_ENV3 = "TMUX_IDE_REGISTRY_DIR";
-    RegistryFileSchemaZ2 = z58.object({
-      version: z58.literal(1),
-      workspaces: z58.array(WorkspaceSchemaZ)
+    RegistryFileSchemaZ2 = z59.object({
+      version: z59.literal(1),
+      workspaces: z59.array(WorkspaceSchemaZ)
     });
     WorkspaceAlreadyExistsError = class extends Error {
       code = "ALREADY_EXISTS";
@@ -23236,7 +23419,7 @@ var init_workspace_pane_creation2 = __esm({
 });
 
 // packages/daemon/src/terminal/attachments/semantic-pane-catalog.ts
-import { z as z59 } from "zod";
+import { z as z60 } from "zod";
 function analyzeTrustedSemanticPaneCatalog(candidates) {
   const rows = [];
   let invalidRuntimeProof = false;
@@ -23285,18 +23468,18 @@ var init_semantic_pane_catalog = __esm({
   "packages/daemon/src/terminal/attachments/semantic-pane-catalog.ts"() {
     "use strict";
     init_src();
-    RuntimeSessionIdSchemaZ = z59.string().max(32).regex(/^\$(?:0|[1-9][0-9]*)$/u);
-    RuntimeWindowIdSchemaZ = z59.string().max(32).regex(/^@(?:0|[1-9][0-9]*)$/u);
-    RuntimePaneIdSchemaZ = z59.string().max(32).regex(/^%(?:0|[1-9][0-9]*)$/u);
-    TrustedSemanticPaneSnapshotSchemaZ = z59.object({
+    RuntimeSessionIdSchemaZ = z60.string().max(32).regex(/^\$(?:0|[1-9][0-9]*)$/u);
+    RuntimeWindowIdSchemaZ = z60.string().max(32).regex(/^@(?:0|[1-9][0-9]*)$/u);
+    RuntimePaneIdSchemaZ = z60.string().max(32).regex(/^%(?:0|[1-9][0-9]*)$/u);
+    TrustedSemanticPaneSnapshotSchemaZ = z60.object({
       workspaceName: WorkspaceIdSchemaZ,
       semanticPaneId: TerminalAttachmentSemanticPaneIdSchemaZ.nullable(),
       windowStamp: TerminalAttachmentSemanticWindowIdSchemaZ.nullable().optional(),
       sessionId: RuntimeSessionIdSchemaZ,
       windowId: RuntimeWindowIdSchemaZ,
       runtimePaneId: RuntimePaneIdSchemaZ,
-      windowPaneCount: z59.number().int().positive(),
-      sessionWindowCount: z59.number().int().positive()
+      windowPaneCount: z60.number().int().positive(),
+      sessionWindowCount: z60.number().int().positive()
     }).strict();
     SemanticPaneCatalogError = class extends Error {
       code;
@@ -23319,7 +23502,7 @@ var init_semantic_pane_catalog = __esm({
       }
       /** Resolves a pane set from one trusted discovery snapshot. */
       async resolveMany(targets) {
-        const parsedTargets = z59.array(TerminalAttachmentSemanticTargetSchemaZ).min(1).max(4096).parse(targets);
+        const parsedTargets = z60.array(TerminalAttachmentSemanticTargetSchemaZ).min(1).max(4096).parse(targets);
         const diagnosticTarget = parsedTargets[0];
         let discovered;
         try {
@@ -25387,23 +25570,23 @@ function isAppWindowCommandSatisfied(document, command2) {
       if (command2.windowId === null) return current.focusedWindowId === null;
       const id = requireWindowId(current, command2.windowId);
       if (current.focusedWindowId !== id) return false;
-      const window = current.windows[id];
-      if (window.placement.mode === "floating") return current.floatingOrder.at(-1) === id;
-      const stack = window.placement.docked ? findStack(current.dockRoot, window.placement.docked.stackId) : null;
+      const window2 = current.windows[id];
+      if (window2.placement.mode === "floating") return current.floatingOrder.at(-1) === id;
+      const stack = window2.placement.docked ? findStack(current.dockRoot, window2.placement.docked.stackId) : null;
       return stack?.activeWindowId === id;
     }
     case "window.float": {
       const id = requireWindowId(current, command2.windowId);
-      const window = current.windows[id];
-      if (window.placement.mode !== "floating" || !window.placement.floating || current.focusedWindowId !== id || current.floatingOrder.at(-1) !== id) {
+      const window2 = current.windows[id];
+      if (window2.placement.mode !== "floating" || !window2.placement.floating || current.focusedWindowId !== id || current.floatingOrder.at(-1) !== id) {
         return false;
       }
-      return command2.rect === void 0 ? true : sameRect(window.placement.floating, normalizeRect(command2.rect));
+      return command2.rect === void 0 ? true : sameRect(window2.placement.floating, normalizeRect(command2.rect));
     }
     case "window.dock": {
       const id = requireWindowId(current, command2.windowId);
-      const window = current.windows[id];
-      if (window.placement.mode !== "docked" || !window.placement.docked) return false;
+      const window2 = current.windows[id];
+      if (window2.placement.mode !== "docked" || !window2.placement.docked) return false;
       if (command2.stackId !== void 0) {
         const stackId = requireId(command2.stackId, "$.stackId");
         if (!findStack(current.dockRoot, stackId)) {
@@ -25413,9 +25596,9 @@ function isAppWindowCommandSatisfied(document, command2) {
             `unknown app window stack "${stackId}"`
           );
         }
-        if (window.placement.docked.stackId !== stackId) return false;
+        if (window2.placement.docked.stackId !== stackId) return false;
       }
-      const stack = findStack(current.dockRoot, window.placement.docked.stackId);
+      const stack = findStack(current.dockRoot, window2.placement.docked.stackId);
       if (!stack || stack.activeWindowId !== id || current.focusedWindowId !== id) return false;
       if (command2.index === void 0) return true;
       requireNonnegativeIndex(command2.index, "$.index", "dock index must be nonnegative");
@@ -25482,16 +25665,16 @@ function isAppWindowCommandSatisfied(document, command2) {
 }
 function floatWindow(current, command2, timestamp) {
   const id = requireWindowId(current, command2.windowId);
-  const window = current.windows[id];
+  const window2 = current.windows[id];
   const rect = normalizeRect(
-    command2.rect ?? window.placement.floating ?? { x: 2, y: 2, width: 80, height: 24 }
+    command2.rect ?? window2.placement.floating ?? { x: 2, y: 2, width: 80, height: 24 }
   );
   const windows = structuredClone(current.windows);
   windows[id] = {
-    ...window,
+    ...window2,
     placement: {
       mode: "floating",
-      docked: window.placement.docked,
+      docked: window2.placement.docked,
       floating: rect
     }
   };
@@ -25506,8 +25689,8 @@ function floatWindow(current, command2, timestamp) {
 }
 function dockWindow(current, command2, timestamp) {
   const id = requireWindowId(current, command2.windowId);
-  const window = current.windows[id];
-  const requestedStackId = command2.stackId !== void 0 ? requireId(command2.stackId, "$.stackId") : window.placement.docked?.stackId;
+  const window2 = current.windows[id];
+  const requestedStackId = command2.stackId !== void 0 ? requireId(command2.stackId, "$.stackId") : window2.placement.docked?.stackId;
   if (command2.stackId !== void 0 && !findStack(current.dockRoot, requestedStackId)) {
     throw new AppWindowKernelError(
       "STACK_NOT_FOUND",
@@ -25517,9 +25700,9 @@ function dockWindow(current, command2, timestamp) {
   }
   const dockRootWithoutWindow = removeDockWindow(current.dockRoot, id);
   const existingFallback = firstStackId(dockRootWithoutWindow);
-  const removedFromRequestedStack = window.placement.mode === "docked" && window.placement.docked?.stackId === requestedStackId;
+  const removedFromRequestedStack = window2.placement.mode === "docked" && window2.placement.docked?.stackId === requestedStackId;
   const targetStackId = (requestedStackId && findStack(dockRootWithoutWindow, requestedStackId) ? requestedStackId : removedFromRequestedStack ? requestedStackId : existingFallback) ?? uniqueRootStackId(dockRootWithoutWindow);
-  const rememberedIndex = command2.index ?? window.placement.docked?.index ?? Number.MAX_SAFE_INTEGER;
+  const rememberedIndex = command2.index ?? window2.placement.docked?.index ?? Number.MAX_SAFE_INTEGER;
   if (!Number.isInteger(rememberedIndex) || rememberedIndex < 0) {
     throw new AppWindowKernelError(
       "INVALID_INPUT",
@@ -25529,11 +25712,11 @@ function dockWindow(current, command2, timestamp) {
   }
   const windows = structuredClone(current.windows);
   windows[id] = {
-    ...window,
+    ...window2,
     placement: {
       mode: "docked",
       docked: { stackId: targetStackId, index: 0 },
-      floating: window.placement.floating
+      floating: window2.placement.floating
     }
   };
   let dockRoot = dockRootWithoutWindow ? insertDockWindow(dockRootWithoutWindow, targetStackId, id, rememberedIndex) : {
@@ -25552,11 +25735,11 @@ function dockWindow(current, command2, timestamp) {
   });
 }
 function moveFloatingWindow(current, command2, timestamp) {
-  const [id, window, rect] = requireFloatingWindow(current, command2.windowId);
+  const [id, window2, rect] = requireFloatingWindow(current, command2.windowId);
   return updateFloatingRect(
     current,
     id,
-    window,
+    window2,
     {
       ...rect,
       x: boundedCoordinate(command2.x, "$.x"),
@@ -25566,11 +25749,11 @@ function moveFloatingWindow(current, command2, timestamp) {
   );
 }
 function resizeFloatingWindow(current, command2, timestamp) {
-  const [id, window, rect] = requireFloatingWindow(current, command2.windowId);
+  const [id, window2, rect] = requireFloatingWindow(current, command2.windowId);
   return updateFloatingRect(
     current,
     id,
-    window,
+    window2,
     {
       ...rect,
       width: boundedExtent(command2.width, APP_WINDOW_FLOAT_MIN_WIDTH, "$.width"),
@@ -25649,11 +25832,11 @@ function deleteLayout(current, layoutId, timestamp) {
     activeLayoutId: current.activeLayoutId === id ? null : current.activeLayoutId
   });
 }
-function updateFloatingRect(current, id, window, rect, timestamp) {
+function updateFloatingRect(current, id, window2, rect, timestamp) {
   return finalize(current, timestamp, {
     windows: {
       ...current.windows,
-      [id]: { ...window, placement: { ...window.placement, floating: rect } }
+      [id]: { ...window2, placement: { ...window2.placement, floating: rect } }
     }
   });
 }
@@ -25670,15 +25853,15 @@ function requireWindowId(current, value) {
 }
 function requireFloatingWindow(current, value) {
   const id = requireWindowId(current, value);
-  const window = current.windows[id];
-  if (window.placement.mode !== "floating" || !window.placement.floating) {
+  const window2 = current.windows[id];
+  if (window2.placement.mode !== "floating" || !window2.placement.floating) {
     throw new AppWindowKernelError(
       "INVALID_PLACEMENT",
       `$.windows.${id}.placement`,
       `window "${id}" is not floating`
     );
   }
-  return [id, window, window.placement.floating];
+  return [id, window2, window2.placement.floating];
 }
 function requireStack(root, stackId) {
   const stack = findStack(root, stackId);
@@ -25767,11 +25950,11 @@ function syncDockMemories(windows, node) {
     return;
   }
   for (const [index, id] of node.windowIds.entries()) {
-    const window = Object.hasOwn(windows, id) ? windows[id] : null;
-    if (!window || window.placement.mode !== "docked") continue;
+    const window2 = Object.hasOwn(windows, id) ? windows[id] : null;
+    if (!window2 || window2.placement.mode !== "docked") continue;
     windows[id] = {
-      ...window,
-      placement: { ...window.placement, docked: { stackId: node.id, index } }
+      ...window2,
+      placement: { ...window2.placement, docked: { stackId: node.id, index } }
     };
   }
 }
@@ -26523,7 +26706,7 @@ var init_tmux_interaction_options = __esm({
 
 // packages/daemon/src/lib/tmux-external-interaction-observer.ts
 import { execFile as execFile3 } from "node:child_process";
-import { z as z60 } from "zod";
+import { z as z61 } from "zod";
 function socketArguments(authority) {
   return authority.socketSelector.kind === "path" ? ["-S", authority.socketSelector.path] : ["-L", authority.socketSelector.name];
 }
@@ -26744,7 +26927,7 @@ var init_tmux_external_interaction_observer = __esm({
         }
         const ownPrefix = `${this.#daemonInstanceId}:`;
         const authoredOperationId = record.operationMarker?.startsWith(ownPrefix) ? record.operationMarker.slice(ownPrefix.length) : null;
-        const operationId = z60.uuid().safeParse(authoredOperationId);
+        const operationId = z61.uuid().safeParse(authoredOperationId);
         let identity;
         try {
           identity = this.#io.runTmux([
@@ -29755,7 +29938,7 @@ var init_interaction_receipt_facts = __esm({
 });
 
 // packages/daemon/src/terminal/session-runtime/semantic-mutation-executor.ts
-import { z as z61 } from "zod";
+import { z as z62 } from "zod";
 function replayedResult(result) {
   return result === void 0 ? void 0 : { ...result, outcome: "replayed" };
 }
@@ -29791,7 +29974,7 @@ var init_semantic_mutation_executor = __esm({
             new SessionRuntimeIntentError("rejected", "Session semantic mutation executor is disposed")
           );
         }
-        const operationId = z61.uuid().parse(rawOperationId);
+        const operationId = z62.uuid().parse(rawOperationId);
         let intent = SessionRuntimeSemanticIntentSchemaZ.parse(rawIntent);
         if (intent.verb === "workspace.pane.send" || intent.verb === "workspace.pane.read") {
           intent = { ...intent, origin: authority.origin };
@@ -30064,9 +30247,8259 @@ var init_semantic_mutation_executor = __esm({
   }
 });
 
+// node_modules/.pnpm/@xterm+headless@6.0.0/node_modules/@xterm/headless/lib-headless/xterm-headless.js
+var require_xterm_headless = __commonJS({
+  "node_modules/.pnpm/@xterm+headless@6.0.0/node_modules/@xterm/headless/lib-headless/xterm-headless.js"(exports) {
+    (() => {
+      "use strict";
+      var e = { 5639: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.CircularList = void 0;
+        const i2 = s2(7150), r2 = s2(802);
+        class n2 extends i2.Disposable {
+          constructor(e3) {
+            super(), this._maxLength = e3, this.onDeleteEmitter = this._register(new r2.Emitter()), this.onDelete = this.onDeleteEmitter.event, this.onInsertEmitter = this._register(new r2.Emitter()), this.onInsert = this.onInsertEmitter.event, this.onTrimEmitter = this._register(new r2.Emitter()), this.onTrim = this.onTrimEmitter.event, this._array = new Array(this._maxLength), this._startIndex = 0, this._length = 0;
+          }
+          get maxLength() {
+            return this._maxLength;
+          }
+          set maxLength(e3) {
+            if (this._maxLength === e3) return;
+            const t3 = new Array(e3);
+            for (let s3 = 0; s3 < Math.min(e3, this.length); s3++) t3[s3] = this._array[this._getCyclicIndex(s3)];
+            this._array = t3, this._maxLength = e3, this._startIndex = 0;
+          }
+          get length() {
+            return this._length;
+          }
+          set length(e3) {
+            if (e3 > this._length) for (let t3 = this._length; t3 < e3; t3++) this._array[t3] = void 0;
+            this._length = e3;
+          }
+          get(e3) {
+            return this._array[this._getCyclicIndex(e3)];
+          }
+          set(e3, t3) {
+            this._array[this._getCyclicIndex(e3)] = t3;
+          }
+          push(e3) {
+            this._array[this._getCyclicIndex(this._length)] = e3, this._length === this._maxLength ? (this._startIndex = ++this._startIndex % this._maxLength, this.onTrimEmitter.fire(1)) : this._length++;
+          }
+          recycle() {
+            if (this._length !== this._maxLength) throw new Error("Can only recycle when the buffer is full");
+            return this._startIndex = ++this._startIndex % this._maxLength, this.onTrimEmitter.fire(1), this._array[this._getCyclicIndex(this._length - 1)];
+          }
+          get isFull() {
+            return this._length === this._maxLength;
+          }
+          pop() {
+            return this._array[this._getCyclicIndex(this._length-- - 1)];
+          }
+          splice(e3, t3, ...s3) {
+            if (t3) {
+              for (let s4 = e3; s4 < this._length - t3; s4++) this._array[this._getCyclicIndex(s4)] = this._array[this._getCyclicIndex(s4 + t3)];
+              this._length -= t3, this.onDeleteEmitter.fire({ index: e3, amount: t3 });
+            }
+            for (let t4 = this._length - 1; t4 >= e3; t4--) this._array[this._getCyclicIndex(t4 + s3.length)] = this._array[this._getCyclicIndex(t4)];
+            for (let t4 = 0; t4 < s3.length; t4++) this._array[this._getCyclicIndex(e3 + t4)] = s3[t4];
+            if (s3.length && this.onInsertEmitter.fire({ index: e3, amount: s3.length }), this._length + s3.length > this._maxLength) {
+              const e4 = this._length + s3.length - this._maxLength;
+              this._startIndex += e4, this._length = this._maxLength, this.onTrimEmitter.fire(e4);
+            } else this._length += s3.length;
+          }
+          trimStart(e3) {
+            e3 > this._length && (e3 = this._length), this._startIndex += e3, this._length -= e3, this.onTrimEmitter.fire(e3);
+          }
+          shiftElements(e3, t3, s3) {
+            if (!(t3 <= 0)) {
+              if (e3 < 0 || e3 >= this._length) throw new Error("start argument out of range");
+              if (e3 + s3 < 0) throw new Error("Cannot shift elements in list beyond index 0");
+              if (s3 > 0) {
+                for (let i4 = t3 - 1; i4 >= 0; i4--) this.set(e3 + i4 + s3, this.get(e3 + i4));
+                const i3 = e3 + t3 + s3 - this._length;
+                if (i3 > 0) for (this._length += i3; this._length > this._maxLength; ) this._length--, this._startIndex++, this.onTrimEmitter.fire(1);
+              } else for (let i3 = 0; i3 < t3; i3++) this.set(e3 + i3 + s3, this.get(e3 + i3));
+            }
+          }
+          _getCyclicIndex(e3) {
+            return (this._startIndex + e3) % this._maxLength;
+          }
+        }
+        t2.CircularList = n2;
+      }, 7453: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.clone = function e3(t3, s2 = 5) {
+          if ("object" != typeof t3) return t3;
+          const i2 = Array.isArray(t3) ? [] : {};
+          for (const r2 in t3) i2[r2] = s2 <= 1 ? t3[r2] : t3[r2] && e3(t3[r2], s2 - 1);
+          return i2;
+        };
+      }, 5777: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.CoreTerminal = void 0;
+        const i2 = s2(6501), r2 = s2(6025), n2 = s2(7276), o = s2(9640), a = s2(56), h = s2(4071), c = s2(7792), l = s2(6415), u = s2(5746), d = s2(5882), f = s2(2486), _ = s2(3562), p = s2(8811), g = s2(802), v = s2(7150);
+        let m = false;
+        class b extends v.Disposable {
+          get onScroll() {
+            return this._onScrollApi || (this._onScrollApi = this._register(new g.Emitter()), this._onScroll.event(((e3) => {
+              this._onScrollApi?.fire(e3.position);
+            }))), this._onScrollApi.event;
+          }
+          get cols() {
+            return this._bufferService.cols;
+          }
+          get rows() {
+            return this._bufferService.rows;
+          }
+          get buffers() {
+            return this._bufferService.buffers;
+          }
+          get options() {
+            return this.optionsService.options;
+          }
+          set options(e3) {
+            for (const t3 in e3) this.optionsService.options[t3] = e3[t3];
+          }
+          constructor(e3) {
+            super(), this._windowsWrappingHeuristics = this._register(new v.MutableDisposable()), this._onBinary = this._register(new g.Emitter()), this.onBinary = this._onBinary.event, this._onData = this._register(new g.Emitter()), this.onData = this._onData.event, this._onLineFeed = this._register(new g.Emitter()), this.onLineFeed = this._onLineFeed.event, this._onResize = this._register(new g.Emitter()), this.onResize = this._onResize.event, this._onWriteParsed = this._register(new g.Emitter()), this.onWriteParsed = this._onWriteParsed.event, this._onScroll = this._register(new g.Emitter()), this._instantiationService = new r2.InstantiationService(), this.optionsService = this._register(new a.OptionsService(e3)), this._instantiationService.setService(i2.IOptionsService, this.optionsService), this._bufferService = this._register(this._instantiationService.createInstance(o.BufferService)), this._instantiationService.setService(i2.IBufferService, this._bufferService), this._logService = this._register(this._instantiationService.createInstance(n2.LogService)), this._instantiationService.setService(i2.ILogService, this._logService), this.coreService = this._register(this._instantiationService.createInstance(h.CoreService)), this._instantiationService.setService(i2.ICoreService, this.coreService), this.coreMouseService = this._register(this._instantiationService.createInstance(c.CoreMouseService)), this._instantiationService.setService(i2.ICoreMouseService, this.coreMouseService), this.unicodeService = this._register(this._instantiationService.createInstance(l.UnicodeService)), this._instantiationService.setService(i2.IUnicodeService, this.unicodeService), this._charsetService = this._instantiationService.createInstance(u.CharsetService), this._instantiationService.setService(i2.ICharsetService, this._charsetService), this._oscLinkService = this._instantiationService.createInstance(p.OscLinkService), this._instantiationService.setService(i2.IOscLinkService, this._oscLinkService), this._inputHandler = this._register(new f.InputHandler(this._bufferService, this._charsetService, this.coreService, this._logService, this.optionsService, this._oscLinkService, this.coreMouseService, this.unicodeService)), this._register(g.Event.forward(this._inputHandler.onLineFeed, this._onLineFeed)), this._register(this._inputHandler), this._register(g.Event.forward(this._bufferService.onResize, this._onResize)), this._register(g.Event.forward(this.coreService.onData, this._onData)), this._register(g.Event.forward(this.coreService.onBinary, this._onBinary)), this._register(this.coreService.onRequestScrollToBottom((() => this.scrollToBottom(true)))), this._register(this.coreService.onUserInput((() => this._writeBuffer.handleUserInput()))), this._register(this.optionsService.onMultipleOptionChange(["windowsMode", "windowsPty"], (() => this._handleWindowsPtyOptionChange()))), this._register(this._bufferService.onScroll((() => {
+              this._onScroll.fire({ position: this._bufferService.buffer.ydisp }), this._inputHandler.markRangeDirty(this._bufferService.buffer.scrollTop, this._bufferService.buffer.scrollBottom);
+            }))), this._writeBuffer = this._register(new _.WriteBuffer(((e4, t3) => this._inputHandler.parse(e4, t3)))), this._register(g.Event.forward(this._writeBuffer.onWriteParsed, this._onWriteParsed));
+          }
+          write(e3, t3) {
+            this._writeBuffer.write(e3, t3);
+          }
+          writeSync(e3, t3) {
+            this._logService.logLevel <= i2.LogLevelEnum.WARN && !m && (this._logService.warn("writeSync is unreliable and will be removed soon."), m = true), this._writeBuffer.writeSync(e3, t3);
+          }
+          input(e3, t3 = true) {
+            this.coreService.triggerDataEvent(e3, t3);
+          }
+          resize(e3, t3) {
+            isNaN(e3) || isNaN(t3) || (e3 = Math.max(e3, o.MINIMUM_COLS), t3 = Math.max(t3, o.MINIMUM_ROWS), this._bufferService.resize(e3, t3));
+          }
+          scroll(e3, t3 = false) {
+            this._bufferService.scroll(e3, t3);
+          }
+          scrollLines(e3, t3) {
+            this._bufferService.scrollLines(e3, t3);
+          }
+          scrollPages(e3) {
+            this.scrollLines(e3 * (this.rows - 1));
+          }
+          scrollToTop() {
+            this.scrollLines(-this._bufferService.buffer.ydisp);
+          }
+          scrollToBottom(e3) {
+            this.scrollLines(this._bufferService.buffer.ybase - this._bufferService.buffer.ydisp);
+          }
+          scrollToLine(e3) {
+            const t3 = e3 - this._bufferService.buffer.ydisp;
+            0 !== t3 && this.scrollLines(t3);
+          }
+          registerEscHandler(e3, t3) {
+            return this._inputHandler.registerEscHandler(e3, t3);
+          }
+          registerDcsHandler(e3, t3) {
+            return this._inputHandler.registerDcsHandler(e3, t3);
+          }
+          registerCsiHandler(e3, t3) {
+            return this._inputHandler.registerCsiHandler(e3, t3);
+          }
+          registerOscHandler(e3, t3) {
+            return this._inputHandler.registerOscHandler(e3, t3);
+          }
+          _setup() {
+            this._handleWindowsPtyOptionChange();
+          }
+          reset() {
+            this._inputHandler.reset(), this._bufferService.reset(), this._charsetService.reset(), this.coreService.reset(), this.coreMouseService.reset();
+          }
+          _handleWindowsPtyOptionChange() {
+            let e3 = false;
+            const t3 = this.optionsService.rawOptions.windowsPty;
+            t3 && void 0 !== t3.buildNumber && void 0 !== t3.buildNumber ? e3 = !!("conpty" === t3.backend && t3.buildNumber < 21376) : this.optionsService.rawOptions.windowsMode && (e3 = true), e3 ? this._enableWindowsWrappingHeuristics() : this._windowsWrappingHeuristics.clear();
+          }
+          _enableWindowsWrappingHeuristics() {
+            if (!this._windowsWrappingHeuristics.value) {
+              const e3 = [];
+              e3.push(this.onLineFeed(d.updateWindowsModeWrappedState.bind(null, this._bufferService))), e3.push(this.registerCsiHandler({ final: "H" }, (() => ((0, d.updateWindowsModeWrappedState)(this._bufferService), false)))), this._windowsWrappingHeuristics.value = (0, v.toDisposable)((() => {
+                for (const t3 of e3) t3.dispose();
+              }));
+            }
+          }
+        }
+        t2.CoreTerminal = b;
+      }, 2486: function(e2, t2, s2) {
+        var i2 = this && this.__decorate || function(e3, t3, s3, i3) {
+          var r3, n3 = arguments.length, o2 = n3 < 3 ? t3 : null === i3 ? i3 = Object.getOwnPropertyDescriptor(t3, s3) : i3;
+          if ("object" == typeof Reflect && "function" == typeof Reflect.decorate) o2 = Reflect.decorate(e3, t3, s3, i3);
+          else for (var a2 = e3.length - 1; a2 >= 0; a2--) (r3 = e3[a2]) && (o2 = (n3 < 3 ? r3(o2) : n3 > 3 ? r3(t3, s3, o2) : r3(t3, s3)) || o2);
+          return n3 > 3 && o2 && Object.defineProperty(t3, s3, o2), o2;
+        }, r2 = this && this.__param || function(e3, t3) {
+          return function(s3, i3) {
+            t3(s3, i3, e3);
+          };
+        };
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.InputHandler = t2.WindowsOptionsReportType = void 0, t2.isValidColorIndex = k;
+        const n2 = s2(3534), o = s2(6760), a = s2(6717), h = s2(7150), c = s2(726), l = s2(6107), u = s2(8938), d = s2(3055), f = s2(5451), _ = s2(6501), p = s2(6415), g = s2(1346), v = s2(9823), m = s2(8693), b = s2(802), S = { "(": 0, ")": 1, "*": 2, "+": 3, "-": 1, ".": 2 }, y = 131072;
+        function C(e3, t3) {
+          if (e3 > 24) return t3.setWinLines || false;
+          switch (e3) {
+            case 1:
+              return !!t3.restoreWin;
+            case 2:
+              return !!t3.minimizeWin;
+            case 3:
+              return !!t3.setWinPosition;
+            case 4:
+              return !!t3.setWinSizePixels;
+            case 5:
+              return !!t3.raiseWin;
+            case 6:
+              return !!t3.lowerWin;
+            case 7:
+              return !!t3.refreshWin;
+            case 8:
+              return !!t3.setWinSizeChars;
+            case 9:
+              return !!t3.maximizeWin;
+            case 10:
+              return !!t3.fullscreenWin;
+            case 11:
+              return !!t3.getWinState;
+            case 13:
+              return !!t3.getWinPosition;
+            case 14:
+              return !!t3.getWinSizePixels;
+            case 15:
+              return !!t3.getScreenSizePixels;
+            case 16:
+              return !!t3.getCellSizePixels;
+            case 18:
+              return !!t3.getWinSizeChars;
+            case 19:
+              return !!t3.getScreenSizeChars;
+            case 20:
+              return !!t3.getIconTitle;
+            case 21:
+              return !!t3.getWinTitle;
+            case 22:
+              return !!t3.pushTitle;
+            case 23:
+              return !!t3.popTitle;
+            case 24:
+              return !!t3.setWinLines;
+          }
+          return false;
+        }
+        var w;
+        !(function(e3) {
+          e3[e3.GET_WIN_SIZE_PIXELS = 0] = "GET_WIN_SIZE_PIXELS", e3[e3.GET_CELL_SIZE_PIXELS = 1] = "GET_CELL_SIZE_PIXELS";
+        })(w || (t2.WindowsOptionsReportType = w = {}));
+        let E = 0;
+        class A extends h.Disposable {
+          getAttrData() {
+            return this._curAttrData;
+          }
+          constructor(e3, t3, s3, i3, r3, h2, u2, d2, f2 = new a.EscapeSequenceParser()) {
+            super(), this._bufferService = e3, this._charsetService = t3, this._coreService = s3, this._logService = i3, this._optionsService = r3, this._oscLinkService = h2, this._coreMouseService = u2, this._unicodeService = d2, this._parser = f2, this._parseBuffer = new Uint32Array(4096), this._stringDecoder = new c.StringToUtf32(), this._utf8Decoder = new c.Utf8ToUtf32(), this._windowTitle = "", this._iconName = "", this._windowTitleStack = [], this._iconNameStack = [], this._curAttrData = l.DEFAULT_ATTR_DATA.clone(), this._eraseAttrDataInternal = l.DEFAULT_ATTR_DATA.clone(), this._onRequestBell = this._register(new b.Emitter()), this.onRequestBell = this._onRequestBell.event, this._onRequestRefreshRows = this._register(new b.Emitter()), this.onRequestRefreshRows = this._onRequestRefreshRows.event, this._onRequestReset = this._register(new b.Emitter()), this.onRequestReset = this._onRequestReset.event, this._onRequestSendFocus = this._register(new b.Emitter()), this.onRequestSendFocus = this._onRequestSendFocus.event, this._onRequestSyncScrollBar = this._register(new b.Emitter()), this.onRequestSyncScrollBar = this._onRequestSyncScrollBar.event, this._onRequestWindowsOptionsReport = this._register(new b.Emitter()), this.onRequestWindowsOptionsReport = this._onRequestWindowsOptionsReport.event, this._onA11yChar = this._register(new b.Emitter()), this.onA11yChar = this._onA11yChar.event, this._onA11yTab = this._register(new b.Emitter()), this.onA11yTab = this._onA11yTab.event, this._onCursorMove = this._register(new b.Emitter()), this.onCursorMove = this._onCursorMove.event, this._onLineFeed = this._register(new b.Emitter()), this.onLineFeed = this._onLineFeed.event, this._onScroll = this._register(new b.Emitter()), this.onScroll = this._onScroll.event, this._onTitleChange = this._register(new b.Emitter()), this.onTitleChange = this._onTitleChange.event, this._onColor = this._register(new b.Emitter()), this.onColor = this._onColor.event, this._parseStack = { paused: false, cursorStartX: 0, cursorStartY: 0, decodedLength: 0, position: 0 }, this._specialColors = [256, 257, 258], this._register(this._parser), this._dirtyRowTracker = new L(this._bufferService), this._activeBuffer = this._bufferService.buffer, this._register(this._bufferService.buffers.onBufferActivate(((e4) => this._activeBuffer = e4.activeBuffer))), this._parser.setCsiHandlerFallback(((e4, t4) => {
+              this._logService.debug("Unknown CSI code: ", { identifier: this._parser.identToString(e4), params: t4.toArray() });
+            })), this._parser.setEscHandlerFallback(((e4) => {
+              this._logService.debug("Unknown ESC code: ", { identifier: this._parser.identToString(e4) });
+            })), this._parser.setExecuteHandlerFallback(((e4) => {
+              this._logService.debug("Unknown EXECUTE code: ", { code: e4 });
+            })), this._parser.setOscHandlerFallback(((e4, t4, s4) => {
+              this._logService.debug("Unknown OSC code: ", { identifier: e4, action: t4, data: s4 });
+            })), this._parser.setDcsHandlerFallback(((e4, t4, s4) => {
+              "HOOK" === t4 && (s4 = s4.toArray()), this._logService.debug("Unknown DCS code: ", { identifier: this._parser.identToString(e4), action: t4, payload: s4 });
+            })), this._parser.setPrintHandler(((e4, t4, s4) => this.print(e4, t4, s4))), this._parser.registerCsiHandler({ final: "@" }, ((e4) => this.insertChars(e4))), this._parser.registerCsiHandler({ intermediates: " ", final: "@" }, ((e4) => this.scrollLeft(e4))), this._parser.registerCsiHandler({ final: "A" }, ((e4) => this.cursorUp(e4))), this._parser.registerCsiHandler({ intermediates: " ", final: "A" }, ((e4) => this.scrollRight(e4))), this._parser.registerCsiHandler({ final: "B" }, ((e4) => this.cursorDown(e4))), this._parser.registerCsiHandler({ final: "C" }, ((e4) => this.cursorForward(e4))), this._parser.registerCsiHandler({ final: "D" }, ((e4) => this.cursorBackward(e4))), this._parser.registerCsiHandler({ final: "E" }, ((e4) => this.cursorNextLine(e4))), this._parser.registerCsiHandler({ final: "F" }, ((e4) => this.cursorPrecedingLine(e4))), this._parser.registerCsiHandler({ final: "G" }, ((e4) => this.cursorCharAbsolute(e4))), this._parser.registerCsiHandler({ final: "H" }, ((e4) => this.cursorPosition(e4))), this._parser.registerCsiHandler({ final: "I" }, ((e4) => this.cursorForwardTab(e4))), this._parser.registerCsiHandler({ final: "J" }, ((e4) => this.eraseInDisplay(e4, false))), this._parser.registerCsiHandler({ prefix: "?", final: "J" }, ((e4) => this.eraseInDisplay(e4, true))), this._parser.registerCsiHandler({ final: "K" }, ((e4) => this.eraseInLine(e4, false))), this._parser.registerCsiHandler({ prefix: "?", final: "K" }, ((e4) => this.eraseInLine(e4, true))), this._parser.registerCsiHandler({ final: "L" }, ((e4) => this.insertLines(e4))), this._parser.registerCsiHandler({ final: "M" }, ((e4) => this.deleteLines(e4))), this._parser.registerCsiHandler({ final: "P" }, ((e4) => this.deleteChars(e4))), this._parser.registerCsiHandler({ final: "S" }, ((e4) => this.scrollUp(e4))), this._parser.registerCsiHandler({ final: "T" }, ((e4) => this.scrollDown(e4))), this._parser.registerCsiHandler({ final: "X" }, ((e4) => this.eraseChars(e4))), this._parser.registerCsiHandler({ final: "Z" }, ((e4) => this.cursorBackwardTab(e4))), this._parser.registerCsiHandler({ final: "`" }, ((e4) => this.charPosAbsolute(e4))), this._parser.registerCsiHandler({ final: "a" }, ((e4) => this.hPositionRelative(e4))), this._parser.registerCsiHandler({ final: "b" }, ((e4) => this.repeatPrecedingCharacter(e4))), this._parser.registerCsiHandler({ final: "c" }, ((e4) => this.sendDeviceAttributesPrimary(e4))), this._parser.registerCsiHandler({ prefix: ">", final: "c" }, ((e4) => this.sendDeviceAttributesSecondary(e4))), this._parser.registerCsiHandler({ final: "d" }, ((e4) => this.linePosAbsolute(e4))), this._parser.registerCsiHandler({ final: "e" }, ((e4) => this.vPositionRelative(e4))), this._parser.registerCsiHandler({ final: "f" }, ((e4) => this.hVPosition(e4))), this._parser.registerCsiHandler({ final: "g" }, ((e4) => this.tabClear(e4))), this._parser.registerCsiHandler({ final: "h" }, ((e4) => this.setMode(e4))), this._parser.registerCsiHandler({ prefix: "?", final: "h" }, ((e4) => this.setModePrivate(e4))), this._parser.registerCsiHandler({ final: "l" }, ((e4) => this.resetMode(e4))), this._parser.registerCsiHandler({ prefix: "?", final: "l" }, ((e4) => this.resetModePrivate(e4))), this._parser.registerCsiHandler({ final: "m" }, ((e4) => this.charAttributes(e4))), this._parser.registerCsiHandler({ final: "n" }, ((e4) => this.deviceStatus(e4))), this._parser.registerCsiHandler({ prefix: "?", final: "n" }, ((e4) => this.deviceStatusPrivate(e4))), this._parser.registerCsiHandler({ intermediates: "!", final: "p" }, ((e4) => this.softReset(e4))), this._parser.registerCsiHandler({ intermediates: " ", final: "q" }, ((e4) => this.setCursorStyle(e4))), this._parser.registerCsiHandler({ final: "r" }, ((e4) => this.setScrollRegion(e4))), this._parser.registerCsiHandler({ final: "s" }, ((e4) => this.saveCursor(e4))), this._parser.registerCsiHandler({ final: "t" }, ((e4) => this.windowOptions(e4))), this._parser.registerCsiHandler({ final: "u" }, ((e4) => this.restoreCursor(e4))), this._parser.registerCsiHandler({ intermediates: "'", final: "}" }, ((e4) => this.insertColumns(e4))), this._parser.registerCsiHandler({ intermediates: "'", final: "~" }, ((e4) => this.deleteColumns(e4))), this._parser.registerCsiHandler({ intermediates: '"', final: "q" }, ((e4) => this.selectProtected(e4))), this._parser.registerCsiHandler({ intermediates: "$", final: "p" }, ((e4) => this.requestMode(e4, true))), this._parser.registerCsiHandler({ prefix: "?", intermediates: "$", final: "p" }, ((e4) => this.requestMode(e4, false))), this._parser.setExecuteHandler(n2.C0.BEL, (() => this.bell())), this._parser.setExecuteHandler(n2.C0.LF, (() => this.lineFeed())), this._parser.setExecuteHandler(n2.C0.VT, (() => this.lineFeed())), this._parser.setExecuteHandler(n2.C0.FF, (() => this.lineFeed())), this._parser.setExecuteHandler(n2.C0.CR, (() => this.carriageReturn())), this._parser.setExecuteHandler(n2.C0.BS, (() => this.backspace())), this._parser.setExecuteHandler(n2.C0.HT, (() => this.tab())), this._parser.setExecuteHandler(n2.C0.SO, (() => this.shiftOut())), this._parser.setExecuteHandler(n2.C0.SI, (() => this.shiftIn())), this._parser.setExecuteHandler(n2.C1.IND, (() => this.index())), this._parser.setExecuteHandler(n2.C1.NEL, (() => this.nextLine())), this._parser.setExecuteHandler(n2.C1.HTS, (() => this.tabSet())), this._parser.registerOscHandler(0, new g.OscHandler(((e4) => (this.setTitle(e4), this.setIconName(e4), true)))), this._parser.registerOscHandler(1, new g.OscHandler(((e4) => this.setIconName(e4)))), this._parser.registerOscHandler(2, new g.OscHandler(((e4) => this.setTitle(e4)))), this._parser.registerOscHandler(4, new g.OscHandler(((e4) => this.setOrReportIndexedColor(e4)))), this._parser.registerOscHandler(8, new g.OscHandler(((e4) => this.setHyperlink(e4)))), this._parser.registerOscHandler(10, new g.OscHandler(((e4) => this.setOrReportFgColor(e4)))), this._parser.registerOscHandler(11, new g.OscHandler(((e4) => this.setOrReportBgColor(e4)))), this._parser.registerOscHandler(12, new g.OscHandler(((e4) => this.setOrReportCursorColor(e4)))), this._parser.registerOscHandler(104, new g.OscHandler(((e4) => this.restoreIndexedColor(e4)))), this._parser.registerOscHandler(110, new g.OscHandler(((e4) => this.restoreFgColor(e4)))), this._parser.registerOscHandler(111, new g.OscHandler(((e4) => this.restoreBgColor(e4)))), this._parser.registerOscHandler(112, new g.OscHandler(((e4) => this.restoreCursorColor(e4)))), this._parser.registerEscHandler({ final: "7" }, (() => this.saveCursor())), this._parser.registerEscHandler({ final: "8" }, (() => this.restoreCursor())), this._parser.registerEscHandler({ final: "D" }, (() => this.index())), this._parser.registerEscHandler({ final: "E" }, (() => this.nextLine())), this._parser.registerEscHandler({ final: "H" }, (() => this.tabSet())), this._parser.registerEscHandler({ final: "M" }, (() => this.reverseIndex())), this._parser.registerEscHandler({ final: "=" }, (() => this.keypadApplicationMode())), this._parser.registerEscHandler({ final: ">" }, (() => this.keypadNumericMode())), this._parser.registerEscHandler({ final: "c" }, (() => this.fullReset())), this._parser.registerEscHandler({ final: "n" }, (() => this.setgLevel(2))), this._parser.registerEscHandler({ final: "o" }, (() => this.setgLevel(3))), this._parser.registerEscHandler({ final: "|" }, (() => this.setgLevel(3))), this._parser.registerEscHandler({ final: "}" }, (() => this.setgLevel(2))), this._parser.registerEscHandler({ final: "~" }, (() => this.setgLevel(1))), this._parser.registerEscHandler({ intermediates: "%", final: "@" }, (() => this.selectDefaultCharset())), this._parser.registerEscHandler({ intermediates: "%", final: "G" }, (() => this.selectDefaultCharset()));
+            for (const e4 in o.CHARSETS) this._parser.registerEscHandler({ intermediates: "(", final: e4 }, (() => this.selectCharset("(" + e4))), this._parser.registerEscHandler({ intermediates: ")", final: e4 }, (() => this.selectCharset(")" + e4))), this._parser.registerEscHandler({ intermediates: "*", final: e4 }, (() => this.selectCharset("*" + e4))), this._parser.registerEscHandler({ intermediates: "+", final: e4 }, (() => this.selectCharset("+" + e4))), this._parser.registerEscHandler({ intermediates: "-", final: e4 }, (() => this.selectCharset("-" + e4))), this._parser.registerEscHandler({ intermediates: ".", final: e4 }, (() => this.selectCharset("." + e4))), this._parser.registerEscHandler({ intermediates: "/", final: e4 }, (() => this.selectCharset("/" + e4)));
+            this._parser.registerEscHandler({ intermediates: "#", final: "8" }, (() => this.screenAlignmentPattern())), this._parser.setErrorHandler(((e4) => (this._logService.error("Parsing error: ", e4), e4))), this._parser.registerDcsHandler({ intermediates: "$", final: "q" }, new v.DcsHandler(((e4, t4) => this.requestStatusString(e4, t4))));
+          }
+          _preserveStack(e3, t3, s3, i3) {
+            this._parseStack.paused = true, this._parseStack.cursorStartX = e3, this._parseStack.cursorStartY = t3, this._parseStack.decodedLength = s3, this._parseStack.position = i3;
+          }
+          _logSlowResolvingAsync(e3) {
+            this._logService.logLevel <= _.LogLevelEnum.WARN && Promise.race([e3, new Promise(((e4, t3) => setTimeout((() => t3("#SLOW_TIMEOUT")), 5e3)))]).catch(((e4) => {
+              if ("#SLOW_TIMEOUT" !== e4) throw e4;
+              console.warn("async parser handler taking longer than 5000 ms");
+            }));
+          }
+          _getCurrentLinkId() {
+            return this._curAttrData.extended.urlId;
+          }
+          parse(e3, t3) {
+            let s3, i3 = this._activeBuffer.x, r3 = this._activeBuffer.y, n3 = 0;
+            const o2 = this._parseStack.paused;
+            if (o2) {
+              if (s3 = this._parser.parse(this._parseBuffer, this._parseStack.decodedLength, t3)) return this._logSlowResolvingAsync(s3), s3;
+              i3 = this._parseStack.cursorStartX, r3 = this._parseStack.cursorStartY, this._parseStack.paused = false, e3.length > y && (n3 = this._parseStack.position + y);
+            }
+            if (this._logService.logLevel <= _.LogLevelEnum.DEBUG && this._logService.debug("parsing data " + ("string" == typeof e3 ? ` "${e3}"` : ` "${Array.prototype.map.call(e3, ((e4) => String.fromCharCode(e4))).join("")}"`)), this._logService.logLevel === _.LogLevelEnum.TRACE && this._logService.trace("parsing data (codes)", "string" == typeof e3 ? e3.split("").map(((e4) => e4.charCodeAt(0))) : e3), this._parseBuffer.length < e3.length && this._parseBuffer.length < y && (this._parseBuffer = new Uint32Array(Math.min(e3.length, y))), o2 || this._dirtyRowTracker.clearRange(), e3.length > y) for (let t4 = n3; t4 < e3.length; t4 += y) {
+              const n4 = t4 + y < e3.length ? t4 + y : e3.length, o3 = "string" == typeof e3 ? this._stringDecoder.decode(e3.substring(t4, n4), this._parseBuffer) : this._utf8Decoder.decode(e3.subarray(t4, n4), this._parseBuffer);
+              if (s3 = this._parser.parse(this._parseBuffer, o3)) return this._preserveStack(i3, r3, o3, t4), this._logSlowResolvingAsync(s3), s3;
+            }
+            else if (!o2) {
+              const t4 = "string" == typeof e3 ? this._stringDecoder.decode(e3, this._parseBuffer) : this._utf8Decoder.decode(e3, this._parseBuffer);
+              if (s3 = this._parser.parse(this._parseBuffer, t4)) return this._preserveStack(i3, r3, t4, 0), this._logSlowResolvingAsync(s3), s3;
+            }
+            this._activeBuffer.x === i3 && this._activeBuffer.y === r3 || this._onCursorMove.fire();
+            const a2 = this._dirtyRowTracker.end + (this._bufferService.buffer.ybase - this._bufferService.buffer.ydisp), h2 = this._dirtyRowTracker.start + (this._bufferService.buffer.ybase - this._bufferService.buffer.ydisp);
+            h2 < this._bufferService.rows && this._onRequestRefreshRows.fire({ start: Math.min(h2, this._bufferService.rows - 1), end: Math.min(a2, this._bufferService.rows - 1) });
+          }
+          print(e3, t3, s3) {
+            let i3, r3;
+            const n3 = this._charsetService.charset, o2 = this._optionsService.rawOptions.screenReaderMode, a2 = this._bufferService.cols, h2 = this._coreService.decPrivateModes.wraparound, d2 = this._coreService.modes.insertMode, f2 = this._curAttrData;
+            let _2 = this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y);
+            this._dirtyRowTracker.markDirty(this._activeBuffer.y), this._activeBuffer.x && s3 - t3 > 0 && 2 === _2.getWidth(this._activeBuffer.x - 1) && _2.setCellFromCodepoint(this._activeBuffer.x - 1, 0, 1, f2);
+            let g2 = this._parser.precedingJoinState;
+            for (let v2 = t3; v2 < s3; ++v2) {
+              if (i3 = e3[v2], i3 < 127 && n3) {
+                const e4 = n3[String.fromCharCode(i3)];
+                e4 && (i3 = e4.charCodeAt(0));
+              }
+              const t4 = this._unicodeService.charProperties(i3, g2);
+              r3 = p.UnicodeService.extractWidth(t4);
+              const s4 = p.UnicodeService.extractShouldJoin(t4), m2 = s4 ? p.UnicodeService.extractWidth(g2) : 0;
+              if (g2 = t4, o2 && this._onA11yChar.fire((0, c.stringFromCodePoint)(i3)), this._getCurrentLinkId() && this._oscLinkService.addLineToLink(this._getCurrentLinkId(), this._activeBuffer.ybase + this._activeBuffer.y), this._activeBuffer.x + r3 - m2 > a2) {
+                if (h2) {
+                  const e4 = _2;
+                  let t5 = this._activeBuffer.x - m2;
+                  for (this._activeBuffer.x = m2, this._activeBuffer.y++, this._activeBuffer.y === this._activeBuffer.scrollBottom + 1 ? (this._activeBuffer.y--, this._bufferService.scroll(this._eraseAttrData(), true)) : (this._activeBuffer.y >= this._bufferService.rows && (this._activeBuffer.y = this._bufferService.rows - 1), this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y).isWrapped = true), _2 = this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y), m2 > 0 && _2 instanceof l.BufferLine && _2.copyCellsFrom(e4, t5, 0, m2, false); t5 < a2; ) e4.setCellFromCodepoint(t5++, 0, 1, f2);
+                } else if (this._activeBuffer.x = a2 - 1, 2 === r3) continue;
+              }
+              if (s4 && this._activeBuffer.x) {
+                const e4 = _2.getWidth(this._activeBuffer.x - 1) ? 1 : 2;
+                _2.addCodepointToCell(this._activeBuffer.x - e4, i3, r3);
+                for (let e5 = r3 - m2; --e5 >= 0; ) _2.setCellFromCodepoint(this._activeBuffer.x++, 0, 0, f2);
+              } else if (d2 && (_2.insertCells(this._activeBuffer.x, r3 - m2, this._activeBuffer.getNullCell(f2)), 2 === _2.getWidth(a2 - 1) && _2.setCellFromCodepoint(a2 - 1, u.NULL_CELL_CODE, u.NULL_CELL_WIDTH, f2)), _2.setCellFromCodepoint(this._activeBuffer.x++, i3, r3, f2), r3 > 0) for (; --r3; ) _2.setCellFromCodepoint(this._activeBuffer.x++, 0, 0, f2);
+            }
+            this._parser.precedingJoinState = g2, this._activeBuffer.x < a2 && s3 - t3 > 0 && 0 === _2.getWidth(this._activeBuffer.x) && !_2.hasContent(this._activeBuffer.x) && _2.setCellFromCodepoint(this._activeBuffer.x, 0, 1, f2), this._dirtyRowTracker.markDirty(this._activeBuffer.y);
+          }
+          registerCsiHandler(e3, t3) {
+            return "t" !== e3.final || e3.prefix || e3.intermediates ? this._parser.registerCsiHandler(e3, t3) : this._parser.registerCsiHandler(e3, ((e4) => !C(e4.params[0], this._optionsService.rawOptions.windowOptions) || t3(e4)));
+          }
+          registerDcsHandler(e3, t3) {
+            return this._parser.registerDcsHandler(e3, new v.DcsHandler(t3));
+          }
+          registerEscHandler(e3, t3) {
+            return this._parser.registerEscHandler(e3, t3);
+          }
+          registerOscHandler(e3, t3) {
+            return this._parser.registerOscHandler(e3, new g.OscHandler(t3));
+          }
+          bell() {
+            return this._onRequestBell.fire(), true;
+          }
+          lineFeed() {
+            return this._dirtyRowTracker.markDirty(this._activeBuffer.y), this._optionsService.rawOptions.convertEol && (this._activeBuffer.x = 0), this._activeBuffer.y++, this._activeBuffer.y === this._activeBuffer.scrollBottom + 1 ? (this._activeBuffer.y--, this._bufferService.scroll(this._eraseAttrData())) : this._activeBuffer.y >= this._bufferService.rows ? this._activeBuffer.y = this._bufferService.rows - 1 : this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y).isWrapped = false, this._activeBuffer.x >= this._bufferService.cols && this._activeBuffer.x--, this._dirtyRowTracker.markDirty(this._activeBuffer.y), this._onLineFeed.fire(), true;
+          }
+          carriageReturn() {
+            return this._activeBuffer.x = 0, true;
+          }
+          backspace() {
+            if (!this._coreService.decPrivateModes.reverseWraparound) return this._restrictCursor(), this._activeBuffer.x > 0 && this._activeBuffer.x--, true;
+            if (this._restrictCursor(this._bufferService.cols), this._activeBuffer.x > 0) this._activeBuffer.x--;
+            else if (0 === this._activeBuffer.x && this._activeBuffer.y > this._activeBuffer.scrollTop && this._activeBuffer.y <= this._activeBuffer.scrollBottom && this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y)?.isWrapped) {
+              this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y).isWrapped = false, this._activeBuffer.y--, this._activeBuffer.x = this._bufferService.cols - 1;
+              const e3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y);
+              e3.hasWidth(this._activeBuffer.x) && !e3.hasContent(this._activeBuffer.x) && this._activeBuffer.x--;
+            }
+            return this._restrictCursor(), true;
+          }
+          tab() {
+            if (this._activeBuffer.x >= this._bufferService.cols) return true;
+            const e3 = this._activeBuffer.x;
+            return this._activeBuffer.x = this._activeBuffer.nextStop(), this._optionsService.rawOptions.screenReaderMode && this._onA11yTab.fire(this._activeBuffer.x - e3), true;
+          }
+          shiftOut() {
+            return this._charsetService.setgLevel(1), true;
+          }
+          shiftIn() {
+            return this._charsetService.setgLevel(0), true;
+          }
+          _restrictCursor(e3 = this._bufferService.cols - 1) {
+            this._activeBuffer.x = Math.min(e3, Math.max(0, this._activeBuffer.x)), this._activeBuffer.y = this._coreService.decPrivateModes.origin ? Math.min(this._activeBuffer.scrollBottom, Math.max(this._activeBuffer.scrollTop, this._activeBuffer.y)) : Math.min(this._bufferService.rows - 1, Math.max(0, this._activeBuffer.y)), this._dirtyRowTracker.markDirty(this._activeBuffer.y);
+          }
+          _setCursor(e3, t3) {
+            this._dirtyRowTracker.markDirty(this._activeBuffer.y), this._coreService.decPrivateModes.origin ? (this._activeBuffer.x = e3, this._activeBuffer.y = this._activeBuffer.scrollTop + t3) : (this._activeBuffer.x = e3, this._activeBuffer.y = t3), this._restrictCursor(), this._dirtyRowTracker.markDirty(this._activeBuffer.y);
+          }
+          _moveCursor(e3, t3) {
+            this._restrictCursor(), this._setCursor(this._activeBuffer.x + e3, this._activeBuffer.y + t3);
+          }
+          cursorUp(e3) {
+            const t3 = this._activeBuffer.y - this._activeBuffer.scrollTop;
+            return t3 >= 0 ? this._moveCursor(0, -Math.min(t3, e3.params[0] || 1)) : this._moveCursor(0, -(e3.params[0] || 1)), true;
+          }
+          cursorDown(e3) {
+            const t3 = this._activeBuffer.scrollBottom - this._activeBuffer.y;
+            return t3 >= 0 ? this._moveCursor(0, Math.min(t3, e3.params[0] || 1)) : this._moveCursor(0, e3.params[0] || 1), true;
+          }
+          cursorForward(e3) {
+            return this._moveCursor(e3.params[0] || 1, 0), true;
+          }
+          cursorBackward(e3) {
+            return this._moveCursor(-(e3.params[0] || 1), 0), true;
+          }
+          cursorNextLine(e3) {
+            return this.cursorDown(e3), this._activeBuffer.x = 0, true;
+          }
+          cursorPrecedingLine(e3) {
+            return this.cursorUp(e3), this._activeBuffer.x = 0, true;
+          }
+          cursorCharAbsolute(e3) {
+            return this._setCursor((e3.params[0] || 1) - 1, this._activeBuffer.y), true;
+          }
+          cursorPosition(e3) {
+            return this._setCursor(e3.length >= 2 ? (e3.params[1] || 1) - 1 : 0, (e3.params[0] || 1) - 1), true;
+          }
+          charPosAbsolute(e3) {
+            return this._setCursor((e3.params[0] || 1) - 1, this._activeBuffer.y), true;
+          }
+          hPositionRelative(e3) {
+            return this._moveCursor(e3.params[0] || 1, 0), true;
+          }
+          linePosAbsolute(e3) {
+            return this._setCursor(this._activeBuffer.x, (e3.params[0] || 1) - 1), true;
+          }
+          vPositionRelative(e3) {
+            return this._moveCursor(0, e3.params[0] || 1), true;
+          }
+          hVPosition(e3) {
+            return this.cursorPosition(e3), true;
+          }
+          tabClear(e3) {
+            const t3 = e3.params[0];
+            return 0 === t3 ? delete this._activeBuffer.tabs[this._activeBuffer.x] : 3 === t3 && (this._activeBuffer.tabs = {}), true;
+          }
+          cursorForwardTab(e3) {
+            if (this._activeBuffer.x >= this._bufferService.cols) return true;
+            let t3 = e3.params[0] || 1;
+            for (; t3--; ) this._activeBuffer.x = this._activeBuffer.nextStop();
+            return true;
+          }
+          cursorBackwardTab(e3) {
+            if (this._activeBuffer.x >= this._bufferService.cols) return true;
+            let t3 = e3.params[0] || 1;
+            for (; t3--; ) this._activeBuffer.x = this._activeBuffer.prevStop();
+            return true;
+          }
+          selectProtected(e3) {
+            const t3 = e3.params[0];
+            return 1 === t3 && (this._curAttrData.bg |= 536870912), 2 !== t3 && 0 !== t3 || (this._curAttrData.bg &= -536870913), true;
+          }
+          _eraseInBufferLine(e3, t3, s3, i3 = false, r3 = false) {
+            const n3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + e3);
+            n3.replaceCells(t3, s3, this._activeBuffer.getNullCell(this._eraseAttrData()), r3), i3 && (n3.isWrapped = false);
+          }
+          _resetBufferLine(e3, t3 = false) {
+            const s3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + e3);
+            s3 && (s3.fill(this._activeBuffer.getNullCell(this._eraseAttrData()), t3), this._bufferService.buffer.clearMarkers(this._activeBuffer.ybase + e3), s3.isWrapped = false);
+          }
+          eraseInDisplay(e3, t3 = false) {
+            let s3;
+            switch (this._restrictCursor(this._bufferService.cols), e3.params[0]) {
+              case 0:
+                for (s3 = this._activeBuffer.y, this._dirtyRowTracker.markDirty(s3), this._eraseInBufferLine(s3++, this._activeBuffer.x, this._bufferService.cols, 0 === this._activeBuffer.x, t3); s3 < this._bufferService.rows; s3++) this._resetBufferLine(s3, t3);
+                this._dirtyRowTracker.markDirty(s3);
+                break;
+              case 1:
+                for (s3 = this._activeBuffer.y, this._dirtyRowTracker.markDirty(s3), this._eraseInBufferLine(s3, 0, this._activeBuffer.x + 1, true, t3), this._activeBuffer.x + 1 >= this._bufferService.cols && (this._activeBuffer.lines.get(s3 + 1).isWrapped = false); s3--; ) this._resetBufferLine(s3, t3);
+                this._dirtyRowTracker.markDirty(0);
+                break;
+              case 2:
+                if (this._optionsService.rawOptions.scrollOnEraseInDisplay) {
+                  for (s3 = this._bufferService.rows, this._dirtyRowTracker.markRangeDirty(0, s3 - 1); s3--; ) {
+                    const e5 = this._activeBuffer.lines.get(this._activeBuffer.ybase + s3);
+                    if (e5?.getTrimmedLength()) break;
+                  }
+                  for (; s3 >= 0; s3--) this._bufferService.scroll(this._eraseAttrData());
+                } else {
+                  for (s3 = this._bufferService.rows, this._dirtyRowTracker.markDirty(s3 - 1); s3--; ) this._resetBufferLine(s3, t3);
+                  this._dirtyRowTracker.markDirty(0);
+                }
+                break;
+              case 3:
+                const e4 = this._activeBuffer.lines.length - this._bufferService.rows;
+                e4 > 0 && (this._activeBuffer.lines.trimStart(e4), this._activeBuffer.ybase = Math.max(this._activeBuffer.ybase - e4, 0), this._activeBuffer.ydisp = Math.max(this._activeBuffer.ydisp - e4, 0), this._onScroll.fire(0));
+            }
+            return true;
+          }
+          eraseInLine(e3, t3 = false) {
+            switch (this._restrictCursor(this._bufferService.cols), e3.params[0]) {
+              case 0:
+                this._eraseInBufferLine(this._activeBuffer.y, this._activeBuffer.x, this._bufferService.cols, 0 === this._activeBuffer.x, t3);
+                break;
+              case 1:
+                this._eraseInBufferLine(this._activeBuffer.y, 0, this._activeBuffer.x + 1, false, t3);
+                break;
+              case 2:
+                this._eraseInBufferLine(this._activeBuffer.y, 0, this._bufferService.cols, true, t3);
+            }
+            return this._dirtyRowTracker.markDirty(this._activeBuffer.y), true;
+          }
+          insertLines(e3) {
+            this._restrictCursor();
+            let t3 = e3.params[0] || 1;
+            if (this._activeBuffer.y > this._activeBuffer.scrollBottom || this._activeBuffer.y < this._activeBuffer.scrollTop) return true;
+            const s3 = this._activeBuffer.ybase + this._activeBuffer.y, i3 = this._bufferService.rows - 1 - this._activeBuffer.scrollBottom, r3 = this._bufferService.rows - 1 + this._activeBuffer.ybase - i3 + 1;
+            for (; t3--; ) this._activeBuffer.lines.splice(r3 - 1, 1), this._activeBuffer.lines.splice(s3, 0, this._activeBuffer.getBlankLine(this._eraseAttrData()));
+            return this._dirtyRowTracker.markRangeDirty(this._activeBuffer.y, this._activeBuffer.scrollBottom), this._activeBuffer.x = 0, true;
+          }
+          deleteLines(e3) {
+            this._restrictCursor();
+            let t3 = e3.params[0] || 1;
+            if (this._activeBuffer.y > this._activeBuffer.scrollBottom || this._activeBuffer.y < this._activeBuffer.scrollTop) return true;
+            const s3 = this._activeBuffer.ybase + this._activeBuffer.y;
+            let i3;
+            for (i3 = this._bufferService.rows - 1 - this._activeBuffer.scrollBottom, i3 = this._bufferService.rows - 1 + this._activeBuffer.ybase - i3; t3--; ) this._activeBuffer.lines.splice(s3, 1), this._activeBuffer.lines.splice(i3, 0, this._activeBuffer.getBlankLine(this._eraseAttrData()));
+            return this._dirtyRowTracker.markRangeDirty(this._activeBuffer.y, this._activeBuffer.scrollBottom), this._activeBuffer.x = 0, true;
+          }
+          insertChars(e3) {
+            this._restrictCursor();
+            const t3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y);
+            return t3 && (t3.insertCells(this._activeBuffer.x, e3.params[0] || 1, this._activeBuffer.getNullCell(this._eraseAttrData())), this._dirtyRowTracker.markDirty(this._activeBuffer.y)), true;
+          }
+          deleteChars(e3) {
+            this._restrictCursor();
+            const t3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y);
+            return t3 && (t3.deleteCells(this._activeBuffer.x, e3.params[0] || 1, this._activeBuffer.getNullCell(this._eraseAttrData())), this._dirtyRowTracker.markDirty(this._activeBuffer.y)), true;
+          }
+          scrollUp(e3) {
+            let t3 = e3.params[0] || 1;
+            for (; t3--; ) this._activeBuffer.lines.splice(this._activeBuffer.ybase + this._activeBuffer.scrollTop, 1), this._activeBuffer.lines.splice(this._activeBuffer.ybase + this._activeBuffer.scrollBottom, 0, this._activeBuffer.getBlankLine(this._eraseAttrData()));
+            return this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom), true;
+          }
+          scrollDown(e3) {
+            let t3 = e3.params[0] || 1;
+            for (; t3--; ) this._activeBuffer.lines.splice(this._activeBuffer.ybase + this._activeBuffer.scrollBottom, 1), this._activeBuffer.lines.splice(this._activeBuffer.ybase + this._activeBuffer.scrollTop, 0, this._activeBuffer.getBlankLine(l.DEFAULT_ATTR_DATA));
+            return this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom), true;
+          }
+          scrollLeft(e3) {
+            if (this._activeBuffer.y > this._activeBuffer.scrollBottom || this._activeBuffer.y < this._activeBuffer.scrollTop) return true;
+            const t3 = e3.params[0] || 1;
+            for (let e4 = this._activeBuffer.scrollTop; e4 <= this._activeBuffer.scrollBottom; ++e4) {
+              const s3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + e4);
+              s3.deleteCells(0, t3, this._activeBuffer.getNullCell(this._eraseAttrData())), s3.isWrapped = false;
+            }
+            return this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom), true;
+          }
+          scrollRight(e3) {
+            if (this._activeBuffer.y > this._activeBuffer.scrollBottom || this._activeBuffer.y < this._activeBuffer.scrollTop) return true;
+            const t3 = e3.params[0] || 1;
+            for (let e4 = this._activeBuffer.scrollTop; e4 <= this._activeBuffer.scrollBottom; ++e4) {
+              const s3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + e4);
+              s3.insertCells(0, t3, this._activeBuffer.getNullCell(this._eraseAttrData())), s3.isWrapped = false;
+            }
+            return this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom), true;
+          }
+          insertColumns(e3) {
+            if (this._activeBuffer.y > this._activeBuffer.scrollBottom || this._activeBuffer.y < this._activeBuffer.scrollTop) return true;
+            const t3 = e3.params[0] || 1;
+            for (let e4 = this._activeBuffer.scrollTop; e4 <= this._activeBuffer.scrollBottom; ++e4) {
+              const s3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + e4);
+              s3.insertCells(this._activeBuffer.x, t3, this._activeBuffer.getNullCell(this._eraseAttrData())), s3.isWrapped = false;
+            }
+            return this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom), true;
+          }
+          deleteColumns(e3) {
+            if (this._activeBuffer.y > this._activeBuffer.scrollBottom || this._activeBuffer.y < this._activeBuffer.scrollTop) return true;
+            const t3 = e3.params[0] || 1;
+            for (let e4 = this._activeBuffer.scrollTop; e4 <= this._activeBuffer.scrollBottom; ++e4) {
+              const s3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + e4);
+              s3.deleteCells(this._activeBuffer.x, t3, this._activeBuffer.getNullCell(this._eraseAttrData())), s3.isWrapped = false;
+            }
+            return this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom), true;
+          }
+          eraseChars(e3) {
+            this._restrictCursor();
+            const t3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y);
+            return t3 && (t3.replaceCells(this._activeBuffer.x, this._activeBuffer.x + (e3.params[0] || 1), this._activeBuffer.getNullCell(this._eraseAttrData())), this._dirtyRowTracker.markDirty(this._activeBuffer.y)), true;
+          }
+          repeatPrecedingCharacter(e3) {
+            const t3 = this._parser.precedingJoinState;
+            if (!t3) return true;
+            const s3 = e3.params[0] || 1, i3 = p.UnicodeService.extractWidth(t3), r3 = this._activeBuffer.x - i3, n3 = this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y).getString(r3), o2 = new Uint32Array(n3.length * s3);
+            let a2 = 0;
+            for (let e4 = 0; e4 < n3.length; ) {
+              const t4 = n3.codePointAt(e4) || 0;
+              o2[a2++] = t4, e4 += t4 > 65535 ? 2 : 1;
+            }
+            let h2 = a2;
+            for (let e4 = 1; e4 < s3; ++e4) o2.copyWithin(h2, 0, a2), h2 += a2;
+            return this.print(o2, 0, h2), true;
+          }
+          sendDeviceAttributesPrimary(e3) {
+            return e3.params[0] > 0 || (this._is("xterm") || this._is("rxvt-unicode") || this._is("screen") ? this._coreService.triggerDataEvent(n2.C0.ESC + "[?1;2c") : this._is("linux") && this._coreService.triggerDataEvent(n2.C0.ESC + "[?6c")), true;
+          }
+          sendDeviceAttributesSecondary(e3) {
+            return e3.params[0] > 0 || (this._is("xterm") ? this._coreService.triggerDataEvent(n2.C0.ESC + "[>0;276;0c") : this._is("rxvt-unicode") ? this._coreService.triggerDataEvent(n2.C0.ESC + "[>85;95;0c") : this._is("linux") ? this._coreService.triggerDataEvent(e3.params[0] + "c") : this._is("screen") && this._coreService.triggerDataEvent(n2.C0.ESC + "[>83;40003;0c")), true;
+          }
+          _is(e3) {
+            return 0 === (this._optionsService.rawOptions.termName + "").indexOf(e3);
+          }
+          setMode(e3) {
+            for (let t3 = 0; t3 < e3.length; t3++) switch (e3.params[t3]) {
+              case 4:
+                this._coreService.modes.insertMode = true;
+                break;
+              case 20:
+                this._optionsService.options.convertEol = true;
+            }
+            return true;
+          }
+          setModePrivate(e3) {
+            for (let t3 = 0; t3 < e3.length; t3++) switch (e3.params[t3]) {
+              case 1:
+                this._coreService.decPrivateModes.applicationCursorKeys = true;
+                break;
+              case 2:
+                this._charsetService.setgCharset(0, o.DEFAULT_CHARSET), this._charsetService.setgCharset(1, o.DEFAULT_CHARSET), this._charsetService.setgCharset(2, o.DEFAULT_CHARSET), this._charsetService.setgCharset(3, o.DEFAULT_CHARSET);
+                break;
+              case 3:
+                this._optionsService.rawOptions.windowOptions.setWinLines && (this._bufferService.resize(132, this._bufferService.rows), this._onRequestReset.fire());
+                break;
+              case 6:
+                this._coreService.decPrivateModes.origin = true, this._setCursor(0, 0);
+                break;
+              case 7:
+                this._coreService.decPrivateModes.wraparound = true;
+                break;
+              case 12:
+                this._optionsService.options.cursorBlink = true;
+                break;
+              case 45:
+                this._coreService.decPrivateModes.reverseWraparound = true;
+                break;
+              case 66:
+                this._logService.debug("Serial port requested application keypad."), this._coreService.decPrivateModes.applicationKeypad = true, this._onRequestSyncScrollBar.fire();
+                break;
+              case 9:
+                this._coreMouseService.activeProtocol = "X10";
+                break;
+              case 1e3:
+                this._coreMouseService.activeProtocol = "VT200";
+                break;
+              case 1002:
+                this._coreMouseService.activeProtocol = "DRAG";
+                break;
+              case 1003:
+                this._coreMouseService.activeProtocol = "ANY";
+                break;
+              case 1004:
+                this._coreService.decPrivateModes.sendFocus = true, this._onRequestSendFocus.fire();
+                break;
+              case 1005:
+                this._logService.debug("DECSET 1005 not supported (see #2507)");
+                break;
+              case 1006:
+                this._coreMouseService.activeEncoding = "SGR";
+                break;
+              case 1015:
+                this._logService.debug("DECSET 1015 not supported (see #2507)");
+                break;
+              case 1016:
+                this._coreMouseService.activeEncoding = "SGR_PIXELS";
+                break;
+              case 25:
+                this._coreService.isCursorHidden = false;
+                break;
+              case 1048:
+                this.saveCursor();
+                break;
+              case 1049:
+                this.saveCursor();
+              case 47:
+              case 1047:
+                this._bufferService.buffers.activateAltBuffer(this._eraseAttrData()), this._coreService.isCursorInitialized = true, this._onRequestRefreshRows.fire(void 0), this._onRequestSyncScrollBar.fire();
+                break;
+              case 2004:
+                this._coreService.decPrivateModes.bracketedPasteMode = true;
+                break;
+              case 2026:
+                this._coreService.decPrivateModes.synchronizedOutput = true;
+            }
+            return true;
+          }
+          resetMode(e3) {
+            for (let t3 = 0; t3 < e3.length; t3++) switch (e3.params[t3]) {
+              case 4:
+                this._coreService.modes.insertMode = false;
+                break;
+              case 20:
+                this._optionsService.options.convertEol = false;
+            }
+            return true;
+          }
+          resetModePrivate(e3) {
+            for (let t3 = 0; t3 < e3.length; t3++) switch (e3.params[t3]) {
+              case 1:
+                this._coreService.decPrivateModes.applicationCursorKeys = false;
+                break;
+              case 3:
+                this._optionsService.rawOptions.windowOptions.setWinLines && (this._bufferService.resize(80, this._bufferService.rows), this._onRequestReset.fire());
+                break;
+              case 6:
+                this._coreService.decPrivateModes.origin = false, this._setCursor(0, 0);
+                break;
+              case 7:
+                this._coreService.decPrivateModes.wraparound = false;
+                break;
+              case 12:
+                this._optionsService.options.cursorBlink = false;
+                break;
+              case 45:
+                this._coreService.decPrivateModes.reverseWraparound = false;
+                break;
+              case 66:
+                this._logService.debug("Switching back to normal keypad."), this._coreService.decPrivateModes.applicationKeypad = false, this._onRequestSyncScrollBar.fire();
+                break;
+              case 9:
+              case 1e3:
+              case 1002:
+              case 1003:
+                this._coreMouseService.activeProtocol = "NONE";
+                break;
+              case 1004:
+                this._coreService.decPrivateModes.sendFocus = false;
+                break;
+              case 1005:
+                this._logService.debug("DECRST 1005 not supported (see #2507)");
+                break;
+              case 1006:
+              case 1016:
+                this._coreMouseService.activeEncoding = "DEFAULT";
+                break;
+              case 1015:
+                this._logService.debug("DECRST 1015 not supported (see #2507)");
+                break;
+              case 25:
+                this._coreService.isCursorHidden = true;
+                break;
+              case 1048:
+                this.restoreCursor();
+                break;
+              case 1049:
+              case 47:
+              case 1047:
+                this._bufferService.buffers.activateNormalBuffer(), 1049 === e3.params[t3] && this.restoreCursor(), this._coreService.isCursorInitialized = true, this._onRequestRefreshRows.fire(void 0), this._onRequestSyncScrollBar.fire();
+                break;
+              case 2004:
+                this._coreService.decPrivateModes.bracketedPasteMode = false;
+                break;
+              case 2026:
+                this._coreService.decPrivateModes.synchronizedOutput = false, this._onRequestRefreshRows.fire(void 0);
+            }
+            return true;
+          }
+          requestMode(e3, t3) {
+            const s3 = this._coreService.decPrivateModes, { activeProtocol: i3, activeEncoding: r3 } = this._coreMouseService, o2 = this._coreService, { buffers: a2, cols: h2 } = this._bufferService, { active: c2, alt: l2 } = a2, u2 = this._optionsService.rawOptions, d2 = (e4) => e4 ? 1 : 2, f2 = e3.params[0];
+            return _2 = f2, p2 = t3 ? 2 === f2 ? 4 : 4 === f2 ? d2(o2.modes.insertMode) : 12 === f2 ? 3 : 20 === f2 ? d2(u2.convertEol) : 0 : 1 === f2 ? d2(s3.applicationCursorKeys) : 3 === f2 ? u2.windowOptions.setWinLines ? 80 === h2 ? 2 : 132 === h2 ? 1 : 0 : 0 : 6 === f2 ? d2(s3.origin) : 7 === f2 ? d2(s3.wraparound) : 8 === f2 ? 3 : 9 === f2 ? d2("X10" === i3) : 12 === f2 ? d2(u2.cursorBlink) : 25 === f2 ? d2(!o2.isCursorHidden) : 45 === f2 ? d2(s3.reverseWraparound) : 66 === f2 ? d2(s3.applicationKeypad) : 67 === f2 ? 4 : 1e3 === f2 ? d2("VT200" === i3) : 1002 === f2 ? d2("DRAG" === i3) : 1003 === f2 ? d2("ANY" === i3) : 1004 === f2 ? d2(s3.sendFocus) : 1005 === f2 ? 4 : 1006 === f2 ? d2("SGR" === r3) : 1015 === f2 ? 4 : 1016 === f2 ? d2("SGR_PIXELS" === r3) : 1048 === f2 ? 1 : 47 === f2 || 1047 === f2 || 1049 === f2 ? d2(c2 === l2) : 2004 === f2 ? d2(s3.bracketedPasteMode) : 2026 === f2 ? d2(s3.synchronizedOutput) : 0, o2.triggerDataEvent(`${n2.C0.ESC}[${t3 ? "" : "?"}${_2};${p2}$y`), true;
+            var _2, p2;
+          }
+          _updateAttrColor(e3, t3, s3, i3, r3) {
+            return 2 === t3 ? (e3 |= 50331648, e3 &= -16777216, e3 |= f.AttributeData.fromColorRGB([s3, i3, r3])) : 5 === t3 && (e3 &= -50331904, e3 |= 33554432 | 255 & s3), e3;
+          }
+          _extractColor(e3, t3, s3) {
+            const i3 = [0, 0, -1, 0, 0, 0];
+            let r3 = 0, n3 = 0;
+            do {
+              if (i3[n3 + r3] = e3.params[t3 + n3], e3.hasSubParams(t3 + n3)) {
+                const s4 = e3.getSubParams(t3 + n3);
+                let o2 = 0;
+                do {
+                  5 === i3[1] && (r3 = 1), i3[n3 + o2 + 1 + r3] = s4[o2];
+                } while (++o2 < s4.length && o2 + n3 + 1 + r3 < i3.length);
+                break;
+              }
+              if (5 === i3[1] && n3 + r3 >= 2 || 2 === i3[1] && n3 + r3 >= 5) break;
+              i3[1] && (r3 = 1);
+            } while (++n3 + t3 < e3.length && n3 + r3 < i3.length);
+            for (let e4 = 2; e4 < i3.length; ++e4) -1 === i3[e4] && (i3[e4] = 0);
+            switch (i3[0]) {
+              case 38:
+                s3.fg = this._updateAttrColor(s3.fg, i3[1], i3[3], i3[4], i3[5]);
+                break;
+              case 48:
+                s3.bg = this._updateAttrColor(s3.bg, i3[1], i3[3], i3[4], i3[5]);
+                break;
+              case 58:
+                s3.extended = s3.extended.clone(), s3.extended.underlineColor = this._updateAttrColor(s3.extended.underlineColor, i3[1], i3[3], i3[4], i3[5]);
+            }
+            return n3;
+          }
+          _processUnderline(e3, t3) {
+            t3.extended = t3.extended.clone(), (!~e3 || e3 > 5) && (e3 = 1), t3.extended.underlineStyle = e3, t3.fg |= 268435456, 0 === e3 && (t3.fg &= -268435457), t3.updateExtended();
+          }
+          _processSGR0(e3) {
+            e3.fg = l.DEFAULT_ATTR_DATA.fg, e3.bg = l.DEFAULT_ATTR_DATA.bg, e3.extended = e3.extended.clone(), e3.extended.underlineStyle = 0, e3.extended.underlineColor &= -67108864, e3.updateExtended();
+          }
+          charAttributes(e3) {
+            if (1 === e3.length && 0 === e3.params[0]) return this._processSGR0(this._curAttrData), true;
+            const t3 = e3.length;
+            let s3;
+            const i3 = this._curAttrData;
+            for (let r3 = 0; r3 < t3; r3++) s3 = e3.params[r3], s3 >= 30 && s3 <= 37 ? (i3.fg &= -50331904, i3.fg |= 16777216 | s3 - 30) : s3 >= 40 && s3 <= 47 ? (i3.bg &= -50331904, i3.bg |= 16777216 | s3 - 40) : s3 >= 90 && s3 <= 97 ? (i3.fg &= -50331904, i3.fg |= 16777224 | s3 - 90) : s3 >= 100 && s3 <= 107 ? (i3.bg &= -50331904, i3.bg |= 16777224 | s3 - 100) : 0 === s3 ? this._processSGR0(i3) : 1 === s3 ? i3.fg |= 134217728 : 3 === s3 ? i3.bg |= 67108864 : 4 === s3 ? (i3.fg |= 268435456, this._processUnderline(e3.hasSubParams(r3) ? e3.getSubParams(r3)[0] : 1, i3)) : 5 === s3 ? i3.fg |= 536870912 : 7 === s3 ? i3.fg |= 67108864 : 8 === s3 ? i3.fg |= 1073741824 : 9 === s3 ? i3.fg |= 2147483648 : 2 === s3 ? i3.bg |= 134217728 : 21 === s3 ? this._processUnderline(2, i3) : 22 === s3 ? (i3.fg &= -134217729, i3.bg &= -134217729) : 23 === s3 ? i3.bg &= -67108865 : 24 === s3 ? (i3.fg &= -268435457, this._processUnderline(0, i3)) : 25 === s3 ? i3.fg &= -536870913 : 27 === s3 ? i3.fg &= -67108865 : 28 === s3 ? i3.fg &= -1073741825 : 29 === s3 ? i3.fg &= 2147483647 : 39 === s3 ? (i3.fg &= -67108864, i3.fg |= 16777215 & l.DEFAULT_ATTR_DATA.fg) : 49 === s3 ? (i3.bg &= -67108864, i3.bg |= 16777215 & l.DEFAULT_ATTR_DATA.bg) : 38 === s3 || 48 === s3 || 58 === s3 ? r3 += this._extractColor(e3, r3, i3) : 53 === s3 ? i3.bg |= 1073741824 : 55 === s3 ? i3.bg &= -1073741825 : 59 === s3 ? (i3.extended = i3.extended.clone(), i3.extended.underlineColor = -1, i3.updateExtended()) : 100 === s3 ? (i3.fg &= -67108864, i3.fg |= 16777215 & l.DEFAULT_ATTR_DATA.fg, i3.bg &= -67108864, i3.bg |= 16777215 & l.DEFAULT_ATTR_DATA.bg) : this._logService.debug("Unknown SGR attribute: %d.", s3);
+            return true;
+          }
+          deviceStatus(e3) {
+            switch (e3.params[0]) {
+              case 5:
+                this._coreService.triggerDataEvent(`${n2.C0.ESC}[0n`);
+                break;
+              case 6:
+                const e4 = this._activeBuffer.y + 1, t3 = this._activeBuffer.x + 1;
+                this._coreService.triggerDataEvent(`${n2.C0.ESC}[${e4};${t3}R`);
+            }
+            return true;
+          }
+          deviceStatusPrivate(e3) {
+            if (6 === e3.params[0]) {
+              const e4 = this._activeBuffer.y + 1, t3 = this._activeBuffer.x + 1;
+              this._coreService.triggerDataEvent(`${n2.C0.ESC}[?${e4};${t3}R`);
+            }
+            return true;
+          }
+          softReset(e3) {
+            return this._coreService.isCursorHidden = false, this._onRequestSyncScrollBar.fire(), this._activeBuffer.scrollTop = 0, this._activeBuffer.scrollBottom = this._bufferService.rows - 1, this._curAttrData = l.DEFAULT_ATTR_DATA.clone(), this._coreService.reset(), this._charsetService.reset(), this._activeBuffer.savedX = 0, this._activeBuffer.savedY = this._activeBuffer.ybase, this._activeBuffer.savedCurAttrData.fg = this._curAttrData.fg, this._activeBuffer.savedCurAttrData.bg = this._curAttrData.bg, this._activeBuffer.savedCharset = this._charsetService.charset, this._coreService.decPrivateModes.origin = false, true;
+          }
+          setCursorStyle(e3) {
+            const t3 = 0 === e3.length ? 1 : e3.params[0];
+            if (0 === t3) this._coreService.decPrivateModes.cursorStyle = void 0, this._coreService.decPrivateModes.cursorBlink = void 0;
+            else {
+              switch (t3) {
+                case 1:
+                case 2:
+                  this._coreService.decPrivateModes.cursorStyle = "block";
+                  break;
+                case 3:
+                case 4:
+                  this._coreService.decPrivateModes.cursorStyle = "underline";
+                  break;
+                case 5:
+                case 6:
+                  this._coreService.decPrivateModes.cursorStyle = "bar";
+              }
+              const e4 = t3 % 2 == 1;
+              this._coreService.decPrivateModes.cursorBlink = e4;
+            }
+            return true;
+          }
+          setScrollRegion(e3) {
+            const t3 = e3.params[0] || 1;
+            let s3;
+            return (e3.length < 2 || (s3 = e3.params[1]) > this._bufferService.rows || 0 === s3) && (s3 = this._bufferService.rows), s3 > t3 && (this._activeBuffer.scrollTop = t3 - 1, this._activeBuffer.scrollBottom = s3 - 1, this._setCursor(0, 0)), true;
+          }
+          windowOptions(e3) {
+            if (!C(e3.params[0], this._optionsService.rawOptions.windowOptions)) return true;
+            const t3 = e3.length > 1 ? e3.params[1] : 0;
+            switch (e3.params[0]) {
+              case 14:
+                2 !== t3 && this._onRequestWindowsOptionsReport.fire(w.GET_WIN_SIZE_PIXELS);
+                break;
+              case 16:
+                this._onRequestWindowsOptionsReport.fire(w.GET_CELL_SIZE_PIXELS);
+                break;
+              case 18:
+                this._bufferService && this._coreService.triggerDataEvent(`${n2.C0.ESC}[8;${this._bufferService.rows};${this._bufferService.cols}t`);
+                break;
+              case 22:
+                0 !== t3 && 2 !== t3 || (this._windowTitleStack.push(this._windowTitle), this._windowTitleStack.length > 10 && this._windowTitleStack.shift()), 0 !== t3 && 1 !== t3 || (this._iconNameStack.push(this._iconName), this._iconNameStack.length > 10 && this._iconNameStack.shift());
+                break;
+              case 23:
+                0 !== t3 && 2 !== t3 || this._windowTitleStack.length && this.setTitle(this._windowTitleStack.pop()), 0 !== t3 && 1 !== t3 || this._iconNameStack.length && this.setIconName(this._iconNameStack.pop());
+            }
+            return true;
+          }
+          saveCursor(e3) {
+            return this._activeBuffer.savedX = this._activeBuffer.x, this._activeBuffer.savedY = this._activeBuffer.ybase + this._activeBuffer.y, this._activeBuffer.savedCurAttrData.fg = this._curAttrData.fg, this._activeBuffer.savedCurAttrData.bg = this._curAttrData.bg, this._activeBuffer.savedCharset = this._charsetService.charset, true;
+          }
+          restoreCursor(e3) {
+            return this._activeBuffer.x = this._activeBuffer.savedX || 0, this._activeBuffer.y = Math.max(this._activeBuffer.savedY - this._activeBuffer.ybase, 0), this._curAttrData.fg = this._activeBuffer.savedCurAttrData.fg, this._curAttrData.bg = this._activeBuffer.savedCurAttrData.bg, this._charsetService.charset = this._savedCharset, this._activeBuffer.savedCharset && (this._charsetService.charset = this._activeBuffer.savedCharset), this._restrictCursor(), true;
+          }
+          setTitle(e3) {
+            return this._windowTitle = e3, this._onTitleChange.fire(e3), true;
+          }
+          setIconName(e3) {
+            return this._iconName = e3, true;
+          }
+          setOrReportIndexedColor(e3) {
+            const t3 = [], s3 = e3.split(";");
+            for (; s3.length > 1; ) {
+              const e4 = s3.shift(), i3 = s3.shift();
+              if (/^\d+$/.exec(e4)) {
+                const s4 = parseInt(e4);
+                if (k(s4)) if ("?" === i3) t3.push({ type: 0, index: s4 });
+                else {
+                  const e5 = (0, m.parseColor)(i3);
+                  e5 && t3.push({ type: 1, index: s4, color: e5 });
+                }
+              }
+            }
+            return t3.length && this._onColor.fire(t3), true;
+          }
+          setHyperlink(e3) {
+            const t3 = e3.indexOf(";");
+            if (-1 === t3) return true;
+            const s3 = e3.slice(0, t3).trim(), i3 = e3.slice(t3 + 1);
+            return i3 ? this._createHyperlink(s3, i3) : !s3.trim() && this._finishHyperlink();
+          }
+          _createHyperlink(e3, t3) {
+            this._getCurrentLinkId() && this._finishHyperlink();
+            const s3 = e3.split(":");
+            let i3;
+            const r3 = s3.findIndex(((e4) => e4.startsWith("id=")));
+            return -1 !== r3 && (i3 = s3[r3].slice(3) || void 0), this._curAttrData.extended = this._curAttrData.extended.clone(), this._curAttrData.extended.urlId = this._oscLinkService.registerLink({ id: i3, uri: t3 }), this._curAttrData.updateExtended(), true;
+          }
+          _finishHyperlink() {
+            return this._curAttrData.extended = this._curAttrData.extended.clone(), this._curAttrData.extended.urlId = 0, this._curAttrData.updateExtended(), true;
+          }
+          _setOrReportSpecialColor(e3, t3) {
+            const s3 = e3.split(";");
+            for (let e4 = 0; e4 < s3.length && !(t3 >= this._specialColors.length); ++e4, ++t3) if ("?" === s3[e4]) this._onColor.fire([{ type: 0, index: this._specialColors[t3] }]);
+            else {
+              const i3 = (0, m.parseColor)(s3[e4]);
+              i3 && this._onColor.fire([{ type: 1, index: this._specialColors[t3], color: i3 }]);
+            }
+            return true;
+          }
+          setOrReportFgColor(e3) {
+            return this._setOrReportSpecialColor(e3, 0);
+          }
+          setOrReportBgColor(e3) {
+            return this._setOrReportSpecialColor(e3, 1);
+          }
+          setOrReportCursorColor(e3) {
+            return this._setOrReportSpecialColor(e3, 2);
+          }
+          restoreIndexedColor(e3) {
+            if (!e3) return this._onColor.fire([{ type: 2 }]), true;
+            const t3 = [], s3 = e3.split(";");
+            for (let e4 = 0; e4 < s3.length; ++e4) if (/^\d+$/.exec(s3[e4])) {
+              const i3 = parseInt(s3[e4]);
+              k(i3) && t3.push({ type: 2, index: i3 });
+            }
+            return t3.length && this._onColor.fire(t3), true;
+          }
+          restoreFgColor(e3) {
+            return this._onColor.fire([{ type: 2, index: 256 }]), true;
+          }
+          restoreBgColor(e3) {
+            return this._onColor.fire([{ type: 2, index: 257 }]), true;
+          }
+          restoreCursorColor(e3) {
+            return this._onColor.fire([{ type: 2, index: 258 }]), true;
+          }
+          nextLine() {
+            return this._activeBuffer.x = 0, this.index(), true;
+          }
+          keypadApplicationMode() {
+            return this._logService.debug("Serial port requested application keypad."), this._coreService.decPrivateModes.applicationKeypad = true, this._onRequestSyncScrollBar.fire(), true;
+          }
+          keypadNumericMode() {
+            return this._logService.debug("Switching back to normal keypad."), this._coreService.decPrivateModes.applicationKeypad = false, this._onRequestSyncScrollBar.fire(), true;
+          }
+          selectDefaultCharset() {
+            return this._charsetService.setgLevel(0), this._charsetService.setgCharset(0, o.DEFAULT_CHARSET), true;
+          }
+          selectCharset(e3) {
+            return 2 !== e3.length ? (this.selectDefaultCharset(), true) : ("/" === e3[0] || this._charsetService.setgCharset(S[e3[0]], o.CHARSETS[e3[1]] || o.DEFAULT_CHARSET), true);
+          }
+          index() {
+            return this._restrictCursor(), this._activeBuffer.y++, this._activeBuffer.y === this._activeBuffer.scrollBottom + 1 ? (this._activeBuffer.y--, this._bufferService.scroll(this._eraseAttrData())) : this._activeBuffer.y >= this._bufferService.rows && (this._activeBuffer.y = this._bufferService.rows - 1), this._restrictCursor(), true;
+          }
+          tabSet() {
+            return this._activeBuffer.tabs[this._activeBuffer.x] = true, true;
+          }
+          reverseIndex() {
+            if (this._restrictCursor(), this._activeBuffer.y === this._activeBuffer.scrollTop) {
+              const e3 = this._activeBuffer.scrollBottom - this._activeBuffer.scrollTop;
+              this._activeBuffer.lines.shiftElements(this._activeBuffer.ybase + this._activeBuffer.y, e3, 1), this._activeBuffer.lines.set(this._activeBuffer.ybase + this._activeBuffer.y, this._activeBuffer.getBlankLine(this._eraseAttrData())), this._dirtyRowTracker.markRangeDirty(this._activeBuffer.scrollTop, this._activeBuffer.scrollBottom);
+            } else this._activeBuffer.y--, this._restrictCursor();
+            return true;
+          }
+          fullReset() {
+            return this._parser.reset(), this._onRequestReset.fire(), true;
+          }
+          reset() {
+            this._curAttrData = l.DEFAULT_ATTR_DATA.clone(), this._eraseAttrDataInternal = l.DEFAULT_ATTR_DATA.clone();
+          }
+          _eraseAttrData() {
+            return this._eraseAttrDataInternal.bg &= -67108864, this._eraseAttrDataInternal.bg |= 67108863 & this._curAttrData.bg, this._eraseAttrDataInternal;
+          }
+          setgLevel(e3) {
+            return this._charsetService.setgLevel(e3), true;
+          }
+          screenAlignmentPattern() {
+            const e3 = new d.CellData();
+            e3.content = 1 << 22 | "E".charCodeAt(0), e3.fg = this._curAttrData.fg, e3.bg = this._curAttrData.bg, this._setCursor(0, 0);
+            for (let t3 = 0; t3 < this._bufferService.rows; ++t3) {
+              const s3 = this._activeBuffer.ybase + this._activeBuffer.y + t3, i3 = this._activeBuffer.lines.get(s3);
+              i3 && (i3.fill(e3), i3.isWrapped = false);
+            }
+            return this._dirtyRowTracker.markAllDirty(), this._setCursor(0, 0), true;
+          }
+          requestStatusString(e3, t3) {
+            const s3 = this._bufferService.buffer, i3 = this._optionsService.rawOptions;
+            return ((e4) => (this._coreService.triggerDataEvent(`${n2.C0.ESC}${e4}${n2.C0.ESC}\\`), true))('"q' === e3 ? `P1$r${this._curAttrData.isProtected() ? 1 : 0}"q` : '"p' === e3 ? 'P1$r61;1"p' : "r" === e3 ? `P1$r${s3.scrollTop + 1};${s3.scrollBottom + 1}r` : "m" === e3 ? "P1$r0m" : " q" === e3 ? `P1$r${{ block: 2, underline: 4, bar: 6 }[i3.cursorStyle] - (i3.cursorBlink ? 1 : 0)} q` : "P0$r");
+          }
+          markRangeDirty(e3, t3) {
+            this._dirtyRowTracker.markRangeDirty(e3, t3);
+          }
+        }
+        t2.InputHandler = A;
+        let L = class {
+          constructor(e3) {
+            this._bufferService = e3, this.clearRange();
+          }
+          clearRange() {
+            this.start = this._bufferService.buffer.y, this.end = this._bufferService.buffer.y;
+          }
+          markDirty(e3) {
+            e3 < this.start ? this.start = e3 : e3 > this.end && (this.end = e3);
+          }
+          markRangeDirty(e3, t3) {
+            e3 > t3 && (E = e3, e3 = t3, t3 = E), e3 < this.start && (this.start = e3), t3 > this.end && (this.end = t3);
+          }
+          markAllDirty() {
+            this.markRangeDirty(0, this._bufferService.rows - 1);
+          }
+        };
+        function k(e3) {
+          return 0 <= e3 && e3 < 256;
+        }
+        L = i2([r2(0, _.IBufferService)], L);
+      }, 701: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.isChromeOS = t2.isLinux = t2.isWindows = t2.isIphone = t2.isIpad = t2.isMac = t2.isSafari = t2.isLegacyEdge = t2.isFirefox = t2.isNode = void 0, t2.getSafariVersion = function() {
+          if (!t2.isSafari) return 0;
+          const e3 = s2.match(/Version\/(\d+)/);
+          return null === e3 || e3.length < 2 ? 0 : parseInt(e3[1]);
+        }, t2.isNode = "undefined" != typeof process && "title" in process;
+        const s2 = t2.isNode ? "node" : navigator.userAgent, i2 = t2.isNode ? "node" : navigator.platform;
+        t2.isFirefox = s2.includes("Firefox"), t2.isLegacyEdge = s2.includes("Edge"), t2.isSafari = /^((?!chrome|android).)*safari/i.test(s2), t2.isMac = ["Macintosh", "MacIntel", "MacPPC", "Mac68K"].includes(i2), t2.isIpad = "iPad" === i2, t2.isIphone = "iPhone" === i2, t2.isWindows = ["Windows", "Win16", "Win32", "WinCE"].includes(i2), t2.isLinux = i2.indexOf("Linux") >= 0, t2.isChromeOS = /\bCrOS\b/.test(s2);
+      }, 6168: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.DebouncedIdleTask = t2.IdleTaskQueue = t2.PriorityTaskQueue = void 0;
+        const i2 = s2(701);
+        class r2 {
+          constructor() {
+            this._tasks = [], this._i = 0;
+          }
+          enqueue(e3) {
+            this._tasks.push(e3), this._start();
+          }
+          flush() {
+            for (; this._i < this._tasks.length; ) this._tasks[this._i]() || this._i++;
+            this.clear();
+          }
+          clear() {
+            this._idleCallback && (this._cancelCallback(this._idleCallback), this._idleCallback = void 0), this._i = 0, this._tasks.length = 0;
+          }
+          _start() {
+            this._idleCallback || (this._idleCallback = this._requestCallback(this._process.bind(this)));
+          }
+          _process(e3) {
+            this._idleCallback = void 0;
+            let t3 = 0, s3 = 0, i3 = e3.timeRemaining(), r3 = 0;
+            for (; this._i < this._tasks.length; ) {
+              if (t3 = performance.now(), this._tasks[this._i]() || this._i++, t3 = Math.max(1, performance.now() - t3), s3 = Math.max(t3, s3), r3 = e3.timeRemaining(), 1.5 * s3 > r3) return i3 - t3 < -20 && console.warn(`task queue exceeded allotted deadline by ${Math.abs(Math.round(i3 - t3))}ms`), void this._start();
+              i3 = r3;
+            }
+            this.clear();
+          }
+        }
+        class n2 extends r2 {
+          _requestCallback(e3) {
+            return setTimeout((() => e3(this._createDeadline(16))));
+          }
+          _cancelCallback(e3) {
+            clearTimeout(e3);
+          }
+          _createDeadline(e3) {
+            const t3 = performance.now() + e3;
+            return { timeRemaining: () => Math.max(0, t3 - performance.now()) };
+          }
+        }
+        t2.PriorityTaskQueue = n2, t2.IdleTaskQueue = !i2.isNode && "requestIdleCallback" in window ? class extends r2 {
+          _requestCallback(e3) {
+            return requestIdleCallback(e3);
+          }
+          _cancelCallback(e3) {
+            cancelIdleCallback(e3);
+          }
+        } : n2, t2.DebouncedIdleTask = class {
+          constructor() {
+            this._queue = new t2.IdleTaskQueue();
+          }
+          set(e3) {
+            this._queue.clear(), this._queue.enqueue(e3);
+          }
+          flush() {
+            this._queue.flush();
+          }
+        };
+      }, 5882: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.updateWindowsModeWrappedState = function(e3) {
+          const t3 = e3.buffer.lines.get(e3.buffer.ybase + e3.buffer.y - 1), s3 = t3?.get(e3.cols - 1), r2 = e3.buffer.lines.get(e3.buffer.ybase + e3.buffer.y);
+          r2 && s3 && (r2.isWrapped = s3[i2.CHAR_DATA_CODE_INDEX] !== i2.NULL_CELL_CODE && s3[i2.CHAR_DATA_CODE_INDEX] !== i2.WHITESPACE_CELL_CODE);
+        };
+        const i2 = s2(8938);
+      }, 5451: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.ExtendedAttrs = t2.AttributeData = void 0;
+        class s2 {
+          constructor() {
+            this.fg = 0, this.bg = 0, this.extended = new i2();
+          }
+          static toColorRGB(e3) {
+            return [e3 >>> 16 & 255, e3 >>> 8 & 255, 255 & e3];
+          }
+          static fromColorRGB(e3) {
+            return (255 & e3[0]) << 16 | (255 & e3[1]) << 8 | 255 & e3[2];
+          }
+          clone() {
+            const e3 = new s2();
+            return e3.fg = this.fg, e3.bg = this.bg, e3.extended = this.extended.clone(), e3;
+          }
+          isInverse() {
+            return 67108864 & this.fg;
+          }
+          isBold() {
+            return 134217728 & this.fg;
+          }
+          isUnderline() {
+            return this.hasExtendedAttrs() && 0 !== this.extended.underlineStyle ? 1 : 268435456 & this.fg;
+          }
+          isBlink() {
+            return 536870912 & this.fg;
+          }
+          isInvisible() {
+            return 1073741824 & this.fg;
+          }
+          isItalic() {
+            return 67108864 & this.bg;
+          }
+          isDim() {
+            return 134217728 & this.bg;
+          }
+          isStrikethrough() {
+            return 2147483648 & this.fg;
+          }
+          isProtected() {
+            return 536870912 & this.bg;
+          }
+          isOverline() {
+            return 1073741824 & this.bg;
+          }
+          getFgColorMode() {
+            return 50331648 & this.fg;
+          }
+          getBgColorMode() {
+            return 50331648 & this.bg;
+          }
+          isFgRGB() {
+            return !(50331648 & ~this.fg);
+          }
+          isBgRGB() {
+            return !(50331648 & ~this.bg);
+          }
+          isFgPalette() {
+            return 16777216 == (50331648 & this.fg) || 33554432 == (50331648 & this.fg);
+          }
+          isBgPalette() {
+            return 16777216 == (50331648 & this.bg) || 33554432 == (50331648 & this.bg);
+          }
+          isFgDefault() {
+            return !(50331648 & this.fg);
+          }
+          isBgDefault() {
+            return !(50331648 & this.bg);
+          }
+          isAttributeDefault() {
+            return 0 === this.fg && 0 === this.bg;
+          }
+          getFgColor() {
+            switch (50331648 & this.fg) {
+              case 16777216:
+              case 33554432:
+                return 255 & this.fg;
+              case 50331648:
+                return 16777215 & this.fg;
+              default:
+                return -1;
+            }
+          }
+          getBgColor() {
+            switch (50331648 & this.bg) {
+              case 16777216:
+              case 33554432:
+                return 255 & this.bg;
+              case 50331648:
+                return 16777215 & this.bg;
+              default:
+                return -1;
+            }
+          }
+          hasExtendedAttrs() {
+            return 268435456 & this.bg;
+          }
+          updateExtended() {
+            this.extended.isEmpty() ? this.bg &= -268435457 : this.bg |= 268435456;
+          }
+          getUnderlineColor() {
+            if (268435456 & this.bg && ~this.extended.underlineColor) switch (50331648 & this.extended.underlineColor) {
+              case 16777216:
+              case 33554432:
+                return 255 & this.extended.underlineColor;
+              case 50331648:
+                return 16777215 & this.extended.underlineColor;
+              default:
+                return this.getFgColor();
+            }
+            return this.getFgColor();
+          }
+          getUnderlineColorMode() {
+            return 268435456 & this.bg && ~this.extended.underlineColor ? 50331648 & this.extended.underlineColor : this.getFgColorMode();
+          }
+          isUnderlineColorRGB() {
+            return 268435456 & this.bg && ~this.extended.underlineColor ? !(50331648 & ~this.extended.underlineColor) : this.isFgRGB();
+          }
+          isUnderlineColorPalette() {
+            return 268435456 & this.bg && ~this.extended.underlineColor ? 16777216 == (50331648 & this.extended.underlineColor) || 33554432 == (50331648 & this.extended.underlineColor) : this.isFgPalette();
+          }
+          isUnderlineColorDefault() {
+            return 268435456 & this.bg && ~this.extended.underlineColor ? !(50331648 & this.extended.underlineColor) : this.isFgDefault();
+          }
+          getUnderlineStyle() {
+            return 268435456 & this.fg ? 268435456 & this.bg ? this.extended.underlineStyle : 1 : 0;
+          }
+          getUnderlineVariantOffset() {
+            return this.extended.underlineVariantOffset;
+          }
+        }
+        t2.AttributeData = s2;
+        class i2 {
+          get ext() {
+            return this._urlId ? -469762049 & this._ext | this.underlineStyle << 26 : this._ext;
+          }
+          set ext(e3) {
+            this._ext = e3;
+          }
+          get underlineStyle() {
+            return this._urlId ? 5 : (469762048 & this._ext) >> 26;
+          }
+          set underlineStyle(e3) {
+            this._ext &= -469762049, this._ext |= e3 << 26 & 469762048;
+          }
+          get underlineColor() {
+            return 67108863 & this._ext;
+          }
+          set underlineColor(e3) {
+            this._ext &= -67108864, this._ext |= 67108863 & e3;
+          }
+          get urlId() {
+            return this._urlId;
+          }
+          set urlId(e3) {
+            this._urlId = e3;
+          }
+          get underlineVariantOffset() {
+            const e3 = (3758096384 & this._ext) >> 29;
+            return e3 < 0 ? 4294967288 ^ e3 : e3;
+          }
+          set underlineVariantOffset(e3) {
+            this._ext &= 536870911, this._ext |= e3 << 29 & 3758096384;
+          }
+          constructor(e3 = 0, t3 = 0) {
+            this._ext = 0, this._urlId = 0, this._ext = e3, this._urlId = t3;
+          }
+          clone() {
+            return new i2(this._ext, this._urlId);
+          }
+          isEmpty() {
+            return 0 === this.underlineStyle && 0 === this._urlId;
+          }
+        }
+        t2.ExtendedAttrs = i2;
+      }, 1073: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.Buffer = t2.MAX_BUFFER_SIZE = void 0;
+        const i2 = s2(5639), r2 = s2(6168), n2 = s2(5451), o = s2(6107), a = s2(732), h = s2(3055), c = s2(8938), l = s2(8158), u = s2(6760);
+        t2.MAX_BUFFER_SIZE = 4294967295, t2.Buffer = class {
+          constructor(e3, t3, s3) {
+            this._hasScrollback = e3, this._optionsService = t3, this._bufferService = s3, this.ydisp = 0, this.ybase = 0, this.y = 0, this.x = 0, this.tabs = {}, this.savedY = 0, this.savedX = 0, this.savedCurAttrData = o.DEFAULT_ATTR_DATA.clone(), this.savedCharset = u.DEFAULT_CHARSET, this.markers = [], this._nullCell = h.CellData.fromCharData([0, c.NULL_CELL_CHAR, c.NULL_CELL_WIDTH, c.NULL_CELL_CODE]), this._whitespaceCell = h.CellData.fromCharData([0, c.WHITESPACE_CELL_CHAR, c.WHITESPACE_CELL_WIDTH, c.WHITESPACE_CELL_CODE]), this._isClearing = false, this._memoryCleanupQueue = new r2.IdleTaskQueue(), this._memoryCleanupPosition = 0, this._cols = this._bufferService.cols, this._rows = this._bufferService.rows, this.lines = new i2.CircularList(this._getCorrectBufferLength(this._rows)), this.scrollTop = 0, this.scrollBottom = this._rows - 1, this.setupTabStops();
+          }
+          getNullCell(e3) {
+            return e3 ? (this._nullCell.fg = e3.fg, this._nullCell.bg = e3.bg, this._nullCell.extended = e3.extended) : (this._nullCell.fg = 0, this._nullCell.bg = 0, this._nullCell.extended = new n2.ExtendedAttrs()), this._nullCell;
+          }
+          getWhitespaceCell(e3) {
+            return e3 ? (this._whitespaceCell.fg = e3.fg, this._whitespaceCell.bg = e3.bg, this._whitespaceCell.extended = e3.extended) : (this._whitespaceCell.fg = 0, this._whitespaceCell.bg = 0, this._whitespaceCell.extended = new n2.ExtendedAttrs()), this._whitespaceCell;
+          }
+          getBlankLine(e3, t3) {
+            return new o.BufferLine(this._bufferService.cols, this.getNullCell(e3), t3);
+          }
+          get hasScrollback() {
+            return this._hasScrollback && this.lines.maxLength > this._rows;
+          }
+          get isCursorInViewport() {
+            const e3 = this.ybase + this.y - this.ydisp;
+            return e3 >= 0 && e3 < this._rows;
+          }
+          _getCorrectBufferLength(e3) {
+            if (!this._hasScrollback) return e3;
+            const s3 = e3 + this._optionsService.rawOptions.scrollback;
+            return s3 > t2.MAX_BUFFER_SIZE ? t2.MAX_BUFFER_SIZE : s3;
+          }
+          fillViewportRows(e3) {
+            if (0 === this.lines.length) {
+              void 0 === e3 && (e3 = o.DEFAULT_ATTR_DATA);
+              let t3 = this._rows;
+              for (; t3--; ) this.lines.push(this.getBlankLine(e3));
+            }
+          }
+          clear() {
+            this.ydisp = 0, this.ybase = 0, this.y = 0, this.x = 0, this.lines = new i2.CircularList(this._getCorrectBufferLength(this._rows)), this.scrollTop = 0, this.scrollBottom = this._rows - 1, this.setupTabStops();
+          }
+          resize(e3, t3) {
+            const s3 = this.getNullCell(o.DEFAULT_ATTR_DATA);
+            let i3 = 0;
+            const r3 = this._getCorrectBufferLength(t3);
+            if (r3 > this.lines.maxLength && (this.lines.maxLength = r3), this.lines.length > 0) {
+              if (this._cols < e3) for (let t4 = 0; t4 < this.lines.length; t4++) i3 += +this.lines.get(t4).resize(e3, s3);
+              let n3 = 0;
+              if (this._rows < t3) for (let i4 = this._rows; i4 < t3; i4++) this.lines.length < t3 + this.ybase && (this._optionsService.rawOptions.windowsMode || void 0 !== this._optionsService.rawOptions.windowsPty.backend || void 0 !== this._optionsService.rawOptions.windowsPty.buildNumber ? this.lines.push(new o.BufferLine(e3, s3)) : this.ybase > 0 && this.lines.length <= this.ybase + this.y + n3 + 1 ? (this.ybase--, n3++, this.ydisp > 0 && this.ydisp--) : this.lines.push(new o.BufferLine(e3, s3)));
+              else for (let e4 = this._rows; e4 > t3; e4--) this.lines.length > t3 + this.ybase && (this.lines.length > this.ybase + this.y + 1 ? this.lines.pop() : (this.ybase++, this.ydisp++));
+              if (r3 < this.lines.maxLength) {
+                const e4 = this.lines.length - r3;
+                e4 > 0 && (this.lines.trimStart(e4), this.ybase = Math.max(this.ybase - e4, 0), this.ydisp = Math.max(this.ydisp - e4, 0), this.savedY = Math.max(this.savedY - e4, 0)), this.lines.maxLength = r3;
+              }
+              this.x = Math.min(this.x, e3 - 1), this.y = Math.min(this.y, t3 - 1), n3 && (this.y += n3), this.savedX = Math.min(this.savedX, e3 - 1), this.scrollTop = 0;
+            }
+            if (this.scrollBottom = t3 - 1, this._isReflowEnabled && (this._reflow(e3, t3), this._cols > e3)) for (let t4 = 0; t4 < this.lines.length; t4++) i3 += +this.lines.get(t4).resize(e3, s3);
+            this._cols = e3, this._rows = t3, this._memoryCleanupQueue.clear(), i3 > 0.1 * this.lines.length && (this._memoryCleanupPosition = 0, this._memoryCleanupQueue.enqueue((() => this._batchedMemoryCleanup())));
+          }
+          _batchedMemoryCleanup() {
+            let e3 = true;
+            this._memoryCleanupPosition >= this.lines.length && (this._memoryCleanupPosition = 0, e3 = false);
+            let t3 = 0;
+            for (; this._memoryCleanupPosition < this.lines.length; ) if (t3 += this.lines.get(this._memoryCleanupPosition++).cleanupMemory(), t3 > 100) return true;
+            return e3;
+          }
+          get _isReflowEnabled() {
+            const e3 = this._optionsService.rawOptions.windowsPty;
+            return e3 && e3.buildNumber ? this._hasScrollback && "conpty" === e3.backend && e3.buildNumber >= 21376 : this._hasScrollback && !this._optionsService.rawOptions.windowsMode;
+          }
+          _reflow(e3, t3) {
+            this._cols !== e3 && (e3 > this._cols ? this._reflowLarger(e3, t3) : this._reflowSmaller(e3, t3));
+          }
+          _reflowLarger(e3, t3) {
+            const s3 = this._optionsService.rawOptions.reflowCursorLine, i3 = (0, a.reflowLargerGetLinesToRemove)(this.lines, this._cols, e3, this.ybase + this.y, this.getNullCell(o.DEFAULT_ATTR_DATA), s3);
+            if (i3.length > 0) {
+              const s4 = (0, a.reflowLargerCreateNewLayout)(this.lines, i3);
+              (0, a.reflowLargerApplyNewLayout)(this.lines, s4.layout), this._reflowLargerAdjustViewport(e3, t3, s4.countRemoved);
+            }
+          }
+          _reflowLargerAdjustViewport(e3, t3, s3) {
+            const i3 = this.getNullCell(o.DEFAULT_ATTR_DATA);
+            let r3 = s3;
+            for (; r3-- > 0; ) 0 === this.ybase ? (this.y > 0 && this.y--, this.lines.length < t3 && this.lines.push(new o.BufferLine(e3, i3))) : (this.ydisp === this.ybase && this.ydisp--, this.ybase--);
+            this.savedY = Math.max(this.savedY - s3, 0);
+          }
+          _reflowSmaller(e3, t3) {
+            const s3 = this._optionsService.rawOptions.reflowCursorLine, i3 = this.getNullCell(o.DEFAULT_ATTR_DATA), r3 = [];
+            let n3 = 0;
+            for (let h2 = this.lines.length - 1; h2 >= 0; h2--) {
+              let c2 = this.lines.get(h2);
+              if (!c2 || !c2.isWrapped && c2.getTrimmedLength() <= e3) continue;
+              const l2 = [c2];
+              for (; c2.isWrapped && h2 > 0; ) c2 = this.lines.get(--h2), l2.unshift(c2);
+              if (!s3) {
+                const e4 = this.ybase + this.y;
+                if (e4 >= h2 && e4 < h2 + l2.length) continue;
+              }
+              const u2 = l2[l2.length - 1].getTrimmedLength(), d = (0, a.reflowSmallerGetNewLineLengths)(l2, this._cols, e3), f = d.length - l2.length;
+              let _;
+              _ = 0 === this.ybase && this.y !== this.lines.length - 1 ? Math.max(0, this.y - this.lines.maxLength + f) : Math.max(0, this.lines.length - this.lines.maxLength + f);
+              const p = [];
+              for (let e4 = 0; e4 < f; e4++) {
+                const e5 = this.getBlankLine(o.DEFAULT_ATTR_DATA, true);
+                p.push(e5);
+              }
+              p.length > 0 && (r3.push({ start: h2 + l2.length + n3, newLines: p }), n3 += p.length), l2.push(...p);
+              let g = d.length - 1, v = d[g];
+              0 === v && (g--, v = d[g]);
+              let m = l2.length - f - 1, b = u2;
+              for (; m >= 0; ) {
+                const e4 = Math.min(b, v);
+                if (void 0 === l2[g]) break;
+                if (l2[g].copyCellsFrom(l2[m], b - e4, v - e4, e4, true), v -= e4, 0 === v && (g--, v = d[g]), b -= e4, 0 === b) {
+                  m--;
+                  const e5 = Math.max(m, 0);
+                  b = (0, a.getWrappedLineTrimmedLength)(l2, e5, this._cols);
+                }
+              }
+              for (let t4 = 0; t4 < l2.length; t4++) d[t4] < e3 && l2[t4].setCell(d[t4], i3);
+              let S = f - _;
+              for (; S-- > 0; ) 0 === this.ybase ? this.y < t3 - 1 ? (this.y++, this.lines.pop()) : (this.ybase++, this.ydisp++) : this.ybase < Math.min(this.lines.maxLength, this.lines.length + n3) - t3 && (this.ybase === this.ydisp && this.ydisp++, this.ybase++);
+              this.savedY = Math.min(this.savedY + f, this.ybase + t3 - 1);
+            }
+            if (r3.length > 0) {
+              const e4 = [], t4 = [];
+              for (let e5 = 0; e5 < this.lines.length; e5++) t4.push(this.lines.get(e5));
+              const s4 = this.lines.length;
+              let i4 = s4 - 1, o2 = 0, a2 = r3[o2];
+              this.lines.length = Math.min(this.lines.maxLength, this.lines.length + n3);
+              let h2 = 0;
+              for (let c3 = Math.min(this.lines.maxLength - 1, s4 + n3 - 1); c3 >= 0; c3--) if (a2 && a2.start > i4 + h2) {
+                for (let e5 = a2.newLines.length - 1; e5 >= 0; e5--) this.lines.set(c3--, a2.newLines[e5]);
+                c3++, e4.push({ index: i4 + 1, amount: a2.newLines.length }), h2 += a2.newLines.length, a2 = r3[++o2];
+              } else this.lines.set(c3, t4[i4--]);
+              let c2 = 0;
+              for (let t5 = e4.length - 1; t5 >= 0; t5--) e4[t5].index += c2, this.lines.onInsertEmitter.fire(e4[t5]), c2 += e4[t5].amount;
+              const l2 = Math.max(0, s4 + n3 - this.lines.maxLength);
+              l2 > 0 && this.lines.onTrimEmitter.fire(l2);
+            }
+          }
+          translateBufferLineToString(e3, t3, s3 = 0, i3) {
+            const r3 = this.lines.get(e3);
+            return r3 ? r3.translateToString(t3, s3, i3) : "";
+          }
+          getWrappedRangeForLine(e3) {
+            let t3 = e3, s3 = e3;
+            for (; t3 > 0 && this.lines.get(t3).isWrapped; ) t3--;
+            for (; s3 + 1 < this.lines.length && this.lines.get(s3 + 1).isWrapped; ) s3++;
+            return { first: t3, last: s3 };
+          }
+          setupTabStops(e3) {
+            for (null != e3 ? this.tabs[e3] || (e3 = this.prevStop(e3)) : (this.tabs = {}, e3 = 0); e3 < this._cols; e3 += this._optionsService.rawOptions.tabStopWidth) this.tabs[e3] = true;
+          }
+          prevStop(e3) {
+            for (null == e3 && (e3 = this.x); !this.tabs[--e3] && e3 > 0; ) ;
+            return e3 >= this._cols ? this._cols - 1 : e3 < 0 ? 0 : e3;
+          }
+          nextStop(e3) {
+            for (null == e3 && (e3 = this.x); !this.tabs[++e3] && e3 < this._cols; ) ;
+            return e3 >= this._cols ? this._cols - 1 : e3 < 0 ? 0 : e3;
+          }
+          clearMarkers(e3) {
+            this._isClearing = true;
+            for (let t3 = 0; t3 < this.markers.length; t3++) this.markers[t3].line === e3 && (this.markers[t3].dispose(), this.markers.splice(t3--, 1));
+            this._isClearing = false;
+          }
+          clearAllMarkers() {
+            this._isClearing = true;
+            for (let e3 = 0; e3 < this.markers.length; e3++) this.markers[e3].dispose();
+            this.markers.length = 0, this._isClearing = false;
+          }
+          addMarker(e3) {
+            const t3 = new l.Marker(e3);
+            return this.markers.push(t3), t3.register(this.lines.onTrim(((e4) => {
+              t3.line -= e4, t3.line < 0 && t3.dispose();
+            }))), t3.register(this.lines.onInsert(((e4) => {
+              t3.line >= e4.index && (t3.line += e4.amount);
+            }))), t3.register(this.lines.onDelete(((e4) => {
+              t3.line >= e4.index && t3.line < e4.index + e4.amount && t3.dispose(), t3.line > e4.index && (t3.line -= e4.amount);
+            }))), t3.register(t3.onDispose((() => this._removeMarker(t3)))), t3;
+          }
+          _removeMarker(e3) {
+            this._isClearing || this.markers.splice(this.markers.indexOf(e3), 1);
+          }
+        };
+      }, 6107: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.BufferLine = t2.DEFAULT_ATTR_DATA = void 0;
+        const i2 = s2(5451), r2 = s2(3055), n2 = s2(8938), o = s2(726);
+        t2.DEFAULT_ATTR_DATA = Object.freeze(new i2.AttributeData());
+        let a = 0;
+        class h {
+          constructor(e3, t3, s3 = false) {
+            this.isWrapped = s3, this._combined = {}, this._extendedAttrs = {}, this._data = new Uint32Array(3 * e3);
+            const i3 = t3 || r2.CellData.fromCharData([0, n2.NULL_CELL_CHAR, n2.NULL_CELL_WIDTH, n2.NULL_CELL_CODE]);
+            for (let t4 = 0; t4 < e3; ++t4) this.setCell(t4, i3);
+            this.length = e3;
+          }
+          get(e3) {
+            const t3 = this._data[3 * e3 + 0], s3 = 2097151 & t3;
+            return [this._data[3 * e3 + 1], 2097152 & t3 ? this._combined[e3] : s3 ? (0, o.stringFromCodePoint)(s3) : "", t3 >> 22, 2097152 & t3 ? this._combined[e3].charCodeAt(this._combined[e3].length - 1) : s3];
+          }
+          set(e3, t3) {
+            this._data[3 * e3 + 1] = t3[n2.CHAR_DATA_ATTR_INDEX], t3[n2.CHAR_DATA_CHAR_INDEX].length > 1 ? (this._combined[e3] = t3[1], this._data[3 * e3 + 0] = 2097152 | e3 | t3[n2.CHAR_DATA_WIDTH_INDEX] << 22) : this._data[3 * e3 + 0] = t3[n2.CHAR_DATA_CHAR_INDEX].charCodeAt(0) | t3[n2.CHAR_DATA_WIDTH_INDEX] << 22;
+          }
+          getWidth(e3) {
+            return this._data[3 * e3 + 0] >> 22;
+          }
+          hasWidth(e3) {
+            return 12582912 & this._data[3 * e3 + 0];
+          }
+          getFg(e3) {
+            return this._data[3 * e3 + 1];
+          }
+          getBg(e3) {
+            return this._data[3 * e3 + 2];
+          }
+          hasContent(e3) {
+            return 4194303 & this._data[3 * e3 + 0];
+          }
+          getCodePoint(e3) {
+            const t3 = this._data[3 * e3 + 0];
+            return 2097152 & t3 ? this._combined[e3].charCodeAt(this._combined[e3].length - 1) : 2097151 & t3;
+          }
+          isCombined(e3) {
+            return 2097152 & this._data[3 * e3 + 0];
+          }
+          getString(e3) {
+            const t3 = this._data[3 * e3 + 0];
+            return 2097152 & t3 ? this._combined[e3] : 2097151 & t3 ? (0, o.stringFromCodePoint)(2097151 & t3) : "";
+          }
+          isProtected(e3) {
+            return 536870912 & this._data[3 * e3 + 2];
+          }
+          loadCell(e3, t3) {
+            return a = 3 * e3, t3.content = this._data[a + 0], t3.fg = this._data[a + 1], t3.bg = this._data[a + 2], 2097152 & t3.content && (t3.combinedData = this._combined[e3]), 268435456 & t3.bg && (t3.extended = this._extendedAttrs[e3]), t3;
+          }
+          setCell(e3, t3) {
+            2097152 & t3.content && (this._combined[e3] = t3.combinedData), 268435456 & t3.bg && (this._extendedAttrs[e3] = t3.extended), this._data[3 * e3 + 0] = t3.content, this._data[3 * e3 + 1] = t3.fg, this._data[3 * e3 + 2] = t3.bg;
+          }
+          setCellFromCodepoint(e3, t3, s3, i3) {
+            268435456 & i3.bg && (this._extendedAttrs[e3] = i3.extended), this._data[3 * e3 + 0] = t3 | s3 << 22, this._data[3 * e3 + 1] = i3.fg, this._data[3 * e3 + 2] = i3.bg;
+          }
+          addCodepointToCell(e3, t3, s3) {
+            let i3 = this._data[3 * e3 + 0];
+            2097152 & i3 ? this._combined[e3] += (0, o.stringFromCodePoint)(t3) : 2097151 & i3 ? (this._combined[e3] = (0, o.stringFromCodePoint)(2097151 & i3) + (0, o.stringFromCodePoint)(t3), i3 &= -2097152, i3 |= 2097152) : i3 = t3 | 1 << 22, s3 && (i3 &= -12582913, i3 |= s3 << 22), this._data[3 * e3 + 0] = i3;
+          }
+          insertCells(e3, t3, s3) {
+            if ((e3 %= this.length) && 2 === this.getWidth(e3 - 1) && this.setCellFromCodepoint(e3 - 1, 0, 1, s3), t3 < this.length - e3) {
+              const i3 = new r2.CellData();
+              for (let s4 = this.length - e3 - t3 - 1; s4 >= 0; --s4) this.setCell(e3 + t3 + s4, this.loadCell(e3 + s4, i3));
+              for (let i4 = 0; i4 < t3; ++i4) this.setCell(e3 + i4, s3);
+            } else for (let t4 = e3; t4 < this.length; ++t4) this.setCell(t4, s3);
+            2 === this.getWidth(this.length - 1) && this.setCellFromCodepoint(this.length - 1, 0, 1, s3);
+          }
+          deleteCells(e3, t3, s3) {
+            if (e3 %= this.length, t3 < this.length - e3) {
+              const i3 = new r2.CellData();
+              for (let s4 = 0; s4 < this.length - e3 - t3; ++s4) this.setCell(e3 + s4, this.loadCell(e3 + t3 + s4, i3));
+              for (let e4 = this.length - t3; e4 < this.length; ++e4) this.setCell(e4, s3);
+            } else for (let t4 = e3; t4 < this.length; ++t4) this.setCell(t4, s3);
+            e3 && 2 === this.getWidth(e3 - 1) && this.setCellFromCodepoint(e3 - 1, 0, 1, s3), 0 !== this.getWidth(e3) || this.hasContent(e3) || this.setCellFromCodepoint(e3, 0, 1, s3);
+          }
+          replaceCells(e3, t3, s3, i3 = false) {
+            if (i3) for (e3 && 2 === this.getWidth(e3 - 1) && !this.isProtected(e3 - 1) && this.setCellFromCodepoint(e3 - 1, 0, 1, s3), t3 < this.length && 2 === this.getWidth(t3 - 1) && !this.isProtected(t3) && this.setCellFromCodepoint(t3, 0, 1, s3); e3 < t3 && e3 < this.length; ) this.isProtected(e3) || this.setCell(e3, s3), e3++;
+            else for (e3 && 2 === this.getWidth(e3 - 1) && this.setCellFromCodepoint(e3 - 1, 0, 1, s3), t3 < this.length && 2 === this.getWidth(t3 - 1) && this.setCellFromCodepoint(t3, 0, 1, s3); e3 < t3 && e3 < this.length; ) this.setCell(e3++, s3);
+          }
+          resize(e3, t3) {
+            if (e3 === this.length) return 4 * this._data.length * 2 < this._data.buffer.byteLength;
+            const s3 = 3 * e3;
+            if (e3 > this.length) {
+              if (this._data.buffer.byteLength >= 4 * s3) this._data = new Uint32Array(this._data.buffer, 0, s3);
+              else {
+                const e4 = new Uint32Array(s3);
+                e4.set(this._data), this._data = e4;
+              }
+              for (let s4 = this.length; s4 < e3; ++s4) this.setCell(s4, t3);
+            } else {
+              this._data = this._data.subarray(0, s3);
+              const t4 = Object.keys(this._combined);
+              for (let s4 = 0; s4 < t4.length; s4++) {
+                const i4 = parseInt(t4[s4], 10);
+                i4 >= e3 && delete this._combined[i4];
+              }
+              const i3 = Object.keys(this._extendedAttrs);
+              for (let t5 = 0; t5 < i3.length; t5++) {
+                const s4 = parseInt(i3[t5], 10);
+                s4 >= e3 && delete this._extendedAttrs[s4];
+              }
+            }
+            return this.length = e3, 4 * s3 * 2 < this._data.buffer.byteLength;
+          }
+          cleanupMemory() {
+            if (4 * this._data.length * 2 < this._data.buffer.byteLength) {
+              const e3 = new Uint32Array(this._data.length);
+              return e3.set(this._data), this._data = e3, 1;
+            }
+            return 0;
+          }
+          fill(e3, t3 = false) {
+            if (t3) for (let t4 = 0; t4 < this.length; ++t4) this.isProtected(t4) || this.setCell(t4, e3);
+            else {
+              this._combined = {}, this._extendedAttrs = {};
+              for (let t4 = 0; t4 < this.length; ++t4) this.setCell(t4, e3);
+            }
+          }
+          copyFrom(e3) {
+            this.length !== e3.length ? this._data = new Uint32Array(e3._data) : this._data.set(e3._data), this.length = e3.length, this._combined = {};
+            for (const t3 in e3._combined) this._combined[t3] = e3._combined[t3];
+            this._extendedAttrs = {};
+            for (const t3 in e3._extendedAttrs) this._extendedAttrs[t3] = e3._extendedAttrs[t3];
+            this.isWrapped = e3.isWrapped;
+          }
+          clone() {
+            const e3 = new h(0);
+            e3._data = new Uint32Array(this._data), e3.length = this.length;
+            for (const t3 in this._combined) e3._combined[t3] = this._combined[t3];
+            for (const t3 in this._extendedAttrs) e3._extendedAttrs[t3] = this._extendedAttrs[t3];
+            return e3.isWrapped = this.isWrapped, e3;
+          }
+          getTrimmedLength() {
+            for (let e3 = this.length - 1; e3 >= 0; --e3) if (4194303 & this._data[3 * e3 + 0]) return e3 + (this._data[3 * e3 + 0] >> 22);
+            return 0;
+          }
+          getNoBgTrimmedLength() {
+            for (let e3 = this.length - 1; e3 >= 0; --e3) if (4194303 & this._data[3 * e3 + 0] || 50331648 & this._data[3 * e3 + 2]) return e3 + (this._data[3 * e3 + 0] >> 22);
+            return 0;
+          }
+          copyCellsFrom(e3, t3, s3, i3, r3) {
+            const n3 = e3._data;
+            if (r3) for (let r4 = i3 - 1; r4 >= 0; r4--) {
+              for (let e4 = 0; e4 < 3; e4++) this._data[3 * (s3 + r4) + e4] = n3[3 * (t3 + r4) + e4];
+              268435456 & n3[3 * (t3 + r4) + 2] && (this._extendedAttrs[s3 + r4] = e3._extendedAttrs[t3 + r4]);
+            }
+            else for (let r4 = 0; r4 < i3; r4++) {
+              for (let e4 = 0; e4 < 3; e4++) this._data[3 * (s3 + r4) + e4] = n3[3 * (t3 + r4) + e4];
+              268435456 & n3[3 * (t3 + r4) + 2] && (this._extendedAttrs[s3 + r4] = e3._extendedAttrs[t3 + r4]);
+            }
+            const o2 = Object.keys(e3._combined);
+            for (let i4 = 0; i4 < o2.length; i4++) {
+              const r4 = parseInt(o2[i4], 10);
+              r4 >= t3 && (this._combined[r4 - t3 + s3] = e3._combined[r4]);
+            }
+          }
+          translateToString(e3, t3, s3, i3) {
+            t3 = t3 ?? 0, s3 = s3 ?? this.length, e3 && (s3 = Math.min(s3, this.getTrimmedLength())), i3 && (i3.length = 0);
+            let r3 = "";
+            for (; t3 < s3; ) {
+              const e4 = this._data[3 * t3 + 0], s4 = 2097151 & e4, a2 = 2097152 & e4 ? this._combined[t3] : s4 ? (0, o.stringFromCodePoint)(s4) : n2.WHITESPACE_CELL_CHAR;
+              if (r3 += a2, i3) for (let e5 = 0; e5 < a2.length; ++e5) i3.push(t3);
+              t3 += e4 >> 22 || 1;
+            }
+            return i3 && i3.push(t3), r3;
+          }
+        }
+        t2.BufferLine = h;
+      }, 732: (e2, t2) => {
+        function s2(e3, t3, s3) {
+          if (t3 === e3.length - 1) return e3[t3].getTrimmedLength();
+          const i2 = !e3[t3].hasContent(s3 - 1) && 1 === e3[t3].getWidth(s3 - 1), r2 = 2 === e3[t3 + 1].getWidth(0);
+          return i2 && r2 ? s3 - 1 : s3;
+        }
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.reflowLargerGetLinesToRemove = function(e3, t3, i2, r2, n2, o) {
+          const a = [];
+          for (let h = 0; h < e3.length - 1; h++) {
+            let c = h, l = e3.get(++c);
+            if (!l.isWrapped) continue;
+            const u = [e3.get(h)];
+            for (; c < e3.length && l.isWrapped; ) u.push(l), l = e3.get(++c);
+            if (!o && r2 >= h && r2 < c) {
+              h += u.length - 1;
+              continue;
+            }
+            let d = 0, f = s2(u, d, t3), _ = 1, p = 0;
+            for (; _ < u.length; ) {
+              const e4 = s2(u, _, t3), r3 = e4 - p, o2 = i2 - f, a2 = Math.min(r3, o2);
+              u[d].copyCellsFrom(u[_], p, f, a2, false), f += a2, f === i2 && (d++, f = 0), p += a2, p === e4 && (_++, p = 0), 0 === f && 0 !== d && 2 === u[d - 1].getWidth(i2 - 1) && (u[d].copyCellsFrom(u[d - 1], i2 - 1, f++, 1, false), u[d - 1].setCell(i2 - 1, n2));
+            }
+            u[d].replaceCells(f, i2, n2);
+            let g = 0;
+            for (let e4 = u.length - 1; e4 > 0 && (e4 > d || 0 === u[e4].getTrimmedLength()); e4--) g++;
+            g > 0 && (a.push(h + u.length - g), a.push(g)), h += u.length - 1;
+          }
+          return a;
+        }, t2.reflowLargerCreateNewLayout = function(e3, t3) {
+          const s3 = [];
+          let i2 = 0, r2 = t3[i2], n2 = 0;
+          for (let o = 0; o < e3.length; o++) if (r2 === o) {
+            const s4 = t3[++i2];
+            e3.onDeleteEmitter.fire({ index: o - n2, amount: s4 }), o += s4 - 1, n2 += s4, r2 = t3[++i2];
+          } else s3.push(o);
+          return { layout: s3, countRemoved: n2 };
+        }, t2.reflowLargerApplyNewLayout = function(e3, t3) {
+          const s3 = [];
+          for (let i2 = 0; i2 < t3.length; i2++) s3.push(e3.get(t3[i2]));
+          for (let t4 = 0; t4 < s3.length; t4++) e3.set(t4, s3[t4]);
+          e3.length = t3.length;
+        }, t2.reflowSmallerGetNewLineLengths = function(e3, t3, i2) {
+          const r2 = [], n2 = e3.map(((i3, r3) => s2(e3, r3, t3))).reduce(((e4, t4) => e4 + t4));
+          let o = 0, a = 0, h = 0;
+          for (; h < n2; ) {
+            if (n2 - h < i2) {
+              r2.push(n2 - h);
+              break;
+            }
+            o += i2;
+            const c = s2(e3, a, t3);
+            o > c && (o -= c, a++);
+            const l = 2 === e3[a].getWidth(o - 1);
+            l && o--;
+            const u = l ? i2 - 1 : i2;
+            r2.push(u), h += u;
+          }
+          return r2;
+        }, t2.getWrappedLineTrimmedLength = s2;
+      }, 4097: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.BufferSet = void 0;
+        const i2 = s2(7150), r2 = s2(1073), n2 = s2(802);
+        class o extends i2.Disposable {
+          constructor(e3, t3) {
+            super(), this._optionsService = e3, this._bufferService = t3, this._onBufferActivate = this._register(new n2.Emitter()), this.onBufferActivate = this._onBufferActivate.event, this.reset(), this._register(this._optionsService.onSpecificOptionChange("scrollback", (() => this.resize(this._bufferService.cols, this._bufferService.rows)))), this._register(this._optionsService.onSpecificOptionChange("tabStopWidth", (() => this.setupTabStops())));
+          }
+          reset() {
+            this._normal = new r2.Buffer(true, this._optionsService, this._bufferService), this._normal.fillViewportRows(), this._alt = new r2.Buffer(false, this._optionsService, this._bufferService), this._activeBuffer = this._normal, this._onBufferActivate.fire({ activeBuffer: this._normal, inactiveBuffer: this._alt }), this.setupTabStops();
+          }
+          get alt() {
+            return this._alt;
+          }
+          get active() {
+            return this._activeBuffer;
+          }
+          get normal() {
+            return this._normal;
+          }
+          activateNormalBuffer() {
+            this._activeBuffer !== this._normal && (this._normal.x = this._alt.x, this._normal.y = this._alt.y, this._alt.clearAllMarkers(), this._alt.clear(), this._activeBuffer = this._normal, this._onBufferActivate.fire({ activeBuffer: this._normal, inactiveBuffer: this._alt }));
+          }
+          activateAltBuffer(e3) {
+            this._activeBuffer !== this._alt && (this._alt.fillViewportRows(e3), this._alt.x = this._normal.x, this._alt.y = this._normal.y, this._activeBuffer = this._alt, this._onBufferActivate.fire({ activeBuffer: this._alt, inactiveBuffer: this._normal }));
+          }
+          resize(e3, t3) {
+            this._normal.resize(e3, t3), this._alt.resize(e3, t3), this.setupTabStops(e3);
+          }
+          setupTabStops(e3) {
+            this._normal.setupTabStops(e3), this._alt.setupTabStops(e3);
+          }
+        }
+        t2.BufferSet = o;
+      }, 3055: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.CellData = void 0;
+        const i2 = s2(726), r2 = s2(8938), n2 = s2(5451);
+        class o extends n2.AttributeData {
+          constructor() {
+            super(...arguments), this.content = 0, this.fg = 0, this.bg = 0, this.extended = new n2.ExtendedAttrs(), this.combinedData = "";
+          }
+          static fromCharData(e3) {
+            const t3 = new o();
+            return t3.setFromCharData(e3), t3;
+          }
+          isCombined() {
+            return 2097152 & this.content;
+          }
+          getWidth() {
+            return this.content >> 22;
+          }
+          getChars() {
+            return 2097152 & this.content ? this.combinedData : 2097151 & this.content ? (0, i2.stringFromCodePoint)(2097151 & this.content) : "";
+          }
+          getCode() {
+            return this.isCombined() ? this.combinedData.charCodeAt(this.combinedData.length - 1) : 2097151 & this.content;
+          }
+          setFromCharData(e3) {
+            this.fg = e3[r2.CHAR_DATA_ATTR_INDEX], this.bg = 0;
+            let t3 = false;
+            if (e3[r2.CHAR_DATA_CHAR_INDEX].length > 2) t3 = true;
+            else if (2 === e3[r2.CHAR_DATA_CHAR_INDEX].length) {
+              const s3 = e3[r2.CHAR_DATA_CHAR_INDEX].charCodeAt(0);
+              if (55296 <= s3 && s3 <= 56319) {
+                const i3 = e3[r2.CHAR_DATA_CHAR_INDEX].charCodeAt(1);
+                56320 <= i3 && i3 <= 57343 ? this.content = 1024 * (s3 - 55296) + i3 - 56320 + 65536 | e3[r2.CHAR_DATA_WIDTH_INDEX] << 22 : t3 = true;
+              } else t3 = true;
+            } else this.content = e3[r2.CHAR_DATA_CHAR_INDEX].charCodeAt(0) | e3[r2.CHAR_DATA_WIDTH_INDEX] << 22;
+            t3 && (this.combinedData = e3[r2.CHAR_DATA_CHAR_INDEX], this.content = 2097152 | e3[r2.CHAR_DATA_WIDTH_INDEX] << 22);
+          }
+          getAsCharData() {
+            return [this.fg, this.getChars(), this.getWidth(), this.getCode()];
+          }
+        }
+        t2.CellData = o;
+      }, 8938: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.WHITESPACE_CELL_CODE = t2.WHITESPACE_CELL_WIDTH = t2.WHITESPACE_CELL_CHAR = t2.NULL_CELL_CODE = t2.NULL_CELL_WIDTH = t2.NULL_CELL_CHAR = t2.CHAR_DATA_CODE_INDEX = t2.CHAR_DATA_WIDTH_INDEX = t2.CHAR_DATA_CHAR_INDEX = t2.CHAR_DATA_ATTR_INDEX = t2.DEFAULT_EXT = t2.DEFAULT_ATTR = t2.DEFAULT_COLOR = void 0, t2.DEFAULT_COLOR = 0, t2.DEFAULT_ATTR = t2.DEFAULT_COLOR << 9 | 256, t2.DEFAULT_EXT = 0, t2.CHAR_DATA_ATTR_INDEX = 0, t2.CHAR_DATA_CHAR_INDEX = 1, t2.CHAR_DATA_WIDTH_INDEX = 2, t2.CHAR_DATA_CODE_INDEX = 3, t2.NULL_CELL_CHAR = "", t2.NULL_CELL_WIDTH = 1, t2.NULL_CELL_CODE = 0, t2.WHITESPACE_CELL_CHAR = " ", t2.WHITESPACE_CELL_WIDTH = 1, t2.WHITESPACE_CELL_CODE = 32;
+      }, 8158: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.Marker = void 0;
+        const i2 = s2(802), r2 = s2(7150);
+        class n2 {
+          get id() {
+            return this._id;
+          }
+          constructor(e3) {
+            this.line = e3, this.isDisposed = false, this._disposables = [], this._id = n2._nextId++, this._onDispose = this.register(new i2.Emitter()), this.onDispose = this._onDispose.event;
+          }
+          dispose() {
+            this.isDisposed || (this.isDisposed = true, this.line = -1, this._onDispose.fire(), (0, r2.dispose)(this._disposables), this._disposables.length = 0);
+          }
+          register(e3) {
+            return this._disposables.push(e3), e3;
+          }
+        }
+        t2.Marker = n2, n2._nextId = 1;
+      }, 6760: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.DEFAULT_CHARSET = t2.CHARSETS = void 0, t2.CHARSETS = {}, t2.DEFAULT_CHARSET = t2.CHARSETS.B, t2.CHARSETS[0] = { "`": "\u25C6", a: "\u2592", b: "\u2409", c: "\u240C", d: "\u240D", e: "\u240A", f: "\xB0", g: "\xB1", h: "\u2424", i: "\u240B", j: "\u2518", k: "\u2510", l: "\u250C", m: "\u2514", n: "\u253C", o: "\u23BA", p: "\u23BB", q: "\u2500", r: "\u23BC", s: "\u23BD", t: "\u251C", u: "\u2524", v: "\u2534", w: "\u252C", x: "\u2502", y: "\u2264", z: "\u2265", "{": "\u03C0", "|": "\u2260", "}": "\xA3", "~": "\xB7" }, t2.CHARSETS.A = { "#": "\xA3" }, t2.CHARSETS.B = void 0, t2.CHARSETS[4] = { "#": "\xA3", "@": "\xBE", "[": "ij", "\\": "\xBD", "]": "|", "{": "\xA8", "|": "f", "}": "\xBC", "~": "\xB4" }, t2.CHARSETS.C = t2.CHARSETS[5] = { "[": "\xC4", "\\": "\xD6", "]": "\xC5", "^": "\xDC", "`": "\xE9", "{": "\xE4", "|": "\xF6", "}": "\xE5", "~": "\xFC" }, t2.CHARSETS.R = { "#": "\xA3", "@": "\xE0", "[": "\xB0", "\\": "\xE7", "]": "\xA7", "{": "\xE9", "|": "\xF9", "}": "\xE8", "~": "\xA8" }, t2.CHARSETS.Q = { "@": "\xE0", "[": "\xE2", "\\": "\xE7", "]": "\xEA", "^": "\xEE", "`": "\xF4", "{": "\xE9", "|": "\xF9", "}": "\xE8", "~": "\xFB" }, t2.CHARSETS.K = { "@": "\xA7", "[": "\xC4", "\\": "\xD6", "]": "\xDC", "{": "\xE4", "|": "\xF6", "}": "\xFC", "~": "\xDF" }, t2.CHARSETS.Y = { "#": "\xA3", "@": "\xA7", "[": "\xB0", "\\": "\xE7", "]": "\xE9", "`": "\xF9", "{": "\xE0", "|": "\xF2", "}": "\xE8", "~": "\xEC" }, t2.CHARSETS.E = t2.CHARSETS[6] = { "@": "\xC4", "[": "\xC6", "\\": "\xD8", "]": "\xC5", "^": "\xDC", "`": "\xE4", "{": "\xE6", "|": "\xF8", "}": "\xE5", "~": "\xFC" }, t2.CHARSETS.Z = { "#": "\xA3", "@": "\xA7", "[": "\xA1", "\\": "\xD1", "]": "\xBF", "{": "\xB0", "|": "\xF1", "}": "\xE7" }, t2.CHARSETS.H = t2.CHARSETS[7] = { "@": "\xC9", "[": "\xC4", "\\": "\xD6", "]": "\xC5", "^": "\xDC", "`": "\xE9", "{": "\xE4", "|": "\xF6", "}": "\xE5", "~": "\xFC" }, t2.CHARSETS["="] = { "#": "\xF9", "@": "\xE0", "[": "\xE9", "\\": "\xE7", "]": "\xEA", "^": "\xEE", _: "\xE8", "`": "\xF4", "{": "\xE4", "|": "\xF6", "}": "\xFC", "~": "\xFB" };
+      }, 3534: (e2, t2) => {
+        var s2, i2, r2;
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.C1_ESCAPED = t2.C1 = t2.C0 = void 0, (function(e3) {
+          e3.NUL = "\0", e3.SOH = "\x01", e3.STX = "\x02", e3.ETX = "\x03", e3.EOT = "\x04", e3.ENQ = "\x05", e3.ACK = "\x06", e3.BEL = "\x07", e3.BS = "\b", e3.HT = "	", e3.LF = "\n", e3.VT = "\v", e3.FF = "\f", e3.CR = "\r", e3.SO = "\x0e", e3.SI = "\x0f", e3.DLE = "\x10", e3.DC1 = "\x11", e3.DC2 = "\x12", e3.DC3 = "\x13", e3.DC4 = "\x14", e3.NAK = "\x15", e3.SYN = "\x16", e3.ETB = "\x17", e3.CAN = "\x18", e3.EM = "\x19", e3.SUB = "\x1a", e3.ESC = "\x1B", e3.FS = "\x1c", e3.GS = "\x1d", e3.RS = "\x1e", e3.US = "\x1f", e3.SP = " ", e3.DEL = "\x7F";
+        })(s2 || (t2.C0 = s2 = {})), (function(e3) {
+          e3.PAD = "\x80", e3.HOP = "\x81", e3.BPH = "\x82", e3.NBH = "\x83", e3.IND = "\x84", e3.NEL = "\x85", e3.SSA = "\x86", e3.ESA = "\x87", e3.HTS = "\x88", e3.HTJ = "\x89", e3.VTS = "\x8A", e3.PLD = "\x8B", e3.PLU = "\x8C", e3.RI = "\x8D", e3.SS2 = "\x8E", e3.SS3 = "\x8F", e3.DCS = "\x90", e3.PU1 = "\x91", e3.PU2 = "\x92", e3.STS = "\x93", e3.CCH = "\x94", e3.MW = "\x95", e3.SPA = "\x96", e3.EPA = "\x97", e3.SOS = "\x98", e3.SGCI = "\x99", e3.SCI = "\x9A", e3.CSI = "\x9B", e3.ST = "\x9C", e3.OSC = "\x9D", e3.PM = "\x9E", e3.APC = "\x9F";
+        })(i2 || (t2.C1 = i2 = {})), (function(e3) {
+          e3.ST = `${s2.ESC}\\`;
+        })(r2 || (t2.C1_ESCAPED = r2 = {}));
+      }, 726: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.Utf8ToUtf32 = t2.StringToUtf32 = void 0, t2.stringFromCodePoint = function(e3) {
+          return e3 > 65535 ? (e3 -= 65536, String.fromCharCode(55296 + (e3 >> 10)) + String.fromCharCode(e3 % 1024 + 56320)) : String.fromCharCode(e3);
+        }, t2.utf32ToString = function(e3, t3 = 0, s2 = e3.length) {
+          let i2 = "";
+          for (let r2 = t3; r2 < s2; ++r2) {
+            let t4 = e3[r2];
+            t4 > 65535 ? (t4 -= 65536, i2 += String.fromCharCode(55296 + (t4 >> 10)) + String.fromCharCode(t4 % 1024 + 56320)) : i2 += String.fromCharCode(t4);
+          }
+          return i2;
+        }, t2.StringToUtf32 = class {
+          constructor() {
+            this._interim = 0;
+          }
+          clear() {
+            this._interim = 0;
+          }
+          decode(e3, t3) {
+            const s2 = e3.length;
+            if (!s2) return 0;
+            let i2 = 0, r2 = 0;
+            if (this._interim) {
+              const s3 = e3.charCodeAt(r2++);
+              56320 <= s3 && s3 <= 57343 ? t3[i2++] = 1024 * (this._interim - 55296) + s3 - 56320 + 65536 : (t3[i2++] = this._interim, t3[i2++] = s3), this._interim = 0;
+            }
+            for (let n2 = r2; n2 < s2; ++n2) {
+              const r3 = e3.charCodeAt(n2);
+              if (55296 <= r3 && r3 <= 56319) {
+                if (++n2 >= s2) return this._interim = r3, i2;
+                const o = e3.charCodeAt(n2);
+                56320 <= o && o <= 57343 ? t3[i2++] = 1024 * (r3 - 55296) + o - 56320 + 65536 : (t3[i2++] = r3, t3[i2++] = o);
+              } else 65279 !== r3 && (t3[i2++] = r3);
+            }
+            return i2;
+          }
+        }, t2.Utf8ToUtf32 = class {
+          constructor() {
+            this.interim = new Uint8Array(3);
+          }
+          clear() {
+            this.interim.fill(0);
+          }
+          decode(e3, t3) {
+            const s2 = e3.length;
+            if (!s2) return 0;
+            let i2, r2, n2, o, a = 0, h = 0, c = 0;
+            if (this.interim[0]) {
+              let i3 = false, r3 = this.interim[0];
+              r3 &= 192 == (224 & r3) ? 31 : 224 == (240 & r3) ? 15 : 7;
+              let n3, o2 = 0;
+              for (; (n3 = 63 & this.interim[++o2]) && o2 < 4; ) r3 <<= 6, r3 |= n3;
+              const h2 = 192 == (224 & this.interim[0]) ? 2 : 224 == (240 & this.interim[0]) ? 3 : 4, l2 = h2 - o2;
+              for (; c < l2; ) {
+                if (c >= s2) return 0;
+                if (n3 = e3[c++], 128 != (192 & n3)) {
+                  c--, i3 = true;
+                  break;
+                }
+                this.interim[o2++] = n3, r3 <<= 6, r3 |= 63 & n3;
+              }
+              i3 || (2 === h2 ? r3 < 128 ? c-- : t3[a++] = r3 : 3 === h2 ? r3 < 2048 || r3 >= 55296 && r3 <= 57343 || 65279 === r3 || (t3[a++] = r3) : r3 < 65536 || r3 > 1114111 || (t3[a++] = r3)), this.interim.fill(0);
+            }
+            const l = s2 - 4;
+            let u = c;
+            for (; u < s2; ) {
+              for (; !(!(u < l) || 128 & (i2 = e3[u]) || 128 & (r2 = e3[u + 1]) || 128 & (n2 = e3[u + 2]) || 128 & (o = e3[u + 3])); ) t3[a++] = i2, t3[a++] = r2, t3[a++] = n2, t3[a++] = o, u += 4;
+              if (i2 = e3[u++], i2 < 128) t3[a++] = i2;
+              else if (192 == (224 & i2)) {
+                if (u >= s2) return this.interim[0] = i2, a;
+                if (r2 = e3[u++], 128 != (192 & r2)) {
+                  u--;
+                  continue;
+                }
+                if (h = (31 & i2) << 6 | 63 & r2, h < 128) {
+                  u--;
+                  continue;
+                }
+                t3[a++] = h;
+              } else if (224 == (240 & i2)) {
+                if (u >= s2) return this.interim[0] = i2, a;
+                if (r2 = e3[u++], 128 != (192 & r2)) {
+                  u--;
+                  continue;
+                }
+                if (u >= s2) return this.interim[0] = i2, this.interim[1] = r2, a;
+                if (n2 = e3[u++], 128 != (192 & n2)) {
+                  u--;
+                  continue;
+                }
+                if (h = (15 & i2) << 12 | (63 & r2) << 6 | 63 & n2, h < 2048 || h >= 55296 && h <= 57343 || 65279 === h) continue;
+                t3[a++] = h;
+              } else if (240 == (248 & i2)) {
+                if (u >= s2) return this.interim[0] = i2, a;
+                if (r2 = e3[u++], 128 != (192 & r2)) {
+                  u--;
+                  continue;
+                }
+                if (u >= s2) return this.interim[0] = i2, this.interim[1] = r2, a;
+                if (n2 = e3[u++], 128 != (192 & n2)) {
+                  u--;
+                  continue;
+                }
+                if (u >= s2) return this.interim[0] = i2, this.interim[1] = r2, this.interim[2] = n2, a;
+                if (o = e3[u++], 128 != (192 & o)) {
+                  u--;
+                  continue;
+                }
+                if (h = (7 & i2) << 18 | (63 & r2) << 12 | (63 & n2) << 6 | 63 & o, h < 65536 || h > 1114111) continue;
+                t3[a++] = h;
+              }
+            }
+            return a;
+          }
+        };
+      }, 7428: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.UnicodeV6 = void 0;
+        const i2 = s2(6415), r2 = [[768, 879], [1155, 1158], [1160, 1161], [1425, 1469], [1471, 1471], [1473, 1474], [1476, 1477], [1479, 1479], [1536, 1539], [1552, 1557], [1611, 1630], [1648, 1648], [1750, 1764], [1767, 1768], [1770, 1773], [1807, 1807], [1809, 1809], [1840, 1866], [1958, 1968], [2027, 2035], [2305, 2306], [2364, 2364], [2369, 2376], [2381, 2381], [2385, 2388], [2402, 2403], [2433, 2433], [2492, 2492], [2497, 2500], [2509, 2509], [2530, 2531], [2561, 2562], [2620, 2620], [2625, 2626], [2631, 2632], [2635, 2637], [2672, 2673], [2689, 2690], [2748, 2748], [2753, 2757], [2759, 2760], [2765, 2765], [2786, 2787], [2817, 2817], [2876, 2876], [2879, 2879], [2881, 2883], [2893, 2893], [2902, 2902], [2946, 2946], [3008, 3008], [3021, 3021], [3134, 3136], [3142, 3144], [3146, 3149], [3157, 3158], [3260, 3260], [3263, 3263], [3270, 3270], [3276, 3277], [3298, 3299], [3393, 3395], [3405, 3405], [3530, 3530], [3538, 3540], [3542, 3542], [3633, 3633], [3636, 3642], [3655, 3662], [3761, 3761], [3764, 3769], [3771, 3772], [3784, 3789], [3864, 3865], [3893, 3893], [3895, 3895], [3897, 3897], [3953, 3966], [3968, 3972], [3974, 3975], [3984, 3991], [3993, 4028], [4038, 4038], [4141, 4144], [4146, 4146], [4150, 4151], [4153, 4153], [4184, 4185], [4448, 4607], [4959, 4959], [5906, 5908], [5938, 5940], [5970, 5971], [6002, 6003], [6068, 6069], [6071, 6077], [6086, 6086], [6089, 6099], [6109, 6109], [6155, 6157], [6313, 6313], [6432, 6434], [6439, 6440], [6450, 6450], [6457, 6459], [6679, 6680], [6912, 6915], [6964, 6964], [6966, 6970], [6972, 6972], [6978, 6978], [7019, 7027], [7616, 7626], [7678, 7679], [8203, 8207], [8234, 8238], [8288, 8291], [8298, 8303], [8400, 8431], [12330, 12335], [12441, 12442], [43014, 43014], [43019, 43019], [43045, 43046], [64286, 64286], [65024, 65039], [65056, 65059], [65279, 65279], [65529, 65531]], n2 = [[68097, 68099], [68101, 68102], [68108, 68111], [68152, 68154], [68159, 68159], [119143, 119145], [119155, 119170], [119173, 119179], [119210, 119213], [119362, 119364], [917505, 917505], [917536, 917631], [917760, 917999]];
+        let o;
+        t2.UnicodeV6 = class {
+          constructor() {
+            if (this.version = "6", !o) {
+              o = new Uint8Array(65536), o.fill(1), o[0] = 0, o.fill(0, 1, 32), o.fill(0, 127, 160), o.fill(2, 4352, 4448), o[9001] = 2, o[9002] = 2, o.fill(2, 11904, 42192), o[12351] = 1, o.fill(2, 44032, 55204), o.fill(2, 63744, 64256), o.fill(2, 65040, 65050), o.fill(2, 65072, 65136), o.fill(2, 65280, 65377), o.fill(2, 65504, 65511);
+              for (let e3 = 0; e3 < r2.length; ++e3) o.fill(0, r2[e3][0], r2[e3][1] + 1);
+            }
+          }
+          wcwidth(e3) {
+            return e3 < 32 ? 0 : e3 < 127 ? 1 : e3 < 65536 ? o[e3] : (function(e4, t3) {
+              let s3, i3 = 0, r3 = t3.length - 1;
+              if (e4 < t3[0][0] || e4 > t3[r3][1]) return false;
+              for (; r3 >= i3; ) if (s3 = i3 + r3 >> 1, e4 > t3[s3][1]) i3 = s3 + 1;
+              else {
+                if (!(e4 < t3[s3][0])) return true;
+                r3 = s3 - 1;
+              }
+              return false;
+            })(e3, n2) ? 0 : e3 >= 131072 && e3 <= 196605 || e3 >= 196608 && e3 <= 262141 ? 2 : 1;
+          }
+          charProperties(e3, t3) {
+            let s3 = this.wcwidth(e3), r3 = 0 === s3 && 0 !== t3;
+            if (r3) {
+              const e4 = i2.UnicodeService.extractWidth(t3);
+              0 === e4 ? r3 = false : e4 > s3 && (s3 = e4);
+            }
+            return i2.UnicodeService.createPropertyValue(0, s3, r3);
+          }
+        };
+      }, 3562: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.WriteBuffer = void 0;
+        const i2 = s2(7150), r2 = s2(802);
+        class n2 extends i2.Disposable {
+          constructor(e3) {
+            super(), this._action = e3, this._writeBuffer = [], this._callbacks = [], this._pendingData = 0, this._bufferOffset = 0, this._isSyncWriting = false, this._syncCalls = 0, this._didUserInput = false, this._onWriteParsed = this._register(new r2.Emitter()), this.onWriteParsed = this._onWriteParsed.event;
+          }
+          handleUserInput() {
+            this._didUserInput = true;
+          }
+          writeSync(e3, t3) {
+            if (void 0 !== t3 && this._syncCalls > t3) return void (this._syncCalls = 0);
+            if (this._pendingData += e3.length, this._writeBuffer.push(e3), this._callbacks.push(void 0), this._syncCalls++, this._isSyncWriting) return;
+            let s3;
+            for (this._isSyncWriting = true; s3 = this._writeBuffer.shift(); ) {
+              this._action(s3);
+              const e4 = this._callbacks.shift();
+              e4 && e4();
+            }
+            this._pendingData = 0, this._bufferOffset = 2147483647, this._isSyncWriting = false, this._syncCalls = 0;
+          }
+          write(e3, t3) {
+            if (this._pendingData > 5e7) throw new Error("write data discarded, use flow control to avoid losing data");
+            if (!this._writeBuffer.length) {
+              if (this._bufferOffset = 0, this._didUserInput) return this._didUserInput = false, this._pendingData += e3.length, this._writeBuffer.push(e3), this._callbacks.push(t3), void this._innerWrite();
+              setTimeout((() => this._innerWrite()));
+            }
+            this._pendingData += e3.length, this._writeBuffer.push(e3), this._callbacks.push(t3);
+          }
+          _innerWrite(e3 = 0, t3 = true) {
+            const s3 = e3 || performance.now();
+            for (; this._writeBuffer.length > this._bufferOffset; ) {
+              const e4 = this._writeBuffer[this._bufferOffset], i3 = this._action(e4, t3);
+              if (i3) {
+                const e5 = (e6) => performance.now() - s3 >= 12 ? setTimeout((() => this._innerWrite(0, e6))) : this._innerWrite(s3, e6);
+                return void i3.catch(((e6) => (queueMicrotask((() => {
+                  throw e6;
+                })), Promise.resolve(false)))).then(e5);
+              }
+              const r3 = this._callbacks[this._bufferOffset];
+              if (r3 && r3(), this._bufferOffset++, this._pendingData -= e4.length, performance.now() - s3 >= 12) break;
+            }
+            this._writeBuffer.length > this._bufferOffset ? (this._bufferOffset > 50 && (this._writeBuffer = this._writeBuffer.slice(this._bufferOffset), this._callbacks = this._callbacks.slice(this._bufferOffset), this._bufferOffset = 0), setTimeout((() => this._innerWrite()))) : (this._writeBuffer.length = 0, this._callbacks.length = 0, this._pendingData = 0, this._bufferOffset = 0), this._onWriteParsed.fire();
+          }
+        }
+        t2.WriteBuffer = n2;
+      }, 8693: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.parseColor = function(e3) {
+          if (!e3) return;
+          let t3 = e3.toLowerCase();
+          if (0 === t3.indexOf("rgb:")) {
+            t3 = t3.slice(4);
+            const e4 = s2.exec(t3);
+            if (e4) {
+              const t4 = e4[1] ? 15 : e4[4] ? 255 : e4[7] ? 4095 : 65535;
+              return [Math.round(parseInt(e4[1] || e4[4] || e4[7] || e4[10], 16) / t4 * 255), Math.round(parseInt(e4[2] || e4[5] || e4[8] || e4[11], 16) / t4 * 255), Math.round(parseInt(e4[3] || e4[6] || e4[9] || e4[12], 16) / t4 * 255)];
+            }
+          } else if (0 === t3.indexOf("#") && (t3 = t3.slice(1), i2.exec(t3) && [3, 6, 9, 12].includes(t3.length))) {
+            const e4 = t3.length / 3, s3 = [0, 0, 0];
+            for (let i3 = 0; i3 < 3; ++i3) {
+              const r3 = parseInt(t3.slice(e4 * i3, e4 * i3 + e4), 16);
+              s3[i3] = 1 === e4 ? r3 << 4 : 2 === e4 ? r3 : 3 === e4 ? r3 >> 4 : r3 >> 8;
+            }
+            return s3;
+          }
+        }, t2.toRgbString = function(e3, t3 = 16) {
+          const [s3, i3, n2] = e3;
+          return `rgb:${r2(s3, t3)}/${r2(i3, t3)}/${r2(n2, t3)}`;
+        };
+        const s2 = /^([\da-f])\/([\da-f])\/([\da-f])$|^([\da-f]{2})\/([\da-f]{2})\/([\da-f]{2})$|^([\da-f]{3})\/([\da-f]{3})\/([\da-f]{3})$|^([\da-f]{4})\/([\da-f]{4})\/([\da-f]{4})$/, i2 = /^[\da-f]+$/;
+        function r2(e3, t3) {
+          const s3 = e3.toString(16), i3 = s3.length < 2 ? "0" + s3 : s3;
+          switch (t3) {
+            case 4:
+              return s3[0];
+            case 8:
+              return i3;
+            case 12:
+              return (i3 + i3).slice(0, 3);
+            default:
+              return i3 + i3;
+          }
+        }
+      }, 1263: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.PAYLOAD_LIMIT = void 0, t2.PAYLOAD_LIMIT = 1e7;
+      }, 9823: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.DcsHandler = t2.DcsParser = void 0;
+        const i2 = s2(726), r2 = s2(7262), n2 = s2(1263), o = [];
+        t2.DcsParser = class {
+          constructor() {
+            this._handlers = /* @__PURE__ */ Object.create(null), this._active = o, this._ident = 0, this._handlerFb = () => {
+            }, this._stack = { paused: false, loopPosition: 0, fallThrough: false };
+          }
+          dispose() {
+            this._handlers = /* @__PURE__ */ Object.create(null), this._handlerFb = () => {
+            }, this._active = o;
+          }
+          registerHandler(e3, t3) {
+            void 0 === this._handlers[e3] && (this._handlers[e3] = []);
+            const s3 = this._handlers[e3];
+            return s3.push(t3), { dispose: () => {
+              const e4 = s3.indexOf(t3);
+              -1 !== e4 && s3.splice(e4, 1);
+            } };
+          }
+          clearHandler(e3) {
+            this._handlers[e3] && delete this._handlers[e3];
+          }
+          setHandlerFallback(e3) {
+            this._handlerFb = e3;
+          }
+          reset() {
+            if (this._active.length) for (let e3 = this._stack.paused ? this._stack.loopPosition - 1 : this._active.length - 1; e3 >= 0; --e3) this._active[e3].unhook(false);
+            this._stack.paused = false, this._active = o, this._ident = 0;
+          }
+          hook(e3, t3) {
+            if (this.reset(), this._ident = e3, this._active = this._handlers[e3] || o, this._active.length) for (let e4 = this._active.length - 1; e4 >= 0; e4--) this._active[e4].hook(t3);
+            else this._handlerFb(this._ident, "HOOK", t3);
+          }
+          put(e3, t3, s3) {
+            if (this._active.length) for (let i3 = this._active.length - 1; i3 >= 0; i3--) this._active[i3].put(e3, t3, s3);
+            else this._handlerFb(this._ident, "PUT", (0, i2.utf32ToString)(e3, t3, s3));
+          }
+          unhook(e3, t3 = true) {
+            if (this._active.length) {
+              let s3 = false, i3 = this._active.length - 1, r3 = false;
+              if (this._stack.paused && (i3 = this._stack.loopPosition - 1, s3 = t3, r3 = this._stack.fallThrough, this._stack.paused = false), !r3 && false === s3) {
+                for (; i3 >= 0 && (s3 = this._active[i3].unhook(e3), true !== s3); i3--) if (s3 instanceof Promise) return this._stack.paused = true, this._stack.loopPosition = i3, this._stack.fallThrough = false, s3;
+                i3--;
+              }
+              for (; i3 >= 0; i3--) if (s3 = this._active[i3].unhook(false), s3 instanceof Promise) return this._stack.paused = true, this._stack.loopPosition = i3, this._stack.fallThrough = true, s3;
+            } else this._handlerFb(this._ident, "UNHOOK", e3);
+            this._active = o, this._ident = 0;
+          }
+        };
+        const a = new r2.Params();
+        a.addParam(0), t2.DcsHandler = class {
+          constructor(e3) {
+            this._handler = e3, this._data = "", this._params = a, this._hitLimit = false;
+          }
+          hook(e3) {
+            this._params = e3.length > 1 || e3.params[0] ? e3.clone() : a, this._data = "", this._hitLimit = false;
+          }
+          put(e3, t3, s3) {
+            this._hitLimit || (this._data += (0, i2.utf32ToString)(e3, t3, s3), this._data.length > n2.PAYLOAD_LIMIT && (this._data = "", this._hitLimit = true));
+          }
+          unhook(e3) {
+            let t3 = false;
+            if (this._hitLimit) t3 = false;
+            else if (e3 && (t3 = this._handler(this._data, this._params), t3 instanceof Promise)) return t3.then(((e4) => (this._params = a, this._data = "", this._hitLimit = false, e4)));
+            return this._params = a, this._data = "", this._hitLimit = false, t3;
+          }
+        };
+      }, 6717: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.EscapeSequenceParser = t2.VT500_TRANSITION_TABLE = t2.TransitionTable = void 0;
+        const i2 = s2(7150), r2 = s2(7262), n2 = s2(1346), o = s2(9823);
+        class a {
+          constructor(e3) {
+            this.table = new Uint8Array(e3);
+          }
+          setDefault(e3, t3) {
+            this.table.fill(e3 << 4 | t3);
+          }
+          add(e3, t3, s3, i3) {
+            this.table[t3 << 8 | e3] = s3 << 4 | i3;
+          }
+          addMany(e3, t3, s3, i3) {
+            for (let r3 = 0; r3 < e3.length; r3++) this.table[t3 << 8 | e3[r3]] = s3 << 4 | i3;
+          }
+        }
+        t2.TransitionTable = a;
+        const h = 160;
+        t2.VT500_TRANSITION_TABLE = (function() {
+          const e3 = new a(4095), t3 = Array.apply(null, Array(256)).map(((e4, t4) => t4)), s3 = (e4, s4) => t3.slice(e4, s4), i3 = s3(32, 127), r3 = s3(0, 24);
+          r3.push(25), r3.push.apply(r3, s3(28, 32));
+          const n3 = s3(0, 14);
+          let o2;
+          for (o2 in e3.setDefault(1, 0), e3.addMany(i3, 0, 2, 0), n3) e3.addMany([24, 26, 153, 154], o2, 3, 0), e3.addMany(s3(128, 144), o2, 3, 0), e3.addMany(s3(144, 152), o2, 3, 0), e3.add(156, o2, 0, 0), e3.add(27, o2, 11, 1), e3.add(157, o2, 4, 8), e3.addMany([152, 158, 159], o2, 0, 7), e3.add(155, o2, 11, 3), e3.add(144, o2, 11, 9);
+          return e3.addMany(r3, 0, 3, 0), e3.addMany(r3, 1, 3, 1), e3.add(127, 1, 0, 1), e3.addMany(r3, 8, 0, 8), e3.addMany(r3, 3, 3, 3), e3.add(127, 3, 0, 3), e3.addMany(r3, 4, 3, 4), e3.add(127, 4, 0, 4), e3.addMany(r3, 6, 3, 6), e3.addMany(r3, 5, 3, 5), e3.add(127, 5, 0, 5), e3.addMany(r3, 2, 3, 2), e3.add(127, 2, 0, 2), e3.add(93, 1, 4, 8), e3.addMany(i3, 8, 5, 8), e3.add(127, 8, 5, 8), e3.addMany([156, 27, 24, 26, 7], 8, 6, 0), e3.addMany(s3(28, 32), 8, 0, 8), e3.addMany([88, 94, 95], 1, 0, 7), e3.addMany(i3, 7, 0, 7), e3.addMany(r3, 7, 0, 7), e3.add(156, 7, 0, 0), e3.add(127, 7, 0, 7), e3.add(91, 1, 11, 3), e3.addMany(s3(64, 127), 3, 7, 0), e3.addMany(s3(48, 60), 3, 8, 4), e3.addMany([60, 61, 62, 63], 3, 9, 4), e3.addMany(s3(48, 60), 4, 8, 4), e3.addMany(s3(64, 127), 4, 7, 0), e3.addMany([60, 61, 62, 63], 4, 0, 6), e3.addMany(s3(32, 64), 6, 0, 6), e3.add(127, 6, 0, 6), e3.addMany(s3(64, 127), 6, 0, 0), e3.addMany(s3(32, 48), 3, 9, 5), e3.addMany(s3(32, 48), 5, 9, 5), e3.addMany(s3(48, 64), 5, 0, 6), e3.addMany(s3(64, 127), 5, 7, 0), e3.addMany(s3(32, 48), 4, 9, 5), e3.addMany(s3(32, 48), 1, 9, 2), e3.addMany(s3(32, 48), 2, 9, 2), e3.addMany(s3(48, 127), 2, 10, 0), e3.addMany(s3(48, 80), 1, 10, 0), e3.addMany(s3(81, 88), 1, 10, 0), e3.addMany([89, 90, 92], 1, 10, 0), e3.addMany(s3(96, 127), 1, 10, 0), e3.add(80, 1, 11, 9), e3.addMany(r3, 9, 0, 9), e3.add(127, 9, 0, 9), e3.addMany(s3(28, 32), 9, 0, 9), e3.addMany(s3(32, 48), 9, 9, 12), e3.addMany(s3(48, 60), 9, 8, 10), e3.addMany([60, 61, 62, 63], 9, 9, 10), e3.addMany(r3, 11, 0, 11), e3.addMany(s3(32, 128), 11, 0, 11), e3.addMany(s3(28, 32), 11, 0, 11), e3.addMany(r3, 10, 0, 10), e3.add(127, 10, 0, 10), e3.addMany(s3(28, 32), 10, 0, 10), e3.addMany(s3(48, 60), 10, 8, 10), e3.addMany([60, 61, 62, 63], 10, 0, 11), e3.addMany(s3(32, 48), 10, 9, 12), e3.addMany(r3, 12, 0, 12), e3.add(127, 12, 0, 12), e3.addMany(s3(28, 32), 12, 0, 12), e3.addMany(s3(32, 48), 12, 9, 12), e3.addMany(s3(48, 64), 12, 0, 11), e3.addMany(s3(64, 127), 12, 12, 13), e3.addMany(s3(64, 127), 10, 12, 13), e3.addMany(s3(64, 127), 9, 12, 13), e3.addMany(r3, 13, 13, 13), e3.addMany(i3, 13, 13, 13), e3.add(127, 13, 0, 13), e3.addMany([27, 156, 24, 26], 13, 14, 0), e3.add(h, 0, 2, 0), e3.add(h, 8, 5, 8), e3.add(h, 6, 0, 6), e3.add(h, 11, 0, 11), e3.add(h, 13, 13, 13), e3;
+        })();
+        class c extends i2.Disposable {
+          constructor(e3 = t2.VT500_TRANSITION_TABLE) {
+            super(), this._transitions = e3, this._parseStack = { state: 0, handlers: [], handlerPos: 0, transition: 0, chunkPos: 0 }, this.initialState = 0, this.currentState = this.initialState, this._params = new r2.Params(), this._params.addParam(0), this._collect = 0, this.precedingJoinState = 0, this._printHandlerFb = (e4, t3, s3) => {
+            }, this._executeHandlerFb = (e4) => {
+            }, this._csiHandlerFb = (e4, t3) => {
+            }, this._escHandlerFb = (e4) => {
+            }, this._errorHandlerFb = (e4) => e4, this._printHandler = this._printHandlerFb, this._executeHandlers = /* @__PURE__ */ Object.create(null), this._csiHandlers = /* @__PURE__ */ Object.create(null), this._escHandlers = /* @__PURE__ */ Object.create(null), this._register((0, i2.toDisposable)((() => {
+              this._csiHandlers = /* @__PURE__ */ Object.create(null), this._executeHandlers = /* @__PURE__ */ Object.create(null), this._escHandlers = /* @__PURE__ */ Object.create(null);
+            }))), this._oscParser = this._register(new n2.OscParser()), this._dcsParser = this._register(new o.DcsParser()), this._errorHandler = this._errorHandlerFb, this.registerEscHandler({ final: "\\" }, (() => true));
+          }
+          _identifier(e3, t3 = [64, 126]) {
+            let s3 = 0;
+            if (e3.prefix) {
+              if (e3.prefix.length > 1) throw new Error("only one byte as prefix supported");
+              if (s3 = e3.prefix.charCodeAt(0), s3 && 60 > s3 || s3 > 63) throw new Error("prefix must be in range 0x3c .. 0x3f");
+            }
+            if (e3.intermediates) {
+              if (e3.intermediates.length > 2) throw new Error("only two bytes as intermediates are supported");
+              for (let t4 = 0; t4 < e3.intermediates.length; ++t4) {
+                const i4 = e3.intermediates.charCodeAt(t4);
+                if (32 > i4 || i4 > 47) throw new Error("intermediate must be in range 0x20 .. 0x2f");
+                s3 <<= 8, s3 |= i4;
+              }
+            }
+            if (1 !== e3.final.length) throw new Error("final must be a single byte");
+            const i3 = e3.final.charCodeAt(0);
+            if (t3[0] > i3 || i3 > t3[1]) throw new Error(`final must be in range ${t3[0]} .. ${t3[1]}`);
+            return s3 <<= 8, s3 |= i3, s3;
+          }
+          identToString(e3) {
+            const t3 = [];
+            for (; e3; ) t3.push(String.fromCharCode(255 & e3)), e3 >>= 8;
+            return t3.reverse().join("");
+          }
+          setPrintHandler(e3) {
+            this._printHandler = e3;
+          }
+          clearPrintHandler() {
+            this._printHandler = this._printHandlerFb;
+          }
+          registerEscHandler(e3, t3) {
+            const s3 = this._identifier(e3, [48, 126]);
+            void 0 === this._escHandlers[s3] && (this._escHandlers[s3] = []);
+            const i3 = this._escHandlers[s3];
+            return i3.push(t3), { dispose: () => {
+              const e4 = i3.indexOf(t3);
+              -1 !== e4 && i3.splice(e4, 1);
+            } };
+          }
+          clearEscHandler(e3) {
+            this._escHandlers[this._identifier(e3, [48, 126])] && delete this._escHandlers[this._identifier(e3, [48, 126])];
+          }
+          setEscHandlerFallback(e3) {
+            this._escHandlerFb = e3;
+          }
+          setExecuteHandler(e3, t3) {
+            this._executeHandlers[e3.charCodeAt(0)] = t3;
+          }
+          clearExecuteHandler(e3) {
+            this._executeHandlers[e3.charCodeAt(0)] && delete this._executeHandlers[e3.charCodeAt(0)];
+          }
+          setExecuteHandlerFallback(e3) {
+            this._executeHandlerFb = e3;
+          }
+          registerCsiHandler(e3, t3) {
+            const s3 = this._identifier(e3);
+            void 0 === this._csiHandlers[s3] && (this._csiHandlers[s3] = []);
+            const i3 = this._csiHandlers[s3];
+            return i3.push(t3), { dispose: () => {
+              const e4 = i3.indexOf(t3);
+              -1 !== e4 && i3.splice(e4, 1);
+            } };
+          }
+          clearCsiHandler(e3) {
+            this._csiHandlers[this._identifier(e3)] && delete this._csiHandlers[this._identifier(e3)];
+          }
+          setCsiHandlerFallback(e3) {
+            this._csiHandlerFb = e3;
+          }
+          registerDcsHandler(e3, t3) {
+            return this._dcsParser.registerHandler(this._identifier(e3), t3);
+          }
+          clearDcsHandler(e3) {
+            this._dcsParser.clearHandler(this._identifier(e3));
+          }
+          setDcsHandlerFallback(e3) {
+            this._dcsParser.setHandlerFallback(e3);
+          }
+          registerOscHandler(e3, t3) {
+            return this._oscParser.registerHandler(e3, t3);
+          }
+          clearOscHandler(e3) {
+            this._oscParser.clearHandler(e3);
+          }
+          setOscHandlerFallback(e3) {
+            this._oscParser.setHandlerFallback(e3);
+          }
+          setErrorHandler(e3) {
+            this._errorHandler = e3;
+          }
+          clearErrorHandler() {
+            this._errorHandler = this._errorHandlerFb;
+          }
+          reset() {
+            this.currentState = this.initialState, this._oscParser.reset(), this._dcsParser.reset(), this._params.reset(), this._params.addParam(0), this._collect = 0, this.precedingJoinState = 0, 0 !== this._parseStack.state && (this._parseStack.state = 2, this._parseStack.handlers = []);
+          }
+          _preserveStack(e3, t3, s3, i3, r3) {
+            this._parseStack.state = e3, this._parseStack.handlers = t3, this._parseStack.handlerPos = s3, this._parseStack.transition = i3, this._parseStack.chunkPos = r3;
+          }
+          parse(e3, t3, s3) {
+            let i3, r3 = 0, n3 = 0, o2 = 0;
+            if (this._parseStack.state) if (2 === this._parseStack.state) this._parseStack.state = 0, o2 = this._parseStack.chunkPos + 1;
+            else {
+              if (void 0 === s3 || 1 === this._parseStack.state) throw this._parseStack.state = 1, new Error("improper continuation due to previous async handler, giving up parsing");
+              const t4 = this._parseStack.handlers;
+              let n4 = this._parseStack.handlerPos - 1;
+              switch (this._parseStack.state) {
+                case 3:
+                  if (false === s3 && n4 > -1) {
+                    for (; n4 >= 0 && (i3 = t4[n4](this._params), true !== i3); n4--) if (i3 instanceof Promise) return this._parseStack.handlerPos = n4, i3;
+                  }
+                  this._parseStack.handlers = [];
+                  break;
+                case 4:
+                  if (false === s3 && n4 > -1) {
+                    for (; n4 >= 0 && (i3 = t4[n4](), true !== i3); n4--) if (i3 instanceof Promise) return this._parseStack.handlerPos = n4, i3;
+                  }
+                  this._parseStack.handlers = [];
+                  break;
+                case 6:
+                  if (r3 = e3[this._parseStack.chunkPos], i3 = this._dcsParser.unhook(24 !== r3 && 26 !== r3, s3), i3) return i3;
+                  27 === r3 && (this._parseStack.transition |= 1), this._params.reset(), this._params.addParam(0), this._collect = 0;
+                  break;
+                case 5:
+                  if (r3 = e3[this._parseStack.chunkPos], i3 = this._oscParser.end(24 !== r3 && 26 !== r3, s3), i3) return i3;
+                  27 === r3 && (this._parseStack.transition |= 1), this._params.reset(), this._params.addParam(0), this._collect = 0;
+              }
+              this._parseStack.state = 0, o2 = this._parseStack.chunkPos + 1, this.precedingJoinState = 0, this.currentState = 15 & this._parseStack.transition;
+            }
+            for (let s4 = o2; s4 < t3; ++s4) {
+              switch (r3 = e3[s4], n3 = this._transitions.table[this.currentState << 8 | (r3 < 160 ? r3 : h)], n3 >> 4) {
+                case 2:
+                  for (let i4 = s4 + 1; ; ++i4) {
+                    if (i4 >= t3 || (r3 = e3[i4]) < 32 || r3 > 126 && r3 < h) {
+                      this._printHandler(e3, s4, i4), s4 = i4 - 1;
+                      break;
+                    }
+                    if (++i4 >= t3 || (r3 = e3[i4]) < 32 || r3 > 126 && r3 < h) {
+                      this._printHandler(e3, s4, i4), s4 = i4 - 1;
+                      break;
+                    }
+                    if (++i4 >= t3 || (r3 = e3[i4]) < 32 || r3 > 126 && r3 < h) {
+                      this._printHandler(e3, s4, i4), s4 = i4 - 1;
+                      break;
+                    }
+                    if (++i4 >= t3 || (r3 = e3[i4]) < 32 || r3 > 126 && r3 < h) {
+                      this._printHandler(e3, s4, i4), s4 = i4 - 1;
+                      break;
+                    }
+                  }
+                  break;
+                case 3:
+                  this._executeHandlers[r3] ? this._executeHandlers[r3]() : this._executeHandlerFb(r3), this.precedingJoinState = 0;
+                  break;
+                case 0:
+                  break;
+                case 1:
+                  if (this._errorHandler({ position: s4, code: r3, currentState: this.currentState, collect: this._collect, params: this._params, abort: false }).abort) return;
+                  break;
+                case 7:
+                  const o3 = this._csiHandlers[this._collect << 8 | r3];
+                  let a2 = o3 ? o3.length - 1 : -1;
+                  for (; a2 >= 0 && (i3 = o3[a2](this._params), true !== i3); a2--) if (i3 instanceof Promise) return this._preserveStack(3, o3, a2, n3, s4), i3;
+                  a2 < 0 && this._csiHandlerFb(this._collect << 8 | r3, this._params), this.precedingJoinState = 0;
+                  break;
+                case 8:
+                  do {
+                    switch (r3) {
+                      case 59:
+                        this._params.addParam(0);
+                        break;
+                      case 58:
+                        this._params.addSubParam(-1);
+                        break;
+                      default:
+                        this._params.addDigit(r3 - 48);
+                    }
+                  } while (++s4 < t3 && (r3 = e3[s4]) > 47 && r3 < 60);
+                  s4--;
+                  break;
+                case 9:
+                  this._collect <<= 8, this._collect |= r3;
+                  break;
+                case 10:
+                  const c2 = this._escHandlers[this._collect << 8 | r3];
+                  let l = c2 ? c2.length - 1 : -1;
+                  for (; l >= 0 && (i3 = c2[l](), true !== i3); l--) if (i3 instanceof Promise) return this._preserveStack(4, c2, l, n3, s4), i3;
+                  l < 0 && this._escHandlerFb(this._collect << 8 | r3), this.precedingJoinState = 0;
+                  break;
+                case 11:
+                  this._params.reset(), this._params.addParam(0), this._collect = 0;
+                  break;
+                case 12:
+                  this._dcsParser.hook(this._collect << 8 | r3, this._params);
+                  break;
+                case 13:
+                  for (let i4 = s4 + 1; ; ++i4) if (i4 >= t3 || 24 === (r3 = e3[i4]) || 26 === r3 || 27 === r3 || r3 > 127 && r3 < h) {
+                    this._dcsParser.put(e3, s4, i4), s4 = i4 - 1;
+                    break;
+                  }
+                  break;
+                case 14:
+                  if (i3 = this._dcsParser.unhook(24 !== r3 && 26 !== r3), i3) return this._preserveStack(6, [], 0, n3, s4), i3;
+                  27 === r3 && (n3 |= 1), this._params.reset(), this._params.addParam(0), this._collect = 0, this.precedingJoinState = 0;
+                  break;
+                case 4:
+                  this._oscParser.start();
+                  break;
+                case 5:
+                  for (let i4 = s4 + 1; ; i4++) if (i4 >= t3 || (r3 = e3[i4]) < 32 || r3 > 127 && r3 < h) {
+                    this._oscParser.put(e3, s4, i4), s4 = i4 - 1;
+                    break;
+                  }
+                  break;
+                case 6:
+                  if (i3 = this._oscParser.end(24 !== r3 && 26 !== r3), i3) return this._preserveStack(5, [], 0, n3, s4), i3;
+                  27 === r3 && (n3 |= 1), this._params.reset(), this._params.addParam(0), this._collect = 0, this.precedingJoinState = 0;
+              }
+              this.currentState = 15 & n3;
+            }
+          }
+        }
+        t2.EscapeSequenceParser = c;
+      }, 1346: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.OscHandler = t2.OscParser = void 0;
+        const i2 = s2(1263), r2 = s2(726), n2 = [];
+        t2.OscParser = class {
+          constructor() {
+            this._state = 0, this._active = n2, this._id = -1, this._handlers = /* @__PURE__ */ Object.create(null), this._handlerFb = () => {
+            }, this._stack = { paused: false, loopPosition: 0, fallThrough: false };
+          }
+          registerHandler(e3, t3) {
+            void 0 === this._handlers[e3] && (this._handlers[e3] = []);
+            const s3 = this._handlers[e3];
+            return s3.push(t3), { dispose: () => {
+              const e4 = s3.indexOf(t3);
+              -1 !== e4 && s3.splice(e4, 1);
+            } };
+          }
+          clearHandler(e3) {
+            this._handlers[e3] && delete this._handlers[e3];
+          }
+          setHandlerFallback(e3) {
+            this._handlerFb = e3;
+          }
+          dispose() {
+            this._handlers = /* @__PURE__ */ Object.create(null), this._handlerFb = () => {
+            }, this._active = n2;
+          }
+          reset() {
+            if (2 === this._state) for (let e3 = this._stack.paused ? this._stack.loopPosition - 1 : this._active.length - 1; e3 >= 0; --e3) this._active[e3].end(false);
+            this._stack.paused = false, this._active = n2, this._id = -1, this._state = 0;
+          }
+          _start() {
+            if (this._active = this._handlers[this._id] || n2, this._active.length) for (let e3 = this._active.length - 1; e3 >= 0; e3--) this._active[e3].start();
+            else this._handlerFb(this._id, "START");
+          }
+          _put(e3, t3, s3) {
+            if (this._active.length) for (let i3 = this._active.length - 1; i3 >= 0; i3--) this._active[i3].put(e3, t3, s3);
+            else this._handlerFb(this._id, "PUT", (0, r2.utf32ToString)(e3, t3, s3));
+          }
+          start() {
+            this.reset(), this._state = 1;
+          }
+          put(e3, t3, s3) {
+            if (3 !== this._state) {
+              if (1 === this._state) for (; t3 < s3; ) {
+                const s4 = e3[t3++];
+                if (59 === s4) {
+                  this._state = 2, this._start();
+                  break;
+                }
+                if (s4 < 48 || 57 < s4) return void (this._state = 3);
+                -1 === this._id && (this._id = 0), this._id = 10 * this._id + s4 - 48;
+              }
+              2 === this._state && s3 - t3 > 0 && this._put(e3, t3, s3);
+            }
+          }
+          end(e3, t3 = true) {
+            if (0 !== this._state) {
+              if (3 !== this._state) if (1 === this._state && this._start(), this._active.length) {
+                let s3 = false, i3 = this._active.length - 1, r3 = false;
+                if (this._stack.paused && (i3 = this._stack.loopPosition - 1, s3 = t3, r3 = this._stack.fallThrough, this._stack.paused = false), !r3 && false === s3) {
+                  for (; i3 >= 0 && (s3 = this._active[i3].end(e3), true !== s3); i3--) if (s3 instanceof Promise) return this._stack.paused = true, this._stack.loopPosition = i3, this._stack.fallThrough = false, s3;
+                  i3--;
+                }
+                for (; i3 >= 0; i3--) if (s3 = this._active[i3].end(false), s3 instanceof Promise) return this._stack.paused = true, this._stack.loopPosition = i3, this._stack.fallThrough = true, s3;
+              } else this._handlerFb(this._id, "END", e3);
+              this._active = n2, this._id = -1, this._state = 0;
+            }
+          }
+        }, t2.OscHandler = class {
+          constructor(e3) {
+            this._handler = e3, this._data = "", this._hitLimit = false;
+          }
+          start() {
+            this._data = "", this._hitLimit = false;
+          }
+          put(e3, t3, s3) {
+            this._hitLimit || (this._data += (0, r2.utf32ToString)(e3, t3, s3), this._data.length > i2.PAYLOAD_LIMIT && (this._data = "", this._hitLimit = true));
+          }
+          end(e3) {
+            let t3 = false;
+            if (this._hitLimit) t3 = false;
+            else if (e3 && (t3 = this._handler(this._data), t3 instanceof Promise)) return t3.then(((e4) => (this._data = "", this._hitLimit = false, e4)));
+            return this._data = "", this._hitLimit = false, t3;
+          }
+        };
+      }, 7262: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.Params = void 0;
+        const s2 = 2147483647;
+        class i2 {
+          static fromArray(e3) {
+            const t3 = new i2();
+            if (!e3.length) return t3;
+            for (let s3 = Array.isArray(e3[0]) ? 1 : 0; s3 < e3.length; ++s3) {
+              const i3 = e3[s3];
+              if (Array.isArray(i3)) for (let e4 = 0; e4 < i3.length; ++e4) t3.addSubParam(i3[e4]);
+              else t3.addParam(i3);
+            }
+            return t3;
+          }
+          constructor(e3 = 32, t3 = 32) {
+            if (this.maxLength = e3, this.maxSubParamsLength = t3, t3 > 256) throw new Error("maxSubParamsLength must not be greater than 256");
+            this.params = new Int32Array(e3), this.length = 0, this._subParams = new Int32Array(t3), this._subParamsLength = 0, this._subParamsIdx = new Uint16Array(e3), this._rejectDigits = false, this._rejectSubDigits = false, this._digitIsSub = false;
+          }
+          clone() {
+            const e3 = new i2(this.maxLength, this.maxSubParamsLength);
+            return e3.params.set(this.params), e3.length = this.length, e3._subParams.set(this._subParams), e3._subParamsLength = this._subParamsLength, e3._subParamsIdx.set(this._subParamsIdx), e3._rejectDigits = this._rejectDigits, e3._rejectSubDigits = this._rejectSubDigits, e3._digitIsSub = this._digitIsSub, e3;
+          }
+          toArray() {
+            const e3 = [];
+            for (let t3 = 0; t3 < this.length; ++t3) {
+              e3.push(this.params[t3]);
+              const s3 = this._subParamsIdx[t3] >> 8, i3 = 255 & this._subParamsIdx[t3];
+              i3 - s3 > 0 && e3.push(Array.prototype.slice.call(this._subParams, s3, i3));
+            }
+            return e3;
+          }
+          reset() {
+            this.length = 0, this._subParamsLength = 0, this._rejectDigits = false, this._rejectSubDigits = false, this._digitIsSub = false;
+          }
+          addParam(e3) {
+            if (this._digitIsSub = false, this.length >= this.maxLength) this._rejectDigits = true;
+            else {
+              if (e3 < -1) throw new Error("values lesser than -1 are not allowed");
+              this._subParamsIdx[this.length] = this._subParamsLength << 8 | this._subParamsLength, this.params[this.length++] = e3 > s2 ? s2 : e3;
+            }
+          }
+          addSubParam(e3) {
+            if (this._digitIsSub = true, this.length) if (this._rejectDigits || this._subParamsLength >= this.maxSubParamsLength) this._rejectSubDigits = true;
+            else {
+              if (e3 < -1) throw new Error("values lesser than -1 are not allowed");
+              this._subParams[this._subParamsLength++] = e3 > s2 ? s2 : e3, this._subParamsIdx[this.length - 1]++;
+            }
+          }
+          hasSubParams(e3) {
+            return (255 & this._subParamsIdx[e3]) - (this._subParamsIdx[e3] >> 8) > 0;
+          }
+          getSubParams(e3) {
+            const t3 = this._subParamsIdx[e3] >> 8, s3 = 255 & this._subParamsIdx[e3];
+            return s3 - t3 > 0 ? this._subParams.subarray(t3, s3) : null;
+          }
+          getSubParamsAll() {
+            const e3 = {};
+            for (let t3 = 0; t3 < this.length; ++t3) {
+              const s3 = this._subParamsIdx[t3] >> 8, i3 = 255 & this._subParamsIdx[t3];
+              i3 - s3 > 0 && (e3[t3] = this._subParams.slice(s3, i3));
+            }
+            return e3;
+          }
+          addDigit(e3) {
+            let t3;
+            if (this._rejectDigits || !(t3 = this._digitIsSub ? this._subParamsLength : this.length) || this._digitIsSub && this._rejectSubDigits) return;
+            const i3 = this._digitIsSub ? this._subParams : this.params, r2 = i3[t3 - 1];
+            i3[t3 - 1] = ~r2 ? Math.min(10 * r2 + e3, s2) : e3;
+          }
+        }
+        t2.Params = i2;
+      }, 3027: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.AddonManager = void 0, t2.AddonManager = class {
+          constructor() {
+            this._addons = [];
+          }
+          dispose() {
+            for (let e3 = this._addons.length - 1; e3 >= 0; e3--) this._addons[e3].instance.dispose();
+          }
+          loadAddon(e3, t3) {
+            const s2 = { instance: t3, dispose: t3.dispose, isDisposed: false };
+            this._addons.push(s2), t3.dispose = () => this._wrappedAddonDispose(s2), t3.activate(e3);
+          }
+          _wrappedAddonDispose(e3) {
+            if (e3.isDisposed) return;
+            let t3 = -1;
+            for (let s2 = 0; s2 < this._addons.length; s2++) if (this._addons[s2] === e3) {
+              t3 = s2;
+              break;
+            }
+            if (-1 === t3) throw new Error("Could not dispose an addon that has not been loaded");
+            e3.isDisposed = true, e3.dispose.apply(e3.instance), this._addons.splice(t3, 1);
+          }
+        };
+      }, 3235: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.BufferApiView = void 0;
+        const i2 = s2(793), r2 = s2(3055);
+        t2.BufferApiView = class {
+          constructor(e3, t3) {
+            this._buffer = e3, this.type = t3;
+          }
+          init(e3) {
+            return this._buffer = e3, this;
+          }
+          get cursorY() {
+            return this._buffer.y;
+          }
+          get cursorX() {
+            return this._buffer.x;
+          }
+          get viewportY() {
+            return this._buffer.ydisp;
+          }
+          get baseY() {
+            return this._buffer.ybase;
+          }
+          get length() {
+            return this._buffer.lines.length;
+          }
+          getLine(e3) {
+            const t3 = this._buffer.lines.get(e3);
+            if (t3) return new i2.BufferLineApiView(t3);
+          }
+          getNullCell() {
+            return new r2.CellData();
+          }
+        };
+      }, 793: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.BufferLineApiView = void 0;
+        const i2 = s2(3055);
+        t2.BufferLineApiView = class {
+          constructor(e3) {
+            this._line = e3;
+          }
+          get isWrapped() {
+            return this._line.isWrapped;
+          }
+          get length() {
+            return this._line.length;
+          }
+          getCell(e3, t3) {
+            if (!(e3 < 0 || e3 >= this._line.length)) return t3 ? (this._line.loadCell(e3, t3), t3) : this._line.loadCell(e3, new i2.CellData());
+          }
+          translateToString(e3, t3, s3) {
+            return this._line.translateToString(e3, t3, s3);
+          }
+        };
+      }, 5101: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.BufferNamespaceApi = void 0;
+        const i2 = s2(3235), r2 = s2(7150), n2 = s2(802);
+        class o extends r2.Disposable {
+          constructor(e3) {
+            super(), this._core = e3, this._onBufferChange = this._register(new n2.Emitter()), this.onBufferChange = this._onBufferChange.event, this._normal = new i2.BufferApiView(this._core.buffers.normal, "normal"), this._alternate = new i2.BufferApiView(this._core.buffers.alt, "alternate"), this._core.buffers.onBufferActivate((() => this._onBufferChange.fire(this.active)));
+          }
+          get active() {
+            if (this._core.buffers.active === this._core.buffers.normal) return this.normal;
+            if (this._core.buffers.active === this._core.buffers.alt) return this.alternate;
+            throw new Error("Active buffer is neither normal nor alternate");
+          }
+          get normal() {
+            return this._normal.init(this._core.buffers.normal);
+          }
+          get alternate() {
+            return this._alternate.init(this._core.buffers.alt);
+          }
+        }
+        t2.BufferNamespaceApi = o;
+      }, 6097: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.ParserApi = void 0, t2.ParserApi = class {
+          constructor(e3) {
+            this._core = e3;
+          }
+          registerCsiHandler(e3, t3) {
+            return this._core.registerCsiHandler(e3, ((e4) => t3(e4.toArray())));
+          }
+          addCsiHandler(e3, t3) {
+            return this.registerCsiHandler(e3, t3);
+          }
+          registerDcsHandler(e3, t3) {
+            return this._core.registerDcsHandler(e3, ((e4, s2) => t3(e4, s2.toArray())));
+          }
+          addDcsHandler(e3, t3) {
+            return this.registerDcsHandler(e3, t3);
+          }
+          registerEscHandler(e3, t3) {
+            return this._core.registerEscHandler(e3, t3);
+          }
+          addEscHandler(e3, t3) {
+            return this.registerEscHandler(e3, t3);
+          }
+          registerOscHandler(e3, t3) {
+            return this._core.registerOscHandler(e3, t3);
+          }
+          addOscHandler(e3, t3) {
+            return this.registerOscHandler(e3, t3);
+          }
+        };
+      }, 4335: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.UnicodeApi = void 0, t2.UnicodeApi = class {
+          constructor(e3) {
+            this._core = e3;
+          }
+          register(e3) {
+            this._core.unicodeService.register(e3);
+          }
+          get versions() {
+            return this._core.unicodeService.versions;
+          }
+          get activeVersion() {
+            return this._core.unicodeService.activeVersion;
+          }
+          set activeVersion(e3) {
+            this._core.unicodeService.activeVersion = e3;
+          }
+        };
+      }, 9640: function(e2, t2, s2) {
+        var i2 = this && this.__decorate || function(e3, t3, s3, i3) {
+          var r3, n3 = arguments.length, o2 = n3 < 3 ? t3 : null === i3 ? i3 = Object.getOwnPropertyDescriptor(t3, s3) : i3;
+          if ("object" == typeof Reflect && "function" == typeof Reflect.decorate) o2 = Reflect.decorate(e3, t3, s3, i3);
+          else for (var a2 = e3.length - 1; a2 >= 0; a2--) (r3 = e3[a2]) && (o2 = (n3 < 3 ? r3(o2) : n3 > 3 ? r3(t3, s3, o2) : r3(t3, s3)) || o2);
+          return n3 > 3 && o2 && Object.defineProperty(t3, s3, o2), o2;
+        }, r2 = this && this.__param || function(e3, t3) {
+          return function(s3, i3) {
+            t3(s3, i3, e3);
+          };
+        };
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.BufferService = t2.MINIMUM_ROWS = t2.MINIMUM_COLS = void 0;
+        const n2 = s2(7150), o = s2(4097), a = s2(6501), h = s2(802);
+        t2.MINIMUM_COLS = 2, t2.MINIMUM_ROWS = 1;
+        let c = class extends n2.Disposable {
+          get buffer() {
+            return this.buffers.active;
+          }
+          constructor(e3) {
+            super(), this.isUserScrolling = false, this._onResize = this._register(new h.Emitter()), this.onResize = this._onResize.event, this._onScroll = this._register(new h.Emitter()), this.onScroll = this._onScroll.event, this.cols = Math.max(e3.rawOptions.cols || 0, t2.MINIMUM_COLS), this.rows = Math.max(e3.rawOptions.rows || 0, t2.MINIMUM_ROWS), this.buffers = this._register(new o.BufferSet(e3, this)), this._register(this.buffers.onBufferActivate(((e4) => {
+              this._onScroll.fire(e4.activeBuffer.ydisp);
+            })));
+          }
+          resize(e3, t3) {
+            const s3 = this.cols !== e3, i3 = this.rows !== t3;
+            this.cols = e3, this.rows = t3, this.buffers.resize(e3, t3), this._onResize.fire({ cols: e3, rows: t3, colsChanged: s3, rowsChanged: i3 });
+          }
+          reset() {
+            this.buffers.reset(), this.isUserScrolling = false;
+          }
+          scroll(e3, t3 = false) {
+            const s3 = this.buffer;
+            let i3;
+            i3 = this._cachedBlankLine, i3 && i3.length === this.cols && i3.getFg(0) === e3.fg && i3.getBg(0) === e3.bg || (i3 = s3.getBlankLine(e3, t3), this._cachedBlankLine = i3), i3.isWrapped = t3;
+            const r3 = s3.ybase + s3.scrollTop, n3 = s3.ybase + s3.scrollBottom;
+            if (0 === s3.scrollTop) {
+              const e4 = s3.lines.isFull;
+              n3 === s3.lines.length - 1 ? e4 ? s3.lines.recycle().copyFrom(i3) : s3.lines.push(i3.clone()) : s3.lines.splice(n3 + 1, 0, i3.clone()), e4 ? this.isUserScrolling && (s3.ydisp = Math.max(s3.ydisp - 1, 0)) : (s3.ybase++, this.isUserScrolling || s3.ydisp++);
+            } else {
+              const e4 = n3 - r3 + 1;
+              s3.lines.shiftElements(r3 + 1, e4 - 1, -1), s3.lines.set(n3, i3.clone());
+            }
+            this.isUserScrolling || (s3.ydisp = s3.ybase), this._onScroll.fire(s3.ydisp);
+          }
+          scrollLines(e3, t3) {
+            const s3 = this.buffer;
+            if (e3 < 0) {
+              if (0 === s3.ydisp) return;
+              this.isUserScrolling = true;
+            } else e3 + s3.ydisp >= s3.ybase && (this.isUserScrolling = false);
+            const i3 = s3.ydisp;
+            s3.ydisp = Math.max(Math.min(s3.ydisp + e3, s3.ybase), 0), i3 !== s3.ydisp && (t3 || this._onScroll.fire(s3.ydisp));
+          }
+        };
+        t2.BufferService = c, t2.BufferService = c = i2([r2(0, a.IOptionsService)], c);
+      }, 5746: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.CharsetService = void 0, t2.CharsetService = class {
+          constructor() {
+            this.glevel = 0, this._charsets = [];
+          }
+          reset() {
+            this.charset = void 0, this._charsets = [], this.glevel = 0;
+          }
+          setgLevel(e3) {
+            this.glevel = e3, this.charset = this._charsets[e3];
+          }
+          setgCharset(e3, t3) {
+            this._charsets[e3] = t3, this.glevel === e3 && (this.charset = t3);
+          }
+        };
+      }, 7792: function(e2, t2, s2) {
+        var i2 = this && this.__decorate || function(e3, t3, s3, i3) {
+          var r3, n3 = arguments.length, o2 = n3 < 3 ? t3 : null === i3 ? i3 = Object.getOwnPropertyDescriptor(t3, s3) : i3;
+          if ("object" == typeof Reflect && "function" == typeof Reflect.decorate) o2 = Reflect.decorate(e3, t3, s3, i3);
+          else for (var a2 = e3.length - 1; a2 >= 0; a2--) (r3 = e3[a2]) && (o2 = (n3 < 3 ? r3(o2) : n3 > 3 ? r3(t3, s3, o2) : r3(t3, s3)) || o2);
+          return n3 > 3 && o2 && Object.defineProperty(t3, s3, o2), o2;
+        }, r2 = this && this.__param || function(e3, t3) {
+          return function(s3, i3) {
+            t3(s3, i3, e3);
+          };
+        };
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.CoreMouseService = void 0;
+        const n2 = s2(6501), o = s2(7150), a = s2(802), h = { NONE: { events: 0, restrict: () => false }, X10: { events: 1, restrict: (e3) => 4 !== e3.button && 1 === e3.action && (e3.ctrl = false, e3.alt = false, e3.shift = false, true) }, VT200: { events: 19, restrict: (e3) => 32 !== e3.action }, DRAG: { events: 23, restrict: (e3) => 32 !== e3.action || 3 !== e3.button }, ANY: { events: 31, restrict: (e3) => true } };
+        function c(e3, t3) {
+          let s3 = (e3.ctrl ? 16 : 0) | (e3.shift ? 4 : 0) | (e3.alt ? 8 : 0);
+          return 4 === e3.button ? (s3 |= 64, s3 |= e3.action) : (s3 |= 3 & e3.button, 4 & e3.button && (s3 |= 64), 8 & e3.button && (s3 |= 128), 32 === e3.action ? s3 |= 32 : 0 !== e3.action || t3 || (s3 |= 3)), s3;
+        }
+        const l = String.fromCharCode, u = { DEFAULT: (e3) => {
+          const t3 = [c(e3, false) + 32, e3.col + 32, e3.row + 32];
+          return t3[0] > 255 || t3[1] > 255 || t3[2] > 255 ? "" : `\x1B[M${l(t3[0])}${l(t3[1])}${l(t3[2])}`;
+        }, SGR: (e3) => {
+          const t3 = 0 === e3.action && 4 !== e3.button ? "m" : "M";
+          return `\x1B[<${c(e3, true)};${e3.col};${e3.row}${t3}`;
+        }, SGR_PIXELS: (e3) => {
+          const t3 = 0 === e3.action && 4 !== e3.button ? "m" : "M";
+          return `\x1B[<${c(e3, true)};${e3.x};${e3.y}${t3}`;
+        } };
+        let d = class extends o.Disposable {
+          constructor(e3, t3, s3) {
+            super(), this._bufferService = e3, this._coreService = t3, this._optionsService = s3, this._protocols = {}, this._encodings = {}, this._activeProtocol = "", this._activeEncoding = "", this._lastEvent = null, this._wheelPartialScroll = 0, this._onProtocolChange = this._register(new a.Emitter()), this.onProtocolChange = this._onProtocolChange.event;
+            for (const e4 of Object.keys(h)) this.addProtocol(e4, h[e4]);
+            for (const e4 of Object.keys(u)) this.addEncoding(e4, u[e4]);
+            this.reset();
+          }
+          addProtocol(e3, t3) {
+            this._protocols[e3] = t3;
+          }
+          addEncoding(e3, t3) {
+            this._encodings[e3] = t3;
+          }
+          get activeProtocol() {
+            return this._activeProtocol;
+          }
+          get areMouseEventsActive() {
+            return 0 !== this._protocols[this._activeProtocol].events;
+          }
+          set activeProtocol(e3) {
+            if (!this._protocols[e3]) throw new Error(`unknown protocol "${e3}"`);
+            this._activeProtocol = e3, this._onProtocolChange.fire(this._protocols[e3].events);
+          }
+          get activeEncoding() {
+            return this._activeEncoding;
+          }
+          set activeEncoding(e3) {
+            if (!this._encodings[e3]) throw new Error(`unknown encoding "${e3}"`);
+            this._activeEncoding = e3;
+          }
+          reset() {
+            this.activeProtocol = "NONE", this.activeEncoding = "DEFAULT", this._lastEvent = null, this._wheelPartialScroll = 0;
+          }
+          consumeWheelEvent(e3, t3, s3) {
+            if (0 === e3.deltaY || e3.shiftKey) return 0;
+            if (void 0 === t3 || void 0 === s3) return 0;
+            const i3 = t3 / s3;
+            let r3 = this._applyScrollModifier(e3.deltaY, e3);
+            return e3.deltaMode === WheelEvent.DOM_DELTA_PIXEL ? (r3 /= i3 + 0, Math.abs(e3.deltaY) < 50 && (r3 *= 0.3), this._wheelPartialScroll += r3, r3 = Math.floor(Math.abs(this._wheelPartialScroll)) * (this._wheelPartialScroll > 0 ? 1 : -1), this._wheelPartialScroll %= 1) : e3.deltaMode === WheelEvent.DOM_DELTA_PAGE && (r3 *= this._bufferService.rows), r3;
+          }
+          _applyScrollModifier(e3, t3) {
+            return t3.altKey || t3.ctrlKey || t3.shiftKey ? e3 * this._optionsService.rawOptions.fastScrollSensitivity * this._optionsService.rawOptions.scrollSensitivity : e3 * this._optionsService.rawOptions.scrollSensitivity;
+          }
+          triggerMouseEvent(e3) {
+            if (e3.col < 0 || e3.col >= this._bufferService.cols || e3.row < 0 || e3.row >= this._bufferService.rows) return false;
+            if (4 === e3.button && 32 === e3.action) return false;
+            if (3 === e3.button && 32 !== e3.action) return false;
+            if (4 !== e3.button && (2 === e3.action || 3 === e3.action)) return false;
+            if (e3.col++, e3.row++, 32 === e3.action && this._lastEvent && this._equalEvents(this._lastEvent, e3, "SGR_PIXELS" === this._activeEncoding)) return false;
+            if (!this._protocols[this._activeProtocol].restrict(e3)) return false;
+            const t3 = this._encodings[this._activeEncoding](e3);
+            return t3 && ("DEFAULT" === this._activeEncoding ? this._coreService.triggerBinaryEvent(t3) : this._coreService.triggerDataEvent(t3, true)), this._lastEvent = e3, true;
+          }
+          explainEvents(e3) {
+            return { down: !!(1 & e3), up: !!(2 & e3), drag: !!(4 & e3), move: !!(8 & e3), wheel: !!(16 & e3) };
+          }
+          _equalEvents(e3, t3, s3) {
+            if (s3) {
+              if (e3.x !== t3.x) return false;
+              if (e3.y !== t3.y) return false;
+            } else {
+              if (e3.col !== t3.col) return false;
+              if (e3.row !== t3.row) return false;
+            }
+            return e3.button === t3.button && e3.action === t3.action && e3.ctrl === t3.ctrl && e3.alt === t3.alt && e3.shift === t3.shift;
+          }
+        };
+        t2.CoreMouseService = d, t2.CoreMouseService = d = i2([r2(0, n2.IBufferService), r2(1, n2.ICoreService), r2(2, n2.IOptionsService)], d);
+      }, 4071: function(e2, t2, s2) {
+        var i2 = this && this.__decorate || function(e3, t3, s3, i3) {
+          var r3, n3 = arguments.length, o2 = n3 < 3 ? t3 : null === i3 ? i3 = Object.getOwnPropertyDescriptor(t3, s3) : i3;
+          if ("object" == typeof Reflect && "function" == typeof Reflect.decorate) o2 = Reflect.decorate(e3, t3, s3, i3);
+          else for (var a2 = e3.length - 1; a2 >= 0; a2--) (r3 = e3[a2]) && (o2 = (n3 < 3 ? r3(o2) : n3 > 3 ? r3(t3, s3, o2) : r3(t3, s3)) || o2);
+          return n3 > 3 && o2 && Object.defineProperty(t3, s3, o2), o2;
+        }, r2 = this && this.__param || function(e3, t3) {
+          return function(s3, i3) {
+            t3(s3, i3, e3);
+          };
+        };
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.CoreService = void 0;
+        const n2 = s2(7453), o = s2(7150), a = s2(6501), h = s2(802), c = Object.freeze({ insertMode: false }), l = Object.freeze({ applicationCursorKeys: false, applicationKeypad: false, bracketedPasteMode: false, cursorBlink: void 0, cursorStyle: void 0, origin: false, reverseWraparound: false, sendFocus: false, synchronizedOutput: false, wraparound: true });
+        let u = class extends o.Disposable {
+          constructor(e3, t3, s3) {
+            super(), this._bufferService = e3, this._logService = t3, this._optionsService = s3, this.isCursorInitialized = false, this.isCursorHidden = false, this._onData = this._register(new h.Emitter()), this.onData = this._onData.event, this._onUserInput = this._register(new h.Emitter()), this.onUserInput = this._onUserInput.event, this._onBinary = this._register(new h.Emitter()), this.onBinary = this._onBinary.event, this._onRequestScrollToBottom = this._register(new h.Emitter()), this.onRequestScrollToBottom = this._onRequestScrollToBottom.event, this.modes = (0, n2.clone)(c), this.decPrivateModes = (0, n2.clone)(l);
+          }
+          reset() {
+            this.modes = (0, n2.clone)(c), this.decPrivateModes = (0, n2.clone)(l);
+          }
+          triggerDataEvent(e3, t3 = false) {
+            if (this._optionsService.rawOptions.disableStdin) return;
+            const s3 = this._bufferService.buffer;
+            t3 && this._optionsService.rawOptions.scrollOnUserInput && s3.ybase !== s3.ydisp && this._onRequestScrollToBottom.fire(), t3 && this._onUserInput.fire(), this._logService.debug(`sending data "${e3}"`), this._logService.trace("sending data (codes)", (() => e3.split("").map(((e4) => e4.charCodeAt(0))))), this._onData.fire(e3);
+          }
+          triggerBinaryEvent(e3) {
+            this._optionsService.rawOptions.disableStdin || (this._logService.debug(`sending binary "${e3}"`), this._logService.trace("sending binary (codes)", (() => e3.split("").map(((e4) => e4.charCodeAt(0))))), this._onBinary.fire(e3));
+          }
+        };
+        t2.CoreService = u, t2.CoreService = u = i2([r2(0, a.IBufferService), r2(1, a.ILogService), r2(2, a.IOptionsService)], u);
+      }, 6025: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.InstantiationService = t2.ServiceCollection = void 0;
+        const i2 = s2(6501), r2 = s2(6201);
+        class n2 {
+          constructor(...e3) {
+            this._entries = /* @__PURE__ */ new Map();
+            for (const [t3, s3] of e3) this.set(t3, s3);
+          }
+          set(e3, t3) {
+            const s3 = this._entries.get(e3);
+            return this._entries.set(e3, t3), s3;
+          }
+          forEach(e3) {
+            for (const [t3, s3] of this._entries.entries()) e3(t3, s3);
+          }
+          has(e3) {
+            return this._entries.has(e3);
+          }
+          get(e3) {
+            return this._entries.get(e3);
+          }
+        }
+        t2.ServiceCollection = n2, t2.InstantiationService = class {
+          constructor() {
+            this._services = new n2(), this._services.set(i2.IInstantiationService, this);
+          }
+          setService(e3, t3) {
+            this._services.set(e3, t3);
+          }
+          getService(e3) {
+            return this._services.get(e3);
+          }
+          createInstance(e3, ...t3) {
+            const s3 = (0, r2.getServiceDependencies)(e3).sort(((e4, t4) => e4.index - t4.index)), i3 = [];
+            for (const t4 of s3) {
+              const s4 = this._services.get(t4.id);
+              if (!s4) throw new Error(`[createInstance] ${e3.name} depends on UNKNOWN service ${t4.id._id}.`);
+              i3.push(s4);
+            }
+            const n3 = s3.length > 0 ? s3[0].index : t3.length;
+            if (t3.length !== n3) throw new Error(`[createInstance] First service dependency of ${e3.name} at position ${n3 + 1} conflicts with ${t3.length} static arguments`);
+            return new e3(...[...t3, ...i3]);
+          }
+        };
+      }, 7276: function(e2, t2, s2) {
+        var i2 = this && this.__decorate || function(e3, t3, s3, i3) {
+          var r3, n3 = arguments.length, o2 = n3 < 3 ? t3 : null === i3 ? i3 = Object.getOwnPropertyDescriptor(t3, s3) : i3;
+          if ("object" == typeof Reflect && "function" == typeof Reflect.decorate) o2 = Reflect.decorate(e3, t3, s3, i3);
+          else for (var a2 = e3.length - 1; a2 >= 0; a2--) (r3 = e3[a2]) && (o2 = (n3 < 3 ? r3(o2) : n3 > 3 ? r3(t3, s3, o2) : r3(t3, s3)) || o2);
+          return n3 > 3 && o2 && Object.defineProperty(t3, s3, o2), o2;
+        }, r2 = this && this.__param || function(e3, t3) {
+          return function(s3, i3) {
+            t3(s3, i3, e3);
+          };
+        };
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.LogService = void 0, t2.setTraceLogger = function(e3) {
+          h = e3;
+        }, t2.traceCall = function(e3, t3, s3) {
+          if ("function" != typeof s3.value) throw new Error("not supported");
+          const i3 = s3.value;
+          s3.value = function(...e4) {
+            if (h.logLevel !== o.LogLevelEnum.TRACE) return i3.apply(this, e4);
+            h.trace(`GlyphRenderer#${i3.name}(${e4.map(((e5) => JSON.stringify(e5))).join(", ")})`);
+            const t4 = i3.apply(this, e4);
+            return h.trace(`GlyphRenderer#${i3.name} return`, t4), t4;
+          };
+        };
+        const n2 = s2(7150), o = s2(6501), a = { trace: o.LogLevelEnum.TRACE, debug: o.LogLevelEnum.DEBUG, info: o.LogLevelEnum.INFO, warn: o.LogLevelEnum.WARN, error: o.LogLevelEnum.ERROR, off: o.LogLevelEnum.OFF };
+        let h, c = class extends n2.Disposable {
+          get logLevel() {
+            return this._logLevel;
+          }
+          constructor(e3) {
+            super(), this._optionsService = e3, this._logLevel = o.LogLevelEnum.OFF, this._updateLogLevel(), this._register(this._optionsService.onSpecificOptionChange("logLevel", (() => this._updateLogLevel()))), h = this;
+          }
+          _updateLogLevel() {
+            this._logLevel = a[this._optionsService.rawOptions.logLevel];
+          }
+          _evalLazyOptionalParams(e3) {
+            for (let t3 = 0; t3 < e3.length; t3++) "function" == typeof e3[t3] && (e3[t3] = e3[t3]());
+          }
+          _log(e3, t3, s3) {
+            this._evalLazyOptionalParams(s3), e3.call(console, (this._optionsService.options.logger ? "" : "xterm.js: ") + t3, ...s3);
+          }
+          trace(e3, ...t3) {
+            this._logLevel <= o.LogLevelEnum.TRACE && this._log(this._optionsService.options.logger?.trace.bind(this._optionsService.options.logger) ?? console.log, e3, t3);
+          }
+          debug(e3, ...t3) {
+            this._logLevel <= o.LogLevelEnum.DEBUG && this._log(this._optionsService.options.logger?.debug.bind(this._optionsService.options.logger) ?? console.log, e3, t3);
+          }
+          info(e3, ...t3) {
+            this._logLevel <= o.LogLevelEnum.INFO && this._log(this._optionsService.options.logger?.info.bind(this._optionsService.options.logger) ?? console.info, e3, t3);
+          }
+          warn(e3, ...t3) {
+            this._logLevel <= o.LogLevelEnum.WARN && this._log(this._optionsService.options.logger?.warn.bind(this._optionsService.options.logger) ?? console.warn, e3, t3);
+          }
+          error(e3, ...t3) {
+            this._logLevel <= o.LogLevelEnum.ERROR && this._log(this._optionsService.options.logger?.error.bind(this._optionsService.options.logger) ?? console.error, e3, t3);
+          }
+        };
+        t2.LogService = c, t2.LogService = c = i2([r2(0, o.IOptionsService)], c);
+      }, 56: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.OptionsService = t2.DEFAULT_OPTIONS = void 0;
+        const i2 = s2(7150), r2 = s2(701), n2 = s2(802);
+        t2.DEFAULT_OPTIONS = { cols: 80, rows: 24, cursorBlink: false, cursorStyle: "block", cursorWidth: 1, cursorInactiveStyle: "outline", customGlyphs: true, drawBoldTextInBrightColors: true, documentOverride: null, fastScrollModifier: "alt", fastScrollSensitivity: 5, fontFamily: "monospace", fontSize: 15, fontWeight: "normal", fontWeightBold: "bold", ignoreBracketedPasteMode: false, lineHeight: 1, letterSpacing: 0, linkHandler: null, logLevel: "info", logger: null, scrollback: 1e3, scrollOnEraseInDisplay: false, scrollOnUserInput: true, scrollSensitivity: 1, screenReaderMode: false, smoothScrollDuration: 0, macOptionIsMeta: false, macOptionClickForcesSelection: false, minimumContrastRatio: 1, disableStdin: false, allowProposedApi: false, allowTransparency: false, tabStopWidth: 8, theme: {}, reflowCursorLine: false, rescaleOverlappingGlyphs: false, rightClickSelectsWord: r2.isMac, windowOptions: {}, windowsMode: false, windowsPty: {}, wordSeparator: " ()[]{}',\"`", altClickMovesCursor: true, convertEol: false, termName: "xterm", cancelEvents: false, overviewRuler: {} };
+        const o = ["normal", "bold", "100", "200", "300", "400", "500", "600", "700", "800", "900"];
+        class a extends i2.Disposable {
+          constructor(e3) {
+            super(), this._onOptionChange = this._register(new n2.Emitter()), this.onOptionChange = this._onOptionChange.event;
+            const s3 = { ...t2.DEFAULT_OPTIONS };
+            for (const t3 in e3) if (t3 in s3) try {
+              const i3 = e3[t3];
+              s3[t3] = this._sanitizeAndValidateOption(t3, i3);
+            } catch (e4) {
+              console.error(e4);
+            }
+            this.rawOptions = s3, this.options = { ...s3 }, this._setupOptions(), this._register((0, i2.toDisposable)((() => {
+              this.rawOptions.linkHandler = null, this.rawOptions.documentOverride = null;
+            })));
+          }
+          onSpecificOptionChange(e3, t3) {
+            return this.onOptionChange(((s3) => {
+              s3 === e3 && t3(this.rawOptions[e3]);
+            }));
+          }
+          onMultipleOptionChange(e3, t3) {
+            return this.onOptionChange(((s3) => {
+              -1 !== e3.indexOf(s3) && t3();
+            }));
+          }
+          _setupOptions() {
+            const e3 = (e4) => {
+              if (!(e4 in t2.DEFAULT_OPTIONS)) throw new Error(`No option with key "${e4}"`);
+              return this.rawOptions[e4];
+            }, s3 = (e4, s4) => {
+              if (!(e4 in t2.DEFAULT_OPTIONS)) throw new Error(`No option with key "${e4}"`);
+              s4 = this._sanitizeAndValidateOption(e4, s4), this.rawOptions[e4] !== s4 && (this.rawOptions[e4] = s4, this._onOptionChange.fire(e4));
+            };
+            for (const t3 in this.rawOptions) {
+              const i3 = { get: e3.bind(this, t3), set: s3.bind(this, t3) };
+              Object.defineProperty(this.options, t3, i3);
+            }
+          }
+          _sanitizeAndValidateOption(e3, s3) {
+            switch (e3) {
+              case "cursorStyle":
+                if (s3 || (s3 = t2.DEFAULT_OPTIONS[e3]), !/* @__PURE__ */ (function(e4) {
+                  return "block" === e4 || "underline" === e4 || "bar" === e4;
+                })(s3)) throw new Error(`"${s3}" is not a valid value for ${e3}`);
+                break;
+              case "wordSeparator":
+                s3 || (s3 = t2.DEFAULT_OPTIONS[e3]);
+                break;
+              case "fontWeight":
+              case "fontWeightBold":
+                if ("number" == typeof s3 && 1 <= s3 && s3 <= 1e3) break;
+                s3 = o.includes(s3) ? s3 : t2.DEFAULT_OPTIONS[e3];
+                break;
+              case "cursorWidth":
+                s3 = Math.floor(s3);
+              case "lineHeight":
+              case "tabStopWidth":
+                if (s3 < 1) throw new Error(`${e3} cannot be less than 1, value: ${s3}`);
+                break;
+              case "minimumContrastRatio":
+                s3 = Math.max(1, Math.min(21, Math.round(10 * s3) / 10));
+                break;
+              case "scrollback":
+                if ((s3 = Math.min(s3, 4294967295)) < 0) throw new Error(`${e3} cannot be less than 0, value: ${s3}`);
+                break;
+              case "fastScrollSensitivity":
+              case "scrollSensitivity":
+                if (s3 <= 0) throw new Error(`${e3} cannot be less than or equal to 0, value: ${s3}`);
+                break;
+              case "rows":
+              case "cols":
+                if (!s3 && 0 !== s3) throw new Error(`${e3} must be numeric, value: ${s3}`);
+                break;
+              case "windowsPty":
+                s3 = s3 ?? {};
+            }
+            return s3;
+          }
+        }
+        t2.OptionsService = a;
+      }, 8811: function(e2, t2, s2) {
+        var i2 = this && this.__decorate || function(e3, t3, s3, i3) {
+          var r3, n3 = arguments.length, o2 = n3 < 3 ? t3 : null === i3 ? i3 = Object.getOwnPropertyDescriptor(t3, s3) : i3;
+          if ("object" == typeof Reflect && "function" == typeof Reflect.decorate) o2 = Reflect.decorate(e3, t3, s3, i3);
+          else for (var a = e3.length - 1; a >= 0; a--) (r3 = e3[a]) && (o2 = (n3 < 3 ? r3(o2) : n3 > 3 ? r3(t3, s3, o2) : r3(t3, s3)) || o2);
+          return n3 > 3 && o2 && Object.defineProperty(t3, s3, o2), o2;
+        }, r2 = this && this.__param || function(e3, t3) {
+          return function(s3, i3) {
+            t3(s3, i3, e3);
+          };
+        };
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.OscLinkService = void 0;
+        const n2 = s2(6501);
+        let o = class {
+          constructor(e3) {
+            this._bufferService = e3, this._nextId = 1, this._entriesWithId = /* @__PURE__ */ new Map(), this._dataByLinkId = /* @__PURE__ */ new Map();
+          }
+          registerLink(e3) {
+            const t3 = this._bufferService.buffer;
+            if (void 0 === e3.id) {
+              const s4 = t3.addMarker(t3.ybase + t3.y), i4 = { data: e3, id: this._nextId++, lines: [s4] };
+              return s4.onDispose((() => this._removeMarkerFromLink(i4, s4))), this._dataByLinkId.set(i4.id, i4), i4.id;
+            }
+            const s3 = e3, i3 = this._getEntryIdKey(s3), r3 = this._entriesWithId.get(i3);
+            if (r3) return this.addLineToLink(r3.id, t3.ybase + t3.y), r3.id;
+            const n3 = t3.addMarker(t3.ybase + t3.y), o2 = { id: this._nextId++, key: this._getEntryIdKey(s3), data: s3, lines: [n3] };
+            return n3.onDispose((() => this._removeMarkerFromLink(o2, n3))), this._entriesWithId.set(o2.key, o2), this._dataByLinkId.set(o2.id, o2), o2.id;
+          }
+          addLineToLink(e3, t3) {
+            const s3 = this._dataByLinkId.get(e3);
+            if (s3 && s3.lines.every(((e4) => e4.line !== t3))) {
+              const e4 = this._bufferService.buffer.addMarker(t3);
+              s3.lines.push(e4), e4.onDispose((() => this._removeMarkerFromLink(s3, e4)));
+            }
+          }
+          getLinkData(e3) {
+            return this._dataByLinkId.get(e3)?.data;
+          }
+          _getEntryIdKey(e3) {
+            return `${e3.id};;${e3.uri}`;
+          }
+          _removeMarkerFromLink(e3, t3) {
+            const s3 = e3.lines.indexOf(t3);
+            -1 !== s3 && (e3.lines.splice(s3, 1), 0 === e3.lines.length && (void 0 !== e3.data.id && this._entriesWithId.delete(e3.key), this._dataByLinkId.delete(e3.id)));
+          }
+        };
+        t2.OscLinkService = o, t2.OscLinkService = o = i2([r2(0, n2.IBufferService)], o);
+      }, 6201: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.serviceRegistry = void 0, t2.getServiceDependencies = function(e3) {
+          return e3[i2] || [];
+        }, t2.createDecorator = function(e3) {
+          if (t2.serviceRegistry.has(e3)) return t2.serviceRegistry.get(e3);
+          const r2 = function(e4, t3, n2) {
+            if (3 !== arguments.length) throw new Error("@IServiceName-decorator can only be used to decorate a parameter");
+            !(function(e5, t4, r3) {
+              t4[s2] === t4 ? t4[i2].push({ id: e5, index: r3 }) : (t4[i2] = [{ id: e5, index: r3 }], t4[s2] = t4);
+            })(r2, e4, n2);
+          };
+          return r2._id = e3, t2.serviceRegistry.set(e3, r2), r2;
+        };
+        const s2 = "di$target", i2 = "di$dependencies";
+        t2.serviceRegistry = /* @__PURE__ */ new Map();
+      }, 6501: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.IDecorationService = t2.IUnicodeService = t2.IOscLinkService = t2.IOptionsService = t2.ILogService = t2.LogLevelEnum = t2.IInstantiationService = t2.ICharsetService = t2.ICoreService = t2.ICoreMouseService = t2.IBufferService = void 0;
+        const i2 = s2(6201);
+        var r2;
+        t2.IBufferService = (0, i2.createDecorator)("BufferService"), t2.ICoreMouseService = (0, i2.createDecorator)("CoreMouseService"), t2.ICoreService = (0, i2.createDecorator)("CoreService"), t2.ICharsetService = (0, i2.createDecorator)("CharsetService"), t2.IInstantiationService = (0, i2.createDecorator)("InstantiationService"), (function(e3) {
+          e3[e3.TRACE = 0] = "TRACE", e3[e3.DEBUG = 1] = "DEBUG", e3[e3.INFO = 2] = "INFO", e3[e3.WARN = 3] = "WARN", e3[e3.ERROR = 4] = "ERROR", e3[e3.OFF = 5] = "OFF";
+        })(r2 || (t2.LogLevelEnum = r2 = {})), t2.ILogService = (0, i2.createDecorator)("LogService"), t2.IOptionsService = (0, i2.createDecorator)("OptionsService"), t2.IOscLinkService = (0, i2.createDecorator)("OscLinkService"), t2.IUnicodeService = (0, i2.createDecorator)("UnicodeService"), t2.IDecorationService = (0, i2.createDecorator)("DecorationService");
+      }, 6415: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.UnicodeService = void 0;
+        const i2 = s2(7428), r2 = s2(802);
+        class n2 {
+          static extractShouldJoin(e3) {
+            return !!(1 & e3);
+          }
+          static extractWidth(e3) {
+            return e3 >> 1 & 3;
+          }
+          static extractCharKind(e3) {
+            return e3 >> 3;
+          }
+          static createPropertyValue(e3, t3, s3 = false) {
+            return (16777215 & e3) << 3 | (3 & t3) << 1 | (s3 ? 1 : 0);
+          }
+          constructor() {
+            this._providers = /* @__PURE__ */ Object.create(null), this._active = "", this._onChange = new r2.Emitter(), this.onChange = this._onChange.event;
+            const e3 = new i2.UnicodeV6();
+            this.register(e3), this._active = e3.version, this._activeProvider = e3;
+          }
+          dispose() {
+            this._onChange.dispose();
+          }
+          get versions() {
+            return Object.keys(this._providers);
+          }
+          get activeVersion() {
+            return this._active;
+          }
+          set activeVersion(e3) {
+            if (!this._providers[e3]) throw new Error(`unknown Unicode version "${e3}"`);
+            this._active = e3, this._activeProvider = this._providers[e3], this._onChange.fire(e3);
+          }
+          register(e3) {
+            this._providers[e3.version] = e3;
+          }
+          wcwidth(e3) {
+            return this._activeProvider.wcwidth(e3);
+          }
+          getStringCellWidth(e3) {
+            let t3 = 0, s3 = 0;
+            const i3 = e3.length;
+            for (let r3 = 0; r3 < i3; ++r3) {
+              let o = e3.charCodeAt(r3);
+              if (55296 <= o && o <= 56319) {
+                if (++r3 >= i3) return t3 + this.wcwidth(o);
+                const s4 = e3.charCodeAt(r3);
+                56320 <= s4 && s4 <= 57343 ? o = 1024 * (o - 55296) + s4 - 56320 + 65536 : t3 += this.wcwidth(s4);
+              }
+              const a = this.charProperties(o, s3);
+              let h = n2.extractWidth(a);
+              n2.extractShouldJoin(a) && (h -= n2.extractWidth(s3)), t3 += h, s3 = a;
+            }
+            return t3;
+          }
+          charProperties(e3, t3) {
+            return this._activeProvider.charProperties(e3, t3);
+          }
+        }
+        t2.UnicodeService = n2;
+      }, 5856: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.Terminal = void 0;
+        const i2 = s2(6107), r2 = s2(5777), n2 = s2(802);
+        class o extends r2.CoreTerminal {
+          constructor(e3 = {}) {
+            super(e3), this._onBell = this._register(new n2.Emitter()), this.onBell = this._onBell.event, this._onCursorMove = this._register(new n2.Emitter()), this.onCursorMove = this._onCursorMove.event, this._onTitleChange = this._register(new n2.Emitter()), this.onTitleChange = this._onTitleChange.event, this._onA11yCharEmitter = this._register(new n2.Emitter()), this.onA11yChar = this._onA11yCharEmitter.event, this._onA11yTabEmitter = this._register(new n2.Emitter()), this.onA11yTab = this._onA11yTabEmitter.event, this._setup(), this._register(this._inputHandler.onRequestBell((() => this.bell()))), this._register(this._inputHandler.onRequestReset((() => this.reset()))), this._register(n2.Event.forward(this._inputHandler.onCursorMove, this._onCursorMove)), this._register(n2.Event.forward(this._inputHandler.onTitleChange, this._onTitleChange)), this._register(n2.Event.forward(this._inputHandler.onA11yChar, this._onA11yCharEmitter)), this._register(n2.Event.forward(this._inputHandler.onA11yTab, this._onA11yTabEmitter));
+          }
+          get buffer() {
+            return this.buffers.active;
+          }
+          get markers() {
+            return this.buffer.markers;
+          }
+          addMarker(e3) {
+            if (this.buffer === this.buffers.normal) return this.buffer.addMarker(this.buffer.ybase + this.buffer.y + e3);
+          }
+          bell() {
+            this._onBell.fire();
+          }
+          input(e3, t3 = true) {
+            this.coreService.triggerDataEvent(e3, t3);
+          }
+          resize(e3, t3) {
+            e3 === this.cols && t3 === this.rows || super.resize(e3, t3);
+          }
+          clear() {
+            if (0 !== this.buffer.ybase || 0 !== this.buffer.y) {
+              this.buffer.lines.set(0, this.buffer.lines.get(this.buffer.ybase + this.buffer.y)), this.buffer.lines.length = 1, this.buffer.ydisp = 0, this.buffer.ybase = 0, this.buffer.y = 0;
+              for (let e3 = 1; e3 < this.rows; e3++) this.buffer.lines.push(this.buffer.getBlankLine(i2.DEFAULT_ATTR_DATA));
+              this._onScroll.fire({ position: this.buffer.ydisp });
+            }
+          }
+          reset() {
+            this.options.rows = this.rows, this.options.cols = this.cols, this._setup(), super.reset();
+          }
+        }
+        t2.Terminal = o;
+      }, 3058: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.Permutation = t2.CallbackIterable = t2.ArrayQueue = t2.booleanComparator = t2.numberComparator = t2.CompareResult = void 0, t2.tail = function(e3, t3 = 0) {
+          return e3[e3.length - (1 + t3)];
+        }, t2.tail2 = function(e3) {
+          if (0 === e3.length) throw new Error("Invalid tail call");
+          return [e3.slice(0, e3.length - 1), e3[e3.length - 1]];
+        }, t2.equals = function(e3, t3, s3 = (e4, t4) => e4 === t4) {
+          if (e3 === t3) return true;
+          if (!e3 || !t3) return false;
+          if (e3.length !== t3.length) return false;
+          for (let i3 = 0, r3 = e3.length; i3 < r3; i3++) if (!s3(e3[i3], t3[i3])) return false;
+          return true;
+        }, t2.removeFastWithoutKeepingOrder = function(e3, t3) {
+          const s3 = e3.length - 1;
+          t3 < s3 && (e3[t3] = e3[s3]), e3.pop();
+        }, t2.binarySearch = function(e3, t3, s3) {
+          return n2(e3.length, ((i3) => s3(e3[i3], t3)));
+        }, t2.binarySearch2 = n2, t2.quickSelect = function e3(t3, s3, i3) {
+          if ((t3 |= 0) >= s3.length) throw new TypeError("invalid index");
+          const r3 = s3[Math.floor(s3.length * Math.random())], n3 = [], o2 = [], a2 = [];
+          for (const e4 of s3) {
+            const t4 = i3(e4, r3);
+            t4 < 0 ? n3.push(e4) : t4 > 0 ? o2.push(e4) : a2.push(e4);
+          }
+          return t3 < n3.length ? e3(t3, n3, i3) : t3 < n3.length + a2.length ? a2[0] : e3(t3 - (n3.length + a2.length), o2, i3);
+        }, t2.groupBy = function(e3, t3) {
+          const s3 = [];
+          let i3;
+          for (const r3 of e3.slice(0).sort(t3)) i3 && 0 === t3(i3[0], r3) ? i3.push(r3) : (i3 = [r3], s3.push(i3));
+          return s3;
+        }, t2.groupAdjacentBy = function* (e3, t3) {
+          let s3, i3;
+          for (const r3 of e3) void 0 !== i3 && t3(i3, r3) ? s3.push(r3) : (s3 && (yield s3), s3 = [r3]), i3 = r3;
+          s3 && (yield s3);
+        }, t2.forEachAdjacent = function(e3, t3) {
+          for (let s3 = 0; s3 <= e3.length; s3++) t3(0 === s3 ? void 0 : e3[s3 - 1], s3 === e3.length ? void 0 : e3[s3]);
+        }, t2.forEachWithNeighbors = function(e3, t3) {
+          for (let s3 = 0; s3 < e3.length; s3++) t3(0 === s3 ? void 0 : e3[s3 - 1], e3[s3], s3 + 1 === e3.length ? void 0 : e3[s3 + 1]);
+        }, t2.sortedDiff = o, t2.delta = function(e3, t3, s3) {
+          const i3 = o(e3, t3, s3), r3 = [], n3 = [];
+          for (const t4 of i3) r3.push(...e3.slice(t4.start, t4.start + t4.deleteCount)), n3.push(...t4.toInsert);
+          return { removed: r3, added: n3 };
+        }, t2.top = function(e3, t3, s3) {
+          if (0 === s3) return [];
+          const i3 = e3.slice(0, s3).sort(t3);
+          return a(e3, t3, i3, s3, e3.length), i3;
+        }, t2.topAsync = function(e3, t3, s3, r3, n3) {
+          return 0 === s3 ? Promise.resolve([]) : new Promise(((o2, h2) => {
+            (async () => {
+              const o3 = e3.length, h3 = e3.slice(0, s3).sort(t3);
+              for (let c2 = s3, l2 = Math.min(s3 + r3, o3); c2 < o3; c2 = l2, l2 = Math.min(l2 + r3, o3)) {
+                if (c2 > s3 && await new Promise(((e4) => setTimeout(e4))), n3 && n3.isCancellationRequested) throw new i2.CancellationError();
+                a(e3, t3, h3, c2, l2);
+              }
+              return h3;
+            })().then(o2, h2);
+          }));
+        }, t2.coalesce = function(e3) {
+          return e3.filter(((e4) => !!e4));
+        }, t2.coalesceInPlace = function(e3) {
+          let t3 = 0;
+          for (let s3 = 0; s3 < e3.length; s3++) e3[s3] && (e3[t3] = e3[s3], t3 += 1);
+          e3.length = t3;
+        }, t2.move = function(e3, t3, s3) {
+          e3.splice(s3, 0, e3.splice(t3, 1)[0]);
+        }, t2.isFalsyOrEmpty = function(e3) {
+          return !Array.isArray(e3) || 0 === e3.length;
+        }, t2.isNonEmptyArray = function(e3) {
+          return Array.isArray(e3) && e3.length > 0;
+        }, t2.distinct = function(e3, t3 = (e4) => e4) {
+          const s3 = /* @__PURE__ */ new Set();
+          return e3.filter(((e4) => {
+            const i3 = t3(e4);
+            return !s3.has(i3) && (s3.add(i3), true);
+          }));
+        }, t2.uniqueFilter = function(e3) {
+          const t3 = /* @__PURE__ */ new Set();
+          return (s3) => {
+            const i3 = e3(s3);
+            return !t3.has(i3) && (t3.add(i3), true);
+          };
+        }, t2.firstOrDefault = function(e3, t3) {
+          return e3.length > 0 ? e3[0] : t3;
+        }, t2.lastOrDefault = function(e3, t3) {
+          return e3.length > 0 ? e3[e3.length - 1] : t3;
+        }, t2.commonPrefixLength = function(e3, t3, s3 = (e4, t4) => e4 === t4) {
+          let i3 = 0;
+          for (let r3 = 0, n3 = Math.min(e3.length, t3.length); r3 < n3 && s3(e3[r3], t3[r3]); r3++) i3++;
+          return i3;
+        }, t2.range = function(e3, t3) {
+          let s3 = "number" == typeof t3 ? e3 : 0;
+          "number" == typeof t3 ? s3 = e3 : (s3 = 0, t3 = e3);
+          const i3 = [];
+          if (s3 <= t3) for (let e4 = s3; e4 < t3; e4++) i3.push(e4);
+          else for (let e4 = s3; e4 > t3; e4--) i3.push(e4);
+          return i3;
+        }, t2.index = function(e3, t3, s3) {
+          return e3.reduce(((e4, i3) => (e4[t3(i3)] = s3 ? s3(i3) : i3, e4)), /* @__PURE__ */ Object.create(null));
+        }, t2.insert = function(e3, t3) {
+          return e3.push(t3), () => h(e3, t3);
+        }, t2.remove = h, t2.arrayInsert = function(e3, t3, s3) {
+          const i3 = e3.slice(0, t3), r3 = e3.slice(t3);
+          return i3.concat(s3, r3);
+        }, t2.shuffle = function(e3, t3) {
+          let s3;
+          if ("number" == typeof t3) {
+            let e4 = t3;
+            s3 = () => {
+              const t4 = 179426549 * Math.sin(e4++);
+              return t4 - Math.floor(t4);
+            };
+          } else s3 = Math.random;
+          for (let t4 = e3.length - 1; t4 > 0; t4 -= 1) {
+            const i3 = Math.floor(s3() * (t4 + 1)), r3 = e3[t4];
+            e3[t4] = e3[i3], e3[i3] = r3;
+          }
+        }, t2.pushToStart = function(e3, t3) {
+          const s3 = e3.indexOf(t3);
+          s3 > -1 && (e3.splice(s3, 1), e3.unshift(t3));
+        }, t2.pushToEnd = function(e3, t3) {
+          const s3 = e3.indexOf(t3);
+          s3 > -1 && (e3.splice(s3, 1), e3.push(t3));
+        }, t2.pushMany = function(e3, t3) {
+          for (const s3 of t3) e3.push(s3);
+        }, t2.mapArrayOrNot = function(e3, t3) {
+          return Array.isArray(e3) ? e3.map(t3) : t3(e3);
+        }, t2.asArray = function(e3) {
+          return Array.isArray(e3) ? e3 : [e3];
+        }, t2.getRandomElement = function(e3) {
+          return e3[Math.floor(Math.random() * e3.length)];
+        }, t2.insertInto = c, t2.splice = function(e3, t3, s3, i3) {
+          const r3 = l(e3, t3);
+          let n3 = e3.splice(r3, s3);
+          return void 0 === n3 && (n3 = []), c(e3, r3, i3), n3;
+        }, t2.compareBy = function(e3, t3) {
+          return (s3, i3) => t3(e3(s3), e3(i3));
+        }, t2.tieBreakComparators = function(...e3) {
+          return (t3, s3) => {
+            for (const i3 of e3) {
+              const e4 = i3(t3, s3);
+              if (!u.isNeitherLessOrGreaterThan(e4)) return e4;
+            }
+            return u.neitherLessOrGreaterThan;
+          };
+        }, t2.reverseOrder = function(e3) {
+          return (t3, s3) => -e3(t3, s3);
+        };
+        const i2 = s2(9807), r2 = s2(8297);
+        function n2(e3, t3) {
+          let s3 = 0, i3 = e3 - 1;
+          for (; s3 <= i3; ) {
+            const e4 = (s3 + i3) / 2 | 0, r3 = t3(e4);
+            if (r3 < 0) s3 = e4 + 1;
+            else {
+              if (!(r3 > 0)) return e4;
+              i3 = e4 - 1;
+            }
+          }
+          return -(s3 + 1);
+        }
+        function o(e3, t3, s3) {
+          const i3 = [];
+          function r3(e4, t4, s4) {
+            if (0 === t4 && 0 === s4.length) return;
+            const r4 = i3[i3.length - 1];
+            r4 && r4.start + r4.deleteCount === e4 ? (r4.deleteCount += t4, r4.toInsert.push(...s4)) : i3.push({ start: e4, deleteCount: t4, toInsert: s4 });
+          }
+          let n3 = 0, o2 = 0;
+          for (; ; ) {
+            if (n3 === e3.length) {
+              r3(n3, 0, t3.slice(o2));
+              break;
+            }
+            if (o2 === t3.length) {
+              r3(n3, e3.length - n3, []);
+              break;
+            }
+            const i4 = e3[n3], a2 = t3[o2], h2 = s3(i4, a2);
+            0 === h2 ? (n3 += 1, o2 += 1) : h2 < 0 ? (r3(n3, 1, []), n3 += 1) : h2 > 0 && (r3(n3, 0, [a2]), o2 += 1);
+          }
+          return i3;
+        }
+        function a(e3, t3, s3, i3, n3) {
+          for (const o2 = s3.length; i3 < n3; i3++) {
+            const n4 = e3[i3];
+            if (t3(n4, s3[o2 - 1]) < 0) {
+              s3.pop();
+              const e4 = (0, r2.findFirstIdxMonotonousOrArrLen)(s3, ((e5) => t3(n4, e5) < 0));
+              s3.splice(e4, 0, n4);
+            }
+          }
+        }
+        function h(e3, t3) {
+          const s3 = e3.indexOf(t3);
+          if (s3 > -1) return e3.splice(s3, 1), t3;
+        }
+        function c(e3, t3, s3) {
+          const i3 = l(e3, t3), r3 = e3.length, n3 = s3.length;
+          e3.length = r3 + n3;
+          for (let t4 = r3 - 1; t4 >= i3; t4--) e3[t4 + n3] = e3[t4];
+          for (let t4 = 0; t4 < n3; t4++) e3[t4 + i3] = s3[t4];
+        }
+        function l(e3, t3) {
+          return t3 < 0 ? Math.max(t3 + e3.length, 0) : Math.min(t3, e3.length);
+        }
+        var u;
+        !(function(e3) {
+          e3.isLessThan = function(e4) {
+            return e4 < 0;
+          }, e3.isLessThanOrEqual = function(e4) {
+            return e4 <= 0;
+          }, e3.isGreaterThan = function(e4) {
+            return e4 > 0;
+          }, e3.isNeitherLessOrGreaterThan = function(e4) {
+            return 0 === e4;
+          }, e3.greaterThan = 1, e3.lessThan = -1, e3.neitherLessOrGreaterThan = 0;
+        })(u || (t2.CompareResult = u = {})), t2.numberComparator = (e3, t3) => e3 - t3, t2.booleanComparator = (e3, s3) => (0, t2.numberComparator)(e3 ? 1 : 0, s3 ? 1 : 0), t2.ArrayQueue = class {
+          constructor(e3) {
+            this.items = e3, this.firstIdx = 0, this.lastIdx = this.items.length - 1;
+          }
+          get length() {
+            return this.lastIdx - this.firstIdx + 1;
+          }
+          takeWhile(e3) {
+            let t3 = this.firstIdx;
+            for (; t3 < this.items.length && e3(this.items[t3]); ) t3++;
+            const s3 = t3 === this.firstIdx ? null : this.items.slice(this.firstIdx, t3);
+            return this.firstIdx = t3, s3;
+          }
+          takeFromEndWhile(e3) {
+            let t3 = this.lastIdx;
+            for (; t3 >= 0 && e3(this.items[t3]); ) t3--;
+            const s3 = t3 === this.lastIdx ? null : this.items.slice(t3 + 1, this.lastIdx + 1);
+            return this.lastIdx = t3, s3;
+          }
+          peek() {
+            if (0 !== this.length) return this.items[this.firstIdx];
+          }
+          peekLast() {
+            if (0 !== this.length) return this.items[this.lastIdx];
+          }
+          dequeue() {
+            const e3 = this.items[this.firstIdx];
+            return this.firstIdx++, e3;
+          }
+          removeLast() {
+            const e3 = this.items[this.lastIdx];
+            return this.lastIdx--, e3;
+          }
+          takeCount(e3) {
+            const t3 = this.items.slice(this.firstIdx, this.firstIdx + e3);
+            return this.firstIdx += e3, t3;
+          }
+        };
+        class d {
+          static {
+            this.empty = new d(((e3) => {
+            }));
+          }
+          constructor(e3) {
+            this.iterate = e3;
+          }
+          forEach(e3) {
+            this.iterate(((t3) => (e3(t3), true)));
+          }
+          toArray() {
+            const e3 = [];
+            return this.iterate(((t3) => (e3.push(t3), true))), e3;
+          }
+          filter(e3) {
+            return new d(((t3) => this.iterate(((s3) => !e3(s3) || t3(s3)))));
+          }
+          map(e3) {
+            return new d(((t3) => this.iterate(((s3) => t3(e3(s3))))));
+          }
+          some(e3) {
+            let t3 = false;
+            return this.iterate(((s3) => (t3 = e3(s3), !t3))), t3;
+          }
+          findFirst(e3) {
+            let t3;
+            return this.iterate(((s3) => !e3(s3) || (t3 = s3, false))), t3;
+          }
+          findLast(e3) {
+            let t3;
+            return this.iterate(((s3) => (e3(s3) && (t3 = s3), true))), t3;
+          }
+          findLastMaxBy(e3) {
+            let t3, s3 = true;
+            return this.iterate(((i3) => ((s3 || u.isGreaterThan(e3(i3, t3))) && (s3 = false, t3 = i3), true))), t3;
+          }
+        }
+        t2.CallbackIterable = d;
+        class f {
+          constructor(e3) {
+            this._indexMap = e3;
+          }
+          static createSortPermutation(e3, t3) {
+            const s3 = Array.from(e3.keys()).sort(((s4, i3) => t3(e3[s4], e3[i3])));
+            return new f(s3);
+          }
+          apply(e3) {
+            return e3.map(((t3, s3) => e3[this._indexMap[s3]]));
+          }
+          inverse() {
+            const e3 = this._indexMap.slice();
+            for (let t3 = 0; t3 < this._indexMap.length; t3++) e3[this._indexMap[t3]] = t3;
+            return new f(e3);
+          }
+        }
+        t2.Permutation = f;
+      }, 8297: (e2, t2) => {
+        function s2(e3, t3, s3 = e3.length - 1) {
+          for (let i3 = s3; i3 >= 0; i3--) if (t3(e3[i3])) return i3;
+          return -1;
+        }
+        function i2(e3, t3, s3 = 0, i3 = e3.length) {
+          let r3 = s3, n3 = i3;
+          for (; r3 < n3; ) {
+            const s4 = Math.floor((r3 + n3) / 2);
+            t3(e3[s4]) ? r3 = s4 + 1 : n3 = s4;
+          }
+          return r3 - 1;
+        }
+        function r2(e3, t3, s3 = 0, i3 = e3.length) {
+          let r3 = s3, n3 = i3;
+          for (; r3 < n3; ) {
+            const s4 = Math.floor((r3 + n3) / 2);
+            t3(e3[s4]) ? n3 = s4 : r3 = s4 + 1;
+          }
+          return r3;
+        }
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.MonotonousArray = void 0, t2.findLast = function(e3, t3) {
+          const i3 = s2(e3, t3);
+          if (-1 !== i3) return e3[i3];
+        }, t2.findLastIdx = s2, t2.findLastMonotonous = function(e3, t3) {
+          const s3 = i2(e3, t3);
+          return -1 === s3 ? void 0 : e3[s3];
+        }, t2.findLastIdxMonotonous = i2, t2.findFirstMonotonous = function(e3, t3) {
+          const s3 = r2(e3, t3);
+          return s3 === e3.length ? void 0 : e3[s3];
+        }, t2.findFirstIdxMonotonousOrArrLen = r2, t2.findFirstIdxMonotonous = function(e3, t3, s3 = 0, i3 = e3.length) {
+          const n3 = r2(e3, t3, s3, i3);
+          return n3 === e3.length ? -1 : n3;
+        }, t2.findFirstMax = o, t2.findLastMax = function(e3, t3) {
+          if (0 === e3.length) return;
+          let s3 = e3[0];
+          for (let i3 = 1; i3 < e3.length; i3++) {
+            const r3 = e3[i3];
+            t3(r3, s3) >= 0 && (s3 = r3);
+          }
+          return s3;
+        }, t2.findFirstMin = function(e3, t3) {
+          return o(e3, ((e4, s3) => -t3(e4, s3)));
+        }, t2.findMaxIdx = function(e3, t3) {
+          if (0 === e3.length) return -1;
+          let s3 = 0;
+          for (let i3 = 1; i3 < e3.length; i3++) t3(e3[i3], e3[s3]) > 0 && (s3 = i3);
+          return s3;
+        }, t2.mapFindFirst = function(e3, t3) {
+          for (const s3 of e3) {
+            const e4 = t3(s3);
+            if (void 0 !== e4) return e4;
+          }
+        };
+        class n2 {
+          static {
+            this.assertInvariants = false;
+          }
+          constructor(e3) {
+            this._array = e3, this._findLastMonotonousLastIdx = 0;
+          }
+          findLastMonotonous(e3) {
+            if (n2.assertInvariants) {
+              if (this._prevFindLastPredicate) {
+                for (const t4 of this._array) if (this._prevFindLastPredicate(t4) && !e3(t4)) throw new Error("MonotonousArray: current predicate must be weaker than (or equal to) the previous predicate.");
+              }
+              this._prevFindLastPredicate = e3;
+            }
+            const t3 = i2(this._array, e3, this._findLastMonotonousLastIdx);
+            return this._findLastMonotonousLastIdx = t3 + 1, -1 === t3 ? void 0 : this._array[t3];
+          }
+        }
+        function o(e3, t3) {
+          if (0 === e3.length) return;
+          let s3 = e3[0];
+          for (let i3 = 1; i3 < e3.length; i3++) {
+            const r3 = e3[i3];
+            t3(r3, s3) > 0 && (s3 = r3);
+          }
+          return s3;
+        }
+        t2.MonotonousArray = n2;
+      }, 9087: (e2, t2) => {
+        var s2;
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.SetWithKey = void 0, t2.groupBy = function(e3, t3) {
+          const s3 = /* @__PURE__ */ Object.create(null);
+          for (const i3 of e3) {
+            const e4 = t3(i3);
+            let r2 = s3[e4];
+            r2 || (r2 = s3[e4] = []), r2.push(i3);
+          }
+          return s3;
+        }, t2.diffSets = function(e3, t3) {
+          const s3 = [], i3 = [];
+          for (const i4 of e3) t3.has(i4) || s3.push(i4);
+          for (const s4 of t3) e3.has(s4) || i3.push(s4);
+          return { removed: s3, added: i3 };
+        }, t2.diffMaps = function(e3, t3) {
+          const s3 = [], i3 = [];
+          for (const [i4, r2] of e3) t3.has(i4) || s3.push(r2);
+          for (const [s4, r2] of t3) e3.has(s4) || i3.push(r2);
+          return { removed: s3, added: i3 };
+        }, t2.intersection = function(e3, t3) {
+          const s3 = /* @__PURE__ */ new Set();
+          for (const i3 of t3) e3.has(i3) && s3.add(i3);
+          return s3;
+        };
+        class i2 {
+          static {
+            s2 = Symbol.toStringTag;
+          }
+          constructor(e3, t3) {
+            this.toKey = t3, this._map = /* @__PURE__ */ new Map(), this[s2] = "SetWithKey";
+            for (const t4 of e3) this.add(t4);
+          }
+          get size() {
+            return this._map.size;
+          }
+          add(e3) {
+            const t3 = this.toKey(e3);
+            return this._map.set(t3, e3), this;
+          }
+          delete(e3) {
+            return this._map.delete(this.toKey(e3));
+          }
+          has(e3) {
+            return this._map.has(this.toKey(e3));
+          }
+          *entries() {
+            for (const e3 of this._map.values()) yield [e3, e3];
+          }
+          keys() {
+            return this.values();
+          }
+          *values() {
+            for (const e3 of this._map.values()) yield e3;
+          }
+          clear() {
+            this._map.clear();
+          }
+          forEach(e3, t3) {
+            this._map.forEach(((s3) => e3.call(t3, s3, s3, this)));
+          }
+          [Symbol.iterator]() {
+            return this.values();
+          }
+        }
+        t2.SetWithKey = i2;
+      }, 9807: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.BugIndicatingError = t2.ErrorNoTelemetry = t2.ExpectedError = t2.NotSupportedError = t2.NotImplementedError = t2.ReadonlyError = t2.CancellationError = t2.errorHandler = t2.ErrorHandler = void 0, t2.setUnexpectedErrorHandler = function(e3) {
+          t2.errorHandler.setUnexpectedErrorHandler(e3);
+        }, t2.isSigPipeError = function(e3) {
+          if (!e3 || "object" != typeof e3) return false;
+          const t3 = e3;
+          return "EPIPE" === t3.code && "WRITE" === t3.syscall?.toUpperCase();
+        }, t2.onUnexpectedError = function(e3) {
+          r2(e3) || t2.errorHandler.onUnexpectedError(e3);
+        }, t2.onUnexpectedExternalError = function(e3) {
+          r2(e3) || t2.errorHandler.onUnexpectedExternalError(e3);
+        }, t2.transformErrorForSerialization = function(e3) {
+          if (e3 instanceof Error) {
+            const { name: t3, message: s3 } = e3;
+            return { $isError: true, name: t3, message: s3, stack: e3.stacktrace || e3.stack, noTelemetry: l.isErrorNoTelemetry(e3) };
+          }
+          return e3;
+        }, t2.transformErrorFromSerialization = function(e3) {
+          let t3;
+          return e3.noTelemetry ? t3 = new l() : (t3 = new Error(), t3.name = e3.name), t3.message = e3.message, t3.stack = e3.stack, t3;
+        }, t2.isCancellationError = r2, t2.canceled = function() {
+          const e3 = new Error(i2);
+          return e3.name = e3.message, e3;
+        }, t2.illegalArgument = function(e3) {
+          return e3 ? new Error(`Illegal argument: ${e3}`) : new Error("Illegal argument");
+        }, t2.illegalState = function(e3) {
+          return e3 ? new Error(`Illegal state: ${e3}`) : new Error("Illegal state");
+        }, t2.getErrorMessage = function(e3) {
+          return e3 ? e3.message ? e3.message : e3.stack ? e3.stack.split("\n")[0] : String(e3) : "Error";
+        };
+        class s2 {
+          constructor() {
+            this.listeners = [], this.unexpectedErrorHandler = function(e3) {
+              setTimeout((() => {
+                if (e3.stack) {
+                  if (l.isErrorNoTelemetry(e3)) throw new l(e3.message + "\n\n" + e3.stack);
+                  throw new Error(e3.message + "\n\n" + e3.stack);
+                }
+                throw e3;
+              }), 0);
+            };
+          }
+          addListener(e3) {
+            return this.listeners.push(e3), () => {
+              this._removeListener(e3);
+            };
+          }
+          emit(e3) {
+            this.listeners.forEach(((t3) => {
+              t3(e3);
+            }));
+          }
+          _removeListener(e3) {
+            this.listeners.splice(this.listeners.indexOf(e3), 1);
+          }
+          setUnexpectedErrorHandler(e3) {
+            this.unexpectedErrorHandler = e3;
+          }
+          getUnexpectedErrorHandler() {
+            return this.unexpectedErrorHandler;
+          }
+          onUnexpectedError(e3) {
+            this.unexpectedErrorHandler(e3), this.emit(e3);
+          }
+          onUnexpectedExternalError(e3) {
+            this.unexpectedErrorHandler(e3);
+          }
+        }
+        t2.ErrorHandler = s2, t2.errorHandler = new s2();
+        const i2 = "Canceled";
+        function r2(e3) {
+          return e3 instanceof n2 || e3 instanceof Error && e3.name === i2 && e3.message === i2;
+        }
+        class n2 extends Error {
+          constructor() {
+            super(i2), this.name = this.message;
+          }
+        }
+        t2.CancellationError = n2;
+        class o extends TypeError {
+          constructor(e3) {
+            super(e3 ? `${e3} is read-only and cannot be changed` : "Cannot change read-only property");
+          }
+        }
+        t2.ReadonlyError = o;
+        class a extends Error {
+          constructor(e3) {
+            super("NotImplemented"), e3 && (this.message = e3);
+          }
+        }
+        t2.NotImplementedError = a;
+        class h extends Error {
+          constructor(e3) {
+            super("NotSupported"), e3 && (this.message = e3);
+          }
+        }
+        t2.NotSupportedError = h;
+        class c extends Error {
+          constructor() {
+            super(...arguments), this.isExpected = true;
+          }
+        }
+        t2.ExpectedError = c;
+        class l extends Error {
+          constructor(e3) {
+            super(e3), this.name = "CodeExpectedError";
+          }
+          static fromError(e3) {
+            if (e3 instanceof l) return e3;
+            const t3 = new l();
+            return t3.message = e3.message, t3.stack = e3.stack, t3;
+          }
+          static isErrorNoTelemetry(e3) {
+            return "CodeExpectedError" === e3.name;
+          }
+        }
+        t2.ErrorNoTelemetry = l;
+        class u extends Error {
+          constructor(e3) {
+            super(e3 || "An unexpected bug occurred."), Object.setPrototypeOf(this, u.prototype);
+          }
+        }
+        t2.BugIndicatingError = u;
+      }, 802: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.ValueWithChangeEvent = t2.Relay = t2.EventBufferer = t2.DynamicListEventMultiplexer = t2.EventMultiplexer = t2.MicrotaskEmitter = t2.DebounceEmitter = t2.PauseableEmitter = t2.AsyncEmitter = t2.createEventDeliveryQueue = t2.Emitter = t2.ListenerRefusalError = t2.ListenerLeakError = t2.EventProfiling = t2.Event = void 0, t2.setGlobalLeakWarningThreshold = function(e3) {
+          const t3 = l;
+          return l = e3, { dispose() {
+            l = t3;
+          } };
+        };
+        const i2 = s2(9807), r2 = s2(8841), n2 = s2(7150), o = s2(6317), a = s2(9725);
+        var h;
+        !(function(e3) {
+          function t3(e4) {
+            return (t4, s4 = null, i4) => {
+              let r4, n3 = false;
+              return r4 = e4(((e5) => {
+                if (!n3) return r4 ? r4.dispose() : n3 = true, t4.call(s4, e5);
+              }), null, i4), n3 && r4.dispose(), r4;
+            };
+          }
+          function s3(e4, t4, s4) {
+            return r3(((s5, i4 = null, r4) => e4(((e5) => s5.call(i4, t4(e5))), null, r4)), s4);
+          }
+          function i3(e4, t4, s4) {
+            return r3(((s5, i4 = null, r4) => e4(((e5) => t4(e5) && s5.call(i4, e5)), null, r4)), s4);
+          }
+          function r3(e4, t4) {
+            let s4;
+            const i4 = new v({ onWillAddFirstListener() {
+              s4 = e4(i4.fire, i4);
+            }, onDidRemoveLastListener() {
+              s4?.dispose();
+            } });
+            return t4?.add(i4), i4.event;
+          }
+          function o2(e4, t4, s4 = 100, i4 = false, r4 = false, n3, o3) {
+            let a3, h3, c3, l2, u2 = 0;
+            const d2 = new v({ leakWarningThreshold: n3, onWillAddFirstListener() {
+              a3 = e4(((e5) => {
+                u2++, h3 = t4(h3, e5), i4 && !c3 && (d2.fire(h3), h3 = void 0), l2 = () => {
+                  const e6 = h3;
+                  h3 = void 0, c3 = void 0, (!i4 || u2 > 1) && d2.fire(e6), u2 = 0;
+                }, "number" == typeof s4 ? (clearTimeout(c3), c3 = setTimeout(l2, s4)) : void 0 === c3 && (c3 = 0, queueMicrotask(l2));
+              }));
+            }, onWillRemoveListener() {
+              r4 && u2 > 0 && l2?.();
+            }, onDidRemoveLastListener() {
+              l2 = void 0, a3.dispose();
+            } });
+            return o3?.add(d2), d2.event;
+          }
+          e3.None = () => n2.Disposable.None, e3.defer = function(e4, t4) {
+            return o2(e4, (() => {
+            }), 0, void 0, true, void 0, t4);
+          }, e3.once = t3, e3.map = s3, e3.forEach = function(e4, t4, s4) {
+            return r3(((s5, i4 = null, r4) => e4(((e5) => {
+              t4(e5), s5.call(i4, e5);
+            }), null, r4)), s4);
+          }, e3.filter = i3, e3.signal = function(e4) {
+            return e4;
+          }, e3.any = function(...e4) {
+            return (t4, s4 = null, i4) => {
+              return r4 = (0, n2.combinedDisposable)(...e4.map(((e5) => e5(((e6) => t4.call(s4, e6)))))), (o3 = i4) instanceof Array ? o3.push(r4) : o3 && o3.add(r4), r4;
+              var r4, o3;
+            };
+          }, e3.reduce = function(e4, t4, i4, r4) {
+            let n3 = i4;
+            return s3(e4, ((e5) => (n3 = t4(n3, e5), n3)), r4);
+          }, e3.debounce = o2, e3.accumulate = function(t4, s4 = 0, i4) {
+            return e3.debounce(t4, ((e4, t5) => e4 ? (e4.push(t5), e4) : [t5]), s4, void 0, true, void 0, i4);
+          }, e3.latch = function(e4, t4 = (e5, t5) => e5 === t5, s4) {
+            let r4, n3 = true;
+            return i3(e4, ((e5) => {
+              const s5 = n3 || !t4(e5, r4);
+              return n3 = false, r4 = e5, s5;
+            }), s4);
+          }, e3.split = function(t4, s4, i4) {
+            return [e3.filter(t4, s4, i4), e3.filter(t4, ((e4) => !s4(e4)), i4)];
+          }, e3.buffer = function(e4, t4 = false, s4 = [], i4) {
+            let r4 = s4.slice(), n3 = e4(((e5) => {
+              r4 ? r4.push(e5) : a3.fire(e5);
+            }));
+            i4 && i4.add(n3);
+            const o3 = () => {
+              r4?.forEach(((e5) => a3.fire(e5))), r4 = null;
+            }, a3 = new v({ onWillAddFirstListener() {
+              n3 || (n3 = e4(((e5) => a3.fire(e5))), i4 && i4.add(n3));
+            }, onDidAddFirstListener() {
+              r4 && (t4 ? setTimeout(o3) : o3());
+            }, onDidRemoveLastListener() {
+              n3 && n3.dispose(), n3 = null;
+            } });
+            return i4 && i4.add(a3), a3.event;
+          }, e3.chain = function(e4, t4) {
+            return (s4, i4, r4) => {
+              const n3 = t4(new h2());
+              return e4((function(e5) {
+                const t5 = n3.evaluate(e5);
+                t5 !== a2 && s4.call(i4, t5);
+              }), void 0, r4);
+            };
+          };
+          const a2 = /* @__PURE__ */ Symbol("HaltChainable");
+          class h2 {
+            constructor() {
+              this.steps = [];
+            }
+            map(e4) {
+              return this.steps.push(e4), this;
+            }
+            forEach(e4) {
+              return this.steps.push(((t4) => (e4(t4), t4))), this;
+            }
+            filter(e4) {
+              return this.steps.push(((t4) => e4(t4) ? t4 : a2)), this;
+            }
+            reduce(e4, t4) {
+              let s4 = t4;
+              return this.steps.push(((t5) => (s4 = e4(s4, t5), s4))), this;
+            }
+            latch(e4 = (e5, t4) => e5 === t4) {
+              let t4, s4 = true;
+              return this.steps.push(((i4) => {
+                const r4 = s4 || !e4(i4, t4);
+                return s4 = false, t4 = i4, r4 ? i4 : a2;
+              })), this;
+            }
+            evaluate(e4) {
+              for (const t4 of this.steps) if ((e4 = t4(e4)) === a2) break;
+              return e4;
+            }
+          }
+          e3.fromNodeEventEmitter = function(e4, t4, s4 = (e5) => e5) {
+            const i4 = (...e5) => r4.fire(s4(...e5)), r4 = new v({ onWillAddFirstListener: () => e4.on(t4, i4), onDidRemoveLastListener: () => e4.removeListener(t4, i4) });
+            return r4.event;
+          }, e3.fromDOMEventEmitter = function(e4, t4, s4 = (e5) => e5) {
+            const i4 = (...e5) => r4.fire(s4(...e5)), r4 = new v({ onWillAddFirstListener: () => e4.addEventListener(t4, i4), onDidRemoveLastListener: () => e4.removeEventListener(t4, i4) });
+            return r4.event;
+          }, e3.toPromise = function(e4) {
+            return new Promise(((s4) => t3(e4)(s4)));
+          }, e3.fromPromise = function(e4) {
+            const t4 = new v();
+            return e4.then(((e5) => {
+              t4.fire(e5);
+            }), (() => {
+              t4.fire(void 0);
+            })).finally((() => {
+              t4.dispose();
+            })), t4.event;
+          }, e3.forward = function(e4, t4) {
+            return e4(((e5) => t4.fire(e5)));
+          }, e3.runAndSubscribe = function(e4, t4, s4) {
+            return t4(s4), e4(((e5) => t4(e5)));
+          };
+          class c2 {
+            constructor(e4, t4) {
+              this._observable = e4, this._counter = 0, this._hasChanged = false;
+              const s4 = { onWillAddFirstListener: () => {
+                e4.addObserver(this);
+              }, onDidRemoveLastListener: () => {
+                e4.removeObserver(this);
+              } };
+              this.emitter = new v(s4), t4 && t4.add(this.emitter);
+            }
+            beginUpdate(e4) {
+              this._counter++;
+            }
+            handlePossibleChange(e4) {
+            }
+            handleChange(e4, t4) {
+              this._hasChanged = true;
+            }
+            endUpdate(e4) {
+              this._counter--, 0 === this._counter && (this._observable.reportChanges(), this._hasChanged && (this._hasChanged = false, this.emitter.fire(this._observable.get())));
+            }
+          }
+          e3.fromObservable = function(e4, t4) {
+            return new c2(e4, t4).emitter.event;
+          }, e3.fromObservableLight = function(e4) {
+            return (t4, s4, i4) => {
+              let r4 = 0, o3 = false;
+              const a3 = { beginUpdate() {
+                r4++;
+              }, endUpdate() {
+                r4--, 0 === r4 && (e4.reportChanges(), o3 && (o3 = false, t4.call(s4)));
+              }, handlePossibleChange() {
+              }, handleChange() {
+                o3 = true;
+              } };
+              e4.addObserver(a3), e4.reportChanges();
+              const h3 = { dispose() {
+                e4.removeObserver(a3);
+              } };
+              return i4 instanceof n2.DisposableStore ? i4.add(h3) : Array.isArray(i4) && i4.push(h3), h3;
+            };
+          };
+        })(h || (t2.Event = h = {}));
+        class c {
+          static {
+            this.all = /* @__PURE__ */ new Set();
+          }
+          static {
+            this._idPool = 0;
+          }
+          constructor(e3) {
+            this.listenerCount = 0, this.invocationCount = 0, this.elapsedOverall = 0, this.durations = [], this.name = `${e3}_${c._idPool++}`, c.all.add(this);
+          }
+          start(e3) {
+            this._stopWatch = new a.StopWatch(), this.listenerCount = e3;
+          }
+          stop() {
+            if (this._stopWatch) {
+              const e3 = this._stopWatch.elapsed();
+              this.durations.push(e3), this.elapsedOverall += e3, this.invocationCount += 1, this._stopWatch = void 0;
+            }
+          }
+        }
+        t2.EventProfiling = c;
+        let l = -1;
+        class u {
+          static {
+            this._idPool = 1;
+          }
+          constructor(e3, t3, s3 = (u._idPool++).toString(16).padStart(3, "0")) {
+            this._errorHandler = e3, this.threshold = t3, this.name = s3, this._warnCountdown = 0;
+          }
+          dispose() {
+            this._stacks?.clear();
+          }
+          check(e3, t3) {
+            const s3 = this.threshold;
+            if (s3 <= 0 || t3 < s3) return;
+            this._stacks || (this._stacks = /* @__PURE__ */ new Map());
+            const i3 = this._stacks.get(e3.value) || 0;
+            if (this._stacks.set(e3.value, i3 + 1), this._warnCountdown -= 1, this._warnCountdown <= 0) {
+              this._warnCountdown = 0.5 * s3;
+              const [e4, i4] = this.getMostFrequentStack(), r3 = `[${this.name}] potential listener LEAK detected, having ${t3} listeners already. MOST frequent listener (${i4}):`;
+              console.warn(r3), console.warn(e4);
+              const n3 = new f(r3, e4);
+              this._errorHandler(n3);
+            }
+            return () => {
+              const t4 = this._stacks.get(e3.value) || 0;
+              this._stacks.set(e3.value, t4 - 1);
+            };
+          }
+          getMostFrequentStack() {
+            if (!this._stacks) return;
+            let e3, t3 = 0;
+            for (const [s3, i3] of this._stacks) (!e3 || t3 < i3) && (e3 = [s3, i3], t3 = i3);
+            return e3;
+          }
+        }
+        class d {
+          static create() {
+            const e3 = new Error();
+            return new d(e3.stack ?? "");
+          }
+          constructor(e3) {
+            this.value = e3;
+          }
+          print() {
+            console.warn(this.value.split("\n").slice(2).join("\n"));
+          }
+        }
+        class f extends Error {
+          constructor(e3, t3) {
+            super(e3), this.name = "ListenerLeakError", this.stack = t3;
+          }
+        }
+        t2.ListenerLeakError = f;
+        class _ extends Error {
+          constructor(e3, t3) {
+            super(e3), this.name = "ListenerRefusalError", this.stack = t3;
+          }
+        }
+        t2.ListenerRefusalError = _;
+        let p = 0;
+        class g {
+          constructor(e3) {
+            this.value = e3, this.id = p++;
+          }
+        }
+        class v {
+          constructor(e3) {
+            this._size = 0, this._options = e3, this._leakageMon = l > 0 || this._options?.leakWarningThreshold ? new u(e3?.onListenerError ?? i2.onUnexpectedError, this._options?.leakWarningThreshold ?? l) : void 0, this._perfMon = this._options?._profName ? new c(this._options._profName) : void 0, this._deliveryQueue = this._options?.deliveryQueue;
+          }
+          dispose() {
+            this._disposed || (this._disposed = true, this._deliveryQueue?.current === this && this._deliveryQueue.reset(), this._listeners && (this._listeners = void 0, this._size = 0), this._options?.onDidRemoveLastListener?.(), this._leakageMon?.dispose());
+          }
+          get event() {
+            return this._event ??= (e3, t3, s3) => {
+              if (this._leakageMon && this._size > this._leakageMon.threshold ** 2) {
+                const e4 = `[${this._leakageMon.name}] REFUSES to accept new listeners because it exceeded its threshold by far (${this._size} vs ${this._leakageMon.threshold})`;
+                console.warn(e4);
+                const t4 = this._leakageMon.getMostFrequentStack() ?? ["UNKNOWN stack", -1], s4 = new _(`${e4}. HINT: Stack shows most frequent listener (${t4[1]}-times)`, t4[0]);
+                return (this._options?.onListenerError || i2.onUnexpectedError)(s4), n2.Disposable.None;
+              }
+              if (this._disposed) return n2.Disposable.None;
+              t3 && (e3 = e3.bind(t3));
+              const r3 = new g(e3);
+              let o2;
+              this._leakageMon && this._size >= Math.ceil(0.2 * this._leakageMon.threshold) && (r3.stack = d.create(), o2 = this._leakageMon.check(r3.stack, this._size + 1)), this._listeners ? this._listeners instanceof g ? (this._deliveryQueue ??= new m(), this._listeners = [this._listeners, r3]) : this._listeners.push(r3) : (this._options?.onWillAddFirstListener?.(this), this._listeners = r3, this._options?.onDidAddFirstListener?.(this)), this._size++;
+              const a2 = (0, n2.toDisposable)((() => {
+                o2?.(), this._removeListener(r3);
+              }));
+              return s3 instanceof n2.DisposableStore ? s3.add(a2) : Array.isArray(s3) && s3.push(a2), a2;
+            }, this._event;
+          }
+          _removeListener(e3) {
+            if (this._options?.onWillRemoveListener?.(this), !this._listeners) return;
+            if (1 === this._size) return this._listeners = void 0, this._options?.onDidRemoveLastListener?.(this), void (this._size = 0);
+            const t3 = this._listeners, s3 = t3.indexOf(e3);
+            if (-1 === s3) throw console.log("disposed?", this._disposed), console.log("size?", this._size), console.log("arr?", JSON.stringify(this._listeners)), new Error("Attempted to dispose unknown listener");
+            this._size--, t3[s3] = void 0;
+            const i3 = this._deliveryQueue.current === this;
+            if (2 * this._size <= t3.length) {
+              let e4 = 0;
+              for (let s4 = 0; s4 < t3.length; s4++) t3[s4] ? t3[e4++] = t3[s4] : i3 && (this._deliveryQueue.end--, e4 < this._deliveryQueue.i && this._deliveryQueue.i--);
+              t3.length = e4;
+            }
+          }
+          _deliver(e3, t3) {
+            if (!e3) return;
+            const s3 = this._options?.onListenerError || i2.onUnexpectedError;
+            if (s3) try {
+              e3.value(t3);
+            } catch (e4) {
+              s3(e4);
+            }
+            else e3.value(t3);
+          }
+          _deliverQueue(e3) {
+            const t3 = e3.current._listeners;
+            for (; e3.i < e3.end; ) this._deliver(t3[e3.i++], e3.value);
+            e3.reset();
+          }
+          fire(e3) {
+            if (this._deliveryQueue?.current && (this._deliverQueue(this._deliveryQueue), this._perfMon?.stop()), this._perfMon?.start(this._size), this._listeners) if (this._listeners instanceof g) this._deliver(this._listeners, e3);
+            else {
+              const t3 = this._deliveryQueue;
+              t3.enqueue(this, e3, this._listeners.length), this._deliverQueue(t3);
+            }
+            this._perfMon?.stop();
+          }
+          hasListeners() {
+            return this._size > 0;
+          }
+        }
+        t2.Emitter = v, t2.createEventDeliveryQueue = () => new m();
+        class m {
+          constructor() {
+            this.i = -1, this.end = 0;
+          }
+          enqueue(e3, t3, s3) {
+            this.i = 0, this.end = s3, this.current = e3, this.value = t3;
+          }
+          reset() {
+            this.i = this.end, this.current = void 0, this.value = void 0;
+          }
+        }
+        t2.AsyncEmitter = class extends v {
+          async fireAsync(e3, t3, s3) {
+            if (this._listeners) for (this._asyncDeliveryQueue || (this._asyncDeliveryQueue = new o.LinkedList()), ((e4, t4) => {
+              if (e4 instanceof g) t4(e4);
+              else for (let s4 = 0; s4 < e4.length; s4++) {
+                const i3 = e4[s4];
+                i3 && t4(i3);
+              }
+            })(this._listeners, ((t4) => this._asyncDeliveryQueue.push([t4.value, e3]))); this._asyncDeliveryQueue.size > 0 && !t3.isCancellationRequested; ) {
+              const [e4, r3] = this._asyncDeliveryQueue.shift(), n3 = [], o2 = { ...r3, token: t3, waitUntil: (t4) => {
+                if (Object.isFrozen(n3)) throw new Error("waitUntil can NOT be called asynchronous");
+                s3 && (t4 = s3(t4, e4)), n3.push(t4);
+              } };
+              try {
+                e4(o2);
+              } catch (e5) {
+                (0, i2.onUnexpectedError)(e5);
+                continue;
+              }
+              Object.freeze(n3), await Promise.allSettled(n3).then(((e5) => {
+                for (const t4 of e5) "rejected" === t4.status && (0, i2.onUnexpectedError)(t4.reason);
+              }));
+            }
+          }
+        };
+        class b extends v {
+          get isPaused() {
+            return 0 !== this._isPaused;
+          }
+          constructor(e3) {
+            super(e3), this._isPaused = 0, this._eventQueue = new o.LinkedList(), this._mergeFn = e3?.merge;
+          }
+          pause() {
+            this._isPaused++;
+          }
+          resume() {
+            if (0 !== this._isPaused && 0 == --this._isPaused) if (this._mergeFn) {
+              if (this._eventQueue.size > 0) {
+                const e3 = Array.from(this._eventQueue);
+                this._eventQueue.clear(), super.fire(this._mergeFn(e3));
+              }
+            } else for (; !this._isPaused && 0 !== this._eventQueue.size; ) super.fire(this._eventQueue.shift());
+          }
+          fire(e3) {
+            this._size && (0 !== this._isPaused ? this._eventQueue.push(e3) : super.fire(e3));
+          }
+        }
+        t2.PauseableEmitter = b, t2.DebounceEmitter = class extends b {
+          constructor(e3) {
+            super(e3), this._delay = e3.delay ?? 100;
+          }
+          fire(e3) {
+            this._handle || (this.pause(), this._handle = setTimeout((() => {
+              this._handle = void 0, this.resume();
+            }), this._delay)), super.fire(e3);
+          }
+        }, t2.MicrotaskEmitter = class extends v {
+          constructor(e3) {
+            super(e3), this._queuedEvents = [], this._mergeFn = e3?.merge;
+          }
+          fire(e3) {
+            this.hasListeners() && (this._queuedEvents.push(e3), 1 === this._queuedEvents.length && queueMicrotask((() => {
+              this._mergeFn ? super.fire(this._mergeFn(this._queuedEvents)) : this._queuedEvents.forEach(((e4) => super.fire(e4))), this._queuedEvents = [];
+            })));
+          }
+        };
+        class S {
+          constructor() {
+            this.hasListeners = false, this.events = [], this.emitter = new v({ onWillAddFirstListener: () => this.onFirstListenerAdd(), onDidRemoveLastListener: () => this.onLastListenerRemove() });
+          }
+          get event() {
+            return this.emitter.event;
+          }
+          add(e3) {
+            const t3 = { event: e3, listener: null };
+            return this.events.push(t3), this.hasListeners && this.hook(t3), (0, n2.toDisposable)((0, r2.createSingleCallFunction)((() => {
+              this.hasListeners && this.unhook(t3);
+              const e4 = this.events.indexOf(t3);
+              this.events.splice(e4, 1);
+            })));
+          }
+          onFirstListenerAdd() {
+            this.hasListeners = true, this.events.forEach(((e3) => this.hook(e3)));
+          }
+          onLastListenerRemove() {
+            this.hasListeners = false, this.events.forEach(((e3) => this.unhook(e3)));
+          }
+          hook(e3) {
+            e3.listener = e3.event(((e4) => this.emitter.fire(e4)));
+          }
+          unhook(e3) {
+            e3.listener?.dispose(), e3.listener = null;
+          }
+          dispose() {
+            this.emitter.dispose();
+            for (const e3 of this.events) e3.listener?.dispose();
+            this.events = [];
+          }
+        }
+        t2.EventMultiplexer = S, t2.DynamicListEventMultiplexer = class {
+          constructor(e3, t3, s3, i3) {
+            this._store = new n2.DisposableStore();
+            const r3 = this._store.add(new S()), o2 = this._store.add(new n2.DisposableMap());
+            function a2(e4) {
+              o2.set(e4, r3.add(i3(e4)));
+            }
+            for (const t4 of e3) a2(t4);
+            this._store.add(t3(((e4) => {
+              a2(e4);
+            }))), this._store.add(s3(((e4) => {
+              o2.deleteAndDispose(e4);
+            }))), this.event = r3.event;
+          }
+          dispose() {
+            this._store.dispose();
+          }
+        }, t2.EventBufferer = class {
+          constructor() {
+            this.data = [];
+          }
+          wrapEvent(e3, t3, s3) {
+            return (i3, r3, n3) => e3(((e4) => {
+              const n4 = this.data[this.data.length - 1];
+              if (!t3) return void (n4 ? n4.buffers.push((() => i3.call(r3, e4))) : i3.call(r3, e4));
+              const o2 = n4;
+              o2 ? (o2.items ??= [], o2.items.push(e4), 0 === o2.buffers.length && n4.buffers.push((() => {
+                o2.reducedResult ??= s3 ? o2.items.reduce(t3, s3) : o2.items.reduce(t3), i3.call(r3, o2.reducedResult);
+              }))) : i3.call(r3, t3(s3, e4));
+            }), void 0, n3);
+          }
+          bufferEvents(e3) {
+            const t3 = { buffers: new Array() };
+            this.data.push(t3);
+            const s3 = e3();
+            return this.data.pop(), t3.buffers.forEach(((e4) => e4())), s3;
+          }
+        }, t2.Relay = class {
+          constructor() {
+            this.listening = false, this.inputEvent = h.None, this.inputEventListener = n2.Disposable.None, this.emitter = new v({ onDidAddFirstListener: () => {
+              this.listening = true, this.inputEventListener = this.inputEvent(this.emitter.fire, this.emitter);
+            }, onDidRemoveLastListener: () => {
+              this.listening = false, this.inputEventListener.dispose();
+            } }), this.event = this.emitter.event;
+          }
+          set input(e3) {
+            this.inputEvent = e3, this.listening && (this.inputEventListener.dispose(), this.inputEventListener = e3(this.emitter.fire, this.emitter));
+          }
+          dispose() {
+            this.inputEventListener.dispose(), this.emitter.dispose();
+          }
+        }, t2.ValueWithChangeEvent = class {
+          static const(e3) {
+            return new y(e3);
+          }
+          constructor(e3) {
+            this._value = e3, this._onDidChange = new v(), this.onDidChange = this._onDidChange.event;
+          }
+          get value() {
+            return this._value;
+          }
+          set value(e3) {
+            e3 !== this._value && (this._value = e3, this._onDidChange.fire(void 0));
+          }
+        };
+        class y {
+          constructor(e3) {
+            this.value = e3, this.onDidChange = h.None;
+          }
+        }
+      }, 8841: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.createSingleCallFunction = function(e3, t3) {
+          const s2 = this;
+          let i2, r2 = false;
+          return function() {
+            if (r2) return i2;
+            if (r2 = true, t3) try {
+              i2 = e3.apply(s2, arguments);
+            } finally {
+              t3();
+            }
+            else i2 = e3.apply(s2, arguments);
+            return i2;
+          };
+        };
+      }, 4218: (e2, t2) => {
+        var s2;
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.Iterable = void 0, (function(e3) {
+          function t3(e4) {
+            return e4 && "object" == typeof e4 && "function" == typeof e4[Symbol.iterator];
+          }
+          e3.is = t3;
+          const s3 = Object.freeze([]);
+          function* i2(e4) {
+            yield e4;
+          }
+          e3.empty = function() {
+            return s3;
+          }, e3.single = i2, e3.wrap = function(e4) {
+            return t3(e4) ? e4 : i2(e4);
+          }, e3.from = function(e4) {
+            return e4 || s3;
+          }, e3.reverse = function* (e4) {
+            for (let t4 = e4.length - 1; t4 >= 0; t4--) yield e4[t4];
+          }, e3.isEmpty = function(e4) {
+            return !e4 || true === e4[Symbol.iterator]().next().done;
+          }, e3.first = function(e4) {
+            return e4[Symbol.iterator]().next().value;
+          }, e3.some = function(e4, t4) {
+            let s4 = 0;
+            for (const i3 of e4) if (t4(i3, s4++)) return true;
+            return false;
+          }, e3.find = function(e4, t4) {
+            for (const s4 of e4) if (t4(s4)) return s4;
+          }, e3.filter = function* (e4, t4) {
+            for (const s4 of e4) t4(s4) && (yield s4);
+          }, e3.map = function* (e4, t4) {
+            let s4 = 0;
+            for (const i3 of e4) yield t4(i3, s4++);
+          }, e3.flatMap = function* (e4, t4) {
+            let s4 = 0;
+            for (const i3 of e4) yield* t4(i3, s4++);
+          }, e3.concat = function* (...e4) {
+            for (const t4 of e4) yield* t4;
+          }, e3.reduce = function(e4, t4, s4) {
+            let i3 = s4;
+            for (const s5 of e4) i3 = t4(i3, s5);
+            return i3;
+          }, e3.slice = function* (e4, t4, s4 = e4.length) {
+            for (t4 < 0 && (t4 += e4.length), s4 < 0 ? s4 += e4.length : s4 > e4.length && (s4 = e4.length); t4 < s4; t4++) yield e4[t4];
+          }, e3.consume = function(t4, s4 = Number.POSITIVE_INFINITY) {
+            const i3 = [];
+            if (0 === s4) return [i3, t4];
+            const r2 = t4[Symbol.iterator]();
+            for (let t5 = 0; t5 < s4; t5++) {
+              const t6 = r2.next();
+              if (t6.done) return [i3, e3.empty()];
+              i3.push(t6.value);
+            }
+            return [i3, { [Symbol.iterator]: () => r2 }];
+          }, e3.asyncToArray = async function(e4) {
+            const t4 = [];
+            for await (const s4 of e4) t4.push(s4);
+            return Promise.resolve(t4);
+          };
+        })(s2 || (t2.Iterable = s2 = {}));
+      }, 7150: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.DisposableMap = t2.ImmortalReference = t2.AsyncReferenceCollection = t2.ReferenceCollection = t2.SafeDisposable = t2.RefCountedDisposable = t2.MandatoryMutableDisposable = t2.MutableDisposable = t2.Disposable = t2.DisposableStore = t2.DisposableTracker = void 0, t2.setDisposableTracker = function(e3) {
+          h = e3;
+        }, t2.trackDisposable = l, t2.markAsDisposed = u, t2.markAsSingleton = function(e3) {
+          return h?.markAsSingleton(e3), e3;
+        }, t2.isDisposable = f, t2.dispose = _, t2.disposeIfDisposable = function(e3) {
+          for (const t3 of e3) f(t3) && t3.dispose();
+          return [];
+        }, t2.combinedDisposable = function(...e3) {
+          const t3 = p((() => _(e3)));
+          return (function(e4, t4) {
+            if (h) for (const s3 of e4) h.setParent(s3, t4);
+          })(e3, t3), t3;
+        }, t2.toDisposable = p, t2.disposeOnReturn = function(e3) {
+          const t3 = new g();
+          try {
+            e3(t3);
+          } finally {
+            t3.dispose();
+          }
+        };
+        const i2 = s2(3058), r2 = s2(9087), n2 = s2(2608), o = s2(8841), a = s2(4218);
+        let h = null;
+        class c {
+          constructor() {
+            this.livingDisposables = /* @__PURE__ */ new Map();
+          }
+          static {
+            this.idx = 0;
+          }
+          getDisposableData(e3) {
+            let t3 = this.livingDisposables.get(e3);
+            return t3 || (t3 = { parent: null, source: null, isSingleton: false, value: e3, idx: c.idx++ }, this.livingDisposables.set(e3, t3)), t3;
+          }
+          trackDisposable(e3) {
+            const t3 = this.getDisposableData(e3);
+            t3.source || (t3.source = new Error().stack);
+          }
+          setParent(e3, t3) {
+            this.getDisposableData(e3).parent = t3;
+          }
+          markAsDisposed(e3) {
+            this.livingDisposables.delete(e3);
+          }
+          markAsSingleton(e3) {
+            this.getDisposableData(e3).isSingleton = true;
+          }
+          getRootParent(e3, t3) {
+            const s3 = t3.get(e3);
+            if (s3) return s3;
+            const i3 = e3.parent ? this.getRootParent(this.getDisposableData(e3.parent), t3) : e3;
+            return t3.set(e3, i3), i3;
+          }
+          getTrackedDisposables() {
+            const e3 = /* @__PURE__ */ new Map();
+            return [...this.livingDisposables.entries()].filter((([, t3]) => null !== t3.source && !this.getRootParent(t3, e3).isSingleton)).flatMap((([e4]) => e4));
+          }
+          computeLeakingDisposables(e3 = 10, t3) {
+            let s3;
+            if (t3) s3 = t3;
+            else {
+              const e4 = /* @__PURE__ */ new Map(), t4 = [...this.livingDisposables.values()].filter(((t5) => null !== t5.source && !this.getRootParent(t5, e4).isSingleton));
+              if (0 === t4.length) return;
+              const i3 = new Set(t4.map(((e5) => e5.value)));
+              if (s3 = t4.filter(((e5) => !(e5.parent && i3.has(e5.parent)))), 0 === s3.length) throw new Error("There are cyclic diposable chains!");
+            }
+            if (!s3) return;
+            function o2(e4) {
+              const t4 = e4.source.split("\n").map(((e5) => e5.trim().replace("at ", ""))).filter(((e5) => "" !== e5));
+              return (function(e5, t5) {
+                for (; e5.length > 0 && t5.some(((t6) => "string" == typeof t6 ? t6 === e5[0] : e5[0].match(t6))); ) e5.shift();
+              })(t4, ["Error", /^trackDisposable \(.*\)$/, /^DisposableTracker.trackDisposable \(.*\)$/]), t4.reverse();
+            }
+            const a2 = new n2.SetMap();
+            for (const e4 of s3) {
+              const t4 = o2(e4);
+              for (let s4 = 0; s4 <= t4.length; s4++) a2.add(t4.slice(0, s4).join("\n"), e4);
+            }
+            s3.sort((0, i2.compareBy)(((e4) => e4.idx), i2.numberComparator));
+            let h2 = "", c2 = 0;
+            for (const t4 of s3.slice(0, e3)) {
+              c2++;
+              const e4 = o2(t4), i3 = [];
+              for (let t5 = 0; t5 < e4.length; t5++) {
+                let n3 = e4[t5];
+                n3 = `(shared with ${a2.get(e4.slice(0, t5 + 1).join("\n")).size}/${s3.length} leaks) at ${n3}`;
+                const h3 = a2.get(e4.slice(0, t5).join("\n")), c3 = (0, r2.groupBy)([...h3].map(((e5) => o2(e5)[t5])), ((e5) => e5));
+                delete c3[e4[t5]];
+                for (const [e5, t6] of Object.entries(c3)) i3.unshift(`    - stacktraces of ${t6.length} other leaks continue with ${e5}`);
+                i3.unshift(n3);
+              }
+              h2 += `
+
+
+==================== Leaking disposable ${c2}/${s3.length}: ${t4.value.constructor.name} ====================
+${i3.join("\n")}
+============================================================
+
+`;
+            }
+            return s3.length > e3 && (h2 += `
+
+
+... and ${s3.length - e3} more leaking disposables
+
+`), { leaks: s3, details: h2 };
+          }
+        }
+        function l(e3) {
+          return h?.trackDisposable(e3), e3;
+        }
+        function u(e3) {
+          h?.markAsDisposed(e3);
+        }
+        function d(e3, t3) {
+          h?.setParent(e3, t3);
+        }
+        function f(e3) {
+          return "object" == typeof e3 && null !== e3 && "function" == typeof e3.dispose && 0 === e3.dispose.length;
+        }
+        function _(e3) {
+          if (a.Iterable.is(e3)) {
+            const t3 = [];
+            for (const s3 of e3) if (s3) try {
+              s3.dispose();
+            } catch (e4) {
+              t3.push(e4);
+            }
+            if (1 === t3.length) throw t3[0];
+            if (t3.length > 1) throw new AggregateError(t3, "Encountered errors while disposing of store");
+            return Array.isArray(e3) ? [] : e3;
+          }
+          if (e3) return e3.dispose(), e3;
+        }
+        function p(e3) {
+          const t3 = l({ dispose: (0, o.createSingleCallFunction)((() => {
+            u(t3), e3();
+          })) });
+          return t3;
+        }
+        t2.DisposableTracker = c;
+        class g {
+          static {
+            this.DISABLE_DISPOSED_WARNING = false;
+          }
+          constructor() {
+            this._toDispose = /* @__PURE__ */ new Set(), this._isDisposed = false, l(this);
+          }
+          dispose() {
+            this._isDisposed || (u(this), this._isDisposed = true, this.clear());
+          }
+          get isDisposed() {
+            return this._isDisposed;
+          }
+          clear() {
+            if (0 !== this._toDispose.size) try {
+              _(this._toDispose);
+            } finally {
+              this._toDispose.clear();
+            }
+          }
+          add(e3) {
+            if (!e3) return e3;
+            if (e3 === this) throw new Error("Cannot register a disposable on itself!");
+            return d(e3, this), this._isDisposed ? g.DISABLE_DISPOSED_WARNING || console.warn(new Error("Trying to add a disposable to a DisposableStore that has already been disposed of. The added object will be leaked!").stack) : this._toDispose.add(e3), e3;
+          }
+          delete(e3) {
+            if (e3) {
+              if (e3 === this) throw new Error("Cannot dispose a disposable on itself!");
+              this._toDispose.delete(e3), e3.dispose();
+            }
+          }
+          deleteAndLeak(e3) {
+            e3 && this._toDispose.has(e3) && (this._toDispose.delete(e3), d(e3, null));
+          }
+        }
+        t2.DisposableStore = g;
+        class v {
+          static {
+            this.None = Object.freeze({ dispose() {
+            } });
+          }
+          constructor() {
+            this._store = new g(), l(this), d(this._store, this);
+          }
+          dispose() {
+            u(this), this._store.dispose();
+          }
+          _register(e3) {
+            if (e3 === this) throw new Error("Cannot register a disposable on itself!");
+            return this._store.add(e3);
+          }
+        }
+        t2.Disposable = v;
+        class m {
+          constructor() {
+            this._isDisposed = false, l(this);
+          }
+          get value() {
+            return this._isDisposed ? void 0 : this._value;
+          }
+          set value(e3) {
+            this._isDisposed || e3 === this._value || (this._value?.dispose(), e3 && d(e3, this), this._value = e3);
+          }
+          clear() {
+            this.value = void 0;
+          }
+          dispose() {
+            this._isDisposed = true, u(this), this._value?.dispose(), this._value = void 0;
+          }
+          clearAndLeak() {
+            const e3 = this._value;
+            return this._value = void 0, e3 && d(e3, null), e3;
+          }
+        }
+        t2.MutableDisposable = m, t2.MandatoryMutableDisposable = class {
+          constructor(e3) {
+            this._disposable = new m(), this._isDisposed = false, this._disposable.value = e3;
+          }
+          get value() {
+            return this._disposable.value;
+          }
+          set value(e3) {
+            this._isDisposed || e3 === this._disposable.value || (this._disposable.value = e3);
+          }
+          dispose() {
+            this._isDisposed = true, this._disposable.dispose();
+          }
+        }, t2.RefCountedDisposable = class {
+          constructor(e3) {
+            this._disposable = e3, this._counter = 1;
+          }
+          acquire() {
+            return this._counter++, this;
+          }
+          release() {
+            return 0 == --this._counter && this._disposable.dispose(), this;
+          }
+        }, t2.SafeDisposable = class {
+          constructor() {
+            this.dispose = () => {
+            }, this.unset = () => {
+            }, this.isset = () => false, l(this);
+          }
+          set(e3) {
+            let t3 = e3;
+            return this.unset = () => t3 = void 0, this.isset = () => void 0 !== t3, this.dispose = () => {
+              t3 && (t3(), t3 = void 0, u(this));
+            }, this;
+          }
+        }, t2.ReferenceCollection = class {
+          constructor() {
+            this.references = /* @__PURE__ */ new Map();
+          }
+          acquire(e3, ...t3) {
+            let s3 = this.references.get(e3);
+            s3 || (s3 = { counter: 0, object: this.createReferencedObject(e3, ...t3) }, this.references.set(e3, s3));
+            const { object: i3 } = s3, r3 = (0, o.createSingleCallFunction)((() => {
+              0 == --s3.counter && (this.destroyReferencedObject(e3, s3.object), this.references.delete(e3));
+            }));
+            return s3.counter++, { object: i3, dispose: r3 };
+          }
+        }, t2.AsyncReferenceCollection = class {
+          constructor(e3) {
+            this.referenceCollection = e3;
+          }
+          async acquire(e3, ...t3) {
+            const s3 = this.referenceCollection.acquire(e3, ...t3);
+            try {
+              return { object: await s3.object, dispose: () => s3.dispose() };
+            } catch (e4) {
+              throw s3.dispose(), e4;
+            }
+          }
+        }, t2.ImmortalReference = class {
+          constructor(e3) {
+            this.object = e3;
+          }
+          dispose() {
+          }
+        };
+        class b {
+          constructor() {
+            this._store = /* @__PURE__ */ new Map(), this._isDisposed = false, l(this);
+          }
+          dispose() {
+            u(this), this._isDisposed = true, this.clearAndDisposeAll();
+          }
+          clearAndDisposeAll() {
+            if (this._store.size) try {
+              _(this._store.values());
+            } finally {
+              this._store.clear();
+            }
+          }
+          has(e3) {
+            return this._store.has(e3);
+          }
+          get size() {
+            return this._store.size;
+          }
+          get(e3) {
+            return this._store.get(e3);
+          }
+          set(e3, t3, s3 = false) {
+            this._isDisposed && console.warn(new Error("Trying to add a disposable to a DisposableMap that has already been disposed of. The added object will be leaked!").stack), s3 || this._store.get(e3)?.dispose(), this._store.set(e3, t3);
+          }
+          deleteAndDispose(e3) {
+            this._store.get(e3)?.dispose(), this._store.delete(e3);
+          }
+          deleteAndLeak(e3) {
+            const t3 = this._store.get(e3);
+            return this._store.delete(e3), t3;
+          }
+          keys() {
+            return this._store.keys();
+          }
+          values() {
+            return this._store.values();
+          }
+          [Symbol.iterator]() {
+            return this._store[Symbol.iterator]();
+          }
+        }
+        t2.DisposableMap = b;
+      }, 6317: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.LinkedList = void 0;
+        class s2 {
+          static {
+            this.Undefined = new s2(void 0);
+          }
+          constructor(e3) {
+            this.element = e3, this.next = s2.Undefined, this.prev = s2.Undefined;
+          }
+        }
+        class i2 {
+          constructor() {
+            this._first = s2.Undefined, this._last = s2.Undefined, this._size = 0;
+          }
+          get size() {
+            return this._size;
+          }
+          isEmpty() {
+            return this._first === s2.Undefined;
+          }
+          clear() {
+            let e3 = this._first;
+            for (; e3 !== s2.Undefined; ) {
+              const t3 = e3.next;
+              e3.prev = s2.Undefined, e3.next = s2.Undefined, e3 = t3;
+            }
+            this._first = s2.Undefined, this._last = s2.Undefined, this._size = 0;
+          }
+          unshift(e3) {
+            return this._insert(e3, false);
+          }
+          push(e3) {
+            return this._insert(e3, true);
+          }
+          _insert(e3, t3) {
+            const i3 = new s2(e3);
+            if (this._first === s2.Undefined) this._first = i3, this._last = i3;
+            else if (t3) {
+              const e4 = this._last;
+              this._last = i3, i3.prev = e4, e4.next = i3;
+            } else {
+              const e4 = this._first;
+              this._first = i3, i3.next = e4, e4.prev = i3;
+            }
+            this._size += 1;
+            let r2 = false;
+            return () => {
+              r2 || (r2 = true, this._remove(i3));
+            };
+          }
+          shift() {
+            if (this._first !== s2.Undefined) {
+              const e3 = this._first.element;
+              return this._remove(this._first), e3;
+            }
+          }
+          pop() {
+            if (this._last !== s2.Undefined) {
+              const e3 = this._last.element;
+              return this._remove(this._last), e3;
+            }
+          }
+          _remove(e3) {
+            if (e3.prev !== s2.Undefined && e3.next !== s2.Undefined) {
+              const t3 = e3.prev;
+              t3.next = e3.next, e3.next.prev = t3;
+            } else e3.prev === s2.Undefined && e3.next === s2.Undefined ? (this._first = s2.Undefined, this._last = s2.Undefined) : e3.next === s2.Undefined ? (this._last = this._last.prev, this._last.next = s2.Undefined) : e3.prev === s2.Undefined && (this._first = this._first.next, this._first.prev = s2.Undefined);
+            this._size -= 1;
+          }
+          *[Symbol.iterator]() {
+            let e3 = this._first;
+            for (; e3 !== s2.Undefined; ) yield e3.element, e3 = e3.next;
+          }
+        }
+        t2.LinkedList = i2;
+      }, 2608: (e2, t2) => {
+        var s2;
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.SetMap = t2.BidirectionalMap = t2.CounterSet = t2.Touch = void 0, t2.getOrSet = function(e3, t3, s3) {
+          let i2 = e3.get(t3);
+          return void 0 === i2 && (i2 = s3, e3.set(t3, i2)), i2;
+        }, t2.mapToString = function(e3) {
+          const t3 = [];
+          return e3.forEach(((e4, s3) => {
+            t3.push(`${s3} => ${e4}`);
+          })), `Map(${e3.size}) {${t3.join(", ")}}`;
+        }, t2.setToString = function(e3) {
+          const t3 = [];
+          return e3.forEach(((e4) => {
+            t3.push(e4);
+          })), `Set(${e3.size}) {${t3.join(", ")}}`;
+        }, t2.mapsStrictEqualIgnoreOrder = function(e3, t3) {
+          if (e3 === t3) return true;
+          if (e3.size !== t3.size) return false;
+          for (const [s3, i2] of e3) if (!t3.has(s3) || t3.get(s3) !== i2) return false;
+          for (const [s3] of t3) if (!e3.has(s3)) return false;
+          return true;
+        }, (function(e3) {
+          e3[e3.None = 0] = "None", e3[e3.AsOld = 1] = "AsOld", e3[e3.AsNew = 2] = "AsNew";
+        })(s2 || (t2.Touch = s2 = {})), t2.CounterSet = class {
+          constructor() {
+            this.map = /* @__PURE__ */ new Map();
+          }
+          add(e3) {
+            return this.map.set(e3, (this.map.get(e3) || 0) + 1), this;
+          }
+          delete(e3) {
+            let t3 = this.map.get(e3) || 0;
+            return 0 !== t3 && (t3--, 0 === t3 ? this.map.delete(e3) : this.map.set(e3, t3), true);
+          }
+          has(e3) {
+            return this.map.has(e3);
+          }
+        }, t2.BidirectionalMap = class {
+          constructor(e3) {
+            if (this._m1 = /* @__PURE__ */ new Map(), this._m2 = /* @__PURE__ */ new Map(), e3) for (const [t3, s3] of e3) this.set(t3, s3);
+          }
+          clear() {
+            this._m1.clear(), this._m2.clear();
+          }
+          set(e3, t3) {
+            this._m1.set(e3, t3), this._m2.set(t3, e3);
+          }
+          get(e3) {
+            return this._m1.get(e3);
+          }
+          getKey(e3) {
+            return this._m2.get(e3);
+          }
+          delete(e3) {
+            const t3 = this._m1.get(e3);
+            return void 0 !== t3 && (this._m1.delete(e3), this._m2.delete(t3), true);
+          }
+          forEach(e3, t3) {
+            this._m1.forEach(((s3, i2) => {
+              e3.call(t3, s3, i2, this);
+            }));
+          }
+          keys() {
+            return this._m1.keys();
+          }
+          values() {
+            return this._m1.values();
+          }
+        }, t2.SetMap = class {
+          constructor() {
+            this.map = /* @__PURE__ */ new Map();
+          }
+          add(e3, t3) {
+            let s3 = this.map.get(e3);
+            s3 || (s3 = /* @__PURE__ */ new Set(), this.map.set(e3, s3)), s3.add(t3);
+          }
+          delete(e3, t3) {
+            const s3 = this.map.get(e3);
+            s3 && (s3.delete(t3), 0 === s3.size && this.map.delete(e3));
+          }
+          forEach(e3, t3) {
+            const s3 = this.map.get(e3);
+            s3 && s3.forEach(t3);
+          }
+          get(e3) {
+            return this.map.get(e3) || /* @__PURE__ */ new Set();
+          }
+        };
+      }, 9725: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.StopWatch = void 0;
+        const s2 = globalThis.performance && "function" == typeof globalThis.performance.now;
+        class i2 {
+          static create(e3) {
+            return new i2(e3);
+          }
+          constructor(e3) {
+            this._now = s2 && false === e3 ? Date.now : globalThis.performance.now.bind(globalThis.performance), this._startTime = this._now(), this._stopTime = -1;
+          }
+          stop() {
+            this._stopTime = this._now();
+          }
+          reset() {
+            this._startTime = this._now(), this._stopTime = -1;
+          }
+          elapsed() {
+            return -1 !== this._stopTime ? this._stopTime - this._startTime : this._now() - this._startTime;
+          }
+        }
+        t2.StopWatch = i2;
+      } }, t = {};
+      function s(i2) {
+        var r2 = t[i2];
+        if (void 0 !== r2) return r2.exports;
+        var n2 = t[i2] = { exports: {} };
+        return e[i2].call(n2.exports, n2, n2.exports, s), n2.exports;
+      }
+      var i = {};
+      (() => {
+        var e2 = i;
+        Object.defineProperty(e2, "__esModule", { value: true }), e2.Terminal = void 0;
+        const t2 = s(5101), r2 = s(6097), n2 = s(4335), o = s(5856), a = s(3027), h = s(7150), c = ["cols", "rows"];
+        class l extends h.Disposable {
+          constructor(e3) {
+            super(), this._core = this._register(new o.Terminal(e3)), this._addonManager = this._register(new a.AddonManager()), this._publicOptions = { ...this._core.options };
+            const t3 = (e4) => this._core.options[e4], s2 = (e4, t4) => {
+              this._checkReadonlyOptions(e4), this._core.options[e4] = t4;
+            };
+            for (const e4 in this._core.options) {
+              Object.defineProperty(this._publicOptions, e4, { get: () => this._core.options[e4], set: (t4) => {
+                this._checkReadonlyOptions(e4), this._core.options[e4] = t4;
+              } });
+              const i2 = { get: t3.bind(this, e4), set: s2.bind(this, e4) };
+              Object.defineProperty(this._publicOptions, e4, i2);
+            }
+          }
+          _checkReadonlyOptions(e3) {
+            if (c.includes(e3)) throw new Error(`Option "${e3}" can only be set in the constructor`);
+          }
+          _checkProposedApi() {
+            if (!this._core.optionsService.options.allowProposedApi) throw new Error("You must set the allowProposedApi option to true to use proposed API");
+          }
+          get onBell() {
+            return this._core.onBell;
+          }
+          get onBinary() {
+            return this._core.onBinary;
+          }
+          get onCursorMove() {
+            return this._core.onCursorMove;
+          }
+          get onData() {
+            return this._core.onData;
+          }
+          get onLineFeed() {
+            return this._core.onLineFeed;
+          }
+          get onResize() {
+            return this._core.onResize;
+          }
+          get onScroll() {
+            return this._core.onScroll;
+          }
+          get onTitleChange() {
+            return this._core.onTitleChange;
+          }
+          get onWriteParsed() {
+            return this._core.onWriteParsed;
+          }
+          get parser() {
+            return this._checkProposedApi(), this._parser || (this._parser = new r2.ParserApi(this._core)), this._parser;
+          }
+          get unicode() {
+            return this._checkProposedApi(), new n2.UnicodeApi(this._core);
+          }
+          get rows() {
+            return this._core.rows;
+          }
+          get cols() {
+            return this._core.cols;
+          }
+          get buffer() {
+            return this._checkProposedApi(), this._buffer || (this._buffer = this._register(new t2.BufferNamespaceApi(this._core))), this._buffer;
+          }
+          get markers() {
+            return this._checkProposedApi(), this._core.markers;
+          }
+          get modes() {
+            const e3 = this._core.coreService.decPrivateModes;
+            let t3 = "none";
+            switch (this._core.coreMouseService.activeProtocol) {
+              case "X10":
+                t3 = "x10";
+                break;
+              case "VT200":
+                t3 = "vt200";
+                break;
+              case "DRAG":
+                t3 = "drag";
+                break;
+              case "ANY":
+                t3 = "any";
+            }
+            return { applicationCursorKeysMode: e3.applicationCursorKeys, applicationKeypadMode: e3.applicationKeypad, bracketedPasteMode: e3.bracketedPasteMode, insertMode: this._core.coreService.modes.insertMode, mouseTrackingMode: t3, originMode: e3.origin, reverseWraparoundMode: e3.reverseWraparound, sendFocusMode: e3.sendFocus, synchronizedOutputMode: e3.synchronizedOutput, wraparoundMode: e3.wraparound };
+          }
+          get options() {
+            return this._publicOptions;
+          }
+          set options(e3) {
+            for (const t3 in e3) this._publicOptions[t3] = e3[t3];
+          }
+          input(e3, t3 = true) {
+            this._core.input(e3, t3);
+          }
+          resize(e3, t3) {
+            this._verifyIntegers(e3, t3), this._core.resize(e3, t3);
+          }
+          registerMarker(e3 = 0) {
+            return this._checkProposedApi(), this._verifyIntegers(e3), this._core.addMarker(e3);
+          }
+          addMarker(e3) {
+            return this.registerMarker(e3);
+          }
+          dispose() {
+            super.dispose();
+          }
+          scrollLines(e3) {
+            this._verifyIntegers(e3), this._core.scrollLines(e3);
+          }
+          scrollPages(e3) {
+            this._verifyIntegers(e3), this._core.scrollPages(e3);
+          }
+          scrollToTop() {
+            this._core.scrollToTop();
+          }
+          scrollToBottom() {
+            this._core.scrollToBottom();
+          }
+          scrollToLine(e3) {
+            this._verifyIntegers(e3), this._core.scrollToLine(e3);
+          }
+          clear() {
+            this._core.clear();
+          }
+          write(e3, t3) {
+            this._core.write(e3, t3);
+          }
+          writeln(e3, t3) {
+            this._core.write(e3), this._core.write("\r\n", t3);
+          }
+          reset() {
+            this._core.reset();
+          }
+          loadAddon(e3) {
+            this._addonManager.loadAddon(this, e3);
+          }
+          _verifyIntegers(...e3) {
+            for (const t3 of e3) if (t3 === 1 / 0 || isNaN(t3) || t3 % 1 != 0) throw new Error("This API only accepts integers");
+          }
+        }
+        e2.Terminal = l;
+      })();
+      var r = exports;
+      for (var n in i) r[n] = i[n];
+      i.__esModule && Object.defineProperty(r, "__esModule", { value: true });
+    })();
+  }
+});
+
+// node_modules/.pnpm/@xterm+addon-unicode11@0.9.0/node_modules/@xterm/addon-unicode11/lib/addon-unicode11.js
+var require_addon_unicode11 = __commonJS({
+  "node_modules/.pnpm/@xterm+addon-unicode11@0.9.0/node_modules/@xterm/addon-unicode11/lib/addon-unicode11.js"(exports, module) {
+    !(function(e, t) {
+      "object" == typeof exports && "object" == typeof module ? module.exports = t() : "function" == typeof define && define.amd ? define([], t) : "object" == typeof exports ? exports.Unicode11Addon = t() : e.Unicode11Addon = t();
+    })(globalThis, (() => (() => {
+      "use strict";
+      var e = { 384: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.UnicodeV11 = void 0;
+        const r2 = s2(765), n = [[768, 879], [1155, 1161], [1425, 1469], [1471, 1471], [1473, 1474], [1476, 1477], [1479, 1479], [1536, 1541], [1552, 1562], [1564, 1564], [1611, 1631], [1648, 1648], [1750, 1757], [1759, 1764], [1767, 1768], [1770, 1773], [1807, 1807], [1809, 1809], [1840, 1866], [1958, 1968], [2027, 2035], [2045, 2045], [2070, 2073], [2075, 2083], [2085, 2087], [2089, 2093], [2137, 2139], [2259, 2306], [2362, 2362], [2364, 2364], [2369, 2376], [2381, 2381], [2385, 2391], [2402, 2403], [2433, 2433], [2492, 2492], [2497, 2500], [2509, 2509], [2530, 2531], [2558, 2558], [2561, 2562], [2620, 2620], [2625, 2626], [2631, 2632], [2635, 2637], [2641, 2641], [2672, 2673], [2677, 2677], [2689, 2690], [2748, 2748], [2753, 2757], [2759, 2760], [2765, 2765], [2786, 2787], [2810, 2815], [2817, 2817], [2876, 2876], [2879, 2879], [2881, 2884], [2893, 2893], [2902, 2902], [2914, 2915], [2946, 2946], [3008, 3008], [3021, 3021], [3072, 3072], [3076, 3076], [3134, 3136], [3142, 3144], [3146, 3149], [3157, 3158], [3170, 3171], [3201, 3201], [3260, 3260], [3263, 3263], [3270, 3270], [3276, 3277], [3298, 3299], [3328, 3329], [3387, 3388], [3393, 3396], [3405, 3405], [3426, 3427], [3530, 3530], [3538, 3540], [3542, 3542], [3633, 3633], [3636, 3642], [3655, 3662], [3761, 3761], [3764, 3772], [3784, 3789], [3864, 3865], [3893, 3893], [3895, 3895], [3897, 3897], [3953, 3966], [3968, 3972], [3974, 3975], [3981, 3991], [3993, 4028], [4038, 4038], [4141, 4144], [4146, 4151], [4153, 4154], [4157, 4158], [4184, 4185], [4190, 4192], [4209, 4212], [4226, 4226], [4229, 4230], [4237, 4237], [4253, 4253], [4448, 4607], [4957, 4959], [5906, 5908], [5938, 5940], [5970, 5971], [6002, 6003], [6068, 6069], [6071, 6077], [6086, 6086], [6089, 6099], [6109, 6109], [6155, 6158], [6277, 6278], [6313, 6313], [6432, 6434], [6439, 6440], [6450, 6450], [6457, 6459], [6679, 6680], [6683, 6683], [6742, 6742], [6744, 6750], [6752, 6752], [6754, 6754], [6757, 6764], [6771, 6780], [6783, 6783], [6832, 6846], [6912, 6915], [6964, 6964], [6966, 6970], [6972, 6972], [6978, 6978], [7019, 7027], [7040, 7041], [7074, 7077], [7080, 7081], [7083, 7085], [7142, 7142], [7144, 7145], [7149, 7149], [7151, 7153], [7212, 7219], [7222, 7223], [7376, 7378], [7380, 7392], [7394, 7400], [7405, 7405], [7412, 7412], [7416, 7417], [7616, 7673], [7675, 7679], [8203, 8207], [8234, 8238], [8288, 8292], [8294, 8303], [8400, 8432], [11503, 11505], [11647, 11647], [11744, 11775], [12330, 12333], [12441, 12442], [42607, 42610], [42612, 42621], [42654, 42655], [42736, 42737], [43010, 43010], [43014, 43014], [43019, 43019], [43045, 43046], [43204, 43205], [43232, 43249], [43263, 43263], [43302, 43309], [43335, 43345], [43392, 43394], [43443, 43443], [43446, 43449], [43452, 43453], [43493, 43493], [43561, 43566], [43569, 43570], [43573, 43574], [43587, 43587], [43596, 43596], [43644, 43644], [43696, 43696], [43698, 43700], [43703, 43704], [43710, 43711], [43713, 43713], [43756, 43757], [43766, 43766], [44005, 44005], [44008, 44008], [44013, 44013], [64286, 64286], [65024, 65039], [65056, 65071], [65279, 65279], [65529, 65531]], i = [[66045, 66045], [66272, 66272], [66422, 66426], [68097, 68099], [68101, 68102], [68108, 68111], [68152, 68154], [68159, 68159], [68325, 68326], [68900, 68903], [69446, 69456], [69633, 69633], [69688, 69702], [69759, 69761], [69811, 69814], [69817, 69818], [69821, 69821], [69837, 69837], [69888, 69890], [69927, 69931], [69933, 69940], [70003, 70003], [70016, 70017], [70070, 70078], [70089, 70092], [70191, 70193], [70196, 70196], [70198, 70199], [70206, 70206], [70367, 70367], [70371, 70378], [70400, 70401], [70459, 70460], [70464, 70464], [70502, 70508], [70512, 70516], [70712, 70719], [70722, 70724], [70726, 70726], [70750, 70750], [70835, 70840], [70842, 70842], [70847, 70848], [70850, 70851], [71090, 71093], [71100, 71101], [71103, 71104], [71132, 71133], [71219, 71226], [71229, 71229], [71231, 71232], [71339, 71339], [71341, 71341], [71344, 71349], [71351, 71351], [71453, 71455], [71458, 71461], [71463, 71467], [71727, 71735], [71737, 71738], [72148, 72151], [72154, 72155], [72160, 72160], [72193, 72202], [72243, 72248], [72251, 72254], [72263, 72263], [72273, 72278], [72281, 72283], [72330, 72342], [72344, 72345], [72752, 72758], [72760, 72765], [72767, 72767], [72850, 72871], [72874, 72880], [72882, 72883], [72885, 72886], [73009, 73014], [73018, 73018], [73020, 73021], [73023, 73029], [73031, 73031], [73104, 73105], [73109, 73109], [73111, 73111], [73459, 73460], [78896, 78904], [92912, 92916], [92976, 92982], [94031, 94031], [94095, 94098], [113821, 113822], [113824, 113827], [119143, 119145], [119155, 119170], [119173, 119179], [119210, 119213], [119362, 119364], [121344, 121398], [121403, 121452], [121461, 121461], [121476, 121476], [121499, 121503], [121505, 121519], [122880, 122886], [122888, 122904], [122907, 122913], [122915, 122916], [122918, 122922], [123184, 123190], [123628, 123631], [125136, 125142], [125252, 125258], [917505, 917505], [917536, 917631], [917760, 917999]], o = [[4352, 4447], [8986, 8987], [9001, 9002], [9193, 9196], [9200, 9200], [9203, 9203], [9725, 9726], [9748, 9749], [9800, 9811], [9855, 9855], [9875, 9875], [9889, 9889], [9898, 9899], [9917, 9918], [9924, 9925], [9934, 9934], [9940, 9940], [9962, 9962], [9970, 9971], [9973, 9973], [9978, 9978], [9981, 9981], [9989, 9989], [9994, 9995], [10024, 10024], [10060, 10060], [10062, 10062], [10067, 10069], [10071, 10071], [10133, 10135], [10160, 10160], [10175, 10175], [11035, 11036], [11088, 11088], [11093, 11093], [11904, 11929], [11931, 12019], [12032, 12245], [12272, 12283], [12288, 12329], [12334, 12350], [12353, 12438], [12443, 12543], [12549, 12591], [12593, 12686], [12688, 12730], [12736, 12771], [12784, 12830], [12832, 12871], [12880, 19903], [19968, 42124], [42128, 42182], [43360, 43388], [44032, 55203], [63744, 64255], [65040, 65049], [65072, 65106], [65108, 65126], [65128, 65131], [65281, 65376], [65504, 65510]], a = [[94176, 94179], [94208, 100343], [100352, 101106], [110592, 110878], [110928, 110930], [110948, 110951], [110960, 111355], [126980, 126980], [127183, 127183], [127374, 127374], [127377, 127386], [127488, 127490], [127504, 127547], [127552, 127560], [127568, 127569], [127584, 127589], [127744, 127776], [127789, 127797], [127799, 127868], [127870, 127891], [127904, 127946], [127951, 127955], [127968, 127984], [127988, 127988], [127992, 128062], [128064, 128064], [128066, 128252], [128255, 128317], [128331, 128334], [128336, 128359], [128378, 128378], [128405, 128406], [128420, 128420], [128507, 128591], [128640, 128709], [128716, 128716], [128720, 128722], [128725, 128725], [128747, 128748], [128756, 128762], [128992, 129003], [129293, 129393], [129395, 129398], [129402, 129442], [129445, 129450], [129454, 129482], [129485, 129535], [129648, 129651], [129656, 129658], [129664, 129666], [129680, 129685], [131072, 196605], [196608, 262141]];
+        let l;
+        function c(e3, t3) {
+          let s3, r3 = 0, n2 = t3.length - 1;
+          if (e3 < t3[0][0] || e3 > t3[n2][1]) return false;
+          for (; n2 >= r3; ) if (s3 = r3 + n2 >> 1, e3 > t3[s3][1]) r3 = s3 + 1;
+          else {
+            if (!(e3 < t3[s3][0])) return true;
+            n2 = s3 - 1;
+          }
+          return false;
+        }
+        t2.UnicodeV11 = class {
+          constructor() {
+            if (this.version = "11", !l) {
+              l = new Uint8Array(65536), l.fill(1), l[0] = 0, l.fill(0, 1, 32), l.fill(0, 127, 160);
+              for (let e3 = 0; e3 < n.length; ++e3) l.fill(0, n[e3][0], n[e3][1] + 1);
+              for (let e3 = 0; e3 < o.length; ++e3) l.fill(2, o[e3][0], o[e3][1] + 1);
+            }
+          }
+          wcwidth(e3) {
+            return e3 < 32 ? 0 : e3 < 127 ? 1 : e3 < 65536 ? l[e3] : c(e3, i) ? 0 : c(e3, a) ? 2 : 1;
+          }
+          charProperties(e3, t3) {
+            let s3 = this.wcwidth(e3), n2 = 0 === s3 && 0 !== t3;
+            if (n2) {
+              const e4 = r2.UnicodeService.extractWidth(t3);
+              0 === e4 ? n2 = false : e4 > s3 && (s3 = e4);
+            }
+            return r2.UnicodeService.createPropertyValue(0, s3, n2);
+          }
+        };
+      }, 546: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.UnicodeV6 = void 0;
+        const r2 = s2(765), n = [[768, 879], [1155, 1158], [1160, 1161], [1425, 1469], [1471, 1471], [1473, 1474], [1476, 1477], [1479, 1479], [1536, 1539], [1552, 1557], [1611, 1630], [1648, 1648], [1750, 1764], [1767, 1768], [1770, 1773], [1807, 1807], [1809, 1809], [1840, 1866], [1958, 1968], [2027, 2035], [2305, 2306], [2364, 2364], [2369, 2376], [2381, 2381], [2385, 2388], [2402, 2403], [2433, 2433], [2492, 2492], [2497, 2500], [2509, 2509], [2530, 2531], [2561, 2562], [2620, 2620], [2625, 2626], [2631, 2632], [2635, 2637], [2672, 2673], [2689, 2690], [2748, 2748], [2753, 2757], [2759, 2760], [2765, 2765], [2786, 2787], [2817, 2817], [2876, 2876], [2879, 2879], [2881, 2883], [2893, 2893], [2902, 2902], [2946, 2946], [3008, 3008], [3021, 3021], [3134, 3136], [3142, 3144], [3146, 3149], [3157, 3158], [3260, 3260], [3263, 3263], [3270, 3270], [3276, 3277], [3298, 3299], [3393, 3395], [3405, 3405], [3530, 3530], [3538, 3540], [3542, 3542], [3633, 3633], [3636, 3642], [3655, 3662], [3761, 3761], [3764, 3769], [3771, 3772], [3784, 3789], [3864, 3865], [3893, 3893], [3895, 3895], [3897, 3897], [3953, 3966], [3968, 3972], [3974, 3975], [3984, 3991], [3993, 4028], [4038, 4038], [4141, 4144], [4146, 4146], [4150, 4151], [4153, 4153], [4184, 4185], [4448, 4607], [4959, 4959], [5906, 5908], [5938, 5940], [5970, 5971], [6002, 6003], [6068, 6069], [6071, 6077], [6086, 6086], [6089, 6099], [6109, 6109], [6155, 6157], [6313, 6313], [6432, 6434], [6439, 6440], [6450, 6450], [6457, 6459], [6679, 6680], [6912, 6915], [6964, 6964], [6966, 6970], [6972, 6972], [6978, 6978], [7019, 7027], [7616, 7626], [7678, 7679], [8203, 8207], [8234, 8238], [8288, 8291], [8298, 8303], [8400, 8431], [12330, 12335], [12441, 12442], [43014, 43014], [43019, 43019], [43045, 43046], [64286, 64286], [65024, 65039], [65056, 65059], [65279, 65279], [65529, 65531]], i = [[68097, 68099], [68101, 68102], [68108, 68111], [68152, 68154], [68159, 68159], [119143, 119145], [119155, 119170], [119173, 119179], [119210, 119213], [119362, 119364], [917505, 917505], [917536, 917631], [917760, 917999]];
+        let o;
+        t2.UnicodeV6 = class {
+          constructor() {
+            if (this.version = "6", !o) {
+              o = new Uint8Array(65536), o.fill(1), o[0] = 0, o.fill(0, 1, 32), o.fill(0, 127, 160), o.fill(2, 4352, 4448), o[9001] = 2, o[9002] = 2, o.fill(2, 11904, 42192), o[12351] = 1, o.fill(2, 44032, 55204), o.fill(2, 63744, 64256), o.fill(2, 65040, 65050), o.fill(2, 65072, 65136), o.fill(2, 65280, 65377), o.fill(2, 65504, 65511);
+              for (let e3 = 0; e3 < n.length; ++e3) o.fill(0, n[e3][0], n[e3][1] + 1);
+            }
+          }
+          wcwidth(e3) {
+            return e3 < 32 ? 0 : e3 < 127 ? 1 : e3 < 65536 ? o[e3] : (function(e4, t3) {
+              let s3, r3 = 0, n2 = t3.length - 1;
+              if (e4 < t3[0][0] || e4 > t3[n2][1]) return false;
+              for (; n2 >= r3; ) if (s3 = r3 + n2 >> 1, e4 > t3[s3][1]) r3 = s3 + 1;
+              else {
+                if (!(e4 < t3[s3][0])) return true;
+                n2 = s3 - 1;
+              }
+              return false;
+            })(e3, i) ? 0 : e3 >= 131072 && e3 <= 196605 || e3 >= 196608 && e3 <= 262141 ? 2 : 1;
+          }
+          charProperties(e3, t3) {
+            let s3 = this.wcwidth(e3), n2 = 0 === s3 && 0 !== t3;
+            if (n2) {
+              const e4 = r2.UnicodeService.extractWidth(t3);
+              0 === e4 ? n2 = false : e4 > s3 && (s3 = e4);
+            }
+            return r2.UnicodeService.createPropertyValue(0, s3, n2);
+          }
+        };
+      }, 765: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.UnicodeService = void 0;
+        const r2 = s2(546), n = s2(276);
+        class i {
+          static extractShouldJoin(e3) {
+            return !!(1 & e3);
+          }
+          static extractWidth(e3) {
+            return e3 >> 1 & 3;
+          }
+          static extractCharKind(e3) {
+            return e3 >> 3;
+          }
+          static createPropertyValue(e3, t3, s3 = false) {
+            return (16777215 & e3) << 3 | (3 & t3) << 1 | (s3 ? 1 : 0);
+          }
+          constructor() {
+            this._providers = /* @__PURE__ */ Object.create(null), this._active = "", this._onChange = new n.Emitter(), this.onChange = this._onChange.event;
+            const e3 = new r2.UnicodeV6();
+            this.register(e3), this._active = e3.version, this._activeProvider = e3;
+          }
+          dispose() {
+            this._onChange.dispose();
+          }
+          get versions() {
+            return Object.keys(this._providers);
+          }
+          get activeVersion() {
+            return this._active;
+          }
+          set activeVersion(e3) {
+            if (!this._providers[e3]) throw new Error(`unknown Unicode version "${e3}"`);
+            this._active = e3, this._activeProvider = this._providers[e3], this._onChange.fire(e3);
+          }
+          register(e3) {
+            this._providers[e3.version] = e3;
+          }
+          wcwidth(e3) {
+            return this._activeProvider.wcwidth(e3);
+          }
+          getStringCellWidth(e3) {
+            let t3 = 0, s3 = 0;
+            const r3 = e3.length;
+            for (let n2 = 0; n2 < r3; ++n2) {
+              let o = e3.charCodeAt(n2);
+              if (55296 <= o && o <= 56319) {
+                if (++n2 >= r3) return t3 + this.wcwidth(o);
+                const s4 = e3.charCodeAt(n2);
+                56320 <= s4 && s4 <= 57343 ? o = 1024 * (o - 55296) + s4 - 56320 + 65536 : t3 += this.wcwidth(s4);
+              }
+              const a = this.charProperties(o, s3);
+              let l = i.extractWidth(a);
+              i.extractShouldJoin(a) && (l -= i.extractWidth(s3)), t3 += l, s3 = a;
+            }
+            return t3;
+          }
+          charProperties(e3, t3) {
+            return this._activeProvider.charProperties(e3, t3);
+          }
+        }
+        t2.UnicodeService = i;
+      }, 732: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.Permutation = t2.CallbackIterable = t2.ArrayQueue = t2.booleanComparator = t2.numberComparator = t2.CompareResult = void 0, t2.tail = function(e3, t3 = 0) {
+          return e3[e3.length - (1 + t3)];
+        }, t2.tail2 = function(e3) {
+          if (0 === e3.length) throw new Error("Invalid tail call");
+          return [e3.slice(0, e3.length - 1), e3[e3.length - 1]];
+        }, t2.equals = function(e3, t3, s3 = (e4, t4) => e4 === t4) {
+          if (e3 === t3) return true;
+          if (!e3 || !t3) return false;
+          if (e3.length !== t3.length) return false;
+          for (let r3 = 0, n2 = e3.length; r3 < n2; r3++) if (!s3(e3[r3], t3[r3])) return false;
+          return true;
+        }, t2.removeFastWithoutKeepingOrder = function(e3, t3) {
+          const s3 = e3.length - 1;
+          t3 < s3 && (e3[t3] = e3[s3]), e3.pop();
+        }, t2.binarySearch = function(e3, t3, s3) {
+          return i(e3.length, ((r3) => s3(e3[r3], t3)));
+        }, t2.binarySearch2 = i, t2.quickSelect = function e3(t3, s3, r3) {
+          if ((t3 |= 0) >= s3.length) throw new TypeError("invalid index");
+          const n2 = s3[Math.floor(s3.length * Math.random())], i2 = [], o2 = [], a2 = [];
+          for (const e4 of s3) {
+            const t4 = r3(e4, n2);
+            t4 < 0 ? i2.push(e4) : t4 > 0 ? o2.push(e4) : a2.push(e4);
+          }
+          return t3 < i2.length ? e3(t3, i2, r3) : t3 < i2.length + a2.length ? a2[0] : e3(t3 - (i2.length + a2.length), o2, r3);
+        }, t2.groupBy = function(e3, t3) {
+          const s3 = [];
+          let r3;
+          for (const n2 of e3.slice(0).sort(t3)) r3 && 0 === t3(r3[0], n2) ? r3.push(n2) : (r3 = [n2], s3.push(r3));
+          return s3;
+        }, t2.groupAdjacentBy = function* (e3, t3) {
+          let s3, r3;
+          for (const n2 of e3) void 0 !== r3 && t3(r3, n2) ? s3.push(n2) : (s3 && (yield s3), s3 = [n2]), r3 = n2;
+          s3 && (yield s3);
+        }, t2.forEachAdjacent = function(e3, t3) {
+          for (let s3 = 0; s3 <= e3.length; s3++) t3(0 === s3 ? void 0 : e3[s3 - 1], s3 === e3.length ? void 0 : e3[s3]);
+        }, t2.forEachWithNeighbors = function(e3, t3) {
+          for (let s3 = 0; s3 < e3.length; s3++) t3(0 === s3 ? void 0 : e3[s3 - 1], e3[s3], s3 + 1 === e3.length ? void 0 : e3[s3 + 1]);
+        }, t2.sortedDiff = o, t2.delta = function(e3, t3, s3) {
+          const r3 = o(e3, t3, s3), n2 = [], i2 = [];
+          for (const t4 of r3) n2.push(...e3.slice(t4.start, t4.start + t4.deleteCount)), i2.push(...t4.toInsert);
+          return { removed: n2, added: i2 };
+        }, t2.top = function(e3, t3, s3) {
+          if (0 === s3) return [];
+          const r3 = e3.slice(0, s3).sort(t3);
+          return a(e3, t3, r3, s3, e3.length), r3;
+        }, t2.topAsync = function(e3, t3, s3, n2, i2) {
+          return 0 === s3 ? Promise.resolve([]) : new Promise(((o2, l2) => {
+            (async () => {
+              const o3 = e3.length, l3 = e3.slice(0, s3).sort(t3);
+              for (let c2 = s3, h2 = Math.min(s3 + n2, o3); c2 < o3; c2 = h2, h2 = Math.min(h2 + n2, o3)) {
+                if (c2 > s3 && await new Promise(((e4) => setTimeout(e4))), i2 && i2.isCancellationRequested) throw new r2.CancellationError();
+                a(e3, t3, l3, c2, h2);
+              }
+              return l3;
+            })().then(o2, l2);
+          }));
+        }, t2.coalesce = function(e3) {
+          return e3.filter(((e4) => !!e4));
+        }, t2.coalesceInPlace = function(e3) {
+          let t3 = 0;
+          for (let s3 = 0; s3 < e3.length; s3++) e3[s3] && (e3[t3] = e3[s3], t3 += 1);
+          e3.length = t3;
+        }, t2.move = function(e3, t3, s3) {
+          e3.splice(s3, 0, e3.splice(t3, 1)[0]);
+        }, t2.isFalsyOrEmpty = function(e3) {
+          return !Array.isArray(e3) || 0 === e3.length;
+        }, t2.isNonEmptyArray = function(e3) {
+          return Array.isArray(e3) && e3.length > 0;
+        }, t2.distinct = function(e3, t3 = (e4) => e4) {
+          const s3 = /* @__PURE__ */ new Set();
+          return e3.filter(((e4) => {
+            const r3 = t3(e4);
+            return !s3.has(r3) && (s3.add(r3), true);
+          }));
+        }, t2.uniqueFilter = function(e3) {
+          const t3 = /* @__PURE__ */ new Set();
+          return (s3) => {
+            const r3 = e3(s3);
+            return !t3.has(r3) && (t3.add(r3), true);
+          };
+        }, t2.firstOrDefault = function(e3, t3) {
+          return e3.length > 0 ? e3[0] : t3;
+        }, t2.lastOrDefault = function(e3, t3) {
+          return e3.length > 0 ? e3[e3.length - 1] : t3;
+        }, t2.commonPrefixLength = function(e3, t3, s3 = (e4, t4) => e4 === t4) {
+          let r3 = 0;
+          for (let n2 = 0, i2 = Math.min(e3.length, t3.length); n2 < i2 && s3(e3[n2], t3[n2]); n2++) r3++;
+          return r3;
+        }, t2.range = function(e3, t3) {
+          let s3 = "number" == typeof t3 ? e3 : 0;
+          "number" == typeof t3 ? s3 = e3 : (s3 = 0, t3 = e3);
+          const r3 = [];
+          if (s3 <= t3) for (let e4 = s3; e4 < t3; e4++) r3.push(e4);
+          else for (let e4 = s3; e4 > t3; e4--) r3.push(e4);
+          return r3;
+        }, t2.index = function(e3, t3, s3) {
+          return e3.reduce(((e4, r3) => (e4[t3(r3)] = s3 ? s3(r3) : r3, e4)), /* @__PURE__ */ Object.create(null));
+        }, t2.insert = function(e3, t3) {
+          return e3.push(t3), () => l(e3, t3);
+        }, t2.remove = l, t2.arrayInsert = function(e3, t3, s3) {
+          const r3 = e3.slice(0, t3), n2 = e3.slice(t3);
+          return r3.concat(s3, n2);
+        }, t2.shuffle = function(e3, t3) {
+          let s3;
+          if ("number" == typeof t3) {
+            let e4 = t3;
+            s3 = () => {
+              const t4 = 179426549 * Math.sin(e4++);
+              return t4 - Math.floor(t4);
+            };
+          } else s3 = Math.random;
+          for (let t4 = e3.length - 1; t4 > 0; t4 -= 1) {
+            const r3 = Math.floor(s3() * (t4 + 1)), n2 = e3[t4];
+            e3[t4] = e3[r3], e3[r3] = n2;
+          }
+        }, t2.pushToStart = function(e3, t3) {
+          const s3 = e3.indexOf(t3);
+          s3 > -1 && (e3.splice(s3, 1), e3.unshift(t3));
+        }, t2.pushToEnd = function(e3, t3) {
+          const s3 = e3.indexOf(t3);
+          s3 > -1 && (e3.splice(s3, 1), e3.push(t3));
+        }, t2.pushMany = function(e3, t3) {
+          for (const s3 of t3) e3.push(s3);
+        }, t2.mapArrayOrNot = function(e3, t3) {
+          return Array.isArray(e3) ? e3.map(t3) : t3(e3);
+        }, t2.asArray = function(e3) {
+          return Array.isArray(e3) ? e3 : [e3];
+        }, t2.getRandomElement = function(e3) {
+          return e3[Math.floor(Math.random() * e3.length)];
+        }, t2.insertInto = c, t2.splice = function(e3, t3, s3, r3) {
+          const n2 = h(e3, t3);
+          let i2 = e3.splice(n2, s3);
+          return void 0 === i2 && (i2 = []), c(e3, n2, r3), i2;
+        }, t2.compareBy = function(e3, t3) {
+          return (s3, r3) => t3(e3(s3), e3(r3));
+        }, t2.tieBreakComparators = function(...e3) {
+          return (t3, s3) => {
+            for (const r3 of e3) {
+              const e4 = r3(t3, s3);
+              if (!u.isNeitherLessOrGreaterThan(e4)) return e4;
+            }
+            return u.neitherLessOrGreaterThan;
+          };
+        }, t2.reverseOrder = function(e3) {
+          return (t3, s3) => -e3(t3, s3);
+        };
+        const r2 = s2(577), n = s2(411);
+        function i(e3, t3) {
+          let s3 = 0, r3 = e3 - 1;
+          for (; s3 <= r3; ) {
+            const e4 = (s3 + r3) / 2 | 0, n2 = t3(e4);
+            if (n2 < 0) s3 = e4 + 1;
+            else {
+              if (!(n2 > 0)) return e4;
+              r3 = e4 - 1;
+            }
+          }
+          return -(s3 + 1);
+        }
+        function o(e3, t3, s3) {
+          const r3 = [];
+          function n2(e4, t4, s4) {
+            if (0 === t4 && 0 === s4.length) return;
+            const n3 = r3[r3.length - 1];
+            n3 && n3.start + n3.deleteCount === e4 ? (n3.deleteCount += t4, n3.toInsert.push(...s4)) : r3.push({ start: e4, deleteCount: t4, toInsert: s4 });
+          }
+          let i2 = 0, o2 = 0;
+          for (; ; ) {
+            if (i2 === e3.length) {
+              n2(i2, 0, t3.slice(o2));
+              break;
+            }
+            if (o2 === t3.length) {
+              n2(i2, e3.length - i2, []);
+              break;
+            }
+            const r4 = e3[i2], a2 = t3[o2], l2 = s3(r4, a2);
+            0 === l2 ? (i2 += 1, o2 += 1) : l2 < 0 ? (n2(i2, 1, []), i2 += 1) : l2 > 0 && (n2(i2, 0, [a2]), o2 += 1);
+          }
+          return r3;
+        }
+        function a(e3, t3, s3, r3, i2) {
+          for (const o2 = s3.length; r3 < i2; r3++) {
+            const i3 = e3[r3];
+            if (t3(i3, s3[o2 - 1]) < 0) {
+              s3.pop();
+              const e4 = (0, n.findFirstIdxMonotonousOrArrLen)(s3, ((e5) => t3(i3, e5) < 0));
+              s3.splice(e4, 0, i3);
+            }
+          }
+        }
+        function l(e3, t3) {
+          const s3 = e3.indexOf(t3);
+          if (s3 > -1) return e3.splice(s3, 1), t3;
+        }
+        function c(e3, t3, s3) {
+          const r3 = h(e3, t3), n2 = e3.length, i2 = s3.length;
+          e3.length = n2 + i2;
+          for (let t4 = n2 - 1; t4 >= r3; t4--) e3[t4 + i2] = e3[t4];
+          for (let t4 = 0; t4 < i2; t4++) e3[t4 + r3] = s3[t4];
+        }
+        function h(e3, t3) {
+          return t3 < 0 ? Math.max(t3 + e3.length, 0) : Math.min(t3, e3.length);
+        }
+        var u;
+        !(function(e3) {
+          e3.isLessThan = function(e4) {
+            return e4 < 0;
+          }, e3.isLessThanOrEqual = function(e4) {
+            return e4 <= 0;
+          }, e3.isGreaterThan = function(e4) {
+            return e4 > 0;
+          }, e3.isNeitherLessOrGreaterThan = function(e4) {
+            return 0 === e4;
+          }, e3.greaterThan = 1, e3.lessThan = -1, e3.neitherLessOrGreaterThan = 0;
+        })(u || (t2.CompareResult = u = {})), t2.numberComparator = (e3, t3) => e3 - t3, t2.booleanComparator = (e3, s3) => (0, t2.numberComparator)(e3 ? 1 : 0, s3 ? 1 : 0), t2.ArrayQueue = class {
+          constructor(e3) {
+            this.items = e3, this.firstIdx = 0, this.lastIdx = this.items.length - 1;
+          }
+          get length() {
+            return this.lastIdx - this.firstIdx + 1;
+          }
+          takeWhile(e3) {
+            let t3 = this.firstIdx;
+            for (; t3 < this.items.length && e3(this.items[t3]); ) t3++;
+            const s3 = t3 === this.firstIdx ? null : this.items.slice(this.firstIdx, t3);
+            return this.firstIdx = t3, s3;
+          }
+          takeFromEndWhile(e3) {
+            let t3 = this.lastIdx;
+            for (; t3 >= 0 && e3(this.items[t3]); ) t3--;
+            const s3 = t3 === this.lastIdx ? null : this.items.slice(t3 + 1, this.lastIdx + 1);
+            return this.lastIdx = t3, s3;
+          }
+          peek() {
+            if (0 !== this.length) return this.items[this.firstIdx];
+          }
+          peekLast() {
+            if (0 !== this.length) return this.items[this.lastIdx];
+          }
+          dequeue() {
+            const e3 = this.items[this.firstIdx];
+            return this.firstIdx++, e3;
+          }
+          removeLast() {
+            const e3 = this.items[this.lastIdx];
+            return this.lastIdx--, e3;
+          }
+          takeCount(e3) {
+            const t3 = this.items.slice(this.firstIdx, this.firstIdx + e3);
+            return this.firstIdx += e3, t3;
+          }
+        };
+        class d {
+          static {
+            this.empty = new d(((e3) => {
+            }));
+          }
+          constructor(e3) {
+            this.iterate = e3;
+          }
+          forEach(e3) {
+            this.iterate(((t3) => (e3(t3), true)));
+          }
+          toArray() {
+            const e3 = [];
+            return this.iterate(((t3) => (e3.push(t3), true))), e3;
+          }
+          filter(e3) {
+            return new d(((t3) => this.iterate(((s3) => !e3(s3) || t3(s3)))));
+          }
+          map(e3) {
+            return new d(((t3) => this.iterate(((s3) => t3(e3(s3))))));
+          }
+          some(e3) {
+            let t3 = false;
+            return this.iterate(((s3) => (t3 = e3(s3), !t3))), t3;
+          }
+          findFirst(e3) {
+            let t3;
+            return this.iterate(((s3) => !e3(s3) || (t3 = s3, false))), t3;
+          }
+          findLast(e3) {
+            let t3;
+            return this.iterate(((s3) => (e3(s3) && (t3 = s3), true))), t3;
+          }
+          findLastMaxBy(e3) {
+            let t3, s3 = true;
+            return this.iterate(((r3) => ((s3 || u.isGreaterThan(e3(r3, t3))) && (s3 = false, t3 = r3), true))), t3;
+          }
+        }
+        t2.CallbackIterable = d;
+        class f {
+          constructor(e3) {
+            this._indexMap = e3;
+          }
+          static createSortPermutation(e3, t3) {
+            const s3 = Array.from(e3.keys()).sort(((s4, r3) => t3(e3[s4], e3[r3])));
+            return new f(s3);
+          }
+          apply(e3) {
+            return e3.map(((t3, s3) => e3[this._indexMap[s3]]));
+          }
+          inverse() {
+            const e3 = this._indexMap.slice();
+            for (let t3 = 0; t3 < this._indexMap.length; t3++) e3[this._indexMap[t3]] = t3;
+            return new f(e3);
+          }
+        }
+        t2.Permutation = f;
+      }, 411: (e2, t2) => {
+        function s2(e3, t3, s3 = e3.length - 1) {
+          for (let r3 = s3; r3 >= 0; r3--) if (t3(e3[r3])) return r3;
+          return -1;
+        }
+        function r2(e3, t3, s3 = 0, r3 = e3.length) {
+          let n2 = s3, i2 = r3;
+          for (; n2 < i2; ) {
+            const s4 = Math.floor((n2 + i2) / 2);
+            t3(e3[s4]) ? n2 = s4 + 1 : i2 = s4;
+          }
+          return n2 - 1;
+        }
+        function n(e3, t3, s3 = 0, r3 = e3.length) {
+          let n2 = s3, i2 = r3;
+          for (; n2 < i2; ) {
+            const s4 = Math.floor((n2 + i2) / 2);
+            t3(e3[s4]) ? i2 = s4 : n2 = s4 + 1;
+          }
+          return n2;
+        }
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.MonotonousArray = void 0, t2.findLast = function(e3, t3) {
+          const r3 = s2(e3, t3);
+          if (-1 !== r3) return e3[r3];
+        }, t2.findLastIdx = s2, t2.findLastMonotonous = function(e3, t3) {
+          const s3 = r2(e3, t3);
+          return -1 === s3 ? void 0 : e3[s3];
+        }, t2.findLastIdxMonotonous = r2, t2.findFirstMonotonous = function(e3, t3) {
+          const s3 = n(e3, t3);
+          return s3 === e3.length ? void 0 : e3[s3];
+        }, t2.findFirstIdxMonotonousOrArrLen = n, t2.findFirstIdxMonotonous = function(e3, t3, s3 = 0, r3 = e3.length) {
+          const i2 = n(e3, t3, s3, r3);
+          return i2 === e3.length ? -1 : i2;
+        }, t2.findFirstMax = o, t2.findLastMax = function(e3, t3) {
+          if (0 === e3.length) return;
+          let s3 = e3[0];
+          for (let r3 = 1; r3 < e3.length; r3++) {
+            const n2 = e3[r3];
+            t3(n2, s3) >= 0 && (s3 = n2);
+          }
+          return s3;
+        }, t2.findFirstMin = function(e3, t3) {
+          return o(e3, ((e4, s3) => -t3(e4, s3)));
+        }, t2.findMaxIdx = function(e3, t3) {
+          if (0 === e3.length) return -1;
+          let s3 = 0;
+          for (let r3 = 1; r3 < e3.length; r3++) t3(e3[r3], e3[s3]) > 0 && (s3 = r3);
+          return s3;
+        }, t2.mapFindFirst = function(e3, t3) {
+          for (const s3 of e3) {
+            const e4 = t3(s3);
+            if (void 0 !== e4) return e4;
+          }
+        };
+        class i {
+          static {
+            this.assertInvariants = false;
+          }
+          constructor(e3) {
+            this._array = e3, this._findLastMonotonousLastIdx = 0;
+          }
+          findLastMonotonous(e3) {
+            if (i.assertInvariants) {
+              if (this._prevFindLastPredicate) {
+                for (const t4 of this._array) if (this._prevFindLastPredicate(t4) && !e3(t4)) throw new Error("MonotonousArray: current predicate must be weaker than (or equal to) the previous predicate.");
+              }
+              this._prevFindLastPredicate = e3;
+            }
+            const t3 = r2(this._array, e3, this._findLastMonotonousLastIdx);
+            return this._findLastMonotonousLastIdx = t3 + 1, -1 === t3 ? void 0 : this._array[t3];
+          }
+        }
+        function o(e3, t3) {
+          if (0 === e3.length) return;
+          let s3 = e3[0];
+          for (let r3 = 1; r3 < e3.length; r3++) {
+            const n2 = e3[r3];
+            t3(n2, s3) > 0 && (s3 = n2);
+          }
+          return s3;
+        }
+        t2.MonotonousArray = i;
+      }, 33: (e2, t2) => {
+        var s2;
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.SetWithKey = void 0, t2.groupBy = function(e3, t3) {
+          const s3 = /* @__PURE__ */ Object.create(null);
+          for (const r3 of e3) {
+            const e4 = t3(r3);
+            let n = s3[e4];
+            n || (n = s3[e4] = []), n.push(r3);
+          }
+          return s3;
+        }, t2.diffSets = function(e3, t3) {
+          const s3 = [], r3 = [];
+          for (const r4 of e3) t3.has(r4) || s3.push(r4);
+          for (const s4 of t3) e3.has(s4) || r3.push(s4);
+          return { removed: s3, added: r3 };
+        }, t2.diffMaps = function(e3, t3) {
+          const s3 = [], r3 = [];
+          for (const [r4, n] of e3) t3.has(r4) || s3.push(n);
+          for (const [s4, n] of t3) e3.has(s4) || r3.push(n);
+          return { removed: s3, added: r3 };
+        }, t2.intersection = function(e3, t3) {
+          const s3 = /* @__PURE__ */ new Set();
+          for (const r3 of t3) e3.has(r3) && s3.add(r3);
+          return s3;
+        };
+        class r2 {
+          static {
+            s2 = Symbol.toStringTag;
+          }
+          constructor(e3, t3) {
+            this.toKey = t3, this._map = /* @__PURE__ */ new Map(), this[s2] = "SetWithKey";
+            for (const t4 of e3) this.add(t4);
+          }
+          get size() {
+            return this._map.size;
+          }
+          add(e3) {
+            const t3 = this.toKey(e3);
+            return this._map.set(t3, e3), this;
+          }
+          delete(e3) {
+            return this._map.delete(this.toKey(e3));
+          }
+          has(e3) {
+            return this._map.has(this.toKey(e3));
+          }
+          *entries() {
+            for (const e3 of this._map.values()) yield [e3, e3];
+          }
+          keys() {
+            return this.values();
+          }
+          *values() {
+            for (const e3 of this._map.values()) yield e3;
+          }
+          clear() {
+            this._map.clear();
+          }
+          forEach(e3, t3) {
+            this._map.forEach(((s3) => e3.call(t3, s3, s3, this)));
+          }
+          [Symbol.iterator]() {
+            return this.values();
+          }
+        }
+        t2.SetWithKey = r2;
+      }, 577: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.BugIndicatingError = t2.ErrorNoTelemetry = t2.ExpectedError = t2.NotSupportedError = t2.NotImplementedError = t2.ReadonlyError = t2.CancellationError = t2.errorHandler = t2.ErrorHandler = void 0, t2.setUnexpectedErrorHandler = function(e3) {
+          t2.errorHandler.setUnexpectedErrorHandler(e3);
+        }, t2.isSigPipeError = function(e3) {
+          if (!e3 || "object" != typeof e3) return false;
+          const t3 = e3;
+          return "EPIPE" === t3.code && "WRITE" === t3.syscall?.toUpperCase();
+        }, t2.onUnexpectedError = function(e3) {
+          n(e3) || t2.errorHandler.onUnexpectedError(e3);
+        }, t2.onUnexpectedExternalError = function(e3) {
+          n(e3) || t2.errorHandler.onUnexpectedExternalError(e3);
+        }, t2.transformErrorForSerialization = function(e3) {
+          if (e3 instanceof Error) {
+            const { name: t3, message: s3 } = e3;
+            return { $isError: true, name: t3, message: s3, stack: e3.stacktrace || e3.stack, noTelemetry: h.isErrorNoTelemetry(e3) };
+          }
+          return e3;
+        }, t2.transformErrorFromSerialization = function(e3) {
+          let t3;
+          return e3.noTelemetry ? t3 = new h() : (t3 = new Error(), t3.name = e3.name), t3.message = e3.message, t3.stack = e3.stack, t3;
+        }, t2.isCancellationError = n, t2.canceled = function() {
+          const e3 = new Error(r2);
+          return e3.name = e3.message, e3;
+        }, t2.illegalArgument = function(e3) {
+          return e3 ? new Error(`Illegal argument: ${e3}`) : new Error("Illegal argument");
+        }, t2.illegalState = function(e3) {
+          return e3 ? new Error(`Illegal state: ${e3}`) : new Error("Illegal state");
+        }, t2.getErrorMessage = function(e3) {
+          return e3 ? e3.message ? e3.message : e3.stack ? e3.stack.split("\n")[0] : String(e3) : "Error";
+        };
+        class s2 {
+          constructor() {
+            this.listeners = [], this.unexpectedErrorHandler = function(e3) {
+              setTimeout((() => {
+                if (e3.stack) {
+                  if (h.isErrorNoTelemetry(e3)) throw new h(e3.message + "\n\n" + e3.stack);
+                  throw new Error(e3.message + "\n\n" + e3.stack);
+                }
+                throw e3;
+              }), 0);
+            };
+          }
+          addListener(e3) {
+            return this.listeners.push(e3), () => {
+              this._removeListener(e3);
+            };
+          }
+          emit(e3) {
+            this.listeners.forEach(((t3) => {
+              t3(e3);
+            }));
+          }
+          _removeListener(e3) {
+            this.listeners.splice(this.listeners.indexOf(e3), 1);
+          }
+          setUnexpectedErrorHandler(e3) {
+            this.unexpectedErrorHandler = e3;
+          }
+          getUnexpectedErrorHandler() {
+            return this.unexpectedErrorHandler;
+          }
+          onUnexpectedError(e3) {
+            this.unexpectedErrorHandler(e3), this.emit(e3);
+          }
+          onUnexpectedExternalError(e3) {
+            this.unexpectedErrorHandler(e3);
+          }
+        }
+        t2.ErrorHandler = s2, t2.errorHandler = new s2();
+        const r2 = "Canceled";
+        function n(e3) {
+          return e3 instanceof i || e3 instanceof Error && e3.name === r2 && e3.message === r2;
+        }
+        class i extends Error {
+          constructor() {
+            super(r2), this.name = this.message;
+          }
+        }
+        t2.CancellationError = i;
+        class o extends TypeError {
+          constructor(e3) {
+            super(e3 ? `${e3} is read-only and cannot be changed` : "Cannot change read-only property");
+          }
+        }
+        t2.ReadonlyError = o;
+        class a extends Error {
+          constructor(e3) {
+            super("NotImplemented"), e3 && (this.message = e3);
+          }
+        }
+        t2.NotImplementedError = a;
+        class l extends Error {
+          constructor(e3) {
+            super("NotSupported"), e3 && (this.message = e3);
+          }
+        }
+        t2.NotSupportedError = l;
+        class c extends Error {
+          constructor() {
+            super(...arguments), this.isExpected = true;
+          }
+        }
+        t2.ExpectedError = c;
+        class h extends Error {
+          constructor(e3) {
+            super(e3), this.name = "CodeExpectedError";
+          }
+          static fromError(e3) {
+            if (e3 instanceof h) return e3;
+            const t3 = new h();
+            return t3.message = e3.message, t3.stack = e3.stack, t3;
+          }
+          static isErrorNoTelemetry(e3) {
+            return "CodeExpectedError" === e3.name;
+          }
+        }
+        t2.ErrorNoTelemetry = h;
+        class u extends Error {
+          constructor(e3) {
+            super(e3 || "An unexpected bug occurred."), Object.setPrototypeOf(this, u.prototype);
+          }
+        }
+        t2.BugIndicatingError = u;
+      }, 276: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.ValueWithChangeEvent = t2.Relay = t2.EventBufferer = t2.DynamicListEventMultiplexer = t2.EventMultiplexer = t2.MicrotaskEmitter = t2.DebounceEmitter = t2.PauseableEmitter = t2.AsyncEmitter = t2.createEventDeliveryQueue = t2.Emitter = t2.ListenerRefusalError = t2.ListenerLeakError = t2.EventProfiling = t2.Event = void 0, t2.setGlobalLeakWarningThreshold = function(e3) {
+          const t3 = h;
+          return h = e3, { dispose() {
+            h = t3;
+          } };
+        };
+        const r2 = s2(577), n = s2(355), i = s2(540), o = s2(711), a = s2(79);
+        var l;
+        !(function(e3) {
+          function t3(e4) {
+            return (t4, s4 = null, r4) => {
+              let n3, i2 = false;
+              return n3 = e4(((e5) => {
+                if (!i2) return n3 ? n3.dispose() : i2 = true, t4.call(s4, e5);
+              }), null, r4), i2 && n3.dispose(), n3;
+            };
+          }
+          function s3(e4, t4, s4) {
+            return n2(((s5, r4 = null, n3) => e4(((e5) => s5.call(r4, t4(e5))), null, n3)), s4);
+          }
+          function r3(e4, t4, s4) {
+            return n2(((s5, r4 = null, n3) => e4(((e5) => t4(e5) && s5.call(r4, e5)), null, n3)), s4);
+          }
+          function n2(e4, t4) {
+            let s4;
+            const r4 = new m({ onWillAddFirstListener() {
+              s4 = e4(r4.fire, r4);
+            }, onDidRemoveLastListener() {
+              s4?.dispose();
+            } });
+            return t4?.add(r4), r4.event;
+          }
+          function o2(e4, t4, s4 = 100, r4 = false, n3 = false, i2, o3) {
+            let a3, l3, c3, h2, u2 = 0;
+            const d2 = new m({ leakWarningThreshold: i2, onWillAddFirstListener() {
+              a3 = e4(((e5) => {
+                u2++, l3 = t4(l3, e5), r4 && !c3 && (d2.fire(l3), l3 = void 0), h2 = () => {
+                  const e6 = l3;
+                  l3 = void 0, c3 = void 0, (!r4 || u2 > 1) && d2.fire(e6), u2 = 0;
+                }, "number" == typeof s4 ? (clearTimeout(c3), c3 = setTimeout(h2, s4)) : void 0 === c3 && (c3 = 0, queueMicrotask(h2));
+              }));
+            }, onWillRemoveListener() {
+              n3 && u2 > 0 && h2?.();
+            }, onDidRemoveLastListener() {
+              h2 = void 0, a3.dispose();
+            } });
+            return o3?.add(d2), d2.event;
+          }
+          e3.None = () => i.Disposable.None, e3.defer = function(e4, t4) {
+            return o2(e4, (() => {
+            }), 0, void 0, true, void 0, t4);
+          }, e3.once = t3, e3.map = s3, e3.forEach = function(e4, t4, s4) {
+            return n2(((s5, r4 = null, n3) => e4(((e5) => {
+              t4(e5), s5.call(r4, e5);
+            }), null, n3)), s4);
+          }, e3.filter = r3, e3.signal = function(e4) {
+            return e4;
+          }, e3.any = function(...e4) {
+            return (t4, s4 = null, r4) => {
+              return n3 = (0, i.combinedDisposable)(...e4.map(((e5) => e5(((e6) => t4.call(s4, e6)))))), (o3 = r4) instanceof Array ? o3.push(n3) : o3 && o3.add(n3), n3;
+              var n3, o3;
+            };
+          }, e3.reduce = function(e4, t4, r4, n3) {
+            let i2 = r4;
+            return s3(e4, ((e5) => (i2 = t4(i2, e5), i2)), n3);
+          }, e3.debounce = o2, e3.accumulate = function(t4, s4 = 0, r4) {
+            return e3.debounce(t4, ((e4, t5) => e4 ? (e4.push(t5), e4) : [t5]), s4, void 0, true, void 0, r4);
+          }, e3.latch = function(e4, t4 = (e5, t5) => e5 === t5, s4) {
+            let n3, i2 = true;
+            return r3(e4, ((e5) => {
+              const s5 = i2 || !t4(e5, n3);
+              return i2 = false, n3 = e5, s5;
+            }), s4);
+          }, e3.split = function(t4, s4, r4) {
+            return [e3.filter(t4, s4, r4), e3.filter(t4, ((e4) => !s4(e4)), r4)];
+          }, e3.buffer = function(e4, t4 = false, s4 = [], r4) {
+            let n3 = s4.slice(), i2 = e4(((e5) => {
+              n3 ? n3.push(e5) : a3.fire(e5);
+            }));
+            r4 && r4.add(i2);
+            const o3 = () => {
+              n3?.forEach(((e5) => a3.fire(e5))), n3 = null;
+            }, a3 = new m({ onWillAddFirstListener() {
+              i2 || (i2 = e4(((e5) => a3.fire(e5))), r4 && r4.add(i2));
+            }, onDidAddFirstListener() {
+              n3 && (t4 ? setTimeout(o3) : o3());
+            }, onDidRemoveLastListener() {
+              i2 && i2.dispose(), i2 = null;
+            } });
+            return r4 && r4.add(a3), a3.event;
+          }, e3.chain = function(e4, t4) {
+            return (s4, r4, n3) => {
+              const i2 = t4(new l2());
+              return e4((function(e5) {
+                const t5 = i2.evaluate(e5);
+                t5 !== a2 && s4.call(r4, t5);
+              }), void 0, n3);
+            };
+          };
+          const a2 = /* @__PURE__ */ Symbol("HaltChainable");
+          class l2 {
+            constructor() {
+              this.steps = [];
+            }
+            map(e4) {
+              return this.steps.push(e4), this;
+            }
+            forEach(e4) {
+              return this.steps.push(((t4) => (e4(t4), t4))), this;
+            }
+            filter(e4) {
+              return this.steps.push(((t4) => e4(t4) ? t4 : a2)), this;
+            }
+            reduce(e4, t4) {
+              let s4 = t4;
+              return this.steps.push(((t5) => (s4 = e4(s4, t5), s4))), this;
+            }
+            latch(e4 = (e5, t4) => e5 === t4) {
+              let t4, s4 = true;
+              return this.steps.push(((r4) => {
+                const n3 = s4 || !e4(r4, t4);
+                return s4 = false, t4 = r4, n3 ? r4 : a2;
+              })), this;
+            }
+            evaluate(e4) {
+              for (const t4 of this.steps) if ((e4 = t4(e4)) === a2) break;
+              return e4;
+            }
+          }
+          e3.fromNodeEventEmitter = function(e4, t4, s4 = (e5) => e5) {
+            const r4 = (...e5) => n3.fire(s4(...e5)), n3 = new m({ onWillAddFirstListener: () => e4.on(t4, r4), onDidRemoveLastListener: () => e4.removeListener(t4, r4) });
+            return n3.event;
+          }, e3.fromDOMEventEmitter = function(e4, t4, s4 = (e5) => e5) {
+            const r4 = (...e5) => n3.fire(s4(...e5)), n3 = new m({ onWillAddFirstListener: () => e4.addEventListener(t4, r4), onDidRemoveLastListener: () => e4.removeEventListener(t4, r4) });
+            return n3.event;
+          }, e3.toPromise = function(e4) {
+            return new Promise(((s4) => t3(e4)(s4)));
+          }, e3.fromPromise = function(e4) {
+            const t4 = new m();
+            return e4.then(((e5) => {
+              t4.fire(e5);
+            }), (() => {
+              t4.fire(void 0);
+            })).finally((() => {
+              t4.dispose();
+            })), t4.event;
+          }, e3.forward = function(e4, t4) {
+            return e4(((e5) => t4.fire(e5)));
+          }, e3.runAndSubscribe = function(e4, t4, s4) {
+            return t4(s4), e4(((e5) => t4(e5)));
+          };
+          class c2 {
+            constructor(e4, t4) {
+              this._observable = e4, this._counter = 0, this._hasChanged = false;
+              const s4 = { onWillAddFirstListener: () => {
+                e4.addObserver(this);
+              }, onDidRemoveLastListener: () => {
+                e4.removeObserver(this);
+              } };
+              this.emitter = new m(s4), t4 && t4.add(this.emitter);
+            }
+            beginUpdate(e4) {
+              this._counter++;
+            }
+            handlePossibleChange(e4) {
+            }
+            handleChange(e4, t4) {
+              this._hasChanged = true;
+            }
+            endUpdate(e4) {
+              this._counter--, 0 === this._counter && (this._observable.reportChanges(), this._hasChanged && (this._hasChanged = false, this.emitter.fire(this._observable.get())));
+            }
+          }
+          e3.fromObservable = function(e4, t4) {
+            return new c2(e4, t4).emitter.event;
+          }, e3.fromObservableLight = function(e4) {
+            return (t4, s4, r4) => {
+              let n3 = 0, o3 = false;
+              const a3 = { beginUpdate() {
+                n3++;
+              }, endUpdate() {
+                n3--, 0 === n3 && (e4.reportChanges(), o3 && (o3 = false, t4.call(s4)));
+              }, handlePossibleChange() {
+              }, handleChange() {
+                o3 = true;
+              } };
+              e4.addObserver(a3), e4.reportChanges();
+              const l3 = { dispose() {
+                e4.removeObserver(a3);
+              } };
+              return r4 instanceof i.DisposableStore ? r4.add(l3) : Array.isArray(r4) && r4.push(l3), l3;
+            };
+          };
+        })(l || (t2.Event = l = {}));
+        class c {
+          static {
+            this.all = /* @__PURE__ */ new Set();
+          }
+          static {
+            this._idPool = 0;
+          }
+          constructor(e3) {
+            this.listenerCount = 0, this.invocationCount = 0, this.elapsedOverall = 0, this.durations = [], this.name = `${e3}_${c._idPool++}`, c.all.add(this);
+          }
+          start(e3) {
+            this._stopWatch = new a.StopWatch(), this.listenerCount = e3;
+          }
+          stop() {
+            if (this._stopWatch) {
+              const e3 = this._stopWatch.elapsed();
+              this.durations.push(e3), this.elapsedOverall += e3, this.invocationCount += 1, this._stopWatch = void 0;
+            }
+          }
+        }
+        t2.EventProfiling = c;
+        let h = -1;
+        class u {
+          static {
+            this._idPool = 1;
+          }
+          constructor(e3, t3, s3 = (u._idPool++).toString(16).padStart(3, "0")) {
+            this._errorHandler = e3, this.threshold = t3, this.name = s3, this._warnCountdown = 0;
+          }
+          dispose() {
+            this._stacks?.clear();
+          }
+          check(e3, t3) {
+            const s3 = this.threshold;
+            if (s3 <= 0 || t3 < s3) return;
+            this._stacks || (this._stacks = /* @__PURE__ */ new Map());
+            const r3 = this._stacks.get(e3.value) || 0;
+            if (this._stacks.set(e3.value, r3 + 1), this._warnCountdown -= 1, this._warnCountdown <= 0) {
+              this._warnCountdown = 0.5 * s3;
+              const [e4, r4] = this.getMostFrequentStack(), n2 = `[${this.name}] potential listener LEAK detected, having ${t3} listeners already. MOST frequent listener (${r4}):`;
+              console.warn(n2), console.warn(e4);
+              const i2 = new f(n2, e4);
+              this._errorHandler(i2);
+            }
+            return () => {
+              const t4 = this._stacks.get(e3.value) || 0;
+              this._stacks.set(e3.value, t4 - 1);
+            };
+          }
+          getMostFrequentStack() {
+            if (!this._stacks) return;
+            let e3, t3 = 0;
+            for (const [s3, r3] of this._stacks) (!e3 || t3 < r3) && (e3 = [s3, r3], t3 = r3);
+            return e3;
+          }
+        }
+        class d {
+          static create() {
+            const e3 = new Error();
+            return new d(e3.stack ?? "");
+          }
+          constructor(e3) {
+            this.value = e3;
+          }
+          print() {
+            console.warn(this.value.split("\n").slice(2).join("\n"));
+          }
+        }
+        class f extends Error {
+          constructor(e3, t3) {
+            super(e3), this.name = "ListenerLeakError", this.stack = t3;
+          }
+        }
+        t2.ListenerLeakError = f;
+        class p extends Error {
+          constructor(e3, t3) {
+            super(e3), this.name = "ListenerRefusalError", this.stack = t3;
+          }
+        }
+        t2.ListenerRefusalError = p;
+        let _ = 0;
+        class v {
+          constructor(e3) {
+            this.value = e3, this.id = _++;
+          }
+        }
+        class m {
+          constructor(e3) {
+            this._size = 0, this._options = e3, this._leakageMon = h > 0 || this._options?.leakWarningThreshold ? new u(e3?.onListenerError ?? r2.onUnexpectedError, this._options?.leakWarningThreshold ?? h) : void 0, this._perfMon = this._options?._profName ? new c(this._options._profName) : void 0, this._deliveryQueue = this._options?.deliveryQueue;
+          }
+          dispose() {
+            this._disposed || (this._disposed = true, this._deliveryQueue?.current === this && this._deliveryQueue.reset(), this._listeners && (this._listeners = void 0, this._size = 0), this._options?.onDidRemoveLastListener?.(), this._leakageMon?.dispose());
+          }
+          get event() {
+            return this._event ??= (e3, t3, s3) => {
+              if (this._leakageMon && this._size > this._leakageMon.threshold ** 2) {
+                const e4 = `[${this._leakageMon.name}] REFUSES to accept new listeners because it exceeded its threshold by far (${this._size} vs ${this._leakageMon.threshold})`;
+                console.warn(e4);
+                const t4 = this._leakageMon.getMostFrequentStack() ?? ["UNKNOWN stack", -1], s4 = new p(`${e4}. HINT: Stack shows most frequent listener (${t4[1]}-times)`, t4[0]);
+                return (this._options?.onListenerError || r2.onUnexpectedError)(s4), i.Disposable.None;
+              }
+              if (this._disposed) return i.Disposable.None;
+              t3 && (e3 = e3.bind(t3));
+              const n2 = new v(e3);
+              let o2;
+              this._leakageMon && this._size >= Math.ceil(0.2 * this._leakageMon.threshold) && (n2.stack = d.create(), o2 = this._leakageMon.check(n2.stack, this._size + 1)), this._listeners ? this._listeners instanceof v ? (this._deliveryQueue ??= new g(), this._listeners = [this._listeners, n2]) : this._listeners.push(n2) : (this._options?.onWillAddFirstListener?.(this), this._listeners = n2, this._options?.onDidAddFirstListener?.(this)), this._size++;
+              const a2 = (0, i.toDisposable)((() => {
+                o2?.(), this._removeListener(n2);
+              }));
+              return s3 instanceof i.DisposableStore ? s3.add(a2) : Array.isArray(s3) && s3.push(a2), a2;
+            }, this._event;
+          }
+          _removeListener(e3) {
+            if (this._options?.onWillRemoveListener?.(this), !this._listeners) return;
+            if (1 === this._size) return this._listeners = void 0, this._options?.onDidRemoveLastListener?.(this), void (this._size = 0);
+            const t3 = this._listeners, s3 = t3.indexOf(e3);
+            if (-1 === s3) throw console.log("disposed?", this._disposed), console.log("size?", this._size), console.log("arr?", JSON.stringify(this._listeners)), new Error("Attempted to dispose unknown listener");
+            this._size--, t3[s3] = void 0;
+            const r3 = this._deliveryQueue.current === this;
+            if (2 * this._size <= t3.length) {
+              let e4 = 0;
+              for (let s4 = 0; s4 < t3.length; s4++) t3[s4] ? t3[e4++] = t3[s4] : r3 && (this._deliveryQueue.end--, e4 < this._deliveryQueue.i && this._deliveryQueue.i--);
+              t3.length = e4;
+            }
+          }
+          _deliver(e3, t3) {
+            if (!e3) return;
+            const s3 = this._options?.onListenerError || r2.onUnexpectedError;
+            if (s3) try {
+              e3.value(t3);
+            } catch (e4) {
+              s3(e4);
+            }
+            else e3.value(t3);
+          }
+          _deliverQueue(e3) {
+            const t3 = e3.current._listeners;
+            for (; e3.i < e3.end; ) this._deliver(t3[e3.i++], e3.value);
+            e3.reset();
+          }
+          fire(e3) {
+            if (this._deliveryQueue?.current && (this._deliverQueue(this._deliveryQueue), this._perfMon?.stop()), this._perfMon?.start(this._size), this._listeners) if (this._listeners instanceof v) this._deliver(this._listeners, e3);
+            else {
+              const t3 = this._deliveryQueue;
+              t3.enqueue(this, e3, this._listeners.length), this._deliverQueue(t3);
+            }
+            this._perfMon?.stop();
+          }
+          hasListeners() {
+            return this._size > 0;
+          }
+        }
+        t2.Emitter = m, t2.createEventDeliveryQueue = () => new g();
+        class g {
+          constructor() {
+            this.i = -1, this.end = 0;
+          }
+          enqueue(e3, t3, s3) {
+            this.i = 0, this.end = s3, this.current = e3, this.value = t3;
+          }
+          reset() {
+            this.i = this.end, this.current = void 0, this.value = void 0;
+          }
+        }
+        t2.AsyncEmitter = class extends m {
+          async fireAsync(e3, t3, s3) {
+            if (this._listeners) for (this._asyncDeliveryQueue || (this._asyncDeliveryQueue = new o.LinkedList()), ((e4, t4) => {
+              if (e4 instanceof v) t4(e4);
+              else for (let s4 = 0; s4 < e4.length; s4++) {
+                const r3 = e4[s4];
+                r3 && t4(r3);
+              }
+            })(this._listeners, ((t4) => this._asyncDeliveryQueue.push([t4.value, e3]))); this._asyncDeliveryQueue.size > 0 && !t3.isCancellationRequested; ) {
+              const [e4, n2] = this._asyncDeliveryQueue.shift(), i2 = [], o2 = { ...n2, token: t3, waitUntil: (t4) => {
+                if (Object.isFrozen(i2)) throw new Error("waitUntil can NOT be called asynchronous");
+                s3 && (t4 = s3(t4, e4)), i2.push(t4);
+              } };
+              try {
+                e4(o2);
+              } catch (e5) {
+                (0, r2.onUnexpectedError)(e5);
+                continue;
+              }
+              Object.freeze(i2), await Promise.allSettled(i2).then(((e5) => {
+                for (const t4 of e5) "rejected" === t4.status && (0, r2.onUnexpectedError)(t4.reason);
+              }));
+            }
+          }
+        };
+        class y extends m {
+          get isPaused() {
+            return 0 !== this._isPaused;
+          }
+          constructor(e3) {
+            super(e3), this._isPaused = 0, this._eventQueue = new o.LinkedList(), this._mergeFn = e3?.merge;
+          }
+          pause() {
+            this._isPaused++;
+          }
+          resume() {
+            if (0 !== this._isPaused && 0 == --this._isPaused) if (this._mergeFn) {
+              if (this._eventQueue.size > 0) {
+                const e3 = Array.from(this._eventQueue);
+                this._eventQueue.clear(), super.fire(this._mergeFn(e3));
+              }
+            } else for (; !this._isPaused && 0 !== this._eventQueue.size; ) super.fire(this._eventQueue.shift());
+          }
+          fire(e3) {
+            this._size && (0 !== this._isPaused ? this._eventQueue.push(e3) : super.fire(e3));
+          }
+        }
+        t2.PauseableEmitter = y, t2.DebounceEmitter = class extends y {
+          constructor(e3) {
+            super(e3), this._delay = e3.delay ?? 100;
+          }
+          fire(e3) {
+            this._handle || (this.pause(), this._handle = setTimeout((() => {
+              this._handle = void 0, this.resume();
+            }), this._delay)), super.fire(e3);
+          }
+        }, t2.MicrotaskEmitter = class extends m {
+          constructor(e3) {
+            super(e3), this._queuedEvents = [], this._mergeFn = e3?.merge;
+          }
+          fire(e3) {
+            this.hasListeners() && (this._queuedEvents.push(e3), 1 === this._queuedEvents.length && queueMicrotask((() => {
+              this._mergeFn ? super.fire(this._mergeFn(this._queuedEvents)) : this._queuedEvents.forEach(((e4) => super.fire(e4))), this._queuedEvents = [];
+            })));
+          }
+        };
+        class b {
+          constructor() {
+            this.hasListeners = false, this.events = [], this.emitter = new m({ onWillAddFirstListener: () => this.onFirstListenerAdd(), onDidRemoveLastListener: () => this.onLastListenerRemove() });
+          }
+          get event() {
+            return this.emitter.event;
+          }
+          add(e3) {
+            const t3 = { event: e3, listener: null };
+            return this.events.push(t3), this.hasListeners && this.hook(t3), (0, i.toDisposable)((0, n.createSingleCallFunction)((() => {
+              this.hasListeners && this.unhook(t3);
+              const e4 = this.events.indexOf(t3);
+              this.events.splice(e4, 1);
+            })));
+          }
+          onFirstListenerAdd() {
+            this.hasListeners = true, this.events.forEach(((e3) => this.hook(e3)));
+          }
+          onLastListenerRemove() {
+            this.hasListeners = false, this.events.forEach(((e3) => this.unhook(e3)));
+          }
+          hook(e3) {
+            e3.listener = e3.event(((e4) => this.emitter.fire(e4)));
+          }
+          unhook(e3) {
+            e3.listener?.dispose(), e3.listener = null;
+          }
+          dispose() {
+            this.emitter.dispose();
+            for (const e3 of this.events) e3.listener?.dispose();
+            this.events = [];
+          }
+        }
+        t2.EventMultiplexer = b, t2.DynamicListEventMultiplexer = class {
+          constructor(e3, t3, s3, r3) {
+            this._store = new i.DisposableStore();
+            const n2 = this._store.add(new b()), o2 = this._store.add(new i.DisposableMap());
+            function a2(e4) {
+              o2.set(e4, n2.add(r3(e4)));
+            }
+            for (const t4 of e3) a2(t4);
+            this._store.add(t3(((e4) => {
+              a2(e4);
+            }))), this._store.add(s3(((e4) => {
+              o2.deleteAndDispose(e4);
+            }))), this.event = n2.event;
+          }
+          dispose() {
+            this._store.dispose();
+          }
+        }, t2.EventBufferer = class {
+          constructor() {
+            this.data = [];
+          }
+          wrapEvent(e3, t3, s3) {
+            return (r3, n2, i2) => e3(((e4) => {
+              const i3 = this.data[this.data.length - 1];
+              if (!t3) return void (i3 ? i3.buffers.push((() => r3.call(n2, e4))) : r3.call(n2, e4));
+              const o2 = i3;
+              o2 ? (o2.items ??= [], o2.items.push(e4), 0 === o2.buffers.length && i3.buffers.push((() => {
+                o2.reducedResult ??= s3 ? o2.items.reduce(t3, s3) : o2.items.reduce(t3), r3.call(n2, o2.reducedResult);
+              }))) : r3.call(n2, t3(s3, e4));
+            }), void 0, i2);
+          }
+          bufferEvents(e3) {
+            const t3 = { buffers: new Array() };
+            this.data.push(t3);
+            const s3 = e3();
+            return this.data.pop(), t3.buffers.forEach(((e4) => e4())), s3;
+          }
+        }, t2.Relay = class {
+          constructor() {
+            this.listening = false, this.inputEvent = l.None, this.inputEventListener = i.Disposable.None, this.emitter = new m({ onDidAddFirstListener: () => {
+              this.listening = true, this.inputEventListener = this.inputEvent(this.emitter.fire, this.emitter);
+            }, onDidRemoveLastListener: () => {
+              this.listening = false, this.inputEventListener.dispose();
+            } }), this.event = this.emitter.event;
+          }
+          set input(e3) {
+            this.inputEvent = e3, this.listening && (this.inputEventListener.dispose(), this.inputEventListener = e3(this.emitter.fire, this.emitter));
+          }
+          dispose() {
+            this.inputEventListener.dispose(), this.emitter.dispose();
+          }
+        }, t2.ValueWithChangeEvent = class {
+          static const(e3) {
+            return new E(e3);
+          }
+          constructor(e3) {
+            this._value = e3, this._onDidChange = new m(), this.onDidChange = this._onDidChange.event;
+          }
+          get value() {
+            return this._value;
+          }
+          set value(e3) {
+            e3 !== this._value && (this._value = e3, this._onDidChange.fire(void 0));
+          }
+        };
+        class E {
+          constructor(e3) {
+            this.value = e3, this.onDidChange = l.None;
+          }
+        }
+      }, 355: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.createSingleCallFunction = function(e3, t3) {
+          const s2 = this;
+          let r2, n = false;
+          return function() {
+            if (n) return r2;
+            if (n = true, t3) try {
+              r2 = e3.apply(s2, arguments);
+            } finally {
+              t3();
+            }
+            else r2 = e3.apply(s2, arguments);
+            return r2;
+          };
+        };
+      }, 956: (e2, t2) => {
+        var s2;
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.Iterable = void 0, (function(e3) {
+          function t3(e4) {
+            return e4 && "object" == typeof e4 && "function" == typeof e4[Symbol.iterator];
+          }
+          e3.is = t3;
+          const s3 = Object.freeze([]);
+          function* r2(e4) {
+            yield e4;
+          }
+          e3.empty = function() {
+            return s3;
+          }, e3.single = r2, e3.wrap = function(e4) {
+            return t3(e4) ? e4 : r2(e4);
+          }, e3.from = function(e4) {
+            return e4 || s3;
+          }, e3.reverse = function* (e4) {
+            for (let t4 = e4.length - 1; t4 >= 0; t4--) yield e4[t4];
+          }, e3.isEmpty = function(e4) {
+            return !e4 || true === e4[Symbol.iterator]().next().done;
+          }, e3.first = function(e4) {
+            return e4[Symbol.iterator]().next().value;
+          }, e3.some = function(e4, t4) {
+            let s4 = 0;
+            for (const r3 of e4) if (t4(r3, s4++)) return true;
+            return false;
+          }, e3.find = function(e4, t4) {
+            for (const s4 of e4) if (t4(s4)) return s4;
+          }, e3.filter = function* (e4, t4) {
+            for (const s4 of e4) t4(s4) && (yield s4);
+          }, e3.map = function* (e4, t4) {
+            let s4 = 0;
+            for (const r3 of e4) yield t4(r3, s4++);
+          }, e3.flatMap = function* (e4, t4) {
+            let s4 = 0;
+            for (const r3 of e4) yield* t4(r3, s4++);
+          }, e3.concat = function* (...e4) {
+            for (const t4 of e4) yield* t4;
+          }, e3.reduce = function(e4, t4, s4) {
+            let r3 = s4;
+            for (const s5 of e4) r3 = t4(r3, s5);
+            return r3;
+          }, e3.slice = function* (e4, t4, s4 = e4.length) {
+            for (t4 < 0 && (t4 += e4.length), s4 < 0 ? s4 += e4.length : s4 > e4.length && (s4 = e4.length); t4 < s4; t4++) yield e4[t4];
+          }, e3.consume = function(t4, s4 = Number.POSITIVE_INFINITY) {
+            const r3 = [];
+            if (0 === s4) return [r3, t4];
+            const n = t4[Symbol.iterator]();
+            for (let t5 = 0; t5 < s4; t5++) {
+              const t6 = n.next();
+              if (t6.done) return [r3, e3.empty()];
+              r3.push(t6.value);
+            }
+            return [r3, { [Symbol.iterator]: () => n }];
+          }, e3.asyncToArray = async function(e4) {
+            const t4 = [];
+            for await (const s4 of e4) t4.push(s4);
+            return Promise.resolve(t4);
+          };
+        })(s2 || (t2.Iterable = s2 = {}));
+      }, 540: (e2, t2, s2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.DisposableMap = t2.ImmortalReference = t2.AsyncReferenceCollection = t2.ReferenceCollection = t2.SafeDisposable = t2.RefCountedDisposable = t2.MandatoryMutableDisposable = t2.MutableDisposable = t2.Disposable = t2.DisposableStore = t2.DisposableTracker = void 0, t2.setDisposableTracker = function(e3) {
+          l = e3;
+        }, t2.trackDisposable = h, t2.markAsDisposed = u, t2.markAsSingleton = function(e3) {
+          return l?.markAsSingleton(e3), e3;
+        }, t2.isDisposable = f, t2.dispose = p, t2.disposeIfDisposable = function(e3) {
+          for (const t3 of e3) f(t3) && t3.dispose();
+          return [];
+        }, t2.combinedDisposable = function(...e3) {
+          const t3 = _((() => p(e3)));
+          return (function(e4, t4) {
+            if (l) for (const s3 of e4) l.setParent(s3, t4);
+          })(e3, t3), t3;
+        }, t2.toDisposable = _, t2.disposeOnReturn = function(e3) {
+          const t3 = new v();
+          try {
+            e3(t3);
+          } finally {
+            t3.dispose();
+          }
+        };
+        const r2 = s2(732), n = s2(33), i = s2(714), o = s2(355), a = s2(956);
+        let l = null;
+        class c {
+          constructor() {
+            this.livingDisposables = /* @__PURE__ */ new Map();
+          }
+          static {
+            this.idx = 0;
+          }
+          getDisposableData(e3) {
+            let t3 = this.livingDisposables.get(e3);
+            return t3 || (t3 = { parent: null, source: null, isSingleton: false, value: e3, idx: c.idx++ }, this.livingDisposables.set(e3, t3)), t3;
+          }
+          trackDisposable(e3) {
+            const t3 = this.getDisposableData(e3);
+            t3.source || (t3.source = new Error().stack);
+          }
+          setParent(e3, t3) {
+            this.getDisposableData(e3).parent = t3;
+          }
+          markAsDisposed(e3) {
+            this.livingDisposables.delete(e3);
+          }
+          markAsSingleton(e3) {
+            this.getDisposableData(e3).isSingleton = true;
+          }
+          getRootParent(e3, t3) {
+            const s3 = t3.get(e3);
+            if (s3) return s3;
+            const r3 = e3.parent ? this.getRootParent(this.getDisposableData(e3.parent), t3) : e3;
+            return t3.set(e3, r3), r3;
+          }
+          getTrackedDisposables() {
+            const e3 = /* @__PURE__ */ new Map();
+            return [...this.livingDisposables.entries()].filter((([, t3]) => null !== t3.source && !this.getRootParent(t3, e3).isSingleton)).flatMap((([e4]) => e4));
+          }
+          computeLeakingDisposables(e3 = 10, t3) {
+            let s3;
+            if (t3) s3 = t3;
+            else {
+              const e4 = /* @__PURE__ */ new Map(), t4 = [...this.livingDisposables.values()].filter(((t5) => null !== t5.source && !this.getRootParent(t5, e4).isSingleton));
+              if (0 === t4.length) return;
+              const r3 = new Set(t4.map(((e5) => e5.value)));
+              if (s3 = t4.filter(((e5) => !(e5.parent && r3.has(e5.parent)))), 0 === s3.length) throw new Error("There are cyclic diposable chains!");
+            }
+            if (!s3) return;
+            function o2(e4) {
+              const t4 = e4.source.split("\n").map(((e5) => e5.trim().replace("at ", ""))).filter(((e5) => "" !== e5));
+              return (function(e5, t5) {
+                for (; e5.length > 0 && t5.some(((t6) => "string" == typeof t6 ? t6 === e5[0] : e5[0].match(t6))); ) e5.shift();
+              })(t4, ["Error", /^trackDisposable \(.*\)$/, /^DisposableTracker.trackDisposable \(.*\)$/]), t4.reverse();
+            }
+            const a2 = new i.SetMap();
+            for (const e4 of s3) {
+              const t4 = o2(e4);
+              for (let s4 = 0; s4 <= t4.length; s4++) a2.add(t4.slice(0, s4).join("\n"), e4);
+            }
+            s3.sort((0, r2.compareBy)(((e4) => e4.idx), r2.numberComparator));
+            let l2 = "", c2 = 0;
+            for (const t4 of s3.slice(0, e3)) {
+              c2++;
+              const e4 = o2(t4), r3 = [];
+              for (let t5 = 0; t5 < e4.length; t5++) {
+                let i2 = e4[t5];
+                i2 = `(shared with ${a2.get(e4.slice(0, t5 + 1).join("\n")).size}/${s3.length} leaks) at ${i2}`;
+                const l3 = a2.get(e4.slice(0, t5).join("\n")), c3 = (0, n.groupBy)([...l3].map(((e5) => o2(e5)[t5])), ((e5) => e5));
+                delete c3[e4[t5]];
+                for (const [e5, t6] of Object.entries(c3)) r3.unshift(`    - stacktraces of ${t6.length} other leaks continue with ${e5}`);
+                r3.unshift(i2);
+              }
+              l2 += `
+
+
+==================== Leaking disposable ${c2}/${s3.length}: ${t4.value.constructor.name} ====================
+${r3.join("\n")}
+============================================================
+
+`;
+            }
+            return s3.length > e3 && (l2 += `
+
+
+... and ${s3.length - e3} more leaking disposables
+
+`), { leaks: s3, details: l2 };
+          }
+        }
+        function h(e3) {
+          return l?.trackDisposable(e3), e3;
+        }
+        function u(e3) {
+          l?.markAsDisposed(e3);
+        }
+        function d(e3, t3) {
+          l?.setParent(e3, t3);
+        }
+        function f(e3) {
+          return "object" == typeof e3 && null !== e3 && "function" == typeof e3.dispose && 0 === e3.dispose.length;
+        }
+        function p(e3) {
+          if (a.Iterable.is(e3)) {
+            const t3 = [];
+            for (const s3 of e3) if (s3) try {
+              s3.dispose();
+            } catch (e4) {
+              t3.push(e4);
+            }
+            if (1 === t3.length) throw t3[0];
+            if (t3.length > 1) throw new AggregateError(t3, "Encountered errors while disposing of store");
+            return Array.isArray(e3) ? [] : e3;
+          }
+          if (e3) return e3.dispose(), e3;
+        }
+        function _(e3) {
+          const t3 = h({ dispose: (0, o.createSingleCallFunction)((() => {
+            u(t3), e3();
+          })) });
+          return t3;
+        }
+        t2.DisposableTracker = c;
+        class v {
+          static {
+            this.DISABLE_DISPOSED_WARNING = false;
+          }
+          constructor() {
+            this._toDispose = /* @__PURE__ */ new Set(), this._isDisposed = false, h(this);
+          }
+          dispose() {
+            this._isDisposed || (u(this), this._isDisposed = true, this.clear());
+          }
+          get isDisposed() {
+            return this._isDisposed;
+          }
+          clear() {
+            if (0 !== this._toDispose.size) try {
+              p(this._toDispose);
+            } finally {
+              this._toDispose.clear();
+            }
+          }
+          add(e3) {
+            if (!e3) return e3;
+            if (e3 === this) throw new Error("Cannot register a disposable on itself!");
+            return d(e3, this), this._isDisposed ? v.DISABLE_DISPOSED_WARNING || console.warn(new Error("Trying to add a disposable to a DisposableStore that has already been disposed of. The added object will be leaked!").stack) : this._toDispose.add(e3), e3;
+          }
+          delete(e3) {
+            if (e3) {
+              if (e3 === this) throw new Error("Cannot dispose a disposable on itself!");
+              this._toDispose.delete(e3), e3.dispose();
+            }
+          }
+          deleteAndLeak(e3) {
+            e3 && this._toDispose.has(e3) && (this._toDispose.delete(e3), d(e3, null));
+          }
+        }
+        t2.DisposableStore = v;
+        class m {
+          static {
+            this.None = Object.freeze({ dispose() {
+            } });
+          }
+          constructor() {
+            this._store = new v(), h(this), d(this._store, this);
+          }
+          dispose() {
+            u(this), this._store.dispose();
+          }
+          _register(e3) {
+            if (e3 === this) throw new Error("Cannot register a disposable on itself!");
+            return this._store.add(e3);
+          }
+        }
+        t2.Disposable = m;
+        class g {
+          constructor() {
+            this._isDisposed = false, h(this);
+          }
+          get value() {
+            return this._isDisposed ? void 0 : this._value;
+          }
+          set value(e3) {
+            this._isDisposed || e3 === this._value || (this._value?.dispose(), e3 && d(e3, this), this._value = e3);
+          }
+          clear() {
+            this.value = void 0;
+          }
+          dispose() {
+            this._isDisposed = true, u(this), this._value?.dispose(), this._value = void 0;
+          }
+          clearAndLeak() {
+            const e3 = this._value;
+            return this._value = void 0, e3 && d(e3, null), e3;
+          }
+        }
+        t2.MutableDisposable = g, t2.MandatoryMutableDisposable = class {
+          constructor(e3) {
+            this._disposable = new g(), this._isDisposed = false, this._disposable.value = e3;
+          }
+          get value() {
+            return this._disposable.value;
+          }
+          set value(e3) {
+            this._isDisposed || e3 === this._disposable.value || (this._disposable.value = e3);
+          }
+          dispose() {
+            this._isDisposed = true, this._disposable.dispose();
+          }
+        }, t2.RefCountedDisposable = class {
+          constructor(e3) {
+            this._disposable = e3, this._counter = 1;
+          }
+          acquire() {
+            return this._counter++, this;
+          }
+          release() {
+            return 0 == --this._counter && this._disposable.dispose(), this;
+          }
+        }, t2.SafeDisposable = class {
+          constructor() {
+            this.dispose = () => {
+            }, this.unset = () => {
+            }, this.isset = () => false, h(this);
+          }
+          set(e3) {
+            let t3 = e3;
+            return this.unset = () => t3 = void 0, this.isset = () => void 0 !== t3, this.dispose = () => {
+              t3 && (t3(), t3 = void 0, u(this));
+            }, this;
+          }
+        }, t2.ReferenceCollection = class {
+          constructor() {
+            this.references = /* @__PURE__ */ new Map();
+          }
+          acquire(e3, ...t3) {
+            let s3 = this.references.get(e3);
+            s3 || (s3 = { counter: 0, object: this.createReferencedObject(e3, ...t3) }, this.references.set(e3, s3));
+            const { object: r3 } = s3, n2 = (0, o.createSingleCallFunction)((() => {
+              0 == --s3.counter && (this.destroyReferencedObject(e3, s3.object), this.references.delete(e3));
+            }));
+            return s3.counter++, { object: r3, dispose: n2 };
+          }
+        }, t2.AsyncReferenceCollection = class {
+          constructor(e3) {
+            this.referenceCollection = e3;
+          }
+          async acquire(e3, ...t3) {
+            const s3 = this.referenceCollection.acquire(e3, ...t3);
+            try {
+              return { object: await s3.object, dispose: () => s3.dispose() };
+            } catch (e4) {
+              throw s3.dispose(), e4;
+            }
+          }
+        }, t2.ImmortalReference = class {
+          constructor(e3) {
+            this.object = e3;
+          }
+          dispose() {
+          }
+        };
+        class y {
+          constructor() {
+            this._store = /* @__PURE__ */ new Map(), this._isDisposed = false, h(this);
+          }
+          dispose() {
+            u(this), this._isDisposed = true, this.clearAndDisposeAll();
+          }
+          clearAndDisposeAll() {
+            if (this._store.size) try {
+              p(this._store.values());
+            } finally {
+              this._store.clear();
+            }
+          }
+          has(e3) {
+            return this._store.has(e3);
+          }
+          get size() {
+            return this._store.size;
+          }
+          get(e3) {
+            return this._store.get(e3);
+          }
+          set(e3, t3, s3 = false) {
+            this._isDisposed && console.warn(new Error("Trying to add a disposable to a DisposableMap that has already been disposed of. The added object will be leaked!").stack), s3 || this._store.get(e3)?.dispose(), this._store.set(e3, t3);
+          }
+          deleteAndDispose(e3) {
+            this._store.get(e3)?.dispose(), this._store.delete(e3);
+          }
+          deleteAndLeak(e3) {
+            const t3 = this._store.get(e3);
+            return this._store.delete(e3), t3;
+          }
+          keys() {
+            return this._store.keys();
+          }
+          values() {
+            return this._store.values();
+          }
+          [Symbol.iterator]() {
+            return this._store[Symbol.iterator]();
+          }
+        }
+        t2.DisposableMap = y;
+      }, 711: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.LinkedList = void 0;
+        class s2 {
+          static {
+            this.Undefined = new s2(void 0);
+          }
+          constructor(e3) {
+            this.element = e3, this.next = s2.Undefined, this.prev = s2.Undefined;
+          }
+        }
+        class r2 {
+          constructor() {
+            this._first = s2.Undefined, this._last = s2.Undefined, this._size = 0;
+          }
+          get size() {
+            return this._size;
+          }
+          isEmpty() {
+            return this._first === s2.Undefined;
+          }
+          clear() {
+            let e3 = this._first;
+            for (; e3 !== s2.Undefined; ) {
+              const t3 = e3.next;
+              e3.prev = s2.Undefined, e3.next = s2.Undefined, e3 = t3;
+            }
+            this._first = s2.Undefined, this._last = s2.Undefined, this._size = 0;
+          }
+          unshift(e3) {
+            return this._insert(e3, false);
+          }
+          push(e3) {
+            return this._insert(e3, true);
+          }
+          _insert(e3, t3) {
+            const r3 = new s2(e3);
+            if (this._first === s2.Undefined) this._first = r3, this._last = r3;
+            else if (t3) {
+              const e4 = this._last;
+              this._last = r3, r3.prev = e4, e4.next = r3;
+            } else {
+              const e4 = this._first;
+              this._first = r3, r3.next = e4, e4.prev = r3;
+            }
+            this._size += 1;
+            let n = false;
+            return () => {
+              n || (n = true, this._remove(r3));
+            };
+          }
+          shift() {
+            if (this._first !== s2.Undefined) {
+              const e3 = this._first.element;
+              return this._remove(this._first), e3;
+            }
+          }
+          pop() {
+            if (this._last !== s2.Undefined) {
+              const e3 = this._last.element;
+              return this._remove(this._last), e3;
+            }
+          }
+          _remove(e3) {
+            if (e3.prev !== s2.Undefined && e3.next !== s2.Undefined) {
+              const t3 = e3.prev;
+              t3.next = e3.next, e3.next.prev = t3;
+            } else e3.prev === s2.Undefined && e3.next === s2.Undefined ? (this._first = s2.Undefined, this._last = s2.Undefined) : e3.next === s2.Undefined ? (this._last = this._last.prev, this._last.next = s2.Undefined) : e3.prev === s2.Undefined && (this._first = this._first.next, this._first.prev = s2.Undefined);
+            this._size -= 1;
+          }
+          *[Symbol.iterator]() {
+            let e3 = this._first;
+            for (; e3 !== s2.Undefined; ) yield e3.element, e3 = e3.next;
+          }
+        }
+        t2.LinkedList = r2;
+      }, 714: (e2, t2) => {
+        var s2;
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.SetMap = t2.BidirectionalMap = t2.CounterSet = t2.Touch = void 0, t2.getOrSet = function(e3, t3, s3) {
+          let r2 = e3.get(t3);
+          return void 0 === r2 && (r2 = s3, e3.set(t3, r2)), r2;
+        }, t2.mapToString = function(e3) {
+          const t3 = [];
+          return e3.forEach(((e4, s3) => {
+            t3.push(`${s3} => ${e4}`);
+          })), `Map(${e3.size}) {${t3.join(", ")}}`;
+        }, t2.setToString = function(e3) {
+          const t3 = [];
+          return e3.forEach(((e4) => {
+            t3.push(e4);
+          })), `Set(${e3.size}) {${t3.join(", ")}}`;
+        }, t2.mapsStrictEqualIgnoreOrder = function(e3, t3) {
+          if (e3 === t3) return true;
+          if (e3.size !== t3.size) return false;
+          for (const [s3, r2] of e3) if (!t3.has(s3) || t3.get(s3) !== r2) return false;
+          for (const [s3] of t3) if (!e3.has(s3)) return false;
+          return true;
+        }, (function(e3) {
+          e3[e3.None = 0] = "None", e3[e3.AsOld = 1] = "AsOld", e3[e3.AsNew = 2] = "AsNew";
+        })(s2 || (t2.Touch = s2 = {})), t2.CounterSet = class {
+          constructor() {
+            this.map = /* @__PURE__ */ new Map();
+          }
+          add(e3) {
+            return this.map.set(e3, (this.map.get(e3) || 0) + 1), this;
+          }
+          delete(e3) {
+            let t3 = this.map.get(e3) || 0;
+            return 0 !== t3 && (t3--, 0 === t3 ? this.map.delete(e3) : this.map.set(e3, t3), true);
+          }
+          has(e3) {
+            return this.map.has(e3);
+          }
+        }, t2.BidirectionalMap = class {
+          constructor(e3) {
+            if (this._m1 = /* @__PURE__ */ new Map(), this._m2 = /* @__PURE__ */ new Map(), e3) for (const [t3, s3] of e3) this.set(t3, s3);
+          }
+          clear() {
+            this._m1.clear(), this._m2.clear();
+          }
+          set(e3, t3) {
+            this._m1.set(e3, t3), this._m2.set(t3, e3);
+          }
+          get(e3) {
+            return this._m1.get(e3);
+          }
+          getKey(e3) {
+            return this._m2.get(e3);
+          }
+          delete(e3) {
+            const t3 = this._m1.get(e3);
+            return void 0 !== t3 && (this._m1.delete(e3), this._m2.delete(t3), true);
+          }
+          forEach(e3, t3) {
+            this._m1.forEach(((s3, r2) => {
+              e3.call(t3, s3, r2, this);
+            }));
+          }
+          keys() {
+            return this._m1.keys();
+          }
+          values() {
+            return this._m1.values();
+          }
+        }, t2.SetMap = class {
+          constructor() {
+            this.map = /* @__PURE__ */ new Map();
+          }
+          add(e3, t3) {
+            let s3 = this.map.get(e3);
+            s3 || (s3 = /* @__PURE__ */ new Set(), this.map.set(e3, s3)), s3.add(t3);
+          }
+          delete(e3, t3) {
+            const s3 = this.map.get(e3);
+            s3 && (s3.delete(t3), 0 === s3.size && this.map.delete(e3));
+          }
+          forEach(e3, t3) {
+            const s3 = this.map.get(e3);
+            s3 && s3.forEach(t3);
+          }
+          get(e3) {
+            return this.map.get(e3) || /* @__PURE__ */ new Set();
+          }
+        };
+      }, 79: (e2, t2) => {
+        Object.defineProperty(t2, "__esModule", { value: true }), t2.StopWatch = void 0;
+        const s2 = globalThis.performance && "function" == typeof globalThis.performance.now;
+        class r2 {
+          static create(e3) {
+            return new r2(e3);
+          }
+          constructor(e3) {
+            this._now = s2 && false === e3 ? Date.now : globalThis.performance.now.bind(globalThis.performance), this._startTime = this._now(), this._stopTime = -1;
+          }
+          stop() {
+            this._stopTime = this._now();
+          }
+          reset() {
+            this._startTime = this._now(), this._stopTime = -1;
+          }
+          elapsed() {
+            return -1 !== this._stopTime ? this._stopTime - this._startTime : this._now() - this._startTime;
+          }
+        }
+        t2.StopWatch = r2;
+      } }, t = {};
+      function s(r2) {
+        var n = t[r2];
+        if (void 0 !== n) return n.exports;
+        var i = t[r2] = { exports: {} };
+        return e[r2](i, i.exports, s), i.exports;
+      }
+      var r = {};
+      return (() => {
+        var e2 = r;
+        Object.defineProperty(e2, "__esModule", { value: true }), e2.Unicode11Addon = void 0;
+        const t2 = s(384);
+        e2.Unicode11Addon = class {
+          activate(e3) {
+            e3.unicode.register(new t2.UnicodeV11());
+          }
+          dispose() {
+          }
+        };
+      })(), r;
+    })()));
+  }
+});
+
+// packages/core/src/application-shell-session.ts
+var init_application_shell_session = __esm({
+  "packages/core/src/application-shell-session.ts"() {
+    "use strict";
+    init_src();
+  }
+});
+
+// packages/core/src/interaction-flow.ts
+var init_interaction_flow = __esm({
+  "packages/core/src/interaction-flow.ts"() {
+    "use strict";
+  }
+});
+
+// packages/core/src/workspace-selection.ts
+var init_workspace_selection = __esm({
+  "packages/core/src/workspace-selection.ts"() {
+    "use strict";
+    init_src();
+  }
+});
+
+// packages/core/src/terminal-conformance.ts
+function buildXtermPalette() {
+  const base = [
+    0,
+    13434880,
+    52480,
+    13487360,
+    238,
+    13435085,
+    52685,
+    15066597,
+    8355711,
+    16711680,
+    65280,
+    16776960,
+    6053119,
+    16711935,
+    65535,
+    16777215
+  ];
+  const palette = [...base];
+  const levels = [0, 95, 135, 175, 215, 255];
+  for (let index = 16; index < 232; index += 1) {
+    const offset = index - 16;
+    const red = levels[Math.floor(offset / 36)];
+    const green = levels[Math.floor(offset / 6) % 6];
+    const blue = levels[offset % 6];
+    palette.push(red << 16 | green << 8 | blue);
+  }
+  for (let index = 232; index < 256; index += 1) {
+    const value = 8 + 10 * (index - 232);
+    palette.push(value << 16 | value << 8 | value);
+  }
+  return palette;
+}
+var XTERM_PALETTE, XTERM_PALETTE_HEX, DEFAULT, indexed, rgb, TERMINAL_CONFORMANCE_FIXTURES;
+var init_terminal_conformance = __esm({
+  "packages/core/src/terminal-conformance.ts"() {
+    "use strict";
+    XTERM_PALETTE = Object.freeze(buildXtermPalette());
+    XTERM_PALETTE_HEX = Object.freeze(
+      XTERM_PALETTE.map((color3) => `#${color3.toString(16).padStart(6, "0")}`)
+    );
+    DEFAULT = Object.freeze({ kind: "default" });
+    indexed = (index) => ({ kind: "indexed", index });
+    rgb = (value) => ({ kind: "rgb", value });
+    TERMINAL_CONFORMANCE_FIXTURES = Object.freeze([
+      {
+        id: "claude-logo-black",
+        description: "Claude's slot-174 foreground, explicit slot-16 black, and SGR 49 reset",
+        cols: 12,
+        rows: 2,
+        writes: [
+          "\x1B[38;5;",
+          "174m \u2590\x1B[48;5;16m\u259B\u2588\u2588\u2588\u259C",
+          "\x1B[49m\u258C\x1B[0m"
+        ],
+        cells: [
+          {
+            row: 0,
+            column: 1,
+            chars: "\u2590",
+            width: 1,
+            foreground: indexed(174),
+            background: DEFAULT
+          },
+          {
+            row: 0,
+            column: 2,
+            chars: "\u259B",
+            width: 1,
+            foreground: indexed(174),
+            background: indexed(16)
+          },
+          {
+            row: 0,
+            column: 3,
+            chars: "\u2588",
+            width: 1,
+            foreground: indexed(174),
+            background: indexed(16)
+          },
+          {
+            row: 0,
+            column: 4,
+            chars: "\u2588",
+            width: 1,
+            foreground: indexed(174),
+            background: indexed(16)
+          },
+          {
+            row: 0,
+            column: 5,
+            chars: "\u2588",
+            width: 1,
+            foreground: indexed(174),
+            background: indexed(16)
+          },
+          {
+            row: 0,
+            column: 6,
+            chars: "\u259C",
+            width: 1,
+            foreground: indexed(174),
+            background: indexed(16)
+          },
+          {
+            row: 0,
+            column: 7,
+            chars: "\u258C",
+            width: 1,
+            foreground: indexed(174),
+            background: DEFAULT
+          }
+        ]
+      },
+      {
+        id: "color-reset-boundaries",
+        description: "39/49 reset one color channel while 0 resets both and all attributes",
+        cols: 12,
+        rows: 2,
+        writes: [
+          "A\x1B[31;44mB\x1B[39mC\x1B[49mD",
+          "\x1B[38;2;10;200;30;48;2;1;2;3mT\x1B[0mZ"
+        ],
+        cells: [
+          { row: 0, column: 0, chars: "A", width: 1, foreground: DEFAULT, background: DEFAULT },
+          { row: 0, column: 1, chars: "B", width: 1, foreground: indexed(1), background: indexed(4) },
+          { row: 0, column: 2, chars: "C", width: 1, foreground: DEFAULT, background: indexed(4) },
+          { row: 0, column: 3, chars: "D", width: 1, foreground: DEFAULT, background: DEFAULT },
+          {
+            row: 0,
+            column: 4,
+            chars: "T",
+            width: 1,
+            foreground: rgb(706590),
+            background: rgb(66051)
+          },
+          { row: 0, column: 5, chars: "Z", width: 1, foreground: DEFAULT, background: DEFAULT }
+        ]
+      },
+      {
+        id: "supported-attributes",
+        description: "Every attribute shared by xterm and OpenTUI, including conceal and inverse",
+        cols: 12,
+        rows: 2,
+        writes: [
+          "\x1B[1mB\x1B[0;2mD\x1B[0;3mI\x1B[0;4mU",
+          "\x1B[0;5mK\x1B[0;8mH\x1B[0;9mS\x1B[0;7;31;44mR\x1B[0m"
+        ],
+        cells: [
+          {
+            row: 0,
+            column: 0,
+            chars: "B",
+            width: 1,
+            foreground: DEFAULT,
+            background: DEFAULT,
+            attributes: ["bold"]
+          },
+          {
+            row: 0,
+            column: 1,
+            chars: "D",
+            width: 1,
+            foreground: DEFAULT,
+            background: DEFAULT,
+            attributes: ["dim"]
+          },
+          {
+            row: 0,
+            column: 2,
+            chars: "I",
+            width: 1,
+            foreground: DEFAULT,
+            background: DEFAULT,
+            attributes: ["italic"]
+          },
+          {
+            row: 0,
+            column: 3,
+            chars: "U",
+            width: 1,
+            foreground: DEFAULT,
+            background: DEFAULT,
+            attributes: ["underline"]
+          },
+          {
+            row: 0,
+            column: 4,
+            chars: "K",
+            width: 1,
+            foreground: DEFAULT,
+            background: DEFAULT,
+            attributes: ["blink"]
+          },
+          {
+            row: 0,
+            column: 5,
+            chars: "H",
+            width: 1,
+            foreground: DEFAULT,
+            background: DEFAULT,
+            attributes: ["hidden"]
+          },
+          {
+            row: 0,
+            column: 6,
+            chars: "S",
+            width: 1,
+            foreground: DEFAULT,
+            background: DEFAULT,
+            attributes: ["strikethrough"]
+          },
+          {
+            row: 0,
+            column: 7,
+            chars: "R",
+            width: 1,
+            foreground: indexed(1),
+            background: indexed(4),
+            attributes: ["inverse"]
+          }
+        ]
+      },
+      {
+        id: "wide-and-combined-graphemes",
+        description: "Wide CJK/emoji continuations and a combining grapheme keep cell alignment",
+        cols: 12,
+        rows: 2,
+        writes: ["A\u754Ce\u0301\u{1F642}"],
+        cells: [
+          { row: 0, column: 0, chars: "A", width: 1, foreground: DEFAULT, background: DEFAULT },
+          { row: 0, column: 1, chars: "\u754C", width: 2, foreground: DEFAULT, background: DEFAULT },
+          { row: 0, column: 2, chars: "", width: 0, foreground: DEFAULT, background: DEFAULT },
+          { row: 0, column: 3, chars: "e\u0301", width: 1, foreground: DEFAULT, background: DEFAULT },
+          {
+            row: 0,
+            column: 4,
+            chars: "\u{1F642}",
+            width: 2,
+            foreground: DEFAULT,
+            background: DEFAULT
+          },
+          { row: 0, column: 5, chars: "", width: 0, foreground: DEFAULT, background: DEFAULT }
+        ]
+      },
+      {
+        id: "inverse-combined-grapheme",
+        description: "The framebuffer grapheme post-pass preserves resolved inverse colors",
+        cols: 8,
+        rows: 2,
+        writes: ["\x1B[7;38;5;1;48;5;4me\u0301\x1B[0m"],
+        cells: [
+          {
+            row: 0,
+            column: 0,
+            chars: "e\u0301",
+            width: 1,
+            foreground: indexed(1),
+            background: indexed(4),
+            attributes: ["inverse"]
+          }
+        ]
+      },
+      {
+        id: "codex-truecolor-status",
+        description: "Codex status text preserves explicit P3-ready truecolor channels",
+        cols: 12,
+        rows: 2,
+        writes: ["\x1B[38;2;99;102;241mCODEX\x1B[0m"],
+        cells: [
+          { row: 0, column: 0, chars: "C", width: 1, foreground: rgb(6514417), background: DEFAULT },
+          { row: 0, column: 1, chars: "O", width: 1, foreground: rgb(6514417), background: DEFAULT }
+        ]
+      },
+      {
+        id: "opencode-indexed-status",
+        description: "OpenCode indexed accent and inverse status remain application-owned",
+        cols: 12,
+        rows: 2,
+        writes: ["\x1B[38;5;75;48;5;234;7mOC\x1B[0m"],
+        cells: [
+          {
+            row: 0,
+            column: 0,
+            chars: "O",
+            width: 1,
+            foreground: indexed(75),
+            background: indexed(234),
+            attributes: ["inverse"]
+          },
+          {
+            row: 0,
+            column: 1,
+            chars: "C",
+            width: 1,
+            foreground: indexed(75),
+            background: indexed(234),
+            attributes: ["inverse"]
+          }
+        ]
+      }
+    ]);
+  }
+});
+
+// packages/core/src/terminal-replica.ts
+function blankTerminalReplicaSnapshot(cols, rows) {
+  const row = blankRow(cols);
+  return freezeSnapshot({
+    cols,
+    rows,
+    grid: Array.from({ length: rows }, () => row),
+    cursor: { x: 0, y: 0, hidden: false, style: "block", blink: false },
+    modes: {
+      alternateScreen: false,
+      applicationCursor: false,
+      applicationKeypad: false,
+      bracketedPaste: false,
+      insert: false,
+      origin: false,
+      wraparound: true,
+      mouseTracking: false,
+      synchronizedOutput: false
+    },
+    history: [],
+    placements: [],
+    bootstrap: { kind: "painted-capture", hiddenState: "unknown" }
+  });
+}
+function applyTerminalReplicaPatch(current, patch) {
+  const cols = patch.dimensions?.cols ?? current.cols;
+  const rows = patch.dimensions?.rows ?? current.rows;
+  const seen = /* @__PURE__ */ new Set();
+  for (const change of patch.rows) {
+    if (change.index >= rows || change.row.cells.length !== cols || !terminalReplicaRowIsValid(change.row) || seen.has(change.index)) {
+      throw new TypeError("Malformed terminal replica row patch");
+    }
+    seen.add(change.index);
+  }
+  const cursor = patch.cursor ?? current.cursor;
+  if (cursor.x >= cols || cursor.y >= rows) throw new TypeError("Terminal cursor is out of bounds");
+  if (patch.history?.some((row) => row.cells.length !== cols || !terminalReplicaRowIsValid(row)))
+    throw new TypeError("Malformed terminal replica history");
+  if (patch.history !== void 0 && patch.historyDelta !== void 0 || (patch.historyDelta?.trim ?? 0) > current.history.length || patch.historyDelta?.append.some(
+    (row) => row.cells.length !== cols || !terminalReplicaRowIsValid(row)
+  ))
+    throw new TypeError("Malformed terminal replica history delta");
+  if (patch.placements?.some(
+    (placement) => placement.row + placement.rows > rows || placement.column + placement.columns > cols
+  ))
+    throw new TypeError("Terminal placement is out of bounds");
+  if (cols !== current.cols) {
+    const retainedHistory = patch.history ?? (patch.historyDelta ? [...current.history.slice(patch.historyDelta.trim), ...patch.historyDelta.append] : current.history);
+    if (retainedHistory.some((row) => row.cells.length !== cols))
+      throw new TypeError("A dimension patch retained old-width terminal history");
+  }
+  if ((cols !== current.cols || rows !== current.rows) && patch.placements === void 0 && current.placements.some(
+    (placement) => placement.row + placement.rows > rows || placement.column + placement.columns > cols
+  ))
+    throw new TypeError("A dimension patch retained an out-of-bounds terminal placement");
+  let grid;
+  if (cols !== current.cols || rows !== current.rows) {
+    const empty = blankRow(cols);
+    grid = Array.from({ length: rows }, (_, index) => {
+      const prior = current.grid[index];
+      return prior && prior.cells.length === cols ? prior : empty;
+    });
+  } else {
+    grid = current.grid;
+  }
+  if (patch.rows.length > 0) {
+    const next = [...grid];
+    let changed = false;
+    for (const change of patch.rows) {
+      const row = freezeRow(change.row);
+      if (!terminalReplicaRowsEqual(next[change.index], row)) {
+        next[change.index] = row;
+        changed = true;
+      }
+    }
+    if (changed) grid = next;
+  }
+  const unchanged = cols === current.cols && rows === current.rows && grid === current.grid && patch.cursor === void 0 && patch.modes === void 0 && patch.history === void 0 && patch.historyDelta === void 0 && patch.placements === void 0 && patch.bootstrap === void 0;
+  if (unchanged) return current;
+  let history;
+  if (patch.history) {
+    history = Object.freeze(patch.history.map(freezeRow));
+  } else if (patch.historyDelta) {
+    const appended = patch.historyDelta.append.map(freezeRow);
+    history = Object.freeze([...current.history.slice(patch.historyDelta.trim), ...appended]);
+    registerRowsDeltaHash(current.history, history, patch.historyDelta.trim, appended);
+  } else {
+    history = current.history;
+  }
+  const candidate = {
+    cols,
+    rows,
+    grid: Object.freeze(grid),
+    history,
+    cursor: Object.freeze(patch.cursor ? { ...patch.cursor } : current.cursor),
+    modes: Object.freeze(patch.modes ? { ...patch.modes } : current.modes),
+    placements: patch.placements ? Object.freeze(
+      patch.placements.map((placement) => Object.freeze({ ...placement }))
+    ) : current.placements,
+    bootstrap: patch.bootstrap ? Object.freeze({ ...patch.bootstrap }) : current.bootstrap
+  };
+  return Object.freeze(candidate);
+}
+function terminalReplicaRowsEqual(left, right) {
+  if (!left || left === right || left.wrapped !== right.wrapped || left.cells.length !== right.cells.length)
+    return left === right;
+  for (let index = 0; index < left.cells.length; index += 1) {
+    const a = left.cells[index];
+    const b = right.cells[index];
+    if (a.grapheme !== b.grapheme || a.width !== b.width || a.attributes !== b.attributes || !colorsEqual(a.foreground, b.foreground) || !colorsEqual(a.background, b.background))
+      return false;
+  }
+  return true;
+}
+function hashTerminalReplicaSnapshot(snapshot) {
+  return hashStable([
+    "terminal-replica-v1",
+    snapshot.cols,
+    snapshot.rows,
+    hashTerminalReplicaRows(snapshot.grid),
+    hashTerminalReplicaRows(snapshot.history),
+    snapshot.cursor,
+    snapshot.modes,
+    snapshot.placements,
+    snapshot.bootstrap
+  ]);
+}
+function hashTerminalReplicaTombstone(reason) {
+  return hashStable(["tombstone", reason]);
+}
+function blankRow(cols) {
+  return Object.freeze({
+    cells: Object.freeze(
+      Array.from(
+        { length: cols },
+        () => Object.freeze({
+          grapheme: " ",
+          width: 1,
+          foreground: DEFAULT_COLOR,
+          background: DEFAULT_COLOR,
+          attributes: 0
+        })
+      )
+    ),
+    wrapped: false
+  });
+}
+function freezeRow(row) {
+  return Object.freeze({
+    wrapped: row.wrapped,
+    cells: Object.freeze(
+      row.cells.map(
+        (cell) => Object.freeze({
+          ...cell,
+          foreground: Object.freeze({ ...cell.foreground }),
+          background: Object.freeze({ ...cell.background })
+        })
+      )
+    )
+  });
+}
+function freezeTerminalReplicaRow(row) {
+  if (!terminalReplicaRowIsValid(row)) throw new TypeError("Malformed terminal replica row");
+  return freezeRow(row);
+}
+function freezeSnapshot(snapshot) {
+  return Object.freeze({
+    ...snapshot,
+    grid: Object.freeze(snapshot.grid.map(freezeRow)),
+    history: Object.freeze(snapshot.history.map(freezeRow)),
+    cursor: Object.freeze({ ...snapshot.cursor }),
+    modes: Object.freeze({ ...snapshot.modes }),
+    placements: Object.freeze(snapshot.placements.map((value) => Object.freeze({ ...value }))),
+    bootstrap: Object.freeze({ ...snapshot.bootstrap })
+  });
+}
+function assembleTerminalReplicaSnapshot(snapshot) {
+  if (snapshot.grid.length !== snapshot.rows || snapshot.cursor.x >= snapshot.cols || snapshot.cursor.y >= snapshot.rows || snapshot.grid.some((row) => row.cells.length !== snapshot.cols)) {
+    throw new TypeError("Malformed trusted terminal replica snapshot");
+  }
+  return Object.freeze({
+    ...snapshot,
+    grid: Object.freeze(snapshot.grid),
+    history: Object.freeze(snapshot.history),
+    cursor: Object.freeze(snapshot.cursor),
+    modes: Object.freeze(snapshot.modes),
+    placements: Object.freeze(snapshot.placements.map((placement) => Object.freeze(placement))),
+    bootstrap: Object.freeze(snapshot.bootstrap)
+  });
+}
+function colorsEqual(left, right) {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "default") return true;
+  if (left.kind === "indexed" && right.kind === "indexed") return left.index === right.index;
+  return left.kind === "rgb" && right.kind === "rgb" && left.value === right.value;
+}
+function hashStable(value) {
+  const bytes = new TextEncoder().encode(canonicalEncode(value));
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of bytes) {
+    hash ^= BigInt(byte);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return hash.toString(16).padStart(16, "0");
+}
+function canonicalEncode(value) {
+  if (value === null) return "n;";
+  if (typeof value === "boolean") return value ? "b1;" : "b0;";
+  if (typeof value === "number") return `d${String(value).length}:${String(value)};`;
+  if (typeof value === "string") {
+    const length = new TextEncoder().encode(value).length;
+    return `s${length}:${value};`;
+  }
+  if (Array.isArray(value)) return `a${value.length}:${value.map(canonicalEncode).join("")};`;
+  const record = value;
+  const keys = Object.keys(record).sort();
+  return `o${keys.length}:${keys.map((key) => `${canonicalEncode(key)}${canonicalEncode(record[key])}`).join("")};`;
+}
+function hashTerminalReplicaRow(row) {
+  const cached2 = ROW_HASH_CACHE.get(row);
+  if (cached2) return cached2;
+  const hash = hashStable([
+    row.wrapped,
+    row.cells.map((cell) => [
+      cell.grapheme,
+      cell.width,
+      cell.foreground,
+      cell.background,
+      cell.attributes
+    ])
+  ]);
+  if (Object.isFrozen(row)) ROW_HASH_CACHE.set(row, hash);
+  return hash;
+}
+function hashTerminalReplicaRows(rows) {
+  const cached2 = ROW_ARRAY_HASH_CACHE.get(rows);
+  if (cached2) return cached2.hash.toString(16).padStart(16, "0");
+  let hash = 0n;
+  for (const row of rows)
+    hash = BigInt.asUintN(
+      64,
+      hash * ROW_SEQUENCE_BASE + BigInt(`0x${hashTerminalReplicaRow(row)}`)
+    );
+  if (Object.isFrozen(rows)) ROW_ARRAY_HASH_CACHE.set(rows, { hash, length: rows.length });
+  return hash.toString(16).padStart(16, "0");
+}
+function registerRowsDeltaHash(previous, next, trim, append) {
+  hashTerminalReplicaRows(previous);
+  const prior = ROW_ARRAY_HASH_CACHE.get(previous);
+  if (!prior) return;
+  let hash = prior.hash;
+  for (let index = 0; index < trim; index += 1) {
+    const exponent = prior.length - 1 - index;
+    const contribution = BigInt.asUintN(
+      64,
+      BigInt(`0x${hashTerminalReplicaRow(previous[index])}`) * pow64(ROW_SEQUENCE_BASE, exponent)
+    );
+    hash = BigInt.asUintN(64, hash - contribution);
+  }
+  for (const row of append)
+    hash = BigInt.asUintN(
+      64,
+      hash * ROW_SEQUENCE_BASE + BigInt(`0x${hashTerminalReplicaRow(row)}`)
+    );
+  ROW_ARRAY_HASH_CACHE.set(next, { hash, length: next.length });
+}
+function pow64(base, exponent) {
+  let result = 1n;
+  let factor = base;
+  let power = exponent;
+  while (power > 0) {
+    if (power % 2 === 1) result = BigInt.asUintN(64, result * factor);
+    factor = BigInt.asUintN(64, factor * factor);
+    power = Math.floor(power / 2);
+  }
+  return result;
+}
+function terminalReplicaRowIsValid(row) {
+  for (let index = 0; index < row.cells.length; index += 1) {
+    const width = row.cells[index].width;
+    if (width === 2 && row.cells[index + 1]?.width !== 0) return false;
+    if (width === 0 && (index === 0 || row.cells[index - 1]?.width !== 2)) return false;
+  }
+  return true;
+}
+var DEFAULT_COLOR, ROW_HASH_CACHE, ROW_ARRAY_HASH_CACHE, ROW_SEQUENCE_BASE;
+var init_terminal_replica2 = __esm({
+  "packages/core/src/terminal-replica.ts"() {
+    "use strict";
+    DEFAULT_COLOR = Object.freeze({ kind: "default" });
+    ROW_HASH_CACHE = /* @__PURE__ */ new WeakMap();
+    ROW_ARRAY_HASH_CACHE = /* @__PURE__ */ new WeakMap();
+    ROW_SEQUENCE_BASE = 0x100000001b3n;
+  }
+});
+
+// packages/core/src/interaction-receipts.ts
+var init_interaction_receipts2 = __esm({
+  "packages/core/src/interaction-receipts.ts"() {
+    "use strict";
+    init_src();
+  }
+});
+
+// packages/core/src/agent-provisioning.ts
+var init_agent_provisioning = __esm({
+  "packages/core/src/agent-provisioning.ts"() {
+    "use strict";
+    init_src();
+  }
+});
+
+// packages/core/src/navigator.ts
+var SCOPE_TOKENS, STATUS_TOKENS;
+var init_navigator = __esm({
+  "packages/core/src/navigator.ts"() {
+    "use strict";
+    SCOPE_TOKENS = Object.freeze({
+      "@all": "all",
+      "@workspace": "workspaces",
+      "@workspaces": "workspaces",
+      "@agent": "agents",
+      "@agents": "agents",
+      "@pane": "panes",
+      "@panes": "panes",
+      "@command": "commands",
+      "@commands": "commands"
+    });
+    STATUS_TOKENS = Object.freeze({
+      "#blocked": "blocked",
+      "#working": "working",
+      "#done": "done",
+      "#idle": "idle"
+    });
+  }
+});
+
+// packages/core/src/index.ts
+var init_src3 = __esm({
+  "packages/core/src/index.ts"() {
+    "use strict";
+    init_application_shell_session();
+    init_interaction_flow();
+    init_workspace_selection();
+    init_terminal_conformance();
+    init_terminal_replica2();
+    init_interaction_receipts2();
+    init_agent_provisioning();
+    init_navigator();
+  }
+});
+
+// packages/daemon/src/terminal/session-runtime/terminal-replica-interpreter.ts
+function writeTerminal(terminal, data) {
+  return new Promise((resolve31) => terminal.write(data, resolve31));
+}
+function projectRowCached(cache3, buffer, index, cols) {
+  const line = buffer.getLine(index);
+  const cacheKey = line?._line ?? line;
+  if (line && cacheKey) {
+    const data = lineData(line);
+    const combined = lineCombinedSignature(line);
+    const prior = cache3.get(cacheKey);
+    if (prior && rawRowsEqual(prior.data, data) && prior.combined === combined && prior.wrapped === line.isWrapped)
+      return prior.row;
+  }
+  const cell = buffer.getNullCell();
+  const cells = [];
+  for (let column = 0; column < cols; column += 1) {
+    line?.getCell(column, cell);
+    cells.push({
+      grapheme: line ? cell.getChars() || (cell.getWidth() === 0 ? "" : " ") : " ",
+      width: line ? cell.getWidth() : 1,
+      foreground: line ? cellColor(cell, "foreground") : { kind: "default" },
+      background: line ? cellColor(cell, "background") : { kind: "default" },
+      attributes: line ? cellAttributes(cell) : 0
+    });
+  }
+  const row = freezeTerminalReplicaRow({ cells, wrapped: line?.isWrapped ?? false });
+  if (line && cacheKey)
+    cache3.set(cacheKey, {
+      data: lineData(line)?.slice() ?? null,
+      combined: lineCombinedSignature(line),
+      wrapped: line.isWrapped,
+      row
+    });
+  return row;
+}
+function lineData(line) {
+  const data = line._line?._data;
+  return data instanceof Uint32Array ? data : null;
+}
+function lineCombinedSignature(line) {
+  const combined = line._line?._combined;
+  if (!combined) return "";
+  return Object.keys(combined).sort((left, right) => Number(left) - Number(right)).map((key) => `${key.length}:${key}${combined[key].length}:${combined[key]}`).join(";");
+}
+function rawRowsEqual(left, right) {
+  if (!left || !right || left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1)
+    if (left[index] !== right[index]) return false;
+  return true;
+}
+function cellColor(cell, channel) {
+  const rgb2 = channel === "foreground" ? cell.isFgRGB() : cell.isBgRGB();
+  const palette = channel === "foreground" ? cell.isFgPalette() : cell.isBgPalette();
+  const value = channel === "foreground" ? cell.getFgColor() : cell.getBgColor();
+  if (rgb2) return { kind: "rgb", value };
+  if (palette) return { kind: "indexed", index: value };
+  return { kind: "default" };
+}
+function cellAttributes(cell) {
+  return (cell.isBold() ? 1 : 0) | (cell.isDim() ? 2 : 0) | (cell.isItalic() ? 4 : 0) | (cell.isUnderline() ? 8 : 0) | (cell.isBlink() ? 16 : 0) | (cell.isInverse() ? 32 : 0) | (cell.isInvisible() ? 64 : 0) | (cell.isStrikethrough() ? 128 : 0);
+}
+function cursorState(terminal) {
+  const buffer = terminal.buffer.active;
+  const service = terminal._core?.coreService;
+  return {
+    x: Math.min(buffer.cursorX, terminal.cols - 1),
+    y: Math.min(buffer.cursorY, terminal.rows - 1),
+    hidden: service?.isCursorHidden === true,
+    style: service?.decPrivateModes?.cursorStyle ?? terminal.options.cursorStyle ?? "block",
+    blink: service?.decPrivateModes?.cursorBlink ?? terminal.options.cursorBlink ?? false
+  };
+}
+function setAuthoritativeCursor(terminal, x, y) {
+  const active2 = terminal.buffer.active;
+  const buffer = active2._buffer;
+  if (!buffer || typeof buffer.x !== "number" || typeof buffer.y !== "number" || buffer._cols !== terminal.cols || buffer._rows !== terminal.rows) {
+    throw new Error("Unsupported @xterm/headless 6.0.0 cursor adapter shape");
+  }
+  buffer.x = Math.max(0, Math.min(x, terminal.cols - 1));
+  buffer.y = Math.max(0, Math.min(y, terminal.rows - 1));
+}
+function terminalModes(terminal) {
+  const core = terminal._core;
+  const dec = core?.coreService?.decPrivateModes ?? {};
+  const modes = core?.coreService?.modes ?? {};
+  return {
+    alternateScreen: terminal.buffer.active.type === "alternate",
+    applicationCursor: dec.applicationCursorKeys === true,
+    applicationKeypad: dec.applicationKeypad === true,
+    bracketedPaste: dec.bracketedPasteMode === true,
+    insert: modes.insertMode === true,
+    origin: dec.origin === true,
+    wraparound: dec.wraparound !== false,
+    mouseTracking: core?.coreMouseService?._activeProtocol !== void 0 && core.coreMouseService._activeProtocol !== "NONE",
+    synchronizedOutput: dec.synchronizedOutput === true
+  };
+}
+function projectPlacements(rows, viewportRows, cols, historyRows) {
+  const marker = detectWidgetMarker(
+    rows.map((row) => ({ cells: row.cells.map((cell) => cell.grapheme), wrapped: row.wrapped }))
+  );
+  if (!marker) return [];
+  return [
+    {
+      id: marker.id,
+      kind: "widget",
+      row: Math.max(0, Math.min(viewportRows - 1, marker.lineIndex - historyRows)),
+      column: 0,
+      columns: Math.max(1, cols),
+      rows: 1,
+      contentDigest: hashTerminalReplicaTombstone(`${marker.id}:${JSON.stringify(marker.args)}`)
+    }
+  ];
+}
+function dirtyRange(terminal) {
+  const tracker = terminal._core?._inputHandler?._dirtyRowTracker;
+  return typeof tracker?.start === "number" && typeof tracker.end === "number" ? { start: tracker.start, end: tracker.end } : void 0;
+}
+var import_headless, import_addon_unicode11, TerminalReplicaInterpreter;
+var init_terminal_replica_interpreter = __esm({
+  "packages/daemon/src/terminal/session-runtime/terminal-replica-interpreter.ts"() {
+    "use strict";
+    import_headless = __toESM(require_xterm_headless(), 1);
+    import_addon_unicode11 = __toESM(require_addon_unicode11(), 1);
+    init_src();
+    init_src3();
+    TerminalReplicaInterpreter = class {
+      #generation;
+      #workspaceName;
+      #semanticPaneId;
+      #incarnation;
+      #scrollback;
+      #listeners = /* @__PURE__ */ new Set();
+      #terminal;
+      #tail = Promise.resolve();
+      #revision = 0;
+      #snapshot;
+      #needsSeed = true;
+      #closed = false;
+      #walkCount = 0;
+      #pendingWrites = [];
+      #writeFlushScheduled = false;
+      #rowCache = /* @__PURE__ */ new WeakMap();
+      #lastViewportY = 0;
+      #lastBufferType = "normal";
+      #widgetGate = false;
+      #markerTail = "";
+      #pendingResize = null;
+      #syncRecovery = null;
+      #bootstrap = {
+        kind: "painted-capture",
+        hiddenState: "unknown"
+      };
+      #scrollEpoch = 0;
+      #lastScrollEpoch = 0;
+      #projectedHistoryDelta = null;
+      #stats = {
+        fullWalks: 0,
+        gridRowsRead: 0,
+        historyRowsRead: 0,
+        placementRowsRead: 0,
+        cellsRead: 0,
+        parseBatches: 0,
+        historyKeyVisits: 0
+      };
+      #seedReady;
+      #resolveSeedReady;
+      #rejectSeedReady;
+      constructor(options) {
+        this.#generation = options.generation;
+        this.#workspaceName = options.workspaceName;
+        this.#semanticPaneId = options.semanticPaneId;
+        this.#incarnation = options.incarnation;
+        this.#revision = options.initialRevision ?? 0;
+        this.#scrollback = options.scrollback ?? 5e3;
+        this.#terminal = this.#createTerminal(options.cols, options.rows);
+        this.#snapshot = blankTerminalReplicaSnapshot(options.cols, options.rows);
+        this.#seedReady = new Promise((resolve31, reject) => {
+          this.#resolveSeedReady = resolve31;
+          this.#rejectSeedReady = reject;
+        });
+        void this.#seedReady.catch(() => void 0);
+        if (options.onUpdate) this.#listeners.add(options.onUpdate);
+      }
+      onUpdate(listener) {
+        this.#listeners.add(listener);
+        return () => this.#listeners.delete(listener);
+      }
+      enqueue(operation) {
+        if (operation.type === "write") {
+          const data = operation.data.slice();
+          const promise = new Promise((resolve31, reject) => {
+            this.#pendingWrites.push({ data, resolve: resolve31, reject });
+          });
+          if (!this.#writeFlushScheduled) {
+            this.#writeFlushScheduled = true;
+            queueMicrotask(() => this.#flushWrites());
+          }
+          return promise;
+        }
+        this.#flushWrites();
+        const admitted = operation.type === "reseed" ? { ...operation, chunks: operation.chunks.map((chunk) => chunk.slice()) } : operation;
+        return this.#append(admitted);
+      }
+      whenIdle() {
+        this.#flushWrites();
+        return this.#tail;
+      }
+      currentSnapshot() {
+        return this.#snapshot;
+      }
+      currentSeed() {
+        return this.#needsSeed ? null : this.#seed(this.#revision, this.#snapshot);
+      }
+      whenSeeded() {
+        return this.#seedReady;
+      }
+      abort(error) {
+        if (this.#needsSeed) this.#rejectSeedReady(error);
+      }
+      gridWalkCount() {
+        return this.#walkCount;
+      }
+      stats() {
+        return Object.freeze({ ...this.#stats });
+      }
+      #append(operation) {
+        const run = this.#tail.then(() => this.#apply(operation));
+        this.#tail = run.catch(() => void 0);
+        return run;
+      }
+      async #apply(operation) {
+        if (this.#closed) return;
+        if (operation.type === "reseed") {
+          const replacement = this.#createTerminal(operation.cols, operation.rows);
+          try {
+            for (const chunk of operation.chunks) {
+              this.#observeMarkerBytes(chunk);
+              await writeTerminal(replacement, chunk);
+            }
+          } catch (error) {
+            replacement.dispose();
+            throw error;
+          }
+          const previous = this.#terminal;
+          this.#terminal = replacement;
+          this.#bootstrap = {
+            kind: operation.bootstrap,
+            hiddenState: operation.bootstrap === "authoritative-stream" ? "observed-from-start" : "unknown"
+          };
+          setAuthoritativeCursor(this.#terminal, operation.cursor.x, operation.cursor.y);
+          this.#commit(true);
+          previous.dispose();
+          return;
+        }
+        if (operation.type === "cursor") {
+          setAuthoritativeCursor(this.#terminal, operation.x, operation.y);
+          this.#commit(false, { start: 1, end: 0 });
+          return;
+        }
+        if (operation.type === "resize") {
+          if (terminalModes(this.#terminal).synchronizedOutput) {
+            this.#terminal.resize(operation.cols, operation.rows);
+            this.#pendingResize = { cols: operation.cols, rows: operation.rows };
+            this.#scheduleSyncRecovery();
+            return;
+          }
+          this.#terminal.resize(operation.cols, operation.rows);
+          this.#commit(false);
+          return;
+        }
+        const baseRevision = this.#revision;
+        const revision = baseRevision + 1;
+        const update = {
+          type: "terminal.tombstone",
+          ...this.#address(),
+          baseRevision,
+          revision,
+          cols: this.#snapshot.cols,
+          rows: this.#snapshot.rows,
+          stateHash: hashTerminalReplicaTombstone(operation.reason),
+          hashAlgorithm: "fnv1a64-v1",
+          tombstone: { reason: operation.reason }
+        };
+        this.#revision = revision;
+        this.#closed = true;
+        this.#clearSyncRecovery();
+        if (this.#needsSeed)
+          this.#rejectSeedReady(new Error("Terminal replica closed before bootstrap"));
+        this.#terminal.dispose();
+        this.#emit(update);
+      }
+      async #write(data) {
+        if (this.#closed) return;
+        this.#stats.parseBatches += 1;
+        this.#observeMarkerBytes(data);
+        await writeTerminal(this.#terminal, data);
+        if (terminalModes(this.#terminal).synchronizedOutput) {
+          this.#scheduleSyncRecovery();
+          return;
+        }
+        this.#clearSyncRecovery();
+        const pendingResize = this.#pendingResize;
+        this.#pendingResize = null;
+        if (pendingResize) {
+          this.#commit(false);
+        } else {
+          this.#commit(false, dirtyRange(this.#terminal));
+        }
+      }
+      #scheduleSyncRecovery() {
+        if (this.#syncRecovery || this.#closed) return;
+        this.#syncRecovery = setTimeout(() => {
+          this.#syncRecovery = null;
+          const run = this.#tail.then(async () => {
+            if (this.#closed || !terminalModes(this.#terminal).synchronizedOutput) return;
+            await writeTerminal(this.#terminal, "\x1B[?2026l");
+            this.#pendingResize = null;
+            this.#commit(false);
+          });
+          this.#tail = run.catch(() => void 0);
+        }, 250);
+        this.#syncRecovery.unref?.();
+      }
+      #clearSyncRecovery() {
+        if (!this.#syncRecovery) return;
+        clearTimeout(this.#syncRecovery);
+        this.#syncRecovery = null;
+      }
+      #commit(forceSeed, dirty) {
+        const projected = this.#project(forceSeed ? void 0 : dirty);
+        const previous = this.#snapshot;
+        const dirtyRows = [];
+        for (let index = 0; index < projected.grid.length; index += 1) {
+          const row = projected.grid[index];
+          if (!terminalReplicaRowsEqual(previous.grid[index], row)) dirtyRows.push({ index, row });
+        }
+        const historyChanged = previous.history !== projected.history;
+        const historyDelta = historyChanged ? this.#projectedHistoryDelta : null;
+        const next = applyTerminalReplicaPatch(previous, {
+          ...projected.cols !== previous.cols || projected.rows !== previous.rows ? { dimensions: { cols: projected.cols, rows: projected.rows } } : {},
+          rows: dirtyRows,
+          ...historyChanged ? historyDelta ? { historyDelta } : { history: projected.history } : {},
+          cursor: projected.cursor,
+          modes: projected.modes,
+          placements: projected.placements,
+          bootstrap: projected.bootstrap
+        });
+        const nextHash = hashTerminalReplicaSnapshot(next);
+        const priorHash = hashTerminalReplicaSnapshot(previous);
+        if (!forceSeed && nextHash === priorHash) return;
+        if (forceSeed || this.#needsSeed) {
+          const revision2 = this.#needsSeed ? this.#revision : this.#revision + 1;
+          this.#revision = revision2;
+          this.#snapshot = next;
+          this.#needsSeed = false;
+          this.#resolveSeedReady();
+          this.#emit(this.#seed(revision2, next));
+          return;
+        }
+        const baseRevision = this.#revision;
+        const revision = baseRevision + 1;
+        const update = {
+          type: "terminal.patch",
+          ...this.#address(),
+          baseRevision,
+          revision,
+          cols: next.cols,
+          rows: next.rows,
+          stateHash: nextHash,
+          hashAlgorithm: "fnv1a64-v1",
+          patch: {
+            ...next.cols !== previous.cols || next.rows !== previous.rows ? { dimensions: { cols: next.cols, rows: next.rows } } : {},
+            rows: dirtyRows,
+            ...historyChanged ? historyDelta ? { historyDelta } : { history: next.history } : {},
+            cursor: next.cursor,
+            modes: next.modes,
+            placements: next.placements,
+            bootstrap: next.bootstrap
+          }
+        };
+        this.#revision = revision;
+        this.#snapshot = next;
+        this.#emit(update);
+      }
+      #project(dirty) {
+        this.#walkCount += 1;
+        if (!dirty) this.#stats.fullWalks += 1;
+        const buffer = this.#terminal.buffer.active;
+        const geometryStable = buffer.viewportY === this.#lastViewportY && buffer.type === this.#lastBufferType && this.#snapshot.cols === this.#terminal.cols;
+        const canReuseHistory = geometryStable && this.#scrollEpoch === this.#lastScrollEpoch;
+        this.#projectedHistoryDelta = null;
+        let history = canReuseHistory ? this.#snapshot.history : [];
+        const scrolls = this.#scrollEpoch - this.#lastScrollEpoch;
+        const previousLength = this.#snapshot.history.length;
+        const nextLength = buffer.viewportY;
+        const incrementalHistory = !canReuseHistory && this.#lastBufferType === buffer.type && this.#snapshot.cols === this.#terminal.cols && nextLength >= previousLength && scrolls > 0;
+        if (incrementalHistory) {
+          const appended = nextLength - previousLength;
+          const trim = Math.min(previousLength, Math.max(0, scrolls - appended));
+          const retained = previousLength - trim;
+          const nextHistory = this.#snapshot.history.slice(trim);
+          for (let index = retained; index < nextLength; index += 1)
+            nextHistory.push(this.#readRow(buffer, index, this.#terminal.cols, "history"));
+          history = nextHistory;
+          this.#projectedHistoryDelta = { trim, append: nextHistory.slice(retained) };
+        } else if (!canReuseHistory && buffer.viewportY > 0) {
+          const nextHistory = [];
+          for (let index = 0; index < buffer.viewportY; index += 1)
+            nextHistory.push(this.#readRow(buffer, index, this.#terminal.cols, "history"));
+          history = nextHistory;
+        }
+        const grid = [];
+        const canUseDirtyRange = dirty !== void 0 && canReuseHistory && this.#snapshot.rows === this.#terminal.rows;
+        for (let row = 0; row < this.#terminal.rows; row += 1) {
+          if (canUseDirtyRange && (row < dirty.start || row > dirty.end)) {
+            grid.push(this.#snapshot.grid[row]);
+          } else {
+            grid.push(this.#readRow(buffer, buffer.viewportY + row, this.#terminal.cols, "grid"));
+          }
+        }
+        this.#lastViewportY = buffer.viewportY;
+        this.#lastBufferType = buffer.type;
+        this.#lastScrollEpoch = this.#scrollEpoch;
+        const scanPlacements = this.#widgetGate || this.#snapshot.placements.length > 0;
+        const placementRows = scanPlacements ? [...history, ...grid] : [];
+        if (scanPlacements) this.#stats.placementRowsRead += placementRows.length;
+        const placements = scanPlacements ? projectPlacements(placementRows, grid.length, this.#terminal.cols, history.length) : [];
+        if (scanPlacements && placements.length === 0) this.#widgetGate = false;
+        return assembleTerminalReplicaSnapshot({
+          cols: this.#terminal.cols,
+          rows: this.#terminal.rows,
+          grid,
+          history,
+          cursor: cursorState(this.#terminal),
+          modes: terminalModes(this.#terminal),
+          placements,
+          bootstrap: this.#bootstrap
+        });
+      }
+      #seed(revision, snapshot) {
+        return {
+          type: "terminal.seed",
+          ...this.#address(),
+          revision,
+          cols: snapshot.cols,
+          rows: snapshot.rows,
+          stateHash: hashTerminalReplicaSnapshot(snapshot),
+          hashAlgorithm: "fnv1a64-v1",
+          snapshot
+        };
+      }
+      #address() {
+        return {
+          workspaceName: this.#workspaceName,
+          semanticPaneId: this.#semanticPaneId,
+          generation: this.#generation,
+          incarnation: this.#incarnation
+        };
+      }
+      #emit(update) {
+        for (const listener of this.#listeners) {
+          try {
+            listener(update);
+          } catch {
+          }
+        }
+      }
+      #createTerminal(cols, rows) {
+        const terminal = new import_headless.Terminal({
+          cols,
+          rows,
+          scrollback: this.#scrollback,
+          allowProposedApi: true
+        });
+        terminal.loadAddon(new import_addon_unicode11.Unicode11Addon());
+        terminal.unicode.activeVersion = "11";
+        terminal.onScroll(() => {
+          this.#scrollEpoch += 1;
+        });
+        const core = terminal._core;
+        if (!core?.coreService) {
+          terminal.dispose();
+          throw new Error("Unsupported @xterm/headless private API shape");
+        }
+        return terminal;
+      }
+      #flushWrites() {
+        this.#writeFlushScheduled = false;
+        if (this.#pendingWrites.length === 0) return;
+        const pending = this.#pendingWrites.splice(0);
+        const length = pending.reduce((total, entry) => total + entry.data.length, 0);
+        const data = new Uint8Array(length);
+        let offset = 0;
+        for (const entry of pending) {
+          data.set(entry.data, offset);
+          offset += entry.data.length;
+        }
+        const run = this.#tail.then(() => this.#write(data));
+        this.#tail = run.catch(() => void 0);
+        void run.then(
+          () => pending.forEach((entry) => entry.resolve()),
+          (error) => pending.forEach((entry) => entry.reject(error))
+        );
+      }
+      #observeMarkerBytes(data) {
+        if (this.#widgetGate) return;
+        const text = this.#markerTail + new TextDecoder().decode(data);
+        if (text.includes("TMUXIDE-WIDGET/1")) this.#widgetGate = true;
+        this.#markerTail = text.slice(-32);
+      }
+      #readRow(buffer, index, cols, kind) {
+        if (kind === "grid") this.#stats.gridRowsRead += 1;
+        else this.#stats.historyRowsRead += 1;
+        this.#stats.cellsRead += cols;
+        return projectRowCached(this.#rowCache, buffer, index, cols);
+      }
+    };
+  }
+});
+
+// packages/daemon/src/terminal/session-runtime/terminal-replica-owner.ts
+var SessionRuntimeTerminalReplicaOwner;
+var init_terminal_replica_owner = __esm({
+  "packages/daemon/src/terminal/session-runtime/terminal-replica-owner.ts"() {
+    "use strict";
+    init_terminal_replica_interpreter();
+    SessionRuntimeTerminalReplicaOwner = class {
+      constructor(generation, session, semanticPaneId3, mirror, options) {
+        this.generation = generation;
+        this.session = session;
+        this.semanticPaneId = semanticPaneId3;
+        this.#onClosed = options.onClosed;
+        this.#onFault = options.onFault;
+        this.#interpreter = new TerminalReplicaInterpreter({
+          generation,
+          workspaceName: session,
+          semanticPaneId: semanticPaneId3,
+          incarnation: options.incarnation,
+          initialRevision: options.initialRevision,
+          cols: this.#cols,
+          rows: this.#rows,
+          onUpdate: (update) => {
+            if (update.type === "terminal.seed") this.#bootstrapped = true;
+            options.onRevision?.(update.revision);
+            for (const listener of this.#listeners) {
+              try {
+                listener(update);
+              } catch {
+              }
+            }
+          }
+        });
+        this.#start = mirror.subscribe({
+          session,
+          semanticPaneId: semanticPaneId3,
+          onEvent: (event) => this.#observePane(event),
+          onLayout: (event) => this.#observeLayout(event)
+        }).then((subscription) => {
+          if (this.#disposed) return subscription.close();
+          this.#upstream = subscription;
+        });
+      }
+      #interpreter;
+      #listeners = /* @__PURE__ */ new Set();
+      #onClosed;
+      #onFault;
+      #start;
+      #upstream = null;
+      #disposed = false;
+      #cols = 80;
+      #rows = 24;
+      #reseed = null;
+      #bootstrapped = false;
+      async subscribe(listener) {
+        if (this.#disposed) throw new Error("Terminal replica owner is disposed");
+        try {
+          await this.#start;
+          await this.#interpreter.whenSeeded();
+          this.#listeners.add(listener);
+          const seed = this.#interpreter.currentSeed();
+          if (!seed) throw new Error("Terminal replica bootstrap did not produce a seed");
+          try {
+            listener(seed);
+          } catch {
+          }
+        } catch (error) {
+          this.#listeners.delete(listener);
+          throw error;
+        }
+        let closed = false;
+        return {
+          generation: this.generation,
+          semanticPaneId: this.semanticPaneId,
+          close: async () => {
+            if (closed) return;
+            closed = true;
+            this.#listeners.delete(listener);
+          }
+        };
+      }
+      async dispose(reason = "runtime-disposed") {
+        if (this.#disposed) return;
+        this.#disposed = true;
+        await this.#interpreter.enqueue({ type: "close", reason });
+        await this.#start.catch(() => void 0);
+        await this.#upstream?.close();
+        this.#upstream = null;
+        this.#listeners.clear();
+      }
+      #observePane(event) {
+        if (event.type === "reset") {
+          this.#cols = event.cols;
+          this.#rows = event.rows;
+          this.#reseed = { cols: event.cols, rows: event.rows, chunks: [] };
+        } else if (event.type === "seed" || event.type === "delta") {
+          if (this.#reseed) this.#reseed.chunks.push(event.data.slice());
+          else this.#supervise(this.#interpreter.enqueue({ type: "write", data: event.data }));
+        } else if (event.type === "cursor") {
+          const reseed = this.#reseed;
+          this.#reseed = null;
+          this.#supervise(
+            reseed ? this.#interpreter.enqueue({
+              type: "reseed",
+              ...reseed,
+              cursor: { x: event.x, y: event.y },
+              bootstrap: "painted-capture"
+            }) : this.#interpreter.enqueue({ type: "cursor", x: event.x, y: event.y })
+          );
+        } else if (event.type === "closed") {
+          const closed = this.#interpreter.enqueue({ type: "close", reason: "pane-closed" });
+          this.#supervise(closed);
+          void closed.then(
+            async () => {
+              await this.dispose("pane-closed");
+              this.#onClosed?.();
+            },
+            () => void 0
+          );
+        }
+      }
+      #observeLayout(event) {
+        const pane = event.panes.find((candidate) => candidate.semanticPaneId === this.semanticPaneId);
+        if (!pane || pane.width === this.#cols && pane.height === this.#rows) return;
+        this.#cols = pane.width;
+        this.#rows = pane.height;
+        if (this.#reseed) {
+          this.#reseed.cols = pane.width;
+          this.#reseed.rows = pane.height;
+          return;
+        }
+        if (!this.#bootstrapped) {
+          return;
+        }
+        this.#supervise(
+          this.#interpreter.enqueue({ type: "resize", cols: pane.width, rows: pane.height })
+        );
+      }
+      #supervise(operation) {
+        void operation.catch((error) => {
+          this.#interpreter.abort(error);
+          this.#onFault?.(error);
+        });
+      }
+    };
+  }
+});
+
 // packages/daemon/src/terminal/session-runtime/registry.ts
 import { randomUUID as randomUUID5 } from "node:crypto";
-import { z as z62 } from "zod";
+import { z as z63 } from "zod";
 function authoredOriginForSurface(surface) {
   if (surface === "opentui") return "tui";
   if (surface === "command-center") return "sdk";
@@ -30080,6 +38513,7 @@ var init_registry2 = __esm({
     init_src();
     init_mirror_service();
     init_semantic_mutation_executor();
+    init_terminal_replica_owner();
     SessionRuntimeControllerLeaseError = class extends Error {
       constructor(code, message) {
         super(message);
@@ -30320,6 +38754,8 @@ var init_registry2 = __esm({
       #mirror;
       #consumers = /* @__PURE__ */ new Set();
       #consumersByClientId = /* @__PURE__ */ new Map();
+      #terminalReplicas = /* @__PURE__ */ new Map();
+      #terminalReplicaClocks = /* @__PURE__ */ new Map();
       #createControllerToken;
       #submitAuthorized;
       #retention = null;
@@ -30461,6 +38897,59 @@ var init_registry2 = __esm({
           onLayout
         });
       }
+      async subscribeReplica(semanticPaneId3, onUpdate) {
+        await this.whenReady();
+        await this.#restartBarrier;
+        let owner = this.#terminalReplicas.get(semanticPaneId3);
+        if (!owner) {
+          const clock = this.#terminalReplicaClocks.get(semanticPaneId3) ?? { epoch: 0, revision: -1 };
+          const initialRevision = clock.revision + 1;
+          let candidate;
+          candidate = new SessionRuntimeTerminalReplicaOwner(
+            this.generation,
+            this.session,
+            semanticPaneId3,
+            this.#mirror,
+            {
+              incarnation: `${this.generation}:${clock.epoch}`,
+              initialRevision,
+              onRevision: (revision) => {
+                const current = this.#terminalReplicaClocks.get(semanticPaneId3) ?? clock;
+                if (revision > current.revision) current.revision = revision;
+                this.#terminalReplicaClocks.set(semanticPaneId3, current);
+              },
+              onClosed: () => {
+                if (this.#terminalReplicas.get(semanticPaneId3) !== candidate) return;
+                this.#terminalReplicas.delete(semanticPaneId3);
+                const current = this.#terminalReplicaClocks.get(semanticPaneId3) ?? clock;
+                current.epoch += 1;
+                this.#terminalReplicaClocks.set(semanticPaneId3, current);
+              },
+              onFault: () => {
+                if (this.#terminalReplicas.get(semanticPaneId3) !== candidate) return;
+                this.#terminalReplicas.delete(semanticPaneId3);
+                this.#restartBarrier = this.#restartBarrier.then(async () => {
+                  await candidate.dispose("session-restarted");
+                  const current = this.#terminalReplicaClocks.get(semanticPaneId3) ?? clock;
+                  current.epoch += 1;
+                  this.#terminalReplicaClocks.set(semanticPaneId3, current);
+                });
+              }
+            }
+          );
+          owner = candidate;
+          this.#terminalReplicas.set(semanticPaneId3, owner);
+        }
+        try {
+          return await owner.subscribe(onUpdate);
+        } catch (error) {
+          if (this.#terminalReplicas.get(semanticPaneId3) === owner) {
+            this.#terminalReplicas.delete(semanticPaneId3);
+          }
+          await owner.dispose("session-restarted");
+          throw error;
+        }
+      }
       release(consumer) {
         this.#consumers.delete(consumer);
         if (this.#consumersByClientId.get(consumer.clientId) === consumer) {
@@ -30472,9 +38961,13 @@ var init_registry2 = __esm({
         const retention = this.#retention;
         this.#retention = null;
         this.#startPromise = null;
-        if (retention) {
-          this.#restartBarrier = this.#restartBarrier.then(() => retention.close());
-        }
+        const owners = [...this.#terminalReplicas.values()];
+        this.#terminalReplicas.clear();
+        this.#restartBarrier = this.#restartBarrier.then(async () => {
+          await Promise.allSettled(owners.map((owner) => owner.dispose("session-restarted")));
+          await retention?.close();
+          for (const clock of this.#terminalReplicaClocks.values()) clock.epoch += 1;
+        });
       }
       async dispose() {
         if (this.#disposed) return;
@@ -30484,6 +38977,10 @@ var init_registry2 = __esm({
         this.#clearController();
         this.#completedHandoffs.clear();
         this.#releasedLeases.clear();
+        await Promise.allSettled(
+          [...this.#terminalReplicas.values()].map((owner) => owner.dispose("runtime-disposed"))
+        );
+        this.#terminalReplicas.clear();
         await this.#restartBarrier;
         await this.#retention?.close();
         this.#retention = null;
@@ -30499,7 +38996,7 @@ var init_registry2 = __esm({
       #assignController(clientId) {
         this.#controllerRevision += 1;
         this.#controllerClientId = clientId;
-        this.#controllerToken = z62.uuid().parse(this.#createControllerToken());
+        this.#controllerToken = z63.uuid().parse(this.#createControllerToken());
         return this.#currentLease();
       }
       #clearController() {
@@ -30556,6 +39053,7 @@ var init_registry2 = __esm({
       session;
       clientId;
       #subscriptions = /* @__PURE__ */ new Set();
+      #replicaSubscriptions = /* @__PURE__ */ new Set();
       #closed = false;
       controllerRole() {
         this.#assertOpen();
@@ -30605,13 +39103,36 @@ var init_registry2 = __esm({
         this.#subscriptions.add(subscription);
         return subscription;
       }
+      async subscribeReplica(semanticPaneId3, onUpdate) {
+        this.#assertOpen();
+        const upstream = await this.#runtime.subscribeReplica(semanticPaneId3, onUpdate);
+        if (this.#closed) {
+          await upstream.close();
+          throw new Error(`SessionRuntime consumer ${this.surface} is closed`);
+        }
+        let closed = false;
+        const subscription = {
+          ...upstream,
+          close: async () => {
+            if (closed) return;
+            closed = true;
+            this.#replicaSubscriptions.delete(subscription);
+            await upstream.close();
+          }
+        };
+        this.#replicaSubscriptions.add(subscription);
+        return subscription;
+      }
       async close() {
         if (this.#closed) return;
         this.#closed = true;
         const subscriptions = [...this.#subscriptions];
+        const replicaSubscriptions = [...this.#replicaSubscriptions];
         this.#subscriptions.clear();
+        this.#replicaSubscriptions.clear();
         this.#runtime.release(this);
         await Promise.allSettled(subscriptions.map((subscription) => subscription.close()));
+        await Promise.allSettled(replicaSubscriptions.map((subscription) => subscription.close()));
       }
       #assertOpen() {
         if (this.#closed) throw new Error(`SessionRuntime consumer ${this.surface} is closed`);
@@ -30621,7 +39142,7 @@ var init_registry2 = __esm({
 });
 
 // packages/daemon/src/terminal/session-runtime/transport-binding.ts
-import { z as z63 } from "zod";
+import { z as z64 } from "zod";
 function assertLiveScope(shared, lease, semanticPaneId3) {
   if (shared.interactiveRefs <= 0 || shared.lease !== lease) {
     throw new SessionRuntimeControllerLeaseError(
@@ -30642,9 +39163,9 @@ var init_transport_binding = __esm({
     "use strict";
     init_src();
     init_registry2();
-    TransportSchemaZ = z63.enum(["terminal-attachment", "pane-stream"]);
-    LeaseIdSchemaZ = z63.uuid();
-    HostClientIdSchemaZ = z63.string().min(1).max(4096).refine((v) => !/[\0\r\n]/u.test(v));
+    TransportSchemaZ = z64.enum(["terminal-attachment", "pane-stream"]);
+    LeaseIdSchemaZ = z64.uuid();
+    HostClientIdSchemaZ = z64.string().min(1).max(4096).refine((v) => !/[\0\r\n]/u.test(v));
     clientsByRegistry = /* @__PURE__ */ new WeakMap();
     SessionRuntimeTransportBinding = class {
       #binder;
@@ -30879,7 +39400,7 @@ var init_admission_util = __esm({
 });
 
 // packages/contracts/src/terminal-attachment-stream.ts
-import { z as z64 } from "zod";
+import { z as z65 } from "zod";
 function decodeTerminalAttachmentInputFrame(frame) {
   if (!(frame instanceof Uint8Array) || frame.byteLength <= TERMINAL_ATTACHMENT_INPUT_FRAME_HEADER_BYTES || frame.byteLength > TERMINAL_ATTACHMENT_MAX_INPUT_WIRE_BYTES || frame[0] !== TERMINAL_ATTACHMENT_INPUT_FRAME_KIND) {
     return null;
@@ -30904,43 +39425,43 @@ var init_terminal_attachment_stream = __esm({
     TERMINAL_ATTACHMENT_MAX_INPUT_SEQUENCE = 4294967295;
     TERMINAL_ATTACHMENT_MAX_INPUT_FRAME_BYTES = 64 * 1024;
     TERMINAL_ATTACHMENT_MAX_INPUT_WIRE_BYTES = TERMINAL_ATTACHMENT_INPUT_FRAME_HEADER_BYTES + TERMINAL_ATTACHMENT_MAX_INPUT_FRAME_BYTES;
-    TerminalAttachmentInputLimitsSchemaZ = z64.object({
-      maxFrameBytes: z64.number().int().positive().max(TERMINAL_ATTACHMENT_MAX_INPUT_FRAME_BYTES),
-      maxAcceptedBytes: z64.number().int().positive().max(4 * 1024 * 1024),
-      maxAcceptedFrames: z64.number().int().positive().max(16384)
+    TerminalAttachmentInputLimitsSchemaZ = z65.object({
+      maxFrameBytes: z65.number().int().positive().max(TERMINAL_ATTACHMENT_MAX_INPUT_FRAME_BYTES),
+      maxAcceptedBytes: z65.number().int().positive().max(4 * 1024 * 1024),
+      maxAcceptedFrames: z65.number().int().positive().max(16384)
     }).strict().refine((limits) => limits.maxFrameBytes <= limits.maxAcceptedBytes, {
       message: "terminal input frame limit cannot exceed its lifetime byte limit"
     });
-    TerminalAttachmentInputCapabilitySchemaZ = z64.union([
-      z64.literal("unavailable"),
-      z64.object({
-        mode: z64.literal("bounded"),
+    TerminalAttachmentInputCapabilitySchemaZ = z65.union([
+      z65.literal("unavailable"),
+      z65.object({
+        mode: z65.literal("bounded"),
         limits: TerminalAttachmentInputLimitsSchemaZ
       }).strict()
     ]);
-    TerminalAttachmentInputAckFrameSchemaZ = z64.object({
-      type: z64.literal("input-ack"),
-      protocolVersion: z64.literal(TERMINAL_ATTACHMENT_PROTOCOL_VERSION),
-      generation: z64.number().int().nonnegative(),
-      sequence: z64.number().int().positive().max(TERMINAL_ATTACHMENT_MAX_INPUT_SEQUENCE),
-      byteLength: z64.number().int().positive().max(TERMINAL_ATTACHMENT_MAX_INPUT_FRAME_BYTES),
-      state: z64.enum(["open", "exhausted"]),
-      acceptedBytes: z64.number().int().positive().max(4 * 1024 * 1024),
-      acceptedFrames: z64.number().int().positive().max(16384),
-      remainingBytes: z64.number().int().nonnegative().max(4 * 1024 * 1024),
-      remainingFrames: z64.number().int().nonnegative().max(16384)
+    TerminalAttachmentInputAckFrameSchemaZ = z65.object({
+      type: z65.literal("input-ack"),
+      protocolVersion: z65.literal(TERMINAL_ATTACHMENT_PROTOCOL_VERSION),
+      generation: z65.number().int().nonnegative(),
+      sequence: z65.number().int().positive().max(TERMINAL_ATTACHMENT_MAX_INPUT_SEQUENCE),
+      byteLength: z65.number().int().positive().max(TERMINAL_ATTACHMENT_MAX_INPUT_FRAME_BYTES),
+      state: z65.enum(["open", "exhausted"]),
+      acceptedBytes: z65.number().int().positive().max(4 * 1024 * 1024),
+      acceptedFrames: z65.number().int().positive().max(16384),
+      remainingBytes: z65.number().int().nonnegative().max(4 * 1024 * 1024),
+      remainingFrames: z65.number().int().nonnegative().max(16384)
     }).strict();
   }
 });
 
 // packages/daemon/src/terminal/attachments/grouped-tmux.ts
-import { z as z65 } from "zod";
+import { z as z66 } from "zod";
 function tmux3(argv) {
   return { executable: "tmux", argv };
 }
 function groupedTmuxViewSessionName(attachmentId, generation) {
   const parsed = GroupedTmuxAttachmentPlanInputSchemaZ.shape.attachmentId.parse(attachmentId);
-  const parsedGeneration = z65.number().int().min(0).max(GROUPED_TMUX_MAX_GENERATION).parse(generation);
+  const parsedGeneration = z66.number().int().min(0).max(GROUPED_TMUX_MAX_GENERATION).parse(generation);
   return `${GROUPED_TMUX_VIEW_SESSION_PREFIX}${parsed.replaceAll("-", "").toLowerCase()}-${parsedGeneration.toString(36)}`;
 }
 function markerValue(attachmentId, generation) {
@@ -31065,17 +39586,17 @@ var init_grouped_tmux = __esm({
     GROUPED_TMUX_MAX_GENERATION = 65535;
     GROUPED_TMUX_PLACEHOLDER_WINDOW = "__tmux_ide_attachment_placeholder";
     GROUPED_TMUX_PLACEHOLDER_COMMAND = "exec sleep 2147483647";
-    RuntimeSessionIdSchemaZ2 = z65.string().max(32).regex(/^\$(?:0|[1-9][0-9]*)$/u, "source session id must be a tmux runtime id");
-    RuntimeWindowIdSchemaZ2 = z65.string().max(32).regex(/^@(?:0|[1-9][0-9]*)$/u, "source window id must be a tmux runtime id");
-    RuntimePaneIdSchemaZ2 = z65.string().max(32).regex(/^%(?:0|[1-9][0-9]*)$/u, "source pane id must be a tmux runtime id");
-    GroupedTmuxAttachmentPlanInputSchemaZ = z65.object({
-      attachmentId: z65.uuid(),
-      generation: z65.number().int().min(0).max(GROUPED_TMUX_MAX_GENERATION),
+    RuntimeSessionIdSchemaZ2 = z66.string().max(32).regex(/^\$(?:0|[1-9][0-9]*)$/u, "source session id must be a tmux runtime id");
+    RuntimeWindowIdSchemaZ2 = z66.string().max(32).regex(/^@(?:0|[1-9][0-9]*)$/u, "source window id must be a tmux runtime id");
+    RuntimePaneIdSchemaZ2 = z66.string().max(32).regex(/^%(?:0|[1-9][0-9]*)$/u, "source pane id must be a tmux runtime id");
+    GroupedTmuxAttachmentPlanInputSchemaZ = z66.object({
+      attachmentId: z66.uuid(),
+      generation: z66.number().int().min(0).max(GROUPED_TMUX_MAX_GENERATION),
       target: TerminalAttachmentSemanticTargetSchemaZ,
       viewerMode: TerminalAttachmentViewerModeSchemaZ,
       geometryOwnership: TerminalAttachmentGeometryOwnershipSchemaZ.default("passive"),
       viewport: TerminalAttachmentViewportSchemaZ,
-      source: z65.object({
+      source: z66.object({
         sessionId: RuntimeSessionIdSchemaZ2,
         windowId: RuntimeWindowIdSchemaZ2,
         runtimePaneId: RuntimePaneIdSchemaZ2,
@@ -31085,7 +39606,7 @@ var init_grouped_tmux = __esm({
          * gate: any positive count is valid. Single-pane windows keep passing
          * `1`, so their plans stay byte-identical.
          */
-        windowPaneCount: z65.number().int().positive()
+        windowPaneCount: z66.number().int().positive()
       }).strict()
     }).strict().superRefine(refuseReadOnlyGeometryOwner);
   }
@@ -31093,7 +39614,7 @@ var init_grouped_tmux = __esm({
 
 // packages/daemon/src/terminal/attachments/lease-manager.ts
 import { createHash as createHash11, randomBytes as randomBytes3, randomUUID as randomUUID6, timingSafeEqual as timingSafeEqual2 } from "node:crypto";
-import { z as z66 } from "zod";
+import { z as z67 } from "zod";
 function positiveDuration(value, fallback, label2) {
   const resolved2 = value ?? fallback;
   if (!Number.isSafeInteger(resolved2) || resolved2 <= 0) {
@@ -31129,10 +39650,10 @@ var init_lease_manager = __esm({
     "use strict";
     init_src();
     init_grouped_tmux();
-    BindingIdSchemaZ = z66.string().min(1).max(4096).refine((value) => !value.includes("\0"));
-    RequestIdSchemaZ = z66.uuid();
+    BindingIdSchemaZ = z67.string().min(1).max(4096).refine((value) => !value.includes("\0"));
+    RequestIdSchemaZ = z67.uuid();
     RuntimeWindowId = /^@(?:0|[1-9][0-9]*)$/u;
-    AttachmentViewOperationSchemaZ = z66.enum(["create", "attach", "recover"]);
+    AttachmentViewOperationSchemaZ = z67.enum(["create", "attach", "recover"]);
     RedemptionTicketPattern = /^ta1_[A-Za-z0-9_-]{43}$/u;
     MarkerPattern = /^v1:([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}):(0|[1-9][0-9]*)$/iu;
     AttachmentLeaseError = class extends Error {
@@ -31423,7 +39944,7 @@ var init_lease_manager = __esm({
             throw new AttachmentLeaseError("lease-expired", "The attachment lease has expired.");
           }
           const clientClaim = typeof executionResult === "object" && executionResult.status === "executed" ? executionResult.clientClaim : null;
-          if (clientClaim && (!z66.uuid().safeParse(clientClaim.attemptId).success || clientClaim.attachmentId !== state.plan.identity.attachmentId || clientClaim.generation !== state.plan.identity.generation || parsedOperation === "create")) {
+          if (clientClaim && (!z67.uuid().safeParse(clientClaim.attemptId).success || clientClaim.attachmentId !== state.plan.identity.attachmentId || clientClaim.generation !== state.plan.identity.generation || parsedOperation === "create")) {
             this.#removeState(state);
             await this.#cleanupPlan(state);
             throw new AttachmentLeaseError(
@@ -31582,7 +40103,7 @@ var init_lease_manager = __esm({
       #freshId() {
         for (let attempt = 0; attempt < 16; attempt += 1) {
           const candidate = this.#createId();
-          if (z66.uuid().safeParse(candidate).success && !this.#leases.has(candidate)) return candidate;
+          if (z67.uuid().safeParse(candidate).success && !this.#leases.has(candidate)) return candidate;
         }
         throw new AttachmentLeaseError(
           "identity-generation-failed",
@@ -31768,7 +40289,7 @@ var init_lease_manager = __esm({
 });
 
 // packages/daemon/src/terminal/attachments/direct-websocket.ts
-import { z as z67 } from "zod";
+import { z as z68 } from "zod";
 function defaultSchedule(callback, delayMs) {
   const timer = setTimeout(callback, delayMs);
   timer.unref?.();
@@ -31819,7 +40340,7 @@ function sameTarget(left, right) {
   return left.workspaceName === right.workspaceName && left.semanticPaneId === right.semanticPaneId;
 }
 function validDescriptorIdentity(descriptor2) {
-  return z67.uuid().safeParse(descriptor2.leaseId).success && z67.uuid().safeParse(descriptor2.requestId).success && Number.isSafeInteger(descriptor2.issuedAt) && Number.isSafeInteger(descriptor2.expiresAt) && Number.isSafeInteger(descriptor2.bindingGeneration) && descriptor2.bindingGeneration >= 0 && Number.isSafeInteger(descriptor2.viewGeneration) && descriptor2.viewGeneration >= 0;
+  return z68.uuid().safeParse(descriptor2.leaseId).success && z68.uuid().safeParse(descriptor2.requestId).success && Number.isSafeInteger(descriptor2.issuedAt) && Number.isSafeInteger(descriptor2.expiresAt) && Number.isSafeInteger(descriptor2.bindingGeneration) && descriptor2.bindingGeneration >= 0 && Number.isSafeInteger(descriptor2.viewGeneration) && descriptor2.viewGeneration >= 0;
 }
 function boundedInputCapability(client, viewerMode) {
   const input = viewerMode === "interactive" ? client.boundedInput : null;
@@ -31859,18 +40380,18 @@ var init_direct_websocket = __esm({
     TERMINAL_ATTACHMENT_MAX_LIVE_CONTROL_FRAMES = 1024;
     WS_OPEN4 = 1;
     TicketPattern = /^ta1_[A-Za-z0-9_-]{43}$/u;
-    BindingIdSchemaZ2 = z67.string().min(1).max(4096).refine((value) => !value.includes("\0"));
-    RedemptionFrameSchemaZ = z67.object({
-      type: z67.literal("redeem"),
-      protocolVersion: z67.literal(TERMINAL_ATTACHMENT_PROTOCOL_VERSION),
-      ticket: z67.string().regex(TicketPattern),
-      requestId: z67.uuid(),
+    BindingIdSchemaZ2 = z68.string().min(1).max(4096).refine((value) => !value.includes("\0"));
+    RedemptionFrameSchemaZ = z68.object({
+      type: z68.literal("redeem"),
+      protocolVersion: z68.literal(TERMINAL_ATTACHMENT_PROTOCOL_VERSION),
+      ticket: z68.string().regex(TicketPattern),
+      requestId: z68.uuid(),
       daemonInstanceId: BindingIdSchemaZ2
     }).strict();
-    ResizeFrameSchemaZ = z67.object({
-      type: z67.literal("resize"),
-      protocolVersion: z67.literal(TERMINAL_ATTACHMENT_PROTOCOL_VERSION),
-      generation: z67.number().int().nonnegative(),
+    ResizeFrameSchemaZ = z68.object({
+      type: z68.literal("resize"),
+      protocolVersion: z68.literal(TERMINAL_ATTACHMENT_PROTOCOL_VERSION),
+      generation: z68.number().int().nonnegative(),
       viewport: TerminalAttachmentViewportSchemaZ
     }).strict();
     GridSchemaZ = TerminalAttachmentViewportSchemaZ;
@@ -31990,7 +40511,7 @@ var init_direct_websocket = __esm({
           }
           const parsedRequest = TerminalAttachRequestSchemaZ.parse(request);
           const origin = canonicalRendererOrigin(context.rendererOrigin);
-          const requestId = z67.uuid().parse(context.requestId);
+          const requestId = z68.uuid().parse(context.requestId);
           const projectIdentity = BindingIdSchemaZ2.parse(context.projectIdentity);
           if (this.#pending.size + this.#pendingReservations >= this.#maxPending) {
             throw new TerminalAttachmentAdmissionError(
@@ -32814,7 +41335,7 @@ var init_direct_websocket = __esm({
 
 // packages/daemon/src/terminal/attachments/tmux-view-executor.ts
 import { isDeepStrictEqual } from "node:util";
-import { z as z68 } from "zod";
+import { z as z69 } from "zod";
 function tmux4(argv) {
   return { executable: "tmux", argv };
 }
@@ -32905,7 +41426,7 @@ function parseViewSessionName(value) {
   const match = ViewNamePattern.exec(value);
   if (!match) return null;
   const attachmentId = uuidFromCompactHex(match[1]);
-  if (!z68.uuid().safeParse(attachmentId).success) return null;
+  if (!z69.uuid().safeParse(attachmentId).success) return null;
   const generation = Number.parseInt(match[2], 36);
   if (!Number.isSafeInteger(generation) || generation < 0 || generation > GROUPED_TMUX_MAX_GENERATION || generation.toString(36) !== match[2]) {
     return null;
@@ -32972,9 +41493,9 @@ var init_tmux_view_executor = __esm({
     MAX_MARKER_OUTPUT_ROWS = 1;
     SOURCE_PROOF_MISMATCH_SENTINEL = "__tmux_ide_source_proof_mismatch_v1__";
     VIEW_PROOF_MISMATCH_SENTINEL = "__tmux_ide_view_proof_mismatch_v1__";
-    RuntimeSessionIdSchemaZ3 = z68.string().max(32).regex(/^\$(?:0|[1-9][0-9]*)$/u);
-    RuntimeWindowIdSchemaZ3 = z68.string().max(32).regex(/^@(?:0|[1-9][0-9]*)$/u);
-    RuntimePaneIdSchemaZ3 = z68.string().max(32).regex(/^%(?:0|[1-9][0-9]*)$/u);
+    RuntimeSessionIdSchemaZ3 = z69.string().max(32).regex(/^\$(?:0|[1-9][0-9]*)$/u);
+    RuntimeWindowIdSchemaZ3 = z69.string().max(32).regex(/^@(?:0|[1-9][0-9]*)$/u);
+    RuntimePaneIdSchemaZ3 = z69.string().max(32).regex(/^%(?:0|[1-9][0-9]*)$/u);
     MarkerPattern2 = /^v1:([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}):(0|[1-9][0-9]*)$/u;
     ViewNamePattern = /^_tmux-ide-view-v1-([0-9a-f]{32})-([0-9a-z]+)$/u;
     TmuxAttachmentClientTransportError = class extends Error {
@@ -33036,18 +41557,18 @@ var init_tmux_view_executor = __esm({
         }
       }
     };
-    TmuxAttachmentClientTransportInputSchemaZ = z68.object({
-      operation: z68.enum(["attach", "recover"]),
-      identity: z68.object({
-        attachmentId: z68.uuid(),
-        generation: z68.number().int().min(0).max(GROUPED_TMUX_MAX_GENERATION),
-        viewSessionName: z68.string(),
-        markerValue: z68.string(),
+    TmuxAttachmentClientTransportInputSchemaZ = z69.object({
+      operation: z69.enum(["attach", "recover"]),
+      identity: z69.object({
+        attachmentId: z69.uuid(),
+        generation: z69.number().int().min(0).max(GROUPED_TMUX_MAX_GENERATION),
+        viewSessionName: z69.string(),
+        markerValue: z69.string(),
         expectedSourceSessionId: RuntimeSessionIdSchemaZ3,
         expectedViewSessionId: RuntimeSessionIdSchemaZ3,
         expectedWindowId: RuntimeWindowIdSchemaZ3,
         expectedPaneId: RuntimePaneIdSchemaZ3,
-        expectedWindowPaneCount: z68.number().int().positive()
+        expectedWindowPaneCount: z69.number().int().positive()
       }).strict(),
       viewport: TerminalAttachmentViewportSchemaZ,
       viewerMode: TerminalAttachmentViewerModeSchemaZ,
@@ -33117,7 +41638,7 @@ var init_tmux_view_executor = __esm({
             throw new TmuxAttachmentViewExecutorError("invalid-request");
           }
           const result = this.#clientTransport.beginGuardedAttach(input);
-          if (result.status !== "claimed" || !z68.uuid().safeParse(result.attemptId).success || result.attachmentId !== plan.identity.attachmentId || result.generation !== plan.identity.generation || !(result.outcome instanceof Promise)) {
+          if (result.status !== "claimed" || !z69.uuid().safeParse(result.attemptId).success || result.attachmentId !== plan.identity.attachmentId || result.generation !== plan.identity.generation || !(result.outcome instanceof Promise)) {
             throw new TmuxAttachmentViewExecutorError("mutation-outcome-uncertain");
           }
           return result;
@@ -34091,7 +42612,7 @@ var init_pty_tmux_attachment_launcher = __esm({
 // packages/daemon/src/terminal/attachments/native-runtime.ts
 import { accessSync as accessSync5, constants as constants6, realpathSync as realpathSync10, statSync as statSync11 } from "node:fs";
 import { isAbsolute as isAbsolute9 } from "node:path";
-import { z as z69 } from "zod";
+import { z as z70 } from "zod";
 function presentationEnvironment(source) {
   const environment = {
     TERM: SAFE_TERMINAL_VALUE2.test(source.TERM ?? "") ? source.TERM : "xterm-256color"
@@ -34388,7 +42909,7 @@ function commandString(argv) {
   return argv.map((value) => value === ";" ? ";" : quoteArgument(value)).join(" ");
 }
 function geometryDescriptorIsValid(descriptor2, client) {
-  return z69.uuid().safeParse(descriptor2.leaseId).success && z69.uuid().safeParse(descriptor2.requestId).success && TerminalAttachmentSemanticTargetSchemaZ.safeParse(descriptor2.target).success && descriptor2.status === "active" && Number.isSafeInteger(descriptor2.bindingGeneration) && descriptor2.bindingGeneration >= 0 && Number.isSafeInteger(descriptor2.viewGeneration) && descriptor2.viewGeneration >= 0 && descriptor2.viewGeneration <= GROUPED_TMUX_MAX_GENERATION && z69.uuid().safeParse(client.attemptId).success && client.attachmentId === descriptor2.leaseId && client.generation === descriptor2.viewGeneration && Number.isSafeInteger(client.pid) && client.pid > 0;
+  return z70.uuid().safeParse(descriptor2.leaseId).success && z70.uuid().safeParse(descriptor2.requestId).success && TerminalAttachmentSemanticTargetSchemaZ.safeParse(descriptor2.target).success && descriptor2.status === "active" && Number.isSafeInteger(descriptor2.bindingGeneration) && descriptor2.bindingGeneration >= 0 && Number.isSafeInteger(descriptor2.viewGeneration) && descriptor2.viewGeneration >= 0 && descriptor2.viewGeneration <= GROUPED_TMUX_MAX_GENERATION && z70.uuid().safeParse(client.attemptId).success && client.attachmentId === descriptor2.leaseId && client.generation === descriptor2.viewGeneration && Number.isSafeInteger(client.pid) && client.pid > 0;
 }
 function createNativeTerminalAttachmentRuntime(options) {
   return new NativeTerminalAttachmentRuntime(options);
@@ -35060,7 +43581,7 @@ var init_terminal_attachment_upgrade = __esm({
 
 // packages/daemon/src/terminal/pane-stream/lease-manager.ts
 import { createHash as createHash12, randomBytes as randomBytes4, randomUUID as randomUUID8, timingSafeEqual as timingSafeEqual3 } from "node:crypto";
-import { z as z70 } from "zod";
+import { z as z71 } from "zod";
 function positiveDuration2(value, fallback, label2) {
   const resolved2 = value ?? fallback;
   if (!Number.isSafeInteger(resolved2) || resolved2 <= 0) {
@@ -35086,9 +43607,9 @@ var init_lease_manager2 = __esm({
   "packages/daemon/src/terminal/pane-stream/lease-manager.ts"() {
     "use strict";
     init_src();
-    BindingIdSchemaZ3 = z70.string().min(1).max(4096).refine((value) => !value.includes("\0"));
-    RequestIdSchemaZ2 = z70.uuid();
-    SessionNameSchemaZ = z70.string().min(1).max(256).refine((value) => !/[\0\r\n]/u.test(value));
+    BindingIdSchemaZ3 = z71.string().min(1).max(4096).refine((value) => !value.includes("\0"));
+    RequestIdSchemaZ2 = z71.uuid();
+    SessionNameSchemaZ = z71.string().min(1).max(256).refine((value) => !/[\0\r\n]/u.test(value));
     TicketPattern2 = /^ps1_[A-Za-z0-9_-]{43}$/u;
     PaneStreamLeaseError = class extends Error {
       code;
@@ -35243,7 +43764,7 @@ var init_lease_manager2 = __esm({
       #freshId() {
         for (let attempt = 0; attempt < 16; attempt += 1) {
           const candidate = this.#createId();
-          if (z70.uuid().safeParse(candidate).success && !this.#leases.has(candidate)) return candidate;
+          if (z71.uuid().safeParse(candidate).success && !this.#leases.has(candidate)) return candidate;
         }
         throw new PaneStreamLeaseError(
           "identity-generation-failed",
@@ -35381,7 +43902,7 @@ var init_wire_ledger = __esm({
 });
 
 // packages/daemon/src/terminal/pane-stream/pane-stream-websocket.ts
-import { z as z71 } from "zod";
+import { z as z72 } from "zod";
 function defaultSchedule3(callback, delayMs) {
   const timer = setTimeout(callback, delayMs);
   timer.unref?.();
@@ -35454,7 +43975,7 @@ var init_pane_stream_websocket = __esm({
     PANE_STREAM_MAX_REDEMPTION_MS = 1e3;
     WS_OPEN5 = 1;
     TicketPattern3 = /^ps1_[A-Za-z0-9_-]{43}$/u;
-    BindingIdSchemaZ4 = z71.string().min(1).max(4096).refine((value) => !value.includes("\0"));
+    BindingIdSchemaZ4 = z72.string().min(1).max(4096).refine((value) => !value.includes("\0"));
     PaneStreamAdmissionError = class extends Error {
       code;
       constructor(code, message) {
@@ -35528,7 +44049,7 @@ var init_pane_stream_websocket = __esm({
           if (origin === null) {
             throw new PaneStreamAdmissionError("invalid-origin", "Renderer Origin is invalid.");
           }
-          const requestId = z71.uuid().parse(context.requestId);
+          const requestId = z72.uuid().parse(context.requestId);
           const projectIdentity = BindingIdSchemaZ4.parse(context.projectIdentity);
           if (this.#pending.size >= this.#maxPending) {
             throw new PaneStreamAdmissionError(
@@ -35562,7 +44083,7 @@ var init_pane_stream_websocket = __esm({
           });
           const descriptor2 = issued.descriptor;
           const ticket = issued.redemptionTicket;
-          const valid = TicketPattern3.test(ticket) && z71.uuid().safeParse(descriptor2.leaseId).success && descriptor2.requestId === requestId && descriptor2.status === "awaiting-redemption" && descriptor2.viewerMode === request.viewerMode && descriptor2.workspaceName === request.workspaceName && descriptor2.panes.length === request.panes.length && descriptor2.panes.every((pane, index) => pane === request.panes[index]) && descriptor2.expiresAt > this.#now();
+          const valid = TicketPattern3.test(ticket) && z72.uuid().safeParse(descriptor2.leaseId).success && descriptor2.requestId === requestId && descriptor2.status === "awaiting-redemption" && descriptor2.viewerMode === request.viewerMode && descriptor2.workspaceName === request.workspaceName && descriptor2.panes.length === request.panes.length && descriptor2.panes.every((pane, index) => pane === request.panes[index]) && descriptor2.expiresAt > this.#now();
           const ticketDigest = digestSecret(ticket);
           const duplicate = [...this.#pending.values()].some(
             (pending2) => digestsEqual(pending2.ticketDigest, ticketDigest)
@@ -37121,74 +45642,74 @@ var init_semantic_multiplexer_actions = __esm({
 });
 
 // packages/daemon/src/command-center/schemas.ts
-import { z as z72 } from "zod";
+import { z as z73 } from "zod";
 var updateTaskSchema, createTaskSchema, savePlanSchema, savePlanContentSchema, sendCommandSchema, createMilestoneSchema, updateMilestoneSchema, updateAssertionSchema, triggerResearchSchema, launchSchema, stopSchema, skillNameRegex, createSkillSchema, updateSkillSchema;
 var init_schemas = __esm({
   "packages/daemon/src/command-center/schemas.ts"() {
     "use strict";
-    updateTaskSchema = z72.object({
-      status: z72.enum(["todo", "in-progress", "review", "done"]).optional(),
-      assignee: z72.string().optional(),
-      title: z72.string().optional(),
-      description: z72.string().optional(),
-      priority: z72.number().optional()
+    updateTaskSchema = z73.object({
+      status: z73.enum(["todo", "in-progress", "review", "done"]).optional(),
+      assignee: z73.string().optional(),
+      title: z73.string().optional(),
+      description: z73.string().optional(),
+      priority: z73.number().optional()
     });
-    createTaskSchema = z72.object({
-      title: z72.string().trim().min(1, "Title is required"),
-      description: z72.string().optional(),
-      priority: z72.number().optional(),
-      goal: z72.string().optional(),
-      tags: z72.array(z72.string()).optional()
+    createTaskSchema = z73.object({
+      title: z73.string().trim().min(1, "Title is required"),
+      description: z73.string().optional(),
+      priority: z73.number().optional(),
+      goal: z73.string().optional(),
+      tags: z73.array(z73.string()).optional()
     });
-    savePlanSchema = z72.object({
-      content: z72.string().max(1e6, "Plan content is too large")
+    savePlanSchema = z73.object({
+      content: z73.string().max(1e6, "Plan content is too large")
     });
-    savePlanContentSchema = z72.object({
-      content: z72.string().max(1e6, "Plan content is too large")
+    savePlanContentSchema = z73.object({
+      content: z73.string().max(1e6, "Plan content is too large")
     });
-    sendCommandSchema = z72.object({
-      target: z72.string().min(1, "Target pane is required"),
-      message: z72.string().min(1, "Message is required"),
-      noEnter: z72.boolean().optional()
+    sendCommandSchema = z73.object({
+      target: z73.string().min(1, "Target pane is required"),
+      message: z73.string().min(1, "Message is required"),
+      noEnter: z73.boolean().optional()
     });
-    createMilestoneSchema = z72.object({
-      title: z72.string().trim().min(1, "Title is required"),
-      sequence: z72.number().int().positive(),
-      description: z72.string().optional()
+    createMilestoneSchema = z73.object({
+      title: z73.string().trim().min(1, "Title is required"),
+      sequence: z73.number().int().positive(),
+      description: z73.string().optional()
     });
-    updateMilestoneSchema = z72.object({
-      status: z72.enum(["locked", "active", "done", "validating"]).optional(),
-      title: z72.string().optional(),
-      description: z72.string().optional()
+    updateMilestoneSchema = z73.object({
+      status: z73.enum(["locked", "active", "done", "validating"]).optional(),
+      title: z73.string().optional(),
+      description: z73.string().optional()
     });
-    updateAssertionSchema = z72.object({
-      status: z72.enum(["pending", "passing", "failing", "blocked"]),
-      evidence: z72.string().optional(),
-      verifiedBy: z72.string().optional()
+    updateAssertionSchema = z73.object({
+      status: z73.enum(["pending", "passing", "failing", "blocked"]),
+      evidence: z73.string().optional(),
+      verifiedBy: z73.string().optional()
     });
-    triggerResearchSchema = z72.object({
-      type: z72.string().trim().min(1, "Research type is required")
+    triggerResearchSchema = z73.object({
+      type: z73.string().trim().min(1, "Research type is required")
     });
-    launchSchema = z72.object({
-      attach: z72.boolean().optional()
+    launchSchema = z73.object({
+      attach: z73.boolean().optional()
     }).optional();
-    stopSchema = z72.object({}).optional();
+    stopSchema = z73.object({}).optional();
     skillNameRegex = /^[A-Za-z0-9._ -]+$/;
-    createSkillSchema = z72.object({
-      name: z72.string().trim().min(1, "Skill name is required").regex(
+    createSkillSchema = z73.object({
+      name: z73.string().trim().min(1, "Skill name is required").regex(
         skillNameRegex,
         "Skill name may only contain letters, digits, dot, dash, underscore, or space"
       ),
-      role: z72.string().trim().optional(),
-      description: z72.string().optional(),
-      specialties: z72.array(z72.string()).optional(),
-      body: z72.string().optional()
+      role: z73.string().trim().optional(),
+      description: z73.string().optional(),
+      specialties: z73.array(z73.string()).optional(),
+      body: z73.string().optional()
     });
-    updateSkillSchema = z72.object({
-      role: z72.string().trim().optional(),
-      description: z72.string().optional(),
-      specialties: z72.array(z72.string()).optional(),
-      body: z72.string().optional()
+    updateSkillSchema = z73.object({
+      role: z73.string().trim().optional(),
+      description: z73.string().optional(),
+      specialties: z73.array(z73.string()).optional(),
+      body: z73.string().optional()
     });
   }
 });
@@ -38891,64 +47412,64 @@ var init_project_init_runner = __esm({
 });
 
 // packages/daemon/src/schemas/inspect.ts
-import { z as z73 } from "zod";
+import { z as z74 } from "zod";
 var ProjectInspectDetectedSchemaZ, ProjectInspectSchemaZ, InspectFilesystemRequestSchemaZ, OnboardProjectRequestSchemaZ;
 var init_inspect = __esm({
   "packages/daemon/src/schemas/inspect.ts"() {
     "use strict";
-    ProjectInspectDetectedSchemaZ = z73.object({
+    ProjectInspectDetectedSchemaZ = z74.object({
       /** Detected package manager from lockfile, or `null`. */
-      packageManager: z73.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
+      packageManager: z74.enum(["pnpm", "npm", "yarn", "bun"]).nullable(),
       /** Detected frameworks (e.g. `["next", "convex"]`). Empty array when none. */
-      frameworks: z73.array(z73.string()),
+      frameworks: z74.array(z74.string()),
       /** Suggested dev command (e.g. `pnpm dev`). `null` if no dev script found. */
-      devCommand: z73.string().nullable(),
+      devCommand: z74.string().nullable(),
       /** Suggested test command (e.g. `pnpm test`). `null` if no test script found. */
-      testCommand: z73.string().nullable()
+      testCommand: z74.string().nullable()
     });
-    ProjectInspectSchemaZ = z73.object({
+    ProjectInspectSchemaZ = z74.object({
       /** Sanitized basename of the directory — safe to use as a tmux session name. */
-      name: z73.string(),
+      name: z74.string(),
       /** Absolute, canonical path to the directory. */
-      dir: z73.string(),
+      dir: z74.string(),
       /** Whether `<dir>/ide.yml` exists. Legacy compatibility fact. */
-      hasIdeYml: z73.boolean(),
+      hasIdeYml: z74.boolean(),
       /** Whether `.tmux-ide/workspace.yml` exists or wins discovery. */
-      hasWorkspaceConfig: z73.boolean().optional(),
+      hasWorkspaceConfig: z74.boolean().optional(),
       /** Generalized winning config kind. Added without replacing `hasIdeYml`. */
-      configKind: z73.enum(["workspace", "legacy", "none"]).optional(),
+      configKind: z74.enum(["workspace", "legacy", "none"]).optional(),
       /** Generalized winning config path. Added without replacing legacy path facts. */
-      configPath: z73.string().nullable().optional(),
+      configPath: z74.string().nullable().optional(),
       /** Legacy config path when an `ide.yml` is present. */
-      ideConfigPath: z73.string().nullable().optional(),
+      ideConfigPath: z74.string().nullable().optional(),
       /** Git remote origin URL, or `null` if not a git repo / no origin / probe failed. */
-      gitOrigin: z73.string().nullable(),
+      gitOrigin: z74.string().nullable(),
       /** Current git branch, or `null` if not a git repo / detached HEAD / probe failed. */
-      gitBranch: z73.string().nullable(),
+      gitBranch: z74.string().nullable(),
       /** Detected stack signals (reuses `tmux-ide detect` logic). */
       detected: ProjectInspectDetectedSchemaZ
     });
-    InspectFilesystemRequestSchemaZ = z73.object({
-      dir: z73.string().min(1)
+    InspectFilesystemRequestSchemaZ = z74.object({
+      dir: z74.string().min(1)
     });
-    OnboardProjectRequestSchemaZ = z73.object({
-      dir: z73.string().min(1),
+    OnboardProjectRequestSchemaZ = z74.object({
+      dir: z74.string().min(1),
       /** Optional override for the project name — defaults to inspect.name. */
-      name: z73.string().min(1).optional(),
+      name: z74.string().min(1).optional(),
       /** 1, 2, or 3 — how many Claude panes to scaffold in the top row. */
-      agents: z73.number().int().min(1).max(3),
+      agents: z74.number().int().min(1).max(3),
       /**
        * Optional per-agent pane titles. When provided, length must equal
        * `agents`; the server uses these as `title:` for the Claude panes
        * instead of the canonical `Lead`/`Teammate N`/`Claude N` defaults.
        */
-      agentNames: z73.array(z73.string().min(1)).optional(),
+      agentNames: z74.array(z74.string().min(1)).optional(),
       /** Dev server command (e.g. `pnpm dev`). Omit / null to skip the dev pane. */
-      devCommand: z73.string().min(1).nullable().optional(),
+      devCommand: z74.string().min(1).nullable().optional(),
       /** Test command (e.g. `pnpm test`). Currently informational; stored for later. */
-      testCommand: z73.string().min(1).nullable().optional(),
+      testCommand: z74.string().min(1).nullable().optional(),
       /** Lint command (e.g. `pnpm lint`). Currently informational; stored for later. */
-      lintCommand: z73.string().min(1).nullable().optional()
+      lintCommand: z74.string().min(1).nullable().optional()
     });
   }
 });
@@ -40433,7 +48954,7 @@ function legacyDefaultCanvasScene(document) {
 function terminalWindowIdBySourceId(document) {
   return new Map(
     Object.values(document.windows).flatMap(
-      (window) => window.source.kind === "terminal" ? [[window.source.terminalSourceId, window.id]] : []
+      (window2) => window2.source.kind === "terminal" ? [[window2.source.terminalSourceId, window2.id]] : []
     )
   );
 }
@@ -41211,9 +49732,9 @@ function groupId(missionId) {
 function projectApplicationShellAgentGraphOverlay(input) {
   const { session, appWindows, missionSnapshot, nowSec } = input;
   const windowIdByTerminalSourceId = /* @__PURE__ */ new Map();
-  for (const window of Object.values(appWindows.windows)) {
-    if (window.source.kind === "terminal") {
-      windowIdByTerminalSourceId.set(window.source.terminalSourceId, window.id);
+  for (const window2 of Object.values(appWindows.windows)) {
+    if (window2.source.kind === "terminal") {
+      windowIdByTerminalSourceId.set(window2.source.terminalSourceId, window2.id);
     }
   }
   const identities = paneIdentities(session);
@@ -42329,7 +50850,7 @@ import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { cors } from "hono/cors";
 import { zValidator } from "@hono/zod-validator";
-import { z as z74 } from "zod";
+import { z as z75 } from "zod";
 import { realpathSync as realpathSync14 } from "node:fs";
 import { homedir as homedir21 } from "node:os";
 import { isAbsolute as isAbsolute13, resolve as pathResolve } from "node:path";
@@ -42379,7 +50900,7 @@ function requireHostCapability(ownerToken) {
       if (denied) return denied;
       markActionOwnerAuthorized(c);
     }
-    if (requirement === "owner-and-operation-id" && !z74.uuid().safeParse(c.req.header("X-Tmux-Ide-Operation-Id")).success) {
+    if (requirement === "owner-and-operation-id" && !z75.uuid().safeParse(c.req.header("X-Tmux-Ide-Operation-Id")).success) {
       return c.json({ error: "A stable host operation id is required" }, 400);
     }
     return next();
@@ -42534,7 +51055,7 @@ function createApp(options = {}) {
       } catch {
         return c.json({ error: "Invalid capability request" }, 400);
       }
-      if (!z74.object({}).strict().safeParse(body).success) {
+      if (!z75.object({}).strict().safeParse(body).success) {
         return c.json({ error: "Invalid capability request" }, 400);
       }
       const appWindowCommandRegistered = daemonActionCommandRegistry.descriptors().some(({ id }) => id === "workspace.app-window.mutate");
@@ -43623,7 +52144,7 @@ import { execFileSync as execFileSync14 } from "node:child_process";
 import { randomBytes as randomBytes7, randomUUID as randomUUID14 } from "node:crypto";
 import { createServer } from "node:http";
 import { createRequire as createRequire2 } from "node:module";
-import { performance } from "node:perf_hooks";
+import { performance as performance2 } from "node:perf_hooks";
 import { WebSocket, WebSocketServer as WebSocketServer4 } from "ws";
 function loadBundledPackage() {
   return requireFromHere("../../package.json");
@@ -43866,13 +52387,13 @@ function createTakeoverDeadline(timeoutMs) {
     throw new TypeError("Takeover deadline must be a positive finite duration.");
   }
   const controller = new AbortController();
-  const expiresAt = performance.now() + timeoutMs;
+  const expiresAt = performance2.now() + timeoutMs;
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   timer.unref?.();
   return {
     signal: controller.signal,
     expiresAt,
-    remainingMs: () => Math.max(0, expiresAt - performance.now()),
+    remainingMs: () => Math.max(0, expiresAt - performance2.now()),
     dispose: () => clearTimeout(timer)
   };
 }
@@ -44763,7 +53284,7 @@ var init_daemon_embed = __esm({
 // packages/daemon/src/lib/cli-action-bridge.ts
 import { createRequire as createRequire3 } from "node:module";
 import { randomUUID as randomUUID15 } from "node:crypto";
-import { z as z75 } from "zod";
+import { z as z76 } from "zod";
 function timeoutSignal2(ms) {
   const controller = new AbortController();
   setTimeout(() => controller.abort(), ms).unref?.();
@@ -44880,7 +53401,7 @@ async function tryDispatchAction(name, input, options = {}) {
           details: failure.data.error.details
         });
       }
-      const success = z75.object({ ok: z75.literal(true), result: contract.result }).safeParse(body);
+      const success = z76.object({ ok: z76.literal(true), result: contract.result }).safeParse(body);
       if (success.success) return success.data.result;
     }
     return null;
@@ -44896,12 +53417,12 @@ var init_cli_action_bridge = __esm({
     init_canonical_daemon();
     init_daemon_embed();
     init_pane_source_credentials();
-    FailureEnvelopeZ = z75.object({
-      ok: z75.literal(false),
-      error: z75.object({
-        code: z75.string(),
-        message: z75.string(),
-        details: z75.unknown().optional()
+    FailureEnvelopeZ = z76.object({
+      ok: z76.literal(false),
+      error: z76.object({
+        code: z76.string(),
+        message: z76.string(),
+        details: z76.unknown().optional()
       })
     });
     RETRY_SAFE_OWNER_ACTIONS = /* @__PURE__ */ new Set([
@@ -47970,7 +56491,7 @@ function buildRestorePlan(snapshot, liveSessionNames, ideProjects = /* @__PURE__
       continue;
     }
     actions.push({ kind: "rebuild", session });
-    for (const window of session.windows) paneCount += window.panes.length;
+    for (const window2 of session.windows) paneCount += window2.panes.length;
   }
   return { actions, paneCount };
 }
@@ -47992,8 +56513,8 @@ function paneResumeCommand(pane, opts) {
 }
 function countResumableAgents(session, resumeAgents) {
   let n = 0;
-  for (const window of session.windows) {
-    for (const pane of window.panes) {
+  for (const window2 of session.windows) {
+    for (const pane of window2.panes) {
       if (paneResumeCommand(pane, { resumeAgents })) n++;
     }
   }
@@ -48013,8 +56534,8 @@ function rebuildSession(session, opts) {
     runTmux(["new-session", "-d", "-s", session.name, "-c", session.cwd]);
     return resumedTitles;
   }
-  windows.forEach((window, w) => {
-    const windowCwd = window.panes[0]?.cwd || session.cwd;
+  windows.forEach((window2, w) => {
+    const windowCwd = window2.panes[0]?.cwd || session.cwd;
     const windowId = w === 0 ? tmuxCapture([
       "new-session",
       "-d",
@@ -48037,8 +56558,8 @@ function rebuildSession(session, opts) {
       windowCwd
     ]);
     const paneIds = [tmuxCapture(["display-message", "-p", "-t", windowId, "#{pane_id}"])];
-    for (let p = 1; p < window.panes.length; p++) {
-      const paneCwd = window.panes[p].cwd || windowCwd;
+    for (let p = 1; p < window2.panes.length; p++) {
+      const paneCwd = window2.panes[p].cwd || windowCwd;
       paneIds.push(
         tmuxCapture([
           "split-window",
@@ -48053,9 +56574,9 @@ function rebuildSession(session, opts) {
         ])
       );
     }
-    if (window.layout) runTmux(["select-layout", "-t", windowId, window.layout]);
-    if (window.name) runTmux(["rename-window", "-t", windowId, window.name]);
-    window.panes.forEach((pane, p) => {
+    if (window2.layout) runTmux(["select-layout", "-t", windowId, window2.layout]);
+    if (window2.name) runTmux(["rename-window", "-t", windowId, window2.name]);
+    window2.panes.forEach((pane, p) => {
       const paneId = paneIds[p];
       if (!paneId) return;
       if (pane.title) runTmux(["select-pane", "-t", paneId, "-T", pane.title]);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -40,6 +40,7 @@ export * from "./desktop-missions.ts";
 export * from "./experience-identifiers.ts";
 export * from "./semantic-identity.ts";
 export * from "./session-runtime.ts";
+export * from "./terminal-replica.ts";
 export * from "./experience-shell.ts";
 export * from "./application-shell.ts";
 export * from "./application-shell-resource.ts";

--- a/packages/contracts/src/session-runtime.ts
+++ b/packages/contracts/src/session-runtime.ts
@@ -14,6 +14,16 @@ import {
   type WorkspaceMultiplexerMutationResult,
 } from "./workspace-multiplexer.ts";
 import { WorkspaceIdSchemaZ, type WorkspaceId } from "./workspace-state.ts";
+import type {
+  TerminalReplicaPatchPayload,
+  TerminalReplicaSnapshot,
+  TerminalReplicaTombstonePayload,
+} from "./terminal-replica.ts";
+import {
+  TerminalReplicaPatchPayloadSchemaZ,
+  TerminalReplicaSnapshotSchemaZ,
+  TerminalReplicaTombstonePayloadSchemaZ,
+} from "./terminal-replica.ts";
 
 /** Architecture-level contract version. Payload encodings land in m56.2. */
 export const SESSION_RUNTIME_CONTRACT_VERSION = 1 as const;
@@ -70,8 +80,30 @@ export interface TerminalReplicaAddress {
   readonly semanticPaneId: TerminalAttachmentSemanticPaneId;
 }
 
+export interface TerminalReplicaFrameMetadata {
+  readonly incarnation: string;
+  readonly cols: number;
+  readonly rows: number;
+  readonly stateHash: string;
+  readonly hashAlgorithm: "fnv1a64-v1";
+}
+
+export const TerminalReplicaFrameMetadataSchemaZ = z
+  .object({
+    workspaceName: WorkspaceIdSchemaZ,
+    semanticPaneId: TerminalAttachmentSemanticPaneIdSchemaZ,
+    generation: SessionRuntimeGenerationSchemaZ,
+    incarnation: z.string().min(1).max(256),
+    cols: z.number().int().positive(),
+    rows: z.number().int().positive(),
+    stateHash: z.string().regex(/^[0-9a-f]{16}$/u),
+    hashAlgorithm: z.literal("fnv1a64-v1"),
+  })
+  .strict();
+
 /** A complete generation-bound renderer seed. Snapshot remains host-neutral. */
-export interface TerminalReplicaSeed<Snapshot = unknown> extends TerminalReplicaAddress {
+export interface TerminalReplicaSeed<Snapshot = unknown>
+  extends TerminalReplicaAddress, TerminalReplicaFrameMetadata {
   readonly type: "terminal.seed";
   readonly generation: SessionRuntimeGeneration;
   readonly revision: TerminalReplicaRevision;
@@ -79,7 +111,8 @@ export interface TerminalReplicaSeed<Snapshot = unknown> extends TerminalReplica
 }
 
 /** A patch is valid only against exactly `baseRevision` in the same generation. */
-export interface TerminalReplicaPatch<Patch = unknown> extends TerminalReplicaAddress {
+export interface TerminalReplicaPatch<Patch = unknown>
+  extends TerminalReplicaAddress, TerminalReplicaFrameMetadata {
   readonly type: "terminal.patch";
   readonly generation: SessionRuntimeGeneration;
   readonly baseRevision: TerminalReplicaRevision;
@@ -87,9 +120,51 @@ export interface TerminalReplicaPatch<Patch = unknown> extends TerminalReplicaAd
   readonly patch: Patch;
 }
 
-export type TerminalReplicaUpdate<Snapshot = unknown, Patch = unknown> =
+export interface TerminalReplicaTombstone<Tombstone = unknown>
+  extends TerminalReplicaAddress, TerminalReplicaFrameMetadata {
+  readonly type: "terminal.tombstone";
+  readonly generation: SessionRuntimeGeneration;
+  readonly baseRevision: TerminalReplicaRevision;
+  readonly revision: TerminalReplicaRevision;
+  readonly tombstone: Tombstone;
+}
+
+export type TerminalReplicaUpdate<Snapshot = unknown, Patch = unknown, Tombstone = unknown> =
   | TerminalReplicaSeed<Snapshot>
-  | TerminalReplicaPatch<Patch>;
+  | TerminalReplicaPatch<Patch>
+  | TerminalReplicaTombstone<Tombstone>;
+
+export type CanonicalTerminalReplicaSeed = TerminalReplicaSeed<TerminalReplicaSnapshot>;
+export type CanonicalTerminalReplicaPatch = TerminalReplicaPatch<TerminalReplicaPatchPayload>;
+export type CanonicalTerminalReplicaTombstone =
+  TerminalReplicaTombstone<TerminalReplicaTombstonePayload>;
+export type CanonicalTerminalReplicaUpdate =
+  | CanonicalTerminalReplicaSeed
+  | CanonicalTerminalReplicaPatch
+  | CanonicalTerminalReplicaTombstone;
+
+export const CanonicalTerminalReplicaSeedSchemaZ = TerminalReplicaFrameMetadataSchemaZ.extend({
+  type: z.literal("terminal.seed"),
+  revision: TerminalReplicaRevisionSchemaZ,
+  snapshot: TerminalReplicaSnapshotSchemaZ,
+}).strict();
+export const CanonicalTerminalReplicaPatchSchemaZ = TerminalReplicaFrameMetadataSchemaZ.extend({
+  type: z.literal("terminal.patch"),
+  baseRevision: TerminalReplicaRevisionSchemaZ,
+  revision: TerminalReplicaRevisionSchemaZ,
+  patch: TerminalReplicaPatchPayloadSchemaZ,
+}).strict();
+export const CanonicalTerminalReplicaTombstoneSchemaZ = TerminalReplicaFrameMetadataSchemaZ.extend({
+  type: z.literal("terminal.tombstone"),
+  baseRevision: TerminalReplicaRevisionSchemaZ,
+  revision: TerminalReplicaRevisionSchemaZ,
+  tombstone: TerminalReplicaTombstonePayloadSchemaZ,
+}).strict();
+export const CanonicalTerminalReplicaUpdateSchemaZ = z.discriminatedUnion("type", [
+  CanonicalTerminalReplicaSeedSchemaZ,
+  CanonicalTerminalReplicaPatchSchemaZ,
+  CanonicalTerminalReplicaTombstoneSchemaZ,
+]);
 
 export const SessionRuntimePaneReadIntentSchemaZ = z
   .object({

--- a/packages/contracts/src/terminal-replica.ts
+++ b/packages/contracts/src/terminal-replica.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+
+export const TerminalReplicaColorSchemaZ = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("default") }).strict(),
+  z.object({ kind: z.literal("indexed"), index: z.number().int().min(0).max(255) }).strict(),
+  z.object({ kind: z.literal("rgb"), value: z.number().int().min(0).max(0xffffff) }).strict(),
+]);
+export type TerminalReplicaColor = z.infer<typeof TerminalReplicaColorSchemaZ>;
+
+export const TerminalReplicaCellAttributesSchemaZ = z.number().int().min(0).max(0xff);
+export type TerminalReplicaCellAttributes = z.infer<typeof TerminalReplicaCellAttributesSchemaZ>;
+
+export const TerminalReplicaCellSchemaZ = z
+  .object({
+    grapheme: z.string(),
+    width: z.union([z.literal(0), z.literal(1), z.literal(2)]),
+    foreground: TerminalReplicaColorSchemaZ,
+    background: TerminalReplicaColorSchemaZ,
+    attributes: TerminalReplicaCellAttributesSchemaZ,
+  })
+  .strict();
+export type TerminalReplicaCell = z.infer<typeof TerminalReplicaCellSchemaZ>;
+
+export const TerminalReplicaRowSchemaZ = z
+  .object({ cells: z.array(TerminalReplicaCellSchemaZ), wrapped: z.boolean() })
+  .strict();
+export type TerminalReplicaRow = z.infer<typeof TerminalReplicaRowSchemaZ>;
+
+export const TerminalReplicaCursorSchemaZ = z
+  .object({
+    x: z.number().int().nonnegative(),
+    y: z.number().int().nonnegative(),
+    hidden: z.boolean(),
+    style: z.enum(["block", "underline", "bar"]),
+    blink: z.boolean(),
+  })
+  .strict();
+export type TerminalReplicaCursor = z.infer<typeof TerminalReplicaCursorSchemaZ>;
+
+export const TerminalReplicaModesSchemaZ = z
+  .object({
+    alternateScreen: z.boolean(),
+    applicationCursor: z.boolean(),
+    applicationKeypad: z.boolean(),
+    bracketedPaste: z.boolean(),
+    insert: z.boolean(),
+    origin: z.boolean(),
+    wraparound: z.boolean(),
+    mouseTracking: z.boolean(),
+    synchronizedOutput: z.boolean(),
+  })
+  .strict();
+export type TerminalReplicaModes = z.infer<typeof TerminalReplicaModesSchemaZ>;
+
+export const TerminalReplicaPlacementSchemaZ = z
+  .object({
+    id: z.string().min(1),
+    kind: z.string().min(1),
+    row: z.number().int().nonnegative(),
+    column: z.number().int().nonnegative(),
+    columns: z.number().int().positive(),
+    rows: z.number().int().positive(),
+    contentDigest: z.string().min(1),
+  })
+  .strict();
+export type TerminalReplicaPlacement = z.infer<typeof TerminalReplicaPlacementSchemaZ>;
+
+export const TerminalReplicaSnapshotSchemaZ = z
+  .object({
+    cols: z.number().int().positive(),
+    rows: z.number().int().positive(),
+    grid: z.array(TerminalReplicaRowSchemaZ),
+    history: z.array(TerminalReplicaRowSchemaZ),
+    cursor: TerminalReplicaCursorSchemaZ,
+    modes: TerminalReplicaModesSchemaZ,
+    placements: z.array(TerminalReplicaPlacementSchemaZ),
+    bootstrap: z
+      .object({
+        kind: z.enum(["painted-capture", "authoritative-stream"]),
+        hiddenState: z.enum(["unknown", "observed-from-start"]),
+      })
+      .strict(),
+  })
+  .strict();
+export type TerminalReplicaSnapshot = z.infer<typeof TerminalReplicaSnapshotSchemaZ>;
+
+export const TerminalReplicaPatchPayloadSchemaZ = z
+  .object({
+    dimensions: z
+      .object({ cols: z.number().int().positive(), rows: z.number().int().positive() })
+      .strict()
+      .optional(),
+    rows: z.array(
+      z.object({ index: z.number().int().nonnegative(), row: TerminalReplicaRowSchemaZ }).strict(),
+    ),
+    history: z.array(TerminalReplicaRowSchemaZ).optional(),
+    historyDelta: z
+      .object({
+        trim: z.number().int().nonnegative(),
+        append: z.array(TerminalReplicaRowSchemaZ),
+      })
+      .strict()
+      .optional(),
+    cursor: TerminalReplicaCursorSchemaZ.optional(),
+    modes: TerminalReplicaModesSchemaZ.optional(),
+    placements: z.array(TerminalReplicaPlacementSchemaZ).optional(),
+    bootstrap: TerminalReplicaSnapshotSchemaZ.shape.bootstrap.optional(),
+  })
+  .strict();
+export type TerminalReplicaPatchPayload = z.infer<typeof TerminalReplicaPatchPayloadSchemaZ>;
+
+export const TerminalReplicaTombstonePayloadSchemaZ = z
+  .object({ reason: z.enum(["pane-closed", "session-restarted", "runtime-disposed"]) })
+  .strict();
+export type TerminalReplicaTombstonePayload = z.infer<
+  typeof TerminalReplicaTombstonePayloadSchemaZ
+>;
+
+export const TERMINAL_REPLICA_ATTRIBUTE = Object.freeze({
+  bold: 1,
+  dim: 2,
+  italic: 4,
+  underline: 8,
+  blink: 16,
+  inverse: 32,
+  hidden: 64,
+  strikethrough: 128,
+} as const);
+
+/** Canonical UTF-8 encoding described by `@tmux-ide/core`; never host JSON or UTF-16. */
+export const TERMINAL_REPLICA_HASH_ALGORITHM = "fnv1a64-v1" as const;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from "./application-shell-session.ts";
 export * from "./interaction-flow.ts";
 export * from "./workspace-selection.ts";
 export * from "./terminal-conformance.ts";
+export * from "./terminal-replica.ts";
 export * from "./interaction-receipts.ts";
 export * from "./agent-provisioning.ts";
 export * from "./navigator.ts";

--- a/packages/core/src/terminal-conformance.ts
+++ b/packages/core/src/terminal-conformance.ts
@@ -299,4 +299,42 @@ export const TERMINAL_CONFORMANCE_FIXTURES: readonly TerminalConformanceFixture[
       },
     ],
   },
+  {
+    id: "codex-truecolor-status",
+    description: "Codex status text preserves explicit P3-ready truecolor channels",
+    cols: 12,
+    rows: 2,
+    writes: ["\u001b[38;2;99;102;241mCODEX\u001b[0m"],
+    cells: [
+      { row: 0, column: 0, chars: "C", width: 1, foreground: rgb(0x6366f1), background: DEFAULT },
+      { row: 0, column: 1, chars: "O", width: 1, foreground: rgb(0x6366f1), background: DEFAULT },
+    ],
+  },
+  {
+    id: "opencode-indexed-status",
+    description: "OpenCode indexed accent and inverse status remain application-owned",
+    cols: 12,
+    rows: 2,
+    writes: ["\u001b[38;5;75;48;5;234;7mOC\u001b[0m"],
+    cells: [
+      {
+        row: 0,
+        column: 0,
+        chars: "O",
+        width: 1,
+        foreground: indexed(75),
+        background: indexed(234),
+        attributes: ["inverse"],
+      },
+      {
+        row: 0,
+        column: 1,
+        chars: "C",
+        width: 1,
+        foreground: indexed(75),
+        background: indexed(234),
+        attributes: ["inverse"],
+      },
+    ],
+  },
 ]);

--- a/packages/core/src/terminal-replica.test.ts
+++ b/packages/core/src/terminal-replica.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CanonicalTerminalReplicaPatch,
+  CanonicalTerminalReplicaSeed,
+  TerminalReplicaPatchPayload,
+  TerminalReplicaSnapshot,
+} from "@tmux-ide/contracts";
+import {
+  applyTerminalReplicaPatch,
+  applyTerminalReplicaUpdate,
+  blankTerminalReplicaSnapshot,
+  hashTerminalReplicaSnapshot,
+} from "./terminal-replica.ts";
+
+const generation = "00000000-0000-4000-8000-000000000001";
+const address = { workspaceName: "workspace", semanticPaneId: "pane-a" } as const;
+
+function seed(snapshot: TerminalReplicaSnapshot, revision = 0): CanonicalTerminalReplicaSeed {
+  return {
+    type: "terminal.seed",
+    ...address,
+    generation,
+    incarnation: "incarnation-a",
+    revision,
+    cols: snapshot.cols,
+    rows: snapshot.rows,
+    stateHash: hashTerminalReplicaSnapshot(snapshot),
+    hashAlgorithm: "fnv1a64-v1",
+    snapshot,
+  };
+}
+
+function patch(
+  current: TerminalReplicaSnapshot,
+  payload: TerminalReplicaPatchPayload,
+  revision = 1,
+): CanonicalTerminalReplicaPatch {
+  const next = applyTerminalReplicaPatch(current, payload);
+  return {
+    type: "terminal.patch",
+    ...address,
+    generation,
+    incarnation: "incarnation-a",
+    baseRevision: revision - 1,
+    revision,
+    cols: next.cols,
+    rows: next.rows,
+    stateHash: hashTerminalReplicaSnapshot(next),
+    hashAlgorithm: "fnv1a64-v1",
+    patch: payload,
+  };
+}
+
+describe("terminal replica reducer", () => {
+  it("reconstructs the uninterrupted state from one seed and ordered patches", () => {
+    const initial = blankTerminalReplicaSnapshot(4, 2);
+    const row = {
+      wrapped: false,
+      cells: initial.grid[0]!.cells.map((cell, index) =>
+        index === 0
+          ? { ...cell, grapheme: "λ", foreground: { kind: "indexed", index: 174 } as const }
+          : cell,
+      ),
+    };
+    const payload: TerminalReplicaPatchPayload = {
+      rows: [{ index: 0, row }],
+      cursor: { x: 1, y: 0, hidden: false, style: "bar", blink: true },
+    };
+    const expected = applyTerminalReplicaPatch(initial, payload);
+    const seeded = applyTerminalReplicaUpdate(null, seed(initial));
+    expect(seeded.status).toBe("applied");
+    const applied = applyTerminalReplicaUpdate(seeded.state, patch(initial, payload));
+    expect(applied.status).toBe("applied");
+    if (!applied.state) throw new Error("expected applied state");
+    expect(applied.state.snapshot).toEqual(expected);
+    expect(applied.state.hash).toBe(hashTerminalReplicaSnapshot(expected));
+  });
+
+  it("fails closed for cross-pane updates, gaps, and same-tuple hash corruption", () => {
+    const initial = blankTerminalReplicaSnapshot(2, 2);
+    const boot = applyTerminalReplicaUpdate(null, seed(initial));
+    const valid = patch(initial, { rows: [] });
+    expect(
+      applyTerminalReplicaUpdate(boot.state, { ...valid, semanticPaneId: "pane-b" }).status,
+    ).toBe("conflict");
+    expect(
+      applyTerminalReplicaUpdate(boot.state, { ...valid, baseRevision: 4, revision: 5 }).status,
+    ).toBe("gap");
+    const once = applyTerminalReplicaUpdate(boot.state, valid);
+    expect(
+      applyTerminalReplicaUpdate(once.state, { ...valid, stateHash: "0000000000000000" }).status,
+    ).toBe("conflict");
+    expect(
+      applyTerminalReplicaUpdate(once.state, {
+        ...valid,
+        patch: { rows: [], cursor: { ...initial.cursor, x: 1 } },
+      }).status,
+    ).toBe("conflict");
+  });
+
+  it("pins opaque daemon generations so delayed seeds cannot roll state backward", () => {
+    const initial = blankTerminalReplicaSnapshot(2, 2);
+    const boot = applyTerminalReplicaUpdate(null, seed(initial));
+    const foreign = {
+      ...seed(initial),
+      generation: "00000000-0000-4000-8000-000000000002",
+    };
+    expect(applyTerminalReplicaUpdate(boot.state, foreign).status).toBe("conflict");
+  });
+
+  it("accepts only a higher revision from a newer ordered pane incarnation", () => {
+    const initial = blankTerminalReplicaSnapshot(2, 2);
+    const first = { ...seed(initial, 2), incarnation: `${generation}:0` };
+    const boot = applyTerminalReplicaUpdate(null, first);
+    const next = { ...seed(initial, 4), incarnation: `${generation}:1` };
+    const advanced = applyTerminalReplicaUpdate(boot.state, next);
+    expect(advanced.status).toBe("applied");
+    expect(applyTerminalReplicaUpdate(advanced.state, { ...first, revision: 5 }).status).toBe(
+      "conflict",
+    );
+  });
+
+  it("rejects malformed rows and cursors rather than clipping them", () => {
+    const initial = blankTerminalReplicaSnapshot(2, 2);
+    expect(() =>
+      applyTerminalReplicaPatch(initial, {
+        rows: [
+          { index: 0, row: initial.grid[0]! },
+          { index: 0, row: initial.grid[0]! },
+        ],
+      }),
+    ).toThrow(/Malformed/u);
+    expect(() =>
+      applyTerminalReplicaPatch(initial, {
+        rows: [],
+        cursor: { x: 2, y: 0, hidden: false, style: "block", blink: false },
+      }),
+    ).toThrow(/out of bounds/u);
+  });
+
+  it("fails closed when a dimension change retains incompatible history or placements", () => {
+    const base = blankTerminalReplicaSnapshot(4, 2);
+    const withHistory = applyTerminalReplicaPatch(base, { rows: [], history: [base.grid[0]!] });
+    expect(() =>
+      applyTerminalReplicaPatch(withHistory, {
+        dimensions: { cols: 2, rows: 2 },
+        rows: [],
+        historyDelta: { trim: 0, append: [] },
+      }),
+    ).toThrow(/old-width/u);
+    const withPlacement = applyTerminalReplicaPatch(base, {
+      rows: [],
+      placements: [
+        {
+          id: "x",
+          kind: "widget",
+          row: 0,
+          column: 2,
+          rows: 1,
+          columns: 2,
+          contentDigest: "fixture",
+        },
+      ],
+    });
+    expect(() =>
+      applyTerminalReplicaPatch(withPlacement, {
+        dimensions: { cols: 2, rows: 2 },
+        rows: [],
+      }),
+    ).toThrow(/out-of-bounds/u);
+  });
+
+  it("retains snapshot, grid, and row identity for a semantic no-op", () => {
+    const initial = blankTerminalReplicaSnapshot(2, 2);
+    const next = applyTerminalReplicaPatch(initial, {
+      rows: [{ index: 0, row: initial.grid[0]! }],
+    });
+    expect(next).toBe(initial);
+    expect(next.grid).toBe(initial.grid);
+    expect(next.grid[0]).toBe(initial.grid[0]);
+  });
+
+  it("deep-freezes applied arrays while retaining unchanged row identity", () => {
+    const initial = blankTerminalReplicaSnapshot(2, 2);
+    const next = applyTerminalReplicaPatch(initial, {
+      rows: [{ index: 1, row: { ...initial.grid[1]!, wrapped: true } }],
+    });
+    expect(Object.isFrozen(next)).toBe(true);
+    expect(Object.isFrozen(next.grid)).toBe(true);
+    expect(Object.isFrozen(next.history)).toBe(true);
+    expect(Object.isFrozen(next.placements)).toBe(true);
+    expect(next.grid[0]).toBe(initial.grid[0]);
+    expect(() => ((next.grid as TerminalReplicaSnapshot["grid"])[0] = next.grid[1]!)).toThrow();
+  });
+
+  it("hashes UTF-8 canonically and distinguishes default from explicit black", () => {
+    const defaults = blankTerminalReplicaSnapshot(1, 1);
+    const explicit = applyTerminalReplicaPatch(defaults, {
+      rows: [
+        {
+          index: 0,
+          row: {
+            wrapped: false,
+            cells: [
+              {
+                ...defaults.grid[0]!.cells[0]!,
+                grapheme: "界",
+                background: { kind: "indexed", index: 16 },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(hashTerminalReplicaSnapshot(explicit)).toMatch(/^[0-9a-f]{16}$/u);
+    expect(hashTerminalReplicaSnapshot(explicit)).not.toBe(hashTerminalReplicaSnapshot(defaults));
+  });
+
+  it("derives the same rolling history hash for trim/append as a full reconstruction", () => {
+    const base = blankTerminalReplicaSnapshot(2, 1);
+    const seeded = applyTerminalReplicaPatch(base, {
+      rows: [],
+      history: [base.grid[0]!, { ...base.grid[0]!, wrapped: true }],
+    });
+    const next = applyTerminalReplicaPatch(seeded, {
+      rows: [],
+      historyDelta: { trim: 1, append: [base.grid[0]!] },
+    });
+    const reconstructed = { ...next, history: [...next.history] };
+    expect(hashTerminalReplicaSnapshot(next)).toBe(hashTerminalReplicaSnapshot(reconstructed));
+  });
+});

--- a/packages/core/src/terminal-replica.ts
+++ b/packages/core/src/terminal-replica.ts
@@ -1,0 +1,676 @@
+import type {
+  CanonicalTerminalReplicaUpdate,
+  SessionRuntimeGeneration,
+  TerminalReplicaAddress,
+  TerminalReplicaColor,
+  TerminalReplicaPatchPayload,
+  TerminalReplicaRow,
+  TerminalReplicaSnapshot,
+  TerminalReplicaTombstonePayload,
+} from "@tmux-ide/contracts";
+
+const DEFAULT_COLOR = Object.freeze({ kind: "default" } as const);
+const ROW_HASH_CACHE = new WeakMap<object, string>();
+const ROW_ARRAY_HASH_CACHE = new WeakMap<
+  object,
+  { readonly hash: bigint; readonly length: number }
+>();
+const ROW_SEQUENCE_BASE = 0x100000001b3n;
+
+export interface TerminalReplicaState extends TerminalReplicaAddress {
+  readonly generation: SessionRuntimeGeneration;
+  readonly revision: number;
+  readonly incarnation: string;
+  readonly snapshot: TerminalReplicaSnapshot | null;
+  readonly tombstone: TerminalReplicaTombstonePayload | null;
+  readonly hash: string;
+  /** Digest of the exact last accepted wire frame, for strict replay identity. */
+  readonly frameHash: string;
+}
+
+export type TerminalReplicaApplyResult =
+  | { readonly status: "applied"; readonly state: TerminalReplicaState }
+  | { readonly status: "idempotent" | "stale"; readonly state: TerminalReplicaState }
+  | {
+      readonly status: "gap" | "conflict";
+      readonly state: TerminalReplicaState | null;
+      readonly expectedRevision: number;
+      readonly receivedRevision: number;
+    };
+
+export function blankTerminalReplicaSnapshot(cols: number, rows: number): TerminalReplicaSnapshot {
+  const row = blankRow(cols);
+  return freezeSnapshot({
+    cols,
+    rows,
+    grid: Array.from({ length: rows }, () => row),
+    cursor: { x: 0, y: 0, hidden: false, style: "block", blink: false },
+    modes: {
+      alternateScreen: false,
+      applicationCursor: false,
+      applicationKeypad: false,
+      bracketedPaste: false,
+      insert: false,
+      origin: false,
+      wraparound: true,
+      mouseTracking: false,
+      synchronizedOutput: false,
+    },
+    history: [],
+    placements: [],
+    bootstrap: { kind: "painted-capture", hiddenState: "unknown" },
+  });
+}
+
+export function applyTerminalReplicaUpdate(
+  current: TerminalReplicaState | null,
+  update: CanonicalTerminalReplicaUpdate,
+): TerminalReplicaApplyResult {
+  const receivedFrameHash = hashStable(update);
+  if (update.type === "terminal.seed") {
+    if (update.hashAlgorithm !== "fnv1a64-v1" || !terminalReplicaSnapshotIsValid(update.snapshot)) {
+      return current
+        ? protocolConflict(current, update.revision)
+        : {
+            status: "conflict",
+            state: null,
+            expectedRevision: 0,
+            receivedRevision: update.revision,
+          };
+    }
+    const hash = hashTerminalReplicaSnapshot(update.snapshot);
+    if (
+      current &&
+      (current.workspaceName !== update.workspaceName ||
+        current.semanticPaneId !== update.semanticPaneId)
+    ) {
+      return protocolConflict(current, update.revision);
+    }
+    // Generations are opaque UUIDs, not sortable epochs. A live reducer is
+    // generation-pinned; callers must discard it and bootstrap a new reducer
+    // from a seed during an authenticated daemon-generation transition.
+    if (current && current.generation !== update.generation) {
+      return protocolConflict(current, update.revision);
+    }
+    if (
+      current &&
+      current.incarnation !== update.incarnation &&
+      (!isNewerIncarnation(current.incarnation, update.incarnation) ||
+        update.revision <= current.revision)
+    ) {
+      return protocolConflict(current, update.revision);
+    }
+    if (
+      current?.generation === update.generation &&
+      current.revision === update.revision &&
+      current.hash === hash &&
+      update.stateHash === hash &&
+      current.incarnation === update.incarnation &&
+      current.frameHash === receivedFrameHash
+    ) {
+      return { status: "idempotent", state: current };
+    }
+    if (
+      current?.generation === update.generation &&
+      current.revision === update.revision &&
+      current.hash !== update.stateHash
+    ) {
+      return {
+        status: "conflict",
+        state: current,
+        expectedRevision: current.revision,
+        receivedRevision: update.revision,
+      };
+    }
+    if (
+      hash !== update.stateHash ||
+      update.cols !== update.snapshot.cols ||
+      update.rows !== update.snapshot.rows
+    ) {
+      return {
+        status: "conflict",
+        state: current,
+        expectedRevision: current?.revision ?? 0,
+        receivedRevision: update.revision,
+      };
+    }
+    if (
+      current?.generation === update.generation &&
+      current.incarnation === update.incarnation &&
+      update.revision < current.revision
+    ) {
+      return { status: "stale", state: current };
+    }
+    const state = Object.freeze({
+      workspaceName: update.workspaceName,
+      semanticPaneId: update.semanticPaneId,
+      generation: update.generation,
+      revision: update.revision,
+      incarnation: update.incarnation,
+      snapshot: freezeSnapshot(update.snapshot),
+      tombstone: null,
+      hash,
+      frameHash: receivedFrameHash,
+    });
+    return { status: "applied", state };
+  }
+
+  if (current === null || current.generation !== update.generation) {
+    return {
+      status: "gap",
+      state: current,
+      expectedRevision: current === null ? 0 : current.revision + 1,
+      receivedRevision: update.revision,
+    };
+  }
+  if (update.hashAlgorithm !== "fnv1a64-v1") return protocolConflict(current, update.revision);
+  if (
+    current.workspaceName !== update.workspaceName ||
+    current.semanticPaneId !== update.semanticPaneId
+  ) {
+    return protocolConflict(current, update.revision);
+  }
+  if (current.incarnation !== update.incarnation) {
+    return {
+      status: "gap",
+      state: current,
+      expectedRevision: current.revision + 1,
+      receivedRevision: update.revision,
+    };
+  }
+  if (update.revision <= current.revision) {
+    if (update.type === "terminal.tombstone") {
+      return update.revision === current.revision &&
+        update.baseRevision === current.revision - 1 &&
+        update.stateHash === current.hash &&
+        current.tombstone?.reason === update.tombstone.reason &&
+        current.frameHash === receivedFrameHash
+        ? { status: "idempotent", state: current }
+        : update.revision === current.revision
+          ? protocolConflict(current, update.revision)
+          : { status: "stale", state: current };
+    }
+    return update.revision === current.revision &&
+      update.baseRevision === current.revision - 1 &&
+      update.stateHash === current.hash &&
+      update.cols === current.snapshot?.cols &&
+      update.rows === current.snapshot?.rows &&
+      current.frameHash === receivedFrameHash
+      ? { status: "idempotent", state: current }
+      : update.revision === current.revision
+        ? protocolConflict(current, update.revision)
+        : { status: "stale", state: current };
+  }
+  if (update.baseRevision !== current.revision || update.revision !== current.revision + 1) {
+    return {
+      status: "gap",
+      state: current,
+      expectedRevision: current.revision + 1,
+      receivedRevision: update.revision,
+    };
+  }
+  if (update.type === "terminal.tombstone") {
+    if (
+      current.snapshot &&
+      (update.cols !== current.snapshot.cols || update.rows !== current.snapshot.rows)
+    ) {
+      return protocolConflict(current, update.revision);
+    }
+    const hash = hashStable(["tombstone", update.tombstone.reason]);
+    if (hash !== update.stateHash) {
+      return {
+        status: "conflict",
+        state: current,
+        expectedRevision: current.revision + 1,
+        receivedRevision: update.revision,
+      };
+    }
+    const state = Object.freeze({
+      ...current,
+      revision: update.revision,
+      snapshot: null,
+      tombstone: Object.freeze({ ...update.tombstone }),
+      hash,
+      frameHash: receivedFrameHash,
+    });
+    return { status: "applied", state };
+  }
+  if (current.snapshot === null) {
+    return {
+      status: "conflict",
+      state: current,
+      expectedRevision: current.revision + 1,
+      receivedRevision: update.revision,
+    };
+  }
+  let snapshot: TerminalReplicaSnapshot;
+  try {
+    snapshot = applyTerminalReplicaPatch(current.snapshot, update.patch);
+  } catch {
+    return protocolConflict(current, update.revision);
+  }
+  const hash = hashTerminalReplicaSnapshot(snapshot);
+  if (hash !== update.stateHash || snapshot.cols !== update.cols || snapshot.rows !== update.rows) {
+    return {
+      status: "conflict",
+      state: current,
+      expectedRevision: current.revision + 1,
+      receivedRevision: update.revision,
+    };
+  }
+  const state = Object.freeze({
+    ...current,
+    revision: update.revision,
+    snapshot,
+    tombstone: null,
+    hash,
+    frameHash: receivedFrameHash,
+  });
+  return { status: "applied", state };
+}
+
+export function applyTerminalReplicaPatch(
+  current: TerminalReplicaSnapshot,
+  patch: TerminalReplicaPatchPayload,
+): TerminalReplicaSnapshot {
+  const cols = patch.dimensions?.cols ?? current.cols;
+  const rows = patch.dimensions?.rows ?? current.rows;
+  const seen = new Set<number>();
+  for (const change of patch.rows) {
+    if (
+      change.index >= rows ||
+      change.row.cells.length !== cols ||
+      !terminalReplicaRowIsValid(change.row) ||
+      seen.has(change.index)
+    ) {
+      throw new TypeError("Malformed terminal replica row patch");
+    }
+    seen.add(change.index);
+  }
+  const cursor = patch.cursor ?? current.cursor;
+  if (cursor.x >= cols || cursor.y >= rows) throw new TypeError("Terminal cursor is out of bounds");
+  if (patch.history?.some((row) => row.cells.length !== cols || !terminalReplicaRowIsValid(row)))
+    throw new TypeError("Malformed terminal replica history");
+  if (
+    (patch.history !== undefined && patch.historyDelta !== undefined) ||
+    (patch.historyDelta?.trim ?? 0) > current.history.length ||
+    patch.historyDelta?.append.some(
+      (row) => row.cells.length !== cols || !terminalReplicaRowIsValid(row),
+    )
+  )
+    throw new TypeError("Malformed terminal replica history delta");
+  if (
+    patch.placements?.some(
+      (placement) =>
+        placement.row + placement.rows > rows || placement.column + placement.columns > cols,
+    )
+  )
+    throw new TypeError("Terminal placement is out of bounds");
+  if (cols !== current.cols) {
+    const retainedHistory =
+      patch.history ??
+      (patch.historyDelta
+        ? [...current.history.slice(patch.historyDelta.trim), ...patch.historyDelta.append]
+        : current.history);
+    if (retainedHistory.some((row) => row.cells.length !== cols))
+      throw new TypeError("A dimension patch retained old-width terminal history");
+  }
+  if (
+    (cols !== current.cols || rows !== current.rows) &&
+    patch.placements === undefined &&
+    current.placements.some(
+      (placement) =>
+        placement.row + placement.rows > rows || placement.column + placement.columns > cols,
+    )
+  )
+    throw new TypeError("A dimension patch retained an out-of-bounds terminal placement");
+  let grid: readonly TerminalReplicaRow[];
+  if (cols !== current.cols || rows !== current.rows) {
+    const empty = blankRow(cols);
+    grid = Array.from({ length: rows }, (_, index) => {
+      const prior = current.grid[index];
+      return prior && prior.cells.length === cols ? prior : empty;
+    });
+  } else {
+    grid = current.grid;
+  }
+  if (patch.rows.length > 0) {
+    const next = [...grid];
+    let changed = false;
+    for (const change of patch.rows) {
+      const row = freezeRow(change.row);
+      if (!terminalReplicaRowsEqual(next[change.index], row)) {
+        next[change.index] = row;
+        changed = true;
+      }
+    }
+    if (changed) grid = next;
+  }
+  const unchanged =
+    cols === current.cols &&
+    rows === current.rows &&
+    grid === current.grid &&
+    patch.cursor === undefined &&
+    patch.modes === undefined &&
+    patch.history === undefined &&
+    patch.historyDelta === undefined &&
+    patch.placements === undefined &&
+    patch.bootstrap === undefined;
+  if (unchanged) return current;
+  let history: readonly TerminalReplicaRow[];
+  if (patch.history) {
+    history = Object.freeze(patch.history.map(freezeRow));
+  } else if (patch.historyDelta) {
+    const appended = patch.historyDelta.append.map(freezeRow);
+    history = Object.freeze([...current.history.slice(patch.historyDelta.trim), ...appended]);
+    registerRowsDeltaHash(current.history, history, patch.historyDelta.trim, appended);
+  } else {
+    history = current.history;
+  }
+  const candidate = {
+    cols,
+    rows,
+    grid: Object.freeze(grid) as unknown as TerminalReplicaRow[],
+    history: history as TerminalReplicaRow[],
+    cursor: Object.freeze(patch.cursor ? { ...patch.cursor } : current.cursor),
+    modes: Object.freeze(patch.modes ? { ...patch.modes } : current.modes),
+    placements: patch.placements
+      ? (Object.freeze(
+          patch.placements.map((placement) => Object.freeze({ ...placement })),
+        ) as unknown as TerminalReplicaSnapshot["placements"])
+      : current.placements,
+    bootstrap: patch.bootstrap ? Object.freeze({ ...patch.bootstrap }) : current.bootstrap,
+  };
+  return Object.freeze(candidate) as TerminalReplicaSnapshot;
+}
+
+export function terminalReplicaRowsEqual(
+  left: TerminalReplicaRow | undefined,
+  right: TerminalReplicaRow,
+): boolean {
+  if (
+    !left ||
+    left === right ||
+    left.wrapped !== right.wrapped ||
+    left.cells.length !== right.cells.length
+  )
+    return left === right;
+  for (let index = 0; index < left.cells.length; index += 1) {
+    const a = left.cells[index]!;
+    const b = right.cells[index]!;
+    if (
+      a.grapheme !== b.grapheme ||
+      a.width !== b.width ||
+      a.attributes !== b.attributes ||
+      !colorsEqual(a.foreground, b.foreground) ||
+      !colorsEqual(a.background, b.background)
+    )
+      return false;
+  }
+  return true;
+}
+
+export function hashTerminalReplicaSnapshot(snapshot: TerminalReplicaSnapshot): string {
+  // Cross-language Merkle stream: each immutable row is FNV-1a over the
+  // type-tagged UTF-8 cell stream, then the snapshot hashes fixed-order row
+  // digests + metadata. WeakMap caching makes dirty-row patches O(rows), not
+  // O(scrollback*cols), without placing host-private hashes on the wire.
+  return hashStable([
+    "terminal-replica-v1",
+    snapshot.cols,
+    snapshot.rows,
+    hashTerminalReplicaRows(snapshot.grid),
+    hashTerminalReplicaRows(snapshot.history),
+    snapshot.cursor,
+    snapshot.modes,
+    snapshot.placements,
+    snapshot.bootstrap,
+  ]);
+}
+
+export function hashTerminalReplicaTombstone(reason: string): string {
+  return hashStable(["tombstone", reason]);
+}
+
+export function resolveTerminalReplicaColor(
+  color: TerminalReplicaColor,
+  defaults: { readonly foreground: number; readonly background: number },
+  channel: "foreground" | "background",
+  indexedPalette: readonly number[],
+): number {
+  if (color.kind === "default") return defaults[channel];
+  if (color.kind === "rgb") return color.value;
+  return indexedPalette[color.index] ?? defaults[channel];
+}
+
+function blankRow(cols: number): TerminalReplicaRow {
+  return Object.freeze({
+    cells: Object.freeze(
+      Array.from({ length: cols }, () =>
+        Object.freeze({
+          grapheme: " ",
+          width: 1 as const,
+          foreground: DEFAULT_COLOR,
+          background: DEFAULT_COLOR,
+          attributes: 0,
+        }),
+      ),
+    ),
+    wrapped: false,
+  }) as unknown as TerminalReplicaRow;
+}
+
+function freezeRow(row: TerminalReplicaRow): TerminalReplicaRow {
+  return Object.freeze({
+    wrapped: row.wrapped,
+    cells: Object.freeze(
+      row.cells.map((cell) =>
+        Object.freeze({
+          ...cell,
+          foreground: Object.freeze({ ...cell.foreground }),
+          background: Object.freeze({ ...cell.background }),
+        }),
+      ),
+    ),
+  }) as unknown as TerminalReplicaRow;
+}
+
+export function freezeTerminalReplicaRow(row: TerminalReplicaRow): TerminalReplicaRow {
+  if (!terminalReplicaRowIsValid(row)) throw new TypeError("Malformed terminal replica row");
+  return freezeRow(row);
+}
+
+function freezeSnapshot(snapshot: TerminalReplicaSnapshot): TerminalReplicaSnapshot {
+  return Object.freeze({
+    ...snapshot,
+    grid: Object.freeze(snapshot.grid.map(freezeRow)),
+    history: Object.freeze(snapshot.history.map(freezeRow)),
+    cursor: Object.freeze({ ...snapshot.cursor }),
+    modes: Object.freeze({ ...snapshot.modes }),
+    placements: Object.freeze(snapshot.placements.map((value) => Object.freeze({ ...value }))),
+    bootstrap: Object.freeze({ ...snapshot.bootstrap }),
+  }) as unknown as TerminalReplicaSnapshot;
+}
+
+export function freezeTerminalReplicaSnapshot(
+  snapshot: TerminalReplicaSnapshot,
+): TerminalReplicaSnapshot {
+  if (!terminalReplicaSnapshotIsValid(snapshot)) {
+    throw new TypeError("Malformed terminal replica snapshot");
+  }
+  return freezeSnapshot(snapshot);
+}
+
+/** Daemon parser seam: rows are already canonical/frozen, so avoid deep cloning the grid. */
+export function assembleTerminalReplicaSnapshot(
+  snapshot: TerminalReplicaSnapshot,
+): TerminalReplicaSnapshot {
+  if (
+    snapshot.grid.length !== snapshot.rows ||
+    snapshot.cursor.x >= snapshot.cols ||
+    snapshot.cursor.y >= snapshot.rows ||
+    snapshot.grid.some((row) => row.cells.length !== snapshot.cols)
+  ) {
+    throw new TypeError("Malformed trusted terminal replica snapshot");
+  }
+  return Object.freeze({
+    ...snapshot,
+    grid: Object.freeze(snapshot.grid),
+    history: Object.freeze(snapshot.history),
+    cursor: Object.freeze(snapshot.cursor),
+    modes: Object.freeze(snapshot.modes),
+    placements: Object.freeze(snapshot.placements.map((placement) => Object.freeze(placement))),
+    bootstrap: Object.freeze(snapshot.bootstrap),
+  }) as TerminalReplicaSnapshot;
+}
+
+function colorsEqual(left: TerminalReplicaColor, right: TerminalReplicaColor): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "default") return true;
+  if (left.kind === "indexed" && right.kind === "indexed") return left.index === right.index;
+  return left.kind === "rgb" && right.kind === "rgb" && left.value === right.value;
+}
+
+function hashStable(value: unknown): string {
+  const bytes = new TextEncoder().encode(canonicalEncode(value));
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of bytes) {
+    hash ^= BigInt(byte);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return hash.toString(16).padStart(16, "0");
+}
+
+function canonicalEncode(value: unknown): string {
+  if (value === null) return "n;";
+  if (typeof value === "boolean") return value ? "b1;" : "b0;";
+  if (typeof value === "number") return `d${String(value).length}:${String(value)};`;
+  if (typeof value === "string") {
+    const length = new TextEncoder().encode(value).length;
+    return `s${length}:${value};`;
+  }
+  if (Array.isArray(value)) return `a${value.length}:${value.map(canonicalEncode).join("")};`;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  return `o${keys.length}:${keys
+    .map((key) => `${canonicalEncode(key)}${canonicalEncode(record[key])}`)
+    .join("")};`;
+}
+
+function protocolConflict(
+  current: TerminalReplicaState,
+  receivedRevision: number,
+): TerminalReplicaApplyResult {
+  return {
+    status: "conflict",
+    state: current,
+    expectedRevision: current.revision + 1,
+    receivedRevision,
+  };
+}
+
+function isNewerIncarnation(current: string, candidate: string): boolean {
+  const currentEpoch = /:([0-9]+)$/u.exec(current)?.[1];
+  const candidateEpoch = /:([0-9]+)$/u.exec(candidate)?.[1];
+  return (
+    currentEpoch !== undefined &&
+    candidateEpoch !== undefined &&
+    Number(candidateEpoch) > Number(currentEpoch)
+  );
+}
+
+function hashTerminalReplicaRow(row: TerminalReplicaRow): string {
+  const cached = ROW_HASH_CACHE.get(row);
+  if (cached) return cached;
+  const hash = hashStable([
+    row.wrapped,
+    row.cells.map((cell) => [
+      cell.grapheme,
+      cell.width,
+      cell.foreground,
+      cell.background,
+      cell.attributes,
+    ]),
+  ]);
+  if (Object.isFrozen(row)) ROW_HASH_CACHE.set(row, hash);
+  return hash;
+}
+
+function hashTerminalReplicaRows(rows: readonly TerminalReplicaRow[]): string {
+  const cached = ROW_ARRAY_HASH_CACHE.get(rows);
+  if (cached) return cached.hash.toString(16).padStart(16, "0");
+  let hash = 0n;
+  for (const row of rows)
+    hash = BigInt.asUintN(
+      64,
+      hash * ROW_SEQUENCE_BASE + BigInt(`0x${hashTerminalReplicaRow(row)}`),
+    );
+  if (Object.isFrozen(rows)) ROW_ARRAY_HASH_CACHE.set(rows, { hash, length: rows.length });
+  return hash.toString(16).padStart(16, "0");
+}
+
+function registerRowsDeltaHash(
+  previous: readonly TerminalReplicaRow[],
+  next: readonly TerminalReplicaRow[],
+  trim: number,
+  append: readonly TerminalReplicaRow[],
+): void {
+  hashTerminalReplicaRows(previous);
+  const prior = ROW_ARRAY_HASH_CACHE.get(previous);
+  if (!prior) return;
+  let hash = prior.hash;
+  for (let index = 0; index < trim; index += 1) {
+    const exponent = prior.length - 1 - index;
+    const contribution = BigInt.asUintN(
+      64,
+      BigInt(`0x${hashTerminalReplicaRow(previous[index]!)}`) * pow64(ROW_SEQUENCE_BASE, exponent),
+    );
+    hash = BigInt.asUintN(64, hash - contribution);
+  }
+  for (const row of append)
+    hash = BigInt.asUintN(
+      64,
+      hash * ROW_SEQUENCE_BASE + BigInt(`0x${hashTerminalReplicaRow(row)}`),
+    );
+  ROW_ARRAY_HASH_CACHE.set(next, { hash, length: next.length });
+}
+
+function pow64(base: bigint, exponent: number): bigint {
+  let result = 1n;
+  let factor = base;
+  let power = exponent;
+  while (power > 0) {
+    if (power % 2 === 1) result = BigInt.asUintN(64, result * factor);
+    factor = BigInt.asUintN(64, factor * factor);
+    power = Math.floor(power / 2);
+  }
+  return result;
+}
+
+function terminalReplicaSnapshotIsValid(snapshot: TerminalReplicaSnapshot): boolean {
+  if (
+    snapshot.grid.length !== snapshot.rows ||
+    snapshot.cursor.x >= snapshot.cols ||
+    snapshot.cursor.y >= snapshot.rows
+  )
+    return false;
+  for (const row of [...snapshot.history, ...snapshot.grid]) {
+    if (row.cells.length !== snapshot.cols || !terminalReplicaRowIsValid(row)) return false;
+  }
+  return snapshot.placements.every(
+    (placement) =>
+      placement.row < snapshot.rows &&
+      placement.column < snapshot.cols &&
+      placement.row + placement.rows <= snapshot.rows &&
+      placement.column + placement.columns <= snapshot.cols,
+  );
+}
+
+function terminalReplicaRowIsValid(row: TerminalReplicaRow): boolean {
+  for (let index = 0; index < row.cells.length; index += 1) {
+    const width = row.cells[index]!.width;
+    if (width === 2 && row.cells[index + 1]?.width !== 0) return false;
+    if (width === 0 && (index === 0 || row.cells[index - 1]?.width !== 2)) return false;
+  }
+  return true;
+}

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -86,7 +86,7 @@
     "@tmux-ide/core": "workspace:*",
     "@tmux-ide/daemon-client": "workspace:*",
     "@tmux-ide/tmux-bridge": "workspace:*",
-    "@xterm/headless": "^6.0.0",
+    "@xterm/headless": "6.0.0",
     "@xterm/addon-unicode11": "0.9.0",
     "hono": "^4.12.34",
     "ignore": "^7.0.5",

--- a/packages/daemon/src/__tests__/engine-import-dag.test.ts
+++ b/packages/daemon/src/__tests__/engine-import-dag.test.ts
@@ -63,6 +63,8 @@ const KNOWN_INVERSIONS: readonly string[] = [
   "terminal/attachments/agent-status-probe.ts -> tui/detect/manifest.ts",
   "terminal/attachments/agent-status-probe.ts -> tui/detect/process-tree.ts",
   "terminal/attachments/agent-status-probe.ts -> tui/detect/snapshot.ts",
+  // Temporary test-only differential oracle; production imports remain adapter -> engine.
+  "terminal/session-runtime/terminal-replica-shadow-projections.test.ts -> tui/mirror/pane-mirror.ts",
 ];
 
 function sourceFiles(root: string): string[] {

--- a/packages/daemon/src/terminal/session-runtime/registry.ts
+++ b/packages/daemon/src/terminal/session-runtime/registry.ts
@@ -10,6 +10,7 @@ import {
   type SessionRuntimeControllerSnapshot,
   type SessionRuntimeGeneration,
   type SessionRuntimeSemanticIntent,
+  type CanonicalTerminalReplicaUpdate,
 } from "@tmux-ide/contracts";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
@@ -31,6 +32,10 @@ import {
   type SessionRuntimeTmuxObservation,
   type SessionSemanticMutationExecutorOptions,
 } from "./semantic-mutation-executor.ts";
+import {
+  SessionRuntimeTerminalReplicaOwner,
+  type TerminalReplicaSubscription,
+} from "./terminal-replica-owner.ts";
 
 export interface SessionRuntimeRegistryOptions {
   readonly generation: string;
@@ -95,6 +100,10 @@ export interface SessionRuntimeConsumer {
     onEvent: (event: MirrorPaneEvent) => void,
     onLayout?: (event: MirrorLayoutEvent) => void,
   ): Promise<MirrorSubscription>;
+  subscribeReplica(
+    semanticPaneId: string,
+    onUpdate: (update: CanonicalTerminalReplicaUpdate) => void,
+  ): Promise<TerminalReplicaSubscription>;
   close(): Promise<void>;
 }
 
@@ -405,6 +414,8 @@ class SessionRuntime {
   readonly #mirror: MirrorService;
   readonly #consumers = new Set<SessionRuntimeConsumerImpl>();
   readonly #consumersByClientId = new Map<string, SessionRuntimeConsumerImpl>();
+  readonly #terminalReplicas = new Map<string, SessionRuntimeTerminalReplicaOwner>();
+  readonly #terminalReplicaClocks = new Map<string, { epoch: number; revision: number }>();
   readonly #createControllerToken: () => string;
   readonly #submitAuthorized: (
     runtime: SessionRuntime,
@@ -604,6 +615,66 @@ class SessionRuntime {
     });
   }
 
+  async subscribeReplica(
+    semanticPaneId: string,
+    onUpdate: (update: CanonicalTerminalReplicaUpdate) => void,
+  ): Promise<TerminalReplicaSubscription> {
+    await this.whenReady();
+    // A replacement parser must never overlap the faulted owner's terminal or
+    // revision epoch. This is intentionally separate from transport readiness:
+    // the retained tmux channel may remain healthy while one pane parser fails.
+    await this.#restartBarrier;
+    let owner = this.#terminalReplicas.get(semanticPaneId);
+    if (!owner) {
+      const clock = this.#terminalReplicaClocks.get(semanticPaneId) ?? { epoch: 0, revision: -1 };
+      const initialRevision = clock.revision + 1;
+      let candidate: SessionRuntimeTerminalReplicaOwner;
+      candidate = new SessionRuntimeTerminalReplicaOwner(
+        this.generation,
+        this.session,
+        semanticPaneId,
+        this.#mirror,
+        {
+          incarnation: `${this.generation}:${clock.epoch}`,
+          initialRevision,
+          onRevision: (revision) => {
+            const current = this.#terminalReplicaClocks.get(semanticPaneId) ?? clock;
+            if (revision > current.revision) current.revision = revision;
+            this.#terminalReplicaClocks.set(semanticPaneId, current);
+          },
+          onClosed: () => {
+            if (this.#terminalReplicas.get(semanticPaneId) !== candidate) return;
+            this.#terminalReplicas.delete(semanticPaneId);
+            const current = this.#terminalReplicaClocks.get(semanticPaneId) ?? clock;
+            current.epoch += 1;
+            this.#terminalReplicaClocks.set(semanticPaneId, current);
+          },
+          onFault: () => {
+            if (this.#terminalReplicas.get(semanticPaneId) !== candidate) return;
+            this.#terminalReplicas.delete(semanticPaneId);
+            this.#restartBarrier = this.#restartBarrier.then(async () => {
+              await candidate.dispose("session-restarted");
+              const current = this.#terminalReplicaClocks.get(semanticPaneId) ?? clock;
+              current.epoch += 1;
+              this.#terminalReplicaClocks.set(semanticPaneId, current);
+            });
+          },
+        },
+      );
+      owner = candidate;
+      this.#terminalReplicas.set(semanticPaneId, owner);
+    }
+    try {
+      return await owner.subscribe(onUpdate);
+    } catch (error) {
+      if (this.#terminalReplicas.get(semanticPaneId) === owner) {
+        this.#terminalReplicas.delete(semanticPaneId);
+      }
+      await owner.dispose("session-restarted");
+      throw error;
+    }
+  }
+
   release(consumer: SessionRuntimeConsumerImpl): void {
     this.#consumers.delete(consumer);
     if (this.#consumersByClientId.get(consumer.clientId) === consumer) {
@@ -616,9 +687,13 @@ class SessionRuntime {
     const retention = this.#retention;
     this.#retention = null;
     this.#startPromise = null;
-    if (retention) {
-      this.#restartBarrier = this.#restartBarrier.then(() => retention.close());
-    }
+    const owners = [...this.#terminalReplicas.values()];
+    this.#terminalReplicas.clear();
+    this.#restartBarrier = this.#restartBarrier.then(async () => {
+      await Promise.allSettled(owners.map((owner) => owner.dispose("session-restarted")));
+      await retention?.close();
+      for (const clock of this.#terminalReplicaClocks.values()) clock.epoch += 1;
+    });
   }
 
   async dispose(): Promise<void> {
@@ -629,6 +704,10 @@ class SessionRuntime {
     this.#clearController();
     this.#completedHandoffs.clear();
     this.#releasedLeases.clear();
+    await Promise.allSettled(
+      [...this.#terminalReplicas.values()].map((owner) => owner.dispose("runtime-disposed")),
+    );
+    this.#terminalReplicas.clear();
     await this.#restartBarrier;
     await this.#retention?.close();
     this.#retention = null;
@@ -709,6 +788,7 @@ class SessionRuntimeConsumerImpl implements SessionRuntimeConsumer {
   readonly session: string;
   readonly clientId: string;
   readonly #subscriptions = new Set<MirrorSubscription>();
+  readonly #replicaSubscriptions = new Set<TerminalReplicaSubscription>();
   #closed = false;
 
   constructor(
@@ -789,15 +869,42 @@ class SessionRuntimeConsumerImpl implements SessionRuntimeConsumer {
     return subscription;
   }
 
+  async subscribeReplica(
+    semanticPaneId: string,
+    onUpdate: (update: CanonicalTerminalReplicaUpdate) => void,
+  ): Promise<TerminalReplicaSubscription> {
+    this.#assertOpen();
+    const upstream = await this.#runtime.subscribeReplica(semanticPaneId, onUpdate);
+    if (this.#closed) {
+      await upstream.close();
+      throw new Error(`SessionRuntime consumer ${this.surface} is closed`);
+    }
+    let closed = false;
+    const subscription: TerminalReplicaSubscription = {
+      ...upstream,
+      close: async () => {
+        if (closed) return;
+        closed = true;
+        this.#replicaSubscriptions.delete(subscription);
+        await upstream.close();
+      },
+    };
+    this.#replicaSubscriptions.add(subscription);
+    return subscription;
+  }
+
   async close(): Promise<void> {
     if (this.#closed) return;
     this.#closed = true;
     const subscriptions = [...this.#subscriptions];
+    const replicaSubscriptions = [...this.#replicaSubscriptions];
     this.#subscriptions.clear();
+    this.#replicaSubscriptions.clear();
     // Authority retirement is synchronous. A slow/frozen mirror subscription
     // must never keep controller leases or previously issued handles alive.
     this.#runtime.release(this);
     await Promise.allSettled(subscriptions.map((subscription) => subscription.close()));
+    await Promise.allSettled(replicaSubscriptions.map((subscription) => subscription.close()));
   }
 
   #assertOpen(): void {

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-architecture.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-architecture.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const daemonSrc = join(import.meta.dirname, "../..");
+
+describe("terminal replica architecture", () => {
+  it("keeps the new canonical xterm parser daemon-owned and singular", () => {
+    const imports = sourceFiles(daemonSrc)
+      .filter((file) => !file.endsWith(".test.ts"))
+      .filter((file) => readFileSync(file, "utf8").includes('from "@xterm/headless"'))
+      .map((file) => file.slice(daemonSrc.length + 1));
+    expect(imports).toEqual([
+      "terminal/session-runtime/terminal-replica-interpreter.ts",
+      "tui/mirror/pane-mirror.ts",
+    ]);
+  });
+
+  it("keeps shadow projections out of production GUI/OpenTUI imports", () => {
+    const consumers = sourceFiles(daemonSrc)
+      .filter((file) => !file.endsWith(".test.ts"))
+      .filter((file) => readFileSync(file, "utf8").includes("terminal-replica-shadow-projections"));
+    expect(consumers).toEqual([]);
+  });
+});
+
+function sourceFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(root, entry.name);
+    return entry.isDirectory() ? sourceFiles(path) : entry.name.endsWith(".ts") ? [path] : [];
+  });
+}

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-interpreter.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-interpreter.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import { widgetMarkerAnnouncement, type CanonicalTerminalReplicaUpdate } from "@tmux-ide/contracts";
+import { TERMINAL_CONFORMANCE_FIXTURES } from "@tmux-ide/core";
+import { TerminalReplicaInterpreter } from "./terminal-replica-interpreter.ts";
+
+const generation = "00000000-0000-4000-8000-000000000001";
+
+function create(updates: CanonicalTerminalReplicaUpdate[], cols = 12, rows = 3) {
+  return new TerminalReplicaInterpreter({
+    generation,
+    workspaceName: "workspace",
+    semanticPaneId: "pane-a",
+    incarnation: `${generation}:0`,
+    cols,
+    rows,
+    onUpdate: (update) => updates.push(update),
+  });
+}
+
+describe("TerminalReplicaInterpreter", () => {
+  it("publishes one atomic painted-capture seed and orders resize after partial CSI", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const interpreter = create(updates);
+    expect(interpreter.currentSeed()).toBeNull();
+    await interpreter.enqueue({
+      type: "reseed",
+      cols: 12,
+      rows: 3,
+      chunks: [new TextEncoder().encode("A\u001b[31"), new TextEncoder().encode("mB")],
+      cursor: { x: 2, y: 0 },
+      bootstrap: "painted-capture",
+    });
+    await interpreter.enqueue({ type: "resize", cols: 10, rows: 2 });
+    expect(updates.map((update) => update.type)).toEqual(["terminal.seed", "terminal.patch"]);
+    expect(interpreter.currentSeed()?.stateHash).toBe(updates[1]!.stateHash);
+    expect(updates.map((update) => update.revision)).toEqual([0, 1]);
+    expect(interpreter.currentSnapshot().grid[0]!.cells[1]!.foreground).toEqual({
+      kind: "indexed",
+      index: 1,
+    });
+    expect(interpreter.currentSnapshot()).toMatchObject({ cols: 10, rows: 2 });
+  });
+
+  it("keeps tmux cursor truth absolute under DECOM without mutating parser state", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const interpreter = create(updates, 20, 8);
+    await interpreter.enqueue({
+      type: "reseed",
+      cols: 20,
+      rows: 8,
+      chunks: [new TextEncoder().encode("\u001b[2;6r\u001b[?6hhello")],
+      cursor: { x: 17, y: 7 },
+      bootstrap: "painted-capture",
+    });
+    expect(interpreter.currentSnapshot().cursor).toMatchObject({ x: 17, y: 7 });
+    expect(interpreter.currentSnapshot().modes.origin).toBe(true);
+  });
+
+  it("makes corrected cursor authoritative for the next relative write", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const interpreter = create(updates, 10, 2);
+    await interpreter.enqueue({
+      type: "reseed",
+      cols: 10,
+      rows: 2,
+      chunks: [new TextEncoder().encode("abc")],
+      cursor: { x: 1, y: 0 },
+      bootstrap: "painted-capture",
+    });
+    await interpreter.enqueue({ type: "write", data: new TextEncoder().encode("Z") });
+    expect(
+      interpreter
+        .currentSnapshot()
+        .grid[0]!.cells.slice(0, 3)
+        .map((cell) => cell.grapheme)
+        .join(""),
+    ).toBe("aZc");
+    expect(interpreter.currentSnapshot().cursor.x).toBe(2);
+  });
+
+  it("invalidates a cached row when xterm's combined-grapheme side table changes", async () => {
+    const interpreter = create([], 8, 2);
+    await interpreter.enqueue({ type: "write", data: new TextEncoder().encode("e\u0301") });
+    await interpreter.enqueue({ type: "write", data: new TextEncoder().encode("\ra\u0301") });
+    expect(interpreter.currentSnapshot().grid[0]!.cells[0]!.grapheme).toBe("a\u0301");
+  });
+
+  it("coalesces a same-turn flood, emits no semantic no-op, and is idle at zero cost", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const interpreter = create(updates, 80, 24);
+    expect(interpreter.gridWalkCount()).toBe(0);
+    const writes = Array.from({ length: 200 }, () =>
+      interpreter.enqueue({ type: "write", data: new TextEncoder().encode("x") }),
+    );
+    await Promise.all(writes);
+    expect(interpreter.gridWalkCount()).toBe(1);
+    expect(updates).toHaveLength(1);
+    const before = interpreter.gridWalkCount();
+    await interpreter.whenIdle();
+    expect(interpreter.gridWalkCount()).toBe(before);
+    const count = updates.length;
+    await interpreter.enqueue({ type: "cursor", x: 0, y: 0 });
+    await interpreter.enqueue({ type: "cursor", x: 0, y: 0 });
+    expect(updates.length).toBeLessThanOrEqual(count + 1);
+  });
+
+  it("matches shared ANSI, inverse, wide and combining conformance fixtures", async () => {
+    for (const fixture of TERMINAL_CONFORMANCE_FIXTURES) {
+      const updates: CanonicalTerminalReplicaUpdate[] = [];
+      const interpreter = create(updates, fixture.cols, fixture.rows);
+      await interpreter.enqueue({
+        type: "reseed",
+        cols: fixture.cols,
+        rows: fixture.rows,
+        chunks: fixture.writes.map((write) => new TextEncoder().encode(write)),
+        cursor: { x: 0, y: 0 },
+        bootstrap: "authoritative-stream",
+      });
+      const snapshot = interpreter.currentSnapshot();
+      for (const expected of fixture.cells) {
+        const actual = snapshot.grid[expected.row]!.cells[expected.column]!;
+        expect(actual, `${fixture.id} ${expected.row}:${expected.column}`).toMatchObject({
+          grapheme: expected.chars,
+          width: expected.width,
+          foreground: expected.foreground,
+          background: expected.background,
+        });
+      }
+    }
+  });
+
+  it("uses a single higher-revision seed for reseed and immutable tombstone after it", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const interpreter = create(updates);
+    const reseed = (text: string) =>
+      interpreter.enqueue({
+        type: "reseed",
+        cols: 12,
+        rows: 3,
+        chunks: [new TextEncoder().encode(text)],
+        cursor: { x: 0, y: 0 },
+        bootstrap: "painted-capture",
+      });
+    await reseed("one");
+    await reseed("two");
+    await interpreter.enqueue({ type: "close", reason: "session-restarted" });
+    expect(updates.map((update) => [update.type, update.revision])).toEqual([
+      ["terminal.seed", 0],
+      ["terminal.seed", 1],
+      ["terminal.tombstone", 2],
+    ]);
+    expect(Object.isFrozen(interpreter.currentSnapshot().grid)).toBe(true);
+  });
+
+  it("withholds synchronized-output intermediates and publishes the final atomic frame", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const interpreter = create(updates);
+    await interpreter.enqueue({ type: "write", data: new TextEncoder().encode("\u001b[?2026hA") });
+    expect(updates).toHaveLength(0);
+    await interpreter.enqueue({ type: "write", data: new TextEncoder().encode("B\u001b[?2026l") });
+    expect(updates).toHaveLength(1);
+    expect(
+      interpreter
+        .currentSnapshot()
+        .grid[0]!.cells.slice(0, 2)
+        .map((cell) => cell.grapheme)
+        .join(""),
+    ).toBe("AB");
+  });
+
+  it("applies admitted resize geometry before later synchronized bytes parse", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const interpreter = create(updates, 4, 2);
+    await interpreter.enqueue({ type: "write", data: new TextEncoder().encode("\u001b[?2026h") });
+    await interpreter.enqueue({ type: "resize", cols: 2, rows: 3 });
+    await interpreter.enqueue({
+      type: "write",
+      data: new TextEncoder().encode("\u001b[?2026lABCD"),
+    });
+    expect(interpreter.currentSnapshot()).toMatchObject({ cols: 2, rows: 3 });
+    expect(interpreter.currentSnapshot().grid[1]!.cells[0]!.grapheme).toBe("C");
+    expect(updates).toHaveLength(1);
+  });
+
+  it("projects and clears authenticated rich-widget placements", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const interpreter = create(updates, 80, 8);
+    await interpreter.enqueue({
+      type: "reseed",
+      cols: 80,
+      rows: 8,
+      chunks: [new TextEncoder().encode(widgetMarkerAnnouncement("markdown", { text: "# Plan" }))],
+      cursor: { x: 0, y: 1 },
+      bootstrap: "authoritative-stream",
+    });
+    expect(interpreter.currentSnapshot().placements[0]).toMatchObject({
+      id: "markdown",
+      kind: "widget",
+      column: 0,
+    });
+    await interpreter.enqueue({
+      type: "write",
+      data: new TextEncoder().encode("\u001b[2J\u001b[3J\u001b[Hshell"),
+    });
+    expect(interpreter.currentSnapshot().placements).toEqual([]);
+  });
+
+  it("discovers a wrapped widget announcement whose sentinel has scrolled into history", async () => {
+    const interpreter = create([], 20, 3);
+    await interpreter.enqueue({
+      type: "write",
+      data: new TextEncoder().encode(
+        widgetMarkerAnnouncement("markdown", { text: "x".repeat(4_000) }),
+      ),
+    });
+    expect(interpreter.currentSnapshot().history.length).toBeGreaterThan(0);
+    expect(interpreter.currentSnapshot().placements[0]?.id).toBe("markdown");
+  });
+});

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-interpreter.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-interpreter.ts
@@ -1,0 +1,721 @@
+import { Terminal } from "@xterm/headless";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
+import {
+  detectWidgetMarker,
+  type CanonicalTerminalReplicaPatch,
+  type CanonicalTerminalReplicaSeed,
+  type CanonicalTerminalReplicaTombstone,
+  type CanonicalTerminalReplicaUpdate,
+  type SessionRuntimeGeneration,
+  type TerminalReplicaCell,
+  type TerminalReplicaColor,
+  type TerminalReplicaModes,
+  type TerminalReplicaRow,
+  type TerminalReplicaSnapshot,
+} from "@tmux-ide/contracts";
+import {
+  applyTerminalReplicaPatch,
+  assembleTerminalReplicaSnapshot,
+  blankTerminalReplicaSnapshot,
+  freezeTerminalReplicaRow,
+  hashTerminalReplicaSnapshot,
+  hashTerminalReplicaTombstone,
+  terminalReplicaRowsEqual,
+} from "@tmux-ide/core";
+
+type CloseReason = "pane-closed" | "session-restarted" | "runtime-disposed";
+export type TerminalReplicaInterpreterOperation =
+  | { readonly type: "write"; readonly data: Uint8Array }
+  | { readonly type: "cursor"; readonly x: number; readonly y: number }
+  | { readonly type: "resize"; readonly cols: number; readonly rows: number }
+  | {
+      readonly type: "reseed";
+      readonly cols: number;
+      readonly rows: number;
+      readonly chunks: readonly Uint8Array[];
+      readonly cursor: { readonly x: number; readonly y: number };
+      /** capture-pane is painted truth, not proof of hidden pre-existing VT modes. */
+      readonly bootstrap: "painted-capture" | "authoritative-stream";
+    }
+  | { readonly type: "close"; readonly reason: CloseReason };
+
+export interface TerminalReplicaInterpreterOptions {
+  readonly generation: SessionRuntimeGeneration;
+  readonly workspaceName: string;
+  readonly semanticPaneId: string;
+  readonly incarnation: string;
+  readonly initialRevision?: number;
+  readonly cols: number;
+  readonly rows: number;
+  readonly scrollback?: number;
+  readonly onUpdate?: (update: CanonicalTerminalReplicaUpdate) => void;
+}
+
+export interface TerminalReplicaInterpreterStats {
+  readonly fullWalks: number;
+  readonly gridRowsRead: number;
+  readonly historyRowsRead: number;
+  readonly placementRowsRead: number;
+  readonly cellsRead: number;
+  readonly parseBatches: number;
+  readonly historyKeyVisits: number;
+}
+
+/** Daemon-owned, sans-I/O VT interpreter with one FIFO for bytes and geometry. */
+export class TerminalReplicaInterpreter {
+  readonly #generation: SessionRuntimeGeneration;
+  readonly #workspaceName: string;
+  readonly #semanticPaneId: string;
+  readonly #incarnation: string;
+  readonly #scrollback: number;
+  readonly #listeners = new Set<(update: CanonicalTerminalReplicaUpdate) => void>();
+  #terminal: Terminal;
+  #tail: Promise<void> = Promise.resolve();
+  #revision = 0;
+  #snapshot: TerminalReplicaSnapshot;
+  #needsSeed = true;
+  #closed = false;
+  #walkCount = 0;
+  #pendingWrites: Array<{
+    data: Uint8Array;
+    resolve: () => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  #writeFlushScheduled = false;
+  readonly #rowCache = new WeakMap<object, CachedRow>();
+  #lastViewportY = 0;
+  #lastBufferType = "normal";
+  #widgetGate = false;
+  #markerTail = "";
+  #pendingResize: { cols: number; rows: number } | null = null;
+  #syncRecovery: ReturnType<typeof setTimeout> | null = null;
+  #bootstrap: TerminalReplicaSnapshot["bootstrap"] = {
+    kind: "painted-capture",
+    hiddenState: "unknown",
+  };
+  #scrollEpoch = 0;
+  #lastScrollEpoch = 0;
+  #projectedHistoryDelta: CanonicalTerminalReplicaPatch["patch"]["historyDelta"] | null = null;
+  #stats = {
+    fullWalks: 0,
+    gridRowsRead: 0,
+    historyRowsRead: 0,
+    placementRowsRead: 0,
+    cellsRead: 0,
+    parseBatches: 0,
+    historyKeyVisits: 0,
+  };
+  readonly #seedReady: Promise<void>;
+  #resolveSeedReady!: () => void;
+  #rejectSeedReady!: (error: unknown) => void;
+
+  constructor(options: TerminalReplicaInterpreterOptions) {
+    this.#generation = options.generation;
+    this.#workspaceName = options.workspaceName;
+    this.#semanticPaneId = options.semanticPaneId;
+    this.#incarnation = options.incarnation;
+    this.#revision = options.initialRevision ?? 0;
+    this.#scrollback = options.scrollback ?? 5000;
+    this.#terminal = this.#createTerminal(options.cols, options.rows);
+    this.#snapshot = blankTerminalReplicaSnapshot(options.cols, options.rows);
+    this.#seedReady = new Promise((resolve, reject) => {
+      this.#resolveSeedReady = resolve;
+      this.#rejectSeedReady = reject;
+    });
+    void this.#seedReady.catch(() => undefined);
+    if (options.onUpdate) this.#listeners.add(options.onUpdate);
+  }
+
+  onUpdate(listener: (update: CanonicalTerminalReplicaUpdate) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  enqueue(operation: TerminalReplicaInterpreterOperation): Promise<void> {
+    if (operation.type === "write") {
+      const data = operation.data.slice();
+      const promise = new Promise<void>((resolve, reject) => {
+        this.#pendingWrites.push({ data, resolve, reject });
+      });
+      if (!this.#writeFlushScheduled) {
+        this.#writeFlushScheduled = true;
+        queueMicrotask(() => this.#flushWrites());
+      }
+      return promise;
+    }
+    this.#flushWrites();
+    const admitted =
+      operation.type === "reseed"
+        ? { ...operation, chunks: operation.chunks.map((chunk) => chunk.slice()) }
+        : operation;
+    return this.#append(admitted);
+  }
+
+  whenIdle(): Promise<void> {
+    this.#flushWrites();
+    return this.#tail;
+  }
+
+  currentSnapshot(): TerminalReplicaSnapshot {
+    return this.#snapshot;
+  }
+
+  currentSeed(): CanonicalTerminalReplicaSeed | null {
+    return this.#needsSeed ? null : this.#seed(this.#revision, this.#snapshot);
+  }
+
+  whenSeeded(): Promise<void> {
+    return this.#seedReady;
+  }
+
+  abort(error: unknown): void {
+    if (this.#needsSeed) this.#rejectSeedReady(error);
+  }
+
+  gridWalkCount(): number {
+    return this.#walkCount;
+  }
+
+  stats(): TerminalReplicaInterpreterStats {
+    return Object.freeze({ ...this.#stats });
+  }
+
+  #append(
+    operation: Exclude<TerminalReplicaInterpreterOperation, { type: "write" }>,
+  ): Promise<void> {
+    const run = this.#tail.then(() => this.#apply(operation));
+    this.#tail = run.catch(() => undefined);
+    return run;
+  }
+
+  async #apply(
+    operation: Exclude<TerminalReplicaInterpreterOperation, { type: "write" }>,
+  ): Promise<void> {
+    if (this.#closed) return;
+    if (operation.type === "reseed") {
+      const replacement = this.#createTerminal(operation.cols, operation.rows);
+      try {
+        for (const chunk of operation.chunks) {
+          this.#observeMarkerBytes(chunk);
+          await writeTerminal(replacement, chunk);
+        }
+      } catch (error) {
+        replacement.dispose();
+        throw error;
+      }
+      const previous = this.#terminal;
+      this.#terminal = replacement;
+      this.#bootstrap = {
+        kind: operation.bootstrap,
+        hiddenState:
+          operation.bootstrap === "authoritative-stream" ? "observed-from-start" : "unknown",
+      };
+      setAuthoritativeCursor(this.#terminal, operation.cursor.x, operation.cursor.y);
+      this.#commit(true);
+      previous.dispose();
+      return;
+    }
+    if (operation.type === "cursor") {
+      // Cursor truth is an overlay. Never inject CUP: DECOM/margins would make
+      // it relative and mutate the parser's saved/wrap state.
+      setAuthoritativeCursor(this.#terminal, operation.x, operation.y);
+      this.#commit(false, { start: 1, end: 0 });
+      return;
+    }
+    if (operation.type === "resize") {
+      if (terminalModes(this.#terminal).synchronizedOutput) {
+        // Geometry is part of the admitted FIFO even while publication is
+        // atomic. Later bytes must parse at the new size.
+        this.#terminal.resize(operation.cols, operation.rows);
+        this.#pendingResize = { cols: operation.cols, rows: operation.rows };
+        this.#scheduleSyncRecovery();
+        return;
+      }
+      this.#terminal.resize(operation.cols, operation.rows);
+      this.#commit(false);
+      return;
+    }
+    const baseRevision = this.#revision;
+    const revision = baseRevision + 1;
+    const update: CanonicalTerminalReplicaTombstone = {
+      type: "terminal.tombstone",
+      ...this.#address(),
+      baseRevision,
+      revision,
+      cols: this.#snapshot.cols,
+      rows: this.#snapshot.rows,
+      stateHash: hashTerminalReplicaTombstone(operation.reason),
+      hashAlgorithm: "fnv1a64-v1",
+      tombstone: { reason: operation.reason },
+    };
+    this.#revision = revision;
+    this.#closed = true;
+    this.#clearSyncRecovery();
+    if (this.#needsSeed)
+      this.#rejectSeedReady(new Error("Terminal replica closed before bootstrap"));
+    this.#terminal.dispose();
+    this.#emit(update);
+  }
+
+  async #write(data: Uint8Array): Promise<void> {
+    if (this.#closed) return;
+    this.#stats.parseBatches += 1;
+    this.#observeMarkerBytes(data);
+    await writeTerminal(this.#terminal, data);
+    // DEC synchronized-output is atomic: no intermediate frame leaks.
+    if (terminalModes(this.#terminal).synchronizedOutput) {
+      this.#scheduleSyncRecovery();
+      return;
+    }
+    this.#clearSyncRecovery();
+    const pendingResize = this.#pendingResize;
+    this.#pendingResize = null;
+    if (pendingResize) {
+      this.#commit(false);
+    } else {
+      this.#commit(false, dirtyRange(this.#terminal));
+    }
+  }
+
+  #scheduleSyncRecovery(): void {
+    if (this.#syncRecovery || this.#closed) return;
+    this.#syncRecovery = setTimeout(() => {
+      this.#syncRecovery = null;
+      const run = this.#tail.then(async () => {
+        if (this.#closed || !terminalModes(this.#terminal).synchronizedOutput) return;
+        await writeTerminal(this.#terminal, "\u001b[?2026l");
+        this.#pendingResize = null;
+        this.#commit(false);
+      });
+      this.#tail = run.catch(() => undefined);
+    }, 250);
+    this.#syncRecovery.unref?.();
+  }
+
+  #clearSyncRecovery(): void {
+    if (!this.#syncRecovery) return;
+    clearTimeout(this.#syncRecovery);
+    this.#syncRecovery = null;
+  }
+
+  #commit(forceSeed: boolean, dirty?: { start: number; end: number }): void {
+    const projected = this.#project(forceSeed ? undefined : dirty);
+    const previous = this.#snapshot;
+    const dirtyRows: CanonicalTerminalReplicaPatch["patch"]["rows"] = [];
+    for (let index = 0; index < projected.grid.length; index += 1) {
+      const row = projected.grid[index]!;
+      if (!terminalReplicaRowsEqual(previous.grid[index], row)) dirtyRows.push({ index, row });
+    }
+    const historyChanged = previous.history !== projected.history;
+    const historyDelta = historyChanged ? this.#projectedHistoryDelta : null;
+    const next = applyTerminalReplicaPatch(previous, {
+      ...(projected.cols !== previous.cols || projected.rows !== previous.rows
+        ? { dimensions: { cols: projected.cols, rows: projected.rows } }
+        : {}),
+      rows: dirtyRows,
+      ...(historyChanged ? (historyDelta ? { historyDelta } : { history: projected.history }) : {}),
+      cursor: projected.cursor,
+      modes: projected.modes,
+      placements: projected.placements,
+      bootstrap: projected.bootstrap,
+    });
+    const nextHash = hashTerminalReplicaSnapshot(next);
+    const priorHash = hashTerminalReplicaSnapshot(previous);
+    if (!forceSeed && nextHash === priorHash) return;
+    if (forceSeed || this.#needsSeed) {
+      const revision = this.#needsSeed ? this.#revision : this.#revision + 1;
+      this.#revision = revision;
+      this.#snapshot = next;
+      this.#needsSeed = false;
+      this.#resolveSeedReady();
+      this.#emit(this.#seed(revision, next));
+      return;
+    }
+    const baseRevision = this.#revision;
+    const revision = baseRevision + 1;
+    const update: CanonicalTerminalReplicaPatch = {
+      type: "terminal.patch",
+      ...this.#address(),
+      baseRevision,
+      revision,
+      cols: next.cols,
+      rows: next.rows,
+      stateHash: nextHash,
+      hashAlgorithm: "fnv1a64-v1",
+      patch: {
+        ...(next.cols !== previous.cols || next.rows !== previous.rows
+          ? { dimensions: { cols: next.cols, rows: next.rows } }
+          : {}),
+        rows: dirtyRows,
+        ...(historyChanged ? (historyDelta ? { historyDelta } : { history: next.history }) : {}),
+        cursor: next.cursor,
+        modes: next.modes,
+        placements: next.placements,
+        bootstrap: next.bootstrap,
+      },
+    };
+    this.#revision = revision;
+    this.#snapshot = next;
+    this.#emit(update);
+  }
+
+  #project(dirty?: { start: number; end: number }): TerminalReplicaSnapshot {
+    this.#walkCount += 1;
+    if (!dirty) this.#stats.fullWalks += 1;
+    const buffer = this.#terminal.buffer.active;
+    const geometryStable =
+      buffer.viewportY === this.#lastViewportY &&
+      buffer.type === this.#lastBufferType &&
+      this.#snapshot.cols === this.#terminal.cols;
+    const canReuseHistory = geometryStable && this.#scrollEpoch === this.#lastScrollEpoch;
+    this.#projectedHistoryDelta = null;
+    let history: readonly TerminalReplicaRow[] = canReuseHistory ? this.#snapshot.history : [];
+    const scrolls = this.#scrollEpoch - this.#lastScrollEpoch;
+    const previousLength = this.#snapshot.history.length;
+    const nextLength = buffer.viewportY;
+    const incrementalHistory =
+      !canReuseHistory &&
+      this.#lastBufferType === buffer.type &&
+      this.#snapshot.cols === this.#terminal.cols &&
+      nextLength >= previousLength &&
+      scrolls > 0;
+    if (incrementalHistory) {
+      const appended = nextLength - previousLength;
+      const trim = Math.min(previousLength, Math.max(0, scrolls - appended));
+      const retained = previousLength - trim;
+      const nextHistory = this.#snapshot.history.slice(trim);
+      for (let index = retained; index < nextLength; index += 1)
+        nextHistory.push(this.#readRow(buffer, index, this.#terminal.cols, "history"));
+      history = nextHistory;
+      this.#projectedHistoryDelta = { trim, append: nextHistory.slice(retained) };
+    } else if (!canReuseHistory && buffer.viewportY > 0) {
+      const nextHistory: TerminalReplicaRow[] = [];
+      for (let index = 0; index < buffer.viewportY; index += 1)
+        nextHistory.push(this.#readRow(buffer, index, this.#terminal.cols, "history"));
+      history = nextHistory;
+    }
+    const grid: TerminalReplicaRow[] = [];
+    const canUseDirtyRange =
+      dirty !== undefined && canReuseHistory && this.#snapshot.rows === this.#terminal.rows;
+    for (let row = 0; row < this.#terminal.rows; row += 1) {
+      if (canUseDirtyRange && (row < dirty.start || row > dirty.end)) {
+        grid.push(this.#snapshot.grid[row]!);
+      } else {
+        grid.push(this.#readRow(buffer, buffer.viewportY + row, this.#terminal.cols, "grid"));
+      }
+    }
+    this.#lastViewportY = buffer.viewportY;
+    this.#lastBufferType = buffer.type;
+    this.#lastScrollEpoch = this.#scrollEpoch;
+    const scanPlacements = this.#widgetGate || this.#snapshot.placements.length > 0;
+    const placementRows = scanPlacements ? [...history, ...grid] : [];
+    if (scanPlacements) this.#stats.placementRowsRead += placementRows.length;
+    const placements = scanPlacements
+      ? projectPlacements(placementRows, grid.length, this.#terminal.cols, history.length)
+      : [];
+    if (scanPlacements && placements.length === 0) this.#widgetGate = false;
+    return assembleTerminalReplicaSnapshot({
+      cols: this.#terminal.cols,
+      rows: this.#terminal.rows,
+      grid,
+      history: history as TerminalReplicaRow[],
+      cursor: cursorState(this.#terminal),
+      modes: terminalModes(this.#terminal),
+      placements,
+      bootstrap: this.#bootstrap,
+    });
+  }
+
+  #seed(revision: number, snapshot: TerminalReplicaSnapshot): CanonicalTerminalReplicaSeed {
+    return {
+      type: "terminal.seed",
+      ...this.#address(),
+      revision,
+      cols: snapshot.cols,
+      rows: snapshot.rows,
+      stateHash: hashTerminalReplicaSnapshot(snapshot),
+      hashAlgorithm: "fnv1a64-v1",
+      snapshot,
+    };
+  }
+
+  #address() {
+    return {
+      workspaceName: this.#workspaceName,
+      semanticPaneId: this.#semanticPaneId,
+      generation: this.#generation,
+      incarnation: this.#incarnation,
+    } as const;
+  }
+
+  #emit(update: CanonicalTerminalReplicaUpdate): void {
+    for (const listener of this.#listeners) {
+      try {
+        listener(update);
+      } catch {
+        // Renderer callbacks never poison the authoritative parser FIFO.
+      }
+    }
+  }
+
+  #createTerminal(cols: number, rows: number): Terminal {
+    const terminal = new Terminal({
+      cols,
+      rows,
+      scrollback: this.#scrollback,
+      allowProposedApi: true,
+    });
+    terminal.loadAddon(new Unicode11Addon());
+    terminal.unicode.activeVersion = "11";
+    terminal.onScroll(() => {
+      this.#scrollEpoch += 1;
+    });
+    const core = (terminal as unknown as { _core?: { coreService?: unknown } })._core;
+    if (!core?.coreService) {
+      terminal.dispose();
+      throw new Error("Unsupported @xterm/headless private API shape");
+    }
+    return terminal;
+  }
+
+  #flushWrites(): void {
+    this.#writeFlushScheduled = false;
+    if (this.#pendingWrites.length === 0) return;
+    const pending = this.#pendingWrites.splice(0);
+    const length = pending.reduce((total, entry) => total + entry.data.length, 0);
+    const data = new Uint8Array(length);
+    let offset = 0;
+    for (const entry of pending) {
+      data.set(entry.data, offset);
+      offset += entry.data.length;
+    }
+    const run = this.#tail.then(() => this.#write(data));
+    this.#tail = run.catch(() => undefined);
+    void run.then(
+      () => pending.forEach((entry) => entry.resolve()),
+      (error) => pending.forEach((entry) => entry.reject(error)),
+    );
+  }
+
+  #observeMarkerBytes(data: Uint8Array): void {
+    if (this.#widgetGate) return;
+    const text = this.#markerTail + new TextDecoder().decode(data);
+    if (text.includes("TMUXIDE-WIDGET/1")) this.#widgetGate = true;
+    this.#markerTail = text.slice(-32);
+  }
+
+  #readRow(
+    buffer: Terminal["buffer"]["active"],
+    index: number,
+    cols: number,
+    kind: "grid" | "history",
+  ): TerminalReplicaRow {
+    if (kind === "grid") this.#stats.gridRowsRead += 1;
+    else this.#stats.historyRowsRead += 1;
+    this.#stats.cellsRead += cols;
+    return projectRowCached(this.#rowCache, buffer, index, cols);
+  }
+}
+
+function writeTerminal(terminal: Terminal, data: Uint8Array | string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve));
+}
+
+function projectRowCached(
+  cache: WeakMap<object, CachedRow>,
+  buffer: Terminal["buffer"]["active"],
+  index: number,
+  cols: number,
+): TerminalReplicaRow {
+  const line = buffer.getLine(index);
+  const cacheKey = (line as unknown as { _line?: object } | undefined)?._line ?? line;
+  if (line && cacheKey) {
+    const data = lineData(line);
+    const combined = lineCombinedSignature(line);
+    const prior = cache.get(cacheKey);
+    if (
+      prior &&
+      rawRowsEqual(prior.data, data) &&
+      prior.combined === combined &&
+      prior.wrapped === line.isWrapped
+    )
+      return prior.row;
+  }
+  const cell = buffer.getNullCell();
+  const cells: TerminalReplicaCell[] = [];
+  for (let column = 0; column < cols; column += 1) {
+    line?.getCell(column, cell);
+    cells.push({
+      grapheme: line ? cell.getChars() || (cell.getWidth() === 0 ? "" : " ") : " ",
+      width: line ? (cell.getWidth() as 0 | 1 | 2) : 1,
+      foreground: line ? cellColor(cell, "foreground") : { kind: "default" },
+      background: line ? cellColor(cell, "background") : { kind: "default" },
+      attributes: line ? cellAttributes(cell) : 0,
+    });
+  }
+  const row = freezeTerminalReplicaRow({ cells, wrapped: line?.isWrapped ?? false });
+  if (line && cacheKey)
+    cache.set(cacheKey, {
+      data: lineData(line)?.slice() ?? null,
+      combined: lineCombinedSignature(line),
+      wrapped: line.isWrapped,
+      row,
+    });
+  return row;
+}
+
+interface CachedRow {
+  readonly data: Uint32Array | null;
+  readonly combined: string;
+  readonly wrapped: boolean;
+  readonly row: TerminalReplicaRow;
+}
+
+function lineData(line: object): Uint32Array | null {
+  const data = (line as { _line?: { _data?: Uint32Array } })._line?._data;
+  return data instanceof Uint32Array ? data : null;
+}
+
+function lineCombinedSignature(line: object): string {
+  const combined = (line as { _line?: { _combined?: Record<string, string> } })._line?._combined;
+  if (!combined) return "";
+  return Object.keys(combined)
+    .sort((left, right) => Number(left) - Number(right))
+    .map((key) => `${key.length}:${key}${combined[key]!.length}:${combined[key]}`)
+    .join(";");
+}
+
+function rawRowsEqual(left: Uint32Array | null, right: Uint32Array | null): boolean {
+  if (!left || !right || left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1)
+    if (left[index] !== right[index]) return false;
+  return true;
+}
+
+function cellColor(
+  cell: ReturnType<Terminal["buffer"]["active"]["getNullCell"]>,
+  channel: "foreground" | "background",
+): TerminalReplicaColor {
+  const rgb = channel === "foreground" ? cell.isFgRGB() : cell.isBgRGB();
+  const palette = channel === "foreground" ? cell.isFgPalette() : cell.isBgPalette();
+  const value = channel === "foreground" ? cell.getFgColor() : cell.getBgColor();
+  if (rgb) return { kind: "rgb", value };
+  if (palette) return { kind: "indexed", index: value };
+  return { kind: "default" };
+}
+
+function cellAttributes(cell: ReturnType<Terminal["buffer"]["active"]["getNullCell"]>): number {
+  return (
+    (cell.isBold() ? 1 : 0) |
+    (cell.isDim() ? 2 : 0) |
+    (cell.isItalic() ? 4 : 0) |
+    (cell.isUnderline() ? 8 : 0) |
+    (cell.isBlink() ? 16 : 0) |
+    (cell.isInverse() ? 32 : 0) |
+    (cell.isInvisible() ? 64 : 0) |
+    (cell.isStrikethrough() ? 128 : 0)
+  );
+}
+
+function cursorState(terminal: Terminal): TerminalReplicaSnapshot["cursor"] {
+  const buffer = terminal.buffer.active;
+  const service = (
+    terminal as unknown as {
+      _core?: {
+        coreService?: {
+          isCursorHidden?: boolean;
+          decPrivateModes?: { cursorStyle?: "block" | "underline" | "bar"; cursorBlink?: boolean };
+        };
+      };
+    }
+  )._core?.coreService;
+  return {
+    x: Math.min(buffer.cursorX, terminal.cols - 1),
+    y: Math.min(buffer.cursorY, terminal.rows - 1),
+    hidden: service?.isCursorHidden === true,
+    style: service?.decPrivateModes?.cursorStyle ?? terminal.options.cursorStyle ?? "block",
+    blink: service?.decPrivateModes?.cursorBlink ?? terminal.options.cursorBlink ?? false,
+  };
+}
+
+/** Pinned xterm 6.0.0 adapter: update parser cursor truth without CSI/DECOM side effects. */
+function setAuthoritativeCursor(terminal: Terminal, x: number, y: number): void {
+  const active = terminal.buffer.active as unknown as {
+    _buffer?: { x?: number; y?: number; _cols?: number; _rows?: number };
+  };
+  const buffer = active._buffer;
+  if (
+    !buffer ||
+    typeof buffer.x !== "number" ||
+    typeof buffer.y !== "number" ||
+    buffer._cols !== terminal.cols ||
+    buffer._rows !== terminal.rows
+  ) {
+    throw new Error("Unsupported @xterm/headless 6.0.0 cursor adapter shape");
+  }
+  buffer.x = Math.max(0, Math.min(x, terminal.cols - 1));
+  buffer.y = Math.max(0, Math.min(y, terminal.rows - 1));
+}
+
+function terminalModes(terminal: Terminal): TerminalReplicaModes {
+  const core = (
+    terminal as unknown as {
+      _core?: {
+        coreService?: {
+          decPrivateModes?: Record<string, boolean>;
+          modes?: Record<string, boolean>;
+        };
+        coreMouseService?: { _activeProtocol?: string };
+      };
+    }
+  )._core;
+  const dec = core?.coreService?.decPrivateModes ?? {};
+  const modes = core?.coreService?.modes ?? {};
+  return {
+    alternateScreen: terminal.buffer.active.type === "alternate",
+    applicationCursor: dec.applicationCursorKeys === true,
+    applicationKeypad: dec.applicationKeypad === true,
+    bracketedPaste: dec.bracketedPasteMode === true,
+    insert: modes.insertMode === true,
+    origin: dec.origin === true,
+    wraparound: dec.wraparound !== false,
+    mouseTracking:
+      core?.coreMouseService?._activeProtocol !== undefined &&
+      core.coreMouseService._activeProtocol !== "NONE",
+    synchronizedOutput: dec.synchronizedOutput === true,
+  };
+}
+
+function projectPlacements(
+  rows: readonly TerminalReplicaRow[],
+  viewportRows: number,
+  cols: number,
+  historyRows: number,
+): TerminalReplicaSnapshot["placements"] {
+  const marker = detectWidgetMarker(
+    rows.map((row) => ({ cells: row.cells.map((cell) => cell.grapheme), wrapped: row.wrapped })),
+  );
+  if (!marker) return [];
+  return [
+    {
+      id: marker.id,
+      kind: "widget",
+      row: Math.max(0, Math.min(viewportRows - 1, marker.lineIndex - historyRows)),
+      column: 0,
+      columns: Math.max(1, cols),
+      rows: 1,
+      contentDigest: hashTerminalReplicaTombstone(`${marker.id}:${JSON.stringify(marker.args)}`),
+    },
+  ];
+}
+
+function dirtyRange(terminal: Terminal): { start: number; end: number } | undefined {
+  const tracker = (
+    terminal as unknown as {
+      _core?: { _inputHandler?: { _dirtyRowTracker?: { start?: number; end?: number } } };
+    }
+  )._core?._inputHandler?._dirtyRowTracker;
+  return typeof tracker?.start === "number" && typeof tracker.end === "number"
+    ? { start: tracker.start, end: tracker.end }
+    : undefined;
+}

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-owner.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-owner.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CanonicalTerminalReplicaUpdate } from "@tmux-ide/contracts";
+import type { MirrorSubscribeRequest, MirrorSubscription } from "../mirror/mirror-service.ts";
+import { SessionRuntimeTerminalReplicaOwner } from "./terminal-replica-owner.ts";
+
+const generation = "00000000-0000-4000-8000-000000000001";
+
+describe("SessionRuntimeTerminalReplicaOwner", () => {
+  it("waits for one atomic capture seed, shares one parser after clients leave, and isolates listeners", async () => {
+    let request: MirrorSubscribeRequest | undefined;
+    let subscriptions = 0;
+    const mirror = {
+      subscribe: async (candidate: MirrorSubscribeRequest): Promise<MirrorSubscription> => {
+        subscriptions += 1;
+        request = candidate;
+        setTimeout(() => {
+          candidate.onEvent({ type: "reset", cols: 10, rows: 2 });
+          candidate.onEvent({ type: "seed", data: new TextEncoder().encode("abc") });
+          candidate.onLayout?.(layout(12, 3));
+          candidate.onEvent({ type: "cursor", x: 1, y: 0 });
+        }, 0);
+        return {
+          session: candidate.session,
+          semanticPaneId: candidate.semanticPaneId,
+          freeze: () => undefined,
+          thaw: () => undefined,
+          sendText: () => undefined,
+          sendKey: () => undefined,
+          close: async () => undefined,
+        };
+      },
+    };
+    const owner = new SessionRuntimeTerminalReplicaOwner(
+      generation,
+      "workspace",
+      "pane-a",
+      mirror as never,
+      { incarnation: `${generation}:0`, initialRevision: 0 },
+    );
+    const firstUpdates: CanonicalTerminalReplicaUpdate[] = [];
+    const first = await owner.subscribe((update) => firstUpdates.push(update));
+    expect(firstUpdates.map((update) => [update.type, update.revision])).toEqual([
+      ["terminal.seed", 0],
+    ]);
+    expect(firstUpdates[0]).toMatchObject({ cols: 12, rows: 3 });
+    await first.close();
+
+    const throwing = await owner.subscribe(() => {
+      throw new Error("client paint failed");
+    });
+    const healthyUpdates: CanonicalTerminalReplicaUpdate[] = [];
+    const healthy = await owner.subscribe((update) => healthyUpdates.push(update));
+    request!.onEvent({ type: "delta", data: new TextEncoder().encode("Z") });
+    await vi.waitFor(() => expect(healthyUpdates.at(-1)?.type).toBe("terminal.patch"));
+    expect(subscriptions).toBe(1);
+    await throwing.close();
+    await healthy.close();
+    await owner.dispose();
+  });
+
+  it("does not publish a blank seed when layout precedes the reset capture", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const mirror = {
+      subscribe: async (candidate: MirrorSubscribeRequest): Promise<MirrorSubscription> => {
+        queueMicrotask(() => {
+          candidate.onLayout?.(layout(12, 3));
+          candidate.onEvent({ type: "reset", cols: 10, rows: 2 });
+          candidate.onEvent({ type: "seed", data: new TextEncoder().encode("populated") });
+          candidate.onEvent({ type: "cursor", x: 9, y: 0 });
+        });
+        return subscription(candidate);
+      },
+    };
+    const owner = new SessionRuntimeTerminalReplicaOwner(
+      generation,
+      "workspace",
+      "pane-a",
+      mirror as never,
+      { incarnation: `${generation}:0`, initialRevision: 0 },
+    );
+    await owner.subscribe((update) => updates.push(update));
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({ type: "terminal.seed", cols: 10, rows: 2 });
+    expect(
+      updates[0]?.type === "terminal.seed" && updates[0].snapshot.grid[0]?.cells[0]?.grapheme,
+    ).toBe("p");
+    await owner.dispose();
+  });
+
+  it("reports pane closure after the tombstone is revisioned", async () => {
+    let request: MirrorSubscribeRequest | undefined;
+    let closed = 0;
+    const mirror = {
+      subscribe: async (candidate: MirrorSubscribeRequest): Promise<MirrorSubscription> => {
+        request = candidate;
+        queueMicrotask(() => {
+          candidate.onEvent({ type: "reset", cols: 4, rows: 1 });
+          candidate.onEvent({ type: "seed", data: new TextEncoder().encode("x") });
+          candidate.onEvent({ type: "cursor", x: 0, y: 0 });
+        });
+        return {
+          session: candidate.session,
+          semanticPaneId: candidate.semanticPaneId,
+          freeze: () => undefined,
+          thaw: () => undefined,
+          sendText: () => undefined,
+          sendKey: () => undefined,
+          close: async () => undefined,
+        };
+      },
+    };
+    const owner = new SessionRuntimeTerminalReplicaOwner(
+      generation,
+      "workspace",
+      "pane-a",
+      mirror as never,
+      { incarnation: `${generation}:0`, initialRevision: 0, onClosed: () => (closed += 1) },
+    );
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    await owner.subscribe((update) => updates.push(update));
+    request!.onEvent({ type: "closed" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(updates.at(-1)?.type).toBe("terminal.tombstone");
+    expect(closed).toBe(1);
+  });
+});
+
+function subscription(candidate: MirrorSubscribeRequest): MirrorSubscription {
+  return {
+    session: candidate.session,
+    semanticPaneId: candidate.semanticPaneId,
+    freeze: () => undefined,
+    thaw: () => undefined,
+    sendText: () => undefined,
+    sendKey: () => undefined,
+    close: async () => undefined,
+  };
+}
+
+function layout(width: number, height: number) {
+  return {
+    type: "layout" as const,
+    session: "workspace",
+    semanticWindowId: "window-a",
+    windowName: "main",
+    currentWindow: true,
+    cols: width,
+    rows: height,
+    zoomed: false,
+    paneBorderStatus: "off" as const,
+    panes: [
+      {
+        semanticPaneId: "pane-a",
+        left: 0,
+        top: 0,
+        width,
+        height,
+        active: true,
+      },
+    ],
+  };
+}

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-owner.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-owner.ts
@@ -1,0 +1,175 @@
+import type { CanonicalTerminalReplicaUpdate, SessionRuntimeGeneration } from "@tmux-ide/contracts";
+import type { MirrorLayoutEvent, MirrorPaneEvent } from "../mirror/events.ts";
+import type { MirrorService, MirrorSubscription } from "../mirror/mirror-service.ts";
+import { TerminalReplicaInterpreter } from "./terminal-replica-interpreter.ts";
+
+export interface TerminalReplicaSubscription {
+  readonly generation: SessionRuntimeGeneration;
+  readonly semanticPaneId: string;
+  close(): Promise<void>;
+}
+
+/** One parser/replica owner for one semantic pane inside one SessionRuntime. */
+export class SessionRuntimeTerminalReplicaOwner {
+  readonly #interpreter: TerminalReplicaInterpreter;
+  readonly #listeners = new Set<(update: CanonicalTerminalReplicaUpdate) => void>();
+  readonly #onClosed: (() => void) | undefined;
+  readonly #onFault: ((error: unknown) => void) | undefined;
+  readonly #start: Promise<void>;
+  #upstream: MirrorSubscription | null = null;
+  #disposed = false;
+  #cols = 80;
+  #rows = 24;
+  #reseed: { cols: number; rows: number; chunks: Uint8Array[] } | null = null;
+  #bootstrapped = false;
+
+  constructor(
+    readonly generation: SessionRuntimeGeneration,
+    readonly session: string,
+    readonly semanticPaneId: string,
+    mirror: MirrorService,
+    options: {
+      readonly incarnation: string;
+      readonly initialRevision: number;
+      readonly onRevision?: (revision: number) => void;
+      readonly onClosed?: () => void;
+      readonly onFault?: (error: unknown) => void;
+    },
+  ) {
+    this.#onClosed = options.onClosed;
+    this.#onFault = options.onFault;
+    this.#interpreter = new TerminalReplicaInterpreter({
+      generation,
+      workspaceName: session,
+      semanticPaneId,
+      incarnation: options.incarnation,
+      initialRevision: options.initialRevision,
+      cols: this.#cols,
+      rows: this.#rows,
+      onUpdate: (update) => {
+        if (update.type === "terminal.seed") this.#bootstrapped = true;
+        options.onRevision?.(update.revision);
+        for (const listener of this.#listeners) {
+          try {
+            listener(update);
+          } catch {
+            // A client projection cannot block sibling subscribers.
+          }
+        }
+      },
+    });
+    this.#start = mirror
+      .subscribe({
+        session,
+        semanticPaneId,
+        onEvent: (event) => this.#observePane(event),
+        onLayout: (event) => this.#observeLayout(event),
+      })
+      .then((subscription) => {
+        if (this.#disposed) return subscription.close();
+        this.#upstream = subscription;
+      });
+  }
+
+  async subscribe(
+    listener: (update: CanonicalTerminalReplicaUpdate) => void,
+  ): Promise<TerminalReplicaSubscription> {
+    if (this.#disposed) throw new Error("Terminal replica owner is disposed");
+    try {
+      await this.#start;
+      await this.#interpreter.whenSeeded();
+      this.#listeners.add(listener);
+      const seed = this.#interpreter.currentSeed();
+      if (!seed) throw new Error("Terminal replica bootstrap did not produce a seed");
+      try {
+        listener(seed);
+      } catch {
+        // Bootstrap delivery has the same client-isolation rule as live frames.
+      }
+    } catch (error) {
+      this.#listeners.delete(listener);
+      throw error;
+    }
+    let closed = false;
+    return {
+      generation: this.generation,
+      semanticPaneId: this.semanticPaneId,
+      close: async () => {
+        if (closed) return;
+        closed = true;
+        this.#listeners.delete(listener);
+      },
+    };
+  }
+
+  async dispose(
+    reason: "pane-closed" | "session-restarted" | "runtime-disposed" = "runtime-disposed",
+  ): Promise<void> {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    await this.#interpreter.enqueue({ type: "close", reason });
+    await this.#start.catch(() => undefined);
+    await this.#upstream?.close();
+    this.#upstream = null;
+    this.#listeners.clear();
+  }
+
+  #observePane(event: MirrorPaneEvent): void {
+    if (event.type === "reset") {
+      this.#cols = event.cols;
+      this.#rows = event.rows;
+      this.#reseed = { cols: event.cols, rows: event.rows, chunks: [] };
+    } else if (event.type === "seed" || event.type === "delta") {
+      if (this.#reseed) this.#reseed.chunks.push(event.data.slice());
+      else this.#supervise(this.#interpreter.enqueue({ type: "write", data: event.data }));
+    } else if (event.type === "cursor") {
+      const reseed = this.#reseed;
+      this.#reseed = null;
+      this.#supervise(
+        reseed
+          ? this.#interpreter.enqueue({
+              type: "reseed",
+              ...reseed,
+              cursor: { x: event.x, y: event.y },
+              bootstrap: "painted-capture",
+            })
+          : this.#interpreter.enqueue({ type: "cursor", x: event.x, y: event.y }),
+      );
+    } else if (event.type === "closed") {
+      const closed = this.#interpreter.enqueue({ type: "close", reason: "pane-closed" });
+      this.#supervise(closed);
+      void closed.then(
+        async () => {
+          await this.dispose("pane-closed");
+          this.#onClosed?.();
+        },
+        () => undefined,
+      );
+    }
+  }
+
+  #observeLayout(event: MirrorLayoutEvent): void {
+    const pane = event.panes.find((candidate) => candidate.semanticPaneId === this.semanticPaneId);
+    if (!pane || (pane.width === this.#cols && pane.height === this.#rows)) return;
+    this.#cols = pane.width;
+    this.#rows = pane.height;
+    if (this.#reseed) {
+      this.#reseed.cols = pane.width;
+      this.#reseed.rows = pane.height;
+      return;
+    }
+    if (!this.#bootstrapped) {
+      return;
+    }
+    this.#supervise(
+      this.#interpreter.enqueue({ type: "resize", cols: pane.width, rows: pane.height }),
+    );
+  }
+
+  #supervise(operation: Promise<void>): void {
+    void operation.catch((error) => {
+      this.#interpreter.abort(error);
+      this.#onFault?.(error);
+    });
+  }
+}

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-performance.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-performance.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { CanonicalTerminalReplicaUpdate } from "@tmux-ide/contracts";
+import { TerminalReplicaInterpreter } from "./terminal-replica-interpreter.ts";
+
+const generation = "00000000-0000-4000-8000-000000000001";
+
+function interpreter(updates: CanonicalTerminalReplicaUpdate[], scrollback = 5000) {
+  return new TerminalReplicaInterpreter({
+    generation,
+    workspaceName: "workspace",
+    semanticPaneId: "pane-a",
+    incarnation: `${generation}:0`,
+    cols: 80,
+    rows: 24,
+    scrollback,
+    onUpdate: (update) => updates.push(update),
+  });
+}
+
+describe("terminal replica performance invariants", () => {
+  it("coalesces 10k same-turn chunks into one parse and one dirty row", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const replica = interpreter(updates);
+    await Promise.all(
+      Array.from({ length: 10_000 }, () =>
+        replica.enqueue({ type: "write", data: new TextEncoder().encode("x\b") }),
+      ),
+    );
+    expect(replica.stats()).toMatchObject({
+      parseBatches: 1,
+      fullWalks: 0,
+      historyRowsRead: 0,
+      placementRowsRead: 0,
+      historyKeyVisits: 0,
+    });
+    expect(replica.stats().gridRowsRead).toBeLessThanOrEqual(1);
+    expect(updates).toHaveLength(1);
+  });
+
+  it("does zero parser/projection work while idle", async () => {
+    const replica = interpreter([]);
+    await replica.enqueue({ type: "write", data: new TextEncoder().encode("ready") });
+    const before = replica.stats();
+    for (let index = 0; index < 10_000; index += 1) replica.currentSnapshot();
+    await replica.whenIdle();
+    expect(replica.stats()).toEqual(before);
+  });
+
+  it("rotates capped history by reading only newly exposed rows", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const replica = interpreter(updates, 20);
+    await replica.enqueue({
+      type: "reseed",
+      cols: 80,
+      rows: 3,
+      chunks: [
+        new TextEncoder().encode(
+          Array.from({ length: 23 }, (_, index) => `line-${index}`).join("\r\n"),
+        ),
+      ],
+      cursor: { x: 7, y: 2 },
+      bootstrap: "authoritative-stream",
+    });
+    const before = replica.stats();
+    const firstBefore = replica.currentSnapshot().history[0];
+    await replica.enqueue({ type: "write", data: new TextEncoder().encode("\r\nnew") });
+    const after = replica.stats();
+    expect(replica.currentSnapshot().history[0]).not.toBe(firstBefore);
+    expect(after.historyRowsRead - before.historyRowsRead).toBeLessThanOrEqual(1);
+    expect(updates.at(-1)?.type).toBe("terminal.patch");
+    if (updates.at(-1)?.type === "terminal.patch") {
+      expect(updates.at(-1)?.patch.historyDelta).toMatchObject({ trim: 1 });
+      expect(updates.at(-1)?.patch.history).toBeUndefined();
+    }
+  });
+
+  it("never leaks a resize or byte frame while DEC synchronized-output is open", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const replica = interpreter(updates);
+    await replica.enqueue({ type: "write", data: new TextEncoder().encode("\u001b[?2026h") });
+    const flood = new TextEncoder().encode("A\b".repeat(550_000));
+    await replica.enqueue({ type: "write", data: flood });
+    await replica.enqueue({ type: "resize", cols: 100, rows: 30 });
+    expect(updates).toHaveLength(0);
+    await replica.enqueue({ type: "write", data: new TextEncoder().encode("\u001b[?2026l") });
+    expect(updates).toHaveLength(1);
+    expect(replica.currentSnapshot()).toMatchObject({ cols: 100, rows: 30 });
+  }, 20_000);
+
+  it("recovers an unterminated synchronized-output block without permanent staleness", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const replica = interpreter(updates);
+    await replica.enqueue({
+      type: "write",
+      data: new TextEncoder().encode("\u001b[?2026hwaiting"),
+    });
+    await replica.enqueue({ type: "resize", cols: 100, rows: 30 });
+    expect(updates).toHaveLength(0);
+    await new Promise((resolve) => setTimeout(resolve, 325));
+    await replica.whenIdle();
+    expect(updates).toHaveLength(1);
+    expect(replica.currentSnapshot()).toMatchObject({ cols: 100, rows: 30 });
+    expect(replica.currentSnapshot().modes.synchronizedOutput).toBe(false);
+  });
+});

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-shadow-projections.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-shadow-projections.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyTerminalReplicaUpdate,
+  blankTerminalReplicaSnapshot,
+  hashTerminalReplicaSnapshot,
+  type TerminalReplicaState,
+} from "@tmux-ide/core";
+import type { CanonicalTerminalReplicaUpdate } from "@tmux-ide/contracts";
+import { PaneMirror } from "../../tui/mirror/pane-mirror.ts";
+import { TerminalReplicaInterpreter } from "./terminal-replica-interpreter.ts";
+import {
+  projectTerminalReplicaForOpenTui,
+  projectTerminalReplicaForWeb,
+} from "./terminal-replica-shadow-projections.ts";
+
+describe("terminal replica shadow projections", () => {
+  it("projects one equal revision/hash without reparsing and themes defaults only", () => {
+    const snapshot = blankTerminalReplicaSnapshot(2, 1);
+    const web = projectTerminalReplicaForWeb(snapshot);
+    const tui = projectTerminalReplicaForOpenTui(snapshot, {
+      foreground: 0xeeeeee,
+      background: 0x111111,
+    });
+    expect(web[0]![0]!.foreground).toEqual({ kind: "default" });
+    expect(tui[0]![0]).toMatchObject({ fg: 0xeeeeee, bg: 0x111111 });
+    expect(hashTerminalReplicaSnapshot(snapshot)).toMatch(/^[0-9a-f]{16}$/u);
+  });
+
+  it.each([
+    ["flood", Array.from({ length: 80 }, (_, index) => `line-${index}`).join("\r\n")],
+    ["alternate-screen", "normal\u001b[?1049hALT\u001b[?1049l"],
+    ["history-clear", "one\r\ntwo\r\nthree\u001b[3Jafter"],
+    ["split-utf8-csi", "界e\u0301\u001b[38;2;10;20;30mRGB\u001b[0m"],
+  ])("matches legacy PaneMirror in shadow for %s", async (_name, text) => {
+    const cols = 32;
+    const rows = 6;
+    const mirror = new PaneMirror(cols, rows);
+    mirror.write(new TextEncoder().encode(text));
+    await waitForMirror(
+      mirror,
+      text.includes("after")
+        ? "after"
+        : text.includes("line-")
+          ? "line-79"
+          : text.includes("RGB")
+            ? "RGB"
+            : "normal",
+    );
+    const legacy = mirror.snapshot();
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const interpreter = new TerminalReplicaInterpreter({
+      generation: "00000000-0000-4000-8000-000000000001",
+      workspaceName: "workspace",
+      semanticPaneId: "pane-a",
+      incarnation: "00000000-0000-4000-8000-000000000001:0",
+      cols,
+      rows,
+      onUpdate: (update) => updates.push(update),
+    });
+    const bytes = new TextEncoder().encode(text);
+    const chunks = Array.from(bytes, (byte) => Uint8Array.of(byte));
+    await interpreter.enqueue({
+      type: "reseed",
+      cols,
+      rows,
+      chunks,
+      cursor: { x: legacy.cursorX, y: legacy.cursorY },
+      bootstrap: "authoritative-stream",
+    });
+    expect(canonicalText(interpreter.currentSnapshot())).toEqual(
+      legacy.rows.map((row) => row.map((run) => run.text).join("")),
+    );
+    expect(interpreter.currentSnapshot().cursor).toMatchObject({
+      x: legacy.cursorX,
+      y: legacy.cursorY,
+    });
+    expect(updates).toHaveLength(1);
+    mirror.dispose();
+  });
+
+  it("keeps partial CSI/UTF-8 ordered across an intervening resize", async () => {
+    const interpreter = new TerminalReplicaInterpreter({
+      generation: "00000000-0000-4000-8000-000000000001",
+      workspaceName: "workspace",
+      semanticPaneId: "pane-a",
+      incarnation: "00000000-0000-4000-8000-000000000001:0",
+      cols: 12,
+      rows: 3,
+    });
+    await interpreter.enqueue({ type: "write", data: Uint8Array.of(0xe7, 0x95) });
+    await interpreter.enqueue({ type: "resize", cols: 10, rows: 2 });
+    await interpreter.enqueue({ type: "write", data: Uint8Array.of(0x8c, 0x1b, 0x5b, 0x33, 0x31) });
+    await interpreter.enqueue({ type: "write", data: new TextEncoder().encode("mR") });
+    expect(interpreter.currentSnapshot().grid[0]!.cells[0]).toMatchObject({
+      grapheme: "界",
+      width: 2,
+    });
+    expect(interpreter.currentSnapshot().grid[0]!.cells[2]!.foreground).toEqual({
+      kind: "indexed",
+      index: 1,
+    });
+    expect(interpreter.currentSnapshot()).toMatchObject({ cols: 10, rows: 2 });
+  });
+
+  it("matches legacy output stepwise and reconstructs every incremental frame", async () => {
+    const mirror = new PaneMirror(12, 3, 20);
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const interpreter = new TerminalReplicaInterpreter({
+      generation: "00000000-0000-4000-8000-000000000001",
+      workspaceName: "workspace",
+      semanticPaneId: "pane-a",
+      incarnation: "00000000-0000-4000-8000-000000000001:0",
+      cols: 12,
+      rows: 3,
+      scrollback: 20,
+      onUpdate: (update) => updates.push(update),
+    });
+    let replay: TerminalReplicaState | null = null;
+    const steps = [
+      "\u001b[31mred\u001b[0m",
+      "\r\nwide界e\u0301",
+      "\r\none\r\ntwo\r\nthree",
+      "\u001b[?1049hALT\u001b[?1049l",
+      "\u001b[2J\u001b[Hfinal",
+    ];
+    for (const text of steps) {
+      const parsed = new Promise<void>((resolve) => {
+        mirror.onParsed = resolve;
+      });
+      mirror.write(new TextEncoder().encode(text));
+      await interpreter.enqueue({ type: "write", data: new TextEncoder().encode(text) });
+      await parsed;
+      while ((replay?.revision ?? -1) < (updates.at(-1)?.revision ?? -1)) {
+        const update = updates[(replay?.revision ?? -1) + 1]!;
+        const result = applyTerminalReplicaUpdate(replay, update);
+        expect(result.status).toBe("applied");
+        replay = result.state;
+      }
+      expect(canonicalBufferText(interpreter.currentSnapshot())).toEqual(mirror.bufferLines());
+      expect(replay?.snapshot).toEqual(interpreter.currentSnapshot());
+    }
+    mirror.resize(9, 4);
+    await interpreter.enqueue({ type: "resize", cols: 9, rows: 4 });
+    expect(canonicalBufferText(interpreter.currentSnapshot())).toEqual(mirror.bufferLines());
+    mirror.dispose();
+  });
+});
+
+async function waitForMirror(mirror: PaneMirror, needle: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (mirror.bufferLines().some((line) => line.includes(needle))) return;
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+}
+
+function canonicalText(
+  snapshot: ReturnType<TerminalReplicaInterpreter["currentSnapshot"]>,
+): string[] {
+  return snapshot.grid.map((row) =>
+    row.cells
+      .filter((cell) => cell.width !== 0)
+      .map((cell) => cell.grapheme)
+      .join(""),
+  );
+}
+
+function canonicalBufferText(
+  snapshot: ReturnType<TerminalReplicaInterpreter["currentSnapshot"]>,
+): string[] {
+  return [...snapshot.history, ...snapshot.grid].map((row) =>
+    row.cells
+      .filter((cell) => cell.width !== 0)
+      .map((cell) => cell.grapheme)
+      .join("")
+      .trimEnd(),
+  );
+}

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-shadow-projections.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-shadow-projections.ts
@@ -1,0 +1,36 @@
+import type { TerminalReplicaSnapshot } from "@tmux-ide/contracts";
+import { resolveTerminalReplicaColor, XTERM_PALETTE } from "@tmux-ide/core";
+
+export interface TerminalReplicaShadowTheme {
+  readonly foreground: number;
+  readonly background: number;
+}
+
+/** Test/shadow-only web projection; production xterm parsing remains until m56.5. */
+export function projectTerminalReplicaForWeb(snapshot: TerminalReplicaSnapshot) {
+  return snapshot.grid.map((row) =>
+    row.cells.map((cell) => ({
+      text: cell.grapheme,
+      width: cell.width,
+      foreground: cell.foreground,
+      background: cell.background,
+      attributes: cell.attributes,
+    })),
+  );
+}
+
+/** Test/shadow-only OpenTUI projection; production PaneMirror remains until m56.4. */
+export function projectTerminalReplicaForOpenTui(
+  snapshot: TerminalReplicaSnapshot,
+  theme: TerminalReplicaShadowTheme,
+) {
+  return snapshot.grid.map((row) =>
+    row.cells.map((cell) => ({
+      text: cell.grapheme,
+      width: cell.width,
+      fg: resolveTerminalReplicaColor(cell.foreground, theme, "foreground", XTERM_PALETTE),
+      bg: resolveTerminalReplicaColor(cell.background, theme, "background", XTERM_PALETTE),
+      attributes: cell.attributes,
+    })),
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,7 +324,7 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@xterm/headless':
-        specifier: ^6.0.0
+        specifier: 6.0.0
         version: 6.0.0
       hono:
         specifier: ^4.12.34

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -26,7 +26,7 @@
 import { build } from "esbuild";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { mkdirSync, readFileSync, chmodSync, statSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, chmodSync, statSync } from "node:fs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..");
@@ -62,6 +62,10 @@ await build({
           if (id.startsWith("node:")) return { external: true };
           // Workspace packages → bundle.
           if (id.startsWith("@tmux-ide/")) return undefined;
+          // xterm/headless is CommonJS and its named ESM import is not usable
+          // when left bare under stock Node. It is pure JS, so bundle the
+          // canonical replica parser and Unicode width addon into the CLI.
+          if (id === "@xterm/headless" || id === "@xterm/addon-unicode11") return undefined;
           // Everything else → external.
           return { external: true };
         });
@@ -82,9 +86,24 @@ await build({
   minify: false,
 });
 
+// Some bundled CommonJS dependencies contain literal C0 bytes inside string
+// constants. They are valid JavaScript, but make git treat the generated CLI
+// as binary and violate the package source hygiene gate. Escaping a literal
+// byte inside the generated string preserves its runtime value exactly.
+const generated = readFileSync(outfile, "utf8");
+const disallowedC0Source = String.raw`[\x00-\x08\x0b\x0c\x0e-\x1f]`;
+const normalized = generated.replace(
+  new RegExp(disallowedC0Source, "gu"),
+  (value) => `\\x${value.charCodeAt(0).toString(16).padStart(2, "0")}`,
+);
+if (normalized !== generated) writeFileSync(outfile, normalized, "utf8");
+
 // Verify the shebang survived, the file is executable, and there's
 // exactly one shebang line — a regression here ships a broken bin.
 const compiled = readFileSync(outfile, "utf-8");
+if (new RegExp(disallowedC0Source, "u").test(compiled)) {
+  throw new Error("[build-cli] generated CLI still contains a disallowed raw control byte");
+}
 if (!compiled.startsWith("#!/usr/bin/env node\n")) {
   throw new Error(
     `[build-cli] expected node shebang at offset 0, got: ${JSON.stringify(compiled.slice(0, 32))}`,


### PR DESCRIPTION
## Summary
- add strict seed/patch/tombstone contracts and a pure shared reducer/hash model
- make SessionRuntime own one ordered xterm-headless interpreter per pane
- preserve ANSI/default colors, Unicode/wide cells, history, modes, resize, synchronized output, and authenticated widget placements
- add incremental dirty-row/history projection, performance instrumentation, and stepwise differential replay against PaneMirror
- keep current GUI/TUI raw paths as shadow compatibility for the later cutover cards
- force-bundle pinned xterm runtimes into the CLI with generated control-byte normalization

## Verification
- independent correctness/performance review: APPROVE
- full `pnpm check` passed
- contracts: 431; core: 51; daemon: 3,222; renderer: 853; Electron: 334
- focused replica: 28/28; shipped headless entrypoint: 7/7
- typechecks, lint, formatting, control-byte gate, Bun parity, docs/packages, installed tarball, native dependency and desktop replay-repair smoke all green

Completes Sfora card #186.