### PR TITLE
Fix OpenTUI topology rebinding

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -47379,8 +47379,13 @@ var init_terminal_replica_interpreter = __esm({
 function boundedPositive(value) {
   return Number.isSafeInteger(value) && value > 0 && value <= 65535;
 }
+function nativeRowsMatchLease(lease, nativeRows) {
+  if (lease.paneBorderStatus === "off") return lease.pane.height === nativeRows;
+  const touchesStatusEdge = lease.paneBorderStatus === "top" ? lease.pane.top === 0 : lease.pane.top + lease.pane.height === lease.windowRows;
+  return lease.pane.height === nativeRows + (touchesStatusEdge ? 1 : 0);
+}
 function layoutLeaseEqual(left, right) {
-  return left.semanticWindowId === right.semanticWindowId && left.currentWindow === right.currentWindow && left.zoomed === right.zoomed && left.windowCols === right.windowCols && left.windowRows === right.windowRows && left.paneBorderStatus === right.paneBorderStatus && left.pane.semanticPaneId === right.pane.semanticPaneId && left.pane.left === right.pane.left && left.pane.top === right.pane.top && left.pane.width === right.pane.width && left.pane.height === right.pane.height && left.pane.active === right.pane.active;
+  return left.semanticWindowId === right.semanticWindowId && left.zoomed === right.zoomed && left.windowCols === right.windowCols && left.windowRows === right.windowRows && left.paneBorderStatus === right.paneBorderStatus && left.pane.semanticPaneId === right.pane.semanticPaneId && left.pane.left === right.pane.left && left.pane.top === right.pane.top && left.pane.width === right.pane.width && left.pane.height === right.pane.height;
 }
 var SessionRuntimeTerminalReplicaOwner;
 var init_terminal_replica_owner = __esm({
@@ -47586,7 +47591,10 @@ var init_terminal_replica_owner = __esm({
               rows: lease.pane.height,
               chunks: reseed.chunks,
               trace: reseed.trace,
-              cursor: { x: event.x, y: event.y },
+              // tmux can report x === cols while its terminal is in the
+              // right-margin wrap-pending state. The canonical replica stores
+              // a cell position, so project that state onto the final column.
+              cursor: { x: Math.min(event.x, reseed.nativeCols - 1), y: event.y },
               bootstrap: "painted-capture",
               validateBeforeCommit: () => this.#leaseIsCurrent(lease, reseed.subscriptionEpoch),
               onInvalidated: () => this.#retryReseedOrFault("terminal reseed layout lease crossed")
@@ -47666,9 +47674,8 @@ var init_terminal_replica_owner = __esm({
         const lease = reseed.layoutLease;
         if (!lease || !this.#leaseIsCurrent(lease, reseed.subscriptionEpoch)) return null;
         if (lease.pane.width !== reseed.nativeCols) return null;
-        const rowsExact = lease.paneBorderStatus === "off" ? lease.pane.height === reseed.nativeRows : lease.pane.height === reseed.nativeRows + 1;
-        if (!rowsExact) return null;
-        if (!Number.isSafeInteger(cursorX) || !Number.isSafeInteger(cursorY) || cursorX < 0 || cursorY < 0 || cursorX >= reseed.nativeCols || cursorY >= reseed.nativeRows)
+        if (!nativeRowsMatchLease(lease, reseed.nativeRows)) return null;
+        if (!Number.isSafeInteger(cursorX) || !Number.isSafeInteger(cursorY) || cursorX < 0 || cursorY < 0 || cursorX > reseed.nativeCols || cursorY >= reseed.nativeRows)
           return null;
         return lease;
       }

--- a/packages/daemon-client/src/workspace-client.test.ts
+++ b/packages/daemon-client/src/workspace-client.test.ts
@@ -908,10 +908,7 @@ describe("WorkspaceClient", () => {
 
   it("does not charge an eager canonical seed against the candidate update buffer", async () => {
     const shell = shellBroker({ alpha: shellResource("alpha", ["pane.alpha"]) });
-    const runtime = new EagerSeedRuntime(
-      ALPHA_DAEMON.instanceId,
-      "x".repeat(8 * 1024 * 1024 + 1),
-    );
+    const runtime = new EagerSeedRuntime(ALPHA_DAEMON.instanceId, "x".repeat(8 * 1024 * 1024 + 1));
     const publications: TerminalReplicaUpdate<string, string>[] = [];
     const activations: FakeRuntime[] = [];
     const client = createWorkspaceClient<string, string>({
@@ -926,9 +923,8 @@ describe("WorkspaceClient", () => {
         actions,
       },
     });
-    client.subscribeTerminal(
-      { workspaceName: "alpha", semanticPaneId: "pane.alpha" },
-      (update) => publications.push(update),
+    client.subscribeTerminal({ workspaceName: "alpha", semanticPaneId: "pane.alpha" }, (update) =>
+      publications.push(update),
     );
 
     shell.connections[0]!.handlers.onVerifiedOpen();

--- a/packages/daemon-client/src/workspace-client.test.ts
+++ b/packages/daemon-client/src/workspace-client.test.ts
@@ -298,6 +298,32 @@ class FakeRuntime implements WorkspaceClientRuntimePort<string, string> {
   }
 }
 
+class EagerSeedRuntime extends FakeRuntime {
+  constructor(
+    generation: string,
+    private readonly snapshot: string,
+  ) {
+    super(generation);
+  }
+
+  override async subscribeTerminal(
+    address: TerminalReplicaAddress,
+  ): Promise<FakeTerminalSubscription> {
+    const subscription = new FakeTerminalSubscription(this.generation);
+    const onUpdate = subscription.onUpdate.bind(subscription);
+    subscription.onUpdate = (listener) => {
+      const unsubscribe = onUpdate(listener);
+      listener({
+        ...terminalSeedFor(address.semanticPaneId, this.generation),
+        snapshot: this.snapshot,
+      });
+      return unsubscribe;
+    };
+    this.subscriptions.set(address.semanticPaneId, subscription);
+    return subscription;
+  }
+}
+
 class ClosableFakeRuntime extends FakeRuntime {
   private readonly closedState = deferred<void>();
   override readonly closed = this.closedState.promise;
@@ -878,6 +904,40 @@ describe("WorkspaceClient", () => {
     expect(
       [...runtime.subscriptions.values()].every((subscription) => subscription.closeCount === 1),
     ).toBe(true);
+  });
+
+  it("does not charge an eager canonical seed against the candidate update buffer", async () => {
+    const shell = shellBroker({ alpha: shellResource("alpha", ["pane.alpha"]) });
+    const runtime = new EagerSeedRuntime(
+      ALPHA_DAEMON.instanceId,
+      "x".repeat(8 * 1024 * 1024 + 1),
+    );
+    const publications: TerminalReplicaUpdate<string, string>[] = [];
+    const activations: FakeRuntime[] = [];
+    const client = createWorkspaceClient<string, string>({
+      target: target("alpha"),
+      ports: {
+        shell: shell.transport,
+        connectRuntime: async (_current, _inventory, _signal, prepare) => {
+          await prepare(runtime);
+          return runtime;
+        },
+        didActivateRuntime: (nextRuntime) => activations.push(nextRuntime as FakeRuntime),
+        actions,
+      },
+    });
+    client.subscribeTerminal(
+      { workspaceName: "alpha", semanticPaneId: "pane.alpha" },
+      (update) => publications.push(update),
+    );
+
+    shell.connections[0]!.handlers.onVerifiedOpen();
+    await settle();
+
+    expect(activations).toEqual([runtime]);
+    expect(publications).toHaveLength(1);
+    expect(publications[0]?.type).toBe("terminal.seed");
+    await client.dispose();
   });
 
   it("does not reconnect when a shell refresh leaves runtime inventory unchanged", async () => {

--- a/packages/daemon-client/src/workspace-client.ts
+++ b/packages/daemon-client/src/workspace-client.ts
@@ -777,11 +777,22 @@ export function createWorkspaceClient<
                 publishTerminalUpdate(interest, nextRuntime, update, metadata);
                 return;
               }
-              let encodedBytes = MAX_PREPARED_TERMINAL_BYTES + 1;
-              try {
-                encodedBytes = UTF8_ENCODER.encode(JSON.stringify({ update, metadata })).byteLength;
-              } catch {
-                // An unencodable canonical update cannot be admitted safely.
+              // A seed is already retained by the candidate runtime as its
+              // canonical baseline. Buffering it here adds only one reference,
+              // so charging its fully expanded JSON representation can reject
+              // an otherwise bounded multi-pane bootstrap before activation.
+              // Patches and tombstones are additional retained payloads and
+              // continue to count against the byte budget.
+              let encodedBytes = 0;
+              if (update.type !== "terminal.seed") {
+                encodedBytes = MAX_PREPARED_TERMINAL_BYTES + 1;
+                try {
+                  encodedBytes = UTF8_ENCODER.encode(
+                    JSON.stringify({ update, metadata }),
+                  ).byteLength;
+                } catch {
+                  // An unencodable canonical update cannot be admitted safely.
+                }
               }
               if (
                 prepared.bufferedUpdateCount + 1 > MAX_PREPARED_TERMINAL_UPDATES ||

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-owner.test.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-owner.test.ts
@@ -212,6 +212,68 @@ describe("SessionRuntimeTerminalReplicaOwner", () => {
     },
   );
 
+  it.each(["top", "bottom"] as const)(
+    "keeps an interior pane's full native height with %s border status",
+    async (status) => {
+      const updates: CanonicalTerminalReplicaUpdate[] = [];
+      const mirror = {
+        subscribe: async (candidate: MirrorSubscribeRequest): Promise<MirrorSubscription> => {
+          queueMicrotask(() => {
+            const base = layout(8, 10, status);
+            candidate.onLayout?.({
+              ...base,
+              panes: [{ ...base.panes[0]!, top: 3, height: 4 }],
+            });
+            candidate.onEvent({ type: "reset", cols: 8, rows: 4 });
+            candidate.onEvent({ type: "seed", data: new TextEncoder().encode("interior") });
+            candidate.onEvent({ type: "cursor", x: 1, y: 0 });
+          });
+          return subscription(candidate);
+        },
+      };
+      const owner = new SessionRuntimeTerminalReplicaOwner(
+        generation,
+        "workspace",
+        "pane-a",
+        mirror as never,
+        { incarnation: `${generation}:0`, initialRevision: 0 },
+      );
+      await owner.subscribe((update) => updates.push(update));
+      expect(updates).toHaveLength(1);
+      expect(updates[0]).toMatchObject({ type: "terminal.seed", cols: 8, rows: 4 });
+      await owner.dispose();
+    },
+  );
+
+  it("normalizes tmux's right-margin cursor state into the final canonical column", async () => {
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const mirror = {
+      subscribe: async (candidate: MirrorSubscribeRequest): Promise<MirrorSubscription> => {
+        queueMicrotask(() => {
+          candidate.onLayout?.(layout(8, 4, "top"));
+          candidate.onEvent({ type: "reset", cols: 8, rows: 3 });
+          candidate.onEvent({ type: "seed", data: new TextEncoder().encode("wrapped!") });
+          candidate.onEvent({ type: "cursor", x: 8, y: 0 });
+        });
+        return subscription(candidate);
+      },
+    };
+    const owner = new SessionRuntimeTerminalReplicaOwner(
+      generation,
+      "workspace",
+      "pane-a",
+      mirror as never,
+      { incarnation: `${generation}:0`, initialRevision: 0 },
+    );
+    await owner.subscribe((update) => updates.push(update));
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({
+      type: "terminal.seed",
+      snapshot: { cursor: { x: 7, y: 0 } },
+    });
+    await owner.dispose();
+  });
+
   it("retries one crossed layout epoch and commits only the current capture", async () => {
     let request: MirrorSubscribeRequest | undefined;
     let reseeds = 0;
@@ -405,10 +467,47 @@ describe("SessionRuntimeTerminalReplicaOwner", () => {
     await owner.dispose();
   });
 
+  it("keeps a pending capture valid across ordinary tmux focus changes", async () => {
+    let reseeds = 0;
+    const updates: CanonicalTerminalReplicaUpdate[] = [];
+    const mirror = {
+      subscribe: async (candidate: MirrorSubscribeRequest): Promise<MirrorSubscription> => {
+        queueMicrotask(() => {
+          const initial = layout(8, 4, "top");
+          candidate.onLayout?.(initial);
+          candidate.onEvent({ type: "reset", cols: 8, rows: 3 });
+          candidate.onEvent({ type: "seed", data: new TextEncoder().encode("stable") });
+          candidate.onLayout?.({
+            ...initial,
+            currentWindow: false,
+            panes: initial.panes.map((pane) => ({ ...pane, active: false })),
+          });
+          candidate.onEvent({ type: "cursor", x: 1, y: 0 });
+        });
+        return {
+          ...subscription(candidate),
+          reseed: () => (reseeds += 1),
+        };
+      },
+    };
+    const owner = new SessionRuntimeTerminalReplicaOwner(
+      generation,
+      "workspace",
+      "pane-a",
+      mirror as never,
+      { incarnation: `${generation}:0`, initialRevision: 0 },
+    );
+    await owner.subscribe((update) => updates.push(update));
+    expect(reseeds).toBe(0);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({ type: "terminal.seed", cols: 8, rows: 4 });
+    await owner.dispose();
+  });
+
   it.each([
     ["column mismatch", layout(9, 4, "top"), { cols: 8, rows: 3, x: 1, y: 0 }],
     ["off-row mismatch", layout(8, 4, "off"), { cols: 8, rows: 3, x: 1, y: 0 }],
-    ["cursor overflow", layout(8, 4, "top"), { cols: 8, rows: 3, x: 8, y: 0 }],
+    ["cursor overflow", layout(8, 4, "top"), { cols: 8, rows: 3, x: 9, y: 0 }],
     [
       "duplicate pane identity",
       {

--- a/packages/daemon/src/terminal/session-runtime/terminal-replica-owner.ts
+++ b/packages/daemon/src/terminal/session-runtime/terminal-replica-owner.ts
@@ -298,7 +298,10 @@ export class SessionRuntimeTerminalReplicaOwner {
               rows: lease.pane.height,
               chunks: reseed.chunks,
               trace: reseed.trace,
-              cursor: { x: event.x, y: event.y },
+              // tmux can report x === cols while its terminal is in the
+              // right-margin wrap-pending state. The canonical replica stores
+              // a cell position, so project that state onto the final column.
+              cursor: { x: Math.min(event.x, reseed.nativeCols - 1), y: event.y },
               bootstrap: "painted-capture",
               validateBeforeCommit: () => this.#leaseIsCurrent(lease, reseed.subscriptionEpoch),
               onInvalidated: () => this.#retryReseedOrFault("terminal reseed layout lease crossed"),
@@ -399,17 +402,13 @@ export class SessionRuntimeTerminalReplicaOwner {
     const lease = reseed.layoutLease;
     if (!lease || !this.#leaseIsCurrent(lease, reseed.subscriptionEpoch)) return null;
     if (lease.pane.width !== reseed.nativeCols) return null;
-    const rowsExact =
-      lease.paneBorderStatus === "off"
-        ? lease.pane.height === reseed.nativeRows
-        : lease.pane.height === reseed.nativeRows + 1;
-    if (!rowsExact) return null;
+    if (!nativeRowsMatchLease(lease, reseed.nativeRows)) return null;
     if (
       !Number.isSafeInteger(cursorX) ||
       !Number.isSafeInteger(cursorY) ||
       cursorX < 0 ||
       cursorY < 0 ||
-      cursorX >= reseed.nativeCols ||
+      cursorX > reseed.nativeCols ||
       cursorY >= reseed.nativeRows
     )
       return null;
@@ -477,13 +476,31 @@ function boundedPositive(value: number): boolean {
   return Number.isSafeInteger(value) && value > 0 && value <= 65_535;
 }
 
+function nativeRowsMatchLease(lease: LayoutLease, nativeRows: number): boolean {
+  if (lease.paneBorderStatus === "off") return lease.pane.height === nativeRows;
+
+  // pane-border-status consumes a terminal row only on the pane touching the
+  // configured outer window edge. Interior separators are drawn inside the
+  // layout and tmux reports their capture at the full visible pane height.
+  const touchesStatusEdge =
+    lease.paneBorderStatus === "top"
+      ? lease.pane.top === 0
+      : lease.pane.top + lease.pane.height === lease.windowRows;
+  return lease.pane.height === nativeRows + (touchesStatusEdge ? 1 : 0);
+}
+
 function layoutLeaseEqual(
   left: LayoutLease | Omit<LayoutLease, "epoch">,
   right: LayoutLease | Omit<LayoutLease, "epoch">,
 ): boolean {
+  // Focus is ordinary mutable tmux state, not terminal geometry. A second
+  // attached client can switch the current window or active pane while an
+  // atomic capture is in flight without changing the bytes' dimensions or
+  // identity. Treating those flags as part of the capture lease made that
+  // harmless navigation invalidate bootstrap, eventually faulting the whole
+  // pane stream after the single reseed retry.
   return (
     left.semanticWindowId === right.semanticWindowId &&
-    left.currentWindow === right.currentWindow &&
     left.zoomed === right.zoomed &&
     left.windowCols === right.windowCols &&
     left.windowRows === right.windowRows &&
@@ -492,7 +509,6 @@ function layoutLeaseEqual(
     left.pane.left === right.pane.left &&
     left.pane.top === right.pane.top &&
     left.pane.width === right.pane.width &&
-    left.pane.height === right.pane.height &&
-    left.pane.active === right.pane.active
+    left.pane.height === right.pane.height
   );
 }

--- a/packages/daemon/src/tui/mirror/open-tui-workspace-runtime-port.test.ts
+++ b/packages/daemon/src/tui/mirror/open-tui-workspace-runtime-port.test.ts
@@ -388,6 +388,40 @@ describe("OpenTUI WorkspaceClient runtime port", () => {
     await port.close();
   });
 
+  it("commits a large compact bootstrap seed before cooperative patch scheduling", async () => {
+    const immediate = vi.spyOn(globalThis, "setImmediate");
+    const test = rig(false, false, "semantic-compact-v1");
+    const opening = connectOpenTuiWorkspaceRuntimePort({
+      inventory: inventory([PANE_A]),
+      routing: test.routing,
+    });
+    await Promise.resolve();
+    test.options().onLayout?.({
+      type: "layout",
+      semanticWindowId: "window.main",
+      windowName: "main",
+      currentWindow: true,
+      cols: 132,
+      rows: 41,
+      zoomed: false,
+      paneBorderStatus: "off",
+      panes: [{ pane: PANE_A, left: 0, top: 0, width: 132, height: 41, active: true }],
+    });
+    const blank = blankTerminalReplicaSnapshot(132, 41);
+    const snapshot = Object.freeze({
+      ...blank,
+      history: repeatedBlankHistoryRows(1_000),
+    }) as TerminalReplicaSnapshot;
+    const seed = seedDelivery(PANE_A, snapshot, "203", undefined, "semantic-compact-v1");
+    test.options().onTerminalDelivery(PANE_A, seed.envelope);
+    for (const chunk of seed.chunks) test.options().onTerminalDelivery(PANE_A, chunk);
+
+    const port = await opening;
+    expect(immediate).not.toHaveBeenCalled();
+    immediate.mockRestore();
+    await port.close();
+  });
+
   for (const [name, mutate] of [
     ["missing", (panes: Array<Record<string, unknown>>) => panes.slice(0, 1)],
     ["extra", (panes: Array<Record<string, unknown>>) => [...panes, { ...panes[0], pane: PANE_C }]],

--- a/packages/daemon/src/tui/mirror/open-tui-workspace-runtime-port.ts
+++ b/packages/daemon/src/tui/mirror/open-tui-workspace-runtime-port.ts
@@ -19,6 +19,7 @@ import type {
 } from "@tmux-ide/contracts";
 import {
   TerminalDeliveryAssembler,
+  decodeVerifiedCompactSemanticTerminalUpdate,
   decodeVerifiedCompactSemanticTerminalUpdateCooperatively,
   decodeVerifiedLegacySemanticTerminalUpdate,
   terminalDeliveryEncodingAccepted,
@@ -474,6 +475,26 @@ class WireTerminalEndpoint {
       if (chunk.index + 1 < envelope.chunkCount) return consumed;
       const bytes = assembler.complete();
       if (envelope.encoding === "semantic-compact-v1") {
+        // Bootstrap every endpoint synchronously. Opening a workspace starts
+        // several cooperative decoders at once while live panes are already
+        // producing deltas; under sustained output one initial seed could be
+        // perpetually retired before it established a canonical baseline.
+        // Compact seeds are already size-bounded and decoding one atomically
+        // gives the endpoint the baseline needed for subsequent cooperative
+        // patches and their normal backpressure.
+        if (envelope.frame === "seed" && !this.#hasCanonicalSeed) {
+          const verified = decodeVerifiedCompactSemanticTerminalUpdate(
+            bytes,
+            this.#canonicalSnapshot,
+            envelope.canonicalStateHash,
+            {
+              grantReducerAdoption: true,
+              ...(this.#compactDecodeProfile ? { onComplete: this.#compactDecodeProfile } : {}),
+            },
+          );
+          this.#acceptVerified(envelope, verified, performanceSink, parseStartedAt);
+          return consumed;
+        }
         const token = Object.freeze({});
         this.#decodeToken = token;
         void this.#completeCooperativeCompactDecode(


### PR DESCRIPTION
## Summary
- keep terminal bootstrap leases valid across ordinary tmux focus changes and pane-border geometry
- normalize tmux right-margin cursor state during canonical reseed
- commit bounded compact bootstrap seeds atomically so sustained agent output cannot starve a topology rebind

## Verification
- targeted daemon tests: 64 passed
- daemon typecheck and lint passed
- reproduced six rapid `tmux break-pane` operations: TUI recovered from `topology-changed` and returned to live with all six windows
- full `pnpm check` reached desktop-renderer tests; the retired desktop suite has an unrelated Node 24 localStorage harness failure