### PR TITLE
Release 2.9.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 2.9.0-beta.7
 
 ### OpenTUI beta
 
@@ -29,6 +29,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Global npm installs no longer mistake packaged `.tsx` files for a development checkout when Bun is present; every direct TUI surface now acquires and verifies the matching compiled runtime automatically.
+- The npm payload now excludes development scripts, declarations, and OpenTUI build-only dependencies, reducing a clean install from 137 packages to 33 and removing its deprecated Glob warning and reported production vulnerabilities.
+- The legacy `tmux-ide server` compatibility surface is explicitly deprecated and restricted to loopback instead of listening on every network interface.
 - Terminal window tabs and the add-window button now own their OpenTUI mouse input directly, switch through each window's canonical activation pane, and show immediate optimistic selection while daemon-owned tmux state reconciles.
 - Standalone TUI binaries now embed OpenTUI's Tree-sitter worker and WebAssembly runtime, so `tmux-ide show` renders Markdown without leaking `/$bunfs/root/parser.worker.ts` errors into terminal panes.
 - Chrome-updater pane snapshots now skip raw shells and carry short-lived, one-use daemon-owner proofs, preventing tmux-ide's own two-second status scan from producing permanent READ chrome or competing with terminal input; genuine external and agent reads remain visible.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13104,10 +13104,10 @@ __export(classify_exports, {
 });
 function parseAuthority(raw, nowSec) {
   if (!raw) return null;
-  const sep9 = raw.lastIndexOf(":");
-  if (sep9 === -1) return null;
-  const state = raw.slice(0, sep9);
-  const epoch = Number(raw.slice(sep9 + 1));
+  const sep10 = raw.lastIndexOf(":");
+  if (sep10 === -1) return null;
+  const state = raw.slice(0, sep10);
+  const epoch = Number(raw.slice(sep10 + 1));
   if (!AUTHORITY_STATES.has(state) || !Number.isFinite(epoch)) return null;
   if ((state === "working" || state === "blocked") && nowSec - epoch > AUTHORITY_STALE_SECONDS) {
     return null;
@@ -13123,9 +13123,9 @@ function sanitizeAgentText(raw) {
 }
 function parseAuthorityEpoch(raw) {
   if (!raw) return null;
-  const sep9 = raw.lastIndexOf(":");
-  if (sep9 === -1) return null;
-  const epoch = Number(raw.slice(sep9 + 1));
+  const sep10 = raw.lastIndexOf(":");
+  if (sep10 === -1) return null;
+  const epoch = Number(raw.slice(sep10 + 1));
   return Number.isFinite(epoch) ? epoch : null;
 }
 function classifyInstant(snapshot, manifest) {
@@ -15526,9 +15526,23 @@ var init_tui_binary = __esm({
 // packages/daemon/src/tui/compiled.ts
 import { existsSync as existsSync11, mkdirSync as mkdirSync9 } from "node:fs";
 import { homedir as homedir8 } from "node:os";
-import { dirname as dirname14, join as join14, resolve as resolve9 } from "node:path";
+import { dirname as dirname14, join as join14, resolve as resolve9, sep as sep3 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 import { execFileSync as execFileSync5 } from "node:child_process";
+function hasDevelopmentTuiSource(scriptPath, environment = process.env) {
+  if (!existsSync11(scriptPath)) return false;
+  if (environment.TMUX_IDE_TUI_SOURCE === "1") return true;
+  if (resolve9(scriptPath).split(sep3).includes("node_modules")) return false;
+  let cursor = dirname14(scriptPath);
+  while (true) {
+    if (existsSync11(join14(cursor, ".git")) && existsSync11(join14(cursor, "pnpm-workspace.yaml"))) {
+      return true;
+    }
+    const parent = dirname14(cursor);
+    if (parent === cursor) return false;
+    cursor = parent;
+  }
+}
 function openTuiLaunchEnvironment(inherited, overlay = {}) {
   const environment = {
     ...inherited,
@@ -15664,7 +15678,7 @@ function sidebarWidgetCommand(scriptPath, session, dir, theme) {
     surface: "sidebar",
     scriptPath,
     args,
-    checkoutExists: existsSync12(scriptPath),
+    checkoutExists: hasDevelopmentTuiSource(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui(),
     preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1"
@@ -15780,7 +15794,7 @@ function resolveWidgetCommand(type, opts) {
     surface: type,
     scriptPath,
     args: widgetArgs(opts),
-    checkoutExists: existsSync13(scriptPath),
+    checkoutExists: hasDevelopmentTuiSource(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui(),
     preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1"
@@ -15802,7 +15816,7 @@ function resolveWidgetSpawn(type, opts) {
     surface: type,
     scriptPath,
     args: widgetArgs(opts),
-    checkoutExists: existsSync13(scriptPath),
+    checkoutExists: hasDevelopmentTuiSource(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui(),
     preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1"
@@ -23467,7 +23481,7 @@ import {
   unlinkSync as unlinkSync3,
   writeFileSync as writeFileSync18
 } from "node:fs";
-import { isAbsolute as isAbsolute6, join as join28, relative as relative3, resolve as resolve29, sep as sep3, win32 } from "node:path";
+import { isAbsolute as isAbsolute6, join as join28, relative as relative3, resolve as resolve29, sep as sep4, win32 } from "node:path";
 function createProjectRuntimeRepository(resolution, options = {}) {
   return new ProjectRuntimeRepository(resolution, options);
 }
@@ -23668,7 +23682,7 @@ function validateSafeStreamId(value) {
 }
 function isWithinDirectory(path2, root) {
   const fromRoot = relative3(root, path2);
-  return fromRoot === "" || fromRoot !== ".." && !fromRoot.startsWith(`..${sep3}`) && !isAbsolute6(fromRoot);
+  return fromRoot === "" || fromRoot !== ".." && !fromRoot.startsWith(`..${sep4}`) && !isAbsolute6(fromRoot);
 }
 function safeTempId(value) {
   return value.replace(/[^A-Za-z0-9_-]/g, "_");
@@ -24338,7 +24352,7 @@ var init_project_runtime_repository = __esm({
 
 // packages/daemon/src/lib/directory-watcher.ts
 import { watch as fsWatch } from "node:fs";
-import { join as join29, sep as sep4 } from "node:path";
+import { join as join29, sep as sep5 } from "node:path";
 async function loadParcel() {
   if (parcel !== void 0) return parcel;
   try {
@@ -24365,7 +24379,7 @@ function fsWatchDirectory(dir, onChange, ignore2, debounceMs, requireInstalled, 
     handle = fsWatch(dir, { recursive: true }, (_event, filename) => {
       if (!filename) return;
       const rel = filename.toString();
-      if (rel.split(sep4).some((part) => ignoreSet.has(part))) return;
+      if (rel.split(sep5).some((part) => ignoreSet.has(part))) return;
       if (timeout) clearTimeout(timeout);
       timeout = setTimeout(() => onChange([{ type: "update", path: join29(dir, rel) }]), debounceMs);
     });
@@ -25769,7 +25783,7 @@ var init_project_readiness = __esm({
 // packages/daemon/src/lib/project-readiness-probe.ts
 import { execFile as execFile5 } from "node:child_process";
 import { accessSync as accessSync3, constants as constants3, existsSync as existsSync30, realpathSync as realpathSync6, statSync as statSync6 } from "node:fs";
-import { delimiter, isAbsolute as isAbsolute8, basename as basename13, resolve as resolve31, sep as sep5 } from "node:path";
+import { delimiter, isAbsolute as isAbsolute8, basename as basename13, resolve as resolve31, sep as sep6 } from "node:path";
 function errorCode(error) {
   if (!error || typeof error !== "object" || !("code" in error)) return void 0;
   const code = error.code;
@@ -25840,7 +25854,7 @@ function locateExecutable(executable, cwd, environment, io) {
   if (!hasValidExecutableToken(executable)) {
     return { availability: "missing", path: null };
   }
-  if (isAbsolute8(executable) || executable.includes(sep5) || executable.includes("/") || executable.includes("\\")) {
+  if (isAbsolute8(executable) || executable.includes(sep6) || executable.includes("/") || executable.includes("\\")) {
     const candidate = isAbsolute8(executable) ? executable : resolve31(cwd, executable);
     const availability = inspectExecutableCandidate(candidate, io);
     return {
@@ -27279,7 +27293,7 @@ var init_tmux_terminal_color = __esm({
 // packages/daemon/src/lib/workspace-pane-creation.ts
 import { execFile as execFile6 } from "node:child_process";
 import { accessSync as accessSync4, constants as constants4, realpathSync as realpathSync7, statSync as statSync7 } from "node:fs";
-import { delimiter as delimiter2, isAbsolute as isAbsolute9, join as join31, relative as relative4, sep as sep6 } from "node:path";
+import { delimiter as delimiter2, isAbsolute as isAbsolute9, join as join31, relative as relative4, sep as sep7 } from "node:path";
 function canonicalProjectDir(path2) {
   const canonical = realpathSync7(path2);
   if (!statSync7(canonical).isDirectory()) throw new Error("project root is not a directory");
@@ -27301,7 +27315,7 @@ function canonicalWorkspaceFile(workspace, canonicalRoot, candidate, source) {
     );
   }
   const ownedRelativePath = relative4(canonicalRoot, canonicalConfig);
-  if (ownedRelativePath === "" || ownedRelativePath === ".." || ownedRelativePath.startsWith(`..${sep6}`) || isAbsolute9(ownedRelativePath)) {
+  if (ownedRelativePath === "" || ownedRelativePath === ".." || ownedRelativePath.startsWith(`..${sep7}`) || isAbsolute9(ownedRelativePath)) {
     throw new WorkspacePaneCreationError("workspace_unavailable", {
       workspaceName: workspace.name,
       reason: `${source}_config_outside_workspace`
@@ -35720,9 +35734,9 @@ function parseControlLine(line, insideReply) {
     const space = rest.indexOf(" ");
     const pane = space === -1 ? rest : rest.slice(0, space);
     const tail = space === -1 ? "" : rest.slice(space + 1);
-    const sep9 = tail.indexOf(" : ");
-    const meta = sep9 === -1 ? tail : tail.slice(0, sep9);
-    const payload = sep9 === -1 ? "" : tail.slice(sep9 + 3);
+    const sep10 = tail.indexOf(" : ");
+    const meta = sep10 === -1 ? tail : tail.slice(0, sep10);
+    const payload = sep10 === -1 ? "" : tail.slice(sep10 + 3);
     const age = Number(meta.trim().split(/\s+/)[0]);
     return {
       kind: "extended-output",
@@ -57136,10 +57150,10 @@ var init_inspect = __esm({
 // packages/daemon/src/lib/filesystem-browser.ts
 import { realpathSync as realpathSync13, readdirSync as readdirSync4, statSync as statSync13 } from "node:fs";
 import { homedir as homedir17 } from "node:os";
-import { isAbsolute as isAbsolute14, join as join36, resolve as resolve33, sep as sep7 } from "node:path";
+import { isAbsolute as isAbsolute14, join as join36, resolve as resolve33, sep as sep8 } from "node:path";
 function isUnderRoot(canonical, root) {
   if (canonical === root) return true;
-  const prefix = root.endsWith(sep7) ? root : root + sep7;
+  const prefix = root.endsWith(sep8) ? root : root + sep8;
   return canonical.startsWith(prefix);
 }
 function assertInsideSandbox(canonical, home) {
@@ -57395,7 +57409,7 @@ var init_workspace_resource_ids = __esm({
 
 // packages/daemon/src/command-center/resources/workspace-files-authority.ts
 import { lstatSync as lstatSync5, readdirSync as readdirSync5, readFileSync as readFileSync27, realpathSync as realpathSync14 } from "node:fs";
-import { basename as basename15, dirname as dirname32, resolve as resolvePath, sep as sep8 } from "node:path";
+import { basename as basename15, dirname as dirname32, resolve as resolvePath, sep as sep9 } from "node:path";
 import ignore from "ignore";
 function extensionOf(name) {
   const dot = name.lastIndexOf(".");
@@ -57479,7 +57493,7 @@ function safeName(value, fallback) {
 }
 function isWithin2(root, candidate) {
   if (candidate === root) return true;
-  const prefix = root.endsWith(sep8) ? root : `${root}${sep8}`;
+  const prefix = root.endsWith(sep9) ? root : `${root}${sep9}`;
   return candidate.startsWith(prefix);
 }
 var ALWAYS_IGNORED_NAMES, LANGUAGE_BY_EXTENSION, MEDIA_TYPE_BY_EXTENSION, FilesAuthority;
@@ -61994,20 +62008,19 @@ var require_package = __commonJS({
   "package.json"(exports, module) {
     module.exports = {
       name: "tmux-ide",
-      version: "2.9.0-beta.3",
+      version: "2.9.0-beta.7",
       description: "A visual, agent-aware IDE for any tmux session, with optional workspace presets",
       type: "module",
       bin: {
         "tmux-ide": "bin/cli.js"
       },
       files: [
-        "bin",
-        "scripts",
+        "bin/cli.js",
+        "scripts/postinstall.js",
         "skill",
         "templates",
         "packages/daemon/dist/**/*.js",
         "packages/daemon/dist/**/*.jsx",
-        "packages/daemon/dist/**/*.d.ts",
         "packages/daemon/dist/native/**",
         "packages/daemon/src",
         "bunfig.toml",
@@ -62101,23 +62114,22 @@ var require_package = __commonJS({
       dependencies: {
         "@hono/node-server": "^2.1.0",
         "@hono/zod-validator": "^0.7.6",
-        "@opentui/core": "^0.5.1",
-        "@opentui/solid": "^0.5.1",
         "@parcel/watcher": "^2.5.6",
-        "@types/ws": "^8.18.1",
         hono: "^4.12.34",
         ignore: "^7.0.5",
         "js-yaml": "^4.3.1",
         "node-pty": "1.2.0-beta.12",
-        "solid-js": "1.9.12",
         "string-width": "^7.2.0",
         ws: "^8.21.0",
         zod: "^4.3.6"
       },
       devDependencies: {
         "@eslint/js": "^10.0.1",
+        "@opentui/core": "^0.5.1",
+        "@opentui/solid": "^0.5.1",
         "@tsconfig/bun": "^1.0.10",
         "@types/node": "^25.5.0",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.57.1",
         "@typescript-eslint/parser": "^8.57.1",
         "@vitest/coverage-v8": "^4.1.6",
@@ -62125,13 +62137,11 @@ var require_package = __commonJS({
         eslint: "^10.0.3",
         globals: "^17.4.0",
         prettier: "^3.8.1",
+        "solid-js": "1.9.12",
         tsx: "^4.20.7",
         turbo: "^2.9.14",
         typescript: "^5.9.3",
         vitest: "^4.1.6"
-      },
-      optionalDependencies: {
-        "@opentui/core-darwin-arm64": "^0.4.3"
       }
     };
   }
@@ -62352,10 +62362,10 @@ function buildReport(target) {
   let ageSeconds = null;
   let stale = false;
   if (authRaw) {
-    const sep9 = authRaw.lastIndexOf(":");
-    if (sep9 !== -1) {
-      authState = authRaw.slice(0, sep9);
-      const epoch = Number(authRaw.slice(sep9 + 1));
+    const sep10 = authRaw.lastIndexOf(":");
+    if (sep10 !== -1) {
+      authState = authRaw.slice(0, sep10);
+      const epoch = Number(authRaw.slice(sep10 + 1));
       if (Number.isFinite(epoch)) {
         authEpoch = epoch;
         ageSeconds = nowSec - epoch;
@@ -63686,6 +63696,7 @@ var init_command_center = __esm({
 // packages/daemon/src/server/index.ts
 var server_exports3 = {};
 __export(server_exports3, {
+  SERVER_BIND_HOST: () => SERVER_BIND_HOST,
   createApp: () => createApp2,
   resolvePort: () => resolvePort,
   start: () => start
@@ -63727,12 +63738,15 @@ async function start(port) {
   });
   await new Promise((resolve37, reject) => {
     server.once("error", reject);
-    server.listen(resolvedPort, "0.0.0.0", () => {
+    server.listen(resolvedPort, SERVER_BIND_HOST, () => {
       server.off("error", reject);
       resolve37();
     });
   });
-  console.log(`tmux-ide server listening on http://0.0.0.0:${resolvedPort}`);
+  console.warn(
+    "[tmux-ide] `tmux-ide server` is deprecated; use `tmux-ide --headless` for the supported daemon."
+  );
+  console.log(`tmux-ide server listening on http://${SERVER_BIND_HOST}:${resolvedPort}`);
   return {
     port: resolvedPort,
     server,
@@ -63743,12 +63757,13 @@ async function start(port) {
     })
   };
 }
-var DEFAULT_PORT;
+var DEFAULT_PORT, SERVER_BIND_HOST;
 var init_server3 = __esm({
   "packages/daemon/src/server/index.ts"() {
     "use strict";
     init_ws_route();
     DEFAULT_PORT = 6070;
+    SERVER_BIND_HOST = "127.0.0.1";
   }
 });
 
@@ -64182,7 +64197,9 @@ async function doctor({
           resolve20(here, "tui/team/index.tsx")
         ].find(existsSync25);
         const binary = findCompiledTui();
-        if (checkoutEntry && isBunAvailable()) return "dev checkout (bun)";
+        if (checkoutEntry && hasDevelopmentTuiSource(checkoutEntry) && isBunAvailable()) {
+          return "dev checkout (bun)";
+        }
         if (binary) return `compiled binary (${binary})`;
         throw new Error(
           "no dev checkout+bun and no compiled binary \u2014 build one with `pnpm build:tui` or install a release that ships it"
@@ -70910,7 +70927,7 @@ ${bold3("Pane Messaging:")}
 ${bold3("Server:")}
   ${cyan2("tmux-ide serve")} [socket-path]         ${dim3("Foreground owner-only local NDJSON control socket")}
   ${cyan2("tmux-ide command-center")} [--port N]    ${dim3("Start the command-center HTTP API")}
-  ${cyan2("tmux-ide server")} [--port N]            ${dim3("Start HTTP + PTY WebSocket server")}
+  ${cyan2("tmux-ide server")} [--port N]            ${dim3("Deprecated loopback-only PTY server")}
 
 ${bold3("Discover (in the TUI):")}
   ${dim3("Bare")} ${cyan2("tmux-ide")} ${dim3("with no project config opens the HOME cockpit \u2014 the fleet home screen.")}
@@ -70930,16 +70947,20 @@ ${bold3("Flags:")}
   ${cyan2("-h, --help")}                  ${dim3("Show usage")}
   ${cyan2("-v, --version")}               ${dim3("Show version number")}`);
 }
-function execBunWidget(surface, scriptPath, args, commandLabel, extraEnv = {}) {
-  const launch2 = resolveTuiLaunch({
-    surface,
-    scriptPath,
-    args,
-    checkoutExists: existsSync38(scriptPath),
-    bunAvailable: isBunAvailable(),
-    compiledBinary: findCompiledTui(),
-    preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1"
-  });
+async function execBunWidget(surface, scriptPath, args, commandLabel, extraEnv = {}) {
+  const launch2 = await ensureTuiLaunchAvailable(
+    {
+      surface,
+      scriptPath,
+      args,
+      checkoutExists: hasDevelopmentTuiSource(scriptPath),
+      bunAvailable: isBunAvailable(),
+      compiledBinary: findCompiledTui(),
+      preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1"
+    },
+    { log: (message) => process.stderr.write(`[tmux-ide] ${message}
+`) }
+  );
   if (launch2.mode === "unavailable") {
     throw new IdeError(
       `\`tmux-ide ${commandLabel}\` is unavailable because ${launch2.reasons.join(" and ")}.
@@ -71038,7 +71059,7 @@ function launchHostedApp(scriptPath, appArgs) {
     surface: "app",
     scriptPath,
     args: appArgs,
-    checkoutExists: existsSync38(scriptPath),
+    checkoutExists: hasDevelopmentTuiSource(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui(),
     preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1"
@@ -71121,8 +71142,8 @@ async function waitOverSocket(params) {
 }
 var teamScriptPath = resolve36(__dirname5, "../packages/daemon/src/tui/team/index.tsx");
 var appScriptPath = resolve36(__dirname5, "../packages/daemon/src/tui/mirror/app.tsx");
-function launchTeamCockpit() {
-  execBunWidget("team", teamScriptPath, [], "team");
+async function launchTeamCockpit() {
+  await execBunWidget("team", teamScriptPath, [], "team");
 }
 async function runApp(appArgs) {
   await ensureTuiLaunchAvailable(
@@ -71130,7 +71151,7 @@ async function runApp(appArgs) {
       surface: "app",
       scriptPath: appScriptPath,
       args: appArgs,
-      checkoutExists: existsSync38(appScriptPath),
+      checkoutExists: hasDevelopmentTuiSource(appScriptPath),
       bunAvailable: isBunAvailable(),
       compiledBinary: findCompiledTui(),
       preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1"
@@ -71146,7 +71167,7 @@ async function runApp(appArgs) {
     hostedEnv: process.env[HOSTED_ENV] === "1"
   });
   if (hosted) launchHostedApp(appScriptPath, appArgs);
-  else execBunWidget("app", appScriptPath, appArgs, "app");
+  else await execBunWidget("app", appScriptPath, appArgs, "app");
 }
 function launchApp() {
   return runApp([]);
@@ -71205,7 +71226,7 @@ try {
           break;
         }
         if (entry === "app") await launchApp();
-        else launchTeamCockpit();
+        else await launchTeamCockpit();
         break;
       }
       await launch(startTargetDir, { json });
@@ -71284,7 +71305,7 @@ try {
         configArgs = [];
       } else if (sub === "edit") {
         const scriptPath = resolve36(__dirname5, "../packages/daemon/src/widgets/setup/index.tsx");
-        execBunWidget(
+        await execBunWidget(
           "setup",
           scriptPath,
           ["--dir=" + resolve36(startTargetDir || "."), "--edit"],
@@ -71300,7 +71321,7 @@ try {
       const setupArgs = ["--dir=" + resolve36(startTargetDir || ".")];
       if (positionals[1] === "--edit" || values.edit) setupArgs.push("--edit");
       if (positionals[1] === "--wizard" || values.wizard) setupArgs.push("--wizard");
-      execBunWidget("setup", scriptPath, setupArgs, "setup");
+      await execBunWidget("setup", scriptPath, setupArgs, "setup");
       break;
     }
     case "send": {
@@ -71316,7 +71337,12 @@ try {
     }
     case "settings": {
       const scriptPath = resolve36(__dirname5, "../packages/daemon/src/widgets/config/index.tsx");
-      execBunWidget("config", scriptPath, ["--dir=" + resolve36(startTargetDir || ".")], "settings");
+      await execBunWidget(
+        "config",
+        scriptPath,
+        ["--dir=" + resolve36(startTargetDir || ".")],
+        "settings"
+      );
       break;
     }
     case "team": {
@@ -71326,12 +71352,12 @@ try {
       }
       if (values.popup === true) {
         const clientArg = typeof values.client === "string" ? values.client : "";
-        execBunWidget("team", teamScriptPath, [], "team --popup", {
+        await execBunWidget("team", teamScriptPath, [], "team --popup", {
           TMUX_IDE_POPUP_CLIENT: clientArg
         });
         break;
       }
-      launchTeamCockpit();
+      await launchTeamCockpit();
       break;
     }
     case "app": {
@@ -71342,7 +71368,9 @@ try {
     }
     case "switcher": {
       const clientArg = typeof values.client === "string" ? values.client : "";
-      execBunWidget("team", teamScriptPath, [], "switcher", { TMUX_IDE_PICKER_CLIENT: clientArg });
+      await execBunWidget("team", teamScriptPath, [], "switcher", {
+        TMUX_IDE_PICKER_CLIENT: clientArg
+      });
       break;
     }
     case "wait": {
@@ -71882,7 +71910,7 @@ Known panels: ${POPUP_WIDGETS2.join(", ")}.`,
       }
       const popupArgs = [`--dir=${process.cwd()}`];
       if (popupSession) popupArgs.push(`--session=${popupSession}`);
-      execBunWidget(widget, scriptPath, popupArgs, `popup ${widget}`);
+      await execBunWidget(widget, scriptPath, popupArgs, `popup ${widget}`);
       break;
     }
     case "sidebar-toggle": {

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -25,6 +25,7 @@ import { resolveProjectConfigContext } from "../packages/daemon/src/lib/config-c
 import {
   ensureCompiledTuiRuntimeDir,
   ensureTuiLaunchAvailable,
+  hasDevelopmentTuiSource,
   resolveTuiLaunch,
   findCompiledTui,
   isBunAvailable,
@@ -277,7 +278,7 @@ ${bold("Pane Messaging:")}
 ${bold("Server:")}
   ${cyan("tmux-ide serve")} [socket-path]         ${dim("Foreground owner-only local NDJSON control socket")}
   ${cyan("tmux-ide command-center")} [--port N]    ${dim("Start the command-center HTTP API")}
-  ${cyan("tmux-ide server")} [--port N]            ${dim("Start HTTP + PTY WebSocket server")}
+  ${cyan("tmux-ide server")} [--port N]            ${dim("Deprecated loopback-only PTY server")}
 
 ${bold("Discover (in the TUI):")}
   ${dim("Bare")} ${cyan("tmux-ide")} ${dim("with no project config opens the HOME cockpit — the fleet home screen.")}
@@ -303,22 +304,25 @@ ${bold("Flags:")}
 // fall back to the compiled `tmux-ide-tui` binary (see scripts/build-tui.mjs).
 // `resolveTuiLaunch` encodes the "checkout first, binary second" order; when
 // nothing is available it hands back an actionable reason set for an IdeError.
-function execBunWidget(
+async function execBunWidget(
   surface: string,
   scriptPath: string,
   args: string[],
   commandLabel: string,
   extraEnv: Record<string, string> = {},
-): void {
-  const launch = resolveTuiLaunch({
-    surface,
-    scriptPath,
-    args,
-    checkoutExists: existsSync(scriptPath),
-    bunAvailable: isBunAvailable(),
-    compiledBinary: findCompiledTui(),
-    preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1",
-  });
+): Promise<void> {
+  const launch = await ensureTuiLaunchAvailable(
+    {
+      surface,
+      scriptPath,
+      args,
+      checkoutExists: hasDevelopmentTuiSource(scriptPath),
+      bunAvailable: isBunAvailable(),
+      compiledBinary: findCompiledTui(),
+      preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1",
+    },
+    { log: (message) => process.stderr.write(`[tmux-ide] ${message}\n`) },
+  );
 
   if (launch.mode === "unavailable") {
     throw new IdeError(
@@ -437,7 +441,7 @@ function launchHostedApp(scriptPath: string, appArgs: string[]): void {
     surface: "app",
     scriptPath,
     args: appArgs,
-    checkoutExists: existsSync(scriptPath),
+    checkoutExists: hasDevelopmentTuiSource(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui(),
     preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1",
@@ -559,8 +563,8 @@ const appScriptPath = resolve(__dirname, "../packages/daemon/src/tui/mirror/app.
 // `tmux-ide team` runs the standalone full-screen cockpit (the OpenTUI app owns
 // the whole terminal). The floating switcher popup (M-p on adopted sessions)
 // supersedes the old nested `[ switcher | main ]` host shell.
-function launchTeamCockpit(): void {
-  execBunWidget("team", teamScriptPath, [], "team");
+async function launchTeamCockpit(): Promise<void> {
+  await execBunWidget("team", teamScriptPath, [], "team");
 }
 
 // The one entry for the unified app: `--detachable`/`--hosted` (or
@@ -579,7 +583,7 @@ async function runApp(appArgs: string[]): Promise<void> {
       surface: "app",
       scriptPath: appScriptPath,
       args: appArgs,
-      checkoutExists: existsSync(appScriptPath),
+      checkoutExists: hasDevelopmentTuiSource(appScriptPath),
       bunAvailable: isBunAvailable(),
       compiledBinary: findCompiledTui(),
       preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1",
@@ -596,7 +600,7 @@ async function runApp(appArgs: string[]): Promise<void> {
     hostedEnv: process.env[HOSTED_ENV] === "1",
   });
   if (hosted) launchHostedApp(appScriptPath, appArgs);
-  else execBunWidget("app", appScriptPath, appArgs, "app");
+  else await execBunWidget("app", appScriptPath, appArgs, "app");
 }
 
 // The unified app as the front door (M22.6): bare `tmux-ide` opens `tmux-ide
@@ -674,7 +678,7 @@ try {
           break;
         }
         if (entry === "app") await launchApp();
-        else launchTeamCockpit();
+        else await launchTeamCockpit();
         break;
       }
       await launch(startTargetDir, { json });
@@ -767,7 +771,7 @@ try {
         configArgs = [];
       } else if (sub === "edit") {
         const scriptPath = resolve(__dirname, "../packages/daemon/src/widgets/setup/index.tsx");
-        execBunWidget(
+        await execBunWidget(
           "setup",
           scriptPath,
           ["--dir=" + resolve(startTargetDir || "."), "--edit"],
@@ -785,7 +789,7 @@ try {
       const setupArgs = ["--dir=" + resolve(startTargetDir || ".")];
       if (positionals[1] === "--edit" || values.edit) setupArgs.push("--edit");
       if (positionals[1] === "--wizard" || values.wizard) setupArgs.push("--wizard");
-      execBunWidget("setup", scriptPath, setupArgs, "setup");
+      await execBunWidget("setup", scriptPath, setupArgs, "setup");
       break;
     }
 
@@ -803,7 +807,12 @@ try {
 
     case "settings": {
       const scriptPath = resolve(__dirname, "../packages/daemon/src/widgets/config/index.tsx");
-      execBunWidget("config", scriptPath, ["--dir=" + resolve(startTargetDir || ".")], "settings");
+      await execBunWidget(
+        "config",
+        scriptPath,
+        ["--dir=" + resolve(startTargetDir || ".")],
+        "settings",
+      );
       break;
     }
 
@@ -822,12 +831,12 @@ try {
       // switcher it keeps the full two-column layout, not the compact picker.
       if (values.popup === true) {
         const clientArg = typeof values.client === "string" ? values.client : "";
-        execBunWidget("team", teamScriptPath, [], "team --popup", {
+        await execBunWidget("team", teamScriptPath, [], "team --popup", {
           TMUX_IDE_POPUP_CLIENT: clientArg,
         });
         break;
       }
-      launchTeamCockpit();
+      await launchTeamCockpit();
       break;
     }
 
@@ -852,7 +861,9 @@ try {
       // both flips the app into picker mode and carries an optional explicit
       // client name; empty means "resolve it yourself from inside the popup".
       const clientArg = typeof values.client === "string" ? values.client : "";
-      execBunWidget("team", teamScriptPath, [], "switcher", { TMUX_IDE_PICKER_CLIENT: clientArg });
+      await execBunWidget("team", teamScriptPath, [], "switcher", {
+        TMUX_IDE_PICKER_CLIENT: clientArg,
+      });
       break;
     }
 
@@ -1553,7 +1564,7 @@ try {
       }
       const popupArgs = [`--dir=${process.cwd()}`];
       if (popupSession) popupArgs.push(`--session=${popupSession}`);
-      execBunWidget(widget, scriptPath, popupArgs, `popup ${widget}`);
+      await execBunWidget(widget, scriptPath, popupArgs, `popup ${widget}`);
       break;
     }
 

--- a/docs/content/docs/commands.mdx
+++ b/docs/content/docs/commands.mdx
@@ -1,10 +1,10 @@
 ---
 title: CLI reference
-description: The supported tmux-ide commands and flags in 2.9.0-beta.3
+description: The supported tmux-ide commands and flags in 2.9.0-beta.7
 ---
 
 This page follows the public surface printed by `tmux-ide --help` in
-`2.9.0-beta.3`. `--json` is available on the scripting commands that explicitly
+`2.9.0-beta.7`. `--json` is available on the scripting commands that explicitly
 list it below; interactive commands do not emit JSON.
 
 ## Open tmux-ide
@@ -138,7 +138,7 @@ the app.
 | ------------------------------------------- | ------------------------------------------------------------------------ |
 | `tmux-ide --headless [--port <N>] [--json]` | Own the canonical daemon in the foreground without opening tmux or a TUI |
 | `tmux-ide command-center [--port <N>]`      | Start the command-center HTTP API (default port 4000)                    |
-| `tmux-ide server [--port <N>]`              | Start the HTTP and PTY-WebSocket server                                  |
+| `tmux-ide server [--port <N>]`              | Deprecated loopback-only PTY server; use `--headless`                    |
 
 The headless owner publishes `~/.tmux-ide/daemon.json` with owner-only
 permissions. A host should wait until both `/identity` matches that record and

--- a/docs/content/docs/release-2-9-0-beta-1.mdx
+++ b/docs/content/docs/release-2-9-0-beta-1.mdx
@@ -1,9 +1,9 @@
 ---
 title: OpenTUI 2.9 beta.3
-description: The current 2.9.0-beta.3 visual tmux release with agent-aware chrome
+description: The current 2.9.0-beta.7 visual tmux release with agent-aware chrome
 ---
 
-The current package is `2.9.0-beta.3`. It ships a polished OpenTUI client around ordinary tmux
+The current package is `2.9.0-beta.7`. It ships a polished OpenTUI client around ordinary tmux
 sessions. tmux owns PTYs, processes, topology, persistence, and SSH; the daemon
 publishes semantic workspace state and pane streams; OpenTUI owns presentation
 and input.

--- a/docs/content/docs/templates.mdx
+++ b/docs/content/docs/templates.mdx
@@ -1,6 +1,6 @@
 ---
 title: Templates
-description: The workspace templates shipped with tmux-ide 2.9.0-beta.3
+description: The workspace templates shipped with tmux-ide 2.9.0-beta.7
 ---
 
 `tmux-ide init --template <name>` copies a shipped template into

--- a/package.json
+++ b/package.json
@@ -1,19 +1,18 @@
 {
   "name": "tmux-ide",
-  "version": "2.9.0-beta.3",
+  "version": "2.9.0-beta.7",
   "description": "A visual, agent-aware IDE for any tmux session, with optional workspace presets",
   "type": "module",
   "bin": {
     "tmux-ide": "bin/cli.js"
   },
   "files": [
-    "bin",
-    "scripts",
+    "bin/cli.js",
+    "scripts/postinstall.js",
     "skill",
     "templates",
     "packages/daemon/dist/**/*.js",
     "packages/daemon/dist/**/*.jsx",
-    "packages/daemon/dist/**/*.d.ts",
     "packages/daemon/dist/native/**",
     "packages/daemon/src",
     "bunfig.toml",
@@ -107,23 +106,22 @@
   "dependencies": {
     "@hono/node-server": "^2.1.0",
     "@hono/zod-validator": "^0.7.6",
-    "@opentui/core": "^0.5.1",
-    "@opentui/solid": "^0.5.1",
     "@parcel/watcher": "^2.5.6",
-    "@types/ws": "^8.18.1",
     "hono": "^4.12.34",
     "ignore": "^7.0.5",
     "js-yaml": "^4.3.1",
     "node-pty": "1.2.0-beta.12",
-    "solid-js": "1.9.12",
     "string-width": "^7.2.0",
     "ws": "^8.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@opentui/core": "^0.5.1",
+    "@opentui/solid": "^0.5.1",
     "@tsconfig/bun": "^1.0.10",
     "@types/node": "^25.5.0",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "@vitest/coverage-v8": "^4.1.6",
@@ -131,12 +129,10 @@
     "eslint": "^10.0.3",
     "globals": "^17.4.0",
     "prettier": "^3.8.1",
+    "solid-js": "1.9.12",
     "tsx": "^4.20.7",
     "turbo": "^2.9.14",
     "typescript": "^5.9.3",
     "vitest": "^4.1.6"
-  },
-  "optionalDependencies": {
-    "@opentui/core-darwin-arm64": "^0.4.3"
   }
 }

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmux-ide/daemon",
-  "version": "2.9.0-beta.3",
+  "version": "2.9.0-beta.7",
   "private": true,
   "description": "Singleton background daemon for tmux-ide — embeddable workspace registry, command-center API, and chat/codex orchestration.",
   "type": "module",
@@ -28,10 +28,6 @@
     "./errors": {
       "types": "./dist/command-center/actions/errors.d.ts",
       "default": "./dist/command-center/actions/errors.js"
-    },
-    "./codex": {
-      "types": "./dist/codex/index.d.ts",
-      "default": "./dist/codex/index.js"
     }
   },
   "files": [

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -217,7 +217,7 @@ ${bold("Pane Messaging:")}
 
 ${bold("Server:")}
   ${cyan("tmux-ide command-center")} [--port N]    ${dim("Start the command-center HTTP API")}
-  ${cyan("tmux-ide server")} [--port N]            ${dim("Start HTTP + PTY WebSocket server")}
+  ${cyan("tmux-ide server")} [--port N]            ${dim("Deprecated loopback-only PTY server")}
 
 ${bold("Flags:")}
   ${cyan("--json")}                      ${dim("Output as JSON (all commands)")}

--- a/packages/daemon/src/doctor.ts
+++ b/packages/daemon/src/doctor.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { getCurrentVersion, getUpdateStatus } from "./lib/update-check.ts";
 import { installedSkillVersion } from "./lib/skill-sync.ts";
 import { discoverAgents, presentAgents, type DiscoveredAgent } from "./lib/agent-discovery.ts";
-import { findCompiledTui, isBunAvailable } from "./tui/compiled.ts";
+import { findCompiledTui, hasDevelopmentTuiSource, isBunAvailable } from "./tui/compiled.ts";
 import { claudeSettingsPath } from "./tui/integrations/claude.ts";
 import { readNotificationPrefs, resolveNativeMacosNotifierPath } from "./tui/chrome/notify.ts";
 import { resolveConfig } from "./lib/resolved-config.ts";
@@ -213,7 +213,9 @@ export async function doctor({
           resolve(here, "tui/team/index.tsx"),
         ].find(existsSync);
         const binary = findCompiledTui();
-        if (checkoutEntry && isBunAvailable()) return "dev checkout (bun)";
+        if (checkoutEntry && hasDevelopmentTuiSource(checkoutEntry) && isBunAvailable()) {
+          return "dev checkout (bun)";
+        }
         if (binary) return `compiled binary (${binary})`;
         throw new Error(
           "no dev checkout+bun and no compiled binary — build one with `pnpm build:tui` or install a release that ships it",

--- a/packages/daemon/src/server/README.md
+++ b/packages/daemon/src/server/README.md
@@ -2,7 +2,7 @@
 
 v2.5.0 unified server. Single-binary HTTP + WS surface.
 
-Slice 1 scope: WebSocket PTY bridge endpoint at `/ws/pty/:id`. Spawns a shell via node-pty, bridges to wterm in the browser.
+Legacy scope: loopback-only WebSocket PTY bridge endpoint at `/ws/pty/:id`. Spawns a shell via node-pty and bridges it to a local browser. This server is deprecated; new integrations use the authenticated canonical daemon started by `tmux-ide --headless`.
 
 See `plans/v2.5.0-protocol.md` for the wire protocol.
 See `plans/v2.5.0-architecture.md` for the v2.5.0 design.

--- a/packages/daemon/src/server/index.test.ts
+++ b/packages/daemon/src/server/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { SERVER_BIND_HOST } from "./index.ts";
+
+describe("legacy standalone server boundary", () => {
+  it("is restricted to loopback while it remains available for compatibility", () => {
+    expect(SERVER_BIND_HOST).toBe("127.0.0.1");
+  });
+});

--- a/packages/daemon/src/server/index.ts
+++ b/packages/daemon/src/server/index.ts
@@ -6,6 +6,7 @@ import { WebSocketServer } from "ws";
 import { handlePtyWebSocket, shutdownPtyBridges } from "./ws-route.ts";
 
 const DEFAULT_PORT = 6070;
+export const SERVER_BIND_HOST = "127.0.0.1";
 
 export interface StartedTmuxIdeServer {
   port: number;
@@ -53,13 +54,16 @@ export async function start(port?: number): Promise<StartedTmuxIdeServer> {
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
-    server.listen(resolvedPort, "0.0.0.0", () => {
+    server.listen(resolvedPort, SERVER_BIND_HOST, () => {
       server.off("error", reject);
       resolve();
     });
   });
 
-  console.log(`tmux-ide server listening on http://0.0.0.0:${resolvedPort}`);
+  console.warn(
+    "[tmux-ide] `tmux-ide server` is deprecated; use `tmux-ide --headless` for the supported daemon.",
+  );
+  console.log(`tmux-ide server listening on http://${SERVER_BIND_HOST}:${resolvedPort}`);
 
   return {
     port: resolvedPort,

--- a/packages/daemon/src/tui/chrome/sidebar.ts
+++ b/packages/daemon/src/tui/chrome/sidebar.ts
@@ -25,6 +25,7 @@ import { shellEscape } from "../../lib/shell.ts";
 import { SIDEBAR_PANE_OPTION } from "../team/sessions.ts";
 import {
   ensureCompiledTuiRuntimeDir,
+  hasDevelopmentTuiSource,
   resolveTuiLaunch,
   findCompiledTui,
   isBunAvailable,
@@ -70,7 +71,7 @@ export function sidebarWidgetCommand(
     surface: "sidebar",
     scriptPath,
     args,
-    checkoutExists: existsSync(scriptPath),
+    checkoutExists: hasDevelopmentTuiSource(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui(),
     preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1",

--- a/packages/daemon/src/tui/compiled.test.ts
+++ b/packages/daemon/src/tui/compiled.test.ts
@@ -4,7 +4,7 @@
  * `tmux-ide-tui` binary when installed).
  */
 import { describe, expect, it } from "vitest";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,6 +12,7 @@ import {
   compiledTuiRuntimeDir,
   ensureTuiLaunchAvailable,
   ensureCompiledTuiRuntimeDir,
+  hasDevelopmentTuiSource,
   openTuiLaunchEnvironment,
   resolveTuiLaunch,
 } from "./compiled.ts";
@@ -24,6 +25,36 @@ const base = {
   scriptPath: "/checkout/widgets/explorer/index.tsx",
   args: ["--session=s", "--dir=/proj"],
 };
+
+describe("hasDevelopmentTuiSource", () => {
+  it("distinguishes a repository checkout from sources shipped in an npm package", () => {
+    const root = mkdtempSync(resolve(tmpdir(), "tmux-ide-source-identity-"));
+    try {
+      const checkoutEntry = resolve(root, "checkout/packages/daemon/src/tui/mirror/app.tsx");
+      mkdirSync(dirname(checkoutEntry), { recursive: true });
+      writeFileSync(checkoutEntry, "export {};\n");
+      writeFileSync(resolve(root, "checkout/.git"), "gitdir: /tmp/example\n");
+      writeFileSync(resolve(root, "checkout/pnpm-workspace.yaml"), "packages: []\n");
+
+      const consumerRoot = resolve(root, "consumer");
+      mkdirSync(consumerRoot, { recursive: true });
+      writeFileSync(resolve(consumerRoot, ".git"), "gitdir: /tmp/consumer\n");
+      writeFileSync(resolve(consumerRoot, "pnpm-workspace.yaml"), "packages: []\n");
+      const installedEntry = resolve(
+        consumerRoot,
+        "node_modules/tmux-ide/packages/daemon/src/tui/mirror/app.tsx",
+      );
+      mkdirSync(dirname(installedEntry), { recursive: true });
+      writeFileSync(installedEntry, "export {};\n");
+
+      expect(hasDevelopmentTuiSource(checkoutEntry, {})).toBe(true);
+      expect(hasDevelopmentTuiSource(installedEntry, {})).toBe(false);
+      expect(hasDevelopmentTuiSource(installedEntry, { TMUX_IDE_TUI_SOURCE: "1" })).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("resolveTuiLaunch — fast binary with an explicit source override", () => {
   it("uses the compiled binary when both paths are present", () => {
@@ -196,6 +227,31 @@ describe("ensureTuiLaunchAvailable — installed first run", () => {
     expect(launch.mode).toBe("bun");
   });
 
+  it("acquires the release runtime when npm-shipped sources exist beside Bun", async () => {
+    let downloads = 0;
+    const launch = await ensureTuiLaunchAvailable(
+      {
+        ...base,
+        checkoutExists: false,
+        bunAvailable: true,
+        compiledBinary: null,
+      },
+      {
+        download: async () => {
+          downloads += 1;
+          return { path: "/downloaded/tmux-ide-tui", bytes: 20_000_000 };
+        },
+      },
+    );
+
+    expect(downloads).toBe(1);
+    expect(launch).toEqual({
+      mode: "binary",
+      bin: "/downloaded/tmux-ide-tui",
+      argv: [base.surface, ...base.args],
+    });
+  });
+
   it("acquires the release runtime when a clean install has no Bun or binary", async () => {
     const messages: string[] = [];
     const launch = await ensureTuiLaunchAvailable(
@@ -277,6 +333,12 @@ describe("packed-install OpenTUI gate", () => {
     expect(runApp.indexOf("ensureCanonicalDaemon")).toBeGreaterThan(
       runApp.indexOf("ensureTuiLaunchAvailable"),
     );
+  });
+
+  it("keeps Bun visible in the packed-install environment", () => {
+    const src = readFileSync(script, "utf8");
+    expect(src).toContain('const runtimeEnv = tmuxEnv(dirname(installedCli), "success", true)');
+    expect(src).toContain("...(bunPath ? [dirname(bunPath)] : [])");
   });
 
   it("keeps the deferred Web GUI out of the OpenTUI beta command graph", () => {

--- a/packages/daemon/src/tui/compiled.ts
+++ b/packages/daemon/src/tui/compiled.ts
@@ -18,7 +18,7 @@
  */
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 import { downloadTuiBinary, findDownloadedTui } from "../lib/tui-binary.ts";
@@ -52,6 +52,36 @@ export interface TuiLaunchAcquisitionOptions {
   readonly download?: (options: {
     readonly log?: (message: string) => void;
   }) => Promise<{ readonly path: string; readonly bytes: number }>;
+}
+
+/**
+ * True only for source files that belong to an actual repository checkout.
+ *
+ * npm releases intentionally ship selected TypeScript sources, so existence of
+ * a `.tsx` entry alone does not prove that Bun can execute it: workspace links,
+ * the JSX preload, and the rest of the monorepo may be absent. Walk upward for
+ * the two checkout markers instead. `TMUX_IDE_TUI_SOURCE=1` remains an explicit
+ * escape hatch for source archives and unusual development layouts.
+ */
+export function hasDevelopmentTuiSource(
+  scriptPath: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!existsSync(scriptPath)) return false;
+  if (environment.TMUX_IDE_TUI_SOURCE === "1") return true;
+  // A dependency can itself be installed inside another pnpm workspace. Do
+  // not mistake the consuming repository's markers for tmux-ide's checkout.
+  if (resolve(scriptPath).split(sep).includes("node_modules")) return false;
+
+  let cursor = dirname(scriptPath);
+  while (true) {
+    if (existsSync(join(cursor, ".git")) && existsSync(join(cursor, "pnpm-workspace.yaml"))) {
+      return true;
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) return false;
+    cursor = parent;
+  }
 }
 
 /**

--- a/packages/daemon/src/widgets/resolve.ts
+++ b/packages/daemon/src/widgets/resolve.ts
@@ -5,6 +5,7 @@ import type { ThemeConfig } from "../types.ts";
 import { shellEscape } from "../lib/shell.ts";
 import {
   ensureCompiledTuiRuntimeDir,
+  hasDevelopmentTuiSource,
   resolveTuiLaunch,
   findCompiledTui,
   isBunAvailable,
@@ -70,7 +71,7 @@ export function resolveWidgetCommand(type: string, opts: WidgetOptions): string 
     surface: type,
     scriptPath,
     args: widgetArgs(opts),
-    checkoutExists: existsSync(scriptPath),
+    checkoutExists: hasDevelopmentTuiSource(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui(),
     preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1",
@@ -111,7 +112,7 @@ export function resolveWidgetSpawn(type: string, opts: WidgetOptions): WidgetSpa
     surface: type,
     scriptPath,
     args: widgetArgs(opts),
-    checkoutExists: existsSync(scriptPath),
+    checkoutExists: hasDevelopmentTuiSource(scriptPath),
     bunAvailable: isBunAvailable(),
     compiledBinary: findCompiledTui(),
     preferSource: process.env.TMUX_IDE_TUI_SOURCE === "1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
+  browserslist: 4.28.8
   flatted: 3.4.2
   minimatch@8>brace-expansion: 2.1.4
   nanoid: 3.3.18
@@ -14,7 +15,7 @@ overrides:
   postcss: 8.5.26
   tsx>esbuild: 0.28.2
   undici: 7.29.0
-  zod: ^4.3.6
+  zod: 4.3.6
 
 patchedDependencies:
   '@opentui/solid@0.5.1':
@@ -31,18 +32,9 @@ importers:
       '@hono/zod-validator':
         specifier: ^0.7.6
         version: 0.7.6(hono@4.12.34)(zod@4.3.6)
-      '@opentui/core':
-        specifier: ^0.5.1
-        version: 0.5.1(typescript@5.9.3)(web-tree-sitter@0.25.10)
-      '@opentui/solid':
-        specifier: ^0.5.1
-        version: 0.5.1(patch_hash=5ce38678f62441c16742735006c64fe8e1fc0d378f6327073c95ef9fcb75f126)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6
-      '@types/ws':
-        specifier: ^8.18.1
-        version: 8.18.1
       hono:
         specifier: ^4.12.34
         version: 4.12.34
@@ -55,9 +47,6 @@ importers:
       node-pty:
         specifier: 1.2.0-beta.12
         version: 1.2.0-beta.12
-      solid-js:
-        specifier: 1.9.12
-        version: 1.9.12
       string-width:
         specifier: ^7.2.0
         version: 7.2.0
@@ -65,18 +54,27 @@ importers:
         specifier: ^8.21.0
         version: 8.21.0
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.3(jiti@2.6.1))
+      '@opentui/core':
+        specifier: ^0.5.1
+        version: 0.5.1(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      '@opentui/solid':
+        specifier: ^0.5.1
+        version: 0.5.1(patch_hash=5ce38678f62441c16742735006c64fe8e1fc0d378f6327073c95ef9fcb75f126)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@tsconfig/bun':
         specifier: ^1.0.10
         version: 1.0.10
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.57.1
         version: 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
@@ -98,6 +96,9 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
+      solid-js:
+        specifier: 1.9.12
+        version: 1.9.12
       tsx:
         specifier: ^4.20.7
         version: 4.21.0
@@ -110,10 +111,6 @@ importers:
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@types/node@25.5.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.12.0)(vite@8.1.4(@types/node@25.5.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
-    optionalDependencies:
-      '@opentui/core-darwin-arm64':
-        specifier: ^0.4.3
-        version: 0.4.3
 
   apps/desktop-renderer:
     dependencies:
@@ -151,7 +148,7 @@ importers:
         specifier: 1.9.12
         version: 1.9.12
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@playwright/test':
@@ -268,7 +265,7 @@ importers:
   packages/contracts:
     dependencies:
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       typescript:
@@ -351,7 +348,7 @@ importers:
         specifier: ^8.21.0
         version: 8.21.0
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@types/node':
@@ -874,7 +871,7 @@ packages:
     resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
     peerDependencies:
       hono: '>=3.9.0'
-      zod: ^4.3.6
+      zod: 4.3.6
 
   '@hugeicons/core-free-icons@4.2.3':
     resolution: {integrity: sha512-fpiU0qFZkv4ABi23xJ2m4qNr0BBfuIaYjPboN8WDA6aj9D+OzXa7eykxKOpACZRuGbDz1U9S5DsNx1d5KNnsgA==}
@@ -1125,11 +1122,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@opentui/core-darwin-arm64@0.4.3':
-    resolution: {integrity: sha512-p5+7AAxpxGuDGagyQfewKtmTFnN7THvTVY4FyKqUtJomNaHdQXPHztapNNzMx0DGWbwOUbVKzpL+yc3CZY3chQ==}
-    cpu: [arm64]
-    os: [darwin]
 
   '@opentui/core-darwin-arm64@0.5.1':
     resolution: {integrity: sha512-Yl3JBLYRrBN+SxXY/gYaqCT/JNrN50K4xO7hYC+/Si8/FgOrBlbRmfJIUNQdZMMLUvOMA+I813+hDw3xfarBzQ==}
@@ -2606,8 +2598,8 @@ packages:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -2891,8 +2883,8 @@ packages:
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
-  electron-to-chromium@1.5.321:
-    resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
+  electron-to-chromium@1.5.420:
+    resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
 
   electron@43.1.1:
     resolution: {integrity: sha512-I5c5vfuVvaXpWx3IZdwvXgxQW44+e7OP1wXGVQkogLeSFSkUZ6sLCcWV05AdEcs65AO5tAIJJwbp7ixw+LdarA==}
@@ -3104,7 +3096,7 @@ packages:
       react-dom: ^19.2.0
       react-router: 7.x.x || 8.x.x
       waku: '*'
-      zod: ^4.3.6
+      zod: 4.3.6
     peerDependenciesMeta:
       '@mdx-js/mdx':
         optional: true
@@ -3864,8 +3856,9 @@ packages:
   node-pty@1.2.0-beta.12:
     resolution: {integrity: sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==}
 
-  node-releases@2.0.36:
-    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
+    engines: {node: '>=18'}
 
   npm-to-yarn@3.2.0:
     resolution: {integrity: sha512-K1HmQeZT2HrjpsR6KgqbN2FAXL2NrJJmNUSD9ck7HGTVu1JKXox8n9SB+tjbU8m8JGLF4OscrroPepew/L7/Xw==}
@@ -4355,11 +4348,11 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.8
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -4631,7 +4624,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -4647,7 +4640,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -4675,13 +4668,13 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -4703,13 +4696,13 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.18.6':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
@@ -4722,14 +4715,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -4745,7 +4738,7 @@ snapshots:
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -4762,7 +4755,7 @@ snapshots:
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@babel/parser@7.29.2':
     dependencies:
@@ -4815,17 +4808,17 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/generator': 7.29.8
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -5245,9 +5238,6 @@ snapshots:
     optional: true
 
   '@next/swc-win32-x64-msvc@16.3.0':
-    optional: true
-
-  '@opentui/core-darwin-arm64@0.4.3':
     optional: true
 
   '@opentui/core-darwin-arm64@0.5.1':
@@ -6587,13 +6577,13 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  browserslist@4.28.1:
+  browserslist@4.28.8:
     dependencies:
       baseline-browser-mapping: 2.11.13
       caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.321
-      node-releases: 2.0.36
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      electron-to-chromium: 1.5.420
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
   buffer-image-size@0.6.4:
     dependencies:
@@ -6875,7 +6865,7 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  electron-to-chromium@1.5.321: {}
+  electron-to-chromium@1.5.420: {}
 
   electron@43.1.1:
     dependencies:
@@ -8155,7 +8145,7 @@ snapshots:
     dependencies:
       node-addon-api: 7.1.1
 
-  node-releases@2.0.36: {}
+  node-releases@2.0.54: {}
 
   npm-to-yarn@3.2.0: {}
 
@@ -8747,9 +8737,9 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ onlyBuiltDependencies:
 
 overrides:
   "@babel/core": 7.29.6
+  browserslist: 4.28.8
   flatted: 3.4.2
   "minimatch@8>brace-expansion": 2.1.4
   nanoid: 3.3.18
@@ -19,7 +20,7 @@ overrides:
   postcss: 8.5.26
   "tsx>esbuild": 0.28.2
   undici: 7.29.0
-  zod: ^4.3.6
+  zod: 4.3.6
 
 patchedDependencies:
   "@opentui/solid@0.5.1": patches/@opentui__solid@0.5.1.patch

--- a/scripts/pack-check-run.mjs
+++ b/scripts/pack-check-run.mjs
@@ -125,8 +125,9 @@ function shQuote(value) {
   return `'${String(value).replaceAll("'", `'\\''`)}'`;
 }
 
-function tmuxEnv(runtimePath, fetchMode = "success") {
+function tmuxEnv(runtimePath, fetchMode = "success", includeBun = false) {
   const tmuxPath = run("sh", ["-c", "command -v tmux"]).stdout.trim();
+  const bunPath = includeBun ? run("sh", ["-c", "command -v bun"]).stdout.trim() : "";
   return {
     HOME: homeDir,
     TMUX_TMPDIR: tmuxTmpDir,
@@ -141,10 +142,17 @@ function tmuxEnv(runtimePath, fetchMode = "success") {
     TMUX_IDE_PACK_FETCH_MODE: fetchMode,
     TMUX_IDE_PACK_TUI_ASSET: mockReleaseAssetPath,
     TMUX_IDE_PACK_TUI_MANIFEST: mockReleaseManifestPath,
-    // Do not let the installed smoke accidentally resolve tools from this
-    // checkout's node_modules/.bin. The compiled TUI needs neither Bun nor the
-    // repository after it has been built.
-    PATH: [runtimePath, dirname(process.execPath), dirname(tmuxPath), "/usr/bin", "/bin"]
+    // Keep Bun visible to reproduce the real installed failure mode: shipped
+    // `.tsx` files must not be mistaken for a development checkout merely
+    // because Bun is installed. Still exclude this checkout's node_modules/.bin.
+    PATH: [
+      runtimePath,
+      dirname(process.execPath),
+      dirname(tmuxPath),
+      ...(bunPath ? [dirname(bunPath)] : []),
+      "/usr/bin",
+      "/bin",
+    ]
       .filter((value, index, values) => value && values.indexOf(value) === index)
       .join(":"),
   };
@@ -323,7 +331,7 @@ async function runInstalledTuiGate(installedCli) {
   const stderrPath = join(tmpRoot, "installed-tui.stderr");
   const launcherPath = join(tmpRoot, "launch-installed-tui.sh");
   const inputMarker = `M59_PACKED_INPUT_${process.pid}`;
-  const runtimeEnv = tmuxEnv(dirname(installedCli));
+  const runtimeEnv = tmuxEnv(dirname(installedCli), "success", true);
   const tmuxArgs = (...args) => ["-S", installedTmuxSocketPath, ...args];
   const tmuxResult = (args, stdio = "pipe") =>
     spawnSync("tmux", tmuxArgs(...args), {

--- a/scripts/pack-tui-check.mjs
+++ b/scripts/pack-tui-check.mjs
@@ -41,10 +41,6 @@ const files = new Set(report.files.map((entry) => entry.path));
 for (const required of [
   "bin/cli.js",
   "scripts/postinstall.js",
-  "scripts/build-tui.mjs",
-  "scripts/opentui-release-check.mjs",
-  "scripts/prepublish-opentui-check.mjs",
-  "scripts/lib/npm-release-tag.mjs",
   "packages/daemon/src/tui/main.ts",
   "packages/daemon/src/tui/compiled.ts",
   "packages/daemon/src/lib/tui-binary.ts",
@@ -56,6 +52,18 @@ for (const required of [
 ]) {
   if (!files.has(required))
     throw new Error(`npm package is missing OpenTUI runtime file ${required}`);
+}
+
+const packagedDevelopmentScripts = [...files].filter(
+  (path) => path.startsWith("scripts/") && path !== "scripts/postinstall.js",
+);
+if (packagedDevelopmentScripts.length > 0) {
+  throw new Error(
+    `OpenTUI npm package leaked development scripts: ${packagedDevelopmentScripts.join(", ")}`,
+  );
+}
+if (files.has("bin/cli.ts")) {
+  throw new Error("OpenTUI npm package leaked the CLI TypeScript source");
 }
 
 const webAssets = [...files].filter((path) => path.startsWith("apps/desktop-renderer/dist/"));


### PR DESCRIPTION
## Summary
- make installed OpenTUI launches acquire the verified compiled runtime even when Bun is present
- trim the npm payload and move OpenTUI build dependencies out of production installs
- pin patched/reproducible transitive dependencies and harden the deprecated legacy server
- update release metadata for 2.9.0-beta.7

## Verification
- full Node 24 `pnpm check`
- `pnpm release:opentui:check`
- packed npm install: 33 packages, zero vulnerabilities
- automatic runtime acquisition and full installed OpenTUI journey
- docs build, native dependency check, and desktop smoke test