### PR TITLE
fix(docs): stabilize production footer and demo sequencing

### DIFF
--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -202,6 +202,8 @@ export default async function HomePage() {
                   <TuiMiniFigure
                     variant={agentVisuals[index]}
                     figure={feature.figure}
+                    motionCount={9}
+                    motionIndex={index}
                     className="mt-10"
                   />
                 </Cell>
@@ -237,6 +239,8 @@ export default async function HomePage() {
                   <TuiMiniFigure
                     variant={architectureVisuals[index]}
                     figure={layer.figure}
+                    motionCount={9}
+                    motionIndex={index + 3}
                     className="mt-6"
                   />
                 </Cell>
@@ -293,8 +297,8 @@ export default async function HomePage() {
                   <TuiMiniFigure
                     variant={capability.visual}
                     figure={capability.figure}
-                    motionCount={3}
-                    motionIndex={index}
+                    motionCount={9}
+                    motionIndex={index + 6}
                     className="mt-8"
                   />
                 </Cell>

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -270,6 +270,36 @@
   color-scheme: dark;
 }
 
+/* Footer colors are deliberately concrete rather than inherited Tailwind
+   theme utilities. Production CSS optimization can flatten theme aliases at
+   their declaration scope; these roles keep the permanent dark close stable
+   in both the light and dark page themes. */
+.marketing-dark-footer,
+.marketing-dark-footer .footer-frame,
+.marketing-dark-footer .footer-rule-grid {
+  border-color: rgb(255 255 255 / 12%);
+}
+
+.marketing-dark-footer .footer-rule-grid {
+  background-color: rgb(255 255 255 / 12%);
+}
+
+.marketing-dark-footer .footer-surface {
+  background-color: #0d0d0d;
+}
+
+.marketing-dark-footer .footer-foreground {
+  color: #f5f5f5;
+}
+
+.marketing-dark-footer .footer-muted {
+  color: #a3a3a3;
+}
+
+.marketing-dark-footer .footer-wordmark {
+  color: rgb(255 255 255 / 32%);
+}
+
 /* The mini TUI figures share a four-second Matinee clock. Cards in each
    section are offset onto a common 12s/24s timeline, so only one performance
    speaks at a time. Diagram state changes land with the cursor action. */
@@ -295,6 +325,10 @@
   animation-duration: 24s;
 }
 
+[data-motion-count="9"] :is(.tui-motion-before, .tui-motion-after, .tui-motion-cursor) {
+  animation-duration: 36s;
+}
+
 .tui-motion-before {
   animation-name: tui-motion-before-3;
 }
@@ -317,6 +351,18 @@
 
 [data-motion-count="6"] .tui-motion-cursor {
   animation-name: tui-motion-cursor-6;
+}
+
+[data-motion-count="9"] .tui-motion-before {
+  animation-name: tui-motion-before-9;
+}
+
+[data-motion-count="9"] .tui-motion-after {
+  animation-name: tui-motion-after-9;
+}
+
+[data-motion-count="9"] .tui-motion-cursor {
+  animation-name: tui-motion-cursor-9;
 }
 
 @keyframes tui-motion-before-3 {
@@ -404,6 +450,51 @@
     opacity: 1;
   }
   16.5%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes tui-motion-before-9 {
+  0%,
+  3% {
+    opacity: 1;
+  }
+  4.3%,
+  9.8% {
+    opacity: 0;
+  }
+  11.1%,
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes tui-motion-after-9 {
+  0%,
+  3% {
+    opacity: 0;
+  }
+  4.3%,
+  9.8% {
+    opacity: 1;
+  }
+  11.1%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes tui-motion-cursor-9 {
+  0%,
+  0.4% {
+    opacity: 0;
+  }
+  1%,
+  10.2% {
+    opacity: 1;
+  }
+  11.1%,
   100% {
     opacity: 0;
   }

--- a/docs/components/marketing/tui-mini-figure.tsx
+++ b/docs/components/marketing/tui-mini-figure.tsx
@@ -23,7 +23,7 @@ type Props = {
     label: string;
   };
   className?: string;
-  motionCount?: 3 | 6;
+  motionCount?: 3 | 6 | 9;
   motionIndex?: number;
 };
 

--- a/docs/components/site-footer.tsx
+++ b/docs/components/site-footer.tsx
@@ -38,25 +38,25 @@ const columns = [
 
 export function SiteFooter() {
   return (
-    <footer className="marketing-dark-footer overflow-hidden border-t border-marketing-line bg-marketing-paper">
-      <MarketingFrame className="border-y-0">
+    <footer className="marketing-dark-footer overflow-hidden border-t">
+      <MarketingFrame className="footer-frame border-y-0">
         {/* A line-colored canvas owns every internal seam; dark cells repaint
             the surface so adjacent columns can never manufacture double rules. */}
-        <div className="grid grid-cols-1 gap-px border-b border-marketing-line bg-marketing-line sm:grid-cols-2 lg:grid-cols-5">
-          <div className="bg-marketing-paper px-6 py-12 sm:col-span-2 lg:py-16 xl:px-10">
+        <div className="footer-rule-grid grid grid-cols-1 gap-px border-b sm:grid-cols-2 lg:grid-cols-5">
+          <div className="footer-surface px-6 py-12 sm:col-span-2 lg:py-16 xl:px-10">
             <Link
               href="/"
               aria-label="tmux-ide home"
-              className="marketing-logo-action inline-flex items-center gap-3 text-fd-foreground"
+              className="footer-foreground marketing-logo-action inline-flex items-center gap-3"
             >
               <AppIcon size={30} />
               <AsciiWordmark size="footer" inverted />
             </Link>
-            <p className="mt-5 max-w-md text-sm leading-6 text-fd-muted-foreground">
+            <p className="footer-muted mt-5 max-w-md text-sm leading-6">
               The agent-aware communication plane for building and coordinating a team of coding
               agents on durable tmux sessions.
             </p>
-            <code className="mt-7 inline-block font-mono text-xs text-fd-foreground">
+            <code className="footer-foreground mt-7 inline-block font-mono text-xs">
               {INSTALL_COMMAND}
             </code>
           </div>
@@ -66,14 +66,14 @@ export function SiteFooter() {
           ))}
         </div>
 
-        <div className="grid grid-cols-1 gap-px border-b border-marketing-line bg-marketing-line sm:grid-cols-2">
-          <div className="flex items-center gap-2 bg-marketing-paper px-6 py-6 font-mono text-xs text-fd-muted-foreground xl:px-10">
+        <div className="footer-rule-grid grid grid-cols-1 gap-px border-b sm:grid-cols-2">
+          <div className="footer-muted footer-surface flex items-center gap-2 px-6 py-6 font-mono text-xs xl:px-10">
             <span className="text-emerald-400" aria-hidden>
               ●
             </span>
             <span>Open source · terminal native · SSH ready</span>
           </div>
-          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 bg-marketing-paper px-6 py-6 text-xs text-fd-muted-foreground sm:justify-end xl:px-10">
+          <div className="footer-muted footer-surface flex flex-wrap items-center gap-x-5 gap-y-2 px-6 py-6 text-xs sm:justify-end xl:px-10">
             <span>© {new Date().getFullYear()} tmux-ide</span>
             <span>tmux owns the processes. tmux-ide gives them a workspace.</span>
           </div>
@@ -84,9 +84,9 @@ export function SiteFooter() {
           target="_blank"
           rel="noreferrer"
           aria-label="Prototyper (opens in a new tab)"
-          className="group block bg-marketing-paper px-4 pt-6 text-fd-foreground sm:px-6 sm:pt-8 xl:px-8"
+          className="footer-foreground footer-surface group block px-4 pt-6 sm:px-6 sm:pt-8 xl:px-8"
         >
-          <span className="marketing-wordmark-action mx-auto block w-[90%] translate-y-[40%] text-white/32">
+          <span className="footer-wordmark marketing-wordmark-action mx-auto block w-[90%] translate-y-[40%]">
             <PrototyperWordmark width="100%" outline className="block h-auto w-full" />
           </span>
         </Link>
@@ -103,12 +103,12 @@ function FooterLinkGroup({
   links: readonly (readonly [string, string])[];
 }) {
   return (
-    <nav className="bg-marketing-paper px-6 py-12 lg:py-16" aria-label={`${title} links`}>
-      <p className="marketing-type-caption font-mono text-fd-muted-foreground">{title}</p>
+    <nav className="footer-surface px-6 py-12 lg:py-16" aria-label={`${title} links`}>
+      <p className="footer-muted marketing-type-caption font-mono">{title}</p>
       <ul className="mt-6 space-y-3">
         {links.map(([label, href]) => (
           <li key={label}>
-            <Link href={href} className="marketing-color-action text-sm text-fd-foreground">
+            <Link href={href} className="footer-foreground marketing-color-action text-sm">
               {label}
             </Link>
           </li>

--- a/docs/scripts/check-marketing-structure.mjs
+++ b/docs/scripts/check-marketing-structure.mjs
@@ -117,6 +117,24 @@ expectAbsent(
   "marketing type roles must not use Tailwind's ambiguous text-* namespace",
 );
 
+for (const role of [
+  "footer-frame",
+  "footer-rule-grid",
+  "footer-surface",
+  "footer-foreground",
+  "footer-muted",
+  "footer-wordmark",
+]) {
+  if (!footer.includes(role) || !globalCss.includes(`.${role}`)) {
+    failures.push(`the production-stable dark footer must define and consume ${role}`);
+  }
+}
+expectAbsent(
+  footer,
+  /\b(?:bg-marketing-(?:paper|line)|text-fd-(?:foreground|muted-foreground))\b/u,
+  "the permanent dark footer must not depend on page-theme utility inheritance",
+);
+
 if (failures.length > 0) {
   console.error(`Marketing structure check failed:\n- ${failures.join("\n- ")}`);
   process.exit(1);

--- a/docs/scripts/check-motion.mjs
+++ b/docs/scripts/check-motion.mjs
@@ -37,6 +37,7 @@ if (/\b(?:animate-fade-in|animate-pane-in)\b|@keyframes\s+(?:fadeIn|paneIn)\b/u.
 }
 
 const css = readFileSync(resolve(root, "app/global.css"), "utf8");
+const page = readFileSync(resolve(root, "app/(home)/page.tsx"), "utf8");
 for (const token of [
   "--ease-smooth",
   "--ease-out-fluid",
@@ -44,6 +45,18 @@ for (const token of [
   "@custom-variant hover-only",
 ]) {
   if (!css.includes(token)) failures.push(`missing shared motion primitive: ${token}`);
+}
+
+for (const token of ["motionCount={9}", "motionIndex={index + 3}", "motionIndex={index + 6}"]) {
+  if (!page.includes(token)) failures.push(`landing-page demos must share one queue: ${token}`);
+}
+for (const token of [
+  '[data-motion-count="9"]',
+  "@keyframes tui-motion-before-9",
+  "@keyframes tui-motion-after-9",
+  "@keyframes tui-motion-cursor-9",
+]) {
+  if (!css.includes(token)) failures.push(`missing nine-figure motion queue primitive: ${token}`);
 }
 
 for (const { path, source } of sources.filter(({ path }) => extname(path) !== ".css")) {


### PR DESCRIPTION
## Summary\n- make the permanent dark footer independent of page-theme utility inheritance\n- queue all nine landing-page TUI figures on one shared timeline\n- add structure and motion regression checks\n\n## Verification\n- optimized docs production build\n- full docs site checks\n- computed production CSS audit\n- visual production-bundle inspection\n