### PR TITLE
Fix show widget viewport rendering

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -40246,17 +40246,21 @@ function terminalModes(terminal) {
     synchronizedOutput: dec.synchronizedOutput === true
   };
 }
-function projectPlacements(rows, viewportRows, cols, historyRows) {
+function projectPlacements(rows, viewportRows, cols) {
   const marker = detectWidgetMarkerFromReplicaRows(rows);
   if (!marker) return [];
   return [
     {
       id: marker.id,
       kind: "widget",
-      row: Math.max(0, Math.min(viewportRows - 1, marker.lineIndex - historyRows)),
+      // A pane widget replaces the terminal viewport while its authenticated
+      // marker remains present. The marker's physical row is transport detail,
+      // not widget geometry: projecting only that row gives the host enough
+      // room for chrome but clips every content row below it.
+      row: 0,
       column: 0,
       columns: Math.max(1, cols),
-      rows: 1,
+      rows: Math.max(1, viewportRows),
       contentDigest: hashTerminalWidgetContent(marker.id, marker.args)
     }
   ];
@@ -40635,7 +40639,7 @@ var init_terminal_replica_interpreter = __esm({
         const scanPlacements = this.#widgetGate || this.#snapshot.placements.length > 0;
         const placementRows = scanPlacements ? [...history, ...grid] : [];
         if (scanPlacements) this.#stats.placementRowsRead += placementRows.length;
-        const placements = scanPlacements ? projectPlacements(placementRows, grid.length, this.#terminal.cols, history.length) : [];
+        const placements = scanPlacements ? projectPlacements(placementRows, grid.length, this.#terminal.cols) : [];
         if (scanPlacements && placements.length === 0) this.#widgetGate = false;
         return assembleTerminalReplicaSnapshot({
           cols: this.#terminal.cols,

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-interpreter.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-interpreter.test.ts
@@ -236,7 +236,10 @@ describe("TerminalReplicaInterpreter", () => {
     expect(interpreter.currentSnapshot().placements[0]).toMatchObject({
       id: "markdown",
       kind: "widget",
+      row: 0,
       column: 0,
+      rows: 8,
+      columns: 80,
     });
     await interpreter.enqueue({
       type: "write",

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-interpreter.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-interpreter.ts
@@ -521,7 +521,7 @@ export class TerminalReplicaInterpreter {
     const placementRows = scanPlacements ? [...history, ...grid] : [];
     if (scanPlacements) this.#stats.placementRowsRead += placementRows.length;
     const placements = scanPlacements
-      ? projectPlacements(placementRows, grid.length, this.#terminal.cols, history.length)
+      ? projectPlacements(placementRows, grid.length, this.#terminal.cols)
       : [];
     if (scanPlacements && placements.length === 0) this.#widgetGate = false;
     return assembleTerminalReplicaSnapshot({
@@ -804,7 +804,6 @@ function projectPlacements(
   rows: readonly TerminalReplicaRow[],
   viewportRows: number,
   cols: number,
-  historyRows: number,
 ): TerminalReplicaSnapshot["placements"] {
   const marker = detectWidgetMarkerFromReplicaRows(rows);
   if (!marker) return [];
@@ -812,10 +811,14 @@ function projectPlacements(
     {
       id: marker.id,
       kind: "widget",
-      row: Math.max(0, Math.min(viewportRows - 1, marker.lineIndex - historyRows)),
+      // A pane widget replaces the terminal viewport while its authenticated
+      // marker remains present. The marker's physical row is transport detail,
+      // not widget geometry: projecting only that row gives the host enough
+      // room for chrome but clips every content row below it.
+      row: 0,
       column: 0,
       columns: Math.max(1, cols),
-      rows: 1,
+      rows: Math.max(1, viewportRows),
       contentDigest: hashTerminalWidgetContent(marker.id, marker.args),
     },
   ];

--- a/packages/daemon/src/tui/mirror/runtime/application-root.tsx
+++ b/packages/daemon/src/tui/mirror/runtime/application-root.tsx
@@ -1049,6 +1049,11 @@ const mountTuiRoot = () => {
             onChange: () => {
               setRichPreviewRevision((revision) => revision + 1);
               publishRichPreviewChange();
+              // Asset resolution is independent of tmux pane output. The
+              // renderer is event-driven, so a resolved Markdown document must
+              // explicitly schedule its own frame instead of waiting for the
+              // next terminal byte or pointer event to happen to repaint it.
+              appRenderer.requestRender();
             },
             afterNativeFrame: (callback) => {
               appRenderer.once("frame", () => {

--- a/packages/daemon/src/tui/mirror/widget-surface.tsx
+++ b/packages/daemon/src/tui/mirror/widget-surface.tsx
@@ -54,6 +54,8 @@ export function TuiRichWidgetSurface(props: TuiRichWidgetSurfaceProps): JSX.Elem
             height={Math.max(1, props.height - 3)}
             content={props.surface.text}
             syntaxStyle={props.syntaxStyle!}
+            fg={props.theme.roles.text.primary}
+            bg={props.theme.roles.surfaces.terminal}
             conceal={true}
             concealCode={false}
             // Keep blocks independent. Besides making long documents cheaper to
@@ -66,9 +68,8 @@ export function TuiRichWidgetSurface(props: TuiRichWidgetSurfaceProps): JSX.Elem
               wrapMode: "word",
               borders: false,
             }}
-            // This surface is swapped atomically rather than appended chunk by
-            // chunk. Keeping OpenTUI's incremental path enabled avoids holding
-            // the first frame behind its optional async syntax worker.
+            // Keep blocks independent and allow their async syntax work to
+            // publish without rebuilding the whole document.
             streaming={true}
           />
         </Show>


### PR DESCRIPTION
Summary:
- project pane widgets across the complete canonical terminal viewport instead of one transport row
- request an OpenTUI frame when asynchronous rich-preview assets resolve
- pin Markdown foreground/background to the semantic terminal theme
- strengthen the interpreter regression with exact full-viewport geometry

Verification:
- pnpm check
- focused terminal-replica and OpenTUI rich-preview suites
- source TUI test-drive against a freshly rebuilt/restarted canonical daemon