### PR TITLE
Fix semantic window switching on OpenTUI 0.5

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7491,8 +7491,8 @@ async function createScriptTerminalId(args) {
   }
   const key = `${args.projectId}::${scope}::${args.kind}::${args.script}`;
   const data = new TextEncoder().encode(key);
-  const digest4 = await crypto.subtle.digest("SHA-256", data);
-  return Array.from(new Uint8Array(digest4)).map((b) => b.toString(16).padStart(2, "0")).join("").slice(0, 32);
+  const digest3 = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest3)).map((b) => b.toString(16).padStart(2, "0")).join("").slice(0, 32);
 }
 var terminalKindSchema, terminalCreateRequestSchema, terminalRenameRequestSchema;
 var init_terminals = __esm({
@@ -8884,13 +8884,13 @@ function decodeWidgetMarkerLine(line) {
   if (!trimmed.startsWith(WIDGET_MARKER_SENTINEL)) return null;
   const fields = trimmed.split(" ").filter((field) => field.length > 0);
   if (fields.length !== 4) return null;
-  const [sentinel, id, payload, digest4] = fields;
+  const [sentinel, id, payload, digest3] = fields;
   if (sentinel !== WIDGET_MARKER_SENTINEL) return null;
   if (!WIDGET_ID_PATTERN.test(id)) return null;
-  if (!DIGEST_PATTERN.test(digest4)) return null;
+  if (!DIGEST_PATTERN.test(digest3)) return null;
   if (payload.length > WIDGET_MARKER_MAX_PAYLOAD_CHARACTERS) return null;
   if (payload !== EMPTY_PAYLOAD && !BASE64URL_PATTERN.test(payload)) return null;
-  if (widgetMarkerDigest(id, payload) !== digest4) return null;
+  if (widgetMarkerDigest(id, payload) !== digest3) return null;
   if (payload === EMPTY_PAYLOAD) return { id, args: null };
   const json2 = decodeBase64Url(payload);
   if (json2 === null) return null;
@@ -9500,8 +9500,8 @@ function markedProjectRoot(inputDir, io) {
 }
 function projectIdentityKey(source, anchor) {
   const prefix = source === "git-common-dir" ? "git" : "path";
-  const digest4 = createHash("sha256").update(source).update("\0").update(anchor).digest("hex");
-  return `${prefix}-${digest4}`;
+  const digest3 = createHash("sha256").update(source).update("\0").update(anchor).digest("hex");
+  return `${prefix}-${digest3}`;
 }
 async function resolveProject(dir, options = {}) {
   const io = { ...defaultProjectResolverIo, ...options.io };
@@ -11317,8 +11317,8 @@ var init_shell = __esm({
 import { resolve as resolve5 } from "node:path";
 import { createHash as createHash2 } from "node:crypto";
 function semanticWindowIdForSession(session) {
-  const digest4 = createHash2("sha256").update("tmux-ide.launch.window.v1\0", "utf8").update(session, "utf8").digest("hex").slice(0, 20);
-  return `window.launch.${digest4}`;
+  const digest3 = createHash2("sha256").update("tmux-ide.launch.window.v1\0", "utf8").update(session, "utf8").digest("hex").slice(0, 20);
+  return `window.launch.${digest3}`;
 }
 function semanticPaneIdForPane(pane) {
   if (pane.id) return pane.id;
@@ -11333,9 +11333,9 @@ function semanticPaneIdForPane(pane) {
       ([left], [right]) => left < right ? -1 : left > right ? 1 : 0
     )
   });
-  const digest4 = createHash2("sha256").update(metadata).digest("hex").slice(0, 16);
+  const digest3 = createHash2("sha256").update(metadata).digest("hex").slice(0, 16);
   const label2 = paneIdentityLabel(pane);
-  return `pane-${label2}-${digest4}`;
+  return `pane-${label2}-${digest3}`;
 }
 function paneIdentityOptions(action) {
   return [
@@ -20110,11 +20110,25 @@ var init_daemon_fleet_facts_observer = __esm({
   }
 });
 
-// packages/daemon/src/command-center/resources/fleet-catalog.ts
+// packages/daemon/src/lib/semantic-resource-id.ts
 import { createHash as createHash5 } from "node:crypto";
+function semanticResourceDigest(value) {
+  return createHash5("sha256").update(value).digest("hex").slice(0, 20);
+}
+function semanticResourceId(namespace, value) {
+  return `${namespace}.${semanticResourceDigest(value)}`;
+}
+var init_semantic_resource_id = __esm({
+  "packages/daemon/src/lib/semantic-resource-id.ts"() {
+    "use strict";
+  }
+});
+
+// packages/daemon/src/command-center/resources/fleet-catalog.ts
+import { createHash as createHash6 } from "node:crypto";
 import { basename as basename8 } from "node:path";
 function digest(value) {
-  return createHash5("sha256").update(value).digest("hex").slice(0, 20);
+  return createHash6("sha256").update(value).digest("hex").slice(0, 20);
 }
 function fleetSessionIdForName(sessionName) {
   return `session.${digest(sessionName)}`;
@@ -20202,17 +20216,10 @@ var init_fleet_catalog2 = __esm({
 });
 
 // packages/daemon/src/command-center/resources/application-shell.ts
-import { createHash as createHash6 } from "node:crypto";
 import { hostname } from "node:os";
 import { basename as basename9 } from "node:path";
-function digest2(value) {
-  return createHash6("sha256").update(value).digest("hex").slice(0, 20);
-}
-function semanticId(namespace, value) {
-  return `${namespace}.${digest2(value)}`;
-}
 function agentIdForPaneStamp(stamp) {
-  return semanticId("agent", stamp);
+  return semanticResourceId("agent", stamp);
 }
 function isHostNameTitle(title, hostName) {
   if (!title) return false;
@@ -20229,7 +20236,7 @@ function label(value, fallback) {
   return normalized || fallback;
 }
 function fallbackPaneId(session, pane) {
-  return semanticId(
+  return semanticResourceId(
     "terminal.discovered",
     JSON.stringify({
       session: session.name,
@@ -20258,7 +20265,7 @@ function proveWindow(windowId, panes, stampToWindowIds) {
     if ((stampToWindowIds.get(stamp)?.size ?? 0) > 1) {
       return { ok: false, reason: "duplicate-window-stamp" };
     }
-    return { ok: true, windowResourceId: semanticId("terminal-window", stamp) };
+    return { ok: true, windowResourceId: semanticResourceId("terminal-window", stamp) };
   }
   return { ok: true, windowResourceId: null };
 }
@@ -20331,7 +20338,7 @@ function paneIdentities(session) {
   });
 }
 function legacyFallbackPaneId(pane) {
-  return semanticId(
+  return semanticResourceId(
     "pane.discovered",
     JSON.stringify({
       index: pane.index,
@@ -20447,7 +20454,7 @@ function dockTools(projectId) {
           ...common("missions"),
           data: {
             kind: "missions",
-            missionId: `mission.unavailable.${digest2(projectId)}`,
+            missionId: `mission.unavailable.${semanticResourceDigest(projectId)}`,
             title: "Missions unavailable",
             status: "disconnected",
             goalCount: 0,
@@ -20473,8 +20480,8 @@ function deepFreeze5(value) {
 function projectApplicationShellResourceV1Core(session, paneIds, nowSec) {
   const sessionName = label(session.name, "tmux session");
   const rootLabel = label(basename9(session.dir), sessionName);
-  const projectId = semanticId("project", session.dir);
-  const sessionId = semanticId("session", session.name);
+  const projectId = semanticResourceId("project", session.dir);
+  const sessionId = semanticResourceId("session", session.name);
   const focusedIndex = session.panes.findIndex((pane) => pane.active);
   const focusedPaneId = focusedIndex < 0 ? null : paneIds[focusedIndex] ?? null;
   const agents = session.panes.flatMap((pane, index) => {
@@ -20483,7 +20490,7 @@ function projectApplicationShellResourceV1Core(session, paneIds, nowSec) {
     const presentation = resolveAgentPresentation(pane, nowSec);
     return [
       {
-        id: semanticId("agent", paneId),
+        id: semanticResourceId("agent", paneId),
         // A fresh authority stamp's sanitized display name outranks the raw pane
         // title; both pass through label()'s control-strip/clamp before the wire.
         name: label(presentation.displayName ?? pane.name ?? pane.title, `Agent ${index + 1}`),
@@ -20509,7 +20516,7 @@ function projectApplicationShellResourceV1Core(session, paneIds, nowSec) {
       }
     },
     workspace: {
-      id: semanticId("workspace", session.dir),
+      id: semanticResourceId("workspace", session.dir),
       name: `${sessionName} workspace`.slice(0, 160),
       activeMode: "terminals",
       session: {
@@ -20693,6 +20700,7 @@ var init_application_shell2 = __esm({
   "packages/daemon/src/command-center/resources/application-shell.ts"() {
     "use strict";
     init_src();
+    init_semantic_resource_id();
     init_classify();
     init_agent_resolution();
     init_fleet_catalog2();
@@ -25074,13 +25082,13 @@ var init_workspace_pane_creation2 = __esm({
           `#{pane_id}	#{${SEMANTIC_PANE_OPTION}}`
         ]);
         const matches = output.split("\n").filter(Boolean).flatMap((line) => {
-          const [paneId, semanticId2, extra] = line.split("	");
+          const [paneId, semanticId, extra] = line.split("	");
           if (extra !== void 0 || !/^%[0-9]+$/u.test(paneId ?? "")) {
             throw new WorkspacePaneCreationError("workspace_unavailable", {
               reason: "pane_listing_shape"
             });
           }
-          return semanticId2 === semanticPaneId3 ? [paneId] : [];
+          return semanticId === semanticPaneId3 ? [paneId] : [];
         });
         if (matches.length === 0) {
           throw new WorkspacePaneCreationError("pane_not_found", { semanticPaneId: semanticPaneId3 });
@@ -26394,7 +26402,7 @@ function resource2(workspaceName) {
 function requestFingerprint2(request) {
   return JSON.stringify(request);
 }
-function digest3(value) {
+function digest2(value) {
   return createHash9("sha256").update(value).digest("hex").slice(0, 20);
 }
 var MAX_OPERATIONS2, MAX_REPLAYABLE_FAILURES3, MAX_TMUX_OUTPUT_BYTES2, ADOPTED_OPTION2, SESSION_PROMOTED_MARKER_OPTION, SESSION_WORKSPACE_OPTION2, SESSION_OPERATION_OPTION2, SEMANTIC_PANE_OPTION3, SEMANTIC_WINDOW_OPTION2, FIELD, SENTINEL, SESSION_FORMAT2, PANE_SCAN_FORMAT, PANE_VERIFY_FORMAT, ERROR_MESSAGES3, WorkspacePromotionError, VALID_SEMANTIC_PANE_ID, RESERVED_DISCOVERED_PREFIX, DEFAULT_IO3, WorkspacePromotionAuthority;
@@ -26707,7 +26715,7 @@ var init_workspace_promotion2 = __esm({
         try {
           for (const pane of scanned) {
             if (!hasValidPaneStamp(pane.semanticPaneId)) {
-              const paneStamp = `pane.promoted.${digest3(`${session.sessionName}\0${pane.paneId}`)}`;
+              const paneStamp = `pane.promoted.${digest2(`${session.sessionName}\0${pane.paneId}`)}`;
               this.#io.runTmux([
                 "set-option",
                 "-p",
@@ -26724,7 +26732,7 @@ var init_workspace_promotion2 = __esm({
             if (!reconciledWindows.has(pane.windowId)) {
               reconciledWindows.add(pane.windowId);
               if (pane.semanticWindowId.length === 0) {
-                const windowStamp = `window.promoted.${digest3(`${session.sessionName}\0${pane.windowId}`)}`;
+                const windowStamp = `window.promoted.${digest2(`${session.sessionName}\0${pane.windowId}`)}`;
                 this.#io.runTmux([
                   "set-option",
                   "-w",
@@ -31288,9 +31296,9 @@ var init_session_channel = __esm({
           if (row.active) this.currentWindow = row.runtimeId;
           const parsed = parseLayout(row.visible);
           if (parsed) this.layoutByWindow.set(row.runtimeId, { ...parsed, zoomed: row.zoomed });
-          let semanticId2 = null;
+          let semanticId = null;
           if (row.stamp && stampCounts.get(row.stamp) === 1) {
-            semanticId2 = row.stamp;
+            semanticId = row.stamp;
           } else {
             let candidate = null;
             for (let attempt = 0; attempt < 32 && !candidate; attempt += 1) {
@@ -31307,7 +31315,7 @@ var init_session_channel = __esm({
                 () => true,
                 () => false
               );
-              if (ok2) semanticId2 = candidate;
+              if (ok2) semanticId = candidate;
               else {
                 this.pushDiagnostic({
                   code: "WINDOW_STAMP_BACK_FAILED",
@@ -31319,7 +31327,7 @@ var init_session_channel = __esm({
           }
           next.set(row.runtimeId, {
             runtimeId: row.runtimeId,
-            semanticId: semanticId2,
+            semanticId,
             name: row.name,
             paneBorderStatus: row.paneBorderStatus
           });
@@ -58018,8 +58026,8 @@ var require_package = __commonJS({
       dependencies: {
         "@hono/node-server": "^2.1.0",
         "@hono/zod-validator": "^0.7.6",
-        "@opentui/core": "^0.4.3",
-        "@opentui/solid": "^0.4.3",
+        "@opentui/core": "^0.5.1",
+        "@opentui/solid": "^0.5.1",
         "@parcel/watcher": "^2.5.6",
         "@types/ws": "^8.18.1",
         hono: "^4.12.34",

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
   "dependencies": {
     "@hono/node-server": "^2.1.0",
     "@hono/zod-validator": "^0.7.6",
-    "@opentui/core": "^0.4.3",
-    "@opentui/solid": "^0.4.3",
+    "@opentui/core": "^0.5.1",
+    "@opentui/solid": "^0.5.1",
     "@parcel/watcher": "^2.5.6",
     "@types/ws": "^8.18.1",
     "hono": "^4.12.34",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -79,8 +79,8 @@
   "dependencies": {
     "@hono/node-server": "^2.1.0",
     "@hono/zod-validator": "^0.7.6",
-    "@opentui/core": "^0.4.3",
-    "@opentui/solid": "^0.4.3",
+    "@opentui/core": "^0.5.1",
+    "@opentui/solid": "^0.5.1",
     "@parcel/watcher": "^2.5.6",
     "@tmux-ide/contracts": "workspace:*",
     "@tmux-ide/core": "workspace:*",

--- a/packages/daemon/src/command-center/resources/application-shell.ts
+++ b/packages/daemon/src/command-center/resources/application-shell.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { hostname } from "node:os";
 import { basename } from "node:path";
 import {
@@ -23,6 +22,11 @@ import {
   type TerminalResourceAttachability,
   type TerminalResourceUnavailableReason,
 } from "@tmux-ide/contracts";
+
+import {
+  semanticResourceDigest,
+  semanticResourceId as semanticId,
+} from "../../lib/semantic-resource-id.ts";
 import { parseAuthority, type InstantState } from "../../tui/detect/classify.ts";
 import { agentDisplayMetadata, resolveAgentStatus } from "../../tui/detect/agent-resolution.ts";
 import { fleetSessionIdForName } from "./fleet-catalog.ts";
@@ -124,14 +128,6 @@ export interface LegacyApplicationShellSessionFacts {
   readonly name: string;
   readonly dir: string;
   readonly panes: readonly LegacyApplicationShellPaneFacts[];
-}
-
-function digest(value: string): string {
-  return createHash("sha256").update(value).digest("hex").slice(0, 20);
-}
-
-function semanticId(namespace: string, value: string): string {
-  return `${namespace}.${digest(value)}`;
 }
 
 /**
@@ -530,7 +526,7 @@ function dockTools(projectId: string): ApplicationShellProjectionInputV1["dock"]
           ...common("missions"),
           data: {
             kind: "missions",
-            missionId: `mission.unavailable.${digest(projectId)}`,
+            missionId: `mission.unavailable.${semanticResourceDigest(projectId)}`,
             title: "Missions unavailable",
             status: "disconnected",
             goalCount: 0,

--- a/packages/daemon/src/lib/semantic-resource-id.ts
+++ b/packages/daemon/src/lib/semantic-resource-id.ts
@@ -1,0 +1,17 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Mint the wire-safe product identity used to correlate a durable tmux stamp
+ * without publishing the raw stamp through application-shell resources.
+ */
+export function semanticResourceDigest(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 20);
+}
+
+export function semanticResourceId(namespace: string, value: string): string {
+  return `${namespace}.${semanticResourceDigest(value)}`;
+}
+
+export function terminalWindowResourceId(semanticWindowId: string): string {
+  return semanticResourceId("terminal-window", semanticWindowId);
+}

--- a/packages/daemon/src/tui/main.ts
+++ b/packages/daemon/src/tui/main.ts
@@ -21,7 +21,6 @@
  */
 
 import parserWorkerPath from "tmux-ide:opentui-parser-worker" with { type: "file" };
-import treeSitterWasmPath from "tmux-ide:opentui-tree-sitter-wasm" with { type: "file" };
 import { existsSync } from "node:fs";
 
 const TREE_SITTER_SMOKE_SURFACE = "__tree-sitter-smoke";
@@ -44,14 +43,12 @@ function isSurface(value: string | undefined): value is Surface {
 }
 
 async function main(): Promise<void> {
-  // OpenTUI normally finds parser.worker.js beside its JS module. A standalone
-  // Bun executable has no such directory: import.meta.url points into /$bunfs.
-  // build-tui embeds a fully bundled worker and its web-tree-sitter wasm as
-  // explicit assets; publish the worker path before any OpenTUI surface imports
-  // create the singleton TreeSitterClient. The wasm binding is intentionally
-  // retained and checked here so Bun cannot tree-shake the worker's sibling.
-  if (!existsSync(parserWorkerPath) || !existsSync(treeSitterWasmPath)) {
-    throw new Error("tmux-ide-tui: embedded Tree-sitter runtime is incomplete");
+  // Bun cannot discover the worker import hidden behind OpenTUI's runtime
+  // resolver when compiling a standalone executable. build-tui embeds the
+  // official 0.5 parser worker as a file asset; OpenTUI continues to own the
+  // WASM, language parser, query, and native-library asset graph.
+  if (!existsSync(parserWorkerPath)) {
+    throw new Error("tmux-ide-tui: embedded OpenTUI parser worker is unavailable");
   }
   process.env.OTUI_TREE_SITTER_WORKER_PATH ??= parserWorkerPath;
 

--- a/packages/daemon/src/tui/mirror/semantic-session-view.test.ts
+++ b/packages/daemon/src/tui/mirror/semantic-session-view.test.ts
@@ -40,6 +40,48 @@ describe("SemanticSessionView local runtime identity", () => {
     ]);
   });
 
+  it("keeps a window actionable while its layout identity converges", async () => {
+    const view = new SemanticSessionView({ target: "alpha" });
+    view.setInventory({
+      activeResourceId: "terminal.editor",
+      resources: [
+        {
+          id: "terminal.editor",
+          title: "Editor",
+          kind: "terminal",
+          active: true,
+          attachability: { status: "available", semanticPaneId: "pane.editor" },
+          windowResourceId: "terminal-window.006869769f156e2088f2",
+        },
+        {
+          id: "terminal.tests",
+          title: "Tests",
+          kind: "terminal",
+          active: false,
+          attachability: { status: "available", semanticPaneId: "pane.tests" },
+          windowResourceId: "terminal-window.fe0a211aa297f1b5834f",
+        },
+      ],
+    });
+    view.acceptLayout({
+      type: "layout",
+      semanticWindowId: "window.tests",
+      windowName: "Tests",
+      currentWindow: false,
+      cols: 80,
+      rows: 24,
+      zoomed: false,
+      panes: [{ pane: null, left: 0, top: 0, width: 80, height: 24, active: true }],
+    });
+
+    expect(await view.windows()).toEqual([
+      expect.objectContaining({
+        semanticWindowId: "window.tests",
+        activePaneId: "pane.tests",
+      }),
+    ]);
+  });
+
   it("joins wire-safe inventory identity to process-local raw tmux descriptors", () => {
     const view = new SemanticSessionView({ target: "alpha" });
     view.setInventory({

--- a/packages/daemon/src/tui/mirror/semantic-session-view.ts
+++ b/packages/daemon/src/tui/mirror/semantic-session-view.ts
@@ -1,5 +1,6 @@
 import type { ApplicationShellTerminalInventory, PaneStreamServerFrame } from "@tmux-ide/contracts";
 import type { SessionPaneDescriptor } from "../../terminal/protocol/session-descriptor-discovery.ts";
+import { terminalWindowResourceId } from "../../lib/semantic-resource-id.ts";
 
 import type { MirrorSnapshot } from "./pane-mirror.ts";
 import type { TerminalPaletteProjection } from "./theme.ts";
@@ -314,14 +315,33 @@ export class SemanticSessionView {
   }
 
   async windows(): Promise<WindowTab[]> {
-    return [...this.#layouts.values()].map((layout, index) => ({
-      index,
-      name: layout.windowName ?? `Window ${index + 1}`,
-      active: layout.currentWindow,
-      sync: false,
-      semanticWindowId: layout.semanticWindowId,
-      activePaneId: layout.panes.find((pane) => pane.active)?.pane ?? null,
-    }));
+    return [...this.#layouts.values()].map((layout, fallbackIndex) => {
+      const layoutPaneId = layout.panes.find((pane) => pane.active)?.pane ?? null;
+      const windowResourceId = layout.semanticWindowId
+        ? terminalWindowResourceId(layout.semanticWindowId)
+        : null;
+      const inventoryPane =
+        windowResourceId === null
+          ? null
+          : (this.#inventoryDescriptors.find(
+              (descriptor) =>
+                descriptor.windowId === windowResourceId && descriptor.semanticPaneId !== null,
+            ) ?? null);
+      const activePaneId = layoutPaneId ?? inventoryPane?.semanticPaneId ?? null;
+      const runtimePane = activePaneId
+        ? (this.#runtimeDescriptors.find(
+            (descriptor) => descriptor.semanticPaneId === activePaneId,
+          ) ?? null)
+        : null;
+      return {
+        index: runtimePane?.windowIndex ?? fallbackIndex,
+        name: layout.windowName ?? runtimePane?.windowName ?? `Window ${fallbackIndex + 1}`,
+        active: layout.currentWindow,
+        sync: false,
+        semanticWindowId: layout.semanticWindowId,
+        activePaneId,
+      };
+    });
   }
 
   dispose(): void {

--- a/patches/@opentui__solid@0.5.1.patch
+++ b/patches/@opentui__solid@0.5.1.patch
@@ -1,8 +1,7 @@
 diff --git a/index.bun.js b/index.bun.js
-index 72c8ce7e28f1f724e80ee84fa52961668b8e62dd..2f9edbfe5f3a52f75d1aeb86eb879443e7a99961 100644
 --- a/index.bun.js
 +++ b/index.bun.js
-@@ -568,7 +568,7 @@ function _insertNode(parent, node, anchor) {
+@@ -570,7 +570,7 @@ function _insertNode(parent, node, anchor) {
    if (anchorIndex === -1) {
      log("[INSERT]", "Could not find anchor", logId(parent), logId(anchor), "[children]", ...children.map((c) => c.id));
    }
@@ -12,7 +11,6 @@ index 72c8ce7e28f1f724e80ee84fa52961668b8e62dd..2f9edbfe5f3a52f75d1aeb86eb879443
  function _removeNode(parent, node) {
    log("Removing node:", logId(node), "from parent:", logId(parent));
 diff --git a/index.js b/index.js
-index 18d70421367d554a9d6a66584b80f0bb46de5ec6..c30cbb50731cef92ee75f984d57e762281303070 100644
 --- a/index.js
 +++ b/index.js
 @@ -542,7 +542,7 @@ function _insertNode(parent, node, anchor) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ overrides:
   zod: ^4.3.6
 
 patchedDependencies:
-  '@opentui/solid@0.4.3':
-    hash: 0b3f46dbad979dced2505fab7aa41bcd7a9606d489e282d251010d80c9600123
-    path: patches/@opentui__solid@0.4.3.patch
+  '@opentui/solid@0.5.1':
+    hash: 5ce38678f62441c16742735006c64fe8e1fc0d378f6327073c95ef9fcb75f126
+    path: patches/@opentui__solid@0.5.1.patch
 
 importers:
 
@@ -23,11 +23,11 @@ importers:
         specifier: ^0.7.6
         version: 0.7.6(hono@4.12.34)(zod@4.3.6)
       '@opentui/core':
-        specifier: ^0.4.3
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        specifier: ^0.5.1
+        version: 0.5.1(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid':
-        specifier: ^0.4.3
-        version: 0.4.3(patch_hash=0b3f46dbad979dced2505fab7aa41bcd7a9606d489e282d251010d80c9600123)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        specifier: ^0.5.1
+        version: 0.5.1(patch_hash=5ce38678f62441c16742735006c64fe8e1fc0d378f6327073c95ef9fcb75f126)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6
@@ -300,11 +300,11 @@ importers:
         specifier: ^0.7.6
         version: 0.7.6(hono@4.12.34)(zod@4.3.6)
       '@opentui/core':
-        specifier: ^0.4.3
-        version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        specifier: ^0.5.1
+        version: 0.5.1(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid':
-        specifier: ^0.4.3
-        version: 0.4.3(patch_hash=0b3f46dbad979dced2505fab7aa41bcd7a9606d489e282d251010d80c9600123)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        specifier: ^0.5.1
+        version: 0.5.1(patch_hash=5ce38678f62441c16742735006c64fe8e1fc0d378f6327073c95ef9fcb75f126)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6
@@ -1082,48 +1082,53 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@opentui/core-darwin-x64@0.4.3':
-    resolution: {integrity: sha512-+fh0vEUE0lwVC7RW5ijYLRlTLp5NfvCRj8SzxDVd7IL2j2ssB6YXcfIbXq2EW7UGnrejwPRXf1tgUrIXW9KmOw==}
+  '@opentui/core-darwin-arm64@0.5.1':
+    resolution: {integrity: sha512-Yl3JBLYRrBN+SxXY/gYaqCT/JNrN50K4xO7hYC+/Si8/FgOrBlbRmfJIUNQdZMMLUvOMA+I813+hDw3xfarBzQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opentui/core-darwin-x64@0.5.1':
+    resolution: {integrity: sha512-kqMVu+LGuHSCxYFkVJtmuyLLLTMztILSNnlx1eSpHHUiDV4PMc+zkxwRIXO+o0TFTW3gNUKleKUkggriYje7Vw==}
     cpu: [x64]
     os: [darwin]
 
-  '@opentui/core-linux-arm64-musl@0.4.3':
-    resolution: {integrity: sha512-8p8g8/AEq/xFGpQ7XcIFKcAqjc0QwsZcv+Ll9RbCDpUA56FGH6jfLDir0KYTNTgYXJTIrBIENI9K46VuxMUMQA==}
+  '@opentui/core-linux-arm64-musl@0.5.1':
+    resolution: {integrity: sha512-rmFMtiCm8I0fESB834sTN/ewoI+QDSber588ZO+i08JR6mbv7hkiKW2H/MhiAY1GxGK4nXApleBMyGVOlVDvgQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@opentui/core-linux-arm64@0.4.3':
-    resolution: {integrity: sha512-gl6qA5QJy6u8Cbt7gOtHbhhfMZ4qQDb0kEwFXHcMGmbnKzz4OHoq74D6tNjyvSQB9saoC7C6C0tvn2DcJOuNog==}
+  '@opentui/core-linux-arm64@0.5.1':
+    resolution: {integrity: sha512-PpE1nCHRkxEvSYyZFMToPHjQoVh50A7+BbgetlTX/5ImXzo6iSO83a+7M/1WgZnNu+uZJf5GZKAAcLoRrvQl3Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@opentui/core-linux-x64-musl@0.4.3':
-    resolution: {integrity: sha512-/QiFpCrpU2O7vy8QYmLIQYbvAtKDgmqcVjR7dGtqSzkiQk3ktNJoo5RozG7ueXnjung1Wp0nKldKxo2Csg/OrA==}
+  '@opentui/core-linux-x64-musl@0.5.1':
+    resolution: {integrity: sha512-WO8RjhqKyqW/7P0xHdEVT8JGfU2MO7RlK0kdkNnRSnAEVwsTNd2ibhmKDPLGpo/DKaLuA00CsnrNiLGZZiQJKQ==}
     cpu: [x64]
     os: [linux]
 
-  '@opentui/core-linux-x64@0.4.3':
-    resolution: {integrity: sha512-dXpJitiZdYE3hq2Pvx6e9I0uPQSOcnaLLp1pDgWAHv+3kvKSHEX//9Yr/pV/Ua6qqT7p+2D/K4vXNap/NKVo2w==}
+  '@opentui/core-linux-x64@0.5.1':
+    resolution: {integrity: sha512-/CxFxFv+ffMof2nYQrpgEfNkWKkKxYUSfwdt2RdDN5fZRhcxjE949743rV0Oovw5Az63qxPgbyfcZVNVO2HVNg==}
     cpu: [x64]
     os: [linux]
 
-  '@opentui/core-win32-arm64@0.4.3':
-    resolution: {integrity: sha512-Mx2zuOjrhm/z2SDS6RExIyjP/SnN/8QhhagxURUw0jQi/NssGSeAllu1cBAFFnhobJL5QLTE4FU4CRhUK9svgg==}
+  '@opentui/core-win32-arm64@0.5.1':
+    resolution: {integrity: sha512-AgeTjZbdMxSiuBjyLvcug91qd1Ds6Dlg5z4lCInqL7mPQicDEnKZs5lF2FAaktcU7RPi2wLybbQ/vM0NbpXYmw==}
     cpu: [arm64]
     os: [win32]
 
-  '@opentui/core-win32-x64@0.4.3':
-    resolution: {integrity: sha512-NuoqvWKGXaYnmlqvu7Gg2lLI6yVMnS9OfWBvxp+7Q+McSgHFSTQmYBXaPpvQ8HikpQXE1nCeMPtuSG4PdZHe2w==}
+  '@opentui/core-win32-x64@0.5.1':
+    resolution: {integrity: sha512-VttbQHVoZQ5uW5IcQeUHPEx/WFQ2mMflukhhbBjpNSdZOPdzmmC4QGFPQznJVwuzXTnjQ2Nll4AY0ROJ/Q3nkw==}
     cpu: [x64]
     os: [win32]
 
-  '@opentui/core@0.4.3':
-    resolution: {integrity: sha512-rrJfAk13tALDqldYjhc78eWQ+aKq1iknJgffIOg3OwyZoqQo+p6gtuqyhmWvXIfQzlNUbpgpCPcxbXlhMnlaHQ==}
+  '@opentui/core@0.5.1':
+    resolution: {integrity: sha512-mIBFyqIP4rkhQ35uldLXWawWQ6S9tvNWvmxGmDJ7W9cLXjegG6gKEfZ/4NyIMma755ERs/sqO/pIh3Ytf3DDFg==}
     peerDependencies:
       web-tree-sitter: 0.25.10
 
-  '@opentui/solid@0.4.3':
-    resolution: {integrity: sha512-RcV0+S8HMdXOASyr7HmJUBuTUIaFPzAxMDa44VftS5C2JUgrmAuWo0Njv1q3TWRB1owjHnyKhEfWGKq7A82wxw==}
+  '@opentui/solid@0.5.1':
+    resolution: {integrity: sha512-eynJILdvxmprr7oou3cqAiAzZ6zzRU0m1y42/L9GZObTKr76tVtPFQpLvQl6ZJTWMoswpwx1pJWqcUN+ZAI8Rg==}
     peerDependencies:
       solid-js: 1.9.12
 
@@ -2404,11 +2409,6 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.8:
-    resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.11.13:
     resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
     engines: {node: '>=6.0.0'}
@@ -2426,13 +2426,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  bun-ffi-structs@0.2.4:
-    resolution: {integrity: sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg==}
+  bun-ffi-structs@0.3.1:
+    resolution: {integrity: sha512-3gM7PpVWLyrwxWjcilSiGuhWanhZivvo6l0u573NziPH6f/gwk6McbaYgn7oJWov6pKGRTDbrg94W5DcJsKTtQ==}
     peerDependencies:
       typescript: ^5
-
-  caniuse-lite@1.0.30001779:
-    resolution: {integrity: sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==}
 
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
@@ -5076,52 +5073,55 @@ snapshots:
   '@opentui/core-darwin-arm64@0.4.3':
     optional: true
 
-  '@opentui/core-darwin-x64@0.4.3':
+  '@opentui/core-darwin-arm64@0.5.1':
     optional: true
 
-  '@opentui/core-linux-arm64-musl@0.4.3':
+  '@opentui/core-darwin-x64@0.5.1':
     optional: true
 
-  '@opentui/core-linux-arm64@0.4.3':
+  '@opentui/core-linux-arm64-musl@0.5.1':
     optional: true
 
-  '@opentui/core-linux-x64-musl@0.4.3':
+  '@opentui/core-linux-arm64@0.5.1':
     optional: true
 
-  '@opentui/core-linux-x64@0.4.3':
+  '@opentui/core-linux-x64-musl@0.5.1':
     optional: true
 
-  '@opentui/core-win32-arm64@0.4.3':
+  '@opentui/core-linux-x64@0.5.1':
     optional: true
 
-  '@opentui/core-win32-x64@0.4.3':
+  '@opentui/core-win32-arm64@0.5.1':
     optional: true
 
-  '@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)':
+  '@opentui/core-win32-x64@0.5.1':
+    optional: true
+
+  '@opentui/core@0.5.1(typescript@5.9.3)(web-tree-sitter@0.25.10)':
     dependencies:
-      bun-ffi-structs: 0.2.4(typescript@5.9.3)
+      bun-ffi-structs: 0.3.1(typescript@5.9.3)
       diff: 9.0.0
       marked: 17.0.1
       string-width: 7.2.0
       strip-ansi: 7.1.2
       web-tree-sitter: 0.25.10
     optionalDependencies:
-      '@opentui/core-darwin-arm64': 0.4.3
-      '@opentui/core-darwin-x64': 0.4.3
-      '@opentui/core-linux-arm64': 0.4.3
-      '@opentui/core-linux-arm64-musl': 0.4.3
-      '@opentui/core-linux-x64': 0.4.3
-      '@opentui/core-linux-x64-musl': 0.4.3
-      '@opentui/core-win32-arm64': 0.4.3
-      '@opentui/core-win32-x64': 0.4.3
+      '@opentui/core-darwin-arm64': 0.5.1
+      '@opentui/core-darwin-x64': 0.5.1
+      '@opentui/core-linux-arm64': 0.5.1
+      '@opentui/core-linux-arm64-musl': 0.5.1
+      '@opentui/core-linux-x64': 0.5.1
+      '@opentui/core-linux-x64-musl': 0.5.1
+      '@opentui/core-win32-arm64': 0.5.1
+      '@opentui/core-win32-x64': 0.5.1
     transitivePeerDependencies:
       - typescript
 
-  '@opentui/solid@0.4.3(patch_hash=0b3f46dbad979dced2505fab7aa41bcd7a9606d489e282d251010d80c9600123)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
+  '@opentui/solid@0.5.1(patch_hash=5ce38678f62441c16742735006c64fe8e1fc0d378f6327073c95ef9fcb75f126)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
-      '@opentui/core': 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      '@opentui/core': 0.5.1(typescript@5.9.3)(web-tree-sitter@0.25.10)
       babel-plugin-module-resolver: 5.0.2
       babel-preset-solid: 1.9.12(@babel/core@7.28.0)(solid-js@1.9.12)
       entities: 7.0.1
@@ -6323,8 +6323,6 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.8: {}
-
   baseline-browser-mapping@2.11.13: {}
 
   brace-expansion@2.0.2:
@@ -6337,17 +6335,15 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.8
-      caniuse-lite: 1.0.30001779
+      baseline-browser-mapping: 2.11.13
+      caniuse-lite: 1.0.30001809
       electron-to-chromium: 1.5.321
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  bun-ffi-structs@0.2.4(typescript@5.9.3):
+  bun-ffi-structs@0.3.1(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
-
-  caniuse-lite@1.0.30001779: {}
 
   caniuse-lite@1.0.30001809: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,4 +13,4 @@ overrides:
   zod: ^4.3.6
 
 patchedDependencies:
-  "@opentui/solid@0.4.3": patches/@opentui__solid@0.4.3.patch
+  "@opentui/solid@0.5.1": patches/@opentui__solid@0.5.1.patch

--- a/scripts/build-tui.mjs
+++ b/scripts/build-tui.mjs
@@ -22,9 +22,8 @@
  */
 
 import { createSolidTransformPlugin } from "@opentui/solid/bun-plugin";
-import { mkdirSync, existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { mkdirSync, existsSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -49,73 +48,42 @@ const outfile =
 mkdirSync(dirname(outfile), { recursive: true });
 
 const start = Date.now();
-const workerBuildDir = mkdtempSync(join(tmpdir(), "tmux-ide-opentui-worker-"));
-let result;
+const parserWorkerSource = fileURLToPath(import.meta.resolve("@opentui/core/parser.worker"));
+const workerAssetPlugin = {
+  name: "tmux-ide-opentui-worker-asset",
+  setup(build) {
+    build.onResolve({ filter: /^tmux-ide:opentui-parser-worker$/ }, () => ({
+      path: parserWorkerSource,
+      namespace: "tmux-ide-opentui-worker-asset",
+    }));
+    build.onLoad(
+      { filter: /.*/, namespace: "tmux-ide-opentui-worker-asset" },
+      async ({ path }) => ({
+        contents: new Uint8Array(await Bun.file(path).arrayBuffer()),
+        loader: "file",
+      }),
+    );
+  },
+};
 
-try {
-  // Bun does not discover a Worker whose URL is selected inside a dependency,
-  // and an unbundled parser.worker.js cannot resolve web-tree-sitter from the
-  // standalone executable's /$bunfs root. Bundle the worker first, including
-  // its JS dependencies, then embed both that bundle and its emitted wasm as
-  // file assets in the production executable.
-  const workerBuild = await Bun.build({
-    entrypoints: [fileURLToPath(import.meta.resolve("@opentui/core/parser.worker"))],
-    outdir: workerBuildDir,
-    target: "bun",
-    naming: "parser.worker.js",
-    minify: true,
-  });
-  if (!workerBuild.success) {
-    for (const log of workerBuild.logs) console.error(log);
-    throw new Error("[build-tui] Tree-sitter worker bundle failed");
-  }
-
-  const workerBundle = workerBuild.outputs.find((output) => output.path.endsWith(".js"))?.path;
-  const treeSitterWasm = workerBuild.outputs.find((output) => output.path.endsWith(".wasm"))?.path;
-  if (!workerBundle || !treeSitterWasm) {
-    throw new Error("[build-tui] Tree-sitter worker bundle did not emit JS and wasm assets");
-  }
-
-  const workerAssetPlugin = {
-    name: "tmux-ide-opentui-worker-assets",
-    setup(build) {
-      build.onResolve({ filter: /^tmux-ide:opentui-parser-worker$/ }, () => ({
-        path: workerBundle,
-        namespace: "tmux-ide-opentui-worker-asset",
-      }));
-      build.onResolve({ filter: /^tmux-ide:opentui-tree-sitter-wasm$/ }, () => ({
-        // Strip the worker build's content hash from its input name. Bun adds
-        // the same content hash while embedding it in the executable, yielding
-        // exactly the basename referenced by the bundled worker.
-        path: "tree-sitter.wasm",
-        namespace: "tmux-ide-opentui-worker-asset",
-      }));
-      build.onLoad(
-        { filter: /.*/, namespace: "tmux-ide-opentui-worker-asset" },
-        async ({ path }) => ({
-          contents: new Uint8Array(
-            await Bun.file(path === "tree-sitter.wasm" ? treeSitterWasm : path).arrayBuffer(),
-          ),
-          loader: "file",
-        }),
-      );
-    },
-  };
-
-  result = await Bun.build({
-    entrypoints: [entry],
-    target: "bun",
-    compile: { outfile, target },
-    // This executable is the production runtime; source-mode development keeps
-    // readable symbols. Minifying the embedded JS cuts cold-start IO and module
-    // evaluation (the dominant first-frame cost) without changing OpenTUI's
-    // native asset or the lazy surface dispatcher.
-    minify: true,
-    plugins: [workerAssetPlugin, createSolidTransformPlugin()],
-  });
-} finally {
-  rmSync(workerBuildDir, { recursive: true, force: true });
-}
+// OpenTUI 0.5 owns its runtime asset graph. Its Bun entry embeds the parser
+// worker, web-tree-sitter WASM, language parsers, queries, and native library
+// through supported `import ... with { type: "file" }` boundaries. Keeping that
+// graph intact lets future OpenTUI asset additions flow into the standalone
+// executable automatically. The one explicit worker asset above bridges Bun's
+// current inability to discover the import behind OpenTUI's runtime resolver;
+// its contents come directly from OpenTUI rather than a forked bundle.
+const result = await Bun.build({
+  entrypoints: [entry],
+  target: "bun",
+  compile: { outfile, target },
+  // This executable is the production runtime; source-mode development keeps
+  // readable symbols. Minifying the embedded JS cuts cold-start IO and module
+  // evaluation (the dominant first-frame cost) without changing OpenTUI's
+  // native asset or the lazy surface dispatcher.
+  minify: true,
+  plugins: [workerAssetPlugin, createSolidTransformPlugin()],
+});
 
 if (!result.success) {
   for (const log of result.logs) console.error(log);


### PR DESCRIPTION
## Summary
- upgrade OpenTUI Core and Solid to 0.5.1 and port the retained-tree stability patch
- use the OpenTUI 0.5 runtime asset graph for compiled TUI binaries
- keep semantic window tabs actionable while layout and inventory identity streams converge
- centralize terminal-window resource identity derivation

## Verification
- `pnpm check`
- installed-package compiled TUI Markdown/Tree-sitter smoke test
- desktop smoke: attachability, pane-stream byte round-trip, and replay repair