### PR TITLE
m56.5: cut web GUI over to semantic runtime

### DIFF
--- a/apps/desktop-renderer/e2e/fixtures/scratch-fleet.ts
+++ b/apps/desktop-renderer/e2e/fixtures/scratch-fleet.ts
@@ -36,7 +36,7 @@ export interface ScratchFleet {
   /** The session's CURRENT window name — what a window tab click must change. */
   readonly currentWindow: (name: string) => string;
   /** Every pane of the session's current window, as `width x height` cells. */
-  readonly paneSizes: (name: string) => readonly string[];
+  readonly paneSizes: (name: string, windowName?: string) => readonly string[];
   /**
    * The session's current WINDOW size in cells, as tmux reports it — the ground
    * truth for whether the app's attachment actually owns the geometry (m50.2).
@@ -211,8 +211,14 @@ export async function createScratchFleet(
       ]).split("x");
       return { cols: Number(cols), rows: Number(rows) };
     },
-    paneSizes: (name) =>
-      runTmux(["list-panes", "-t", `${name}:`, "-F", "#{pane_width}x#{pane_height}"])
+    paneSizes: (name, windowName) =>
+      runTmux([
+        "list-panes",
+        "-t",
+        windowName === undefined ? `${name}:` : `=${name}:=${windowName}`,
+        "-F",
+        "#{pane_width}x#{pane_height}",
+      ])
         .split("\n")
         .filter(Boolean),
     // `<session>:` is the session's current window, active pane. A bare `=name`

--- a/apps/desktop-renderer/e2e/mouse-verbs.e2e.ts
+++ b/apps/desktop-renderer/e2e/mouse-verbs.e2e.ts
@@ -2,7 +2,8 @@
  * Chain: the mouse reaches tmux, through the layout-faithful view.
  *
  *   the window tabs show the session's real windows → clicking an inactive tab
- *   moves tmux's OWN current window → right-click a pane tile for the verb menu,
+ *   changes this client's visible window without stealing shared tmux focus →
+ *   right-click a pane tile for the verb menu,
  *   in sections → rename the window and see both the tab and `tmux list-windows`
  *   change → split from the menu and watch the view re-tile to match the layout
  *   frame → drag the new border and watch the tmux pane actually resize → close
@@ -65,7 +66,7 @@ test("the mouse reaches the multiplexer: switch windows, rename, split, resize, 
     })
     .toEqual([...startingWindows].sort());
 
-  // --- Clicking an inactive tab moves tmux's current window ----------------
+  // --- Clicking an inactive tab changes only this renderer's local view ----
   const inactiveTab = page.locator('.window-tabs__tab[data-active="false"]').first();
   await proveVisible(inactiveTab, "the inactive window tab", { minWidth: 30, minHeight: 16 });
   const targetWindow = (await inactiveTab.innerText()).trim();
@@ -75,21 +76,23 @@ test("the mouse reaches the multiplexer: switch windows, rename, split, resize, 
   );
   await inactiveTab.click();
 
-  /*
-   * Bug this catches: the tab switches which window the APP shows and never
-   * tells tmux, so a client attached over ssh stays on the old window and the
-   * two views of one session disagree about where the user is.
-   */
+  // Browser tabs are per-client navigation. A second browser or ssh client
+  // keeps its own focus; later mutations remain semantically addressed to the
+  // pane visible here rather than relying on tmux's process-global current one.
   await expect
     .poll(() => liveApp.fleet.currentWindow(session), {
-      message: "clicking the window tab did not change tmux's own current window",
+      message: "local browser navigation stole tmux focus from another client",
       timeout: 30_000,
     })
-    .toBe(targetWindow);
+    .toBe(startingCurrent);
   await expect(
     page.locator('.window-tabs__tab[data-active="true"]'),
-    "tmux switched windows but the tab strip still marks the old one",
+    "the local tab strip did not mark the selected window",
   ).toHaveText(targetWindow, { timeout: 30_000 });
+  await expect(
+    page.locator('.pane-tile[data-active="true"]'),
+    "the active tile did not follow the locally selected window",
+  ).toHaveCount(1, { timeout: 30_000 });
   await page.screenshot({ path: testInfo.outputPath("1-window-tabs.png") });
 
   // --- The verb menu, on a pane tile ---------------------------------------
@@ -202,7 +205,7 @@ test("the mouse reaches the multiplexer: switch windows, rename, split, resize, 
             .sort((left, right) => left - right),
         );
         const cells = liveApp.fleet
-          .paneSizes(session)
+          .paneSizes(session, RENAMED)
           .map((size) => Number(size.split("x")[0]))
           .sort((left, right) => left - right);
         if (widths.length !== 2 || cells.length !== 2 || widths[0]! === 0) return "not measurable";
@@ -224,7 +227,7 @@ test("the mouse reaches the multiplexer: switch windows, rename, split, resize, 
   const border = page.locator(".pane-border").first();
   await proveVisible(border, "the draggable pane border", { minWidth: 1, minHeight: 20 });
   const borderBox = (await border.boundingBox())!;
-  const sizesBefore = liveApp.fleet.paneSizes(session).join(",");
+  const sizesBefore = liveApp.fleet.paneSizes(session, RENAMED).join(",");
 
   await page.mouse.move(borderBox.x + borderBox.width / 2, borderBox.y + borderBox.height / 2);
   await page.mouse.down();
@@ -241,7 +244,7 @@ test("the mouse reaches the multiplexer: switch windows, rename, split, resize, 
    * in its purest form, since a resize has no other observable effect.
    */
   await expect
-    .poll(() => liveApp.fleet.paneSizes(session).join(","), {
+    .poll(() => liveApp.fleet.paneSizes(session, RENAMED).join(","), {
       message: "the border drag never reached tmux — the panes are the same size",
       timeout: 30_000,
     })

--- a/apps/desktop-renderer/e2e/multi-client-sync.e2e.ts
+++ b/apps/desktop-renderer/e2e/multi-client-sync.e2e.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "./fixtures/live-app.ts";
+import { proveVisible } from "./fixtures/visible.ts";
+
+test.use({ scratchSessions: 1, promoteSessions: 1 });
+
+test("two browsers keep local navigation independent and share canonical mutations", async ({
+  page: first,
+  browser,
+  liveApp,
+}) => {
+  const session = liveApp.fleet.sessionNames[0]!;
+  const secondContext = await browser.newContext({ viewport: { width: 1_400, height: 900 } });
+  const second = await secondContext.newPage();
+  const ready = async (page: typeof first): Promise<void> => {
+    await expect(page.locator(".app")).toHaveAttribute("data-shell-source", "runtime", {
+      timeout: 60_000,
+    });
+    await expect(page.locator('.terminal-surface[data-phase="connected"]')).toHaveCount(1, {
+      timeout: 60_000,
+    });
+    await expect(page.locator(".pane-tile")).toHaveCount(1, { timeout: 30_000 });
+    await expect
+      .poll(async () => {
+        const box = await page.locator(".pane-tile").boundingBox();
+        return box && box.width >= 100 && box.height >= 100 ? "ready" : "not-ready";
+      })
+      .toBe("ready");
+  };
+
+  // Sequential readiness makes the authority claim deterministic: the first
+  // independent client owns control; the second joins as a passive viewer.
+  await first.goto(liveApp.pageUrl, { waitUntil: "domcontentloaded" });
+  await ready(first);
+  await expect(first.locator('.terminal-surface[data-phase="connected"]')).toHaveAttribute(
+    "data-viewer-mode",
+    "interactive",
+  );
+  await second.goto(liveApp.pageUrl, { waitUntil: "domcontentloaded" });
+  await ready(second);
+  await expect(first.locator('.terminal-surface[data-phase="connected"]')).toHaveAttribute(
+    "data-viewer-mode",
+    "interactive",
+  );
+  await expect(second.locator('.terminal-surface[data-phase="connected"]')).toHaveAttribute(
+    "data-viewer-mode",
+    "read-only",
+  );
+
+  const sharedCurrent = liveApp.fleet.currentWindow(session);
+  const inactive = first.locator('.window-tabs__tab[data-active="false"]').first();
+  const locallySelected = (await inactive.innerText()).trim();
+  await inactive.click();
+  await expect(first.locator('.window-tabs__tab[data-active="true"]')).toHaveText(locallySelected);
+  await expect(first.locator('.terminal-surface[data-phase="connected"]')).toHaveCount(1, {
+    timeout: 60_000,
+  });
+  await expect
+    .poll(async () => {
+      const box = await first.locator(".pane-tile").boundingBox();
+      return box && box.width >= 100 && box.height >= 100 ? "ready" : "not-ready";
+    })
+    .toBe("ready");
+  await expect(second.locator('.window-tabs__tab[data-active="true"]')).toHaveText(sharedCurrent);
+
+  const tile = (await first.locator(".pane-tile").first().boundingBox())!;
+  await first.mouse.click(tile.x + 20, tile.y + tile.height / 2, { button: "right" });
+  const menu = first.locator('[role="menu"][data-context-menu="true"]');
+  await proveVisible(menu, "the first browser's pane menu", { minWidth: 180, minHeight: 100 });
+  await menu.locator('[data-context-menu-item="window.rename"]').click();
+  const field = first.locator(".window-tabs__rename-field");
+  await field.fill("shared-rename");
+  await field.press("Enter");
+  await expect(field).toHaveCount(0);
+
+  await expect
+    .poll(() => liveApp.fleet.listWindows(session), { timeout: 30_000 })
+    .toContain("shared-rename");
+  await expect(first.locator(".window-tabs__tab", { hasText: "shared-rename" })).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await expect(second.locator(".window-tabs__tab", { hasText: "shared-rename" })).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await expect(second.locator('.window-tabs__tab[data-active="true"]')).toHaveText(sharedCurrent);
+  await secondContext.close();
+});

--- a/apps/desktop-renderer/e2e/terminal-selection.e2e.ts
+++ b/apps/desktop-renderer/e2e/terminal-selection.e2e.ts
@@ -65,7 +65,11 @@ test("xterm pointer selection copies text without mutating tmux", async ({ page,
       { once: true },
     );
   });
-  await page.keyboard.press(process.platform === "darwin" ? "Meta+c" : "Control+c");
+  // Headless Chromium on Linux has no window manager to translate Control-C
+  // into the browser's native copy command. `execCommand("copy")` invokes that
+  // same browser command and emits the real bubbling ClipboardEvent whose
+  // payload the workspace copy authority owns.
+  expect(await page.evaluate(() => document.execCommand("copy"))).toBe(true);
   await expect
     .poll(
       () =>

--- a/apps/desktop-renderer/e2e/terminal-selection.e2e.ts
+++ b/apps/desktop-renderer/e2e/terminal-selection.e2e.ts
@@ -50,12 +50,33 @@ test("xterm pointer selection copies text without mutating tmux", async ({ page,
   await expect(
     page.locator(".terminal-surface__viewport .xterm-selection div").first(),
   ).toBeVisible();
+  await page.evaluate(() => {
+    const observed = window as Window & { __tmuxIdeCopiedText?: string };
+    observed.__tmuxIdeCopiedText = "";
+    window.addEventListener(
+      "copy",
+      (event) => {
+        // This window-level bubble listener runs after the tiled surface's
+        // copy authority has populated the browser ClipboardEvent. Reading
+        // that payload is deterministic in headless Linux; the OS clipboard
+        // backing navigator.clipboard is not.
+        observed.__tmuxIdeCopiedText = event.clipboardData?.getData("text/plain") ?? "";
+      },
+      { once: true },
+    );
+  });
   await page.keyboard.press(process.platform === "darwin" ? "Meta+c" : "Control+c");
   await expect
-    .poll(() => page.evaluate(() => navigator.clipboard.readText()), {
-      message: "the live xterm selection did not reach the clipboard",
-      timeout: 10_000,
-    })
+    .poll(
+      () =>
+        page.evaluate(
+          () => (window as Window & { __tmuxIdeCopiedText?: string }).__tmuxIdeCopiedText ?? "",
+        ),
+      {
+        message: "the live xterm selection did not populate the browser copy event",
+        timeout: 10_000,
+      },
+    )
     .toContain(marker);
 
   expect(liveApp.fleet.countPanes(session)).toBe(before.panes);

--- a/apps/desktop-renderer/e2e/terminal-selection.e2e.ts
+++ b/apps/desktop-renderer/e2e/terminal-selection.e2e.ts
@@ -17,9 +17,10 @@ test("xterm pointer selection copies text without mutating tmux", async ({ page,
   await expect(page.locator('.terminal-surface[data-phase="connected"]')).toHaveCount(1, {
     timeout: 60_000,
   });
-  await expect(page.locator(".terminal-surface__viewport .xterm-rows")).toContainText("sh-3.2$", {
-    timeout: 30_000,
-  });
+  // Do not key readiness to the host shell's prompt: macOS' /bin/sh renders
+  // `sh-3.2$`, while the Linux CI image renders `$`. A redeemed interactive
+  // attachment and its mounted helper textarea are the portable input-ready
+  // contract; the unique marker below proves the real shell consumed it.
   await page.locator(".terminal-surface__viewport").click({ position: { x: 24, y: 48 } });
   await input.focus();
   const marker = `TMUX_IDE_COPY_${Date.now()}`;

--- a/apps/desktop-renderer/e2e/terminal-selection.e2e.ts
+++ b/apps/desktop-renderer/e2e/terminal-selection.e2e.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "./fixtures/live-app.ts";
+
+test.use({ scratchSessions: 1, promoteSessions: 1 });
+
+test("xterm pointer selection copies text without mutating tmux", async ({ page, liveApp }) => {
+  const session = liveApp.fleet.sessionNames[0]!;
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"], {
+    origin: new URL(liveApp.pageUrl).origin,
+  });
+  await page.goto(liveApp.pageUrl, { waitUntil: "domcontentloaded" });
+  await expect(page.locator(".app")).toHaveAttribute("data-shell-source", "runtime", {
+    timeout: 60_000,
+  });
+
+  const input = page.locator(".terminal-surface__viewport .xterm-helper-textarea").first();
+  await expect(input).toBeAttached({ timeout: 60_000 });
+  await expect(page.locator('.terminal-surface[data-phase="connected"]')).toHaveCount(1, {
+    timeout: 60_000,
+  });
+  await expect(page.locator(".terminal-surface__viewport .xterm-rows")).toContainText("sh-3.2$", {
+    timeout: 30_000,
+  });
+  await page.locator(".terminal-surface__viewport").click({ position: { x: 24, y: 48 } });
+  await input.focus();
+  const marker = `TMUX_IDE_COPY_${Date.now()}`;
+  await page.keyboard.type(`printf '${marker}\\n'`);
+  await page.keyboard.press("Enter");
+  await expect
+    .poll(() => liveApp.fleet.capturePane(session), {
+      message: "the marker did not reach the live tmux pane",
+      timeout: 30_000,
+    })
+    .toContain(marker);
+
+  const before = {
+    panes: liveApp.fleet.countPanes(session),
+    sizes: liveApp.fleet.paneSizes(session).join(","),
+    window: liveApp.fleet.currentWindow(session),
+  };
+  const row = page
+    .locator(".terminal-surface__viewport .xterm-rows > div", { hasText: marker })
+    .last();
+  await expect(row).toBeVisible({ timeout: 30_000 });
+  const box = (await row.boundingBox())!;
+  // Triple-click is xterm's line-selection pointer gesture. It avoids making
+  // this proof depend on a particular font's cell width while still exercising
+  // the real selection/copy path through the live terminal surface.
+  await page.mouse.click(box.x + 12, box.y + box.height / 2, { clickCount: 3 });
+  await expect(
+    page.locator(".terminal-surface__viewport .xterm-selection div").first(),
+  ).toBeVisible();
+  await page.keyboard.press(process.platform === "darwin" ? "Meta+c" : "Control+c");
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()), {
+      message: "the live xterm selection did not reach the clipboard",
+      timeout: 10_000,
+    })
+    .toContain(marker);
+
+  expect(liveApp.fleet.countPanes(session)).toBe(before.panes);
+  expect(liveApp.fleet.paneSizes(session).join(",")).toBe(before.sizes);
+  expect(liveApp.fleet.currentWindow(session)).toBe(before.window);
+});

--- a/apps/desktop-renderer/src/experience/application-shell.test.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.test.tsx
@@ -442,6 +442,15 @@ describe("visible DOM application shell", () => {
         () => (
           <DomApplicationShell
             host={host()}
+            daemonState={{
+              status: "connected",
+              identity: {
+                protocolVersion: 1,
+                productVersion: "test",
+                instanceId: "22222222-2222-4222-8222-222222222222",
+                startedAt: "2026-08-08T00:00:00.000Z",
+              },
+            }}
             runtime="browser"
             platform="darwin"
             windowState={WINDOW_STATE}
@@ -720,8 +729,9 @@ describe("visible DOM application shell", () => {
       }),
     );
     expect(pane.getAttribute("data-border-role")).toBe("focused");
-    expect(pane.getAttribute("data-terminal-input-owner")).toBe("true");
-    expect(otherPane.getAttribute("data-terminal-input-owner")).toBe("false");
+    // Local DOM focus is orthogonal to the shared controller/input owner.
+    expect(pane.getAttribute("data-terminal-input-owner")).toBe("false");
+    expect(otherPane.getAttribute("data-terminal-input-owner")).toBe("true");
     expect(pane.querySelector(".terminal-surface__viewport")).toBe(terminalMount);
     expect(styles).toContain(
       '.agent-grid[data-has-maximized="true"] > .web-pane-frame:not([data-structure="maximized"])',
@@ -1253,7 +1263,7 @@ describe("visible DOM application shell", () => {
     ]);
   });
 
-  it("activates the correlated tmux pane when an agent is chosen in the sidebar", async () => {
+  it("changes only this client's view when an agent is chosen in the sidebar", async () => {
     const baseHost = host();
     const invokeVerb = vi.fn(async () => ({
       status: "ok" as const,
@@ -1309,19 +1319,11 @@ describe("visible DOM application shell", () => {
       APPLICATION_SHELL_COMMAND_IDS.selectResource,
       APPLICATION_SHELL_COMMAND_IDS.moveFocus,
     ]);
-    await vi.waitFor(() =>
-      expect(invokeVerb).toHaveBeenCalledWith({
-        verbId: "pane.select",
-        intent: {
-          verb: "workspace.pane.select",
-          workspaceName: "workspace.product",
-          semanticPaneId: "pane.reviewer",
-        },
-      }),
-    );
+    await Promise.resolve();
+    expect(invokeVerb).not.toHaveBeenCalled();
   });
 
-  it("reconciles the sidebar and local focus from a newer active-pane inventory", async () => {
+  it("keeps local sidebar selection when canonical tmux focus changes", async () => {
     const baseHost = host();
     const liveHost: HostCapabilities = {
       ...baseHost,
@@ -1372,10 +1374,81 @@ describe("visible DOM application shell", () => {
     setInput(withTerminalInventory("pane.reviewer"));
     await vi.waitFor(() =>
       expect(
-        root.querySelector("#sidebar-agent-agent\\.reviewer")?.getAttribute("aria-pressed"),
+        root.querySelector("#sidebar-agent-agent\\.implementer")?.getAttribute("aria-pressed"),
       ).toBe("true"),
     );
     expect(onCommand).not.toHaveBeenCalled();
+  });
+
+  it("repairs sidebar and pane chrome together when the viewed pane becomes unavailable", async () => {
+    const [input, setInput] = createSignal(withTerminalInventory("pane.implementer"));
+    const root = document.createElement("div");
+    document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <DomApplicationShell
+            host={host()}
+            daemonState={{
+              status: "connected",
+              identity: {
+                protocolVersion: 1,
+                productVersion: "test",
+                instanceId: "22222222-2222-4222-8222-222222222222",
+                startedAt: "2026-08-08T00:00:00.000Z",
+              },
+            }}
+            runtime="browser"
+            platform="darwin"
+            windowState={WINDOW_STATE}
+            input={input()}
+            dataMode="runtime"
+            paneFrames={createDefaultDomPaneFrames()}
+            experimentalSurfaces
+          />
+        ),
+        root,
+      ),
+    );
+    pointerClick(root.querySelector("#primary-tab-terminals")!);
+    await vi.waitFor(() =>
+      expect(
+        root.querySelector("#sidebar-agent-agent\\.implementer")?.getAttribute("aria-pressed"),
+      ).toBe("true"),
+    );
+
+    const replacement = withTerminalInventory("pane.reviewer");
+    setInput(
+      ApplicationShellProjectionInputV1SchemaZ.parse({
+        ...replacement,
+        terminalInventory: {
+          ...replacement.terminalInventory!,
+          resources: replacement.terminalInventory!.resources.map((resource) =>
+            resource.id === "pane.implementer"
+              ? {
+                  ...resource,
+                  active: false,
+                  attachability: {
+                    status: "unavailable" as const,
+                    reason: "not-single-pane-window" as const,
+                  },
+                }
+              : resource,
+          ),
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        root.querySelector("#sidebar-agent-agent\\.reviewer")?.getAttribute("aria-pressed"),
+      ).toBe("true");
+      // This is the single local-view source consumed by both rendered pane
+      // chrome and WorkspaceTiledSurface's `viewPane` prop.
+      expect(root.querySelector(".shell-workbench")?.getAttribute("data-view-pane-resource")).toBe(
+        "pane.reviewer",
+      );
+    });
   });
 });
 

--- a/apps/desktop-renderer/src/experience/application-shell.tsx
+++ b/apps/desktop-renderer/src/experience/application-shell.tsx
@@ -30,6 +30,7 @@ import {
   Match,
   Show,
   Switch,
+  batch,
   createComputed,
   createEffect,
   createMemo,
@@ -349,13 +350,10 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
   const [paletteTransitionSource, setPaletteTransitionSource] = createSignal<"keyboard" | "mouse">(
     "keyboard",
   );
-  const [pendingAgentPaneSelection, setPendingAgentPaneSelection] = createSignal<string | null>(
-    null,
-  );
-  const [pendingAgentPaneOperationId, setPendingAgentPaneOperationId] = createSignal<string | null>(
-    null,
-  );
-  let pendingAgentPaneSelectionTimer: ReturnType<typeof setTimeout> | null = null;
+  // Presentation selection belongs to this renderer view. tmux's active pane
+  // remains canonical input-owner state, but it must never overwrite what a
+  // second browser tab is looking at or make sidebar navigation mutate tmux.
+  const [viewPaneResourceId, setViewPaneResourceId] = createSignal<string | null>(null);
   let titlebarStyle: RuntimeStyleBinding | null = null;
   let workbenchStyle: RuntimeStyleBinding | null = null;
   let previousInput = input();
@@ -441,9 +439,6 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
   onCleanup(() => {
     titlebarStyle?.dispose();
     workbenchStyle?.dispose();
-    if (pendingAgentPaneSelectionTimer !== null) {
-      clearTimeout(pendingAgentPaneSelectionTimer);
-    }
   });
   const appWindowDocument = createMemo(() => {
     const value = input();
@@ -565,7 +560,9 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
       structure: appearance.structure,
       applicationFocus: {
         pane: focused,
-        terminalInput: focused,
+        // Viewing a pane is not controller ownership. Preserve the daemon's
+        // input-owner fact so a passive browser never paints a lying cursor.
+        terminalInput: appearance.accessibility.terminalInputOwner,
         windowActive: appearance.header.windowActive,
       },
       agentActivity: appearance.header.agentActivity,
@@ -573,7 +570,7 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
       attention: appearance.status.attention,
       layoutInteraction: {
         editable: true,
-        selected: appearance.accessibility.layoutSelected,
+        selected: focused,
         dragging: false,
         resizing: false,
         previewing: false,
@@ -587,7 +584,7 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
       },
     });
   const renderedPaneFrames = createMemo<readonly PaneFrameModel[]>(() => {
-    const localTerminalFocus = shell().focus.terminalInputPaneId;
+    const localTerminalFocus = viewPaneResourceId() ?? shell().focus.terminalInputPaneId;
     if (!localTerminalFocus) return paneFrames();
     return paneFrames().map((model) => ({
       ...model,
@@ -981,7 +978,11 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
     const attachable = inventory.resources.filter(
       (resource) => resource.attachability.status === "available",
     );
-    const active = attachable.find((resource) => resource.active) ?? attachable[0];
+    const viewed = viewPaneResourceId();
+    const active =
+      attachable.find((resource) => resource.id === viewed) ??
+      attachable.find((resource) => resource.active) ??
+      attachable[0];
     return active?.attachability.status === "available"
       ? active.attachability.semanticPaneId
       : null;
@@ -1089,6 +1090,7 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
     source: "keyboard" | "mouse" | "programmatic",
     surface: CommandSource["surface"] = "application-shell",
   ): void => {
+    setViewPaneResourceId(paneResourceId);
     const agent = sidebarAgentForPaneResource(paneResourceId);
     if (!agent || shell().sidebar.selectedResourceId === agent.id) return;
     dispatch(
@@ -1103,86 +1105,51 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
     );
   };
 
-  const beginPendingAgentPaneSelection = (paneResourceId: string): void => {
-    if (pendingAgentPaneSelectionTimer !== null) {
-      clearTimeout(pendingAgentPaneSelectionTimer);
-    }
-    setPendingAgentPaneSelection(paneResourceId);
-    setPendingAgentPaneOperationId(null);
-    // A selection is optimistic only while the daemon is expected to publish
-    // its fresh inventory. If that event never arrives, return to canonical
-    // tmux state instead of leaving the sidebar and terminal disagreeing.
-    pendingAgentPaneSelectionTimer = setTimeout(() => {
-      pendingAgentPaneSelectionTimer = null;
-      setPendingAgentPaneSelection(null);
-      setPendingAgentPaneOperationId(null);
-    }, 4_000);
-  };
-
-  const clearPendingAgentPaneSelection = (): void => {
-    if (pendingAgentPaneSelectionTimer !== null) {
-      clearTimeout(pendingAgentPaneSelectionTimer);
-      pendingAgentPaneSelectionTimer = null;
-    }
-    setPendingAgentPaneSelection(null);
-    setPendingAgentPaneOperationId(null);
-  };
-
-  createEffect(() => {
-    const operationId = pendingAgentPaneOperationId();
-    if (operationId && props.acknowledgedOperationIds?.includes(operationId)) {
-      clearPendingAgentPaneSelection();
-    }
-  });
-
   createEffect(() => {
     if (!workspaceConnected()) return;
     const inventory = shell().terminalInventory;
-    if (!inventory?.activeResourceId) return;
-
-    const pending = pendingAgentPaneSelection();
-    if (pending) {
-      if (pending === inventory.activeResourceId) {
-        clearPendingAgentPaneSelection();
-      }
-      return;
-    }
-
-    const activeAgent = sidebarAgentForPaneResource(inventory.activeResourceId);
-    if (!activeAgent) return;
-    if (
-      shell().sidebar.selectedResourceId === activeAgent.id &&
-      shell().focus.terminalInputPaneId === inventory.activeResourceId
-    ) {
-      return;
-    }
-
-    // This is reconciliation from a daemon snapshot, not a new user command.
-    // Apply it locally so a second browser client changing tmux updates this
-    // client's chrome without echoing another mutation back to the daemon.
-    setState((current) => {
-      const focused = applyApplicationShellInvocationV1(
-        current,
-        applicationShellCommandInvocation(
-          APPLICATION_SHELL_COMMAND_IDS.moveFocus,
-          {
-            target: {
-              kind: "pane",
-              paneId: inventory.activeResourceId!,
-              input: "terminal",
-            },
-          },
-          { kind: "keyboard", surface: "application-shell" },
-        ),
-      );
-      return applyApplicationShellInvocationV1(
-        focused,
-        applicationShellCommandInvocation(
-          APPLICATION_SHELL_COMMAND_IDS.selectResource,
-          { surface: "terminals", resourceId: activeAgent.id },
-          { kind: "keyboard", surface: "application-shell" },
-        ),
-      );
+    if (!inventory) return;
+    // A discovered resource is not necessarily viewable. Repair local view
+    // from the same attachable subset used by the tiled surface so sidebar,
+    // tile and chrome change together when a pane is retired.
+    const attachable = inventory.resources.filter(
+      (resource) => resource.attachability.status === "available",
+    );
+    const live = new Set(attachable.map(({ id }) => id));
+    const selected = viewPaneResourceId();
+    if (selected && live.has(selected)) return;
+    // First fit and stale-reference repair are local. Later canonical focus
+    // changes are exposed as input ownership, not promoted into view selection.
+    const next =
+      (inventory.activeResourceId && live.has(inventory.activeResourceId)
+        ? inventory.activeResourceId
+        : null) ??
+      attachable.find((resource) => resource.active)?.id ??
+      attachable[0]?.id ??
+      null;
+    if (!next) return;
+    const activeAgent = sidebarAgentForPaneResource(next);
+    batch(() => {
+      setViewPaneResourceId(next);
+      if (!activeAgent) return;
+      setState((current) => {
+        const focused = applyApplicationShellInvocationV1(
+          current,
+          applicationShellCommandInvocation(
+            APPLICATION_SHELL_COMMAND_IDS.moveFocus,
+            { target: { kind: "pane", paneId: next, input: "terminal" } },
+            { kind: "keyboard", surface: "application-shell" },
+          ),
+        );
+        return applyApplicationShellInvocationV1(
+          focused,
+          applicationShellCommandInvocation(
+            APPLICATION_SHELL_COMMAND_IDS.selectResource,
+            { surface: "terminals", resourceId: activeAgent.id },
+            { kind: "keyboard", surface: "application-shell" },
+          ),
+        );
+      });
     });
   });
 
@@ -1250,10 +1217,6 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
     source: "keyboard" | "mouse",
   ): void => {
     const paneResourceId = agent.paneId;
-    const semanticPaneId = paneResourceId ? semanticPaneIdFor(paneResourceId) : null;
-    const willSelectTmuxPane =
-      paneResourceId !== null && semanticPaneId !== null && workspaceConnected();
-    if (willSelectTmuxPane) beginPendingAgentPaneSelection(paneResourceId);
 
     dispatch(
       applicationShellCommandInvocation(
@@ -1263,6 +1226,7 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
       ),
     );
     if (!paneResourceId) return;
+    setViewPaneResourceId(paneResourceId);
 
     const appWindow = Object.values(appWindowDocument()?.windows ?? {}).find(
       (window) =>
@@ -1281,20 +1245,6 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
         ),
       );
     }
-
-    if (!willSelectTmuxPane || !semanticPaneId) return;
-    void verbAccess
-      .invoke("pane.select", {
-        workspaceName: verbWorkspaceName(),
-        semanticPaneId,
-      })
-      .then((result) => {
-        if (result.status === "error") {
-          clearPendingAgentPaneSelection();
-        } else {
-          setPendingAgentPaneOperationId(result.result.operationId);
-        }
-      }, clearPendingAgentPaneSelection);
   };
 
   const acceptCanvasClientViewState = (next: ClientViewStateV1): void => {
@@ -1716,6 +1666,7 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
         class="shell-workbench"
         data-shell-source={dataMode()}
         data-sidebar-collapsed={sidebarCollapsed()}
+        data-view-pane-resource={viewPaneResourceId() ?? undefined}
       >
         <aside class="workspace-sidebar" aria-label="Workspace overview" data-focus-zone="sidebar">
           <div class="workspace-sidebar__project">
@@ -2056,6 +2007,11 @@ export function DomApplicationShell(props: DomApplicationShellProps) {
                     interactionSequence={props.interactionFeed?.sequence}
                     livePanes={livePaneIds()}
                     fallbackPane={activeSemanticPaneId()}
+                    viewPane={activeSemanticPaneId()}
+                    onSelectViewPane={(semanticPaneId, source) => {
+                      const paneResourceId = paneResourceIdForSemanticPane(semanticPaneId);
+                      selectSidebarAgentForPane(paneResourceId, source);
+                    }}
                     paneTitles={paneTitles()}
                     fallbackWindows={inventoryWindows()}
                     reducedMotion={props.reducedMotion}

--- a/apps/desktop-renderer/src/experience/workspace-tiled-surface.test.tsx
+++ b/apps/desktop-renderer/src/experience/workspace-tiled-surface.test.tsx
@@ -149,23 +149,23 @@ describe("the layout-faithful workspace view", () => {
     expect(tabs.map((tab) => tab.dataset.active)).toEqual(["false", "true"]);
   });
 
-  it("selects a window through tmux when its tab is clicked", () => {
-    /*
-     * Bug this catches: the tab switches which window the APP shows and never
-     * tells tmux, so an attached ssh client stays on the old window and the two
-     * views of one session disagree about where the user is.
-     */
-    const { root, invoke } = renderSurface([
-      layout({ semanticWindowId: "window.editor", currentWindow: true }),
-      layout({
-        semanticWindowId: "window.shell",
-        windowName: "shell",
-        currentWindow: false,
-        panes: [{ pane: "pane.z", left: 0, top: 0, width: 200, height: 50, active: true }],
-      }),
-    ]);
+  it("selects a window in this client without mutating shared tmux focus", () => {
+    const selectView = vi.fn();
+    const { root, invoke } = renderSurface(
+      [
+        layout({ semanticWindowId: "window.editor", currentWindow: true }),
+        layout({
+          semanticWindowId: "window.shell",
+          windowName: "shell",
+          currentWindow: false,
+          panes: [{ pane: "pane.z", left: 0, top: 0, width: 200, height: 50, active: true }],
+        }),
+      ],
+      { onSelectViewPane: selectView },
+    );
     root.querySelectorAll<HTMLButtonElement>(".window-tabs__tab")[1]!.click();
-    expect(invoke).toHaveBeenCalledWith("pane.select", "pane.z");
+    expect(selectView).toHaveBeenCalledWith("pane.z", "mouse");
+    expect(invoke).not.toHaveBeenCalled();
   });
 
   it("does not re-select the window the user is already in", () => {
@@ -434,6 +434,51 @@ describe("the layout-faithful workspace view", () => {
     vi.useRealTimers();
   });
 
+  it("does not clear a pane receipt when an unrelated global receipt arrives", () => {
+    vi.useFakeTimers();
+    const receipt = {
+      paneId: "pane.b",
+      direction: "incoming" as const,
+      sourcePaneId: "pane.a",
+      destinationPaneId: "pane.b",
+      operationKind: "workspace.pane.send" as const,
+      operationId: "10000000-0000-4000-8000-000000000042",
+      phase: "observed" as const,
+      origin: "sdk" as const,
+      label: "sdk observed · delivered 12 characters + Enter",
+      sequence: 42,
+      at: new Date().toISOString(),
+    };
+    const [feed, setFeed] = createSignal({ sequence: 42, panes: { "pane.b": receipt } });
+    const root = document.createElement("div");
+    document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <WorkspaceTiledSurface
+            layouts={[SPLIT]}
+            workspaceName="workspace.product"
+            transport={null}
+            paneFrames={[]}
+            verbs={{ workspaceConnected: true, invoke: vi.fn() }}
+            paneInteractions={feed().panes}
+            interactionSequence={feed().sequence}
+          />
+        ),
+        root,
+      ),
+    );
+    const target = root.querySelector<HTMLElement>('[data-pane="pane.b"]')!;
+    expect(target.dataset.communicationActive).toBe("true");
+    setFeed({ sequence: 99, panes: { "pane.b": receipt } });
+    expect(target.dataset.communicationActive).toBe("true");
+    vi.advanceTimersByTime(PANE_COMMUNICATION_HIGHLIGHT_MS - 1);
+    expect(target.dataset.communicationActive).toBe("true");
+    vi.advanceTimersByTime(1);
+    expect(target.dataset.communicationActive).toBeUndefined();
+    vi.useRealTimers();
+  });
+
   it("uses honest privacy-safe copy for observed and authored pane sends", () => {
     const common = {
       paneId: "pane.b",
@@ -582,7 +627,7 @@ describe("the layout-faithful workspace view", () => {
     expect(renderSurface([SPLIT]).root.querySelectorAll(".pane-tile")).toHaveLength(2);
   });
 
-  it("uses the whole panel header as the drag handle", () => {
+  it("uses the whole panel header as the drag handle", async () => {
     const { root, invoke } = renderSurface([SPLIT]);
     const overlay = root.querySelector<HTMLElement>(".tiled-pane-area__overlay")!;
     overlay.getBoundingClientRect = () =>
@@ -601,6 +646,7 @@ describe("the layout-faithful workspace view", () => {
     };
     header.dispatchEvent(pointer("pointerdown", 250));
     header.dispatchEvent(pointer("pointermove", 750));
+    await new Promise((resolve) => setTimeout(resolve, 20));
     expect(root.querySelector(".pane-drop-ghost__label")?.textContent).toContain(
       "Swap with Terminal",
     );
@@ -684,6 +730,110 @@ describe("the layout-faithful workspace view", () => {
     expect(root.querySelector<HTMLElement>('[data-pane="pane.a"]')!.style.transform).toBe("");
   });
 
+  it("keeps each browser client's viewed window local while sharing canonical layout", () => {
+    const windows = [
+      layout({ semanticWindowId: "window.editor", windowName: "editor", currentWindow: true }),
+      layout({
+        semanticWindowId: "window.shell",
+        windowName: "shell",
+        currentWindow: false,
+        panes: [{ pane: "pane.z", left: 0, top: 0, width: 200, height: 50, active: true }],
+      }),
+    ];
+    const [viewA, setViewA] = createSignal<string | null>("pane.a");
+    const [viewB, setViewB] = createSignal<string | null>("pane.a");
+    const invoke = vi.fn();
+    const roots = [document.createElement("div"), document.createElement("div")];
+    for (const root of roots) document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <WorkspaceTiledSurface
+            layouts={windows}
+            workspaceName="workspace.product"
+            transport={null}
+            paneFrames={[]}
+            verbs={{ workspaceConnected: true, invoke }}
+            viewPane={viewA()}
+            onSelectViewPane={(pane) => setViewA(pane)}
+          />
+        ),
+        roots[0]!,
+      ),
+      render(
+        () => (
+          <WorkspaceTiledSurface
+            layouts={windows}
+            workspaceName="workspace.product"
+            transport={null}
+            paneFrames={[]}
+            verbs={{ workspaceConnected: true, invoke }}
+            viewPane={viewB()}
+            onSelectViewPane={(pane) => setViewB(pane)}
+          />
+        ),
+        roots[1]!,
+      ),
+    );
+    roots[0]!.querySelectorAll<HTMLButtonElement>(".window-tabs__tab")[1]!.click();
+    expect(viewA()).toBe("pane.z");
+    expect(viewB()).toBe("pane.a");
+    expect(roots[0]!.querySelector<HTMLElement>('.pane-tile[data-pane="pane.z"]')).not.toBeNull();
+    expect(roots[1]!.querySelector<HTMLElement>('.pane-tile[data-pane="pane.a"]')).not.toBeNull();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("retains a pane's terminal owner when an earlier semantic id is inserted", () => {
+    const recording = createRecordingMirrorRendererFactory();
+    const node = (pane: string) => ({
+      pane,
+      title: pane,
+      frame: null,
+      state: { kind: "live", flowPaused: false } as const,
+      registerSink: () => () => undefined,
+    });
+    const mirror: AppWindowCanvasMirrorProps = {
+      enabled: true,
+      onToggle: vi.fn(),
+      nodes: [node("pane.a"), node("pane.b"), node("pane.0")],
+      connection: { kind: "connected" },
+      onRetry: vi.fn(),
+      rendererFactory: recording.factory,
+    };
+    const [frames, setFrames] = createSignal<readonly PaneStreamLayoutEvent[]>([SPLIT]);
+    const root = document.createElement("div");
+    document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <WorkspaceTiledSurface
+            layouts={frames()}
+            workspaceName="workspace.product"
+            transport={null}
+            paneFrames={[]}
+            verbs={{ workspaceConnected: true, invoke: vi.fn() }}
+            mirror={mirror}
+          />
+        ),
+        root,
+      ),
+    );
+    const paneA = root.querySelector<HTMLElement>('[data-pane="pane.a"]')!;
+    const paneATerminal = paneA.querySelector(".mirror-pane-node");
+    setFrames([
+      layout({
+        panes: [
+          { pane: "pane.0", left: 0, top: 0, width: 65, height: 50, active: false },
+          { pane: "pane.a", left: 66, top: 0, width: 66, height: 50, active: true },
+          { pane: "pane.b", left: 133, top: 0, width: 67, height: 50, active: false },
+        ],
+      }),
+    ]);
+    expect(root.querySelector<HTMLElement>('[data-pane="pane.a"]')).toBe(paneA);
+    expect(paneA.querySelector(".mirror-pane-node")).toBe(paneATerminal);
+    expect(recording.renderers).toHaveLength(3);
+  });
+
   it("puts a draggable border on tmux's own border cell, and none when there is one pane", () => {
     const { root } = renderSurface([SPLIT]);
     const border = root.querySelector<HTMLElement>(".pane-border")!;
@@ -729,6 +879,91 @@ describe("the layout-faithful workspace view", () => {
     expect(invoke.mock.calls.filter(([verb]) => verb === "pane.resize")).toEqual([
       ["pane.resize", "pane.a", { resize: { axis: "cols", cells: 109 } }],
     ]);
+  });
+
+  it("settles on tmux's clamped resize result without rolling back to the requested size", async () => {
+    const [frames, setFrames] = createSignal<readonly PaneStreamLayoutEvent[]>([SPLIT]);
+    let resolveMutation!: (value: {
+      status: "ok";
+      result: {
+        operationId: string;
+        daemonInstanceId: string;
+        outcome: "applied";
+        workspaceName: string;
+        verb: "workspace.pane.resize";
+        semanticPaneId: string;
+        axis: "cols";
+        cells: number;
+      };
+    }) => void;
+    const invoke = vi.fn(
+      () =>
+        new Promise<Parameters<typeof resolveMutation>[0]>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+    const root = document.createElement("div");
+    document.body.append(root);
+    disposers.push(
+      render(
+        () => (
+          <WorkspaceTiledSurface
+            layouts={frames()}
+            workspaceName="workspace.product"
+            transport={null}
+            paneFrames={[]}
+            verbs={{ workspaceConnected: true, invoke }}
+            reducedMotion
+          />
+        ),
+        root,
+      ),
+    );
+    const overlay = root.querySelector<HTMLElement>(".tiled-pane-area__overlay")!;
+    overlay.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 1_000, height: 500, right: 1_000, bottom: 500 }) as DOMRect;
+    const border = root.querySelector<HTMLElement>(".pane-border")!;
+    border.setPointerCapture = () => undefined;
+    border.releasePointerCapture = () => undefined;
+    const pointer = (type: string, x: number): PointerEvent => {
+      const event = new MouseEvent(type, { bubbles: true, button: 0, clientX: x, clientY: 200 });
+      Object.defineProperties(event, { pointerId: { value: 19 }, isPrimary: { value: true } });
+      return event as PointerEvent;
+    };
+    border.dispatchEvent(pointer("pointerdown", 500));
+    border.dispatchEvent(pointer("pointerup", 550));
+    resolveMutation({
+      status: "ok",
+      result: {
+        operationId: "30000000-0000-4000-8000-000000000001",
+        daemonInstanceId: "30000000-0000-4000-8000-000000000002",
+        outcome: "applied",
+        workspaceName: "workspace.product",
+        verb: "workspace.pane.resize",
+        semanticPaneId: "pane.a",
+        axis: "cols",
+        cells: 105,
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(
+      root.querySelector<HTMLElement>(".tiled-pane-area")!.dataset.manipulationPreviewCells,
+    ).toBe("105");
+    setFrames([
+      layout({
+        panes: [
+          { pane: "pane.a", left: 0, top: 0, width: 105, height: 50, active: true },
+          { pane: "pane.b", left: 106, top: 0, width: 94, height: 50, active: false },
+        ],
+      }),
+    ]);
+    await Promise.resolve();
+    expect(root.querySelector<HTMLElement>(".tiled-pane-area")!.dataset.manipulationPhase).toBe(
+      "idle",
+    );
+    expect(root.querySelector<HTMLElement>('[data-pane="pane.a"]')!.style.transform).toBe("");
+    expect(root.querySelector<HTMLElement>('[data-pane="pane.a"]')!.style.width).toBe("52.7500%");
   });
 
   it("keeps horizontal resize authority on the edge instead of consuming panel chrome", () => {
@@ -803,6 +1038,7 @@ describe("the layout-faithful workspace view", () => {
       "resize-preview",
     );
     border.dispatchEvent(pointer("pointermove", 505));
+    await new Promise((resolve) => setTimeout(resolve, 20));
     expect(
       root.querySelector<HTMLElement>(".tiled-pane-area")!.dataset.manipulationPreviewCells,
     ).toBe("101");
@@ -818,6 +1054,50 @@ describe("the layout-faithful workspace view", () => {
     expect(resizes.length, "the release did not flush a resize").toBe(1);
     expect(resizes[0]![1]).toBe("pane.a");
     expect(resizes[0]![2]).toEqual({ resize: { axis: "cols", cells: 101 } });
+  });
+
+  it("coalesces pointer floods to one preview frame and one durable resize", () => {
+    const callbacks = new Map<number, FrameRequestCallback>();
+    let frameId = 0;
+    const originalRequest = globalThis.requestAnimationFrame;
+    const originalCancel = globalThis.cancelAnimationFrame;
+    globalThis.requestAnimationFrame = (callback) => {
+      callbacks.set(++frameId, callback);
+      return frameId;
+    };
+    globalThis.cancelAnimationFrame = (id) => callbacks.delete(id);
+    try {
+      const { root, invoke } = renderSurface([SPLIT]);
+      const border = root.querySelector<HTMLElement>(".pane-border")!;
+      const overlay = root.querySelector<HTMLElement>(".tiled-pane-area__overlay")!;
+      overlay.getBoundingClientRect = () =>
+        ({ left: 0, top: 0, width: 1_000, height: 500, right: 1_000, bottom: 500 }) as DOMRect;
+      border.setPointerCapture = () => undefined;
+      border.releasePointerCapture = () => undefined;
+      // Mirror mounting schedules an unrelated fit frame. This assertion owns
+      // only the manipulation compositor's frame budget.
+      callbacks.clear();
+      const pointer = (type: string, x: number): PointerEvent => {
+        const event = new MouseEvent(type, { bubbles: true, button: 0, clientX: x, clientY: 200 });
+        Object.defineProperties(event, { pointerId: { value: 17 }, isPrimary: { value: true } });
+        return event as PointerEvent;
+      };
+      border.dispatchEvent(pointer("pointerdown", 495));
+      for (let x = 496; x < 996; x += 1) border.dispatchEvent(pointer("pointermove", x));
+      expect(callbacks).toHaveLength(1);
+      expect(invoke).not.toHaveBeenCalled();
+      const callback = [...callbacks.values()][0]!;
+      callbacks.clear();
+      callback(performance.now());
+      expect(
+        root.querySelector<HTMLElement>(".tiled-pane-area")!.dataset.manipulationPreviewCells,
+      ).toBe("199");
+      border.dispatchEvent(pointer("pointerup", 995));
+      expect(invoke.mock.calls.filter(([verb]) => verb === "pane.resize")).toHaveLength(1);
+    } finally {
+      globalThis.requestAnimationFrame = originalRequest;
+      globalThis.cancelAnimationFrame = originalCancel;
+    }
   });
 
   it("prunes a window whose panes the daemon no longer reports as attachable", () => {

--- a/apps/desktop-renderer/src/experience/workspace-tiled-surface.test.tsx
+++ b/apps/desktop-renderer/src/experience/workspace-tiled-surface.test.tsx
@@ -571,6 +571,23 @@ describe("the layout-faithful workspace view", () => {
     // One row of a tile that is 25 pane rows plus the borrowed separator row.
     expect(headers[1]!.style.top).toBe("1px");
     expect(headers[1]!.style.height).toBe(`calc(${((1 / 26) * 100).toFixed(4)}% - 1px)`);
+
+    // The tmux layout can be one resize behind xterm. Once xterm has painted,
+    // its real cell height owns chrome geometry so a stale 1/26 fraction cannot
+    // cover two 14px terminal rows in a tall browser viewport.
+    const area = root.querySelector<HTMLElement>(".tiled-pane-area")!;
+    const viewport = area.querySelector<HTMLElement>(".terminal-surface__viewport")!;
+    const grid = document.createElement("div");
+    grid.className = "xterm";
+    const rows = document.createElement("div");
+    rows.className = "xterm-rows";
+    const paintedRow = document.createElement("div");
+    paintedRow.getBoundingClientRect = () => ({ height: 14 }) as DOMRect;
+    rows.append(paintedRow);
+    grid.append(rows);
+    viewport.append(grid);
+    area.dispatchEvent(new Event("tmux-ide-terminal-grid-resized"));
+    expect(headers[1]!.style.height).toBe("calc(14px - 1px)");
   });
 
   it("arms the pane header's close before it kills anything", () => {
@@ -660,6 +677,38 @@ describe("the layout-faithful workspace view", () => {
       "swap-committing",
     );
     expect(root.querySelector<HTMLElement>('[data-pane="pane.a"]')!.dataset.elevated).toBe("false");
+  });
+
+  it("commits before a synchronous lostpointercapture cleanup can cancel the swap", async () => {
+    const { root, invoke } = renderSurface([SPLIT]);
+    const overlay = root.querySelector<HTMLElement>(".tiled-pane-area__overlay")!;
+    overlay.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 1_000, height: 500, right: 1_000, bottom: 500 }) as DOMRect;
+    const header = root.querySelector<HTMLElement>('[data-pane="pane.a"] .pane-tile__header')!;
+    header.setPointerCapture = () => undefined;
+    header.releasePointerCapture = () => {
+      header.dispatchEvent(new Event("lostpointercapture", { bubbles: true }));
+    };
+    const pointer = (type: string, x: number): PointerEvent => {
+      const event = new MouseEvent(type, { bubbles: true, button: 0, clientX: x, clientY: 10 });
+      Object.defineProperties(event, {
+        pointerId: { value: 27 },
+        isPrimary: { value: true },
+        pointerType: { value: "mouse" },
+      });
+      return event as PointerEvent;
+    };
+    header.dispatchEvent(pointer("pointerdown", 250));
+    header.dispatchEvent(pointer("pointermove", 750));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    header.dispatchEvent(pointer("pointerup", 750));
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith("pane.swap", "pane.a", {
+      swapTargetSemanticPaneId: "pane.b",
+    });
+    expect(root.querySelector<HTMLElement>(".tiled-pane-area")!.dataset.manipulationPhase).toBe(
+      "swap-committing",
+    );
   });
 
   it("adopts the confirming tmux swap without replaying a FLIP transition", async () => {

--- a/apps/desktop-renderer/src/experience/workspace-tiled-surface.tsx
+++ b/apps/desktop-renderer/src/experience/workspace-tiled-surface.tsx
@@ -26,8 +26,17 @@
  * between two panes, and the drag handles plus persistent panel header sit on
  * those reserved cells; a tile's output region stays transparent.
  */
-import { Index, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
-import type { SemanticIconId } from "@tmux-ide/contracts";
+import {
+  For,
+  Index,
+  Show,
+  batch,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+} from "solid-js";
+import type { SemanticIconId, WorkspaceMultiplexerMutationResult } from "@tmux-ide/contracts";
 import {
   INTERACTION_PRESENCE_MS,
   interactionPresenceIsFresh,
@@ -85,6 +94,7 @@ type PaneManipulationPhase =
   | "drop-ready"
   | "swap-committing"
   | "rollback";
+type PaneTransactionState = "idle" | "previewing" | "committing" | "settled" | "rejected";
 
 /**
  * A mutation can be accepted by tmux before its authoritative layout frame
@@ -140,7 +150,10 @@ export function terminalGridOverlayBox(area: HTMLElement): {
   };
 }
 
-type TiledVerbResult = void | Promise<{ readonly status: "ok" | "error" }>;
+type TiledVerbResult = void | Promise<
+  | { readonly status: "ok"; readonly result?: WorkspaceMultiplexerMutationResult }
+  | { readonly status: "error"; readonly error?: unknown }
+>;
 
 export interface TiledSurfaceVerbs {
   readonly workspaceConnected: boolean;
@@ -220,6 +233,9 @@ export interface WorkspaceTiledSurfaceProps {
     pointer: { readonly x: number; readonly y: number },
   ) => void;
   readonly onFocusPane?: (semanticPaneId: string, source: "keyboard" | "mouse") => void;
+  /** This browser view's pane selection; never interpreted as shared tmux focus. */
+  readonly viewPane?: string | null;
+  readonly onSelectViewPane?: (semanticPaneId: string, source: "keyboard" | "mouse") => void;
   /**
    * The window whose tab is being renamed, named by a pane inside it. The tab
    * is where a rename belongs: it is where the name is READ, so it is where a
@@ -309,7 +325,12 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
   let observedInteractionSequence = 0;
 
   createEffect(() => {
-    const sequence = props.interactionSequence ?? 0;
+    // Pane presence has its own revision lane. A newer unrelated receipt (for
+    // example resize) must not erase a still-fresh read/send relationship.
+    const sequence = Math.max(
+      0,
+      ...Object.values(props.paneInteractions ?? {}).map((interaction) => interaction.sequence),
+    );
     if (sequence <= observedInteractionSequence) return;
     observedInteractionSequence = sequence;
     const latest = Object.values(props.paneInteractions ?? {}).find(
@@ -364,19 +385,37 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
   });
   const tabs = createMemo<readonly WindowTab[]>(() => {
     const fromFrames = windowTabs(frames());
-    if (fromFrames.length > 0) return fromFrames;
+    if (fromFrames.length > 0) {
+      const selectedFrame = frames().find((frame) =>
+        frame.panes.some((pane) => pane.pane === props.viewPane),
+      );
+      if (!selectedFrame) return fromFrames;
+      const selectedKey = windowTabKey(selectedFrame);
+      return fromFrames.map((tab, index) => ({
+        ...tab,
+        active: frames()[index] ? windowTabKey(frames()[index]!) === selectedKey : false,
+      }));
+    }
     return (props.fallbackWindows ?? []).map((window) => ({
       semanticWindowId: null,
       label: window.label,
-      active: window.active,
+      active: props.viewPane ? window.panes.includes(props.viewPane) : window.active,
       paneCount: window.panes.length,
       zoomed: false,
       addressPane: window.panes[0] ?? null,
     }));
   });
-  const currentFrame = createMemo<LayoutFrame | null>(
-    () => frames().find((frame) => frame.currentWindow) ?? frames()[0] ?? null,
-  );
+  const currentFrame = createMemo<LayoutFrame | null>(() => {
+    const selected = props.viewPane;
+    return (
+      (selected
+        ? frames().find((frame) => frame.panes.some((pane) => pane.pane === selected))
+        : null) ??
+      frames().find((frame) => frame.currentWindow) ??
+      frames()[0] ??
+      null
+    );
+  });
   const tiles = createMemo(() => {
     const frame = currentFrame();
     if (frame) return layoutTiles(frame);
@@ -584,13 +623,46 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
   // A transaction freezes the frame it began on. Pointer feedback is local and
   // compositor-only; tmux mutations are confirmations of that preview, never
   // the source of the preview itself.
-  const [manipulation, setManipulation] = createSignal<WorkspacePaneManipulation | null>(null);
-  const [localPreview, setLocalPreview] = createSignal<WorkspacePanePreview | null>(null);
-  const [committingState, setCommittingState] = createSignal<
-    WorkspacePaneResize | WorkspacePaneDrag | null
-  >(null);
-  const [committingPreview, setCommittingPreview] = createSignal<WorkspacePanePreview | null>(null);
-  const [phase, setPhase] = createSignal<PaneManipulationPhase>("idle");
+  interface PaneTransactionSnapshot {
+    readonly manipulation: WorkspacePaneManipulation | null;
+    readonly localPreview: WorkspacePanePreview | null;
+    readonly committingState: WorkspacePaneResize | WorkspacePaneDrag | null;
+    readonly committingPreview: WorkspacePanePreview | null;
+    readonly phase: PaneManipulationPhase;
+    readonly state: PaneTransactionState;
+  }
+  const [paneTransaction, setPaneTransaction] = createSignal<PaneTransactionSnapshot>({
+    manipulation: null,
+    localPreview: null,
+    committingState: null,
+    committingPreview: null,
+    phase: "idle",
+    state: "idle",
+  });
+  const manipulation = () => paneTransaction().manipulation;
+  const localPreview = () => paneTransaction().localPreview;
+  const committingState = () => paneTransaction().committingState;
+  const committingPreview = () => paneTransaction().committingPreview;
+  const phase = () => paneTransaction().phase;
+  const transactionState = () => paneTransaction().state;
+  const setManipulation = (value: WorkspacePaneManipulation | null): void => {
+    setPaneTransaction((current) => ({ ...current, manipulation: value }));
+  };
+  const setLocalPreview = (value: WorkspacePanePreview | null): void => {
+    setPaneTransaction((current) => ({ ...current, localPreview: value }));
+  };
+  const setCommittingState = (value: WorkspacePaneResize | WorkspacePaneDrag | null): void => {
+    setPaneTransaction((current) => ({ ...current, committingState: value }));
+  };
+  const setCommittingPreview = (value: WorkspacePanePreview | null): void => {
+    setPaneTransaction((current) => ({ ...current, committingPreview: value }));
+  };
+  const setPhase = (value: PaneManipulationPhase): void => {
+    setPaneTransaction((current) => ({ ...current, phase: value }));
+  };
+  const setTransactionState = (value: PaneTransactionState): void => {
+    setPaneTransaction((current) => ({ ...current, state: value }));
+  };
   const [lastConfirmedCells, setLastConfirmedCells] = createSignal<number | null>(null);
   const [endingPanes, setEndingPanes] = createSignal<ReadonlySet<string>>(new Set());
   const [lastLayoutTransition, setLastLayoutTransition] = createSignal<
@@ -605,6 +677,9 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
     readonly x: number;
     readonly y: number;
   } | null = null;
+  let transactionId = 0;
+  let pendingPointerSample: WorkspacePointerSample | null = null;
+  let previewAnimationFrame: number | null = null;
 
   const clearResizeWireTimer = (): void => {
     if (resizeWireTimer !== null) clearTimeout(resizeWireTimer);
@@ -623,6 +698,9 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
     clearResizeWireTimer();
     clearCommitTimeout();
     clearTouchLongPress();
+    if (previewAnimationFrame !== null && typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(previewAnimationFrame);
+    }
   });
   if (typeof window !== "undefined") {
     const onManipulationKeyDown = (event: KeyboardEvent): void => {
@@ -666,23 +744,37 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
     };
   };
 
-  const settle = (rolledBack = false): void => {
+  const settle = (rolledBack = false, expectedTransactionId = transactionId): void => {
+    if (expectedTransactionId !== transactionId) return;
     clearResizeWireTimer();
     clearCommitTimeout();
-    setCommittingState(null);
-    setCommittingPreview(null);
-    setLocalPreview(null);
-    setPhase(rolledBack ? "rollback" : "idle");
     const frame = currentFrame();
-    setManipulation(
-      frame ? createWorkspacePaneIdle(frame, { reducedMotion: props.reducedMotion }) : null,
-    );
+    // One reactive publication: consumers can never observe authoritative new
+    // geometry with the old preview transform still attached.
+    setPaneTransaction({
+      manipulation: frame
+        ? createWorkspacePaneIdle(frame, { reducedMotion: props.reducedMotion })
+        : null,
+      localPreview: null,
+      committingState: null,
+      committingPreview: null,
+      phase: rolledBack ? "rollback" : "idle",
+      state: rolledBack ? "rejected" : "settled",
+    });
+    const id = transactionId;
     if (rolledBack) {
       const settleMs = props.reducedMotion ? 0 : 150;
       commitTimeout = setTimeout(() => {
+        if (id !== transactionId) return;
         commitTimeout = null;
-        setPhase("idle");
+        setPaneTransaction((current) => ({ ...current, phase: "idle", state: "idle" }));
       }, settleMs);
+    } else {
+      queueMicrotask(() => {
+        if (id === transactionId && transactionState() === "settled") {
+          setTransactionState("idle");
+        }
+      });
     }
   };
 
@@ -718,12 +810,35 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
     clearResizeWireTimer();
     if (plan.dispatch) {
       const { pane, axis, cells } = plan.dispatch.command;
+      const issuedFor = transactionId;
       Promise.resolve(props.verbs.invoke("pane.resize", pane, { resize: { axis, cells } })).then(
         (result) => {
-          if (mutationFailed(result) && phase() === "resize-preview") cancelManipulation();
+          if (issuedFor !== transactionId) return;
+          if (mutationFailed(result)) {
+            if (phase() === "resize-preview") cancelManipulation();
+            else if (phase() === "resize-committing") settle(true, issuedFor);
+            return;
+          }
+          if (
+            result &&
+            result.status === "ok" &&
+            result.result?.verb === "workspace.pane.resize" &&
+            phase() === "resize-committing"
+          ) {
+            const pending = committingState();
+            if (pending?.kind !== "resize") return;
+            const actual = result.result.cells;
+            const adjusted: WorkspacePaneResize = { ...pending, previewCells: actual };
+            batch(() => {
+              setCommittingState(adjusted);
+              setCommittingPreview(previewWorkspacePaneManipulation(adjusted));
+            });
+          }
         },
         () => {
+          if (issuedFor !== transactionId) return;
           if (phase() === "resize-preview") cancelManipulation();
+          else if (phase() === "resize-committing") settle(true, issuedFor);
         },
       );
     }
@@ -749,12 +864,18 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
       { borderId, pointer: pointerSample(event), gridBox: currentGridBox() },
     );
     if (started.kind !== "resize") return;
+    transactionId += 1;
     event.preventDefault();
     (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
     setLastConfirmedCells(started.border.cells);
-    setManipulation(started);
-    setLocalPreview(previewWorkspacePaneManipulation(started));
-    setPhase("resize-preview");
+    setPaneTransaction({
+      manipulation: started,
+      localPreview: previewWorkspacePaneManipulation(started),
+      committingState: null,
+      committingPreview: null,
+      phase: "resize-preview",
+      state: "previewing",
+    });
   };
 
   const beginPaneDrag = (pane: string, event: PointerEvent): void => {
@@ -766,12 +887,18 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
       { pane, pointer: pointerSample(event), gridBox: currentGridBox() },
     );
     if (started.kind !== "drag") return;
+    transactionId += 1;
     event.preventDefault();
     event.stopPropagation();
     (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
-    setManipulation(started);
-    setLocalPreview(previewWorkspacePaneManipulation(started));
-    setPhase("dragging");
+    setPaneTransaction({
+      manipulation: started,
+      localPreview: previewWorkspacePaneManipulation(started),
+      committingState: null,
+      committingPreview: null,
+      phase: "dragging",
+      state: "previewing",
+    });
     if (event.pointerType === "touch") {
       pendingTouchDrag = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
       touchLongPressTimer = setTimeout(() => {
@@ -779,6 +906,39 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
         pendingTouchDrag = null;
       }, 400);
     }
+  };
+
+  const applyPointerPreview = (sample: WorkspacePointerSample): void => {
+    const state = manipulation();
+    if (!state || state.kind === "idle") return;
+    /*
+     * Pointer feedback is renderer-local. A verified daemon mutation per sample
+     * made the browser trail the TUI and caused layout/xterm work to queue behind
+     * the pointer. Release emits the one durable resize command below.
+     */
+    const updated = updateWorkspacePaneManipulation(state, sample, {
+      wireResize: false,
+    });
+    if (updated.ignored) return;
+    setPaneTransaction((current) => ({
+      ...current,
+      manipulation: updated.state,
+      localPreview: updated.preview,
+      phase:
+        updated.preview.kind === "drag"
+          ? updated.preview.targetPane
+            ? "drop-ready"
+            : "dragging"
+          : current.phase,
+    }));
+    dispatchResize(updated.wire);
+  };
+
+  const flushPointerPreview = (): void => {
+    previewAnimationFrame = null;
+    const sample = pendingPointerSample;
+    pendingPointerSample = null;
+    if (sample) applyPointerPreview(sample);
   };
 
   const moveManipulation = (event: PointerEvent): void => {
@@ -790,32 +950,30 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
       }
       return;
     }
-    /*
-     * Pointer feedback is renderer-local. A verified daemon mutation per sample
-     * made the browser trail the TUI and caused layout/xterm work to queue behind
-     * the pointer. Release emits the one durable resize command below.
-     */
-    const updated = updateWorkspacePaneManipulation(state, pointerSample(event), {
-      wireResize: false,
-    });
-    if (updated.ignored) return;
-    setManipulation(updated.state);
-    setLocalPreview(updated.preview);
-    if (updated.preview.kind === "drag") {
-      setPhase(updated.preview.targetPane ? "drop-ready" : "dragging");
+    pendingPointerSample = pointerSample(event);
+    if (previewAnimationFrame !== null) return;
+    if (typeof requestAnimationFrame === "function") {
+      previewAnimationFrame = requestAnimationFrame(flushPointerPreview);
+    } else {
+      // Deterministic non-browser/test fallback.
+      flushPointerPreview();
     }
-    dispatchResize(updated.wire);
   };
 
-  const beginCommitTimeout = (): void => {
+  const beginCommitTimeout = (id = transactionId): void => {
     clearCommitTimeout();
-    commitTimeout = setTimeout(() => settle(true), MANIPULATION_CONFIRM_TIMEOUT_MS);
+    commitTimeout = setTimeout(() => settle(true, id), MANIPULATION_CONFIRM_TIMEOUT_MS);
   };
 
   const finishManipulation = (event: PointerEvent): void => {
     const state = manipulation();
     if (!state || state.kind === "idle") return;
     clearTouchLongPress();
+    if (previewAnimationFrame !== null && typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(previewAnimationFrame);
+      previewAnimationFrame = null;
+    }
+    pendingPointerSample = null;
     const releaseSample = pointerSample(event);
     // The release coordinate is authoritative even when no pointermove landed
     // in that frame. Preview it without adopting its wire bookkeeping; finish
@@ -827,7 +985,6 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
     const finished = finishWorkspacePaneManipulation(state, releaseSample);
     if (finished.ignored || !finished.completion) return;
     clearResizeWireTimer();
-    setManipulation(finished.state);
     // Retire the transaction before releasing capture. `lostpointercapture`
     // can fire synchronously in some engines; seeing the idle state keeps that
     // cleanup signal from re-entering cancellation during a valid commit.
@@ -838,17 +995,28 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
       finished.completion.kind === "resize" &&
       (finished.completion.changed || finished.wire.dispatch !== null)
     ) {
-      setCommittingState(state);
-      setCommittingPreview(preview);
-      setPhase("resize-committing");
+      setPaneTransaction({
+        manipulation: finished.state,
+        localPreview: null,
+        committingState: state,
+        committingPreview: preview,
+        phase: "resize-committing",
+        state: "committing",
+      });
       beginCommitTimeout();
       return;
     }
     if (finished.completion.kind === "swap") {
       const releasedDrag = released.state as WorkspacePaneDrag;
-      setCommittingState(releasedDrag);
-      setCommittingPreview(commitWorkspacePaneDragPreview(releasedDrag));
-      setPhase("swap-committing");
+      const issuedFor = transactionId;
+      setPaneTransaction({
+        manipulation: finished.state,
+        localPreview: null,
+        committingState: releasedDrag,
+        committingPreview: commitWorkspacePaneDragPreview(releasedDrag),
+        phase: "swap-committing",
+        state: "committing",
+      });
       beginCommitTimeout();
       Promise.resolve(
         props.verbs.invoke("pane.swap", finished.completion.sourcePane, {
@@ -856,9 +1024,9 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
         }),
       ).then(
         (result) => {
-          if (mutationFailed(result)) settle(true);
+          if (mutationFailed(result)) settle(true, issuedFor);
         },
-        () => settle(true),
+        () => settle(true, issuedFor),
       );
       return;
     }
@@ -875,10 +1043,14 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
     );
     if (cancelled.ignored) return;
     clearResizeWireTimer();
+    const cancelledId = transactionId;
     setManipulation(cancelled.state);
     if (event) (event.currentTarget as HTMLElement).releasePointerCapture?.(event.pointerId);
     dispatchResize(cancelled.wire);
-    settle(cancelled.completion?.kind === "cancelled" ? cancelled.completion.rolledBack : false);
+    settle(
+      cancelled.completion?.kind === "cancelled" ? cancelled.completion.rolledBack : false,
+      cancelledId,
+    );
   }
 
   createEffect(() => {
@@ -939,6 +1111,10 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
      */
     return [...visible].sort((left, right) => left.pane.localeCompare(right.pane));
   });
+  // Key the retained DOM/xterm owner by semantic pane id. Layout objects are
+  // replaced on every canonical frame; using them (or array position) as the
+  // keyed value can retarget an existing renderer to another pane on insert.
+  const displayPaneIds = createMemo(() => displayTiles().map(({ pane }) => pane));
   const displayBorders = createMemo(() => {
     const state = displayState();
     const visible = state && state.kind !== "idle" ? state.snapshot.borders : borders();
@@ -1175,10 +1351,16 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
       atMs: atMs + 1,
     });
     if (moved.state.kind !== "drag" || moved.preview.kind !== "drag") return;
-    setManipulation(createWorkspacePaneIdle(frame, { reducedMotion: props.reducedMotion }));
-    setCommittingState(moved.state);
-    setCommittingPreview(commitWorkspacePaneDragPreview(moved.state));
-    setPhase("swap-committing");
+    const movedDrag = moved.state;
+    transactionId += 1;
+    const issuedFor = transactionId;
+    batch(() => {
+      setManipulation(createWorkspacePaneIdle(frame, { reducedMotion: props.reducedMotion }));
+      setCommittingState(movedDrag);
+      setCommittingPreview(commitWorkspacePaneDragPreview(movedDrag));
+      setPhase("swap-committing");
+      setTransactionState("committing");
+    });
     beginCommitTimeout();
     Promise.resolve(
       props.verbs.invoke("pane.swap", sourcePane, {
@@ -1186,9 +1368,9 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
       }),
     ).then(
       (result) => {
-        if (mutationFailed(result)) settle(true);
+        if (mutationFailed(result)) settle(true, issuedFor);
       },
-      () => settle(true),
+      () => settle(true, issuedFor),
     );
   };
 
@@ -1215,24 +1397,47 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
       atMs: performance.now(),
     });
     if (moved.state.kind !== "resize" || moved.preview.kind !== "resize") return;
-    setLastConfirmedCells(border.cells);
-    setManipulation(createWorkspacePaneIdle(frame, { reducedMotion: props.reducedMotion }));
-    setCommittingState(moved.state);
-    setCommittingPreview(moved.preview);
-    setPhase("resize-committing");
+    const movedResize = moved.state;
+    const movedResizePreview = moved.preview;
+    transactionId += 1;
+    const issuedFor = transactionId;
+    batch(() => {
+      setLastConfirmedCells(border.cells);
+      setManipulation(createWorkspacePaneIdle(frame, { reducedMotion: props.reducedMotion }));
+      setCommittingState(movedResize);
+      setCommittingPreview(movedResizePreview);
+      setPhase("resize-committing");
+      setTransactionState("committing");
+    });
     beginCommitTimeout();
     Promise.resolve(
       props.verbs.invoke("pane.resize", border.pane, {
         resize: {
           axis: border.orientation === "vertical" ? "cols" : "rows",
-          cells: moved.preview.cells,
+          cells: movedResizePreview.cells,
         },
       }),
     ).then(
       (result) => {
-        if (mutationFailed(result)) settle(true);
+        if (issuedFor !== transactionId) return;
+        if (mutationFailed(result)) {
+          settle(true, issuedFor);
+          return;
+        }
+        if (result && result.status === "ok" && result.result?.verb === "workspace.pane.resize") {
+          const pending = committingState();
+          if (pending?.kind !== "resize") return;
+          const adjusted: WorkspacePaneResize = {
+            ...pending,
+            previewCells: result.result.cells,
+          };
+          batch(() => {
+            setCommittingState(adjusted);
+            setCommittingPreview(previewWorkspacePaneManipulation(adjusted));
+          });
+        }
       },
-      () => settle(true),
+      () => settle(true, issuedFor),
     );
   };
 
@@ -1265,7 +1470,7 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
               }
               onClick={() => {
                 const pane = tab().addressPane;
-                if (pane && !tab().active) props.verbs.invoke("pane.select", pane);
+                if (pane && !tab().active) props.onSelectViewPane?.(pane, "mouse");
               }}
               onContextMenu={(event) => {
                 const pane = tab().addressPane;
@@ -1350,6 +1555,7 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
         data-zoomed={currentFrame()?.zoomed ?? false}
         data-focus-zone="canvas"
         data-manipulation-phase={phase()}
+        data-transaction-state={transactionState()}
         data-manipulation-preview-cells={resizePreview()?.cells}
         data-last-confirmed-cells={lastConfirmedCells() ?? undefined}
         data-last-layout-transition={lastLayoutTransition()}
@@ -1366,8 +1572,7 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
         onPointerDown={(event) => {
           if (event.button !== 0) return;
           const pane = tileAtPointer(event);
-          const active = tiles().find((tile) => tile.active)?.pane;
-          if (pane && pane !== active) props.verbs.invoke("pane.select", pane);
+          if (pane && pane !== props.viewPane) props.onSelectViewPane?.(pane, "mouse");
         }}
         onCopy={copyMirrorSelection}
       >
@@ -1425,12 +1630,13 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
         </Show>
 
         <div class="tiled-pane-area__overlay" ref={(element) => (overlayElement = element)}>
-          <Index each={displayTiles()}>
-            {(tile) => {
+          <For each={displayPaneIds()}>
+            {(paneId) => {
+              const tile = createMemo(() => displayTiles().find(({ pane }) => pane === paneId)!);
               const rect = createMemo(() => tile().rect);
-              const placement = createMemo(() => placementFor(tile().pane));
-              const compositorNode = createMemo(() => compositorNodes().get(tile().pane));
-              const interaction = createMemo(() => props.paneInteractions?.[tile().pane] ?? null);
+              const placement = createMemo(() => placementFor(paneId));
+              const compositorNode = createMemo(() => compositorNodes().get(paneId));
+              const interaction = createMemo(() => props.paneInteractions?.[paneId] ?? null);
               const interactionPresence = createMemo(() => {
                 const value = interaction();
                 return value ? paneInteractionPresence(value) : null;
@@ -1444,16 +1650,17 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
               return (
                 <div
                   class="pane-tile"
-                  data-pane={tile().pane}
-                  data-active={tile().active}
+                  data-pane={paneId}
+                  data-active={
+                    (props.viewPane ?? tiles().find((entry) => entry.active)?.pane) === paneId
+                  }
+                  data-tmux-active={tile().active}
                   data-drop-target={
-                    pointerDragActive() && dragPreview()?.targetPane === tile().pane
-                      ? "true"
-                      : undefined
+                    pointerDragActive() && dragPreview()?.targetPane === paneId ? "true" : undefined
                   }
                   data-elevated={placement()?.elevated ?? false}
-                  data-ending={endingPanes().has(tile().pane) ? "true" : undefined}
-                  data-identity-icon={iconIdFor(tile().pane)}
+                  data-ending={endingPanes().has(paneId) ? "true" : undefined}
+                  data-identity-icon={iconIdFor(paneId)}
                   data-composed={Boolean(compositorNode())}
                   data-interaction-phase={interaction()?.phase}
                   data-interaction-sequence={interaction()?.sequence}
@@ -1479,14 +1686,16 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
                   }}
                 >
                   <PaneHeader
-                    pane={tile().pane}
-                    title={titleFor(tile().pane)}
-                    icon={iconFor(tile().pane)}
-                    iconId={iconIdFor(tile().pane)}
-                    status={frameFor(tile().pane)?.status ?? null}
+                    pane={paneId}
+                    title={titleFor(paneId)}
+                    icon={iconFor(paneId)}
+                    iconId={iconIdFor(paneId)}
+                    status={frameFor(paneId)?.status ?? null}
                     interaction={interaction()}
                     interactionActive={communicationActive()}
-                    active={tile().active}
+                    active={
+                      (props.viewPane ?? tiles().find((entry) => entry.active)?.pane) === paneId
+                    }
                     composed={Boolean(compositorNode())}
                     /*
                      * The header's share of its own tile.
@@ -1501,19 +1710,19 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
                      */
                     heightFraction={tile().headerRows / (tile().cells.rows + tile().headerRows)}
                     hoisted={tile().headerRows === 1}
-                    onOpenMenu={(pointer) => props.onOpenPaneMenu?.(tile().pane, pointer)}
-                    onClose={() => closePane(tile().pane)}
+                    onOpenMenu={(pointer) => props.onOpenPaneMenu?.(paneId, pointer)}
+                    onClose={() => closePane(paneId)}
                     onToggleZoom={() =>
-                      props.verbs.invoke("window.zoom.toggle", tile().pane, {
+                      props.verbs.invoke("window.zoom.toggle", paneId, {
                         desiredZoom: currentFrame()?.zoomed ? "unzoomed" : "zoomed",
                       })
                     }
-                    dragging={pointerDragActive() && dragPreview()?.sourcePane === tile().pane}
-                    onPointerDown={(event) => beginPaneDrag(tile().pane, event)}
+                    dragging={pointerDragActive() && dragPreview()?.sourcePane === paneId}
+                    onPointerDown={(event) => beginPaneDrag(paneId, event)}
                     onPointerMove={moveManipulation}
                     onPointerUp={finishManipulation}
                     onPointerCancel={(event) => cancelManipulation(event)}
-                    onKeyboardSwap={(key) => keyboardSwap(tile().pane, key)}
+                    onKeyboardSwap={(key) => keyboardSwap(paneId, key)}
                   />
                   <Show when={communicationActive() && interaction()}>
                     {(activeInteraction) => {
@@ -1554,17 +1763,26 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
                     {(node) => (
                       <div
                         class="pane-tile__body"
-                        aria-label={`${titleFor(tile().pane)} terminal output`}
+                        aria-label={`${titleFor(paneId)} terminal output`}
                         onPointerDown={(event) => {
                           if (event.button !== 0) return;
-                          selectedMirrorPane = tile().pane;
-                          props.onFocusPane?.(tile().pane, "mouse");
+                          // Selection/copy owns the pointer in terminal output.
+                          // Never let it bubble into layout drag or tmux focus.
+                          event.stopPropagation();
+                          selectedMirrorPane = paneId;
+                          props.onSelectViewPane?.(paneId, "mouse");
+                          props.onFocusPane?.(paneId, "mouse");
                         }}
                         onPointerUp={(event) => {
                           if (event.button !== 0) return;
                           // Let xterm finish its selection transaction first,
-                          // then restore the one terminal that owns tmux input.
-                          queueMicrotask(() => setTerminalFocusRequest((value) => value + 1));
+                          // then restore input only for a click. A selection
+                          // keeps visible xterm ownership through Copy.
+                          queueMicrotask(() => {
+                            if ((mirrorSelections.get(paneId) ?? "").length === 0) {
+                              setTerminalFocusRequest((value) => value + 1);
+                            }
+                          });
                         }}
                       >
                         <MirrorPaneNode
@@ -1579,20 +1797,23 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
                           themeKey={props.terminalThemeKey}
                           rendererFactory={props.mirror!.rendererFactory}
                           onSelectionChange={(selection) =>
-                            updateMirrorSelection(tile().pane, selection)
+                            updateMirrorSelection(paneId, selection)
                           }
                         />
                       </div>
                     )}
                   </Show>
                   <span class="sr-only">
-                    {titleFor(tile().pane)}
-                    {tile().active ? ", active pane" : ""}
+                    {titleFor(paneId)}
+                    {(props.viewPane ?? tiles().find((entry) => entry.active)?.pane) === paneId
+                      ? ", selected in this view"
+                      : ""}
+                    {tile().active ? ", tmux input owner" : ""}
                   </span>
                 </div>
               );
             }}
-          </Index>
+          </For>
           <Index each={displayBorders()}>
             {(border) => {
               const vertical = createMemo(() => border().orientation === "vertical");

--- a/apps/desktop-renderer/src/experience/workspace-tiled-surface.tsx
+++ b/apps/desktop-renderer/src/experience/workspace-tiled-surface.tsx
@@ -150,6 +150,15 @@ export function terminalGridOverlayBox(area: HTMLElement): {
   };
 }
 
+/** The row xterm actually painted, rather than the possibly stale tmux frame ratio. */
+export function renderedTerminalRowHeight(area: HTMLElement): number | null {
+  const row = area.querySelector<HTMLElement>(
+    ".terminal-surface__viewport > .xterm .xterm-rows > div",
+  );
+  const height = row?.getBoundingClientRect().height ?? 0;
+  return Number.isFinite(height) && height > 0 ? height : null;
+}
+
 type TiledVerbResult = void | Promise<
   | { readonly status: "ok"; readonly result?: WorkspaceMultiplexerMutationResult }
   | { readonly status: "error"; readonly error?: unknown }
@@ -344,10 +353,12 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
     }
     setHighlightedInteractionSequence(sequence);
     if (communicationTimer !== null) clearTimeout(communicationTimer);
+    const occurredAt = Date.parse(latest.at);
+    const remainingMs = Math.max(0, PANE_COMMUNICATION_HIGHLIGHT_MS - (Date.now() - occurredAt));
     communicationTimer = setTimeout(() => {
       communicationTimer = null;
       setHighlightedInteractionSequence(0);
-    }, PANE_COMMUNICATION_HIGHLIGHT_MS);
+    }, remainingMs);
   });
   onCleanup(() => {
     if (communicationTimer !== null) clearTimeout(communicationTimer);
@@ -514,6 +525,7 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
     width: 0,
     height: 0,
   });
+  const [paintedRowHeight, setPaintedRowHeight] = createSignal<number | null>(null);
 
   const positionOverlay = (): void => {
     if (!overlayElement || !areaElement) return;
@@ -531,6 +543,7 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
     // grid's true padding inset for an owner and its clipping/letterbox offset
     // for a passive viewer; re-centring only the dimensions loses both.
     const box = terminalGridOverlayBox(areaElement);
+    setPaintedRowHeight(renderedTerminalRowHeight(areaElement));
     overlayStyle.update({
       left: `${box.left}px`,
       top: `${box.top}px`,
@@ -985,11 +998,6 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
     const finished = finishWorkspacePaneManipulation(state, releaseSample);
     if (finished.ignored || !finished.completion) return;
     clearResizeWireTimer();
-    // Retire the transaction before releasing capture. `lostpointercapture`
-    // can fire synchronously in some engines; seeing the idle state keeps that
-    // cleanup signal from re-entering cancellation during a valid commit.
-    (event.currentTarget as HTMLElement).releasePointerCapture?.(event.pointerId);
-    dispatchResize(finished.wire);
 
     if (
       finished.completion.kind === "resize" &&
@@ -1003,6 +1011,11 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
         phase: "resize-committing",
         state: "committing",
       });
+      // Some engines dispatch lostpointercapture synchronously. Publish the
+      // committing state first so that cleanup cannot cancel/roll back a valid
+      // release or race a second settlement.
+      (event.currentTarget as HTMLElement).releasePointerCapture?.(event.pointerId);
+      dispatchResize(finished.wire);
       beginCommitTimeout();
       return;
     }
@@ -1017,6 +1030,8 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
         phase: "swap-committing",
         state: "committing",
       });
+      (event.currentTarget as HTMLElement).releasePointerCapture?.(event.pointerId);
+      dispatchResize(finished.wire);
       beginCommitTimeout();
       Promise.resolve(
         props.verbs.invoke("pane.swap", finished.completion.sourcePane, {
@@ -1031,6 +1046,8 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
       return;
     }
     settle(false);
+    (event.currentTarget as HTMLElement).releasePointerCapture?.(event.pointerId);
+    dispatchResize(finished.wire);
   };
 
   function cancelManipulation(event?: PointerEvent): void {
@@ -1709,6 +1726,7 @@ export function WorkspaceTiledSurface(props: WorkspaceTiledSurfaceProps) {
                      * make chrome obscure terminal content.
                      */
                     heightFraction={tile().headerRows / (tile().cells.rows + tile().headerRows)}
+                    paintedRowHeight={paintedRowHeight()}
                     hoisted={tile().headerRows === 1}
                     onOpenMenu={(pointer) => props.onOpenPaneMenu?.(paneId, pointer)}
                     onClose={() => closePane(paneId)}
@@ -1982,6 +2000,8 @@ function PaneHeader(props: {
   /** Header owns a flex row; false means it still overlays tmux's separator. */
   readonly composed: boolean;
   readonly heightFraction: number;
+  /** Measured xterm cell height; frame-derived fraction is bootstrap fallback only. */
+  readonly paintedRowHeight: number | null;
   readonly hoisted: boolean;
   readonly dragging: boolean;
   readonly onPointerDown: (event: PointerEvent) => void;
@@ -2029,7 +2049,10 @@ function PaneHeader(props: {
                 // device pixel of the preceding content row; painting from the
                 // exact boundary made that last pixel look clipped at HiDPI.
                 top: "1px",
-                height: `calc(${percent(props.heightFraction)} - 1px)`,
+                height:
+                  props.paintedRowHeight === null
+                    ? `calc(${percent(props.heightFraction)} - 1px)`
+                    : `calc(${props.paintedRowHeight}px - 1px)`,
               }
           : undefined
       }

--- a/apps/desktop-renderer/src/terminal/pane-mirror-controller.test.ts
+++ b/apps/desktop-renderer/src/terminal/pane-mirror-controller.test.ts
@@ -62,6 +62,14 @@ async function flush(): Promise<void> {
   for (let i = 0; i < 12; i += 1) await Promise.resolve();
 }
 
+function deferred<T>(): { readonly promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 interface FakeSessionHandle {
   readonly request: PaneStreamRequest;
   readonly listeners: PaneStreamSessionListeners;
@@ -269,17 +277,18 @@ describe("pane mirror controller lifecycle", () => {
     h.controller.registerPaneSink(PANE_A, sink);
     await flush();
     expect(sink.seeds).toHaveLength(1);
-    expect(sink.outputs).toEqual(["early"]);
+    expect(sink.outputs).toEqual([]);
+    expect(sink.seeds[0]!.held.map((bytes) => new TextDecoder().decode(bytes))).toEqual(["early"]);
     // A live event after registration lands after the replayed backlog.
     await session.listeners.onPaneEvent(PANE_A, {
       type: "output",
       bytes: new TextEncoder().encode("late"),
     });
     await flush();
-    expect(sink.outputs).toEqual(["early", "late"]);
+    expect(sink.outputs).toEqual(["late"]);
   });
 
-  it("releases one fresh seed lease when a painted pane renderer remounts", async () => {
+  it("replays one retained canonical batch when a painted pane renderer remounts", async () => {
     const h = controllerHarness([PANE_A]);
     const firstSink = recordingSink();
     const unregister = h.controller.registerPaneSink(PANE_A, firstSink);
@@ -298,16 +307,39 @@ describe("pane mirror controller lifecycle", () => {
     h.controller.registerPaneSink(PANE_A, replacementSink);
     await flush();
 
-    expect(first.dispose).toHaveBeenCalledOnce();
-    expect(h.transport.sessions).toHaveLength(2);
-    expect(h.controller.state().panes.get(PANE_A)).toEqual({ kind: "connecting" });
-    await h.transport.latest().listeners.onPaneEvent(PANE_A, {
-      type: "seed-batch",
-      batch: seedBatch("replacement"),
-    });
-    await flush();
+    expect(first.dispose).not.toHaveBeenCalled();
+    expect(h.transport.sessions).toHaveLength(1);
     expect(replacementSink.seeds.map((batch) => new TextDecoder().decode(batch.seed))).toEqual([
-      "replacement",
+      "first",
+    ]);
+  });
+
+  it("never applies an old sink's queued delta to its replacement before replay", async () => {
+    const h = controllerHarness([PANE_A]);
+    const blocked = deferred<void>();
+    const first = recordingSink();
+    first.applyOutput = vi.fn(() => blocked.promise);
+    const unregister = h.controller.registerPaneSink(PANE_A, first);
+    h.controller.start();
+    await flush();
+    const session = h.transport.latest();
+    await session.listeners.onPaneEvent(PANE_A, {
+      type: "seed-batch",
+      batch: seedBatch("base"),
+    });
+    const pending = session.listeners.onPaneEvent(PANE_A, {
+      type: "output",
+      bytes: new TextEncoder().encode("queued"),
+    });
+    unregister();
+    const replacement = recordingSink();
+    h.controller.registerPaneSink(PANE_A, replacement);
+    blocked.resolve(undefined);
+    await pending;
+    await flush();
+    expect(replacement.calls).toEqual(["seed"]);
+    expect(replacement.seeds[0]!.held.map((bytes) => new TextDecoder().decode(bytes))).toEqual([
+      "queued",
     ]);
   });
 
@@ -412,16 +444,220 @@ describe("pane mirror controller lifecycle", () => {
     expect(h.controller.state().panes.get(PANE_A)).toEqual({ kind: "ended" });
   });
 
-  it("re-issues a new lease when the pane set changes", async () => {
+  it("keeps the active lease until the changed pane set has layouts and seeds", async () => {
     const h = controllerHarness([PANE_A]);
     h.controller.start();
     await flush();
     const first = h.transport.latest();
+    first.listeners.onLayout?.(layout(100, 30));
     h.controller.setPanes([PANE_A, PANE_B]);
     await flush();
-    expect(first.dispose).toHaveBeenCalled();
+    expect(first.dispose).not.toHaveBeenCalled();
+    expect(h.controller.state().layouts[0]?.rows).toBe(30);
     expect(h.transport.sessions).toHaveLength(2);
-    expect(h.transport.latest().request.panes).toEqual([PANE_A, PANE_B]);
+    const candidate = h.transport.latest();
+    expect(candidate.request.panes).toEqual([PANE_A, PANE_B]);
+    candidate.listeners.onLayout?.(layout(180, 50));
+    await candidate.listeners.onPaneEvent(PANE_A, {
+      type: "seed-batch",
+      batch: seedBatch("a"),
+    });
+    expect(first.dispose).not.toHaveBeenCalled();
+    await candidate.listeners.onPaneEvent(PANE_B, {
+      type: "seed-batch",
+      batch: seedBatch("b"),
+    });
+    await flush();
+    expect(first.dispose).toHaveBeenCalledOnce();
+    expect(h.controller.state().layouts[0]?.rows).toBe(50);
+    expect(h.controller.state().panes.get(PANE_B)).toEqual({ kind: "live", flowPaused: false });
+    await h.clock.advance(5_000);
+    expect(candidate.dispose).not.toHaveBeenCalled();
+  });
+
+  it("treats a pane closed before its first layout as candidate-ready", async () => {
+    const h = controllerHarness([PANE_A]);
+    h.controller.start();
+    await flush();
+    const active = h.transport.latest();
+    h.controller.setPanes([PANE_A, PANE_B]);
+    await flush();
+    const candidate = h.transport.latest();
+    candidate.listeners.onLayout?.({
+      ...layout(),
+      panes: [{ pane: PANE_A, left: 0, top: 0, width: 160, height: 40, active: true }],
+    });
+    await candidate.listeners.onPaneEvent(PANE_A, {
+      type: "seed-batch",
+      batch: seedBatch("a"),
+    });
+    candidate.listeners.onPaneEvent(PANE_B, { type: "closed" });
+    await flush();
+    expect(active.dispose).toHaveBeenCalledOnce();
+    expect(h.controller.state().panes.get(PANE_B)).toEqual({ kind: "ended" });
+  });
+
+  it("retires an incomplete candidate at its bounded readiness deadline", async () => {
+    const h = controllerHarness([PANE_A]);
+    h.controller.start();
+    await flush();
+    const active = h.transport.latest();
+    h.controller.setPanes([PANE_A, PANE_B]);
+    await flush();
+    const candidate = h.transport.latest();
+    await h.clock.advance(5_000);
+    expect(candidate.dispose).toHaveBeenCalledOnce();
+    expect(active.dispose).not.toHaveBeenCalled();
+    expect(h.controller.state().fault?.code).toBe("candidate-ready-timeout");
+  });
+
+  it("never lets a stale pane-set candidate commit over the newest request", async () => {
+    const h = controllerHarness([PANE_A]);
+    h.controller.start();
+    await flush();
+    const active = h.transport.latest();
+    h.controller.setPanes([PANE_A, PANE_B]);
+    h.controller.setPanes([PANE_B]);
+    await flush();
+    const stale = h.transport.sessions[1]!;
+    const newest = h.transport.sessions[2]!;
+    expect(stale.dispose).toHaveBeenCalledOnce();
+    stale.listeners.onLayout?.(layout(170, 41));
+    await stale.listeners.onPaneEvent(PANE_A, {
+      type: "seed-batch",
+      batch: seedBatch("stale"),
+    });
+    expect(active.dispose).not.toHaveBeenCalled();
+    newest.listeners.onLayout?.({
+      ...layout(190, 55),
+      panes: [{ pane: PANE_B, left: 0, top: 0, width: 190, height: 55, active: true }],
+    });
+    await newest.listeners.onPaneEvent(PANE_B, {
+      type: "seed-batch",
+      batch: seedBatch("newest"),
+    });
+    await flush();
+    expect(active.dispose).toHaveBeenCalledOnce();
+    expect(h.controller.state().panes.has(PANE_A)).toBe(false);
+    expect(h.controller.state().panes.get(PANE_B)).toEqual({ kind: "live", flowPaused: false });
+  });
+
+  it("retires a connected candidate that is superseded before its first complete paint", async () => {
+    const h = controllerHarness([PANE_A]);
+    h.controller.start();
+    await flush();
+    h.controller.setPanes([PANE_A, PANE_B]);
+    await flush();
+    const waiting = h.transport.latest();
+    expect(waiting.dispose).not.toHaveBeenCalled();
+    h.controller.setPanes([PANE_B]);
+    expect(waiting.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("retires a connected candidate when the controller is disposed", async () => {
+    const h = controllerHarness([PANE_A]);
+    h.controller.start();
+    await flush();
+    const active = h.transport.latest();
+    h.controller.setPanes([PANE_A, PANE_B]);
+    await flush();
+    const waiting = h.transport.latest();
+    h.controller.dispose();
+    expect(active.dispose).toHaveBeenCalledOnce();
+    expect(waiting.dispose).toHaveBeenCalledOnce();
+    await h.clock.advance(5_000);
+    expect(waiting.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("lets a ready candidate take over when the active lease ends during handoff", async () => {
+    const h = controllerHarness([PANE_A]);
+    h.controller.start();
+    await flush();
+    const active = h.transport.latest();
+    h.controller.setPanes([PANE_A, PANE_B]);
+    await flush();
+    const candidate = h.transport.latest();
+    active.listeners.onEnd({ code: "stream-closed", reason: "old ended", retryable: true });
+    expect(h.controller.state().transport.phase).toBe("connecting");
+    candidate.listeners.onLayout?.(layout());
+    await candidate.listeners.onPaneEvent(PANE_A, {
+      type: "seed-batch",
+      batch: seedBatch("a"),
+    });
+    await candidate.listeners.onPaneEvent(PANE_B, {
+      type: "seed-batch",
+      batch: seedBatch("b"),
+    });
+    await flush();
+    expect(h.controller.state().transport.phase).toBe("connected");
+    await h.clock.advance(5_000);
+    expect(h.transport.sessions).toHaveLength(2);
+    // A late close callback from the retired active generation is inert.
+    active.listeners.onEnd({ code: "stream-closed", reason: "late", retryable: true });
+    expect(h.controller.state().transport.phase).toBe("connected");
+  });
+
+  it("explicit retry fences and retires an in-flight connected candidate", async () => {
+    const h = controllerHarness([PANE_A]);
+    h.controller.start();
+    await flush();
+    const active = h.transport.latest();
+    h.controller.setPanes([PANE_A, PANE_B]);
+    await flush();
+    const candidate = h.transport.latest();
+    h.controller.retry();
+    await flush();
+    expect(active.dispose).toHaveBeenCalledOnce();
+    expect(candidate.dispose).toHaveBeenCalledOnce();
+    expect(h.transport.sessions).toHaveLength(3);
+    expect(h.controller.state().transport.phase).toBe("connected");
+  });
+
+  it("prunes retained replay for panes removed by a committed candidate", async () => {
+    const h = controllerHarness([PANE_A]);
+    const firstSink = recordingSink();
+    h.controller.registerPaneSink(PANE_A, firstSink);
+    h.controller.start();
+    await flush();
+    await h.transport.latest().listeners.onPaneEvent(PANE_A, {
+      type: "seed-batch",
+      batch: seedBatch("removed"),
+    });
+    h.controller.setPanes([PANE_B]);
+    await flush();
+    const candidate = h.transport.latest();
+    candidate.listeners.onLayout?.({
+      ...layout(),
+      panes: [{ pane: PANE_B, left: 0, top: 0, width: 160, height: 40, active: true }],
+    });
+    await candidate.listeners.onPaneEvent(PANE_B, {
+      type: "seed-batch",
+      batch: seedBatch("kept"),
+    });
+    await flush();
+    const removedSink = recordingSink();
+    h.controller.registerPaneSink(PANE_A, removedSink);
+    await flush();
+    expect(removedSink.seeds).toEqual([]);
+  });
+
+  it("bounds a noisy candidate while a sibling never becomes seed-ready", async () => {
+    const h = controllerHarness([PANE_A]);
+    h.controller.start();
+    await flush();
+    const active = h.transport.latest();
+    h.controller.setPanes([PANE_A, PANE_B]);
+    await flush();
+    const candidate = h.transport.latest();
+    for (let index = 0; index < 1_025; index += 1) {
+      candidate.listeners.onPaneEvent(PANE_A, {
+        type: "output",
+        bytes: new Uint8Array([index % 255]),
+      });
+    }
+    expect(candidate.dispose).toHaveBeenCalledOnce();
+    expect(active.dispose).not.toHaveBeenCalled();
+    expect(h.controller.state().fault?.code).toBe("candidate-staging-overflow");
   });
 
   it("discards stale buffered bytes across a reconnect", async () => {

--- a/apps/desktop-renderer/src/terminal/pane-mirror-controller.ts
+++ b/apps/desktop-renderer/src/terminal/pane-mirror-controller.ts
@@ -86,6 +86,7 @@ export interface PaneMirrorControllerDependencies {
 const DEFAULT_RECONNECT_INITIAL_DELAY_MS = 250;
 const DEFAULT_RECONNECT_MAXIMUM_DELAY_MS = 4_000;
 const DEFAULT_RECONNECT_MAXIMUM_ATTEMPTS = 4;
+const CANDIDATE_READY_TIMEOUT_MS = 5_000;
 /**
  * Events that arrive before the pane's node registers its sink are buffered
  * and replayed in order on registration (the mount/connect race). There is no
@@ -93,6 +94,7 @@ const DEFAULT_RECONNECT_MAXIMUM_ATTEMPTS = 4;
  * the session reconnects for a fresh seed instead of splicing a gap.
  */
 const MAX_BUFFERED_EVENTS_PER_PANE = 1_024;
+const MAX_STAGED_CANDIDATE_EVENTS = 1_024;
 
 type MirrorSinkEvent =
   | PaneMirrorEvent
@@ -100,11 +102,28 @@ type MirrorSinkEvent =
 
 interface SinkChannel {
   sink: MirrorPaneSink | null;
+  sinkEpoch: number;
   readonly buffer: MirrorSinkEvent[];
-  /** True once this lease's atomic seed has reached (or passed) the channel. */
-  seedSeen: boolean;
+  /** Latest complete terminal representation, bounded to one atomic repaint. */
+  replay: PaneMirrorSeedBatch | (() => PaneMirrorSeedBatch) | null;
+  /** Latest authoritative pane geometry. */
+  geometry: { readonly cols: number; readonly rows: number } | null;
   /** Serializes buffered replay and live events so paint order is wire order. */
   tail: Promise<void>;
+}
+
+type StagedCandidateEvent =
+  | { readonly kind: "layout"; readonly layout: PaneStreamLayoutEvent }
+  | { readonly kind: "pane"; readonly pane: string; readonly event: PaneMirrorEvent };
+
+interface CandidateSession {
+  readonly generation: number;
+  readonly panes: readonly string[];
+  readonly staged: StagedCandidateEvent[];
+  readonly seeded: Set<string>;
+  readonly laidOut: Set<string>;
+  session: PaneStreamSessionHandle | null;
+  cancelDeadline: (() => void) | null;
 }
 
 function defaultSchedule(callback: () => void, delayMs: number): () => void {
@@ -145,11 +164,12 @@ export class PaneMirrorController {
   #transportState: DesktopDaemonTransportState = { phase: "idle" };
   #fault: PaneStreamTransportError | null = null;
   #session: PaneStreamSessionHandle | null = null;
+  #activeGeneration = 0;
+  #candidate: CandidateSession | null = null;
   #cancelRetry: (() => void) | null = null;
   #attempt = 0;
   #generation = 0;
   #disposed = false;
-  #freshSeedScheduled = false;
 
   constructor(dependencies: PaneMirrorControllerDependencies) {
     this.#transport = dependencies.transport;
@@ -186,7 +206,7 @@ export class PaneMirrorController {
    * place in the tab strip rather than appending a new tab per frame.
    */
   #onLayout(generation: number, layout: PaneStreamLayoutEvent): void {
-    if (this.#disposed || generation !== this.#generation) return;
+    if (this.#disposed || generation !== this.#activeGeneration) return;
     const key = layoutWindowKey(layout);
     const index = this.#layouts.findIndex((known) => layoutWindowKey(known) === key);
     if (index >= 0) this.#layouts[index] = layout;
@@ -222,41 +242,53 @@ export class PaneMirrorController {
    */
   registerPaneSink(pane: string, sink: MirrorPaneSink): () => void {
     const channel = this.#channel(pane);
-    const needsFreshSeed =
-      channel.seedSeen && !channel.buffer.some((event) => event.type === "seed-batch");
+    const sinkEpoch = ++channel.sinkEpoch;
     channel.sink = sink;
     const buffered = channel.buffer.splice(0, channel.buffer.length);
-    for (const event of buffered) {
+    if (channel.replay) {
+      const replay = typeof channel.replay === "function" ? channel.replay() : channel.replay;
       channel.tail = channel.tail
-        .then(() => (channel.sink === sink ? this.#applyToSink(sink, event) : undefined))
+        .then(() =>
+          channel.sink === sink && channel.sinkEpoch === sinkEpoch
+            ? sink.applySeedBatch(replay)
+            : undefined,
+        )
+        .catch(() => undefined);
+    } else if (channel.geometry) {
+      const geometry = channel.geometry;
+      channel.tail = channel.tail
+        .then(() =>
+          channel.sink === sink && channel.sinkEpoch === sinkEpoch
+            ? sink.applyGeometry(geometry.cols, geometry.rows)
+            : undefined,
+        )
         .catch(() => undefined);
     }
-    if (needsFreshSeed) this.#scheduleFreshSeed();
+    for (const event of buffered) {
+      channel.tail = channel.tail
+        .then(() =>
+          channel.sink === sink && channel.sinkEpoch === sinkEpoch
+            ? this.#applyToSink(sink, event)
+            : undefined,
+        )
+        .catch(() => undefined);
+    }
     return () => {
       if (channel.sink === sink) channel.sink = null;
     };
   }
 
-  /**
-   * A pane node can be remounted after its one-shot seed was consumed (HMR,
-   * view reparenting, or a recovered renderer). The protocol intentionally has
-   * no per-pane reseed verb, so coalesce all such registrations into one fresh
-   * lease. That gives every mounted sink a new atomic seed without retaining an
-   * unbounded replay log of terminal output in the renderer process.
-   */
-  #scheduleFreshSeed(): void {
-    if (this.#disposed || this.#freshSeedScheduled) return;
-    this.#freshSeedScheduled = true;
-    queueMicrotask(() => {
-      this.#freshSeedScheduled = false;
-      if (!this.#disposed) this.retry();
-    });
-  }
-
   #channel(pane: string): SinkChannel {
     let channel = this.#channels.get(pane);
     if (!channel) {
-      channel = { sink: null, buffer: [], seedSeen: false, tail: Promise.resolve() };
+      channel = {
+        sink: null,
+        sinkEpoch: 0,
+        buffer: [],
+        replay: null,
+        geometry: null,
+        tail: Promise.resolve(),
+      };
       this.#channels.set(pane, channel);
     }
     return channel;
@@ -275,7 +307,36 @@ export class PaneMirrorController {
 
   #enqueueSinkEvent(pane: string, event: MirrorSinkEvent): void | Promise<void> {
     const channel = this.#channel(pane);
+    if (event.type === "geometry") {
+      channel.geometry = { cols: event.cols, rows: event.rows };
+      if (channel.replay && typeof channel.replay !== "function") {
+        channel.replay = { ...channel.replay, reset: channel.geometry };
+      }
+    } else if (event.type === "seed-batch") {
+      channel.replay = event.batch;
+    } else if (event.type === "output" && event.replay) {
+      channel.replay = event.replay;
+    } else if (event.type === "output" && channel.replay && typeof channel.replay !== "function") {
+      if (channel.replay.held.length >= MAX_BUFFERED_EVENTS_PER_PANE) {
+        this.#scheduleReconnect({
+          code: "mirror-replay-overflow",
+          reason: "The retained terminal replay exceeded its bounded legacy tail.",
+          retryable: true,
+        });
+      } else {
+        channel.replay = { ...channel.replay, held: [...channel.replay.held, event.bytes] };
+      }
+    } else if (event.type === "cursor" && channel.replay && typeof channel.replay !== "function") {
+      channel.replay = { ...channel.replay, cursor: { x: event.x, y: event.y } };
+    }
     if (!channel.sink) {
+      if (event.type === "geometry") return;
+      if (
+        channel.replay &&
+        (event.type === "seed-batch" || event.type === "output" || event.type === "cursor")
+      ) {
+        return;
+      }
       if (channel.buffer.length >= MAX_BUFFERED_EVENTS_PER_PANE) {
         this.#scheduleReconnect({
           code: "mirror-sink-missing",
@@ -287,8 +348,14 @@ export class PaneMirrorController {
       channel.buffer.push(event);
       return;
     }
+    const sink = channel.sink;
+    const sinkEpoch = channel.sinkEpoch;
     channel.tail = channel.tail
-      .then(() => (channel.sink ? this.#applyToSink(channel.sink, event) : undefined))
+      .then(() =>
+        channel.sink === sink && channel.sinkEpoch === sinkEpoch
+          ? this.#applyToSink(sink, event)
+          : undefined,
+      )
       .catch(() => undefined);
     return channel.tail;
   }
@@ -304,6 +371,7 @@ export class PaneMirrorController {
     this.#attempt = 0;
     this.#cancelRetry?.();
     this.#cancelRetry = null;
+    this.#retireCandidate();
     this.#retireSession();
     this.#connect();
   }
@@ -316,18 +384,23 @@ export class PaneMirrorController {
       return;
     }
     this.#panes = next;
-    this.#paneStates = new Map(next.map((pane) => [pane, { kind: "connecting" } as const]));
     this.#attempt = 0;
     this.#cancelRetry?.();
     this.#cancelRetry = null;
-    this.#retireSession();
-    this.#connect();
+    if (!this.#session) {
+      this.#paneStates = new Map(next.map((pane) => [pane, { kind: "connecting" } as const]));
+      this.#connect();
+      return;
+    }
+    this.#connectCandidate(next);
   }
 
   dispose(): void {
     if (this.#disposed) return;
     this.#disposed = true;
     this.#generation += 1;
+    this.#activeGeneration = 0;
+    this.#retireCandidate();
     this.#cancelRetry?.();
     this.#cancelRetry = null;
     this.#retireSession();
@@ -343,6 +416,18 @@ export class PaneMirrorController {
       } catch {
         // The session is already the retired generation.
       }
+    }
+  }
+
+  #retireCandidate(): void {
+    const candidate = this.#candidate;
+    this.#candidate = null;
+    candidate?.cancelDeadline?.();
+    if (!candidate?.session) return;
+    try {
+      candidate.session.dispose();
+    } catch {
+      // The candidate never became authoritative; teardown is best-effort.
     }
   }
 
@@ -367,16 +452,201 @@ export class PaneMirrorController {
     this.#emit();
   }
 
+  /**
+   * Establish a changed pane-set beside the live lease. The old session keeps
+   * painting (and its layouts remain authoritative) until redemption of the
+   * candidate succeeds. A newer candidate fences every callback/result from an
+   * older one, so a slow issue call can never roll the surface backwards.
+   */
+  #connectCandidate(panes: readonly string[]): void {
+    this.#retireCandidate();
+    const generation = ++this.#generation;
+    const candidate: CandidateSession = {
+      generation,
+      panes: [...panes],
+      staged: [],
+      seeded: new Set(),
+      laidOut: new Set(),
+      session: null,
+      cancelDeadline: null,
+    };
+    this.#candidate = candidate;
+    candidate.cancelDeadline = this.#schedule(() => {
+      if (
+        this.#disposed ||
+        this.#candidate !== candidate ||
+        candidate.generation !== this.#generation
+      )
+        return;
+      this.#retireCandidate();
+      this.#fault = {
+        code: "candidate-ready-timeout",
+        reason: "The replacement pane stream did not provide a complete initial layout and seed.",
+        retryable: true,
+      };
+      this.#emit();
+    }, CANDIDATE_READY_TIMEOUT_MS);
+    void this.#transport
+      .connect(
+        { workspaceName: this.#workspaceName, panes: candidate.panes },
+        {
+          onPaneEvent: (pane, event) => {
+            if (generation === this.#activeGeneration) {
+              return this.#onPaneEvent(generation, pane, event);
+            }
+            if (
+              this.#disposed ||
+              generation !== this.#generation ||
+              this.#candidate?.generation !== generation
+            )
+              return;
+            if (!this.#stageCandidate(candidate, { kind: "pane", pane, event })) return;
+            if (event.type === "seed-batch" || event.type === "closed") {
+              candidate.seeded.add(pane);
+            }
+            if (event.type === "closed") candidate.laidOut.add(pane);
+            this.#commitCandidateIfReady(candidate);
+          },
+          onLayout: (layout) => {
+            if (generation === this.#activeGeneration) {
+              this.#onLayout(generation, layout);
+              return;
+            }
+            if (
+              this.#disposed ||
+              generation !== this.#generation ||
+              this.#candidate?.generation !== generation
+            )
+              return;
+            if (!this.#stageCandidate(candidate, { kind: "layout", layout })) return;
+            for (const pane of layout.panes) {
+              if (pane.pane) candidate.laidOut.add(pane.pane);
+            }
+            this.#commitCandidateIfReady(candidate);
+          },
+          onEnd: (error) => {
+            if (generation === this.#activeGeneration) {
+              this.#onEnd(generation, error);
+              return;
+            }
+            if (generation !== this.#generation || this.#candidate?.generation !== generation)
+              return;
+            this.#retireCandidate();
+            if (error && !this.#session) this.#scheduleReconnect(error);
+            else {
+              if (error) this.#fault = error;
+              this.#emit();
+            }
+          },
+        },
+      )
+      .then((result) => {
+        if (
+          this.#disposed ||
+          generation !== this.#generation ||
+          this.#candidate?.generation !== generation
+        ) {
+          if (result.status === "connected") result.session.dispose();
+          return;
+        }
+        if (result.status === "error") {
+          this.#retireCandidate();
+          if (!this.#session) this.#scheduleReconnect(result.error);
+          else {
+            this.#fault = result.error;
+            this.#emit();
+          }
+          return;
+        }
+
+        candidate.session = result.session;
+        this.#commitCandidateIfReady(candidate);
+      })
+      .catch(() => {
+        if (
+          this.#disposed ||
+          generation !== this.#generation ||
+          this.#candidate?.generation !== generation
+        )
+          return;
+        this.#retireCandidate();
+        const error: PaneStreamTransportError = {
+          code: "attachment-unavailable",
+          reason: "The pane stream candidate could not be established.",
+          retryable: true,
+        };
+        if (!this.#session) this.#scheduleReconnect(error);
+        else {
+          this.#fault = error;
+          this.#emit();
+        }
+      });
+  }
+
+  #stageCandidate(candidate: CandidateSession, event: StagedCandidateEvent): boolean {
+    if (candidate.staged.length >= MAX_STAGED_CANDIDATE_EVENTS) {
+      this.#retireCandidate();
+      this.#fault = {
+        code: "candidate-staging-overflow",
+        reason:
+          "The replacement pane stream did not become paint-ready within its bounded staging window.",
+        retryable: true,
+      };
+      this.#emit();
+      return false;
+    }
+    candidate.staged.push(event);
+    return true;
+  }
+
+  #commitCandidateIfReady(candidate: CandidateSession): void {
+    if (
+      this.#disposed ||
+      this.#candidate !== candidate ||
+      candidate.generation !== this.#generation ||
+      !candidate.session ||
+      candidate.panes.some((pane) => !candidate.seeded.has(pane) || !candidate.laidOut.has(pane))
+    ) {
+      return;
+    }
+    const previous = this.#session;
+    this.#session = candidate.session;
+    this.#activeGeneration = candidate.generation;
+    candidate.cancelDeadline?.();
+    this.#candidate = null;
+    this.#paneStates = new Map(
+      candidate.panes.map((pane) => [pane, { kind: "connecting" } as const]),
+    );
+    const retainedPanes = new Set(candidate.panes);
+    for (const [pane, channel] of this.#channels) {
+      if (!retainedPanes.has(pane)) this.#channels.delete(pane);
+      else channel.buffer.length = 0;
+    }
+    this.#setTransport({ phase: "connected" }, null);
+    for (const staged of candidate.staged) {
+      if (staged.kind === "layout") this.#onLayout(candidate.generation, staged.layout);
+      else void this.#onPaneEvent(candidate.generation, staged.pane, staged.event);
+    }
+    try {
+      previous?.dispose();
+    } catch {
+      // The candidate is already active; an old-handle teardown fault must not
+      // invalidate the successful handoff.
+    }
+  }
+
   #connect(): void {
     if (this.#disposed || this.#panes.length === 0) return;
     const generation = ++this.#generation;
+    this.#activeGeneration = generation;
     // A new lease reseeds every pane; bytes buffered for the old one are stale.
     // The layouts are NOT cleared: tmux re-sends a frame per window on
     // subscribe, and blanking the tab strip for the width of a reconnect would
     // make a recoverable stream drop look like the session losing its windows.
     for (const channel of this.#channels.values()) {
       channel.buffer.length = 0;
-      channel.seedSeen = false;
+      channel.replay = null;
+      channel.geometry = null;
     }
     for (const [pane, state] of this.#paneStates) {
       if (state.kind !== "ended") this.#paneStates.set(pane, { kind: "connecting" });
@@ -401,6 +671,7 @@ export class PaneMirrorController {
           return;
         }
         this.#session = result.session;
+        this.#activeGeneration = generation;
         this.#attempt = 0;
         this.#setTransport({ phase: "connected" }, null);
       })
@@ -415,7 +686,7 @@ export class PaneMirrorController {
   }
 
   #onPaneEvent(generation: number, pane: string, event: PaneMirrorEvent): void | Promise<void> {
-    if (this.#disposed || generation !== this.#generation) return;
+    if (this.#disposed || generation !== this.#activeGeneration) return;
     const current = this.#paneStates.get(pane);
     if (!current) return;
     if (event.type === "closed") {
@@ -430,15 +701,18 @@ export class PaneMirrorController {
       return;
     }
     if (event.type === "seed-batch" && current.kind !== "ended") {
-      this.#channel(pane).seedSeen = true;
       this.#setPaneState(pane, { kind: "live", flowPaused: false });
     }
     return this.#enqueueSinkEvent(pane, event);
   }
 
   #onEnd(generation: number, error: PaneStreamTransportError | null): void {
-    if (this.#disposed || generation !== this.#generation) return;
+    if (this.#disposed || generation !== this.#activeGeneration) return;
     this.#session = null;
+    if (this.#candidate) {
+      this.#setTransport({ phase: "connecting" }, error);
+      return;
+    }
     if (error === null) {
       // Clean end: every leased pane closed in tmux. Nothing to reconnect to.
       this.#setTransport({ phase: "idle" }, null);
@@ -471,7 +745,8 @@ export class PaneMirrorController {
     );
     this.#cancelRetry = this.#schedule(() => {
       this.#cancelRetry = null;
-      if (this.#disposed || generation !== this.#generation) return;
+      if (this.#disposed || generation !== this.#generation || this.#session || this.#candidate)
+        return;
       this.#connect();
     }, delay);
   }

--- a/apps/desktop-renderer/src/terminal/pane-stream-transport.test.ts
+++ b/apps/desktop-renderer/src/terminal/pane-stream-transport.test.ts
@@ -1,4 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  blankTerminalReplicaSnapshot,
+  encodeSemanticTerminalUpdate,
+  hashTerminalDeliveryRepresentation,
+  hashTerminalReplicaSnapshot,
+  negotiateTerminalDelivery,
+  splitTerminalDeliveryChunks,
+} from "@tmux-ide/core";
 
 import {
   PANE_STREAM_MAX_DESCRIPTOR_LIFETIME_MS,
@@ -23,6 +31,20 @@ const PANE_B = "pane.workspace.b2";
 
 function encodeBase64(text: string): string {
   return Buffer.from(text, "utf8").toString("base64");
+}
+
+function encodeBytesBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+function sendSemanticReady(socket: FakeSocket, pane = PANE_A): void {
+  const negotiation = negotiateTerminalDelivery(
+    { protocolVersions: [1], encodings: ["semantic-v1"], richPlacements: true },
+    "20000000-0000-4000-8000-000000000001",
+    "20000000-0000-4000-8000-000000000002",
+  );
+  if (!negotiation.accepted) throw new Error("semantic negotiation failed");
+  socket.serverSends({ type: "terminal-delivery-ready", pane, negotiation });
 }
 
 interface Scheduled {
@@ -136,6 +158,7 @@ function harness(options: {
   panes?: readonly string[];
   deferApplies?: boolean;
   listeners?: Partial<PaneStreamSessionListeners>;
+  terminalDelivery?: null;
 }): Harness {
   const clock = new Clock();
   const socket = new FakeSocket();
@@ -147,6 +170,7 @@ function harness(options: {
     createWebSocket: () => socket,
     now: clock.now,
     schedule: clock.schedule,
+    ...(options.terminalDelivery === null ? { terminalDelivery: null } : {}),
   });
   const connect = transport.connect(
     { workspaceName: "workspace-a", panes: options.panes ?? [PANE_A, PANE_B] },
@@ -263,9 +287,20 @@ describe("pane-stream transport admission", () => {
     });
   });
 
-  it("sends exactly one redeem frame committing to delivery acks", async () => {
+  it("sends exactly one redeem frame without claiming the legacy ACK lane", async () => {
     const h = await liveHarness();
     expect(h.socket.sent).toHaveLength(1);
+    expect(JSON.parse(h.socket.sent[0]!)).toEqual({
+      type: "redeem",
+      protocolVersion: 1,
+      ticket: TICKET,
+      requestId: REQUEST_ID,
+      daemonInstanceId: DAEMON_INSTANCE_ID,
+    });
+  });
+
+  it("retains cumulative delivery ACKs for the explicit legacy profile", async () => {
+    const h = await liveHarness({ terminalDelivery: null });
     expect(JSON.parse(h.socket.sent[0]!)).toEqual({
       type: "redeem",
       protocolVersion: 1,
@@ -337,6 +372,113 @@ describe("pane-stream transport admission", () => {
 });
 
 describe("pane-stream transport demultiplexing", () => {
+  it("accepts semantic negotiation exactly once", async () => {
+    const h = await liveHarness();
+    sendSemanticReady(h.socket);
+    sendSemanticReady(h.socket);
+    await flushMicrotasks();
+    expect(h.ends).toEqual([expect.objectContaining({ code: "protocol-error", retryable: false })]);
+  });
+
+  it("rejects legacy terminal bytes after semantic cutover", async () => {
+    const h = await liveHarness();
+    sendSemanticReady(h.socket);
+    h.socket.serverSends({ type: "output", pane: PANE_A, seq: 1, data: encodeBase64("stale") });
+    await flushMicrotasks();
+    expect(h.events).toHaveLength(0);
+    expect(h.ends).toEqual([expect.objectContaining({ code: "protocol-error", retryable: false })]);
+  });
+
+  it("never resurrects a semantic lane after a delivery fault", async () => {
+    const h = await liveHarness();
+    h.socket.serverSends({
+      type: "terminal-delivery-fault",
+      pane: PANE_A,
+      fault: {
+        type: "terminal.delivery.fault",
+        reason: "source-closed",
+        message: "source closed",
+        deliveryNonce: "20000000-0000-4000-8000-000000000002",
+      },
+    });
+    sendSemanticReady(h.socket);
+    await flushMicrotasks();
+    // The invalid resurrection retires the session before the queued fault
+    // paint can run; importantly, no stale terminal state reaches the sink.
+    expect(h.events).toEqual([]);
+    expect(h.ends).toEqual([expect.objectContaining({ code: "protocol-error", retryable: false })]);
+  });
+
+  it("applies a semantic seed atomically and ACKs only after the renderer settles", async () => {
+    const h = await liveHarness({ deferApplies: true });
+    const generation = "20000000-0000-4000-8000-000000000001";
+    const deliveryNonce = "20000000-0000-4000-8000-000000000002";
+    const transactionId = "20000000-0000-4000-8000-000000000003";
+    const negotiation = negotiateTerminalDelivery(
+      { protocolVersions: [1], encodings: ["semantic-v1"], richPlacements: true },
+      generation,
+      deliveryNonce,
+    );
+    if (!negotiation.accepted) throw new Error("semantic negotiation failed");
+    const snapshot = blankTerminalReplicaSnapshot(12, 4);
+    const bytes = encodeSemanticTerminalUpdate({ frame: "seed", revision: 0, snapshot });
+    const incarnation = `${generation}:0`;
+    h.socket.serverSends({
+      type: "terminal-delivery-ready",
+      pane: PANE_A,
+      negotiation,
+    });
+    h.socket.serverSends({
+      type: "terminal-delivery-envelope",
+      pane: PANE_A,
+      envelope: {
+        type: "terminal.delivery",
+        workspaceName: "workspace-a",
+        semanticPaneId: PANE_A,
+        generation,
+        incarnation,
+        deliveryNonce,
+        transactionId,
+        protocolVersion: 1,
+        encoding: "semantic-v1",
+        frame: "seed",
+        baseRevision: null,
+        canonicalRevision: 0,
+        canonicalStateHash: hashTerminalReplicaSnapshot(snapshot),
+        representationHash: hashTerminalDeliveryRepresentation(bytes),
+        representationBytes: bytes.byteLength,
+        chunkCount: splitTerminalDeliveryChunks(transactionId, bytes).length,
+        canonicalEquivalent: true,
+        history: "complete",
+        richPlacements: true,
+      },
+    });
+    for (const chunk of splitTerminalDeliveryChunks(transactionId, bytes)) {
+      h.socket.serverSends({
+        type: "terminal-delivery-chunk",
+        pane: PANE_A,
+        transactionId,
+        index: chunk.index,
+        data: encodeBytesBase64(chunk.bytes),
+      });
+    }
+    await flushMicrotasks();
+    expect(h.events).toHaveLength(1);
+    expect(h.events[0]).toMatchObject({ pane: PANE_A, event: { type: "seed-batch" } });
+    expect(h.socket.sent).toHaveLength(1);
+    h.settleApply();
+    await flushMicrotasks();
+    expect(JSON.parse(h.socket.sent[1]!)).toMatchObject({
+      type: "terminal-delivery-ack",
+      ack: {
+        workspaceName: "workspace-a",
+        semanticPaneId: PANE_A,
+        canonicalRevision: 0,
+        transactionId,
+      },
+    });
+  });
+
   it("delivers per-pane events in wire order with decoded bytes", async () => {
     const h = await liveHarness();
     h.socket.serverSends({ type: "output", pane: PANE_A, seq: 1, data: encodeBase64("alpha") });

--- a/apps/desktop-renderer/src/terminal/pane-stream-transport.ts
+++ b/apps/desktop-renderer/src/terminal/pane-stream-transport.ts
@@ -11,7 +11,20 @@ import {
   type PaneStreamIssueDescriptor,
   type PaneStreamLeaseRequest,
   type PaneStreamServerFrame,
+  type TerminalDeliveryAck,
+  type TerminalDeliveryOffer,
 } from "@tmux-ide/contracts";
+import {
+  TerminalDeliveryAssembler,
+  admitTerminalDeliveryChunk,
+  admitTerminalDeliveryEnvelope,
+  commitTerminalDelivery,
+  completeTerminalDelivery,
+  createTerminalDeliveryClientState,
+  decodeSemanticTerminalUpdate,
+  encodeAnsiTerminalRepresentation,
+  type TerminalDeliveryClientState,
+} from "@tmux-ide/core";
 import { browserWebSocketHandshakeUrl } from "../runtime/browser-websocket-session.ts";
 import { browserInitiatedWebSocketCloseCode } from "../browser-websocket.ts";
 
@@ -167,6 +180,8 @@ export interface PaneStreamTransportDependencies {
   readonly now?: () => number;
   readonly schedule?: (callback: () => void, delayMs: number) => () => void;
   readonly issueTimeoutMs?: number;
+  /** Default is the canonical semantic lane; null is the legacy compatibility profile. */
+  readonly terminalDelivery?: TerminalDeliveryOffer | null;
 }
 
 /**
@@ -251,6 +266,7 @@ function decodeBase64(value: string): Uint8Array | null {
 }
 
 interface SafeStreamDescriptor {
+  readonly workspaceName: string;
   readonly webSocketUrl: string;
   readonly daemonInstanceId: string;
   readonly requestId: string;
@@ -286,9 +302,13 @@ function validateIssueDescriptor(
     ticket: descriptor.redemptionTicket,
     requestId: descriptor.requestId,
     daemonInstanceId: descriptor.daemonInstanceId,
-    deliveryAcks: true,
+    // Semantic delivery owns its transaction ACK lifecycle. Advertising the
+    // legacy cumulative renderer ACK lane at the same time is an invalid dual
+    // ownership claim and the daemon correctly rejects it.
+    ...(request.terminalDelivery ? {} : { deliveryAcks: true }),
   });
   return {
+    workspaceName: request.workspaceName,
     webSocketUrl: descriptor.webSocketUrl,
     daemonInstanceId: descriptor.daemonInstanceId,
     requestId: descriptor.requestId,
@@ -318,6 +338,9 @@ interface PaneChannel {
   pendingApplies: number;
   applyTail: Promise<void>;
   closed: boolean;
+  semanticPhase: "awaiting" | "live" | "faulted";
+  semanticDelivery: TerminalDeliveryClientState | null;
+  semanticAssembler: TerminalDeliveryAssembler | null;
 }
 
 class PaneStreamSession {
@@ -363,6 +386,9 @@ class PaneStreamSession {
         pendingApplies: 0,
         applyTail: Promise.resolve(),
         closed: false,
+        semanticPhase: "awaiting",
+        semanticDelivery: null,
+        semanticAssembler: null,
       });
     }
     this.#connectPromise = new Promise((resolve) => {
@@ -617,11 +643,131 @@ class PaneStreamSession {
       return;
     }
 
-    // This renderer still requests the raw-v1 delivery profile. Keep its
-    // parser closed over that profile instead of relying on every future
-    // server-frame variant to happen to carry the legacy pane/sequence pair.
-    // Semantic delivery/control acknowledgements on this socket therefore
-    // fail closed until this client explicitly negotiates and consumes them.
+    const addressedChannel = "pane" in frame ? this.#panes.get(frame.pane) : undefined;
+    if ("pane" in frame && (!addressedChannel || addressedChannel.closed)) {
+      // Pane lanes are monotonic. Once closed/faulted, no later ready, seed or
+      // patch can resurrect the lane or reset its generation/revision.
+      this.#protocolFailure();
+      return;
+    }
+
+    if (frame.type === "terminal-delivery-ready") {
+      const channel = addressedChannel!;
+      if (
+        channel.semanticPhase !== "awaiting" ||
+        channel.semanticDelivery !== null ||
+        !frame.negotiation.accepted
+      ) {
+        this.#protocolFailure();
+        return;
+      }
+      channel.semanticDelivery = createTerminalDeliveryClientState(
+        frame.negotiation.negotiated,
+        this.#descriptor.workspaceName,
+        frame.pane,
+      );
+      channel.semanticPhase = "live";
+      channel.semanticAssembler = null;
+      return;
+    }
+    if (frame.type === "terminal-delivery-envelope") {
+      const channel = addressedChannel!;
+      if (
+        channel.semanticPhase !== "live" ||
+        !channel.semanticDelivery ||
+        frame.envelope.semanticPaneId !== frame.pane
+      ) {
+        this.#protocolFailure();
+        return;
+      }
+      const next = admitTerminalDeliveryEnvelope(channel.semanticDelivery, frame.envelope);
+      if (next.failed) {
+        this.#protocolFailure();
+        return;
+      }
+      channel.semanticDelivery = next;
+      channel.semanticAssembler = new TerminalDeliveryAssembler(frame.envelope);
+      return;
+    }
+    if (frame.type === "terminal-delivery-chunk") {
+      const channel = addressedChannel!;
+      if (
+        channel.semanticPhase !== "live" ||
+        !channel.semanticDelivery ||
+        !channel.semanticAssembler
+      ) {
+        this.#protocolFailure();
+        return;
+      }
+      try {
+        const decoded = decodeBase64(frame.data);
+        if (!decoded) throw new TypeError("Terminal delivery chunk was not base64");
+        const bytes = new Uint8Array(decoded);
+        channel.semanticAssembler.write({
+          type: "terminal.delivery.chunk",
+          transactionId: frame.transactionId,
+          index: frame.index,
+          bytes,
+        });
+        channel.semanticDelivery = admitTerminalDeliveryChunk(channel.semanticDelivery, {
+          type: "terminal.delivery.chunk",
+          transactionId: frame.transactionId,
+          index: frame.index,
+          bytes,
+        });
+        const envelope = channel.semanticDelivery.inFlight;
+        if (!envelope || channel.semanticDelivery.nextChunk !== envelope.chunkCount) return;
+        const staged = completeTerminalDelivery(
+          channel.semanticDelivery,
+          channel.semanticAssembler,
+        );
+        // Decode before commit so malformed semantic payloads retire the lane.
+        decodeSemanticTerminalUpdate(staged.bytes);
+        const previousSnapshot = channel.semanticDelivery.canonicalSnapshot;
+        const committed = commitTerminalDelivery(channel.semanticDelivery, staged);
+        channel.semanticDelivery = committed.state;
+        channel.semanticAssembler = null;
+        const snapshot = committed.state.canonicalSnapshot;
+        if (!snapshot) {
+          this.#deliverSemantic(channel, { type: "closed" }, committed.ack);
+          return;
+        }
+        const ansi = encodeAnsiTerminalRepresentation(previousSnapshot, snapshot);
+        const requiresAtomicReset =
+          !previousSnapshot ||
+          previousSnapshot.cols !== snapshot.cols ||
+          previousSnapshot.rows !== snapshot.rows;
+        this.#deliverSemantic(
+          channel,
+          requiresAtomicReset
+            ? {
+                type: "seed-batch",
+                batch: {
+                  reset: { cols: snapshot.cols, rows: snapshot.rows },
+                  seed: ansi,
+                  held: [],
+                  cursor: { x: snapshot.cursor.x, y: snapshot.cursor.y },
+                },
+              }
+            : { type: "output", bytes: ansi },
+          committed.ack,
+        );
+      } catch {
+        this.#protocolFailure();
+      }
+      return;
+    }
+    if (frame.type === "terminal-delivery-fault") {
+      const channel = addressedChannel!;
+      channel.semanticPhase = "faulted";
+      channel.closed = true;
+      channel.semanticAssembler = null;
+      this.#deliverSemantic(channel, { type: "closed" }, null);
+      return;
+    }
+
+    // Keep the legacy parser closed over the old sequenced profile. Semantic
+    // delivery frames were consumed above and use transaction acknowledgements.
     if (
       frame.type !== "seed-batch" &&
       frame.type !== "output" &&
@@ -635,6 +781,18 @@ class PaneStreamSession {
 
     const channel = this.#panes.get(frame.pane);
     if (!channel || channel.closed || frame.seq !== channel.receivedSeq + 1) {
+      this.#protocolFailure();
+      return;
+    }
+    if (
+      channel.semanticPhase === "live" &&
+      (frame.type === "seed-batch" ||
+        frame.type === "output" ||
+        frame.type === "cursor" ||
+        frame.type === "flow")
+    ) {
+      // Negotiation is a one-way cutover. Accepting legacy bytes afterwards
+      // creates two competing revision lanes and can repaint stale terminal state.
       this.#protocolFailure();
       return;
     }
@@ -725,6 +883,50 @@ class PaneStreamSession {
           1013,
           "renderer-consumer-failed",
         );
+      })
+      .finally(() => {
+        channel.pendingApplies -= 1;
+      });
+  }
+
+  #deliverSemantic(
+    channel: PaneChannel,
+    event: PaneMirrorEvent,
+    ack: TerminalDeliveryAck | null,
+  ): void {
+    if (channel.pendingApplies >= PANE_STREAM_MAX_PENDING_EVENTS_PER_PANE) {
+      this.#retire(
+        transportError(
+          "renderer-backpressure",
+          "The renderer could not keep up with the pane stream.",
+          true,
+        ),
+        1013,
+        "renderer-backpressure",
+      );
+      return;
+    }
+    channel.pendingApplies += 1;
+    channel.applyTail = channel.applyTail
+      .then(async () => {
+        if (this.#phase === "closed") return;
+        await this.#listeners.onPaneEvent(channel.pane, event);
+        if (ack && this.#socket.readyState === WS_OPEN) {
+          this.#socket.send(JSON.stringify({ type: "terminal-delivery-ack", ack }));
+        }
+      })
+      .catch(() => {
+        if (this.#phase !== "closed") {
+          this.#retire(
+            transportError(
+              "renderer-consumer-failed",
+              "The renderer could not consume the pane stream.",
+              true,
+            ),
+            1013,
+            "renderer-consumer-failed",
+          );
+        }
       })
       .finally(() => {
         channel.pendingApplies -= 1;
@@ -862,6 +1064,14 @@ export function createPaneStreamTransport(
   const schedule = dependencies.schedule ?? defaultSchedule;
   const createWebSocket = dependencies.createWebSocket ?? defaultCreateWebSocket;
   const issueTimeoutMs = boundedIssueTimeout(dependencies.issueTimeoutMs);
+  const terminalDelivery =
+    dependencies.terminalDelivery === undefined
+      ? ({
+          protocolVersions: [1],
+          encodings: ["semantic-v1"],
+          richPlacements: true,
+        } as const)
+      : dependencies.terminalDelivery;
 
   return Object.freeze({
     connect: async (
@@ -873,6 +1083,7 @@ export function createPaneStreamTransport(
         workspaceName: request.workspaceName,
         panes: request.panes,
         viewerMode: "read-only",
+        ...(terminalDelivery ? { terminalDelivery } : {}),
       });
       if (
         !parsedRequest.success ||

--- a/apps/desktop-renderer/src/terminal/pane-stream-transport.ts
+++ b/apps/desktop-renderer/src/terminal/pane-stream-transport.ts
@@ -22,6 +22,7 @@ import {
   completeTerminalDelivery,
   createTerminalDeliveryClientState,
   decodeSemanticTerminalUpdate,
+  encodeAnsiTerminalPatchRepresentation,
   encodeAnsiTerminalRepresentation,
   type TerminalDeliveryClientState,
 } from "@tmux-ide/core";
@@ -114,7 +115,12 @@ export interface PaneMirrorSeedBatch {
 
 export type PaneMirrorEvent =
   | { readonly type: "seed-batch"; readonly batch: PaneMirrorSeedBatch }
-  | { readonly type: "output"; readonly bytes: Uint8Array }
+  | {
+      readonly type: "output";
+      readonly bytes: Uint8Array;
+      /** Lazily materialized canonical repaint retained for sink handoff. */
+      readonly replay?: () => PaneMirrorSeedBatch;
+    }
   | { readonly type: "cursor"; readonly x: number; readonly y: number }
   | {
       readonly type: "flow";
@@ -722,7 +728,7 @@ class PaneStreamSession {
           channel.semanticAssembler,
         );
         // Decode before commit so malformed semantic payloads retire the lane.
-        decodeSemanticTerminalUpdate(staged.bytes);
+        const semanticUpdate = decodeSemanticTerminalUpdate(staged.bytes);
         const previousSnapshot = channel.semanticDelivery.canonicalSnapshot;
         const committed = commitTerminalDelivery(channel.semanticDelivery, staged);
         channel.semanticDelivery = committed.state;
@@ -732,7 +738,10 @@ class PaneStreamSession {
           this.#deliverSemantic(channel, { type: "closed" }, committed.ack);
           return;
         }
-        const ansi = encodeAnsiTerminalRepresentation(previousSnapshot, snapshot);
+        const ansi =
+          semanticUpdate.frame === "patch"
+            ? encodeAnsiTerminalPatchRepresentation(semanticUpdate.patch, snapshot)
+            : encodeAnsiTerminalRepresentation(previousSnapshot, snapshot);
         const requiresAtomicReset =
           !previousSnapshot ||
           previousSnapshot.cols !== snapshot.cols ||
@@ -749,7 +758,19 @@ class PaneStreamSession {
                   cursor: { x: snapshot.cursor.x, y: snapshot.cursor.y },
                 },
               }
-            : { type: "output", bytes: ansi },
+            : {
+                type: "output",
+                bytes: ansi,
+                // Snapshot state already exists for semantic validation. Keep
+                // it by reference and do the full-grid ANSI materialization
+                // only if a replacement sink actually asks for a repaint.
+                replay: () => ({
+                  reset: { cols: snapshot.cols, rows: snapshot.rows },
+                  seed: encodeAnsiTerminalRepresentation(null, snapshot),
+                  held: [],
+                  cursor: { x: snapshot.cursor.x, y: snapshot.cursor.y },
+                }),
+              },
           committed.ack,
         );
       } catch {

--- a/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
+++ b/apps/desktop-renderer/src/terminal/terminal-surface.test.tsx
@@ -68,6 +68,10 @@ const TARGET_B: TerminalAttachmentSemanticTarget = {
   workspaceName: "workspace-b",
   semanticPaneId: "agent-b",
 };
+const TARGET_C: TerminalAttachmentSemanticTarget = {
+  workspaceName: "workspace-c",
+  semanticPaneId: "agent-c",
+};
 
 function connectedState(
   clientViewport: TerminalAttachmentViewport = { cols: 80, rows: 24 },
@@ -904,13 +908,17 @@ describe("TerminalSurface", () => {
     blockedWrite.resolve();
   });
 
-  it("retires the old attachment and reconnects when the semantic target changes", async () => {
+  it("retires pane-scoped authority immediately when the semantic target changes", async () => {
     const attachments = [attachmentHarness(), attachmentHarness()];
+    const replacement = deferred<NativeTerminalConnectResult>();
     const listeners: Array<(event: NativeTerminalEvent) => void | Promise<void>> = [];
     let connectionIndex = 0;
     const transport = transportHarness(async (_request, listener) => {
       listeners.push(listener);
-      return { status: "connected", attachment: attachments[connectionIndex++]! };
+      const index = connectionIndex++;
+      return index === 0
+        ? { status: "connected", attachment: attachments[0]! }
+        : replacement.promise;
     });
     const rendererFleet = rendererFleetHarness();
     const blockedWrite = deferred<void>();
@@ -939,6 +947,11 @@ describe("TerminalSurface", () => {
     await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledTimes(2));
     await vi.waitFor(() => expect(rendererFleet.instances).toHaveLength(2));
     const newRenderer = rendererFleet.instances[1]!;
+    // Pane-scoped input authority is not a continuity token. The daemon binder
+    // retains the host/session principal through the passive pane stream while
+    // this old interactive grant is retired immediately.
+    expect(attachments[0]!.dispose).toHaveBeenCalledOnce();
+    replacement.resolve({ status: "connected", attachment: attachments[1]! });
     expect(attachments[0]!.dispose).toHaveBeenCalledOnce();
     expect(oldRenderer.renderer.dispose).toHaveBeenCalledOnce();
     expect(oldRenderer.disposeInput).toHaveBeenCalledOnce();
@@ -952,6 +965,44 @@ describe("TerminalSurface", () => {
     blockedWrite.resolve();
     await Promise.resolve();
     expect(newRenderer.writes).toEqual([new Uint8Array([2])]);
+    dispose();
+  });
+
+  it("fences rapid A to pending B to C retargets without retaining A's pane grant", async () => {
+    const attachments = [attachmentHarness(), attachmentHarness(), attachmentHarness()];
+    const b = deferred<NativeTerminalConnectResult>();
+    const c = deferred<NativeTerminalConnectResult>();
+    let connectionIndex = 0;
+    const transport = transportHarness(async () => {
+      const index = connectionIndex++;
+      if (index === 0) return { status: "connected", attachment: attachments[0]! };
+      return index === 1 ? b.promise : c.promise;
+    });
+    const [target, setTarget] = createSignal(TARGET_A);
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={target()}
+          title="Codex"
+          transport={transport}
+          rendererFactory={rendererFleetHarness().factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    setTarget(TARGET_B);
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledTimes(2));
+    setTarget(TARGET_C);
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledTimes(3));
+    expect(attachments[0]!.dispose).toHaveBeenCalledOnce();
+    b.resolve({ status: "connected", attachment: attachments[1]! });
+    await vi.waitFor(() => expect(attachments[1]!.dispose).toHaveBeenCalledOnce());
+    expect(attachments[0]!.dispose).toHaveBeenCalledOnce();
+    c.resolve({ status: "connected", attachment: attachments[2]! });
+    expect(attachments[0]!.dispose).toHaveBeenCalledOnce();
+    expect(attachments[2]!.dispose).not.toHaveBeenCalled();
     dispose();
   });
 
@@ -1263,6 +1314,52 @@ describe("TerminalSurface", () => {
     await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledTimes(2));
     expect(root.querySelector(".terminal-surface")?.getAttribute("data-phase")).toBe("connected");
     expect(attempts).toBe(2);
+    dispose();
+    vi.useRealTimers();
+  });
+
+  it("keeps session continuity without retaining a failed replacement's old pane grant", async () => {
+    vi.useFakeTimers();
+    const oldAttachment = attachmentHarness();
+    const replacement = attachmentHarness();
+    let attempts = 0;
+    const transport = transportHarness(async () => {
+      attempts += 1;
+      if (attempts === 1) return { status: "connected", attachment: oldAttachment };
+      if (attempts === 2) {
+        return {
+          status: "error" as const,
+          error: {
+            code: "attachment-unavailable" as const,
+            reason: "replacement issue raced discovery",
+            retryable: true,
+          },
+        };
+      }
+      return { status: "connected" as const, attachment: replacement };
+    });
+    const [target, setTarget] = createSignal(TARGET_A);
+    const renderer = rendererFleetHarness();
+    const root = document.body.appendChild(document.createElement("div"));
+    const dispose = render(
+      () => (
+        <TerminalSurface
+          target={target()}
+          title="Codex"
+          transport={transport}
+          rendererFactory={renderer.factory}
+        />
+      ),
+      root,
+    );
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledOnce());
+    setTarget(TARGET_B);
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledTimes(2));
+    expect(oldAttachment.dispose).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(transport.connect).toHaveBeenCalledTimes(3));
+    expect(oldAttachment.dispose).toHaveBeenCalledOnce();
+    expect(replacement.dispose).not.toHaveBeenCalled();
     dispose();
     vi.useRealTimers();
   });

--- a/apps/electron-shell/src/desktop-pane-stream-live.test.ts
+++ b/apps/electron-shell/src/desktop-pane-stream-live.test.ts
@@ -58,6 +58,15 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
 }
 
+/** Semantic delivery is projected to ANSI row patches before the xterm sink. */
+function visibleTerminalText(value: string): string {
+  const ansiEscapeSequence = new RegExp(
+    `${String.fromCharCode(27)}(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~])`,
+    "gu",
+  );
+  return value.replace(ansiEscapeSequence, "");
+}
+
 async function waitUntil<T>(read: () => T | null, message: string, timeoutMs = 10_000): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -278,6 +287,7 @@ describe
       const ends: (PaneStreamTransportError | null)[] = [];
       const paneText = (pane: string): string =>
         Buffer.concat(paneBytes.get(pane) ?? []).toString("utf8");
+      const visiblePaneText = (pane: string): string => visibleTerminalText(paneText(pane));
 
       const transport = createPaneStreamTransport({
         createWebSocket: auditingWebSocketFactory(transcript),
@@ -337,10 +347,10 @@ describe
       const markerOne = `M43_ONE_${randomUUID().slice(0, 8)}`;
       runTmux(["send-keys", "-t", `=${sessionName}:0.0`, `echo ${markerOne}`, "Enter"]);
       await waitUntil(
-        () => (paneText(PANE_ONE).includes(markerOne) ? true : null),
+        () => (visiblePaneText(PANE_ONE).includes(markerOne) ? true : null),
         "external tmux input must stream into the mirror node",
       );
-      expect(paneText(PANE_TWO)).not.toContain(markerOne);
+      expect(visiblePaneText(PANE_TWO)).not.toContain(markerOne);
 
       // Flood pane two; pane one must stay independently live DURING the flood.
       runTmux([
@@ -351,13 +361,13 @@ describe
         "Enter",
       ]);
       await waitUntil(
-        () => (paneText(PANE_TWO).includes("FLOOD-") ? true : null),
+        () => (visiblePaneText(PANE_TWO).includes("FLOOD-") ? true : null),
         "flood output must reach the flooded pane's node",
       );
       const markerDuringFlood = `M43_LIVE_${randomUUID().slice(0, 8)}`;
       runTmux(["send-keys", "-t", `=${sessionName}:0.0`, `echo ${markerDuringFlood}`, "Enter"]);
       await waitUntil(
-        () => (paneText(PANE_ONE).includes(markerDuringFlood) ? true : null),
+        () => (visiblePaneText(PANE_ONE).includes(markerDuringFlood) ? true : null),
         "the sibling pane must stay live while another pane floods",
       );
       expect(ends).toEqual([]);
@@ -374,13 +384,14 @@ describe
       const markerAfterClose = `M43_POST_${randomUUID().slice(0, 8)}`;
       runTmux(["send-keys", "-t", `=${sessionName}:0.0`, `echo ${markerAfterClose}`, "Enter"]);
       await waitUntil(
-        () => (paneText(PANE_ONE).includes(markerAfterClose) ? true : null),
+        () => (visiblePaneText(PANE_ONE).includes(markerAfterClose) ? true : null),
         "surviving panes must stay live after a sibling pane closes",
       );
       expect(ends).toEqual([]);
 
-      // Wire transcript audit: one redeem, one ready, per-pane seeds, cumulative
-      // consumed acks flowing back, and the pane-three closed frame.
+      // Wire transcript audit: one redeem, one lease ready, one semantic lane
+      // per pane, semantic ACKs flowing back, and an honest pane-three close at
+      // the renderer boundary (the wire close is a semantic tombstone envelope).
       expect(transcript.filter(({ type }) => type === "redeem")).toHaveLength(1);
       expect(transcript.filter(({ type }) => type === "ready")).toHaveLength(1);
       expect(transcript[0]).toMatchObject({ direction: "sent", type: "redeem" });
@@ -389,24 +400,20 @@ describe
           transcript.some(
             (record) =>
               record.direction === "received" &&
-              record.type === "seed-batch" &&
+              record.type === "terminal-delivery-ready" &&
               record.pane === pane,
           ),
-          `transcript must carry the ${pane} seed-batch`,
+          `transcript must negotiate the ${pane} semantic lane`,
         ).toBe(true);
       }
       expect(
-        transcript.filter((record) => record.direction === "sent" && record.type === "consumed")
-          .length,
+        transcript.filter(
+          (record) => record.direction === "sent" && record.type === "terminal-delivery-ack",
+        ).length,
       ).toBeGreaterThan(0);
-      expect(
-        transcript.some(
-          (record) =>
-            record.direction === "received" &&
-            record.type === "closed" &&
-            record.pane === PANE_THREE,
-        ),
-      ).toBe(true);
+      expect(paneEvents.some((event) => event.pane === PANE_THREE && event.type === "closed")).toBe(
+        true,
+      );
       expect(
         transcript.filter((record) => record.direction === "sent" && record.type === "input"),
       ).toHaveLength(0);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39329,6 +39329,7 @@ var init_terminal_delivery_hub = __esm({
             sending: false,
             retireAfterDrain: false,
             lastAck: null,
+            sourceClosedFlight: null,
             backgroundTimer: null
           };
           this.#clients.set(key, client);
@@ -39671,6 +39672,9 @@ var init_terminal_delivery_hub = __esm({
         const flight = client.inFlight;
         if (!flight) {
           if (client.lastAck && JSON.stringify(client.lastAck) === JSON.stringify(ack)) return;
+          const closed = client.sourceClosedFlight;
+          if (closed && ack.workspaceName === closed.workspaceName && ack.semanticPaneId === closed.semanticPaneId && ack.generation === closed.generation && ack.incarnation === closed.incarnation && ack.deliveryNonce === closed.deliveryNonce && ack.transactionId === closed.transactionId && ack.canonicalRevision === closed.canonicalRevision && ack.canonicalStateHash === closed.canonicalStateHash && ack.representationHash === closed.representationHash)
+            return;
           this.#fault(client, "protocol-violation", "ACK has no in-flight transaction");
           return;
         }
@@ -39702,13 +39706,22 @@ var init_terminal_delivery_hub = __esm({
       }
       #fault(client, reason, message) {
         client.outgoing.length = 0;
+        if (reason === "source-closed") client.sourceClosedFlight = client.inFlight?.envelope ?? null;
         client.inFlight = null;
-        this.#enqueue(client, {
+        const fault = {
           type: "terminal.delivery.fault",
           reason,
           message: message.slice(0, 1024),
           deliveryNonce: client.negotiated.deliveryNonce
-        });
+        };
+        if (reason === "source-closed" && client.sending) {
+          void Promise.resolve(client.accept(fault)).then(
+            () => this.#closeClient(client),
+            () => this.#closeClient(client)
+          );
+          return;
+        }
+        this.#enqueue(client, fault);
         client.retireAfterDrain = true;
       }
       #enqueue(client, message) {
@@ -40535,6 +40548,14 @@ function assertLiveScope(shared, lease, semanticPaneId3) {
     );
   }
 }
+function assertLiveControllerPrincipal(shared, lease) {
+  if (shared.lease !== lease) {
+    throw new SessionRuntimeControllerLeaseError(
+      "stale-controller-lease",
+      "The host no longer owns session controller authority."
+    );
+  }
+}
 var TransportSchemaZ, LeaseIdSchemaZ, HostClientIdSchemaZ, clientsByRegistry, SessionRuntimeTransportBinding, SessionRuntimeTransportBinder;
 var init_transport_binding = __esm({
   "packages/daemon/src/terminal/session-runtime/transport-binding.ts"() {
@@ -40791,7 +40812,10 @@ var init_transport_binding = __esm({
           shared.consumer,
           lease,
           grants,
-          (semanticPaneId3) => assertLiveScope(shared, lease, semanticPaneId3)
+          (semanticPaneId3) => {
+            if (semanticPaneId3 === void 0) assertLiveControllerPrincipal(shared, lease);
+            else assertLiveScope(shared, lease, semanticPaneId3);
+          }
         );
         return sourceSemanticPaneId === void 0 ? base : this.registry.bindExecutionSource(base, sourceSemanticPaneId);
       }
@@ -40804,14 +40828,14 @@ var init_transport_binding = __esm({
         }
         if (interactive) {
           shared.interactiveRefs -= 1;
-          if (shared.interactiveRefs === 0 && shared.lease) {
-            const retired = shared.lease;
-            shared.lease = null;
-            shared.consumer.releaseController(retired);
-          }
         }
         shared.refs -= 1;
         if (shared.refs > 0) return;
+        if (shared.lease) {
+          const retired = shared.lease;
+          shared.lease = null;
+          shared.consumer.releaseController(retired);
+        }
         for (const [key, candidate] of this.#clients) {
           if (candidate === shared) this.#clients.delete(key);
         }
@@ -41856,6 +41880,7 @@ var init_direct_websocket = __esm({
     init_terminal_attachment_stream();
     init_src();
     init_lease_manager();
+    init_registry2();
     TERMINAL_ATTACHMENT_WEBSOCKET_PROTOCOL = TERMINAL_ATTACHMENT_WEBSOCKET_SUBPROTOCOL;
     TERMINAL_ATTACHMENT_MAX_REDEMPTION_BYTES = 4 * 1024;
     TERMINAL_ATTACHMENT_MAX_CONTROL_BYTES = 4 * 1024;
@@ -42266,9 +42291,10 @@ var init_direct_websocket = __esm({
                 "Terminal attachment redemption was rejected."
               );
             }
-            const sessionRuntimeBinding = this.#bindSessionRuntime?.(activeDescriptor) ?? null;
+            let sessionRuntimeBinding = null;
             let live;
             try {
+              sessionRuntimeBinding = this.#bindSessionRuntime?.(activeDescriptor) ?? null;
               live = new TerminalAttachmentLiveConnection({
                 onRetire: (connection) => this.#trackRetiringRelease(connection),
                 socket,
@@ -42451,13 +42477,13 @@ var init_direct_websocket = __esm({
         this.beginRedemption();
         void this.#onRedeem(this, frame, socket).catch((error) => {
           if (!this.#open) return;
-          const code = error instanceof TerminalAttachmentAdmissionError ? error.code : error instanceof AttachmentLeaseError && error.code === "ticket-expired" ? "ticket-expired" : "attachment-unavailable";
+          const code = error instanceof TerminalAttachmentAdmissionError ? error.code : error instanceof AttachmentLeaseError && error.code === "ticket-expired" ? "ticket-expired" : error instanceof SessionRuntimeControllerLeaseError && error.code === "controller-conflict" ? "interactive-viewer-conflict" : "attachment-unavailable";
           try {
             sendControl(socket, {
               type: "error",
               protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
               code,
-              retryable: code === "live-capacity-exhausted" || code === "ticket-expired"
+              retryable: code === "live-capacity-exhausted" || code === "ticket-expired" || code === "interactive-viewer-conflict"
             });
           } catch {
           }
@@ -46204,7 +46230,11 @@ var init_pane_stream_websocket = __esm({
         if (message.type === "terminal.delivery") {
           const channel = this.#panes.get(pane);
           if (channel?.deliveryAddress) channel.deliveryAddress.incarnation = message.incarnation;
-          this.#sendFrame(pane, { type: "terminal-delivery-envelope", pane, envelope: message });
+          this.#sendFrame(pane, {
+            type: "terminal-delivery-envelope",
+            pane,
+            envelope: { ...message, workspaceName: this.#descriptor.workspaceName }
+          });
         } else if (message.type === "terminal.delivery.chunk") {
           this.#sendFrame(pane, {
             type: "terminal-delivery-chunk",
@@ -46215,12 +46245,12 @@ var init_pane_stream_websocket = __esm({
           });
         } else {
           this.#sendFrame(pane, { type: "terminal-delivery-fault", pane, fault: message });
+          return;
         }
         await this.#awaitSemanticCredit(pane);
       }
       #awaitSemanticCredit(pane) {
-        const aggregateHigh = (this.#socket.bufferedAmount ?? 0) > this.#maxSocketBufferedBytes >> 2;
-        if (!aggregateHigh && !this.#ledger.isStalled(this.#clientId, pane)) return Promise.resolve();
+        if (!this.#ledger.isStalled(this.#clientId, pane)) return Promise.resolve();
         return new Promise((resolve31) => {
           const waiters = this.#semanticDrainWaiters.get(pane) ?? [];
           waiters.push(resolve31);
@@ -46453,7 +46483,7 @@ var init_pane_stream_websocket = __esm({
           if (channel.frozenByWire) this.#evaluateResume(pane);
           else this.#evaluateStall(pane);
           const waiters = this.#semanticDrainWaiters.get(pane);
-          if (waiters && this.#ledger.shouldResume(this.#clientId, pane) && buffered <= this.#maxSocketBufferedBytes >> 3) {
+          if (waiters && this.#ledger.shouldResume(this.#clientId, pane)) {
             this.#semanticDrainWaiters.delete(pane);
             for (const resolve31 of waiters) resolve31();
           }
@@ -46481,13 +46511,13 @@ var init_pane_stream_websocket = __esm({
         if (frame.type === "terminal-delivery-ack") {
           const channel = this.#deliveryChannel(frame.ack);
           if (!channel) return;
-          channel.delivery.ack(frame.ack);
+          channel.delivery.ack({ ...frame.ack, workspaceName: this.#descriptor.sessionName });
           return;
         }
         if (frame.type === "terminal-delivery-nack") {
           const channel = this.#deliveryChannel(frame.nack);
           if (!channel) return;
-          channel.delivery.nack(frame.nack);
+          channel.delivery.nack({ ...frame.nack, workspaceName: this.#descriptor.sessionName });
           return;
         }
         if (frame.type === "terminal-delivery-visibility") {

--- a/packages/core/src/terminal-delivery.test.ts
+++ b/packages/core/src/terminal-delivery.test.ts
@@ -10,6 +10,7 @@ import {
   commitTerminalDelivery,
   completeTerminalDelivery,
   createTerminalDeliveryClientState,
+  encodeAnsiTerminalPatchRepresentation,
   encodeSemanticTerminalUpdate,
   hashTerminalDeliveryRepresentation,
   hashTerminalReplicaSnapshot,
@@ -53,6 +54,20 @@ function seedEnvelope(): { envelope: TerminalDeliveryEnvelope; bytes: Uint8Array
 }
 
 describe("terminal delivery client", () => {
+  it("encodes ordinary ANSI deltas from dirty rows without inspecting the full grid", () => {
+    const snapshot = blankTerminalReplicaSnapshot(4, 3);
+    const inaccessibleGrid = new Proxy(snapshot.grid, {
+      get() {
+        throw new Error("unchanged grid row was inspected");
+      },
+    });
+    const target = { ...snapshot, grid: inaccessibleGrid };
+    const bytes = encodeAnsiTerminalPatchRepresentation(
+      { rows: [{ index: 1, row: snapshot.grid[1]! }] },
+      target,
+    );
+    expect(new TextDecoder().decode(bytes)).toContain("\u001b[2;1H");
+  });
   it("negotiates deterministically and rejects unsupported rich ANSI", () => {
     expect(
       negotiateTerminalDelivery(

--- a/packages/core/src/terminal-delivery.ts
+++ b/packages/core/src/terminal-delivery.ts
@@ -155,6 +155,30 @@ export function encodeAnsiTerminalRepresentation(
   return bytes;
 }
 
+/**
+ * Encode an admitted semantic patch from its explicit dirty rows.
+ *
+ * The patch is the canonical change set; comparing every immutable grid row
+ * again in the renderer turns a one-line terminal update into O(screen rows)
+ * work. Dimension changes remain a full repaint, while ordinary deltas touch
+ * only `patch.rows` plus the cursor.
+ */
+export function encodeAnsiTerminalPatchRepresentation(
+  patch: TerminalReplicaPatchPayload,
+  target: TerminalReplicaSnapshot,
+): Uint8Array {
+  if (patch.dimensions) return encodeAnsiTerminalRepresentation(null, target);
+  let output = "";
+  for (const { index, row } of patch.rows) {
+    output += `\u001b[${index + 1};1H${renderAnsiRow(row)}\u001b[K`;
+  }
+  output += `\u001b[${target.cursor.y + 1};${target.cursor.x + 1}H`;
+  output += target.cursor.hidden ? "\u001b[?25l" : "\u001b[?25h";
+  const bytes = new TextEncoder().encode(output);
+  assertRepresentationSize(bytes);
+  return bytes;
+}
+
 export interface TerminalDeliveryClientState {
   readonly negotiated: TerminalDeliveryNegotiated;
   readonly workspaceName: string;

--- a/packages/daemon-client/src/pane-stream-client.ts
+++ b/packages/daemon-client/src/pane-stream-client.ts
@@ -52,6 +52,18 @@ export interface OpenPaneStreamClientOptions {
   readonly onFault?: (error: Error) => void;
 }
 
+export type ConnectIssuedPaneStreamRuntimeClientOptions = Pick<
+  OpenPaneStreamClientOptions,
+  | "createSocket"
+  | "origin"
+  | "hostClientId"
+  | "onNegotiated"
+  | "onTerminalDelivery"
+  | "onLayout"
+  | "onInputAck"
+  | "onFault"
+>;
+
 export interface PaneStreamRuntimeClient {
   readonly daemonInstanceId: string;
   readonly requestId: string;
@@ -119,11 +131,11 @@ export async function openPaneStreamRuntimeClient(
   ) {
     throw new Error("Pane-stream issue returned another daemon generation");
   }
-  return await connectIssued(options, issued.descriptor);
+  return await connectIssuedPaneStreamRuntimeClient(options, issued.descriptor);
 }
 
-async function connectIssued(
-  options: OpenPaneStreamClientOptions,
+export async function connectIssuedPaneStreamRuntimeClient(
+  options: ConnectIssuedPaneStreamRuntimeClientOptions,
   descriptor: PaneStreamIssueDescriptor,
 ): Promise<PaneStreamRuntimeClient> {
   const socket = options.createSocket(descriptor, {
@@ -322,7 +334,7 @@ async function connectIssued(
 }
 
 function routeFrame(
-  options: OpenPaneStreamClientOptions,
+  options: ConnectIssuedPaneStreamRuntimeClientOptions,
   frame: PaneStreamServerFrame,
   fail: (message: string) => void,
 ): void {

--- a/packages/daemon/src/terminal/__tests__/direct-websocket.test.ts
+++ b/packages/daemon/src/terminal/__tests__/direct-websocket.test.ts
@@ -24,6 +24,7 @@ import type { ClaimedPtyTmuxAttachment } from "../attachments/pty-tmux-attachmen
 import { DEFAULT_PTY_INPUT_LIMITS, MonotonicPtyInput } from "../MonotonicPtyInput.ts";
 import type { PtyInputLimits } from "../PtyAdapter.ts";
 import { attachTerminalAttachmentWebSocket } from "../../server/terminal-attachment-upgrade.ts";
+import { SessionRuntimeControllerLeaseError } from "../session-runtime/registry.ts";
 
 const INSTANCE_ID = "daemon-instance-1";
 const ORIGIN = "tmux-ide://app";
@@ -391,6 +392,36 @@ describe("TerminalAttachmentAdmissionCoordinator", () => {
     await vi.waitFor(() => expect(bindSessionRuntime).toHaveBeenCalledOnce());
     socket.close();
     await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+  });
+
+  it("preserves a controller conflict at redemption for passive-viewer fallback", async () => {
+    const { coordinator, client } = rig({
+      bindSessionRuntime: () => {
+        throw new SessionRuntimeControllerLeaseError(
+          "controller-conflict",
+          "Another browser document owns the session controller.",
+        );
+      },
+    });
+    const issued = await issue(coordinator);
+    const socket = new FakeSocket();
+    admission(coordinator).bind(socket);
+    socket.frame(redemption(issued.redemptionTicket));
+
+    await vi.waitFor(() =>
+      expect(
+        socket.sent
+          .filter((entry) => typeof entry.data === "string")
+          .map((entry) => JSON.parse(entry.data as string)),
+      ).toContainEqual({
+        type: "error",
+        protocolVersion: 1,
+        code: "interactive-viewer-conflict",
+        retryable: true,
+      }),
+    );
+    expect(client.disposed).toBe(1);
+    expect(socket.closes.at(-1)).toEqual({ code: 1008, reason: "redemption-rejected" });
   });
 
   it("issues one renderer descriptor while retaining only bounded redacted state", async () => {

--- a/packages/daemon/src/terminal/attachments/direct-websocket.ts
+++ b/packages/daemon/src/terminal/attachments/direct-websocket.ts
@@ -39,6 +39,7 @@ import type {
   ClaimedPtyTmuxAttachment,
   PtyTmuxAttachmentClaimKey,
 } from "./pty-tmux-attachment-launcher.ts";
+import { SessionRuntimeControllerLeaseError } from "../session-runtime/registry.ts";
 
 export { TERMINAL_ATTACHMENT_REDEEM_PATH };
 /** @deprecated Import the authoritative shared subprotocol constant from contracts. */
@@ -761,9 +762,10 @@ export class TerminalAttachmentAdmissionCoordinator {
             "Terminal attachment redemption was rejected.",
           );
         }
-        const sessionRuntimeBinding = this.#bindSessionRuntime?.(activeDescriptor) ?? null;
+        let sessionRuntimeBinding: SessionRuntimeRedeemedTransportBinding | null = null;
         let live: TerminalAttachmentLiveConnection;
         try {
+          sessionRuntimeBinding = this.#bindSessionRuntime?.(activeDescriptor) ?? null;
           live = new TerminalAttachmentLiveConnection({
             onRetire: (connection) => this.#trackRetiringRelease(connection),
             socket,
@@ -999,13 +1001,19 @@ class PreAuthAdmission implements TerminalAttachmentPreAuthAdmission {
           ? error.code
           : error instanceof AttachmentLeaseError && error.code === "ticket-expired"
             ? "ticket-expired"
-            : "attachment-unavailable";
+            : error instanceof SessionRuntimeControllerLeaseError &&
+                error.code === "controller-conflict"
+              ? "interactive-viewer-conflict"
+              : "attachment-unavailable";
       try {
         sendControl(socket, {
           type: "error",
           protocolVersion: TERMINAL_ATTACHMENT_PROTOCOL_VERSION,
           code,
-          retryable: code === "live-capacity-exhausted" || code === "ticket-expired",
+          retryable:
+            code === "live-capacity-exhausted" ||
+            code === "ticket-expired" ||
+            code === "interactive-viewer-conflict",
         });
       } catch {
         // Closing below is the fail-closed response.

--- a/packages/daemon/src/terminal/pane-stream/pane-stream-websocket.test.ts
+++ b/packages/daemon/src/terminal/pane-stream/pane-stream-websocket.test.ts
@@ -207,6 +207,7 @@ function harness(
     maxInputFramesPerWindow?: number;
     maxInputBytesPerWindow?: number;
     inputRateWindowMs?: number;
+    maxSocketBufferedBytes?: number;
     bindSessionRuntime?: ConstructorParameters<
       typeof PaneStreamAdmissionCoordinator
     >[0]["bindSessionRuntime"];
@@ -267,6 +268,7 @@ function harness(
     maxInputFramesPerWindow: options.maxInputFramesPerWindow,
     maxInputBytesPerWindow: options.maxInputBytesPerWindow,
     inputRateWindowMs: options.inputRateWindowMs,
+    maxSocketBufferedBytes: options.maxSocketBufferedBytes,
     now,
     schedule: scheduler.schedule,
   });
@@ -791,6 +793,49 @@ describe("PaneStreamAdmissionCoordinator", () => {
     expect(h.mirror.subs).toHaveLength(0);
     expect(h.mirror.layoutHandlers).toHaveLength(1);
     expect(h.deliveryListeners.size).toBe(2);
+    const transactionId = "00000000-0000-4000-8000-000000000095";
+    await h.deliveryListeners.get("pane.shell")?.({
+      type: "terminal.delivery",
+      workspaceName: SESSION,
+      semanticPaneId: "pane.shell",
+      generation: INSTANCE,
+      incarnation: `${INSTANCE}:0`,
+      deliveryNonce: "00000000-0000-4000-8000-000000000098",
+      transactionId,
+      protocolVersion: 1,
+      encoding: "semantic-v1",
+      frame: "seed",
+      baseRevision: null,
+      canonicalRevision: 0,
+      canonicalStateHash: "1111111111111111",
+      representationHash: "2222222222222222",
+      representationBytes: 1,
+      chunkCount: 1,
+      canonicalEquivalent: true,
+      history: "complete",
+      richPlacements: false,
+    } as never);
+    expect(socket.framesOfType("terminal-delivery-envelope")[0]).toMatchObject({
+      envelope: { workspaceName: "workspace.alpha" },
+    });
+    socket.message({
+      type: "terminal-delivery-ack",
+      ack: {
+        type: "terminal.delivery.ack",
+        workspaceName: "workspace.alpha",
+        semanticPaneId: "pane.shell",
+        generation: INSTANCE,
+        incarnation: `${INSTANCE}:0`,
+        deliveryNonce: "00000000-0000-4000-8000-000000000098",
+        transactionId,
+        canonicalRevision: 0,
+        canonicalStateHash: "1111111111111111",
+        representationHash: "2222222222222222",
+      },
+    });
+    expect(h.deliveryAcks).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceName: SESSION, transactionId }),
+    );
     h.deliveryListeners.get("pane.editor")?.({
       type: "terminal.delivery.fault",
       reason: "source-closed",
@@ -864,6 +909,27 @@ describe("PaneStreamAdmissionCoordinator", () => {
     expect(socket.framesOfType("viewport-ack")).toEqual([
       { type: "viewport-ack", seq: 1, cols: 132, rows: 44 },
     ]);
+  });
+
+  it("does not park a sibling source-close behind aggregate semantic output pressure", async () => {
+    const h = harness({ maxSocketBufferedBytes: 2_000 });
+    const { socket } = await connect(h, {
+      viewerMode: "interactive",
+      semanticDelivery: true,
+    });
+    await vi.waitFor(() => expect(socket.framesOfType("terminal-delivery-ready")).toHaveLength(2));
+
+    // Raise aggregate buffered bytes without exhausting shell's pane-local
+    // ledger. The sibling close callback must settle immediately.
+    socket.send(JSON.stringify({ padding: "x".repeat(600) }));
+    const close = h.deliveryListeners.get("pane.shell")!({
+      type: "terminal.delivery.fault",
+      reason: "source-closed",
+      message: "closed",
+      deliveryNonce: "00000000-0000-4000-8000-000000000098",
+    } as never) as unknown;
+    await expect(Promise.resolve(close)).resolves.toBeUndefined();
+    expect(socket.framesOfType("terminal-delivery-fault")).toHaveLength(1);
   });
 
   it("meters renderer backlog for acking clients and thaws on consumed frames", async () => {

--- a/packages/daemon/src/terminal/pane-stream/pane-stream-websocket.ts
+++ b/packages/daemon/src/terminal/pane-stream/pane-stream-websocket.ts
@@ -1168,7 +1168,14 @@ export class PaneStreamLiveConnection {
     if (message.type === "terminal.delivery") {
       const channel = this.#panes.get(pane);
       if (channel?.deliveryAddress) channel.deliveryAddress.incarnation = message.incarnation;
-      this.#sendFrame(pane, { type: "terminal-delivery-envelope", pane, envelope: message });
+      // SessionRuntime keys canonical replicas by the tmux session, while the
+      // public pane-stream lease is keyed by its workspace identity. Translate
+      // at this boundary so the renderer has one coherent address vocabulary.
+      this.#sendFrame(pane, {
+        type: "terminal-delivery-envelope",
+        pane,
+        envelope: { ...message, workspaceName: this.#descriptor.workspaceName },
+      });
     } else if (message.type === "terminal.delivery.chunk") {
       this.#sendFrame(pane, {
         type: "terminal-delivery-chunk",
@@ -1179,13 +1186,19 @@ export class PaneStreamLiveConnection {
       });
     } else {
       this.#sendFrame(pane, { type: "terminal-delivery-fault", pane, fault: message });
+      // Lifecycle/control truth must never queue behind bulk terminal bytes.
+      // The hard socket-wide ceiling still closes a genuinely wedged client in
+      // #drainNow; a source-close frame itself is small and immediately useful.
+      return;
     }
     await this.#awaitSemanticCredit(pane);
   }
 
   #awaitSemanticCredit(pane: string): Promise<void> {
-    const aggregateHigh = (this.#socket.bufferedAmount ?? 0) > this.#maxSocketBufferedBytes >> 2;
-    if (!aggregateHigh && !this.#ledger.isStalled(this.#clientId, pane)) return Promise.resolve();
+    // Backpressure is pane-local. Aggregate pressure is guarded by the hard
+    // socket ceiling in #drainNow, but must not let a noisy sibling prevent a
+    // pane-close (or any other pane's next semantic delivery) from surfacing.
+    if (!this.#ledger.isStalled(this.#clientId, pane)) return Promise.resolve();
     return new Promise((resolve) => {
       const waiters = this.#semanticDrainWaiters.get(pane) ?? [];
       waiters.push(resolve);
@@ -1457,11 +1470,7 @@ export class PaneStreamLiveConnection {
       if (channel.frozenByWire) this.#evaluateResume(pane);
       else this.#evaluateStall(pane);
       const waiters = this.#semanticDrainWaiters.get(pane);
-      if (
-        waiters &&
-        this.#ledger.shouldResume(this.#clientId, pane) &&
-        buffered <= this.#maxSocketBufferedBytes >> 3
-      ) {
+      if (waiters && this.#ledger.shouldResume(this.#clientId, pane)) {
         this.#semanticDrainWaiters.delete(pane);
         for (const resolve of waiters) resolve();
       }
@@ -1494,13 +1503,13 @@ export class PaneStreamLiveConnection {
     if (frame.type === "terminal-delivery-ack") {
       const channel = this.#deliveryChannel(frame.ack);
       if (!channel) return;
-      channel.delivery!.ack(frame.ack);
+      channel.delivery!.ack({ ...frame.ack, workspaceName: this.#descriptor.sessionName });
       return;
     }
     if (frame.type === "terminal-delivery-nack") {
       const channel = this.#deliveryChannel(frame.nack);
       if (!channel) return;
-      channel.delivery!.nack(frame.nack);
+      channel.delivery!.nack({ ...frame.nack, workspaceName: this.#descriptor.sessionName });
       return;
     }
     if (frame.type === "terminal-delivery-visibility") {

--- a/packages/daemon/src/terminal/session-runtime/terminal-delivery-hub.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-delivery-hub.test.ts
@@ -388,6 +388,50 @@ describe("SessionRuntimeTerminalDeliveryHub", () => {
     await hub.close();
   });
 
+  it("preempts a blocked representation with source close and tolerates its racing ACK", async () => {
+    const owner = new FakeOwner();
+    const hub = new SessionRuntimeTerminalDeliveryHub(generation, "workspace", () => owner);
+    const messages: TerminalDeliveryServerMessage[] = [];
+    let releaseRepresentation!: () => void;
+    const blockedRepresentation = new Promise<void>((resolve) => {
+      releaseRepresentation = resolve;
+    });
+    const connection = await hub.open(
+      "slow",
+      "pane-a",
+      { protocolVersions: [1], encodings: ["semantic-v1"], richPlacements: false },
+      (message) => {
+        messages.push(message);
+        return message.type === "terminal.delivery" ? blockedRepresentation : undefined;
+      },
+    );
+    owner.emit(seed());
+    await settle();
+    const displaced = messages[0] as TerminalDeliveryEnvelope;
+
+    owner.emit(tombstone(1));
+    await settle();
+    expect(messages.at(-1)).toMatchObject({
+      type: "terminal.delivery.fault",
+      reason: "source-closed",
+    });
+
+    // The renderer may have applied the representation immediately before it
+    // observed close. That authenticated ACK belongs to the displaced flight,
+    // and must not transform honest lifecycle racing into protocol failure.
+    connection.ack(ack(displaced));
+    expect(
+      messages.filter(
+        (message) =>
+          message.type === "terminal.delivery.fault" && message.reason === "protocol-violation",
+      ),
+    ).toHaveLength(0);
+    releaseRepresentation();
+    await settle();
+    await connection.close();
+    await hub.close();
+  });
+
   it("accepts only an exact duplicate ACK and faults mutated replays", async () => {
     const owner = new FakeOwner();
     const hub = new SessionRuntimeTerminalDeliveryHub(generation, "workspace", () => owner);

--- a/packages/daemon/src/terminal/session-runtime/terminal-delivery-hub.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-delivery-hub.ts
@@ -116,6 +116,8 @@ interface ClientState {
   sending: boolean;
   retireAfterDrain: boolean;
   lastAck: TerminalDeliveryAck | null;
+  /** Delivery displaced by authoritative source close; its racing ACK is benign. */
+  sourceClosedFlight: TerminalDeliveryEnvelope | null;
   backgroundTimer: ReturnType<typeof setTimeout> | null;
 }
 
@@ -198,6 +200,7 @@ export class SessionRuntimeTerminalDeliveryHub {
         sending: false,
         retireAfterDrain: false,
         lastAck: null,
+        sourceClosedFlight: null,
         backgroundTimer: null,
       };
       this.#clients.set(key, client);
@@ -600,6 +603,20 @@ export class SessionRuntimeTerminalDeliveryHub {
     const flight = client.inFlight;
     if (!flight) {
       if (client.lastAck && JSON.stringify(client.lastAck) === JSON.stringify(ack)) return;
+      const closed = client.sourceClosedFlight;
+      if (
+        closed &&
+        ack.workspaceName === closed.workspaceName &&
+        ack.semanticPaneId === closed.semanticPaneId &&
+        ack.generation === closed.generation &&
+        ack.incarnation === closed.incarnation &&
+        ack.deliveryNonce === closed.deliveryNonce &&
+        ack.transactionId === closed.transactionId &&
+        ack.canonicalRevision === closed.canonicalRevision &&
+        ack.canonicalStateHash === closed.canonicalStateHash &&
+        ack.representationHash === closed.representationHash
+      )
+        return;
       this.#fault(client, "protocol-violation", "ACK has no in-flight transaction");
       return;
     }
@@ -656,13 +673,26 @@ export class SessionRuntimeTerminalDeliveryHub {
     message: string,
   ): void {
     client.outgoing.length = 0;
+    if (reason === "source-closed") client.sourceClosedFlight = client.inFlight?.envelope ?? null;
     client.inFlight = null;
-    this.#enqueue(client, {
+    const fault: TerminalDeliveryServerMessage = {
       type: "terminal.delivery.fault",
       reason,
       message: message.slice(0, 1024),
       deliveryNonce: client.negotiated.deliveryNonce,
-    });
+    };
+    if (reason === "source-closed" && client.sending) {
+      // A data callback may be waiting for renderer credit. Source closure is
+      // authoritative control state, so send it out-of-band and retire after
+      // that small frame has reached the transport instead of waiting behind
+      // a transaction which can no longer become current.
+      void Promise.resolve(client.accept(fault)).then(
+        () => this.#closeClient(client),
+        () => this.#closeClient(client),
+      );
+      return;
+    }
+    this.#enqueue(client, fault);
     client.retireAfterDrain = true;
   }
 

--- a/packages/daemon/src/terminal/session-runtime/transport-binding.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/transport-binding.test.ts
@@ -316,7 +316,7 @@ describe("SessionRuntimeTransportBinder", () => {
     await first.close();
   });
 
-  it("retires the last interactive lease while a passive sibling remains readable", async () => {
+  it("retains session authority but no source grant across an interactive retarget", async () => {
     const executed: string[] = [];
     const registry = new SessionRuntimeRegistry({
       generation: GENERATION,
@@ -357,12 +357,20 @@ describe("SessionRuntimeTransportBinder", () => {
     await vi.waitFor(() => expect(executed).toEqual([OP_A]));
 
     await interactive.close();
-    expect(registry.activeControllerLeaseCount()).toBe(0);
-    expect(binder.resolveExecutionHandle("alpha-session", "web:document-a")).toBeUndefined();
+    expect(registry.activeControllerLeaseCount()).toBe(1);
+    const sessionHandle = binder.resolveExecutionHandle("alpha-session", "web:document-a");
+    expect(sessionHandle).toBeTruthy();
+    expect(() => registry.assertExecutionHandle(sessionHandle!)).not.toThrow();
+    expect(
+      binder.resolveExecutionHandle("alpha-session", "web:document-a", "pane.editor"),
+    ).toBeUndefined();
+    expect(
+      binder.resolveExecutionHandle("alpha-session", "web:document-a", "pane.tests"),
+    ).toBeUndefined();
     expect(passive.toJSON()).toMatchObject({ interactive: false, clientId: "web:document-a" });
     expect(() => passive.assertController()).toThrow("Passive transport has no input authority");
     expect(() => registry.assertExecutionHandle(source)).toThrowError(
-      expect.objectContaining({ code: "stale-controller-lease" }),
+      expect.objectContaining({ code: "invalid-source-pane-binding" }),
     );
 
     registry.observeTmuxInteraction({
@@ -386,6 +394,27 @@ describe("SessionRuntimeTransportBinder", () => {
     replacement.assertController("pane.editor");
     expect(registry.activeControllerLeaseCount()).toBe(1);
     await replacement.close();
+    expect(registry.activeControllerLeaseCount()).toBe(1);
+    await passive.close();
+    expect(registry.activeControllerLeaseCount()).toBe(0);
+    await registry.dispose();
+  });
+
+  it("never grants a controller principal to a passive-only host", async () => {
+    const registry = new SessionRuntimeRegistry({
+      generation: GENERATION,
+      createControllerToken: () => "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    });
+    const binder = new SessionRuntimeTransportBinder(registry);
+    const passive = binder.bind({
+      transport: "pane-stream",
+      transportLeaseId: "00000000-0000-4000-8000-000000000002",
+      session: "alpha",
+      hostClientId: "web:passive-only",
+      allowedSourcePaneIds: ["pane.tests"],
+      interactive: false,
+    });
+    expect(binder.resolveExecutionHandle("alpha", "web:passive-only")).toBeUndefined();
     expect(registry.activeControllerLeaseCount()).toBe(0);
     await passive.close();
     await registry.dispose();

--- a/packages/daemon/src/terminal/session-runtime/transport-binding.ts
+++ b/packages/daemon/src/terminal/session-runtime/transport-binding.ts
@@ -65,6 +65,18 @@ function assertLiveScope(
   }
 }
 
+function assertLiveControllerPrincipal(
+  shared: SharedClient,
+  lease: SessionRuntimeControllerLease,
+): void {
+  if (shared.lease !== lease) {
+    throw new SessionRuntimeControllerLeaseError(
+      "stale-controller-lease",
+      "The host no longer owns session controller authority.",
+    );
+  }
+}
+
 const clientsByRegistry = new WeakMap<object, Map<string, SharedClient>>();
 
 export class SessionRuntimeTransportBinding {
@@ -369,7 +381,10 @@ export class SessionRuntimeTransportBinder {
       shared.consumer,
       lease,
       grants,
-      (semanticPaneId) => assertLiveScope(shared, lease, semanticPaneId),
+      (semanticPaneId) => {
+        if (semanticPaneId === undefined) assertLiveControllerPrincipal(shared, lease);
+        else assertLiveScope(shared, lease, semanticPaneId);
+      },
     );
     return sourceSemanticPaneId === undefined
       ? base
@@ -389,16 +404,18 @@ export class SessionRuntimeTransportBinder {
     }
     if (interactive) {
       shared.interactiveRefs -= 1;
-      if (shared.interactiveRefs === 0 && shared.lease) {
-        // Passive visibility may keep the shared consumer alive, but never its
-        // controller lease or any execution handle derived from that lease.
-        const retired = shared.lease;
-        shared.lease = null;
-        shared.consumer.releaseController(retired);
-      }
     }
     shared.refs -= 1;
     if (shared.refs > 0) return;
+    if (shared.lease) {
+      // A same-host passive session channel keeps the controller PRINCIPAL
+      // continuous across interactive pane retargeting. It contributes no
+      // source-pane grant and cannot type; the lease retires with the last
+      // host/session ref, while a passive-only host never acquires one.
+      const retired = shared.lease;
+      shared.lease = null;
+      shared.consumer.releaseController(retired);
+    }
     for (const [key, candidate] of this.#clients) {
       if (candidate === shared) this.#clients.delete(key);
     }

--- a/packages/daemon/src/tui/async-disposable-slot.test.ts
+++ b/packages/daemon/src/tui/async-disposable-slot.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { AsyncDisposableSlot, type AsyncDisposer } from "./async-disposable-slot.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((accept) => {
+    resolve = accept;
+  });
+  return { promise, resolve };
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("AsyncDisposableSlot", () => {
+  it("retires a resource that resolves after its owner is disposed", async () => {
+    const pending = deferred<AsyncDisposer>();
+    const stop = vi.fn();
+    const slot = new AsyncDisposableSlot<string>();
+
+    slot.ensure("/workspace", () => pending.promise);
+    expect(slot.key).toBe("/workspace");
+    slot.dispose();
+    expect(slot.key).toBeNull();
+
+    pending.resolve(stop);
+    await settle();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("never lets an older generation replace the current resource", async () => {
+    const first = deferred<AsyncDisposer>();
+    const second = deferred<AsyncDisposer>();
+    const stopFirst = vi.fn();
+    const stopSecond = vi.fn();
+    const slot = new AsyncDisposableSlot<string>();
+
+    slot.ensure("one", () => first.promise);
+    slot.ensure("two", () => second.promise);
+    second.resolve(stopSecond);
+    await settle();
+    first.resolve(stopFirst);
+    await settle();
+
+    expect(stopFirst).toHaveBeenCalledOnce();
+    expect(stopSecond).not.toHaveBeenCalled();
+    expect(slot.key).toBe("two");
+
+    slot.dispose();
+    expect(stopSecond).toHaveBeenCalledOnce();
+  });
+
+  it("clears a failed generation so the same key can retry", async () => {
+    const slot = new AsyncDisposableSlot<string>();
+    const stop = vi.fn();
+
+    slot.ensure("workspace", () => Promise.reject(new Error("unavailable")));
+    await settle();
+    expect(slot.key).toBeNull();
+
+    slot.ensure("workspace", async () => stop);
+    await settle();
+    expect(slot.key).toBe("workspace");
+    slot.dispose();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/daemon/src/tui/async-disposable-slot.ts
+++ b/packages/daemon/src/tui/async-disposable-slot.ts
@@ -1,0 +1,60 @@
+export type AsyncDisposer = () => void | Promise<void>;
+
+/**
+ * Owns one asynchronously-created resource across replacement and shutdown.
+ *
+ * Creation cannot be cancelled, so every request captures a generation. A
+ * resource that resolves after replacement/disposal is retired immediately
+ * instead of being adopted by a dead UI root.
+ */
+export class AsyncDisposableSlot<Key> {
+  private generation = 0;
+  private currentKey: Key | null = null;
+  private currentDisposer: AsyncDisposer | null = null;
+  private disposed = false;
+
+  get key(): Key | null {
+    return this.currentKey;
+  }
+
+  ensure(key: Key, create: () => Promise<AsyncDisposer>): void {
+    if (this.disposed || Object.is(this.currentKey, key)) return;
+
+    const generation = ++this.generation;
+    this.currentKey = key;
+    const previous = this.currentDisposer;
+    this.currentDisposer = null;
+    this.retire(previous);
+
+    void create()
+      .then((disposer) => {
+        if (this.disposed || generation !== this.generation) {
+          this.retire(disposer);
+          return;
+        }
+        this.currentDisposer = disposer;
+      })
+      .catch(() => {
+        if (!this.disposed && generation === this.generation) this.currentKey = null;
+      });
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.generation += 1;
+    this.currentKey = null;
+    const current = this.currentDisposer;
+    this.currentDisposer = null;
+    this.retire(current);
+  }
+
+  private retire(disposer: AsyncDisposer | null): void {
+    if (!disposer) return;
+    try {
+      void Promise.resolve(disposer()).catch(() => {});
+    } catch {
+      // Resource cleanup is best-effort and must not interrupt later owners.
+    }
+  }
+}

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -599,6 +599,7 @@ import {
 } from "../chrome/notify.ts";
 import { adoptMarkArgv, updaterProbeArgv, updaterSpawnArgv } from "../chrome/front-door.ts";
 import { APP_HOST_SESSION } from "./hosted.ts";
+import { publishTuiInputReady } from "../readiness.ts";
 import {
   ATTENTION_FLASH_MS,
   attentionNoteLine,
@@ -7196,6 +7197,11 @@ try {
       }
       pasteIntoFocused(text);
     });
+
+    // OpenTUI's Solid hooks install their input owners from onMount. Register
+    // this barrier after both root hooks so an automation/host that observes it
+    // can send lifecycle input without racing a merely-painted first frame.
+    onMount(() => publishTuiInputReady("app"));
 
     /** The per-window strip's x-spans — one segment per tmux window, laid out from
      *  the main column's first cell (SIDEBAR_W + paddingLeft 1) with a 1-cell gap,

--- a/packages/daemon/src/tui/mirror/app.tsx
+++ b/packages/daemon/src/tui/mirror/app.tsx
@@ -600,6 +600,7 @@ import {
 import { adoptMarkArgv, updaterProbeArgv, updaterSpawnArgv } from "../chrome/front-door.ts";
 import { APP_HOST_SESSION } from "./hosted.ts";
 import { publishTuiInputReady } from "../readiness.ts";
+import { AsyncDisposableSlot } from "../async-disposable-slot.ts";
 import {
   ATTENTION_FLASH_MS,
   attentionNoteLine,
@@ -3981,8 +3982,7 @@ try {
     // tab is backgrounded they only mark it stale (refreshed on tab return).
     // The watcher ignores .git, so index-only changes (external staging) ride
     // the 3s status poll armed in onMount instead.
-    let stopFilesWatch: (() => Promise<void>) | null = null;
-    let filesWatchDir = "";
+    const filesWatch = new AsyncDisposableSlot<string>();
     let filesStale = false;
     const onFilesWatchEvent = () => {
       if (mode() === "editor") {
@@ -3992,25 +3992,11 @@ try {
       }
     };
     const ensureFilesWatch = (root: string) => {
-      if (filesWatchDir === root) return;
-      filesWatchDir = root;
-      const prev = stopFilesWatch;
-      stopFilesWatch = null;
-      void prev?.().catch(() => {});
-      void watchDirectory(root, onFilesWatchEvent, { ignore: [...ALWAYS_IGNORE] })
-        .then((stop) => {
-          if (filesWatchDir !== root) {
-            void stop().catch(() => {});
-            return;
-          }
-          stopFilesWatch = stop;
-        })
-        .catch(() => {
-          // watcher unavailable — the Files-tab status poll still runs, and
-          // `r` / toggles / mutations refresh on demand.
-        });
+      filesWatch.ensure(root, () =>
+        watchDirectory(root, onFilesWatchEvent, { ignore: [...ALWAYS_IGNORE] }),
+      );
     };
-    cleanupRegistry.set("files-watch", () => void stopFilesWatch?.().catch(() => {}));
+    cleanupRegistry.set("files-watch", () => filesWatch.dispose());
     /** A tab switch back onto a stale Files surface catches up in one shot. */
     const catchUpFilesIfStale = () => {
       if (!filesStale) return;

--- a/packages/daemon/src/tui/readiness.test.ts
+++ b/packages/daemon/src/tui/readiness.test.ts
@@ -1,0 +1,51 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { publishTuiInputReady } from "./readiness.ts";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("TUI input readiness", () => {
+  it("is inert unless a launcher requests the handshake", () => {
+    expect(publishTuiInputReady("app", { path: "" })).toBeNull();
+  });
+
+  it("atomically publishes a versioned input-ready record", () => {
+    const root = mkdtempSync(join(tmpdir(), "tmux-ide-tui-ready-"));
+    roots.push(root);
+    const path = join(root, "nested", "ready.json");
+    const now = new Date("2026-08-12T08:00:00.000Z");
+
+    expect(publishTuiInputReady("app", { path, pid: 42, now })).toEqual({
+      version: 1,
+      phase: "input-ready",
+      surface: "app",
+      pid: 42,
+      at: now.toISOString(),
+    });
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+      version: 1,
+      phase: "input-ready",
+      surface: "app",
+      pid: 42,
+      at: now.toISOString(),
+    });
+    expect(existsSync(`${path}.42.tmp`)).toBe(false);
+  });
+
+  it("publishes the app barrier after its root keyboard and paste owners mount", () => {
+    const source = readFileSync(new URL("./mirror/app.tsx", import.meta.url), "utf8");
+    const keyboard = source.indexOf("useKeyboard((evt) =>");
+    const paste = source.indexOf("usePaste((e) =>", keyboard);
+    const ready = source.indexOf('onMount(() => publishTuiInputReady("app"))', paste);
+
+    expect(keyboard).toBeGreaterThan(-1);
+    expect(paste).toBeGreaterThan(keyboard);
+    expect(ready).toBeGreaterThan(paste);
+  });
+});

--- a/packages/daemon/src/tui/readiness.ts
+++ b/packages/daemon/src/tui/readiness.ts
@@ -1,0 +1,52 @@
+import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export const TUI_READY_FILE_ENV = "TMUX_IDE_TUI_READY_FILE";
+
+export interface TuiReadyRecord {
+  version: 1;
+  phase: "input-ready";
+  surface: string;
+  pid: number;
+  at: string;
+}
+
+export interface PublishTuiReadyOptions {
+  path?: string;
+  pid?: number;
+  now?: Date;
+}
+
+/**
+ * Publish the point at which a TUI surface can accept lifecycle input.
+ *
+ * A painted frame is not an input-readiness barrier: Solid installs OpenTUI
+ * keyboard owners from `onMount`, and a fast host can observe the first paint
+ * before those callbacks have run. Launchers that need to drive a surface may
+ * opt into this atomic file handshake instead of racing visible text.
+ */
+export function publishTuiInputReady(
+  surface: string,
+  options: PublishTuiReadyOptions = {},
+): TuiReadyRecord | null {
+  const path = options.path ?? process.env[TUI_READY_FILE_ENV];
+  if (!path) return null;
+
+  const record: TuiReadyRecord = {
+    version: 1,
+    phase: "input-ready",
+    surface,
+    pid: options.pid ?? process.pid,
+    at: (options.now ?? new Date()).toISOString(),
+  };
+  const temporaryPath = `${path}.${record.pid}.tmp`;
+  try {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    writeFileSync(temporaryPath, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+    renameSync(temporaryPath, path);
+    return record;
+  } catch {
+    rmSync(temporaryPath, { force: true });
+    return null;
+  }
+}

--- a/scripts/pack-check-run.mjs
+++ b/scripts/pack-check-run.mjs
@@ -69,13 +69,20 @@ function tmuxEnv(runtimePath) {
   };
 }
 
-async function waitUntil(predicate, timeoutMs, description) {
+async function waitUntil(predicate, timeoutMs, description, diagnostics) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (predicate()) return;
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
   }
-  throw new Error(`Timed out waiting for ${description}`);
+  const detail = (() => {
+    try {
+      return diagnostics?.() ?? "";
+    } catch (error) {
+      return `diagnostics failed: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  })();
+  throw new Error(`Timed out waiting for ${description}${detail ? `\n${detail}` : ""}`);
 }
 
 function findTarball(prefix) {
@@ -161,6 +168,24 @@ async function runInstalledTuiGate(installedCli) {
       encoding: "utf8",
       stdio,
     });
+  const gateDiagnostics = () => {
+    const frame = tmuxResult(["capture-pane", "-p", "-t", `=${hostSession}:0.0`]);
+    const pane = tmuxResult([
+      "list-panes",
+      "-t",
+      `=${hostSession}`,
+      "-F",
+      "pid=#{pane_pid} dead=#{pane_dead} status=#{pane_dead_status} command=#{pane_current_command}",
+    ]);
+    const readiness = existsSync(readyPath) ? readFileSync(readyPath, "utf8").trim() : "missing";
+    const stderr = existsSync(stderrPath) ? readFileSync(stderrPath, "utf8").trim() : "";
+    return [
+      `readiness: ${readiness}`,
+      `pane: ${pane.status === 0 ? pane.stdout.trim() : pane.stderr.trim()}`,
+      `frame:\n${frame.status === 0 ? frame.stdout : frame.stderr}`,
+      `stderr:\n${stderr || "(empty)"}`,
+    ].join("\n");
+  };
 
   for (const forbidden of ["bunfig.toml", "node_modules", join(".tmux-ide", "workspace.yml")]) {
     if (existsSync(join(launchDir, forbidden))) {
@@ -237,6 +262,7 @@ async function runInstalledTuiGate(installedCli) {
       },
       20_000,
       "the installed TUI's input-ready barrier",
+      gateDiagnostics,
     );
 
     if (!existsSync(statusPath)) {
@@ -251,7 +277,12 @@ async function runInstalledTuiGate(installedCli) {
       const quit = tmuxResult(["send-keys", "-t", `=${hostSession}:0.0`, "C-q"]);
       if (quit.status !== 0) throw new Error(`Could not ask installed TUI to exit: ${quit.stderr}`);
     }
-    await waitUntil(() => existsSync(statusPath), 10_000, "the installed TUI's clean exit");
+    await waitUntil(
+      () => existsSync(statusPath),
+      10_000,
+      "the installed TUI's clean exit",
+      gateDiagnostics,
+    );
 
     const status = readFileSync(statusPath, "utf8").trim();
     const stderr = existsSync(stderrPath) ? readFileSync(stderrPath, "utf8") : "";

--- a/scripts/pack-check-run.mjs
+++ b/scripts/pack-check-run.mjs
@@ -149,6 +149,7 @@ async function runInstalledTuiGate(installedCli) {
   const targetSession = "ordinary-isolated";
   const hostSession = "installed-tui-gate";
   const statusPath = join(tmpRoot, "installed-tui.status");
+  const readyPath = join(tmpRoot, "installed-tui.ready.json");
   const stderrPath = join(tmpRoot, "installed-tui.stderr");
   const launcherPath = join(tmpRoot, "launch-installed-tui.sh");
   const runtimeEnv = tmuxEnv(dirname(installedCli));
@@ -184,6 +185,7 @@ async function runInstalledTuiGate(installedCli) {
     launcherPath,
     [
       "#!/bin/sh",
+      `export TMUX_IDE_TUI_READY_FILE=${shQuote(readyPath)}`,
       `${shQuote(installedCli)} app ${shQuote(targetSession)} 2>${shQuote(stderrPath)}`,
       "status=$?",
       `printf '%s\\n' "$status" > ${shQuote(statusPath)}`,
@@ -231,13 +233,21 @@ async function runInstalledTuiGate(installedCli) {
         if (existsSync(statusPath)) return true;
         const frame = tmuxResult(["capture-pane", "-p", "-t", `=${hostSession}:0.0`]);
         if (frame.status === 0) captured = frame.stdout;
-        return captured.includes("tmux-ide");
+        return existsSync(readyPath) && captured.includes("tmux-ide");
       },
       20_000,
-      "the installed TUI's first frame",
+      "the installed TUI's input-ready barrier",
     );
 
     if (!existsSync(statusPath)) {
+      const readiness = JSON.parse(readFileSync(readyPath, "utf8"));
+      if (
+        readiness.version !== 1 ||
+        readiness.phase !== "input-ready" ||
+        readiness.surface !== "app"
+      ) {
+        throw new Error(`Installed TUI published invalid readiness: ${JSON.stringify(readiness)}`);
+      }
       const quit = tmuxResult(["send-keys", "-t", `=${hostSession}:0.0`, "C-q"]);
       if (quit.status !== 0) throw new Error(`Could not ask installed TUI to exit: ${quit.stderr}`);
     }


### PR DESCRIPTION
## Outcome

Cuts the web workspace onto the shared semantic pane runtime and gives drag/resize one exactly-once transaction lifecycle.

- keeps sidebar/window/pane selection client-local while preserving canonical tmux input ownership
- coalesces pointer previews with requestAnimationFrame and sends one durable resize on release
- settles against daemon-clamped geometry without preview/revert double transitions
- retains xterm owners by semantic pane identity
- isolates terminal selection/copy from panel dragging
- consumes semantic seed/patch delivery with ACK-after-paint and fail-closed monotonic lanes
- preserves explicit legacy raw-profile compatibility

## Verification

- `pnpm check`
- independent interaction review: approved, no P0/P1
- independent protocol review after fixes: approved, no P0/P1

Sfora: #189