### PR TITLE
Fix Markdown rendering in compiled TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Replaced the legacy `/tmp`-file performance taps with shared, demand-only OpenTUI and web HUD telemetry plus a deterministic multi-client SessionRuntime qualification gate.
 
+### Fixed
+
+- Standalone TUI binaries now embed OpenTUI's Tree-sitter worker and WebAssembly runtime, so `tmux-ide show` renders Markdown without leaking `/$bunfs/root/parser.worker.ts` errors into terminal panes.
+
 ## 2.7.0
 
 The unified app release: `tmux-ide app` is now a real terminal IDE over your fleet — panes feel native, agents are visible at a glance, and you can start it anywhere.

--- a/packages/daemon/src/tui/main.ts
+++ b/packages/daemon/src/tui/main.ts
@@ -20,6 +20,12 @@
  * exactly one surface's top-level `render()` side effect from firing.
  */
 
+import parserWorkerPath from "tmux-ide:opentui-parser-worker" with { type: "file" };
+import treeSitterWasmPath from "tmux-ide:opentui-tree-sitter-wasm" with { type: "file" };
+import { existsSync } from "node:fs";
+
+const TREE_SITTER_SMOKE_SURFACE = "__tree-sitter-smoke";
+
 const SURFACES = [
   "team",
   "app",
@@ -38,10 +44,39 @@ function isSurface(value: string | undefined): value is Surface {
 }
 
 async function main(): Promise<void> {
+  // OpenTUI normally finds parser.worker.js beside its JS module. A standalone
+  // Bun executable has no such directory: import.meta.url points into /$bunfs.
+  // build-tui embeds a fully bundled worker and its web-tree-sitter wasm as
+  // explicit assets; publish the worker path before any OpenTUI surface imports
+  // create the singleton TreeSitterClient. The wasm binding is intentionally
+  // retained and checked here so Bun cannot tree-shake the worker's sibling.
+  if (!existsSync(parserWorkerPath) || !existsSync(treeSitterWasmPath)) {
+    throw new Error("tmux-ide-tui: embedded Tree-sitter runtime is incomplete");
+  }
+  process.env.OTUI_TREE_SITTER_WORKER_PATH ??= parserWorkerPath;
+
   // Carries process entry time across the lazy surface import. The app's
   // opt-in profiler turns this into phase timings without IO on normal runs.
   process.env.TMUX_IDE_TUI_LAUNCH_EPOCH_MS ??= String(Date.now());
   const surface = process.argv[2];
+
+  // Private release/packaging gate. This exercises the same OpenTUI singleton
+  // that Markdown uses, including Worker startup and web-tree-sitter wasm, but
+  // mounts no terminal renderer and leaves no alternate-screen state behind.
+  if (surface === TREE_SITTER_SMOKE_SURFACE) {
+    const { destroyTreeSitterClient, getTreeSitterClient } = await import("@opentui/core");
+    const client = getTreeSitterClient();
+    await client.initialize();
+    const highlighted = await client.highlightOnce("# tmux-ide\n\n**ready**", "markdown");
+    if (highlighted.error || !highlighted.highlights?.length) {
+      throw new Error(
+        `tmux-ide-tui: embedded Markdown parser failed: ${highlighted.error ?? "no highlights"}`,
+      );
+    }
+    await destroyTreeSitterClient();
+    process.stdout.write("tree-sitter-worker-ready\n");
+    return;
+  }
 
   if (!isSurface(surface)) {
     process.stderr.write(

--- a/scripts/build-tui.mjs
+++ b/scripts/build-tui.mjs
@@ -22,8 +22,9 @@
  */
 
 import { createSolidTransformPlugin } from "@opentui/solid/bun-plugin";
-import { mkdirSync, existsSync, statSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { mkdirSync, existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -48,17 +49,73 @@ const outfile =
 mkdirSync(dirname(outfile), { recursive: true });
 
 const start = Date.now();
-const result = await Bun.build({
-  entrypoints: [entry],
-  target: "bun",
-  compile: { outfile, target },
-  // This executable is the production runtime; source-mode development keeps
-  // readable symbols. Minifying the embedded JS cuts cold-start IO and module
-  // evaluation (the dominant first-frame cost) without changing OpenTUI's
-  // native asset or the lazy surface dispatcher.
-  minify: true,
-  plugins: [createSolidTransformPlugin()],
-});
+const workerBuildDir = mkdtempSync(join(tmpdir(), "tmux-ide-opentui-worker-"));
+let result;
+
+try {
+  // Bun does not discover a Worker whose URL is selected inside a dependency,
+  // and an unbundled parser.worker.js cannot resolve web-tree-sitter from the
+  // standalone executable's /$bunfs root. Bundle the worker first, including
+  // its JS dependencies, then embed both that bundle and its emitted wasm as
+  // file assets in the production executable.
+  const workerBuild = await Bun.build({
+    entrypoints: [fileURLToPath(import.meta.resolve("@opentui/core/parser.worker"))],
+    outdir: workerBuildDir,
+    target: "bun",
+    naming: "parser.worker.js",
+    minify: true,
+  });
+  if (!workerBuild.success) {
+    for (const log of workerBuild.logs) console.error(log);
+    throw new Error("[build-tui] Tree-sitter worker bundle failed");
+  }
+
+  const workerBundle = workerBuild.outputs.find((output) => output.path.endsWith(".js"))?.path;
+  const treeSitterWasm = workerBuild.outputs.find((output) => output.path.endsWith(".wasm"))?.path;
+  if (!workerBundle || !treeSitterWasm) {
+    throw new Error("[build-tui] Tree-sitter worker bundle did not emit JS and wasm assets");
+  }
+
+  const workerAssetPlugin = {
+    name: "tmux-ide-opentui-worker-assets",
+    setup(build) {
+      build.onResolve({ filter: /^tmux-ide:opentui-parser-worker$/ }, () => ({
+        path: workerBundle,
+        namespace: "tmux-ide-opentui-worker-asset",
+      }));
+      build.onResolve({ filter: /^tmux-ide:opentui-tree-sitter-wasm$/ }, () => ({
+        // Strip the worker build's content hash from its input name. Bun adds
+        // the same content hash while embedding it in the executable, yielding
+        // exactly the basename referenced by the bundled worker.
+        path: "tree-sitter.wasm",
+        namespace: "tmux-ide-opentui-worker-asset",
+      }));
+      build.onLoad(
+        { filter: /.*/, namespace: "tmux-ide-opentui-worker-asset" },
+        async ({ path }) => ({
+          contents: new Uint8Array(
+            await Bun.file(path === "tree-sitter.wasm" ? treeSitterWasm : path).arrayBuffer(),
+          ),
+          loader: "file",
+        }),
+      );
+    },
+  };
+
+  result = await Bun.build({
+    entrypoints: [entry],
+    target: "bun",
+    compile: { outfile, target },
+    // This executable is the production runtime; source-mode development keeps
+    // readable symbols. Minifying the embedded JS cuts cold-start IO and module
+    // evaluation (the dominant first-frame cost) without changing OpenTUI's
+    // native asset or the lazy surface dispatcher.
+    minify: true,
+    plugins: [workerAssetPlugin, createSolidTransformPlugin()],
+  });
+} finally {
+  rmSync(workerBuildDir, { recursive: true, force: true });
+}
 
 if (!result.success) {
   for (const log of result.logs) console.error(log);

--- a/scripts/pack-check-run.mjs
+++ b/scripts/pack-check-run.mjs
@@ -152,6 +152,21 @@ async function runInstalledTuiGate(installedCli) {
   );
   run("bun", ["scripts/build-tui.mjs", "--outfile", downloadedTui], { stdio: "inherit" });
 
+  const treeSitterSmoke = spawnSync(downloadedTui, ["__tree-sitter-smoke"], {
+    cwd: launchDir,
+    env: { ...process.env, ...tmuxEnv(dirname(installedCli)) },
+    encoding: "utf8",
+  });
+  if (
+    treeSitterSmoke.status !== 0 ||
+    treeSitterSmoke.stdout.trim() !== "tree-sitter-worker-ready"
+  ) {
+    throw new Error(
+      `Installed TUI Tree-sitter worker smoke failed (${treeSitterSmoke.status}):\n` +
+        `${treeSitterSmoke.stdout}${treeSitterSmoke.stderr}`,
+    );
+  }
+
   const socketName = `p${process.pid}`;
   const targetSession = "ordinary-isolated";
   const hostSession = "installed-tui-gate";


### PR DESCRIPTION
## Summary
- prebundle and embed OpenTUI's Tree-sitter worker plus web-tree-sitter WebAssembly in standalone TUI binaries
- route OpenTUI to the embedded worker before any rich-preview surface mounts
- add an installed-binary smoke that performs real Markdown highlighting

## Root cause
The standalone Bun executable exposed `import.meta.url` under `/$bunfs/root`. OpenTUI could not find its sibling `parser.worker.js`, fell back to `parser.worker.ts`, and printed a `ModuleNotFound` error into the terminal. Embedding the raw worker alone was insufficient because its `web-tree-sitter` dependency and wasm also needed a resolvable runtime path.

## Verification
- `pnpm build:tui`
- config-free `tmux-ide-tui __tree-sitter-smoke` (worker init + real Markdown highlights)
- `pnpm test:pack-installed`
- 31 rich-preview/widget Vitest tests
- 3 OpenTUI renderer tests
- targeted ESLint, Prettier, and `git diff --check`